### PR TITLE
sql: add `CREATE CLUSTER` and `DROP CLUSTER` statements

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -188,6 +188,10 @@ pub enum ExecuteResponse {
     },
     /// The requested role was created.
     CreatedRole,
+    /// The requested compute instance was created.
+    CreatedComputeInstance {
+        existed: bool,
+    },
     /// The requested index was created.
     CreatedIndex {
         existed: bool,
@@ -224,6 +228,8 @@ pub enum ExecuteResponse {
     DiscardedTemp,
     /// All state associated with the session has been discarded.
     DiscardedAll,
+    /// The requested compute instance was dropped.
+    DroppedComputeInstance,
     /// The requested database was dropped.
     DroppedDatabase,
     /// The requested role was dropped.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -127,12 +127,13 @@ use mz_sql::catalog::{CatalogError, CatalogTypeDetails, SessionCatalog as _};
 use mz_sql::names::{DatabaseSpecifier, FullName};
 use mz_sql::plan::{
     AlterIndexEnablePlan, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan,
-    AlterItemRenamePlan, CreateDatabasePlan, CreateIndexPlan, CreateRolePlan, CreateSchemaPlan,
-    CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan,
-    CreateViewsPlan, DropDatabasePlan, DropItemsPlan, DropRolesPlan, DropSchemaPlan, ExecutePlan,
-    ExplainPlan, FetchPlan, HirRelationExpr, IndexOption, IndexOptionName, InsertPlan,
-    MutationKind, Params, PeekPlan, Plan, QueryWhen, RaisePlan, ReadThenWritePlan, SendDiffsPlan,
-    SetVariablePlan, ShowVariablePlan, TailFrom, TailPlan,
+    AlterItemRenamePlan, ComputeInstanceConfig, CreateComputeInstancePlan, CreateDatabasePlan,
+    CreateIndexPlan, CreateRolePlan, CreateSchemaPlan, CreateSinkPlan, CreateSourcePlan,
+    CreateTablePlan, CreateTypePlan, CreateViewPlan, CreateViewsPlan, DropComputeInstancesPlan,
+    DropDatabasePlan, DropItemsPlan, DropRolesPlan, DropSchemaPlan, ExecutePlan, ExplainPlan,
+    FetchPlan, HirRelationExpr, IndexOption, IndexOptionName, InsertPlan, MutationKind, Params,
+    PeekPlan, Plan, QueryWhen, RaisePlan, ReadThenWritePlan, SendDiffsPlan, SetVariablePlan,
+    ShowVariablePlan, TailFrom, TailPlan,
 };
 use mz_sql::plan::{OptimizerConfig, StatementDesc, View};
 use mz_transform::Optimizer;
@@ -1165,6 +1166,7 @@ impl Coordinator {
                                 | Statement::CreateDatabase(_)
                                 | Statement::CreateIndex(_)
                                 | Statement::CreateRole(_)
+                                | Statement::CreateCluster(_)
                                 | Statement::CreateSchema(_)
                                 | Statement::CreateSecret(_)
                                 | Statement::CreateSink(_)
@@ -1599,6 +1601,9 @@ impl Coordinator {
             Plan::CreateRole(plan) => {
                 tx.send(self.sequence_create_role(plan).await, session);
             }
+            Plan::CreateComputeInstance(plan) => {
+                tx.send(self.sequence_create_compute_instance(plan).await, session);
+            }
             Plan::CreateTable(plan) => {
                 tx.send(self.sequence_create_table(&session, plan).await, session);
             }
@@ -1634,6 +1639,9 @@ impl Coordinator {
             }
             Plan::DropRoles(plan) => {
                 tx.send(self.sequence_drop_roles(plan).await, session);
+            }
+            Plan::DropComputeInstances(plan) => {
+                tx.send(self.sequence_drop_compute_instances(plan).await, session);
             }
             Plan::DropItems(plan) => {
                 tx.send(self.sequence_drop_items(plan).await, session);
@@ -1896,6 +1904,20 @@ impl Coordinator {
         self.catalog_transact(vec![op])
             .await
             .map(|_| ExecuteResponse::CreatedRole)
+    }
+
+    async fn sequence_create_compute_instance(
+        &mut self,
+        plan: CreateComputeInstancePlan,
+    ) -> Result<ExecuteResponse, CoordError> {
+        match plan.config {
+            ComputeInstanceConfig::Virtual => (),
+            ComputeInstanceConfig::Real { .. } => {
+                coord_bail!("SIZE not yet supported");
+            }
+        }
+        // TODO(benesch,sploiselle): actually create compute instances.
+        Ok(ExecuteResponse::CreatedComputeInstance { existed: false })
     }
 
     async fn sequence_create_table(
@@ -2517,6 +2539,14 @@ impl Coordinator {
         Ok(ExecuteResponse::DroppedRole)
     }
 
+    async fn sequence_drop_compute_instances(
+        &mut self,
+        _plan: DropComputeInstancesPlan,
+    ) -> Result<ExecuteResponse, CoordError> {
+        // TODO(benesch,sploiselle): actually drop compute instances.
+        Ok(ExecuteResponse::DroppedComputeInstance)
+    }
+
     async fn sequence_drop_items(
         &mut self,
         plan: DropItemsPlan,
@@ -2531,8 +2561,9 @@ impl Coordinator {
             ObjectType::Sink => ExecuteResponse::DroppedSink,
             ObjectType::Index => ExecuteResponse::DroppedIndex,
             ObjectType::Type => ExecuteResponse::DroppedType,
-            ObjectType::Role => unreachable!("DROP ROLE not supported"),
-            ObjectType::Secret => unreachable!("DROP SECRET not supported"),
+            ObjectType::Role => unreachable!("DROP ROLE is handled elsewhere"),
+            ObjectType::Cluster => unreachable!("DROP CLUSTER is handled elsewhere"),
+            ObjectType::Secret => unreachable!("DROP SECRET is handled elsewhere"),
             ObjectType::Object => unreachable!("generic OBJECT cannot be dropped"),
         })
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1067,6 +1067,9 @@ where
                 let existed = false;
                 created!(existed, SqlState::DUPLICATE_OBJECT, "role")
             }
+            ExecuteResponse::CreatedComputeInstance { existed } => {
+                created!(existed, SqlState::DUPLICATE_OBJECT, "cluster")
+            }
             ExecuteResponse::CreatedTable { existed } => {
                 created!(existed, SqlState::DUPLICATE_TABLE, "table")
             }
@@ -1094,6 +1097,7 @@ where
             ExecuteResponse::DroppedDatabase => command_complete!("DROP DATABASE"),
             ExecuteResponse::DroppedSchema => command_complete!("DROP SCHEMA"),
             ExecuteResponse::DroppedRole => command_complete!("DROP ROLE"),
+            ExecuteResponse::DroppedComputeInstance => command_complete!("DROP CLUSTER"),
             ExecuteResponse::DroppedSource => command_complete!("DROP SOURCE"),
             ExecuteResponse::DroppedIndex => command_complete!("DROP INDEX"),
             ExecuteResponse::DroppedSink => command_complete!("DROP SINK"),

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -54,6 +54,8 @@ Character
 Characteristics
 Check
 Close
+Cluster
+Clusters
 Coalesce
 Collate
 Columns
@@ -247,6 +249,7 @@ Set
 Show
 Sink
 Sinks
+Size
 Slot
 Smallint
 Snapshot
@@ -297,6 +300,7 @@ Varchar
 Varying
 View
 Views
+Virtual
 Warning
 When
 Where

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1565,6 +1565,8 @@ impl<'a> Parser<'a> {
             self.parse_create_type()
         } else if self.peek_keyword(ROLE) || self.peek_keyword(USER) {
             self.parse_create_role()
+        } else if self.peek_keyword(CLUSTER) {
+            self.parse_create_cluster()
         } else if self.peek_keyword(INDEX) || self.peek_keywords(&[DEFAULT, INDEX]) {
             self.parse_create_index()
         } else if self.peek_keyword(SOURCE) || self.peek_keywords(&[MATERIALIZED, SOURCE]) {
@@ -2432,6 +2434,34 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn parse_create_cluster(&mut self) -> Result<Statement<Raw>, ParserError> {
+        self.next_token();
+        let if_not_exists = self.parse_if_not_exists()?;
+        let name = self.parse_identifier()?;
+        let _ = self.parse_keyword(WITH);
+        let options = if matches!(self.peek_token(), Some(Token::Semicolon) | None) {
+            vec![]
+        } else {
+            self.parse_comma_separated(Parser::parse_cluster_option)?
+        };
+        Ok(Statement::CreateCluster(CreateClusterStatement {
+            name,
+            if_not_exists,
+            options,
+        }))
+    }
+
+    fn parse_cluster_option(&mut self) -> Result<ClusterOption, ParserError> {
+        match self.expect_one_of_keywords(&[VIRTUAL, SIZE])? {
+            VIRTUAL => Ok(ClusterOption::Virtual),
+            SIZE => {
+                let _ = self.consume_token(&Token::Eq);
+                Ok(ClusterOption::Size(self.parse_literal_string()?))
+            }
+            _ => unreachable!(),
+        }
+    }
+
     fn parse_if_exists(&mut self) -> Result<bool, ParserError> {
         if self.parse_keyword(IF) {
             self.expect_keyword(EXISTS)?;
@@ -2489,7 +2519,7 @@ impl<'a> Parser<'a> {
         let materialized = self.parse_keyword(MATERIALIZED);
 
         let object_type = match self.parse_one_of_keywords(&[
-            DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW, SECRET,
+            DATABASE, INDEX, ROLE, CLUSTER, SECRET, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW,
         ]) {
             Some(DATABASE) => {
                 let if_exists = self.parse_if_exists()?;
@@ -2506,6 +2536,7 @@ impl<'a> Parser<'a> {
             }
             Some(INDEX) => ObjectType::Index,
             Some(ROLE) | Some(USER) => ObjectType::Role,
+            Some(CLUSTER) => ObjectType::Cluster,
             Some(SCHEMA) => ObjectType::Schema,
             Some(SINK) => ObjectType::Sink,
             Some(SOURCE) => ObjectType::Source,
@@ -2516,8 +2547,8 @@ impl<'a> Parser<'a> {
             _ => {
                 return self.expected(
                     self.peek_pos(),
-                    "DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, \
-                     TABLE, TYPE, USER, VIEW, SECRET after DROP",
+                    "DATABASE, INDEX, ROLE, CLUSTER, SECRET, SCHEMA, SINK, SOURCE, \
+                     TABLE, TYPE, USER, VIEW after DROP",
                     self.peek_token(),
                 );
             }
@@ -3810,12 +3841,13 @@ impl<'a> Parser<'a> {
         if self.parse_one_of_keywords(&[COLUMNS, FIELDS]).is_some() {
             self.parse_show_columns(extended, full)
         } else if let Some(object_type) = self.parse_one_of_keywords(&[
-            OBJECTS, ROLES, SCHEMAS, SINKS, SOURCES, TABLES, TYPES, USERS, VIEWS,
+            OBJECTS, ROLES, CLUSTERS, SCHEMAS, SINKS, SOURCES, TABLES, TYPES, USERS, VIEWS,
         ]) {
             Ok(Statement::ShowObjects(ShowObjectsStatement {
                 object_type: match object_type {
                     OBJECTS => ObjectType::Object,
                     ROLES | USERS => ObjectType::Role,
+                    CLUSTERS => ObjectType::Cluster,
                     SCHEMAS => ObjectType::Schema,
                     SINKS => ObjectType::Sink,
                     SOURCES => ObjectType::Source,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1246,3 +1246,66 @@ ALTER INDEX name SET ENABLED (property = true)
 error: Expected end of statement, found left parenthesis
 ALTER INDEX name SET ENABLED (property = true)
                              ^
+
+parse-statement
+CREATE CLUSTER cluster
+----
+CREATE CLUSTER cluster
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [] })
+
+parse-statement
+CREATE CLUSTER cluster VIRTUAL
+----
+CREATE CLUSTER cluster VIRTUAL
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual] })
+
+parse-statement
+CREATE CLUSTER cluster SIZE 'small'
+----
+CREATE CLUSTER cluster SIZE 'small'
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size("small")] })
+
+parse-statement
+CREATE CLUSTER cluster SIZE = 'small'
+----
+CREATE CLUSTER cluster SIZE 'small'
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size("small")] })
+
+parse-statement
+CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
+----
+CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual, Virtual, Size("small"), Virtual, Size("medium")] })
+
+parse-statement
+DROP CLUSTER cluster
+----
+DROP CLUSTER cluster
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Cluster, if_exists: false, names: [UnresolvedObjectName([Ident("cluster")])], cascade: false })
+
+parse-statement
+DROP CLUSTER IF EXISTS cluster
+----
+DROP CLUSTER IF EXISTS cluster
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Cluster, if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: false })
+
+parse-statement
+DROP CLUSTER IF EXISTS cluster RESTRICT
+----
+DROP CLUSTER IF EXISTS cluster
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Cluster, if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: false })
+
+parse-statement
+DROP CLUSTER IF EXISTS cluster CASCADE
+----
+DROP CLUSTER IF EXISTS cluster CASCADE
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Cluster, if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: true })

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -40,6 +40,13 @@ SHOW ROLES
 ShowObjects(ShowObjectsStatement { object_type: Role, from: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
+SHOW CLUSTERS
+----
+SHOW CLUSTERS
+=>
+ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, extended: false, full: false, materialized: false, filter: None })
+
+parse-statement
 SHOW USERS
 ----
 SHOW ROLES

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -20,6 +20,7 @@ use lazy_static::lazy_static;
 use mz_dataflow_types::sources::{AwsExternalId, SourceConnector};
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
+use mz_dataflow_types::client::ComputeInstanceId;
 use mz_expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, RelationDesc, ScalarType};
