### PR TITLE
Deduplicate imported indexes

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -110,7 +110,7 @@ impl<'a> DataflowBuilder<'a> {
                 let mut valid_indexes = valid_indexes.collect::<Vec<_>>();
                 valid_indexes.sort_by_key(|(_, idx)| &idx.keys);
                 valid_indexes.dedup_by_key(|(_, idx)| &idx.keys);
-                for (index_id, idx) in valid_indexes.into_iter() {
+                for (index_id, idx) in valid_indexes {
                     let index_desc = IndexDesc {
                         on_id: *id,
                         key: idx.keys.to_vec(),

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -106,7 +106,11 @@ impl<'a> DataflowBuilder<'a> {
             let index_oracle = self.index_oracle();
             let mut valid_indexes = index_oracle.indexes_on(*id).peekable();
             if valid_indexes.peek().is_some() {
-                for (index_id, idx) in valid_indexes {
+                // Deduplicate indexes by keys, in case we have redundant indexes.
+                let mut valid_indexes = valid_indexes.collect::<Vec<_>>();
+                valid_indexes.sort_by_key(|(_, idx)| &idx.keys);
+                valid_indexes.dedup_by_key(|(_, idx)| &idx.keys);
+                for (index_id, idx) in valid_indexes.into_iter() {
                     let index_desc = IndexDesc {
                         on_id: *id,
                         key: idx.keys.to_vec(),


### PR DESCRIPTION
We import all indexes associated with a `GlobalId`, not yet knowing any better. This results in quadratic behavior if one creates multiple indexes on the same table over and over again.

This could be addressed at multiple layers, and this fix only has `DataflowBuilder` not import multiple indexes on the same key. It is also reasonable to have `from_mir` do more thorough arrangement pruning, which could have noticed that not all arrangements could be used. 

### Motivation

  * This PR fixes a recognized bug.

https://github.com/MaterializeInc/materialize/issues/11134

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
