### PR TITLE
coord: make session and dataflow builder generic

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -260,9 +260,9 @@ struct PendingPeek {
 }
 
 /// State provided to a catalog transaction closure.
-pub struct CatalogTxn<'a> {
+pub struct CatalogTxn<'a, T> {
     dataflow_client:
-        &'a mz_dataflow_types::client::Controller<Box<dyn mz_dataflow_types::client::Client>>,
+        &'a mz_dataflow_types::client::Controller<Box<dyn mz_dataflow_types::client::Client<T>>>,
     catalog: &'a CatalogState,
     persister: &'a PersisterWithConfig,
 }
@@ -3967,7 +3967,7 @@ impl Coordinator {
     /// [`CatalogState`]: crate::catalog::CatalogState
     async fn catalog_transact<F, R>(&mut self, ops: Vec<catalog::Op>, f: F) -> Result<R, CoordError>
     where
-        F: FnOnce(CatalogTxn) -> Result<R, CoordError>,
+        F: FnOnce(CatalogTxn<Timestamp>) -> Result<R, CoordError>,
     {
         let mut sources_to_drop = vec![];
         let mut tables_to_drop = vec![];
@@ -5268,3 +5268,10 @@ mod timeline {
         }
     }
 }
+
+pub trait CoordTimestamp:
+    timely::progress::Timestamp + differential_dataflow::lattice::Lattice + std::fmt::Debug
+{
+}
+
+impl CoordTimestamp for mz_repr::Timestamp {}

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1537,7 +1537,10 @@ impl Coordinator {
 
     /// Handle removing in-progress transaction state regardless of the end action
     /// of the transaction.
-    async fn clear_transaction(&mut self, session: &mut Session) -> TransactionStatus {
+    async fn clear_transaction(
+        &mut self,
+        session: &mut Session,
+    ) -> TransactionStatus<mz_repr::Timestamp> {
         let (drop_sinks, txn) = session.clear_transaction();
         self.drop_sinks(drop_sinks).await;
 

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -23,10 +23,11 @@ use tokio::sync::OwnedMutexGuard;
 use mz_dataflow_types::client::ComputeInstanceId;
 use mz_expr::GlobalId;
 use mz_pgrepr::Format;
-use mz_repr::{Datum, Diff, Row, ScalarType, Timestamp};
+use mz_repr::{Datum, Diff, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 
+use crate::coord::CoordTimestamp;
 use crate::error::CoordError;
 
 mod vars;
@@ -39,20 +40,20 @@ const DUMMY_CONNECTION_ID: u32 = 0;
 
 /// A session holds per-connection state.
 #[derive(Debug)]
-pub struct Session {
+pub struct Session<T = mz_repr::Timestamp> {
     conn_id: u32,
     prepared_statements: HashMap<String, PreparedStatement>,
     portals: HashMap<String, Portal>,
-    transaction: TransactionStatus,
+    transaction: TransactionStatus<T>,
     pcx: Option<PlanContext>,
     user: String,
     vars: Vars,
     drop_sinks: Vec<(ComputeInstanceId, GlobalId)>,
 }
 
-impl Session {
+impl<T: CoordTimestamp> Session<T> {
     /// Creates a new session for the specified connection ID.
-    pub fn new(conn_id: u32, user: String) -> Session {
+    pub fn new(conn_id: u32, user: String) -> Session<T> {
         assert_ne!(conn_id, DUMMY_CONNECTION_ID);
         Self::new_internal(conn_id, user)
     }
@@ -61,11 +62,11 @@ impl Session {
     ///
     /// Dummy sessions are intended for use when executing queries on behalf of
     /// the system itself, rather than on behalf of a user.
-    pub fn dummy() -> Session {
+    pub fn dummy() -> Session<T> {
         Self::new_internal(DUMMY_CONNECTION_ID, "mz_system".into())
     }
 
-    fn new_internal(conn_id: u32, user: String) -> Session {
+    fn new_internal(conn_id: u32, user: String) -> Session<T> {
         Session {
             conn_id,
             transaction: TransactionStatus::Default,
@@ -143,7 +144,9 @@ impl Session {
     /// and
     /// > An unnamed portal is destroyed at the end of the transaction
     #[must_use]
-    pub fn clear_transaction(&mut self) -> (Vec<(ComputeInstanceId, GlobalId)>, TransactionStatus) {
+    pub fn clear_transaction(
+        &mut self,
+    ) -> (Vec<(ComputeInstanceId, GlobalId)>, TransactionStatus<T>) {
         self.portals.clear();
         self.pcx = None;
         let drop_sinks = mem::take(&mut self.drop_sinks);
@@ -166,13 +169,13 @@ impl Session {
     }
 
     /// Returns the current transaction status.
-    pub fn transaction(&self) -> &TransactionStatus {
+    pub fn transaction(&self) -> &TransactionStatus<T> {
         &self.transaction
     }
 
     /// Adds operations to the current transaction. An error is produced if they
     /// cannot be merged (i.e., a read cannot be merged to an insert).
-    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps) -> Result<(), CoordError> {
+    pub fn add_transaction_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), CoordError> {
         match &mut self.transaction {
             TransactionStatus::Started(Transaction { ops, access, .. })
             | TransactionStatus::InTransaction(Transaction { ops, access, .. })
@@ -231,7 +234,7 @@ impl Session {
     ///
     /// Returns `None` if there is no active transaction, or if the active
     /// transaction is not a read transaction.
-    pub fn get_transaction_timestamp(&self) -> Option<Timestamp> {
+    pub fn get_transaction_timestamp(&self) -> Option<T> {
         // If the transaction already has a peek timestamp, use it. Otherwise generate
         // one. We generate one even though we could check here that the transaction
         // isn't in some other conflicting state because we want all of that logic to
@@ -242,7 +245,7 @@ impl Session {
                 ops: TransactionOps::Peeks(ts),
                 write_lock_guard: _,
                 access: _,
-            }) => Some(*ts),
+            }) => Some(ts.clone()),
             _ => None,
         }
     }
@@ -518,25 +521,25 @@ pub type RowBatchStream = UnboundedReceiver<Vec<Row>>;
 ///
 /// PostgreSQL's transaction states are in backend/access/transam/xact.c.
 #[derive(Debug)]
-pub enum TransactionStatus {
+pub enum TransactionStatus<T> {
     /// Idle. Matches `TBLOCK_DEFAULT`.
     Default,
     /// Running a single-query transaction. Matches `TBLOCK_STARTED`.
-    Started(Transaction),
+    Started(Transaction<T>),
     /// Currently in a transaction issued from a `BEGIN`. Matches `TBLOCK_INPROGRESS`.
-    InTransaction(Transaction),
+    InTransaction(Transaction<T>),
     /// Currently in an implicit transaction started from a multi-statement query
     /// with more than 1 statements. Matches `TBLOCK_IMPLICIT_INPROGRESS`.
-    InTransactionImplicit(Transaction),
+    InTransactionImplicit(Transaction<T>),
     /// In a failed transaction that was started explicitly (i.e., previously
     /// InTransaction). We do not use Failed for implicit transactions because
     /// those cleanup after themselves. Matches `TBLOCK_ABORT`.
-    Failed(Transaction),
+    Failed(Transaction<T>),
 }
 
-impl TransactionStatus {
+impl<T> TransactionStatus<T> {
     /// Extracts the inner transaction ops if not failed.
-    pub fn into_ops(self) -> Option<TransactionOps> {
+    pub fn into_ops(self) -> Option<TransactionOps<T>> {
         match self {
             TransactionStatus::Default | TransactionStatus::Failed(_) => None,
             TransactionStatus::Started(txn)
@@ -546,7 +549,7 @@ impl TransactionStatus {
     }
 
     /// Exposes the inner transaction.
-    pub fn inner(&self) -> Option<&Transaction> {
+    pub fn inner(&self) -> Option<&Transaction<T>> {
         match self {
             TransactionStatus::Default => None,
             TransactionStatus::Started(txn)
@@ -557,7 +560,7 @@ impl TransactionStatus {
     }
 
     /// Exposes the inner transaction.
-    pub fn inner_mut(&mut self) -> Option<&mut Transaction> {
+    pub fn inner_mut(&mut self) -> Option<&mut Transaction<T>> {
         match self {
             TransactionStatus::Default => None,
             TransactionStatus::Started(txn)
@@ -595,7 +598,7 @@ impl TransactionStatus {
     }
 }
 
-impl Default for TransactionStatus {
+impl<T> Default for TransactionStatus<T> {
     fn default() -> Self {
         TransactionStatus::Default
     }
@@ -603,18 +606,18 @@ impl Default for TransactionStatus {
 
 /// State data for transactions.
 #[derive(Debug)]
-pub struct Transaction {
+pub struct Transaction<T> {
     /// Plan context.
     pub pcx: PlanContext,
     /// Transaction operations.
-    pub ops: TransactionOps,
+    pub ops: TransactionOps<T>,
     /// Holds the coordinator's write lock.
     write_lock_guard: Option<OwnedMutexGuard<()>>,
     /// Access mode (read only, read write).
     access: Option<TransactionAccessMode>,
 }
 
-impl Transaction {
+impl<T> Transaction<T> {
     /// Grants the write lock to this transaction for the remainder of its lifetime.
     fn grant_write_lock(&mut self, guard: OwnedMutexGuard<()>) {
         self.write_lock_guard = Some(guard);
@@ -627,12 +630,12 @@ impl Transaction {
 /// a transaction. Use this to record what we have done, and what may need to
 /// happen at commit.
 #[derive(Debug, Clone, PartialEq)]
-pub enum TransactionOps {
+pub enum TransactionOps<T> {
     /// The transaction has been initiated, but no statement has yet been executed
     /// in it.
     None,
     /// This transaction has had a peek (`SELECT`, `TAIL`) and must only do other peeks.
-    Peeks(Timestamp),
+    Peeks(T),
     /// This transaction has done a TAIL and must do nothing else.
     Tail,
     /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must only do

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -270,9 +270,9 @@ pub enum TransactionStatus {
     Failed,
 }
 
-impl From<&CoordTransactionStatus> for TransactionStatus {
+impl<T> From<&CoordTransactionStatus<T>> for TransactionStatus {
     /// Convert from the Session's version
-    fn from(status: &CoordTransactionStatus) -> TransactionStatus {
+    fn from(status: &CoordTransactionStatus<T>) -> TransactionStatus {
         match status {
             CoordTransactionStatus::Default => TransactionStatus::Idle,
             CoordTransactionStatus::Started(_) => TransactionStatus::InTransaction,


### PR DESCRIPTION
Transaction ops live in Sessions, and they hold Timestamps for Peek operations. Also work on dataflow builder while here. Start a new CoordTimestamp trait as a common place to dump trait definitions instead of copying them all over.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing changes.