@@ -62,6 +63,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
     /// Returns the database to use if one is not explicitly specified.
     fn active_database(&self) -> &str;
 
+    /// Returns the compute instance to use if one is not explicitly specified.
+    fn active_compute_instance(&self) -> &str;
+
     /// Returns the descriptor of the named prepared statement on the session, or
     /// None if the prepared statement does not exist.
     fn get_prepared_statement_desc(&self, name: &str) -> Option<&StatementDesc>;
@@ -87,6 +91,15 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
 
     /// Resolves the named role.
     fn resolve_role(&self, role_name: &str) -> Result<&dyn CatalogRole, CatalogError>;
+
+    /// Resolves the named compute instance.
+    ///
+    /// If the provided name is `None`, resolves the currently-active compute
+    /// instance.
+    fn resolve_compute_instance(
+        &self,
+        compute_instance_name: Option<&str>,
+    ) -> Result<&dyn CatalogComputeInstance, CatalogError>;
 
     /// Resolves a partially-specified item name.
     ///
@@ -208,6 +221,15 @@ pub trait CatalogRole {
 
     /// Returns a stable ID for the role.
     fn id(&self) -> i64;
+}
+
+/// A compute instance in a [`SessionCatalog`].
+pub trait CatalogComputeInstance {
+    /// Returns a fully-specified name of the compute instance.
+    fn name(&self) -> &str;
+
+    /// Returns a stable ID for the compute instance.
+    fn id(&self) -> ComputeInstanceId;
 }
 
 /// An item in a [`SessionCatalog`].
