### PR TITLE
persist: handle TODO around empty build version

### DIFF
--- a/src/persist/src/gen.rs
+++ b/src/persist/src/gen.rs
@@ -45,8 +45,6 @@ impl ProtoMeta {
     /// proto_meta = u8* (the protobuf serialization of ProtoMeta)
     /// md5_checksum = u8 u8 u8 u8 (little endian, md5 of proto_meta)
     /// ```
-    // TODO: Once this gets bumped to 8, we can clean up:
-    // - The TODO in Blob::Cache.check_meta_build_version.
     pub const ENCODING_VERSION: u8 = 11;
 
     /// The [Self::ENCODING_VERSION] of this previously encoded ProtoMeta.

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -276,17 +276,11 @@ impl<B: BlobRead> BlobCache<B> {
     }
 
     fn check_meta_build_version(&self, meta: &ProtoMeta) -> Result<(), Error> {
-        // TODO: After ENCODING_VERSION is bumped to 8 or higher, this can be
-        // removed.
-        let meta_version = if meta.version.is_empty() {
-            // Any build that includes this check comes after a ProtoMeta that
-            // was written with no version set.
-            Version::new(0, 0, 0)
-        } else {
-            meta.version
-                .parse::<Version>()
-                .map_err(|err| err.to_string())?
-        };
+        let meta_version = meta
+            .version
+            .parse::<Version>()
+            .map_err(|err| err.to_string())?;
+
         // Allow data written by any previous version of persist (backward
         // compatible for all time) but disallow data written by a future
         // version of persist (aka we're currently *not* forward compatible).
@@ -659,13 +653,6 @@ mod tests {
         assert_eq!(
             cache.get_meta(),
             Err("persist v0.9.9 cannot read data written by future persist v1.0.0".into())
-        );
-
-        // Holdover until ENCODING_VERSION gets bumped to 8. We have to handle a
-        // ProtoMeta that was written with no version.
-        assert_eq!(
-            cache.check_meta_build_version(&ProtoMeta::default()),
-            Ok(())
         );
 
         Ok(())


### PR DESCRIPTION
This commit performs an outstanding task to clean up checks for empty build versions
as the encoding version is at 11 - at this point persist sets the build version
correctly and we no longer have to reason about the case when this is not so.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
