### PR TITLE
pgcopy: invert dependency on sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,6 +3068,7 @@ dependencies = [
  "mz-kafka-util",
  "mz-ore",
  "mz-persist-types",
+ "mz-pgcopy",
  "mz-pgrepr",
  "mz-postgres-util",
  "mz-repr",
@@ -3667,7 +3668,6 @@ dependencies = [
  "csv",
  "mz-pgrepr",
  "mz-repr",
- "mz-sql",
 ]
 
 [[package]]
@@ -3900,6 +3900,7 @@ dependencies = [
  "mz-kafka-util",
  "mz-lowertest",
  "mz-ore",
+ "mz-pgcopy",
  "mz-pgrepr",
  "mz-postgres-util",
  "mz-repr",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -26,6 +26,7 @@ mz-expr = { path = "../expr" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-types = { path = "../persist-types" }
+mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -15,12 +15,13 @@ use std::sync::Arc;
 use derivative::Derivative;
 use serde::Serialize;
 use tokio::sync::oneshot;
+use tokio::sync::watch;
 
 use mz_ore::str::StrExt;
+use mz_pgcopy::CopyFormatParams;
 use mz_repr::{GlobalId, Row, ScalarType};
 use mz_sql::ast::{FetchDirection, NoticeSeverity, ObjectType, Raw, Statement};
 use mz_sql::plan::ExecuteTimeout;
-use tokio::sync::watch;
 
 use crate::coord::PeekResponseUnary;
 use crate::error::CoordError;
@@ -180,7 +181,7 @@ pub enum ExecuteResponse {
     CopyFrom {
         id: GlobalId,
         columns: Vec<usize>,
-        params: mz_sql::plan::CopyParams,
+        params: CopyFormatParams<'static>,
     },
     /// The requested connection was created.
     CreatedConnection {

--- a/src/pgcopy/Cargo.toml
+++ b/src/pgcopy/Cargo.toml
@@ -11,4 +11,3 @@ bytes = "1.1.0"
 csv = "1.1.6"
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
-mz-sql = { path = "../sql" }

--- a/src/pgcopy/src/copy.rs
+++ b/src/pgcopy/src/copy.rs
@@ -17,8 +17,7 @@ use csv::ReaderBuilder;
 use mz_repr::{Datum, RelationType, Row, RowArena};
 use mz_sql::plan::{CopyFormat, CopyParams};
 
-// This is equivalent to a backslash followed by a dot, i.e "\."
-static END_OF_COPY_MARKER: [u8; 2] = [92, 46];
+const END_OF_COPY_MARKER: &[u8] = b"\\.";
 
 #[derive(Debug)]
 pub struct CopyErrorNotSupportedResponse {
@@ -143,12 +142,8 @@ impl<'a> CopyTextFormatParser<'a> {
         self.peek().is_none() || self.is_end_of_copy_marker()
     }
 
-    fn end_of_copy_marker() -> &'static [u8] {
-        &END_OF_COPY_MARKER
-    }
-
     pub fn is_end_of_copy_marker(&self) -> bool {
-        self.check_bytes(Self::end_of_copy_marker())
+        self.check_bytes(END_OF_COPY_MARKER)
     }
 
     fn is_end_of_line(&self) -> bool {

--- a/src/pgcopy/src/lib.rs
+++ b/src/pgcopy/src/lib.rs
@@ -16,4 +16,4 @@
 mod copy;
 
 pub use copy::{decode_copy_format, encode_copy_row_binary, encode_copy_row_text};
-pub use copy::{CopyErrorNotSupportedResponse, CopyFormatParams, CopyTextFormatParser};
+pub use copy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams, CopyTextFormatParser};

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -16,7 +16,6 @@ use mz_coord::session::ClientSeverity as CoordClientSeverity;
 use mz_coord::session::TransactionStatus as CoordTransactionStatus;
 use mz_coord::{CoordError, StartupMessage};
 use mz_expr::EvalError;
-use mz_pgcopy::CopyErrorNotSupportedResponse;
 use mz_repr::{ColumnName, NotNullViolation, RelationDesc};
 
 // Pgwire protocol versions are represented as 32-bit integers, where the
@@ -444,12 +443,6 @@ impl ErrorResponse {
     pub fn with_position(mut self, position: usize) -> ErrorResponse {
         self.position = Some(position);
         self
-    }
-}
-
-impl From<CopyErrorNotSupportedResponse> for ErrorResponse {
-    fn from(error: CopyErrorNotSupportedResponse) -> Self {
-        ErrorResponse::error(SqlState::FEATURE_NOT_SUPPORTED, error.message)
     }
 }
 

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -23,6 +23,7 @@ mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-ore = { path = "../ore", features = ["task"] }
+mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -37,6 +37,7 @@ use mz_dataflow_types::sinks::{SinkConnectionBuilder, SinkEnvelope};
 use mz_dataflow_types::sources::SourceConnection;
 use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
+use mz_pgcopy::CopyFormatParams;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
@@ -334,7 +335,7 @@ pub struct SendRowsPlan {
 pub struct CopyFromPlan {
     pub id: GlobalId,
     pub columns: Vec<usize>,
-    pub params: CopyParams,
+    pub params: CopyFormatParams<'static>,
 }
 
 #[derive(Debug)]
@@ -557,16 +558,6 @@ pub enum CopyFormat {
     Text,
     Csv,
     Binary,
-}
-
-#[derive(Debug, Clone)]
-pub struct CopyParams {
-    pub format: CopyFormat,
-    pub null: Option<String>,
-    pub delimiter: Option<String>,
-    pub quote: Option<String>,
-    pub escape: Option<String>,
-    pub header: Option<bool>,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/test/pgtest-mz/copy-from-csv.pt
+++ b/test/pgtest-mz/copy-from-csv.pt
@@ -187,11 +187,11 @@ ReadyForQuery
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote must be a single one-byte character"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY quote must be a single one-byte character"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape must be a single one-byte character"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY escape must be a single one-byte character"}]}
 ReadyForQuery {"status":"I"}
 
 send
@@ -208,9 +208,9 @@ ReadyForQuery
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY delimiter and quote must be different"}]}
 ReadyForQuery {"status":"I"}

--- a/test/pgtest/copy-from-2.pt
+++ b/test/pgtest/copy-from-2.pt
@@ -333,7 +333,7 @@ until
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY delimiter must be a single one-byte character"}]}
 ReadyForQuery {"status":"I"}
 
 send
@@ -350,9 +350,9 @@ ReadyForQuery
 ErrorResponse
 ReadyForQuery
 ----
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY quote available only in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY quote available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY escape available only in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY escape available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}
-ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"0A000"},{"typ":"M","value":"COPY HEADER available only in CSV mode"}]}
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"},{"typ":"C","value":"XX000"},{"typ":"M","value":"COPY HEADER available only in CSV mode"}]}
 ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Make sql depend on pgcopy, rather than vice-versa. This prevents changes
to sql requiring that the dataflow crate be recompiled, which is slow.
(dataflow depends on pgcopy).

Doing it this way is also keeps the responsbility for translating a SQL
AST into a more structured type *in* the sql crate. The previous
CopyParams struct exported by the sql crate was basically just the AST
for the COPY statement, and the responsibility of validating that AST
was kicked downstream (i.e., to pgcopy). Better for pgcopy to assert its
needs (via the properly-structured CopyFormatParams type) and let the
sql crate do the hard work of producing that struct.

### Motivation

* This PR refactors existing code to make compiling the sql crate fast again!

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
