### PR TITLE
test: Tone down the Indexes scenario in the limits test

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -93,6 +93,10 @@ class Tables(Generator):
 
 
 class Indexes(Generator):
+    COUNT = min(
+        Generator.COUNT, 100
+    )  # https://github.com/MaterializeInc/materialize/issues/11134
+
     @classmethod
     def body(cls) -> None:
         print(


### PR DESCRIPTION
Due to #11134 it is not possible to have 1000 indexes over the same
table, so have the test create 100 indexes instead.