### PR TITLE
Add opentelemetry-tracing support to materialized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
 dependencies = [
  "cc",
  "libc",
@@ -2677,6 +2677,8 @@ dependencies = [
  "http",
  "hyper",
  "hyper-openssl",
+ "hyper-proxy",
+ "hyper-tls",
  "include_dir",
  "itertools",
  "jsonwebtoken",
@@ -2701,10 +2703,13 @@ dependencies = [
  "mz-prof",
  "mz-repr",
  "mz-sql",
+ "native-tls",
  "nix",
  "num_cpus",
  "openssl",
  "openssl-sys",
+ "opentelemetry",
+ "opentelemetry-otlp",
  "os_info",
  "postgres",
  "postgres-openssl",
@@ -2728,10 +2733,13 @@ dependencies = [
  "tikv-jemallocator",
  "timely",
  "tokio",
+ "tokio-native-tls",
  "tokio-openssl",
  "tokio-postgres",
  "tokio-stream",
+ "tonic",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -4239,6 +4247,45 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -6126,6 +6173,19 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,8 @@ wrappers = [
     "junit-report",
     "mysql_async",
     "mysql_common",
+    "opentelemetry",
+    "opentelemetry-otlp",
     "pprof",
     "proc-macro-crate",
     "prometheus",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -201,7 +201,7 @@ impl CatalogState {
             })
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     fn insert_item(&mut self, id: GlobalId, oid: u32, name: FullName, item: CatalogItem) {
         if !id.is_system() && !item.is_placeholder() {
             info!("create {} {} ({})", item.typ(), name, id);

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -201,6 +201,7 @@ impl CatalogState {
             })
     }
 
+    #[tracing::instrument(skip(self))]
     fn insert_item(&mut self, id: GlobalId, oid: u32, name: FullName, item: CatalogItem) {
         if !id.is_system() && !item.is_placeholder() {
             info!("create {} {} ({})", item.typ(), name, id);

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -59,7 +59,7 @@ mz-dataflow = { path = "../dataflow" }
 mz-dataflow-types = { path = "../dataflow-types" }
 mz-dataflowd = { path = "../dataflowd" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
-mz-http-proxy = { path = "../http-proxy", features = ["reqwest"] }
+mz-http-proxy = { path = "../http-proxy", features = ["reqwest", "hyper"] }
 mz-ore = { path = "../ore", features = ["task"] }
 mz-pgwire = { path = "../pgwire" }
 mz-pid-file = { path = "../pid-file" }
@@ -89,6 +89,17 @@ tokio-openssl = "0.6.3"
 tokio-stream = { version = "0.1.8", features = ["net"] }
 tracing = "0.1.31"
 tracing-subscriber = "0.3.9"
+
+# Deps for a correct opentelemetry setup!
+opentelemetry = { version = "0.17", features = ["rt-tokio", "trace"] }
+opentelemetry-otlp = { version = "0.10"}
+tracing-opentelemetry = "0.17"
+tonic = { version = "0.6.2", features = ["transport"] }
+tokio-native-tls = { version = "0.3.0" }
+native-tls = { version = "0.2.8", features = ["alpn"] }
+hyper-proxy = { version = "0.9.1" }
+hyper-tls = { version = "0.5.0" }
+
 url = "2.2.2"
 uuid = "0.8.2"
 

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -64,7 +64,7 @@ fn parse_optional_duration(s: &str) -> Result<OptionalDuration, anyhow::Error> {
 }
 
 /// The streaming SQL materialized view engine.
-#[derive(Parser)]
+#[derive(Parser, Debug)]
 #[clap(next_line_help = true, args_override_self = true, global_setting = AppSettings::NoAutoVersion)]
 pub struct Args {
     // === Special modes. ===
@@ -373,6 +373,24 @@ pub struct Args {
     #[clap(long, env = "MZ_TELEMETRY_INTERVAL", parse(try_from_str = mz_repr::util::parse_duration), hide = true)]
     telemetry_interval: Option<Duration>,
 
+    /// The endpoint to send opentelemetry traces to.
+    /// If not provided, tracing is not sent.
+    ///
+    /// You most likely also need to provide
+    ///
+    #[clap(
+        long,
+        env = "MZ_OPENTELEMETRY_ENDPOINT",
+        requires = "opentelemetry-headers",
+        hide = true
+    )]
+    opentelemetry_endpoint: Option<String>,
+
+    /// Comma separated headers to pass through to the opentelemetry
+    /// collector. Only used if `opentelemetry-endpoint` is set
+    #[clap(long, env = "MZ_OPENTELEMETRY_HEADERS", hide = true)]
+    opentelemetry_headers: Option<String>,
+
     #[cfg(feature = "tokio-console")]
     /// Turn on the console-subscriber to use materialize with `tokio-console`
     #[clap(long, hide = true)]
@@ -382,6 +400,7 @@ pub struct Args {
 /// This type is a hack to allow a dynamic default for the `--workers` argument,
 /// which depends on the number of available CPUs. Ideally clap would
 /// expose a `default_fn` rather than accepting only string literals.
+#[derive(Debug)]
 struct WorkerCount(usize);
 
 impl Default for WorkerCount {
@@ -428,6 +447,23 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     sys::enable_sigusr2_coverage_dump()?;
     sys::enable_termination_signal_cleanup()?;
 
+    // Start Tokio runtime.
+
+    let ncpus_useful = usize::max(1, cmp::min(num_cpus::get(), num_cpus::get_physical()));
+    let runtime = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(ncpus_useful)
+            // The default thread name exceeds the Linux limit on thread name
+            // length, so pick something shorter.
+            .thread_name_fn(|| {
+                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
+                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
+                format!("tokio:work-{}", id)
+            })
+            .enable_all()
+            .build()?,
+    );
+
     // Install a custom panic handler that instructs users to file a bug report.
     // This requires that we configure tracing, so that the panic can be
     // reported as a trace event.
@@ -435,7 +471,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     // Avoid adding code above this point, because panics in that code won't get
     // handled by the custom panic handler.
     let metrics_registry = MetricsRegistry::new();
-    tracing::configure(&args, &metrics_registry)?;
+    tracing::configure(&args, &metrics_registry, &runtime)?;
     panic::set_hook(Box::new(handle_panic));
 
     // Initialize fail crate for failpoint support
@@ -557,7 +593,6 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
 
     // When inside a cgroup with a cpu limit,
     // the logical cpus can be lower than the physical cpus.
-    let ncpus_useful = usize::max(1, cmp::min(num_cpus::get(), num_cpus::get_physical()));
     let memory_limit = detect_memory_limit().unwrap_or(MemoryLimit {
         max: None,
         swap_max: None,
@@ -632,21 +667,6 @@ dataflow workers: {workers}",
         &differential_dataflow::Config {
             idle_merge_effort: args.differential_idle_merge_effort,
         },
-    );
-
-    // Start Tokio runtime.
-    let runtime = Arc::new(
-        tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(ncpus_useful)
-            // The default thread name exceeds the Linux limit on thread name
-            // length, so pick something shorter.
-            .thread_name_fn(|| {
-                static ATOMIC_ID: AtomicUsize = AtomicUsize::new(0);
-                let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
-                format!("tokio:work-{}", id)
-            })
-            .enable_all()
-            .build()?,
     );
 
     // Configure persistence core.


### PR DESCRIPTION
Adds an optional set of environment variables to turn on an unfiltered, experimental setup for a `tracing-opentelemetry` layer that allows us to send data to honeycomb!

### Motivation
  * This PR adds a known-desirable feature.
distributed tracing support for materialized

### Tips for reviewer

This was a journey:
The important parts:

- We are using `native-tls` + `tonic` using `h2`; `h2` requires `alpn` to setup the handshake correctly (https://docs.rs/h2/latest/h2/#handshake)
- I didn't test if the proxy config works, but at least a direct connection worked through the `ProxyConnector` type
- See below for how I tested it
- I decided not to hide this behind a feature, let me know if you want me too, but it make the tracing setup even more messy than it already does
- We are currently sending UNFILTERED data to opentelemetry, so every single trace, including `hyper` internals and what not are sent. we will definitely need to clean this up in the future (or at least sample)

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
Locally I did `MZ_OPENTELEMETRY_ENDPOINT="https://api.honeycomb.io/" MZ_OPENTELEMETRY_HEADERS="x-honeycomb-team=<redacted>,x-honeycomb-dataset=envtest" cargo run --dev

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

I don't think we should reveal this yet to users
