### PR TITLE
http-proxy: make hyper connector generic over inner connector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,6 +2951,7 @@ dependencies = [
  "aws-smithy-client",
  "aws-smithy-http",
  "aws-types",
+ "hyper-tls",
  "mz-http-proxy",
  "openssl-sys",
 ]
@@ -3313,9 +3314,7 @@ name = "mz-http-proxy"
 version = "0.1.0"
 dependencies = [
  "http",
- "hyper",
  "hyper-proxy",
- "hyper-tls",
  "ipnet",
  "lazy_static",
  "reqwest",

--- a/src/aws-util/Cargo.toml
+++ b/src/aws-util/Cargo.toml
@@ -16,6 +16,7 @@ aws-smithy-client = { version = "0.38.0", default-features = false }
 aws-smithy-http = "0.38.0"
 aws-types = "0.8.0"
 mz-http-proxy = { path = "../http-proxy", features = ["hyper"] }
+hyper-tls = { version = "0.5.0" }
 openssl-sys = { version = "0.9.72", features = ["vendored"] }
 
 [features]

--- a/src/aws-util/src/util.rs
+++ b/src/aws-util/src/util.rs
@@ -9,7 +9,9 @@
 
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::hyper_ext::Adapter;
+use hyper_tls::HttpsConnector;
 
 pub fn connector() -> DynConnector {
-    DynConnector::new(Adapter::builder().build(mz_http_proxy::hyper::connector()))
+    let connector = mz_http_proxy::hyper::connector(HttpsConnector::new());
+    DynConnector::new(Adapter::builder().build(connector))
 }

--- a/src/http-proxy/CHANGELOG.md
+++ b/src/http-proxy/CHANGELOG.md
@@ -1,0 +1,10 @@
+# mz-http-proxy Changelog
+
+## 0.2.0 - 2022-03-08
+
+* Change `hyper::connector` so that it wraps a provided connector, rather
+  than creating a `hyper_tls::HttpsConnector`.
+
+## 0.1.0 - 2021-08-03
+
+Initial release.

--- a/src/http-proxy/Cargo.toml
+++ b/src/http-proxy/Cargo.toml
@@ -22,13 +22,11 @@ rustdoc-args = ["--cfg", "nightly_doc_features"]
 
 [dependencies]
 http = "0.2.6"
-hyper-dep = { version = "0.14.11", package = "hyper", optional = true }
 hyper-proxy = { version = "0.9.1", optional = true }
-hyper-tls = { version = "0.5.0", optional = true }
 ipnet = "2.4.0"
 lazy_static = "1.1.1"
 reqwest = { version = "0.11.9", optional = true }
 tracing = "0.1.31"
 
 [features]
-hyper = ["hyper-dep", "hyper-proxy", "hyper-tls"]
+hyper = ["hyper-proxy"]

--- a/src/http-proxy/README.md
+++ b/src/http-proxy/README.md
@@ -12,7 +12,7 @@ HTTP proxy adapters that respect the system's proxy configuration.
 ```toml
 # Cargo.toml
 [dependencies]
-mz-http-proxy = { version = "0.1", features = ["hyper", "reqwest"] }
+mz-http-proxy = { version = "0.2", features = ["hyper", "reqwest"] }
 ```
 
-[docs]: https://docs.rs/mz-http-proxy/0.1.0/
+[docs]: https://docs.rs/mz-http-proxy/0.2.0/

--- a/src/http-proxy/src/hyper.rs
+++ b/src/http-proxy/src/hyper.rs
@@ -13,28 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Proxy adapters for [`hyper`](hyper_dep).
+//! Proxy adapters for [`hyper`](https://docs.rs/hyper).
 
-use hyper_dep::client::HttpConnector;
 use hyper_proxy::{Proxy, ProxyConnector};
-use hyper_tls::HttpsConnector;
 
 use crate::proxy::PROXY_CONFIG;
 
-/// A proxying HTTPS connector for hyper.
-pub type Connector = ProxyConnector<HttpsConnector<HttpConnector>>;
-
-/// Create a `hyper` connector that obeys the system proxy configuration.
+/// Wraps a `hyper` connector in a new connector that obeys the system proxy
+/// configuration.
 ///
 /// For details about the system proxy configuration, see the
 /// [crate documentation](crate).
-pub fn connector() -> Connector {
-    // `ProxyConnector::new` only errors if creating a TLS context fails, and if
-    // that's broken, `HttpsConnector::new()` has already panicked. So no point
-    // returning an error here instead of panicking. It's much more convenient
-    // downstream and more consistent with the rest of the Rust ecosystem if
-    // creating a connector is infallible.
-    let mut connector = ProxyConnector::new(HttpsConnector::new())
+pub fn connector<C>(connector: C) -> ProxyConnector<C> {
+    // `ProxyConnector::new` only errors if creating a TLS context fails, but
+    // `hyper_tls::HttpsConnector::new()` panics in the same situation. So no
+    // point returning an error here instead of panicking. It's much more
+    // convenient downstream and more consistent with the rest of the Rust
+    // ecosystem if creating a connector is infallible.
+    let mut connector = ProxyConnector::new(connector)
         .unwrap_or_else(|e| panic!("hyper_proxy::ProxyConnector::new failure: {}", e));
 
     if let Some(http_proxy) = PROXY_CONFIG.http_proxy() {


### PR DESCRIPTION
This allows callers to sub in their desired connector, rather than being
forced to use a default-configured HTTPS connector.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified. This PR will allow #11107 to land without requiring any changes to the `mz-http-proxy` crate.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
