### PR TITLE
sql-parser: add support for ALTER SECRET

### DIFF
--- a/doc/developer/design/20220303_secrets.md
+++ b/doc/developer/design/20220303_secrets.md
@@ -17,10 +17,10 @@ create_secret_stmt ::=
   CREATE SECRET [IF NOT EXISTS] <name> AS <value>
 
 alter_secret_stmt ::=
-  ALTER SECRET <name> AS <value>
+  ALTER SECRET [IF EXISTS] <name> AS <value>
 
 alter_secret_rename_stmt ::=
-  ALTER SECRET <name> RENAME TO <name>
+  ALTER SECRET [IF EXISTS] <name> RENAME TO <name>
 
 drop_secret_stmt ::=
   DROP SECRET [IF EXISTS] <name> [{ RESTRICT | CASCADE }]

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1434,6 +1434,7 @@ impl Coordinator {
 
                     // Statements below must by run singly (in Started).
                     Statement::AlterIndex(_)
+                    | Statement::AlterSecret(_)
                     | Statement::AlterObjectRename(_)
                     | Statement::CreateDatabase(_)
                     | Statement::CreateIndex(_)

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -50,6 +50,7 @@ pub enum Statement<T: AstInfo> {
     CreateSecret(CreateSecretStatement<T>),
     AlterObjectRename(AlterObjectRenameStatement<T>),
     AlterIndex(AlterIndexStatement<T>),
+    AlterSecret(AlterSecretStatement<T>),
     Discard(DiscardStatement),
     DropDatabase(DropDatabaseStatement),
     DropObjects(DropObjectsStatement),
@@ -101,6 +102,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::CreateCluster(stmt) => f.write_node(stmt),
             Statement::AlterObjectRename(stmt) => f.write_node(stmt),
             Statement::AlterIndex(stmt) => f.write_node(stmt),
+            Statement::AlterSecret(stmt) => f.write_node(stmt),
             Statement::Discard(stmt) => f.write_node(stmt),
             Statement::DropDatabase(stmt) => f.write_node(stmt),
             Statement::DropObjects(stmt) => f.write_node(stmt),
@@ -795,7 +797,7 @@ impl<T: AstInfo> AstDisplay for CreateSecretStatement<T> {
             f.write_str("IF NOT EXISTS ");
         }
         f.write_node(&self.name);
-        f.write_str("AS ");
+        f.write_str(" AS ");
         f.write_node(&self.value);
     }
 }
@@ -968,6 +970,28 @@ impl<T: AstInfo> AstDisplay for AlterIndexStatement<T> {
 }
 
 impl_display_t!(AlterIndexStatement);
