### PR TITLE
sql: support SHOW CLUSTERS

### DIFF
--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -284,6 +284,13 @@ SHOW a
 =>
 ShowVariable(ShowVariableStatement { variable: Ident("a") })
 
+parse-statement
+SHOW CLUSTERS
+----
+SHOW CLUSTERS
+=>
+ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, extended: false, full: false, materialized: false, filter: None })
+
 # TODO(justin): "all" here should be its own token so that it doesn't get
 # downcased.
 parse-statement

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -216,7 +216,7 @@ pub fn show_objects<'a>(
         ObjectType::Type => show_types(scx, extended, full, from, filter),
         ObjectType::Object => show_all_objects(scx, extended, full, from, filter),
         ObjectType::Role => bail_unsupported!("SHOW ROLES"),
-        ObjectType::Cluster => bail_unsupported!("SHOW CLUSTERS"),
+        ObjectType::Cluster => show_clusters(scx, filter),
         ObjectType::Secret => bail_unsupported!("SHOW SECRETS"),
         ObjectType::Index => unreachable!("SHOW INDEX handled separately"),
     }
@@ -571,6 +571,17 @@ pub fn show_columns<'a>(
         Some("position"),
         Some(&["name", "nullable", "type"]),
     ))
+}
+
+pub fn show_clusters<'a>(
+    scx: &'a StatementContext<'a>,
+    filter: Option<ShowStatementFilter<Raw>>,
+) -> Result<ShowSelect<'a>, anyhow::Error> {
+    scx.require_experimental_mode("SHOW CLUSTERS")?;
+
+    let query = "SELECT mz_clusters.name FROM mz_catalog.mz_clusters".to_string();
+
+    Ok(ShowSelect::new(scx, query, filter, None, None))
 }
 
 /// An intermediate result when planning a `SHOW` query.

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -29,6 +29,18 @@ SELECT * FROM mz_clusters
 2 foo
 3 bar
 
+query T rowsort
+SHOW CLUSTERS
+----
+bar
+default
+foo
+
+query T rowsort
+SHOW CLUSTERS LIKE 'd%'
+----
+default
+
 # Creating a sized cluster should be rejected.
 statement error SIZE not yet supported
 CREATE CLUSTER baz SIZE 'small'


### PR DESCRIPTION
### Motivation

This PR adds a known-desirable feature. Closes #11128

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - no user-facing behavior changes
