### PR TITLE
ore: introduce a canceling retry_async variant

### DIFF
--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -62,6 +62,7 @@ use std::thread;
 use futures::{ready, Stream, StreamExt};
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, ReadBuf};
+use tokio::time::error::Elapsed;
 use tokio::time::{self, Duration, Instant, Sleep};
 
 /// The state of a retry operation constructed with [`Retry`].
@@ -211,6 +212,36 @@ impl Retry {
             }
         }
         Err(err.expect("retry produces at least one element"))
+    }
+
+    /// Like [`Retry::retry_async`] but the operation will be canceled if the
+    /// maximum duration is reached.
+    ///
+    /// Specifically, if the maximum duration is reached, the operation `f` will
+    /// be forcibly canceled by dropping it, and an [`Elapsed`] error will be
+    /// returned. Canceling `f` can be surprising if the operation is not
+    /// programmed to expect the possibility of not resuming from an `await`
+    /// point; if you wish to always run `f` to completion, use
+    /// [`Retry::retry_async`] instead.
+    pub async fn retry_async_canceling<F, U, T, E>(self, mut f: F) -> Result<T, E>
+    where
+        F: FnMut(RetryState) -> U,
+        U: Future<Output = Result<T, E>>,
+        E: From<Elapsed>,
+    {
+        let start = Instant::now();
+        let max_duration = self.max_duration;
+        self.retry_async(|state| {
+            let fut = time::timeout(max_duration.saturating_sub(start.elapsed()), f(state));
+            async move {
+                match fut.await {
+                    Ok(Ok(t)) => Ok(t),
+                    Ok(Err(e)) => Err(e),
+                    Err(e) => Err(e.into()),
+                }
+            }
+        })
+        .await
     }
 
     /// Convert into [`RetryStream`]

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -280,7 +280,7 @@ impl State {
     async fn delete_bucket_objects(&self, bucket: String) -> Result<(), anyhow::Error> {
         Retry::default()
             .max_duration(self.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 // loop until error or response has no continuation token
                 let mut continuation_token = None;
                 loop {
@@ -319,7 +319,7 @@ impl State {
     pub async fn reset_sqs(&self) -> Result<(), anyhow::Error> {
         Retry::default()
             .max_duration(self.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 for queue_url in &self.sqs_queues_created {
                     self.sqs_client
                         .delete_queue()

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -141,7 +141,7 @@ impl Action for VerifyAction {
     async fn redo(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
         let path = Retry::default()
             .max_duration(state.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 let row = state
                     .pgclient
                     .query_one(

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -87,7 +87,7 @@ impl Action for AddPartitionsAction {
 
         Retry::default()
             .max_duration(state.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 let metadata = state.kafka_producer.client().fetch_metadata(
                     Some(&topic_name),
                     Some(cmp::max(state.default_timeout, Duration::from_secs(1))),

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -57,7 +57,7 @@ impl Action for CreateStreamAction {
 
         Retry::default()
             .max_duration(cmp::max(state.default_timeout, Duration::from_secs(60)))
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 let description = state
                     .kinesis_client
                     .describe_stream()

--- a/src/testdrive/src/action/kinesis/ingest.rs
+++ b/src/testdrive/src/action/kinesis/ingest.rs
@@ -60,7 +60,7 @@ impl Action for IngestAction {
             // be prepared to back off.
             Retry::default()
                 .max_duration(state.default_timeout)
-                .retry_async(|_| async {
+                .retry_async_canceling(|_| async {
                     match state
                         .kinesis_client
                         .put_record()

--- a/src/testdrive/src/action/kinesis/update_shards.rs
+++ b/src/testdrive/src/action/kinesis/update_shards.rs
@@ -63,7 +63,7 @@ impl Action for UpdateShardCountAction {
         // Verify the current shard count.
         Retry::default()
             .max_duration(cmp::max(state.default_timeout, Duration::from_secs(60)))
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 // Wait for shards to stop updating.
                 let description = state
                     .kinesis_client

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -57,7 +57,7 @@ impl Action for VerifySlotAction {
         Retry::default()
             .initial_backoff(Duration::from_millis(50))
             .max_duration(cmp::max(state.default_timeout, Duration::from_secs(3)))
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 println!(">> checking for postgres replication slot {}", &self.slot);
                 let rows = client
                     .query(

--- a/src/testdrive/src/action/schema_registry.rs
+++ b/src/testdrive/src/action/schema_registry.rs
@@ -95,7 +95,7 @@ impl Action for WaitSchemaAction {
             .initial_backoff(Duration::from_millis(50))
             .factor(1.5)
             .max_duration(state.timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 state
                     .ccsr_client
                     .get_schema_by_subject(&self.schema)

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -131,7 +131,7 @@ impl Action for SqlAction {
                 .max_duration(state.timeout),
             false => Retry::default().max_tries(1),
         }
-        .retry_async(|retry_state| async move {
+        .retry_async_canceling(|retry_state| async move {
             match self.try_redo(state, &query).await {
                 Ok(()) => {
                     if retry_state.i != 0 {

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -57,7 +57,7 @@ impl Action for VerifyTimestampCompactionAction {
             Retry::default()
                 .initial_backoff(Duration::from_secs(1))
                 .max_duration(Duration::from_secs(30))
-                .retry_async(|retry_state| {
+                .retry_async_canceling(|retry_state| {
                     let initial_highest = Arc::clone(&initial_highest_base);
                     async move {
                         let mut catalog = Catalog::open_debug(path, NOW_ZERO.clone())

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -29,7 +29,7 @@ SERVICES = [
     SchemaRegistry(kafka_servers=[("kafka", f"{KAFKA_SINK_PORT}")]),
     Materialized(),
     Toxiproxy(),
-    Testdrive(kafka_url="toxiproxy:9093"),
+    Testdrive(kafka_url="toxiproxy:9093", default_timeout="120s"),
 ]
 
 #


### PR DESCRIPTION
It is often desirable to forcibly terminate the operation under retry
when the max duration is reached. Add a `retry_async_canceling` variant
that does this, and use this in testdrive.

Alternative to https://github.com/MaterializeInc/materialize/pull/11172.

### Motivation

  * This PR fixes a previously unreported bug: CI hangs forever if a `SELECT` statement wedges.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