+
+/// `ALTER SECRET ... AS`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AlterSecretStatement<T: AstInfo> {
+    pub secret_name: T::ObjectName,
+    pub if_exists: bool,
+    pub value: Expr<T>,
+}
+
+impl<T: AstInfo> AstDisplay for AlterSecretStatement<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("ALTER SECRET ");
+        if self.if_exists {
+            f.write_str("IF EXISTS ");
+        }
+        f.write_node(&self.secret_name);
+        f.write_str(" AS ");
+        f.write_node(&self.value);
+    }
+}
+
+impl_display_t!(AlterSecretStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DiscardStatement {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1337,3 +1337,52 @@ DROP CLUSTER IF EXISTS cluster CASCADE
 DROP CLUSTER IF EXISTS cluster CASCADE
 =>
 DropObjects(DropObjectsStatement { materialized: false, object_type: Cluster, if_exists: true, names: [UnresolvedObjectName([Ident("cluster")])], cascade: true })
+
+parse-statement
+CREATE SECRET secret AS decode('base64-encoded secret', 'base64')
+----
+CREATE SECRET secret AS decode('base64-encoded secret', 'base64')
+=>
+CreateSecret(CreateSecretStatement { name: Ident("secret"), if_not_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("base64-encoded secret")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+
+parse-statement
+CREATE SECRET IF NOT EXISTS secret AS decode('base64-encoded secret', 'base64')
+----
+CREATE SECRET IF NOT EXISTS secret AS decode('base64-encoded secret', 'base64')
+=>
+CreateSecret(CreateSecretStatement { name: Ident("secret"), if_not_exists: true, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("base64-encoded secret")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+
+parse-statement
+DROP SECRET secret
+----
+DROP SECRET secret
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Secret, if_exists: false, names: [UnresolvedObjectName([Ident("secret")])], cascade: false })
+
+parse-statement
+DROP SECRET IF EXISTS secret
+----
+DROP SECRET IF EXISTS secret
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Secret, if_exists: true, names: [UnresolvedObjectName([Ident("secret")])], cascade: false })
+
+parse-statement
+SHOW SECRETS
+----
+SHOW SECRETS
+=>
+ShowObjects(ShowObjectsStatement { object_type: Secret, from: None, extended: false, full: false, materialized: false, filter: None })
+
+parse-statement
+ALTER SECRET secret RENAME TO secret2
+----
+ALTER SECRET secret RENAME TO secret2
+=>
+AlterObjectRename(AlterObjectRenameStatement { object_type: Secret, if_exists: false, name: Name(UnresolvedObjectName([Ident("secret")])), to_item_name: Ident("secret2") })
+
+parse-statement
+ALTER SECRET secret AS decode('new base64-encoded secret', 'base64')
+----
+ALTER SECRET secret AS decode('new base64-encoded secret', 'base64')
+=>
+AlterSecret(AlterSecretStatement { secret_name: Name(UnresolvedObjectName([Ident("secret")])), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new base64-encoded secret")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -138,6 +138,7 @@ pub fn describe(
         (Statement::DropObjects(stmt), _) => ddl::describe_drop_objects(&scx, stmt)?,
         (Statement::AlterObjectRename(stmt), _) => ddl::describe_alter_object_rename(&scx, stmt)?,
         (Statement::AlterIndex(stmt), _) => ddl::describe_alter_index_options(&scx, stmt)?,
+        (Statement::AlterSecret(stmt), _) => ddl::describe_alter_secret_options(&scx, stmt)?,
 
         // `SHOW` statements.
         (Statement::ShowCreateTable(stmt), _) => show::describe_show_create_table(&scx, stmt)?,
@@ -239,6 +240,7 @@ pub fn plan(
         Statement::DropObjects(stmt) => ddl::plan_drop_objects(scx, stmt),
         Statement::AlterIndex(stmt) => ddl::plan_alter_index_options(scx, stmt),
         Statement::AlterObjectRename(stmt) => ddl::plan_alter_object_rename(scx, stmt),
+        Statement::AlterSecret(stmt) => ddl::plan_alter_secret(scx, stmt),
 
         // DML statements.
         Statement::Insert(stmt) => dml::plan_insert(scx, stmt, params),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -54,9 +54,10 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::str::StrExt;
 use mz_repr::{strconv, ColumnName, RelationDesc, RelationType, ScalarType};
 use mz_sql_parser::ast::{
-    AstInfo, CreateClusterStatement, CreateSecretStatement, CreateViewsSourceTarget,
-    CsrSeedCompiledOrLegacy, Op, Query, RawName, Select, SelectItem, SetExpr,
-    SourceIncludeMetadata, SubscriptPosition, TableFactor, TableWithJoins, UnresolvedObjectName,
+    AlterSecretStatement, AstInfo, CreateClusterStatement, CreateSecretStatement,
+    CreateViewsSourceTarget, CsrSeedCompiledOrLegacy, Op, Query, RawName, Select, SelectItem,
+    SetExpr, SourceIncludeMetadata, SubscriptPosition, TableFactor, TableWithJoins,
+    UnresolvedObjectName,
 };
 
 use crate::ast::display::AstDisplay;
@@ -2917,4 +2918,22 @@ pub fn plan_alter_object_rename(
         to_name: normalize::ident(to_item_name),
         object_type,
     }))
+}
+
+pub fn describe_alter_secret_options(
+    _: &StatementContext,
+    _: AlterSecretStatement<Raw>,
+) -> Result<StatementDesc, anyhow::Error> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_alter_secret(
+    _: &StatementContext,
+    AlterSecretStatement {
+        secret_name: _,
+        if_exists: _,
+        value: _,
+    }: AlterSecretStatement<Aug>,
+) -> Result<Plan, anyhow::Error> {
+    bail_unsupported!("ALTER SECRET")
 }


### PR DESCRIPTION
Add support for ALTER SECRET required for the platform. For the motivation see https://github.com/MaterializeInc/materialize/pull/11022

Tested manually, all cases parse as expected.
```
materialize=> alter secret foo;
ERROR:  Expected one of AS or RENAME, found semicolon
LINE 1: alter secret foo;
                        ^

materialize=> alter secret foo as bar;
ERROR:  ALTER SECRET not yet supported

materialize=> alter secret foo rename to bar;
ERROR:  unknown catalog item 'foo'

materialize=> alter secret if exists foo rename to bar;
ALTER INDEX

materialize=> alter secret if exists foo as bar;
ERROR:  ALTER SECRET not yet supported

```