### PR TITLE
pg-cdc: add timeouts to connection / copy out postgres calls

### DIFF
--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -261,7 +261,7 @@ impl PostgresSourceReader {
             let mut mz_row = Row::default();
             // TODO: once tokio-stream is released with https://github.com/tokio-rs/tokio/pull/4502
             //    we can convert this into a single `timeout(...)` call on the reader CopyOutStream
-            while let Some(b) = tokio::time::timeout(Duration::from_secs(15), reader.next())
+            while let Some(b) = tokio::time::timeout(Duration::from_secs(30), reader.next())
                 .await?
                 .transpose()?
             {

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -12,6 +12,7 @@
 use anyhow::{anyhow, bail};
 use openssl::ssl::{SslConnector, SslFiletype, SslMethod, SslVerifyMode};
 use postgres_openssl::MakeTlsConnector;
+use std::time::Duration;
 use tokio_postgres::config::{ReplicationMode, SslMode};
 use tokio_postgres::{Client, Config};
 
@@ -232,6 +233,8 @@ pub async fn connect_replication(conn: &str) -> Result<Client, anyhow::Error> {
     let tls = make_tls(&config)?;
     let (client, connection) = config
         .replication_mode(ReplicationMode::Logical)
+        .connect_timeout(Duration::from_secs(30))
+        .keepalives_idle(Duration::from_secs(10 * 60))
         .connect(tls)
         .await?;
     task::spawn(


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

As further protection against network-related-stalls (https://github.com/MaterializeInc/materialize/issues/10938) this PR adds in a basic Postgres replication client connection timeout, as well as a per-row timeout for our `CopyOutStream`. Since adding in these timeouts, I have not been able to reproduce the pg-cdc-resumption test failures we were seeing in the linked issue.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/10938

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A - Same release note as https://github.com/MaterializeInc/materialize/pull/11098