### PR TITLE
Update `Timeline` naming to clash less, match others

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -279,7 +279,7 @@ pub struct Coordinator {
 
     /// Mechanism for totally ordering write and read timestamps, so that all reads
     /// reflect exactly the set of writes that precede them, and no writes that follow.
-    global_timeline: timeline::Timeline,
+    global_timeline: timeline::TimestampOracle,
 
     transient_id_counter: u64,
     /// A map from connection ID to metadata about that connection for all
@@ -4495,7 +4495,7 @@ pub async fn serve(
                 logging_enabled: logging.is_some(),
                 internal_cmd_tx,
                 metric_scraper,
-                global_timeline: timeline::Timeline::new(now()),
+                global_timeline: timeline::TimestampOracle::new(now()),
                 transient_id_counter: 1,
                 active_conns: HashMap::new(),
                 read_capability: Default::default(),
@@ -5195,7 +5195,7 @@ mod timeline {
     ///
     /// At each time, writes happen and then reads happen, meaning that writes at a time are
     /// visible to exactly reads at that time or greater, and no other times.
-    enum TimelineState {
+    enum TimestampOracleState {
         /// The timeline is producing collection updates timestamped with the argument.
         Writing(mz_repr::Timestamp),
         /// The timeline is observing collections aot the time of the argument.
@@ -5206,16 +5206,16 @@ mod timeline {
     ///
     /// Specifically, all read timestamps will be greater or equal to all previously reported write timestamps,
     /// and strictly less than all subsequently emitted write timestamps.
-    pub struct Timeline {
-        state: TimelineState,
+    pub struct TimestampOracle {
+        state: TimestampOracleState,
         advance_to: Option<mz_repr::Timestamp>,
     }
 
-    impl Timeline {
+    impl TimestampOracle {
         /// Create a new timeline, starting at the indicated time.
         pub fn new(initially: mz_repr::Timestamp) -> Self {
             Self {
-                state: TimelineState::Writing(initially),
+                state: TimestampOracleState::Writing(initially),
                 advance_to: Some(initially),
             }
         }
@@ -5226,9 +5226,9 @@ mod timeline {
         /// and less than or equal to all subsequent values of `self.read_ts()`.
         pub fn write_ts(&mut self) -> mz_repr::Timestamp {
             match self.state {
-                TimelineState::Writing(ts) => ts,
-                TimelineState::Reading(ts) => {
-                    self.state = TimelineState::Writing(ts + 1);
+                TimestampOracleState::Writing(ts) => ts,
+                TimestampOracleState::Reading(ts) => {
+                    self.state = TimestampOracleState::Writing(ts + 1);
                     ts + 1
                 }
             }
@@ -5239,9 +5239,9 @@ mod timeline {
         /// and strictly less than all subsequent values of `self.write_ts()`.
         pub fn read_ts(&mut self) -> mz_repr::Timestamp {
             match self.state {
-                TimelineState::Reading(ts) => ts,
-                TimelineState::Writing(ts) => {
-                    self.state = TimelineState::Reading(ts);
+                TimestampOracleState::Reading(ts) => ts,
+                TimestampOracleState::Writing(ts) => {
+                    self.state = TimestampOracleState::Reading(ts);
                     self.advance_to = Some(ts + 1);
                     ts
                 }
@@ -5253,18 +5253,18 @@ mod timeline {
         /// resulting state will be `Writing(lower_bound)`.
         pub fn fast_forward(&mut self, lower_bound: mz_repr::Timestamp) {
             match self.state {
-                TimelineState::Writing(ts) => {
+                TimestampOracleState::Writing(ts) => {
                     if lower_bound > ts {
                         self.advance_to = Some(lower_bound);
-                        self.state = TimelineState::Writing(lower_bound);
+                        self.state = TimestampOracleState::Writing(lower_bound);
                     }
                 }
-                TimelineState::Reading(ts) => {
+                TimestampOracleState::Reading(ts) => {
                     if lower_bound > ts {
                         // This may result in repetition in the case `lower_bound == ts + 1`.
                         // This is documented as fine, and concerned users can protect themselves.
                         self.advance_to = Some(lower_bound);
-                        self.state = TimelineState::Writing(lower_bound);
+                        self.state = TimestampOracleState::Writing(lower_bound);
                     }
                 }
             }


### PR DESCRIPTION
Renames `timeline::Timeline` to `timeline::TimestampOracle`. The timeline concept still seems to check out, and we likely want (at least) one of the oracles for each timeline, but the thing handing out the timestamps is the oracle not the timeline.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
