### PR TITLE
feature-benchmark: Increase CI timeout to 3 hours

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -47,7 +47,7 @@ steps:
 
   - id: feature-benchmark
     label: "Feature benchmark against latest release"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
@@ -57,7 +57,7 @@ steps:
 
   - id: feature-benchmark-persistence
     label: "Feature benchmark against latest release with persistence"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark


### PR DESCRIPTION
We have now accumulated more than 1h 30min worth of benchmark scenarios
so sometimes the previous timeout of 2h was not sufficient.