### PR TITLE
Add test for create views from source after an alter table

### DIFF
--- a/test/pg-cdc/create-views-after-alter.td
+++ b/test/pg-cdc/create-views-after-alter.td
@@ -1,0 +1,88 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test creating a materialized view after altering the upstream source
+# This is expected to fail
+#
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 INTEGER);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE MATERIALIZED SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> SELECT COUNT(*) > 0 FROM mz_source;
+true
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE t1 ADD COLUMN f2 varchar(1);
+INSERT INTO t1 VALUES (2, 'a');
+
+# Its debatable if this should succeed when we technically know by here that the source has errored
+# but for now this is how it behaves since it still will not serve incorrect results
+> CREATE VIEWS FROM SOURCE mz_source;
+
+! SELECT * FROM t1
+contains:altered
+
+#
+# Test creating a materialized view after altering an irrelevant table in the upstream source
+# This is expected to succeed
+#
+
+> DROP SOURCE mz_source CASCADE;
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 INTEGER);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE MATERIALIZED SOURCE mz_source
+  FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
+  PUBLICATION 'mz_source';
+
+> SELECT COUNT(*) = 1 FROM mz_source;
+true
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+CREATE TABLE t2 (f1 INTEGER);
+ALTER TABLE t2 REPLICA IDENTITY FULL;
+INSERT INTO t2 VALUES (2);
+
+> SELECT COUNT(*) = 1 FROM mz_source;
+true
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER TABLE t2 ADD COLUMN f2 varchar(1);
+INSERT INTO t2 VALUES (3, 'c');
+
+> SELECT COUNT(*) = 1 FROM mz_source;
+true
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> SELECT * FROM t1;
+1


### PR DESCRIPTION
This PR introduces a new test focused on verifying behavior of create views from source in the face of upstream alter tables being run in Postgres. An alter expected to cause the source to error is validated to allow view creation but no queries to succeed, and then an alter expected to be ignored by the source is validated to allow view creation and querying.

### Motivation
   * This PR refactors existing code.

      - Existing code lacked sufficient testing of these interactions, especially since the view creation could logically be expected to fail but it succeeds and then queries fail. This test therefor not only validates behavior but serves as documentation that this slightly unexpected behavior is actually correct.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user facing changes here, only tests.
