### PR TITLE
materialized: refactor panic handling setup

### DIFF
--- a/src/materialized/src/bin/materialized/tracing.rs
+++ b/src/materialized/src/bin/materialized/tracing.rs
@@ -7,13 +7,110 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::fs;
+use std::io;
 use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::str::FromStr;
 
-use mz_ore::metrics::ThirdPartyMetric;
+use anyhow::Context as _;
 use prometheus::IntCounterVec;
 use tracing::{Event, Subscriber};
-use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::filter::{LevelFilter, Targets};
+use tracing_subscriber::fmt;
+use tracing_subscriber::layer::{Context, Layer, SubscriberExt};
 use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use mz_ore::metric;
+use mz_ore::metrics::{MetricsRegistry, ThirdPartyMetric};
+
+use crate::Args;
+
+/// Configures tracing according to the provided command-line arguments.
+pub fn configure(args: &Args, metrics_registry: &MetricsRegistry) -> Result<(), anyhow::Error> {
+    // NOTE: Try harder than usual to avoid panicking in this function. It runs
+    // before our custom panic hook is installed (because the panic hook needs
+    // tracing configured to execute), so a panic here will not direct the
+    // user to file a bug report.
+
+    let filter = Targets::from_str(&args.log_filter)
+        .context("parsing --log-filter option")?
+        // Ensure panics are logged, even if the user has specified
+        // otherwise.
+        .with_target("panic", LevelFilter::ERROR);
+
+    let log_message_counter: ThirdPartyMetric<IntCounterVec> = metrics_registry
+        .register_third_party_visible(metric!(
+            name: "mz_log_message_total",
+            help: "The number of log messages produced by this materialized instance",
+            var_labels: ["severity"],
+        ));
+
+    match args.log_file.as_deref() {
+        Some("stderr") => {
+            // The user explicitly directed logs to stderr. Log only to
+            // stderr with the user-specified `filter`.
+            let stack = tracing_subscriber::registry()
+                .with(MetricsRecorderLayer::new(log_message_counter).with_filter(filter.clone()))
+                .with(
+                    fmt::layer()
+                        .with_writer(io::stderr)
+                        .with_ansi(atty::is(atty::Stream::Stderr))
+                        .with_filter(filter),
+                );
+
+            #[cfg(feature = "tokio-console")]
+            let stack = stack.with(args.tokio_console.then(|| console_subscriber::spawn()));
+
+            stack.init()
+        }
+        log_file => {
+            // Logging to a file. If the user did not explicitly specify
+            // a file, bubble up warnings and errors to stderr.
+            let stderr_level = match log_file {
+                Some(_) => LevelFilter::OFF,
+                None => LevelFilter::WARN,
+            };
+            let stack = tracing_subscriber::registry()
+                .with(MetricsRecorderLayer::new(log_message_counter).with_filter(filter.clone()))
+                .with({
+                    let path = match log_file {
+                        Some(log_file) => PathBuf::from(log_file),
+                        None => args.data_directory.join("materialized.log"),
+                    };
+                    if let Some(parent) = path.parent() {
+                        fs::create_dir_all(parent).with_context(|| {
+                            format!("creating log file directory: {}", parent.display())
+                        })?;
+                    }
+                    let file = fs::OpenOptions::new()
+                        .append(true)
+                        .create(true)
+                        .open(&path)
+                        .with_context(|| format!("creating log file: {}", path.display()))?;
+                    fmt::layer()
+                        .with_ansi(false)
+                        .with_writer(move || file.try_clone().expect("failed to clone log file"))
+                        .with_filter(filter.clone())
+                })
+                .with(
+                    fmt::layer()
+                        .with_writer(io::stderr)
+                        .with_ansi(atty::is(atty::Stream::Stderr))
+                        .with_filter(stderr_level)
+                        .with_filter(filter),
+                );
+
+            #[cfg(feature = "tokio-console")]
+            let stack = stack.with(args.tokio_console.then(|| console_subscriber::spawn()));
+
+            stack.init()
+        }
+    }
+
+    Ok(())
+}
 
 /// A tracing [`Layer`] that allows hooking into the reporting/filtering chain
 /// for log messages, incrementing a counter for the severity of messages


### PR DESCRIPTION
@guswynn noticed in #11107 that our custom panic handler will sometimes
fail to report a panic. The issue is that the panic hook calls
`tracing::error!` but is installed before tracing is configured; that
means that a panic before tracing is configured will shout into the
void.

Refactor the startup sequence to avoid that. Specifically, configure
tracing *before* installing the custom panic hook.

This commit is pure code movement, except for a few new comments that
explain what is going on.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
