### PR TITLE
scratch: Improve debugging of test failures in CI

### DIFF
--- a/misc/scratch/ci.json
+++ b/misc/scratch/ci.json
@@ -1,0 +1,8 @@
+{
+    "name": "c5.2xlarge as used by the CI",
+    "launch_script": "true",
+    "instance_type": "c5.2xlarge",
+    "ami": "ami-0b29b6e62f2343b46",
+    "size_gb": 50,
+    "tags": {}
+}

--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -41,4 +41,8 @@ aws/install
 rm -r aws awscliv2.zip
 touch /opt/provision/awscli-installed
 
+# Step 5. Install the psql CLI
+apt-get install -y postgresql-client
+touch /opt/provision/psql-installed
+
 touch /opt/provision/done


### PR DESCRIPTION
- Add a "ci" instance type that matches the AWS instance type
currently used by Buildkite
- Install the psql command-line tool on provision

### Motivation

  * This PR adds a feature that has not yet been specified.

I have had the need to use the two suggested enhancements on a daily basis.