### PR TITLE
coord: install clusters in the catalog on CREATE

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1241,6 +1241,15 @@ lazy_static! {
         // for this to be persisted.
         persistent: true,
     };
+    pub static ref MZ_CLUSTERS: BuiltinTable = BuiltinTable {
+        name: "mz_clusters",
+        schema: MZ_CATALOG_SCHEMA,
+        desc: RelationDesc::empty()
+            .with_column("id", ScalarType::Int64.nullable(false))
+            .with_column("name", ScalarType::String.nullable(false)),
+        id: GlobalId::System(4049),
+        persistent: false,
+    };
 }
 
 pub const MZ_RELATIONS: BuiltinView = BuiltinView {
@@ -2196,6 +2205,7 @@ lazy_static! {
             Builtin::Table(&MZ_PROMETHEUS_READINGS),
             Builtin::Table(&MZ_PROMETHEUS_HISTOGRAMS),
             Builtin::Table(&MZ_PROMETHEUS_METRICS),
+            Builtin::Table(&MZ_CLUSTERS),
             Builtin::View(&MZ_CATALOG_NAMES),
             Builtin::View(&MZ_ARRANGEMENT_SHARING),
             Builtin::View(&MZ_ARRANGEMENT_SIZES),

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -20,9 +20,9 @@ use mz_sql::names::DatabaseSpecifier;
 use mz_sql_parser::ast::display::AstDisplay;
 
 use crate::catalog::builtin::{
-    MZ_ARRAY_TYPES, MZ_AVRO_OCF_SINKS, MZ_BASE_TYPES, MZ_COLUMNS, MZ_DATABASES, MZ_FUNCTIONS,
-    MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_SINKS, MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_PSEUDO_TYPES,
-    MZ_ROLES, MZ_SCHEMAS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
+    MZ_ARRAY_TYPES, MZ_AVRO_OCF_SINKS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_COLUMNS, MZ_DATABASES,
+    MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_SINKS, MZ_LIST_TYPES, MZ_MAP_TYPES,
+    MZ_PSEUDO_TYPES, MZ_ROLES, MZ_SCHEMAS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
     CatalogItem, CatalogState, Func, Index, Sink, SinkConnector, SinkConnectorState, Source, Table,
@@ -88,6 +88,19 @@ impl CatalogState {
                 Datum::UInt32(role.oid),
                 Datum::String(&name),
             ]),
+            diff,
+        }
+    }
+
+    pub(super) fn pack_compute_instance_update(
+        &self,
+        name: &str,
+        diff: Diff,
+    ) -> BuiltinTableUpdate {
+        let compute_instance_id = &self.compute_instance_names[name];
+        BuiltinTableUpdate {
+            id: MZ_CLUSTERS.id,
+            row: Row::pack_slice(&[Datum::Int64(*compute_instance_id), Datum::String(&name)]),
             diff,
         }
     }

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -25,8 +25,9 @@ pub struct Config<'a> {
     pub experimental_mode: Option<bool>,
     /// Whether to enable safe mode.
     pub safe_mode: bool,
-    /// Whether to enable logging sources and the views that depend upon them.
-    pub enable_logging: bool,
+    /// Whether to enable logging sources and the views that depend upon them
+    /// for the default cluster.
+    pub default_compute_instance_logging: Option<LoggingConfig>,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// An [External ID][] to use for all AWS AssumeRole operations.
@@ -45,4 +46,13 @@ pub struct Config<'a> {
     pub disable_user_indexes: bool,
     /// A runtime for the `persist` crate alongside its configuration.
     pub persister: &'a PersisterWithConfig,
+}
+
+/// Configuration of logging for a compute instance.
+#[derive(Debug)]
+pub struct LoggingConfig {
+    /// The interval at which to update logging sources.
+    pub granularity: Duration,
+    // Whether to report logs for the log-processing dataflows.
+    pub log_logging: bool,
 }

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -31,9 +31,11 @@ pub enum ErrorKind {
     DatabaseAlreadyExists(String),
     SchemaAlreadyExists(String),
     RoleAlreadyExists(String),
+    ClusterAlreadyExists(String),
     ItemAlreadyExists(String),
     ReservedSchemaName(String),
     ReservedRoleName(String),
+    ReservedClusterName(String),
     ReadOnlySystemSchema(String),
     ReadOnlyItem(String),
     SchemaNotEmpty(String),
@@ -77,6 +79,9 @@ impl Error {
             ErrorKind::ReservedRoleName(_) => {
                 Some("The prefixes \"mz_\" and \"pg_\" are reserved for system roles.".into())
             }
+            ErrorKind::ReservedClusterName(_) => {
+                Some("The prefixes \"mz_\" and \"pg_\" are reserved for system clusters.".into())
+            }
             _ => None,
         }
     }
