### PR TITLE
coord: improve table timestamp generation

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -297,7 +297,7 @@ pub struct Coordinator {
 
     /// Mechanism for totally ordering write and read timestamps, so that all reads
     /// reflect exactly the set of writes that precede them, and no writes that follow.
-    global_timeline: timeline::TimestampOracle,
+    global_timeline: timeline::TimestampOracle<Timestamp>,
 
     transient_id_counter: u64,
     /// A map from connection ID to metadata about that connection for all
@@ -4488,6 +4488,7 @@ pub async fn serve(
     let thread = thread::Builder::new()
         .name("coordinator".to_string())
         .spawn(move || {
+            use core::ops::Deref;
             let mut coord = Coordinator {
                 dataflow_client: mz_dataflow_types::client::Controller::new(dataflow_client),
                 dataflow_instance,
@@ -4499,7 +4500,7 @@ pub async fn serve(
                 logging,
                 internal_cmd_tx,
                 metric_scraper,
-                global_timeline: timeline::TimestampOracle::new(now()),
+                global_timeline: timeline::TimestampOracle::new(now(), move || (now.deref())()),
                 transient_id_counter: 1,
                 active_conns: HashMap::new(),
                 read_capability: Default::default(),
@@ -5182,41 +5183,53 @@ mod timeline {
     ///
     /// At each time, writes happen and then reads happen, meaning that writes at a time are
     /// visible to exactly reads at that time or greater, and no other times.
-    enum TimestampOracleState {
+    enum TimestampOracleState<T> {
         /// The timeline is producing collection updates timestamped with the argument.
-        Writing(mz_repr::Timestamp),
+        Writing(T),
         /// The timeline is observing collections aot the time of the argument.
-        Reading(mz_repr::Timestamp),
+        Reading(T),
     }
 
     /// A type that provides write and read timestamps, reads observe exactly their preceding writes..
     ///
     /// Specifically, all read timestamps will be greater or equal to all previously reported write timestamps,
     /// and strictly less than all subsequently emitted write timestamps.
-    pub struct TimestampOracle {
-        state: TimestampOracleState,
-        advance_to: Option<mz_repr::Timestamp>,
+    pub struct TimestampOracle<T> {
+        state: TimestampOracleState<T>,
+        advance_to: Option<T>,
+        next: Box<dyn Fn() -> T>,
     }
 
-    impl TimestampOracle {
-        /// Create a new timeline, starting at the indicated time.
-        pub fn new(initially: mz_repr::Timestamp) -> Self {
+    impl<T: super::CoordTimestamp> TimestampOracle<T> {
+        /// Create a new timeline, starting at the indicated time. `next` generates
+        /// new timestamps when invoked. The timestamps have no requirements, and can
+        /// retreat from previous invocations.
+        pub fn new<F>(initially: T, next: F) -> Self
+        where
+            F: Fn() -> T + 'static,
+        {
             Self {
-                state: TimestampOracleState::Writing(initially),
+                state: TimestampOracleState::Writing(initially.clone()),
                 advance_to: Some(initially),
+                next: Box::new(next),
             }
         }
 
         /// Acquire a new timestamp for writing.
         ///
-        /// This timestamp will be strictly greater than all prior values of `self.read_ts()`,
-        /// and less than or equal to all subsequent values of `self.read_ts()`.
-        pub fn write_ts(&mut self) -> mz_repr::Timestamp {
-            match self.state {
-                TimestampOracleState::Writing(ts) => ts,
+        /// This timestamp will be strictly greater than all prior values of
+        /// `self.read_ts()`, and less than or equal to all subsequent values of
+        /// `self.read_ts()`.
+        pub fn write_ts(&mut self) -> T {
+            match &self.state {
+                TimestampOracleState::Writing(ts) => ts.clone(),
                 TimestampOracleState::Reading(ts) => {
-                    self.state = TimestampOracleState::Writing(ts + 1);
-                    ts + 1
+                    let mut next = (self.next)();
+                    if next.less_equal(&ts) {
+                        next = ts.step_forward();
+                    }
+                    self.state = TimestampOracleState::Writing(next.clone());
+                    next
                 }
             }
         }
@@ -5224,12 +5237,14 @@ mod timeline {
         ///
         /// This timestamp will be greater or equal to all prior values of `self.write_ts()`,
         /// and strictly less than all subsequent values of `self.write_ts()`.
-        pub fn read_ts(&mut self) -> mz_repr::Timestamp {
-            match self.state {
-                TimestampOracleState::Reading(ts) => ts,
+        pub fn read_ts(&mut self) -> T {
+            match &self.state {
+                TimestampOracleState::Reading(ts) => ts.clone(),
                 TimestampOracleState::Writing(ts) => {
-                    self.state = TimestampOracleState::Reading(ts);
-                    self.advance_to = Some(ts + 1);
+                    // Avoid rust borrow complaint.
+                    let ts = ts.clone();
+                    self.state = TimestampOracleState::Reading(ts.clone());
+                    self.advance_to = Some(ts.step_forward());
                     ts
                 }
             }
@@ -5238,19 +5253,19 @@ mod timeline {
         ///
         /// If `lower_bound` is strictly greater than the current time (of either state), the
         /// resulting state will be `Writing(lower_bound)`.
-        pub fn fast_forward(&mut self, lower_bound: mz_repr::Timestamp) {
-            match self.state {
+        pub fn fast_forward(&mut self, lower_bound: T) {
+            match &self.state {
                 TimestampOracleState::Writing(ts) => {
-                    if lower_bound > ts {
-                        self.advance_to = Some(lower_bound);
+                    if ts.less_than(&lower_bound) {
+                        self.advance_to = Some(lower_bound.clone());
                         self.state = TimestampOracleState::Writing(lower_bound);
                     }
                 }
                 TimestampOracleState::Reading(ts) => {
-                    if lower_bound > ts {
+                    if ts.less_than(&lower_bound) {
                         // This may result in repetition in the case `lower_bound == ts + 1`.
                         // This is documented as fine, and concerned users can protect themselves.
-                        self.advance_to = Some(lower_bound);
+                        self.advance_to = Some(lower_bound.clone());
                         self.state = TimestampOracleState::Writing(lower_bound);
                     }
                 }
@@ -5260,8 +5275,18 @@ mod timeline {
         ///
         /// This method may produce the same value multiple times, and should not be used as a test for whether
         /// a write-to-read transition has occurred, so much as an advisory signal that write capabilities can advance.
-        pub fn should_advance_to(&mut self) -> Option<mz_repr::Timestamp> {
+        pub fn should_advance_to(&mut self) -> Option<T> {
             self.advance_to.take()
         }
+    }
+}
+
+pub trait CoordTimestamp: timely::progress::Timestamp {
+    fn step_forward(&self) -> Self;
+}
+
+impl CoordTimestamp for mz_repr::Timestamp {
+    fn step_forward(&self) -> Self {
+        self.saturating_add(1)
     }
 }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -41,6 +41,7 @@ use clap::{AppSettings, Parser};
 use fail::FailScenario;
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use mz_ore::now::SYSTEM_TIME;
 use sysinfo::{ProcessorExt, SystemExt};
 use uuid::Uuid;
 
@@ -768,6 +769,7 @@ dataflow workers: {workers}",
             .unwrap_or_else(|| Duration::from_secs(1)),
         metrics_registry,
         persist: persist_config,
+        now: SYSTEM_TIME.clone(),
     }))?;
 
     eprintln!(

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -34,7 +34,7 @@ use mz_build_info::BuildInfo;
 use mz_coord::LoggingConfig;
 use mz_dataflow_types::client::InstanceConfig;
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::now::SYSTEM_TIME;
+use mz_ore::now::NowFn;
 use mz_ore::option::OptionExt;
 use mz_ore::task;
 use mz_pid_file::PidFile;
@@ -144,6 +144,8 @@ pub struct Config {
     pub metrics_registry: MetricsRegistry,
     /// Configuration of the persistence runtime and features.
     pub persist: PersistConfig,
+    /// Now generation function.
+    pub now: NowFn,
 }
 
 /// Configures TLS encryption for connections.
@@ -274,7 +276,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             worker: timely::WorkerConfig::default(),
         },
         experimental_mode: config.experimental_mode,
-        now: SYSTEM_TIME.clone(),
+        now: config.now.clone(),
         metrics_registry: config.metrics_registry.clone(),
         persister: persister.runtime.clone(),
         aws_external_id: config.aws_external_id.clone(),
@@ -295,7 +297,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         aws_external_id: config.aws_external_id.clone(),
         metrics_registry: config.metrics_registry.clone(),
         persister,
-        now: SYSTEM_TIME.clone(),
+        now: config.now,
     })
     .await?;
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -45,6 +45,7 @@ use md5::{Digest, Md5};
 use mz_coord::PersistConfig;
 use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task;
 use postgres_protocol::types;
 use regex::Regex;
@@ -568,6 +569,7 @@ impl Runner {
             metrics_registry: MetricsRegistry::new(),
             persist: PersistConfig::disabled(),
             third_party_metrics_listen_addr: None,
+            now: SYSTEM_TIME.clone(),
         };
         let server = materialized::serve(mz_config).await?;
         let client = connect(&server).await;


### PR DESCRIPTION
For all writes that are ready to commit (which does not include deferred
writes waiting on `write_lock`), add them to a queue and immediately try
to process it. If a timestamp in advance of previous timestamps cannot
be produced, try again later. This allows us to stop using `ts+1` logic
in the timestamp oracle to manually force timestamps forward by 1ms even
if 1ms of time has not occurred (or the system clock has retreated).
    
Plumb now through more of the mz infra so we are able to inject clock
failures during testing.

### Motivation

  * This PR fixes a recognized bug. #8424

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Change `INSERT` statements to block if the system clock goes backward until it catches up to its previous value.
