### PR TITLE
Update pg source docs

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -73,6 +73,8 @@ where each row of every upstream table is represented as a single row with two c
 | `oid`  | A unique identifier for the tables included in the publication. |
 | `row_data` | A text-encoded, variable length `list`. The number of text elements in a list is always equal to the number of columns in the upstream table. |
 
+It's important to note that the schema metadata is captured when the source is initially created, and is validated against the upstream schema upon restart. If you wish to add additional tables to the original publication and use them in Materialize, the source must be dropped and recreated.
+
 #### Creating replication views
 
 From here, you can break down the source into views that reproduce the publication's original tables based on the `oid` identifier and convert the text elements in `row_data` to the original data types:
@@ -134,7 +136,7 @@ For PostgreSQL 13+, it is recommended that you set a reasonable value for [`max_
 
 ## Known limitations
 
-- **Schema changes:** Materialize does not support changes to schemas for existing publications. You need to drop the existing sources and then recreate them after creating new publications for the updated schemas.
+ **Schema changes:** Materialize does not support changes to schemas for existing publications, and will set the source into an error state if a breaking DDL change is detected upstream. To handle schema changes, you need to drop the existing sources and then recreate them after creating new publications for the updated schemas.
 - **Supported data types:** Sources can only be created from publications that use [data types](/sql/types/) supported by Materialize. Attempts to create sources from publications which contain unsupported data types will fail with an error.
 - **Truncation:** Tables replicated into Materialize should not be truncated. If a table is truncated while replicated, the whole source becomes inaccessible and will not produce any data until it is recreated.
 


### PR DESCRIPTION
This PR updates the docs for creating Postgres sources to reflect the latest behavior after #10721 and 
#11083 have merged, specifically calling out that when a postgres source is created that we take a snapshot of the tables in the publication and their schemas and then use that to detect DDL changes during replication since they are not part of the protocol.


### Motivation

  * This PR adds a feature that has not yet been specified.

      - Documentation of the new Postgres source behavior.



### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user facing changes, this is a docs only change