@@ -114,9 +119,11 @@ impl std::error::Error for Error {
             | ErrorKind::DatabaseAlreadyExists(_)
             | ErrorKind::SchemaAlreadyExists(_)
             | ErrorKind::RoleAlreadyExists(_)
+            | ErrorKind::ClusterAlreadyExists(_)
             | ErrorKind::ItemAlreadyExists(_)
             | ErrorKind::ReservedSchemaName(_)
             | ErrorKind::ReservedRoleName(_)
+            | ErrorKind::ReservedClusterName(_)
             | ErrorKind::ReadOnlySystemSchema(_)
             | ErrorKind::ReadOnlyItem(_)
             | ErrorKind::SchemaNotEmpty(_)
@@ -150,6 +157,9 @@ impl fmt::Display for Error {
             ErrorKind::RoleAlreadyExists(name) => {
                 write!(f, "role '{}' already exists", name)
             }
+            ErrorKind::ClusterAlreadyExists(name) => {
+                write!(f, "cluster '{}' already exists", name)
+            }
             ErrorKind::ItemAlreadyExists(name) => {
                 write!(f, "catalog item '{}' already exists", name)
             }
@@ -158,6 +168,9 @@ impl fmt::Display for Error {
             }
             ErrorKind::ReservedRoleName(name) => {
                 write!(f, "role name {} is reserved", name.quoted())
+            }
+            ErrorKind::ReservedClusterName(name) => {
+                write!(f, "cluster name {} is reserved", name.quoted())
             }
             ErrorKind::ReadOnlySystemSchema(name) => {
                 write!(f, "system schema '{}' cannot be modified", name)

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -43,13 +43,13 @@ pub enum Command<T = mz_repr::Timestamp> {
 }
 
 /// An abstraction allowing us to name difference compute instances.
-// NOTE(benesch): this is an `i64` rather than a `u64` because SQLite does not
+// TODO(benesch): this is an `i64` rather than a `u64` because SQLite does not
 // support natively storing `u64`. Revisit this before shipping Platform, as we
 // might not like to bake in this decision based on a SQLite limitation.
 // See #11123.
 pub type ComputeInstanceId = i64;
 /// A default value whose use we can track down and remove later.
-pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 0;
+pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 1;
 
 /// Instance configuration
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -43,7 +43,11 @@ pub enum Command<T = mz_repr::Timestamp> {
 }
 
 /// An abstraction allowing us to name difference compute instances.
-pub type ComputeInstanceId = usize;
+// NOTE(benesch): this is an `i64` rather than a `u64` because SQLite does not
+// support natively storing `u64`. Revisit this before shipping Platform, as we
+// might not like to bake in this decision based on a SQLite limitation.
+// See #11123.
+pub type ComputeInstanceId = i64;
 /// A default value whose use we can track down and remove later.
 pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 0;
 

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -11,36 +11,50 @@
 
 mode cockroach
 
-# Creating a cluster without any options should work. (It creates a virtual
-# cluster.)
+# Creating a cluster without any options works.
 statement ok
 CREATE CLUSTER foo
 
-# Creating a virtual cluster should "work". (Nothing happens presently.)
+statement error cluster 'foo' already exists
+CREATE CLUSTER foo
+
+# Creating a virtual cluster works.
 statement ok
-CREATE CLUSTER foo VIRTUAL
+CREATE CLUSTER bar VIRTUAL
+
+query TT rowsort
+SELECT * FROM mz_clusters
+----
+1 default
+2 foo
+3 bar
 
 # Creating a sized cluster should be rejected.
 statement error SIZE not yet supported
-CREATE CLUSTER foo SIZE 'small'
+CREATE CLUSTER baz SIZE 'small'
 
 # Test invalid option combinations.
 
 statement error VIRTUAL specified more than once
-CREATE CLUSTER foo VIRTUAL, VIRTUAL
+CREATE CLUSTER baz VIRTUAL, VIRTUAL
 
 statement error SIZE specified more than once
-CREATE CLUSTER foo SIZE 'small', SIZE 'medium'
+CREATE CLUSTER baz SIZE 'small', SIZE 'medium'
 
 statement error VIRTUAL and SIZE options cannot be specified together
-CREATE CLUSTER foo VIRTUAL, SIZE 'small'
+CREATE CLUSTER baz VIRTUAL, SIZE 'small'
 
 # Test invalid DROPs.
 
 statement error active cluster cannot be dropped
 DROP CLUSTER default
 
-statement error unknown cluster 'foo'
+statement error unknown cluster 'baz'
+DROP CLUSTER baz
+
+# Test valid DROPs, which aren't yet supported.
+
+statement error cannot yet drop clusters
 DROP CLUSTER foo
 
 # Test `cluster` session variable.

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -391,6 +391,7 @@ mz_worker_materialization_frontiers           system true          volatile    l
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
+mz_clusters
 mz_columns
 mz_databases
 mz_functions
@@ -419,6 +420,7 @@ name                  type
 mz_array_types        system
 mz_avro_ocf_sinks     system
 mz_base_types         system
+mz_clusters           system
 mz_columns            system
 mz_databases          system
 mz_functions          system
@@ -449,6 +451,7 @@ mz_views              system
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
+mz_clusters
 mz_columns
 mz_databases
 mz_functions
@@ -480,6 +483,7 @@ test_table
 mz_array_types
 mz_avro_ocf_sinks
 mz_base_types
+mz_clusters
 mz_columns
 mz_databases
 mz_functions
@@ -505,7 +509,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-24
+25
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
Creates virtual instances on `CREATE CLUSTER` and on reboot. They're pretty useless, but they exist.

Note that I am not totally sure how to _really_ test this, but modified the SLT.

### Motivation

This PR adds a known-desirable feature, creating platform clusters.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - no user-facing behavior changes
