### PR TITLE
feature-benchmark: Stabilize the KafkaEnvelopeNoneBytes

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -553,12 +553,13 @@ true
 
 class KafkaEnvelopeNoneBytes(Kafka):
     def shared(self) -> Action:
+        data = "a" * 512
         return TdAction(
             f"""
 $ kafka-create-topic topic=kafka-envelope-none-bytes
 
 $ kafka-ingest format=bytes topic=kafka-envelope-none-bytes repeat={self.n()}
-12345678901234567890123456789012345678901234567890
+{data}
 """
         )
 
@@ -566,12 +567,12 @@ $ kafka-ingest format=bytes topic=kafka-envelope-none-bytes repeat={self.n()}
         return Td(
             f"""
 > DROP SOURCE IF EXISTS s1;
-  /* A */
 
 > CREATE MATERIALIZED SOURCE s1
   FROM KAFKA BROKER '${{testdrive.kafka-addr}}' TOPIC 'testdrive-kafka-envelope-none-bytes-${{testdrive.seed}}'
   FORMAT BYTES
   ENVELOPE NONE
+  /* A */
 
 > SELECT COUNT(*) = {self.n()} FROM s1
   /* B */


### PR DESCRIPTION
The KafkaEnvelopeNoneBytes is suffering from sporadic false positives due
to a very short running time in the face of extreme variability.

- Increase the running time of the test by increasing the record size
of the data being ingested.

-Do not count the time of the CREATE SOURCE statement, as it appears
to be variable by up to 1 second.

### Motivation

  * This PR fixes a previously unreported bug.

Sporadic feature-benchmark failures in Nightly
