### PR TITLE
coord: add cluster session variable

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2177,7 +2177,7 @@ impl Coordinator {
 
         // The dataflow must (eventually) be built on a specific compute instance.
         // Use this in `catalog_transact` and stash for eventual sink construction.
-        let compute_instance = DEFAULT_COMPUTE_INSTANCE_ID;
+        let compute_instance = sink.compute_instance;
 
         // First try to allocate an ID and an OID. If either fails, we're done.
         let id = match self.catalog.allocate_user_id() {
@@ -2439,9 +2439,10 @@ impl Coordinator {
             if_not_exists,
         } = plan;
 
-        let id = self.catalog.allocate_user_id()?;
         // An index must be created on a specific compute instance.
-        let compute_instance = DEFAULT_COMPUTE_INSTANCE_ID;
+        let compute_instance = index.compute_instance;
+
+        let id = self.catalog.allocate_user_id()?;
         let index = catalog::Index {
             create_sql: index.create_sql,
             keys: index.keys,

--- a/src/coord/src/session/vars.rs
+++ b/src/coord/src/session/vars.rs
@@ -58,6 +58,12 @@ const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
     description: "Sets the message levels that are sent to the client (PostgreSQL).",
 };
 
+const CLUSTER: ServerVar<str> = ServerVar {
+    name: static_uncased_str!("cluster"),
+    value: "default",
+    description: "Sets the current cluster (Materialize).",
+};
+
 const DATABASE: ServerVar<str> = ServerVar {
     name: static_uncased_str!("database"),
     value: "materialize",
@@ -176,6 +182,7 @@ pub struct Vars {
     application_name: SessionVar<str>,
     client_encoding: ServerVar<str>,
     client_min_messages: SessionVar<ClientSeverity>,
+    cluster: SessionVar<str>,
     database: SessionVar<str>,
     date_style: ServerVar<str>,
     extra_float_digits: SessionVar<i32>,
@@ -197,6 +204,7 @@ impl Default for Vars {
             application_name: SessionVar::new(&APPLICATION_NAME),
             client_encoding: CLIENT_ENCODING,
             client_min_messages: SessionVar::new(&CLIENT_MIN_MESSAGES),
+            cluster: SessionVar::new(&CLUSTER),
             database: SessionVar::new(&DATABASE),
             date_style: DATE_STYLE,
             extra_float_digits: SessionVar::new(&EXTRA_FLOAT_DIGITS),
@@ -222,6 +230,7 @@ impl Vars {
             &self.application_name as &dyn Var,
             &self.client_encoding,
             &self.client_min_messages,
+            &self.cluster,
             &self.database,
             &self.date_style,
             &self.extra_float_digits,
@@ -271,6 +280,8 @@ impl Vars {
             Ok(&self.client_encoding)
         } else if name == CLIENT_MIN_MESSAGES.name {
             Ok(&self.client_min_messages)
+        } else if name == CLUSTER.name {
+            Ok(&self.cluster)
         } else if name == DATABASE.name {
             Ok(&self.database)
         } else if name == DATE_STYLE.name {
@@ -335,6 +346,8 @@ impl Vars {
                     valid_values: Some(ClientSeverity::valid_values()),
                 });
             }
+        } else if name == CLUSTER.name {
+            return Err(CoordError::ReadOnlyParameter(&CLUSTER));
         } else if name == DATABASE.name {
             self.database.set(value, local)
         } else if name == DATE_STYLE.name {
@@ -423,6 +436,7 @@ impl Vars {
             application_name,
             client_encoding: _,
             client_min_messages,
+            cluster: _,
             database,
             date_style: _,
             extra_float_digits,
@@ -458,6 +472,11 @@ impl Vars {
     /// Returns the value of the `client_min_messages` configuration parameter.
     pub fn client_min_messages(&self) -> &ClientSeverity {
         self.client_min_messages.value()
+    }
+
+    /// Returns the value of the `cluster` configuration parameter.
+    pub fn cluster(&self) -> &str {
+        self.cluster.value()
     }
 
     /// Returns the value of the `DateStyle` configuration parameter.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -34,7 +34,8 @@ use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
 use mz_dataflow_types::{
-    sinks::SinkConnectorBuilder, sinks::SinkEnvelope, sources::SourceConnector,
+    client::ComputeInstanceId, sinks::SinkConnectorBuilder, sinks::SinkEnvelope,
+    sources::SourceConnector,
 };
 use mz_expr::{GlobalId, MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
@@ -410,6 +411,7 @@ pub struct Sink {
     pub connector_builder: SinkConnectorBuilder,
     pub envelope: SinkEnvelope,
     pub depends_on: Vec<GlobalId>,
+    pub compute_instance: ComputeInstanceId,
 }
 
 #[derive(Clone, Debug)]
@@ -427,6 +429,7 @@ pub struct Index {
     pub on: GlobalId,
     pub keys: Vec<mz_expr::MirScalarExpr>,
     pub depends_on: Vec<GlobalId>,
+    pub compute_instance: ComputeInstanceId,
 }
 
 #[derive(Clone, Debug)]

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -42,3 +42,13 @@ DROP CLUSTER default
 
 statement error unknown cluster 'foo'
 DROP CLUSTER foo
+
+# Test `cluster` session variable.
+
+query T
+SHOW cluster
+----
+default
+
+statement error parameter "cluster" cannot be changed
+SET cluster = 'foo'

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -11,6 +11,7 @@
 application_name            ""                                         "Sets the application name to be reported in statistics and logs (PostgreSQL)."
 client_encoding             UTF8                                       "Sets the client's character set encoding (PostgreSQL)."
 client_min_messages         notice                                     "Sets the message levels that are sent to the client (PostgreSQL)."
+cluster                     default                                    "Sets the current cluster (Materialize)."
 database                    materialize                                "Sets the current database (CockroachDB)."
 extra_float_digits          3                                          "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                  ""                                         "Allows failpoints to be dynamically activated."


### PR DESCRIPTION
Add a `cluster` session variable, which determines which cluster is
active. For now, the value is hardcoded to the one known `default`
cluster.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A (all cluster stuff will be documented when it is de-experimentalized.)
