### PR TITLE
consolidate the type of the current_values map in upsert_core

### DIFF
--- a/src/dataflow/src/render/upsert.rs
+++ b/src/dataflow/src/render/upsert.rs
@@ -390,54 +390,78 @@ where
                             // later retraction of the key (it will never decode correctly, but
                             // we could produce and then remove the error from the output).
                             match key {
-                                Some(Ok(decoded_key)) => {
-                                    let decoded_value = match data.value {
-                                        None => Ok(None),
-                                        Some(value) => match value {
-                                            Ok(row) => {
-                                                let envelope_value = match upsert_envelope.style {
-                                                    UpsertStyle::Debezium { after_idx } => {
-                                                        match row.iter().nth(after_idx).unwrap() {
-                                                            Datum::List(after) => {
+                                Some(decoded_key) => {
+                                    let (decoded_key, decoded_value): (
+                                        _,
+                                        Result<_, DataflowError>,
+                                    ) = match decoded_key {
+                                        Err(key_decode_error) => {
+                                            // placeholder value that will not be used
+                                            (
+                                                Err(key_decode_error.clone()),
+                                                Err(key_decode_error.into()),
+                                            )
+                                        }
+                                        Ok(decoded_key) => match data.value {
+                                            None => (Ok(decoded_key), Ok(None)),
+                                            Some(value) => {
+                                                let decoded_value = match value {
+                                                    Ok(row) => {
+                                                        let envelope_value = match upsert_envelope
+                                                            .style
+                                                        {
+                                                            UpsertStyle::Debezium { after_idx } => {
+                                                                match row
+                                                                    .iter()
+                                                                    .nth(after_idx)
+                                                                    .unwrap()
+                                                                {
+                                                                    Datum::List(after) => {
+                                                                        let mut datums =
+                                                                            Vec::with_capacity(
+                                                                                source_arity,
+                                                                            );
+                                                                        datums.extend(after.iter());
+                                                                        Some(datums)
+                                                                    }
+                                                                    Datum::Null => None,
+                                                                    d => panic!(
+                                                                    "type error: expected record, \
+                                                                        found {:?}",
+                                                                    d
+                                                                ),
+                                                                }
+                                                            }
+                                                            UpsertStyle::Default(_) => {
                                                                 let mut datums = Vec::with_capacity(
                                                                     source_arity,
                                                                 );
-                                                                datums.extend(after.iter());
+                                                                datums.extend(decoded_key.iter());
+                                                                datums.extend(row.iter());
                                                                 Some(datums)
                                                             }
-                                                            Datum::Null => None,
-                                                            d => panic!(
-                                                                "type error: expected record, \
-                                                                        found {:?}",
-                                                                d
-                                                            ),
+                                                        };
+
+                                                        if let Some(mut datums) = envelope_value {
+                                                            datums.extend(data.metadata.iter());
+                                                            evaluate(
+                                                                &datums,
+                                                                &predicates,
+                                                                &position_or,
+                                                                &mut row_packer,
+                                                            )
+                                                            .map_err(DataflowError::from)
+                                                        } else {
+                                                            Ok(None)
                                                         }
                                                     }
-                                                    UpsertStyle::Default(_) => {
-                                                        let mut datums =
-                                                            Vec::with_capacity(source_arity);
-                                                        datums.extend(decoded_key.iter());
-                                                        datums.extend(row.iter());
-                                                        Some(datums)
-                                                    }
+                                                    Err(err) => Err(err),
                                                 };
-
-                                                if let Some(mut datums) = envelope_value {
-                                                    datums.extend(data.metadata.iter());
-                                                    evaluate(
-                                                        &datums,
-                                                        &predicates,
-                                                        &position_or,
-                                                        &mut row_packer,
-                                                    )
-                                                    .map_err(DataflowError::from)
-                                                } else {
-                                                    Ok(None)
-                                                }
+                                                (Ok(decoded_key), decoded_value)
                                             }
-                                            Err(err) => Err(err),
                                         },
                                     };
+
                                     // Turns Ok(None) into None, and others into Some(OK) and Some(Err).
                                     // We store errors as well as non-None values, so that they can be
                                     // retracted if new rows show up for the same key.
@@ -462,7 +486,9 @@ where
                                                 res.map(|v| {
                                                     rehydrate(
                                                         &upsert_envelope.key_indices,
-                                                        &decoded_key,
+                                                        // The value is never Ok
+                                                        // unless the key is also
+                                                        &decoded_key.as_ref().unwrap(),
                                                         &v,
                                                         &mut row_packer,
                                                     )
@@ -473,7 +499,9 @@ where
                                             res.map(|v| {
                                                 rehydrate(
                                                     &upsert_envelope.key_indices,
-                                                    &decoded_key,
+                                                    // The value is never Ok
+                                                    // unless the key is also
+                                                    &decoded_key.as_ref().unwrap(),
                                                     &v,
                                                     &mut row_packer,
                                                 )
@@ -482,8 +510,12 @@ where
                                     };
 
                                     if let Some(old_value) = old_value {
-                                        // retract old value
-                                        session.give((old_value, cap.time().clone(), -1));
+                                        // Ensure we put the source in a permanently error'd state
+                                        // than to keep on trucking with wrong results.
+                                        if !decoded_key.is_err() {
+                                            // retract old value
+                                            session.give((old_value, cap.time().clone(), -1));
+                                        }
                                     }
                                     if let Some(new_value) = new_value {
                                         // give new value
@@ -491,11 +523,6 @@ where
                                     }
                                 }
                                 None => {}
-                                Some(Err(err)) => {
-                                    // This can never be retracted! But at least it's better to put the source in a
-                                    // permanently errored state than to keep on trucking with wrong results.
-                                    session.give((Err(err.into()), cap.time().clone(), 1));
-                                }
                             }
                         }
                     } else {


### PR DESCRIPTION
In this pr, I switch the `current_values` map in `upsert_core` to be a map of `Result<Row, ...> -> Result<Row, DataflowError>`
This is primarily to clean this code up to ready it for the merge with `persistent_upsert`, which stores key-values as `Result`''s always: https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/operators/upsert.rs#L182-L186

When we merge `upsert_core` and `persistent_upsert`, this will simplify the code and behavioral changes.

Additionally, we NEVER retract if the decoded key is an `Err`. This is the match the previous behavior of the `upsert` operator.  This is because unrelated err's could be `==` if they have the same message, so we ensure that new key errors that come along cause new errors to be written out, but NEVER are retracted. We can imagine a world where we enhance the way errors work to allow retraction, tho.

<details>
  <summary>Extra details</summary>
  
When I merge persistent_upsert into this code, their will be a subtlety for me to point out in a comment; basically, persist may pre-populate the `current_values` map with decode error keys, but they may never be observed, unless a new decode error key comes along; the error case being propagated seems to be happen here: https://github.com/MaterializeInc/materialize/blob/main/src/persist/src/operators/upsert.rs#L277-L290. I will make sure my comment explains this (I hope its accurate) in the later pr. In that case, this pr is mostly a mechanical type change that makes that pr easier to review and digest

</details>


### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

