### PR TITLE
Attempt to wire up materialized with remote compute

### DIFF
--- a/src/dataflowd/src/lib.rs
+++ b/src/dataflowd/src/lib.rs
@@ -145,9 +145,13 @@ impl<S: Client> Client for SplitClient<S> {
                 futures.push(client.recv());
             }
         }
-        tokio::select! {
-            response = futures.select_next_some() => response,
-            response = self.storage_client.recv() => response,
+        if futures.is_empty() {
+            self.storage_client.recv().await
+        } else {
+            tokio::select! {
+                response = futures.select_next_some() => response,
+                response = self.storage_client.recv() => response,
+            }
         }
     }
 }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -377,6 +377,9 @@ pub struct Args {
     /// Turn on the console-subscriber to use materialize with `tokio-console`
     #[clap(long, hide = true)]
     tokio_console: bool,
+
+    #[clap(long, hide = true)]
+    platform_addr: Option<String>,
 }
 
 /// This type is a hack to allow a dynamic default for the `--workers` argument,
@@ -722,6 +725,8 @@ dataflow workers: {workers}",
         }
     };
 
+    let platform_addr = args.platform_addr;
+
     let server = runtime.block_on(materialized::serve(materialized::Config {
         workers: args.workers.0,
         timely_worker,
@@ -746,6 +751,7 @@ dataflow workers: {workers}",
             .unwrap_or_else(|| Duration::from_secs(1)),
         metrics_registry,
         persist: persist_config,
+        platform_addr,
     }))?;
 
     eprintln!(

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -156,6 +156,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         metrics_registry: metrics_registry.clone(),
         persist: PersistConfig::disabled(),
         third_party_metrics_listen_addr: None,
+        platform_addr: None,
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -563,6 +563,7 @@ impl Runner {
             metrics_registry: MetricsRegistry::new(),
             persist: PersistConfig::disabled(),
             third_party_metrics_listen_addr: None,
+            platform_addr: None,
         };
         let server = materialized::serve(mz_config).await?;
         let client = connect(&server).await;


### PR DESCRIPTION
~Do not merge.~ Idk could merge.

Attempt to have `materialized` serve two flavors of dataflow server: either a "conventional" single process server that uses an in-process event-link boundary between Storage and Compute, or a server that uses TCP for the boundary and which responds to `create_instance` commands to remote instances by attempting a connection.

### Motivation

Allow platform experimentation.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
