### PR TITLE
Refactor Postgres source metrics using table metadata

### DIFF
--- a/src/dataflow/src/source/metrics.rs
+++ b/src/dataflow/src/source/metrics.rs
@@ -142,12 +142,9 @@ impl PartitionSpecificMetrics {
 
 #[derive(Clone, Debug)]
 pub(super) struct PostgresSourceSpecificMetrics {
-    pub(super) total_messages: UIntCounterVec,
     pub(super) transactions: UIntCounterVec,
     pub(super) ignored_messages: UIntCounterVec,
-    pub(super) insert_messages: UIntCounterVec,
-    pub(super) update_messages: UIntCounterVec,
-    pub(super) delete_messages: UIntCounterVec,
+    pub(super) dml_messages: UIntCounterVec,
     pub(super) tables_in_publication: UIntGaugeVec,
     pub(super) wal_lsn: UIntGaugeVec,
 }
@@ -155,11 +152,6 @@ pub(super) struct PostgresSourceSpecificMetrics {
 impl PostgresSourceSpecificMetrics {
     fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
-            total_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_messages_total",
-                help: "The total number of replication messages for this source, not expected to be the sum of the other values.",
-                var_labels: ["source_id"],
-            )),
             transactions: registry.register(metric!(
                 name: "mz_postgres_per_source_transactions_total",
                 help: "The number of committed transactions for all tables in this source",
@@ -170,20 +162,10 @@ impl PostgresSourceSpecificMetrics {
                 help: "The number of messages ignored because of an irrelevant type or relation_id",
                 var_labels: ["source_id"],
             )),
-            insert_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_inserts",
-                help: "The number of inserts for all tables in this source",
-                var_labels: ["source_id"],
-            )),
-            update_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_updates",
-                help: "The number of updates for all tables in this source",
-                var_labels: ["source_id"],
-            )),
-            delete_messages: registry.register(metric!(
-                name: "mz_postgres_per_source_deletes",
-                help: "The number of deletes for all tables in this source",
-                var_labels: ["source_id"],
+            dml_messages: registry.register(metric!(
+                name: "mz_postgres_per_source_operations",
+                help: "The number of DML operations (INSERT/UPDATE/DELETE) for all tables in this source",
+                var_labels: ["source_id", "namespace", "table", "operation"],
             )),
             tables_in_publication: registry.register(metric!(
                 name: "mz_postgres_per_source_tables_count",

--- a/src/dataflow/src/source/postgres.rs
+++ b/src/dataflow/src/source/postgres.rs
@@ -519,8 +519,8 @@ impl PostgresSourceReader {
                                 // Ignore messages for tables we do not know about
                                 None => {
                                     self.metrics.ignored();
-                                    continue
-                                },
+                                    continue;
+                                }
                             }
                         }
                         Origin(_) | Type(_) => {

--- a/src/dataflow/src/source/postgres/metrics.rs
+++ b/src/dataflow/src/source/postgres/metrics.rs
@@ -7,51 +7,106 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use prometheus::core::AtomicU64;
+use std::collections::HashMap;
 
+use mz_dataflow_types::postgres_source::PostgresSourceDetails;
 use mz_expr::SourceInstanceId;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
+use prometheus::core::AtomicU64;
 
 use crate::source::metrics::SourceBaseMetrics;
 
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Hash, Copy, Clone)]
+pub enum PgOp {
+    INSERT,
+    UPDATE,
+    DELETE,
+}
+
+impl From<&PgOp> for String {
+    fn from(op: &PgOp) -> String {
+        match op {
+            PgOp::INSERT => String::from("INSERT"),
+            PgOp::UPDATE => String::from("UPDATE"),
+            PgOp::DELETE => String::from("DELETE"),
+        }
+    }
+}
 pub(super) struct PgSourceMetrics {
-    pub inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub updates: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub ignored: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub total: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub transactions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    pub tables: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
-    pub lsn: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    /// Maps table_oid -> operation -> DeleteOnDropCounter with appropriate tag values
+    table_ops: HashMap<u32, HashMap<PgOp, DeleteOnDropCounter<'static, AtomicU64, Vec<String>>>>,
+    ignored: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    transactions: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    tables: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    lsn: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
 impl PgSourceMetrics {
-    pub(super) fn new(base_metrics: &SourceBaseMetrics, source_id: SourceInstanceId) -> Self {
-        let labels = &[source_id.to_string()];
+    pub(super) fn new(
+        base_metrics: &SourceBaseMetrics,
+        source_id: SourceInstanceId,
+        pg_source: &PostgresSourceDetails,
+    ) -> Self {
         let pg_metrics = &base_metrics.postgres_source_specific;
+        let source_label = &[source_id.to_string()];
+        let ops = vec![PgOp::INSERT, PgOp::UPDATE, PgOp::DELETE];
+        let table_metrics = HashMap::from_iter(pg_source.tables.iter().map(|table| {
+            (
+                table.relation_id,
+                HashMap::from_iter(ops.iter().map(|o| {
+                    let labels = &[
+                        source_id.to_string(),
+                        table.namespace.clone(),
+                        table.name.clone(),
+                        o.into(),
+                    ];
+                    (
+                        *o,
+                        pg_metrics
+                            .dml_messages
+                            .get_delete_on_drop_counter(labels.to_vec()),
+                    )
+                })),
+            )
+        }));
+
         Self {
-            inserts: pg_metrics
-                .insert_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            updates: pg_metrics
-                .update_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            deletes: pg_metrics
-                .delete_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            ignored: pg_metrics
-                .ignored_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            total: pg_metrics
-                .total_messages
-                .get_delete_on_drop_counter(labels.to_vec()),
-            transactions: pg_metrics
-                .transactions
-                .get_delete_on_drop_counter(labels.to_vec()),
+            table_ops: table_metrics,
             tables: pg_metrics
                 .tables_in_publication
-                .get_delete_on_drop_gauge(labels.to_vec()),
-            lsn: pg_metrics.wal_lsn.get_delete_on_drop_gauge(labels.to_vec()),
+                .get_delete_on_drop_gauge(source_label.to_vec()),
+            lsn: pg_metrics
+                .wal_lsn
+                .get_delete_on_drop_gauge(source_label.to_vec()),
+            ignored: pg_metrics
+                .ignored_messages
+                .get_delete_on_drop_counter(source_label.to_vec()),
+            transactions: pg_metrics
+                .transactions
+                .get_delete_on_drop_counter(source_label.to_vec()),
         }
+    }
+
+    pub fn op(&self, table_id: u32, op: PgOp) {
+        self.table_ops
+            .get(&table_id)
+            .and_then(|t| t.get(&op))
+            .and_then(|ctr| Some(ctr.inc()));
+    }
+
+    pub fn lsn(&self, lsn: u64) {
+        self.lsn.set(lsn);
+    }
+
+    pub fn tables(&self) {
+        self.tables.inc();
+    }
+
+    pub fn transactions(&self) {
+        self.transactions.inc();
+    }
+
+    pub fn ignored(&self) {
+        self.ignored.inc();
     }
 }


### PR DESCRIPTION
This PR reworks the Postgres metrics to tag all relevant metrics with per table stats and consolidates insert/update/delete statements into "mz_postgres_per_source_operations" with an operation tag to allow distinguishing by type. Since cardinality is fixed and low using tags for these is a more "Prometheus"-y way of reporting which eliminates the need for a separate metric or doing arithmetic during queries to determine the total operations processed. 


### Motivation

   * This PR refactors existing code.
      - This updates the Postgres metrics to use tags with all of the metadata we have allowing for more precise analysis of the behavior of the Postgres source.

### Tips for reviewer
While the core user visible change here is metrics which are more specific but also more conducive to aggregation there is also a change to the exposure of instrumentation details to the code being instrumented. Originally this struct just held these wrapped structs and handed out references to them but with this PR I am trying out using associated functions to encapsulate the details of figuring out which counter to manipulate in what way with function calls that only accept arguments with types that are `Send` so that in the future if desirable this function call boundary can be used to immediately move the counter manipulation work off to another thread since it involves locking at some level whether its atomic types or more sophisticated locks.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Small changes to the Postgres per source metrics, `mz_postgres_per_source_inserts`, `mz_postgres_per_source_updates`, `mz_postgres_per_source_deletes`, and `mz_postgres_per_source_messages_total` have been removed in favor of `mz_postgres_per_source_operations` which includes an `operation` tag that distinguishes between the three operations. The value of this counter when not filtering by the `operation` tag will be the same as the `mz_postgres_per_source_messages_total` was previously. `mz_postgres_per_source_ignored` will also now include insert/update/delete messages for tables which are not part of the source (such as tables added to the Postgres publication after the Materialize source was created) where previously it only reported the number of `Origin` and `Type` messages received.