@@ -368,6 +390,8 @@ pub enum CatalogError {
     UnknownSchema(String),
     /// Unknown role.
     UnknownRole(String),
+    /// Unknown compute instance.
+    UnknownComputeInstance(String),
     /// Unknown item.
     UnknownItem(String),
     /// Unknown function.
@@ -391,6 +415,7 @@ impl fmt::Display for CatalogError {
             Self::UnknownSource(name) => write!(f, "source \"{}\" does not exist", name),
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),
+            Self::UnknownComputeInstance(name) => write!(f, "unknown cluster '{}'", name),
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
             Self::InvalidDependency { name, typ } => write!(
                 f,
@@ -442,6 +467,10 @@ impl SessionCatalog for DummyCatalog {
         "dummy"
     }
 
+    fn active_compute_instance(&self) -> &str {
+        "dummy"
+    }
+
     fn get_prepared_statement_desc(&self, _: &str) -> Option<&StatementDesc> {
         None
     }
@@ -467,6 +496,13 @@ impl SessionCatalog for DummyCatalog {
     }
 
     fn resolve_function(&self, _: &PartialName) -> Result<&dyn CatalogItem, CatalogError> {
+        unimplemented!();
+    }
+
+    fn resolve_compute_instance(
+        &self,
+        _: Option<&str>,
+    ) -> Result<&dyn CatalogComputeInstance, CatalogError> {
         unimplemented!();
     }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -73,6 +73,7 @@ pub enum Plan {
     CreateDatabase(CreateDatabasePlan),
     CreateSchema(CreateSchemaPlan),
     CreateRole(CreateRolePlan),
+    CreateComputeInstance(CreateComputeInstancePlan),
     CreateSource(CreateSourcePlan),
     CreateSink(CreateSinkPlan),
     CreateTable(CreateTablePlan),
@@ -85,6 +86,7 @@ pub enum Plan {
     DropDatabase(DropDatabasePlan),
     DropSchema(DropSchemaPlan),
     DropRoles(DropRolesPlan),
+    DropComputeInstances(DropComputeInstancesPlan),
     DropItems(DropItemsPlan),
     EmptyQuery,
     ShowAllVariables,
@@ -136,6 +138,19 @@ pub struct CreateSchemaPlan {
 #[derive(Debug)]
 pub struct CreateRolePlan {
     pub name: String,
+}
+
+#[derive(Debug)]
+pub struct CreateComputeInstancePlan {
+    pub name: String,
+    pub if_not_exists: bool,
+    pub config: ComputeInstanceConfig,
+}
+
+#[derive(Debug)]
+pub enum ComputeInstanceConfig {
+    Virtual,
+    Real { size: String },
 }
 
 #[derive(Debug)]
@@ -205,6 +220,11 @@ pub struct DropSchemaPlan {
 
 #[derive(Debug)]
 pub struct DropRolesPlan {
+    pub names: Vec<String>,
+}
+
+#[derive(Debug)]
+pub struct DropComputeInstancesPlan {
     pub names: Vec<String>,
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -216,6 +216,7 @@ pub fn show_objects<'a>(
         ObjectType::Type => show_types(scx, extended, full, from, filter),
         ObjectType::Object => show_all_objects(scx, extended, full, from, filter),
         ObjectType::Role => bail_unsupported!("SHOW ROLES"),
+        ObjectType::Cluster => bail_unsupported!("SHOW CLUSTERS"),
         ObjectType::Secret => bail_unsupported!("SHOW SECRETS"),
         ObjectType::Index => unreachable!("SHOW INDEX handled separately"),
     }

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -9,8 +9,8 @@
 
 use crate::ast::{Expr, Raw};
 use crate::catalog::{
-    CatalogConfig, CatalogDatabase, CatalogError, CatalogItem, CatalogItemType, CatalogRole,
-    CatalogSchema, CatalogTypeDetails, SessionCatalog,
+    CatalogComputeInstance, CatalogConfig, CatalogDatabase, CatalogError, CatalogItem,
+    CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, SessionCatalog,
 };
 use crate::func::{Func, MZ_CATALOG_BUILTINS, MZ_INTERNAL_BUILTINS, PG_CATALOG_BUILTINS};
 use crate::names::{DatabaseSpecifier, FullName, PartialName};
@@ -188,6 +188,10 @@ impl SessionCatalog for TestCatalog {
         "dummy"
     }
 
+    fn active_compute_instance(&self) -> &str {
+        "dummy"
+    }
+
     fn resolve_database(&self, _: &str) -> Result<&dyn CatalogDatabase, CatalogError> {
         unimplemented!();
     }
@@ -219,6 +223,17 @@ impl SessionCatalog for TestCatalog {
             return Ok(result);
         }
         Err(CatalogError::UnknownFunction(partial_name.item.clone()))
+    }
+
+    fn resolve_compute_instance(
+        &self,
+        compute_instance_name: Option<&str>,
+    ) -> Result<&dyn CatalogComputeInstance, CatalogError> {
+        Err(CatalogError::UnknownComputeInstance(
+            compute_instance_name
+                .unwrap_or_else(|| self.active_compute_instance())
+                .into(),
+        ))
     }
 
     fn get_item_by_id(&self, id: &GlobalId) -> &dyn CatalogItem {

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Basic tests of the `CREATE CLUSTER` and `DROP CLUSTER` DDL statements.
+
+mode cockroach
+
+# Creating a cluster without any options should work. (It creates a virtual
+# cluster.)
+statement ok
+CREATE CLUSTER foo
+
+# Creating a virtual cluster should "work". (Nothing happens presently.)
+statement ok
+CREATE CLUSTER foo VIRTUAL
+
+# Creating a sized cluster should be rejected.
+statement error SIZE not yet supported
+CREATE CLUSTER foo SIZE 'small'
+
+# Test invalid option combinations.
+
+statement error VIRTUAL specified more than once
+CREATE CLUSTER foo VIRTUAL, VIRTUAL
+
+statement error SIZE specified more than once
+CREATE CLUSTER foo SIZE 'small', SIZE 'medium'
+
+statement error VIRTUAL and SIZE options cannot be specified together
+CREATE CLUSTER foo VIRTUAL, SIZE 'small'
+
+# Test invalid DROPs.
+
+statement error active cluster cannot be dropped
+DROP CLUSTER default
+
+statement error unknown cluster 'foo'
+DROP CLUSTER foo

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -228,7 +228,7 @@ public.bool
 > DROP DATABASE foo
 
 ! DROP OBJECT v1
-contains:Expected DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW, SECRET after DROP, found identifier
+contains:Expected DATABASE, INDEX, ROLE, CLUSTER, SECRET, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW after DROP, found identifier
 
 > SHOW FULL OBJECTS
 name            type


### PR DESCRIPTION
Extracted from #11029.

This is one step on the path to supporting `CREATE CLUSTER`. See #10680
for details.

These statements presently bottom out in the coordinator, but the
parsing and option validation is sufficiently fleshed out that we can
write some basic tests.


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A. We'll do one big release note for Platform at the end.
