### PR TITLE
debugging: add hidden flag to print tracing log level

### DIFF
--- a/src/materialized/src/bin/materialized/tracing.rs
+++ b/src/materialized/src/bin/materialized/tracing.rs
@@ -114,6 +114,8 @@ where
     }
 }
 /// Configures tracing according to the provided command-line arguments.
+/// Returns a `Write` stream that represents the main place `tracing` will
+/// log to
 pub async fn configure(
     args: &Args,
     metrics_registry: &MetricsRegistry,

--- a/src/materialized/src/bin/materialized/tracing.rs
+++ b/src/materialized/src/bin/materialized/tracing.rs
@@ -190,7 +190,7 @@ pub async fn configure(
                     }
                     fmt::layer()
                         .with_ansi(false)
-                        .with_writer(move || file.try_clone().expect("failed to clone log file"))
+                        .with_writer(file)
                         .with_filter(filter.clone())
                 })
                 .with(


### PR DESCRIPTION
I keep having to add this println locally to debug, and because as we add more filters and change things, its important to ensure the default hits the fast path in tracing macros where the max level is `INFO`, this helps confirm that things are working as intended

### Motivation
  * This PR adds a feature that has not yet been specified.
Local testing hidden feature

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

