### PR TITLE
sql-parser: add support for DROP SECRET

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2489,7 +2489,7 @@ impl<'a> Parser<'a> {
         let materialized = self.parse_keyword(MATERIALIZED);
 
         let object_type = match self.parse_one_of_keywords(&[
-            DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW,
+            DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW, SECRET,
         ]) {
             Some(DATABASE) => {
                 let if_exists = self.parse_if_exists()?;
@@ -2512,11 +2512,12 @@ impl<'a> Parser<'a> {
             Some(TABLE) => ObjectType::Table,
             Some(TYPE) => ObjectType::Type,
             Some(VIEW) => ObjectType::View,
+            Some(SECRET) => ObjectType::Secret,
             _ => {
                 return self.expected(
                     self.peek_pos(),
                     "DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, \
-                     TABLE, TYPE, USER, VIEW after DROP",
+                     TABLE, TYPE, USER, VIEW, SECRET after DROP",
                     self.peek_token(),
                 );
             }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2372,7 +2372,7 @@ pub fn plan_drop_objects(
         | ObjectType::Sink
         | ObjectType::Type => plan_drop_items(scx, object_type, if_exists, names, cascade),
         ObjectType::Role => plan_drop_role(scx, if_exists, names),
-        ObjectType::Secret => unreachable!("DROP SECRET"),
+        ObjectType::Secret => bail_unsupported!("DROP SECRET"),
         ObjectType::Object => unreachable!("cannot drop generic OBJECT, must provide object type"),
     }
 }

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -228,7 +228,7 @@ public.bool
 > DROP DATABASE foo
 
 ! DROP OBJECT v1
-contains:Expected DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW after DROP, found identifier
+contains:Expected DATABASE, INDEX, ROLE, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW, SECRET after DROP, found identifier
 
 > SHOW FULL OBJECTS
 name            type


### PR DESCRIPTION
Add support for DROP SECRET required for the platform. For the motivation see https://github.com/MaterializeInc/materialize/pull/11022

Tested manually, all variants work as expected:
```
materialize=> drop secret;
ERROR:  Expected identifier, found semicolon
LINE 1: drop secret;
                   ^

materialize=> drop secret foo;
ERROR:  DROP SECRET not yet supported

materialize=> drop secret if exists foo;
ERROR:  DROP SECRET not yet supported

materialize=> drop secret if exists foo cascade;
ERROR:  DROP SECRET not yet supported

materialize=> drop secret if exists foo restrict;
ERROR:  DROP SECRET not yet supported
```