### PR TITLE
Command reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,6 +3364,7 @@ dependencies = [
  "mz-dataflow",
  "mz-dataflow-types",
  "mz-ore",
+ "mz-repr",
  "timely",
  "tokio",
  "tokio-serde",

--- a/doc/developer/platform/reconciliation.md
+++ b/doc/developer/platform/reconciliation.md
@@ -1,0 +1,111 @@
+# Reconciling COMPUTE
+
+The controller and compute instances are logically related but can be hosted on different processes, and the state shared between the two needs to be reconciled.
+State includes for example installed dataflows, source subscriptions and sinks, as well as the current progress of the computation.
+On restart, the controller wants to dictate the instances what their state should be.
+The instances want to come up with this state, either by restarting or reconciling their state.
+This document lines out the requirements for reconciling the state compute and storage instances, and active replication.
+
+Initially, compute instances have no state.
+As they receive commands from the controller, they evolve their local state.
+Reconciliation kicks in when the system encounters a failure, such as processes terminating, network failures or logic bugs.
+On each boundary, Materializes reconciles commands to maintain a local representation of the state of the system.
+In the following, we explain what this means for reconciling compute commands on compute instances, storage commands on storage instances, and response reconciliation to enable active replication within the coordinator.
+
+## Compute command reconciliation
+
+Commands represent instructions the COMPUTE controller sends to COMPUTE instances.
+Compute command reconciliation (CR) is hosted by each compute instance.
+* The COMPUTE controller may restart independently of a COMPUTE instance.
+* Reconciling commands is the mechanism to match a COMPUTE instance's state to what the COMPUTE controller expects after startup.
+* On startup, the COMPUTE controller provides the current configuration to the COMPUTE instances.
+* COMPUTE instances can match the configuration to their own state and only apply changes.
+
+For this purpose, we interpret the commands COMPUTE controller provides to COMPUTE as an append-only log.
+Upon COMPUTE controller restart, the new configuration is/should be a suffix of the log of all previously received commands.
+
+The log can be compacted by collapsing commands that semantically supersede previous commands.
+
+The `ComputeCommand` protocol should provide enough information to fully reconcile the command history.
+Each `CreateInstance` command serves as the punctuation to truncate and restart the command log.
+
+### State
+
+We assume that the mapping of `GlobalId` to an object is unique, i.e., after restarts they still name the same object.
+This allows us to maintain a small amount of state to enable command reconciling.
+
+* For each installed identifier, CR maintains its upper frontier.
+* CR retains a copy of dataflow plans to detect plan changes.
+* CR maintains the set of created instances.
+
+The controller sends commands that implicitly start tracking an upper frontier, each identified by a `GlobalId`.
+If the command reconciliation is not yet tracking the frontier for a specific identifier, it starts tracking it.
+If it is already tracking the frontier, it needs to update the controller about past progress, because the controller assumes that the frontier tracking starts at the minimum timestamp.
+Afterwards, the frontier tracking continues as usual.
+
+### Interpreting commands and responses
+
+The command protocol exposes the following verbs to communicate state updates from the controller to a compute instance.
+For each, we describe the associated action applied by CR.
+* `CreateInstance`: If the instance is unknown, remember it and forward the command.
+  Start tracking the frontiers of the logging dataflows if enabled.
+* `DropInstance`: Forget the instance, stop tracking all associated frontiers.
+* `CreateDataflows`: For each dataflow, start tracking the frontiers of all items it exports.
+  Lookup existing dataflow by its `GlobalId` (see [Quirks](#quirks)), and remember the dataflow if it is new.
+  If the identifier is bound, assert that the existing dataflow is compatible with the new definition.
+  Dataflows are considered compatible when the imports, plan, and exports are equal and the `as_of` of the existing dataflow is not in advance of the new `as_of`.
+  Forward the subset of new dataflows.
+* `AllowCompaction`: Stop tracking an upper frontier if the controller permits compaction to the empty frontier.
+  Forward command as-is.
+* `Peek`: Remember active peek, forward command.
+* `CancelPeeks`: Remove cancled peeks from active peeks, forward command.
+
+CR handles responses similarly:
+* `FrontierUppers`: Update the maintained frontier from the provided change batch and return the effective changes.
+* `PeekResponse`: If there is an active peek, return the response.
+* `TailResponse`: Pass through.
+
+### Quirks
+
+The implementation of the command reconciliation (CR) applies the following shortcuts, which should be handled better in the future:
+
+* CR wants identifies plans by a single `GlobalId`, which only works for dataflows exporting a single index.
+
+### Open questions
+
+* The controller does not indicate the set of known IDs.
+  This makes it difficult to determine which objects to uninstall once a controller reconnects.
+  * The IDs are partially-ordered, which would allow the controller to indicate the lower bound of not-in-use IDs.
+* How to handle inserts at a time <= the current object's frontier?
+  We could just discard the data as it would probably be the same information already inserted earlier.
+* When reconnecting, we have to get the controller's state up-to-date.
+  The controller starts with a frontier of `[0]` when creating objects.
+  STORAGE and controller should agree on a frontier before telling COMPUTE about it.
+* The controller assumes that dataflows are rendered with a specific initial time.
+  When restarting, we do not render previously rendered dataflows, which might violate the implicit contract expected by the controller.
+  The reconciler tries to bring the controller up-to-date by replying with a correcting `FrontiersUppers` response.
+  There might be a brief moment in time when the two are not synchronized and the controller could produce invalid commands.
+  Is this a correct way of reconciling dataflows or do we need to drop and reconstruct?
+  * In different world, the controller might create dataflows at `now` instead of the minimum time, which should always be in advance of the current dataflow's frontier.
+
+## Storage command reconciliation
+
+TODO: This section needs expanding.
+
+Currently, the `StorageCommand` protocol does not express enough information to provide full command reconciliation.
+* Materialize initiates tables with ephemeral information.
+  For example, `show databases` reads from a table that is unconditionally initialized with `materialize`.
+  The reconciler has no good mechanism to distinguish initialization updates from others.
+    * *Current solution:* The storage command reconcile truncates all tables that saw inserts on `CreateInstance`.
+* We need to validate if STORAGE's timestamp bindings are safe to be stored in memory within the instance until a controller picks them up.
+* The commands supplied by the controller should be idempotent, but in fact are not.
+  For example, when reading a Kafka topic, we create a new topic name each time we instantiate the source.
+  This is incorrect because we bind an existing identifier to a new definition.
+
+## Response reconciliation
+
+TODO: This section needs expanding.
+
+Responses represent results and data a COMPUTE instance provides the ADAPTER.
+* Multiple COMPUTE instances can appear as a single unit outwards.
+* Response reconciliation ensures that responses from many COMPUTE instances appear as if it was a single instance.

--- a/src/dataflow-types/src/lib.rs
+++ b/src/dataflow-types/src/lib.rs
@@ -16,6 +16,7 @@
 pub mod client;
 pub mod logging;
 pub mod plan;
+pub mod reconciliation;
 
 mod errors;
 mod explain;

--- a/src/dataflow-types/src/plan/join/delta_join.rs
+++ b/src/dataflow-types/src/plan/join/delta_join.rs
@@ -35,7 +35,7 @@ use serde::{Deserialize, Serialize};
 /// in arrangements for other join inputs. These lookups require specific
 /// instructions about which expressions to use as keys. Along the way,
 /// various closures are applied to filter and project as early as possible.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DeltaJoinPlan {
     /// The set of path plans.
     ///
@@ -45,7 +45,7 @@ pub struct DeltaJoinPlan {
 }
 
 /// A delta query path is implemented by a sequences of stages,
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DeltaPathPlan {
     /// The relation whose updates seed the dataflow path.
     pub source_relation: usize,
@@ -62,7 +62,7 @@ pub struct DeltaPathPlan {
 }
 
 /// A delta query stage performs a stream lookup into an arrangement.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DeltaStagePlan {
     /// The relation index into which we will look up.
     pub lookup_relation: usize,

--- a/src/dataflow-types/src/plan/join/linear_join.rs
+++ b/src/dataflow-types/src/plan/join/linear_join.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// A linear join is a sequence of stages, each of which introduces
 /// a new collecion. Each stage is represented by a [LinearStagePlan].
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct LinearJoinPlan {
     /// The source relation from which we start the join.
     pub source_relation: usize,
@@ -48,7 +48,7 @@ pub struct LinearJoinPlan {
 /// Each stage is a binary join between the current accumulated
 /// join results, and a new collection. The former is referred to
 /// as the "stream" and the latter the "lookup".
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct LinearStagePlan {
     /// The relation index into which we will look up.
     pub lookup_relation: usize,

--- a/src/dataflow-types/src/plan/join/mod.rs
+++ b/src/dataflow-types/src/plan/join/mod.rs
@@ -41,7 +41,7 @@ pub use delta_join::DeltaJoinPlan;
 pub use linear_join::LinearJoinPlan;
 
 /// A complete enumeration of possible join plans to render.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum JoinPlan {
     /// A join implemented by a linear join.
     Linear(LinearJoinPlan),
@@ -55,7 +55,7 @@ pub enum JoinPlan {
 /// as there is a relationship between the borrowed lifetime of the closed-over
 /// state and the arguments it takes when invoked. It was not clear how to do
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct JoinClosure {
     ready_equivalences: Vec<Vec<MirScalarExpr>>,
     before: mz_expr::SafeMfpPlan,

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -133,7 +133,7 @@ impl AvailableCollections {
 }
 
 /// A rendering plan with as much conditional logic as possible removed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Plan<T = mz_repr::Timestamp> {
     /// A collection containing a pre-determined collection.
     Constant {

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -100,7 +100,7 @@ pub enum ReductionType {
 /// shape / general computation of the rendered dataflow graph
 /// in this plan, and then make actually rendering the graph
 /// be as simple (and compiler verifiable) as possible.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ReducePlan {
     /// Plan for not computing any aggregations, just determining the set of
     /// distinct keys.
@@ -129,7 +129,7 @@ pub enum ReducePlan {
 /// apply only to the distinct set of values. We need
 /// to apply a distinct operator to those before we
 /// combine them with everything else.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct AccumulablePlan {
     /// All of the aggregations we were asked to compute, stored
     /// in order.
@@ -150,7 +150,7 @@ pub struct AccumulablePlan {
 /// with monotonic plans, but otherwise, we need to render
 /// them with a reduction tree that splits the inputs into
 /// small, and then progressively larger, buckets
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum HierarchicalPlan {
     /// Plan hierarchical aggregations under monotonic inputs.
     Monotonic(MonotonicPlan),
@@ -166,7 +166,7 @@ pub enum HierarchicalPlan {
 /// append only, so we can change our computation to
 /// only retain the "best" value in the diff field, instead
 /// of holding onto all values.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct MonotonicPlan {
     /// All of the aggregations we were asked to compute.
     pub aggr_funcs: Vec<AggregateFunc>,
@@ -185,7 +185,7 @@ pub struct MonotonicPlan {
 /// fraction of the original input) and redo the reduction in another
 /// layer. Effectively, we'll construct a min / max heap out of a series
 /// of reduce operators (each one is a separate layer).
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BucketedPlan {
     /// All of the aggregations we were asked to compute.
     pub aggr_funcs: Vec<AggregateFunc>,
@@ -211,7 +211,7 @@ pub struct BucketedPlan {
 /// were only asked to compute a single aggregation, we can skip
 /// that step and return the arrangement provided by computing the aggregation
 /// directly.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum BasicPlan {
     /// Plan for rendering a single basic aggregation. Here, the
     /// first element denotes the index in the set of inputs
@@ -229,7 +229,7 @@ pub enum BasicPlan {
 /// types.
 ///
 /// TODO: could we express this as a delta join
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CollationPlan {
     /// Accumulable aggregation results to collate, if any.
     pub accumulable: Option<AccumulablePlan>,
@@ -448,7 +448,7 @@ impl ReducePlan {
 }
 
 /// Plan for extracting keys and values in preparation for a reduction.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeyValPlan {
     /// Extracts the columns used as the key.
     pub key_plan: mz_expr::SafeMfpPlan,

--- a/src/dataflow-types/src/plan/threshold.rs
+++ b/src/dataflow-types/src/plan/threshold.rs
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 use super::AvailableCollections;
 
 /// A plan describing how to compute a threshold operation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum ThresholdPlan {
     /// Basic threshold maintains all positive inputs.
     Basic(BasicThresholdPlan),
@@ -56,7 +56,7 @@ impl ThresholdPlan {
 }
 
 /// A plan to maintain all inputs with positive counts.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BasicThresholdPlan {
     /// Description of how the input has been arranged, and how to arrange the output
     pub ensure_arrangement: (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>),
@@ -64,7 +64,7 @@ pub struct BasicThresholdPlan {
 
 /// A plan to maintain all inputs with negative counts, which are subtracted from the output
 /// in order to maintain an equivalent collection compared to [BasicThresholdPlan].
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct RetractionsThresholdPlan {
     /// Description of how the input has been arranged
     pub ensure_arrangement: (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>),

--- a/src/dataflow-types/src/plan/top_k.rs
+++ b/src/dataflow-types/src/plan/top_k.rs
@@ -21,7 +21,7 @@ use mz_expr::ColumnOrder;
 use serde::{Deserialize, Serialize};
 
 /// A plan encapsulating different variants to compute a TopK operation.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum TopKPlan {
     /// A plan for Top1 for monotonic inputs.
     MonotonicTop1(MonotonicTop1Plan),
@@ -97,7 +97,7 @@ impl TopKPlan {
 /// differential's semantics. (2) is especially interesting because Kafka is
 /// monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
 /// Materialize and commonly used by users.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct MonotonicTop1Plan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,
@@ -106,7 +106,7 @@ pub struct MonotonicTop1Plan {
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct MonotonicTopKPlan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,
@@ -120,7 +120,7 @@ pub struct MonotonicTopKPlan {
 }
 
 /// A plan for generic TopKs that don't fit any more specific category.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct BasicTopKPlan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -1,0 +1,268 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Functionality to reconcile commands between a COMPUTE controller and a COMPUTE instance.
+//!
+//! The [ComputeCommandReconcile] struct implements [GenericClient],
+//! which allow the controller to reconnect after restarts. It maintains enough state to
+//! get a newly connected instance up-to-date and matches existing installed objects with
+//! what the controller wants to provide.
+//!
+//! [ComputeCommandReconcile] is designed to live in a COMPUTE instance and liberally uses `assert` to
+//! validate the correctness of commands. It is not intended to be part of a COMPUTE controller as
+//! it might have correctness issues.
+//!
+//! The contract between this and the COMPUTE controller is that identifiers are not re-used and
+//! describe the same object after restarts. Failure to do so will result in undefined behavior.
+//!
+//! The reconciliation presents to a restarted COMPUTE controller as if the COMPUTE instance was
+//! restarted as well. It responds with the expected replies after a `CreateInstance` command and
+//! brings the controller  up-to-date by notifying it about the current upper frontiers.
+//!
+//! Controllers should ignore all responses received before `CreateInstance` as those were intended
+//! for the previous instance. The implementation currently does not distinguish between buffering
+//! messages for a disconnected controller and talking to a live controller.
+
+use crate::client::{
+    Command, ComputeCommand, ComputeInstanceId, ComputeResponse, GenericClient, Response,
+};
+use crate::{DataflowDescription, Plan};
+use async_trait::async_trait;
+use mz_expr::GlobalId;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet, VecDeque};
+use timely::progress::frontier::MutableAntichain;
+use timely::progress::ChangeBatch;
+use tracing::warn;
+
+/// Reconcile commands targeted at a COMPUTE instance.
+///
+/// See the module-level documentation for details.
+#[derive(Debug)]
+pub struct ComputeCommandReconcile<T, C> {
+    /// The client wrapped by this struct.
+    client: C,
+    /// The known compute instances we're responsible for.
+    created: HashSet<ComputeInstanceId>,
+    /// Dataflows by ID.
+    dataflows: HashMap<GlobalId, DataflowDescription<Plan>>,
+    /// Outstanding peek identifiers, to guide responses (and which to suppress).
+    peeks: HashSet<uuid::Uuid>,
+    /// Stash of responses to send back to the controller.
+    responses: VecDeque<Response>,
+    /// Upper frontiers for indexes, sources, and sinks.
+    uppers: HashMap<(GlobalId, ComputeInstanceId), MutableAntichain<T>>,
+}
+
+#[async_trait]
+impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>> + 'static>
+    GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
+    for ComputeCommandReconcile<mz_repr::Timestamp, C>
+{
+    async fn send(&mut self, cmd: Command<mz_repr::Timestamp>) -> Result<(), anyhow::Error> {
+        self.absorb_command(cmd).await
+    }
+
+    async fn recv(&mut self) -> Result<Option<Response<mz_repr::Timestamp>>, anyhow::Error> {
+        if let Some(response) = self.responses.pop_front() {
+            Ok(Some(response))
+        } else {
+            let response = self.client.recv().await;
+            if let Ok(Some(response)) = response {
+                self.absorb_response(response)
+            }
+            Ok(self.responses.pop_front())
+        }
+    }
+}
+
+impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>>
+    ComputeCommandReconcile<mz_repr::Timestamp, C>
+{
+    /// Construct a new [ComputeCommandReconcile].
+    ///
+    /// * `client`: The client wrapped by this struct.
+    pub fn new(client: C) -> Self {
+        Self {
+            client,
+            created: Default::default(),
+            dataflows: Default::default(),
+            peeks: Default::default(),
+            responses: Default::default(),
+            uppers: Default::default(),
+        }
+    }
+
+    /// Start tracking of a id within an instance.
+    ///
+    /// If we're already tracking this ID, it means that the controller lost connection and
+    /// reconnected (or has a bug). We're updating the controller's upper to match the local state.
+    fn start_tracking(&mut self, id: GlobalId, instance: ComputeInstanceId) {
+        let frontier = timely::progress::frontier::MutableAntichain::new_bottom(
+            <mz_repr::Timestamp as timely::progress::Timestamp>::minimum(),
+        );
+        match self.uppers.entry((id, instance)) {
+            Entry::Occupied(entry) => {
+                // We're about to start tracking an already-bound ID. This means that the controller
+                // needs to be informed about the `upper`.
+                let mut change_batch = ChangeBatch::new_from(
+                    <mz_repr::Timestamp as timely::progress::Timestamp>::minimum(),
+                    -1,
+                );
+                change_batch.extend(entry.get().frontier().iter().copied().map(|t| (t, 1)));
+                self.responses.push_back(Response::Compute(
+                    ComputeResponse::FrontierUppers(vec![(id, change_batch)]),
+                    instance,
+                ));
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(frontier);
+            }
+        }
+    }
+
+    /// Stop tracking the id within an instance.
+    fn stop_tracking(&mut self, id: GlobalId, instance: ComputeInstanceId) {
+        let previous = self.uppers.remove(&(id, instance));
+        if previous.is_none() {
+            warn!("Protocol error: ceasing frontier tracking for absent identifier {id:?}");
+        }
+        // Remove dataflow export information.
+        self.dataflows.remove(&id);
+    }
+
+    async fn absorb_command(&mut self, command: Command) -> Result<(), anyhow::Error> {
+        use Command::*;
+        match command {
+            Compute(command, instance) => self.absorb_compute_command(command, instance).await,
+            Storage(_) => panic!("ComputeCommandReconcile cannot handle Storage commands"),
+        }
+    }
+
+    /// Absorbs a response, and produces response that should be emitted.
+    pub fn absorb_response(&mut self, message: Response) {
+        match message {
+            Response::Compute(ComputeResponse::FrontierUppers(mut list), instance) => {
+                for (id, changes) in list.iter_mut() {
+                    if let Some(frontier) = self.uppers.get_mut(&(*id, instance)) {
+                        let iter = frontier.update_iter(changes.drain());
+                        changes.extend(iter);
+                    } else {
+                        changes.clear();
+                    }
+                }
+
+                self.responses.push_back(Response::Compute(
+                    ComputeResponse::FrontierUppers(list),
+                    instance,
+                ));
+            }
+            Response::Compute(ComputeResponse::PeekResponse(uuid, response), instance) => {
+                if self.peeks.remove(&uuid) {
+                    self.responses.push_back(Response::Compute(
+                        ComputeResponse::PeekResponse(uuid, response),
+                        instance,
+                    ));
+                }
+            }
+            Response::Compute(ComputeResponse::TailResponse(id, response), instance) => {
+                self.responses.push_back(Response::Compute(
+                    ComputeResponse::TailResponse(id, response),
+                    instance,
+                ));
+            }
+            Response::Storage(_) => {
+                panic!("ComputeCommandReconcile cannot handle Storage responses")
+            }
+        }
+    }
+
+    async fn absorb_compute_command(
+        &mut self,
+        command: ComputeCommand,
+        instance: ComputeInstanceId,
+    ) -> Result<(), anyhow::Error> {
+        use Command::Compute;
+        use ComputeCommand::*;
+        match command {
+            CreateInstance(config) => {
+                // TODO: Handle `logging` correctly when reconnecting. We currently assume that the
+                // logging config stays the same.
+                if self.created.insert(instance) {
+                    if let Some(logging) = &config {
+                        for id in logging.log_identifiers() {
+                            if !self.uppers.contains_key(&(id, instance)) {
+                                self.start_tracking(id, instance);
+                            }
+                        }
+                    }
+                    self.client
+                        .send(Compute(CreateInstance(config), instance))
+                        .await?;
+                }
+                Ok(())
+            }
+            cmd @ DropInstance => {
+                if self.created.remove(&instance) {
+                    self.uppers.retain(|(_, i), _| i != &instance);
+                    self.client.send(Compute(cmd, instance)).await
+                } else {
+                    Ok(())
+                }
+            }
+            CreateDataflows(dataflows) => {
+                let mut create = Vec::new();
+                for dataflow in dataflows {
+                    for id in dataflow.export_ids() {
+                        self.start_tracking(id, instance);
+                    }
+                    match self.dataflows.entry(dataflow.global_id().unwrap()) {
+                        Entry::Vacant(entry) => {
+                            entry.insert(dataflow.clone());
+                            create.push(dataflow);
+                        }
+                        Entry::Occupied(entry) => {
+                            assert!(
+                                entry.get().compatible_with(&dataflow),
+                                "New dataflow with same ID {:?}",
+                                dataflow.id
+                            );
+                        }
+                    }
+                }
+                if !create.is_empty() {
+                    self.client
+                        .send(Compute(CreateDataflows(create), instance))
+                        .await?
+                }
+                Ok(())
+            }
+            AllowCompaction(frontiers) => {
+                for (id, frontier) in &frontiers {
+                    if frontier.is_empty() {
+                        self.stop_tracking(*id, instance);
+                    }
+                }
+                self.client
+                    .send(Compute(AllowCompaction(frontiers), instance))
+                    .await
+            }
+            Peek(peek) => {
+                self.peeks.insert(peek.uuid);
+                self.client
+                    .send(Compute(ComputeCommand::Peek(peek), instance))
+                    .await
+            }
+            CancelPeeks { uuids } => {
+                for uuid in &uuids {
+                    self.peeks.remove(uuid);
+                }
+                self.client
+                    .send(Compute(CancelPeeks { uuids }, instance))
+                    .await
+            }
+        }
+    }
+}

--- a/src/dataflow-types/src/reconciliation/mod.rs
+++ b/src/dataflow-types/src/reconciliation/mod.rs
@@ -1,0 +1,6 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+pub mod command;

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -143,7 +143,7 @@ impl<T> SourceInstanceRequest<T> {
 }
 
 /// A description of a dataflow to construct and results to surface.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DataflowDescription<P, T = mz_repr::Timestamp> {
     /// Sources instantiations made available to the dataflow.
     pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc<T>>,
@@ -1644,7 +1644,7 @@ pub mod sinks {
     use mz_repr::RelationDesc;
 
     /// A sink for updates to a relational collection.
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub struct SinkDesc<T = mz_repr::Timestamp> {
         pub from: GlobalId,
         pub from_desc: RelationDesc,
@@ -1665,7 +1665,7 @@ pub mod sinks {
         pub strict: bool,
     }
 
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub enum SinkConnector {
         Kafka(KafkaSinkConnector),
         Tail(TailSinkConnector),
@@ -1753,7 +1753,7 @@ pub mod sinks {
         }
     }
 
-    #[derive(Default, Clone, Debug, Serialize, Deserialize)]
+    #[derive(Default, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub struct TailSinkConnector {}
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -372,6 +372,42 @@ where
             self.depends_on_into(id, out)
         }
     }
+
+    /// Determine a unique id for this dataflow based on the indexes it exports.
+    // TODO: The semantics of this function are only useful for command reconciliation at the moment.
+    pub fn global_id(&self) -> Option<GlobalId> {
+        // TODO: This could be implemented without heap allocation.
+        let mut exports = self.export_ids().collect::<Vec<_>>();
+        exports.sort_unstable();
+        exports.dedup();
+        if exports.len() == 1 {
+            return exports.pop();
+        } else {
+            None
+        }
+    }
+}
+
+impl<P: PartialEq, T: timely::PartialOrder> DataflowDescription<P, T> {
+    /// Determine if a dataflow description is compatible with this dataflow description.
+    ///
+    /// Compatible dataflows have equal exports, imports, and objects to build. The `as_of` of
+    /// the receiver has to be less equal the `other` `as_of`.
+    ///
+    // TODO: The semantics of this function are only useful for command reconciliation at the moment.
+    pub fn compatible_with(&self, other: &Self) -> bool {
+        let equality = self.index_exports == other.index_exports
+            && self.sink_exports == other.sink_exports
+            && self.objects_to_build == other.objects_to_build
+            && self.index_imports == other.index_imports
+            && self.source_imports == other.source_imports;
+        let partial = if let (Some(as_of), Some(other_as_of)) = (&self.as_of, &other.as_of) {
+            timely::PartialOrder::less_equal(as_of, other_as_of)
+        } else {
+            false
+        };
+        equality && partial
+    }
 }
 
 /// Types and traits related to the introduction of changing collections into `dataflow`.

--- a/src/dataflowd/Cargo.toml
+++ b/src/dataflowd/Cargo.toml
@@ -14,6 +14,7 @@ futures = "0.3.21"
 mz-dataflow = { path = "../dataflow" }
 mz-dataflow-types = { path = "../dataflow-types" }
 mz-ore = { path = "../ore" }
+mz-repr = { path = "../repr" }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
 tokio-serde = { version = "0.8.0", features = ["bincode"] }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1244,7 +1244,7 @@ pub mod plan {
     use mz_repr::{Datum, Diff, Row, RowArena, ScalarType};
 
     /// A wrapper type which indicates it is safe to simply evaluate all expressions.
-    #[derive(Clone, Debug, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub struct SafeMfpPlan {
         mfp: MapFilterProject,
     }


### PR DESCRIPTION
Add a client that reconciles commands from compute coordinator to instance.

The behavior needs to be explicitly enabled using the `--reconcile` flag on `dataflowd`. By default, none of the functionality is enabled.

This is ready for review.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
