### PR TITLE
Support mutually recursive dataflows

### DIFF
--- a/src/compute/src/render/recursion.rs
+++ b/src/compute/src/render/recursion.rs
@@ -1,0 +1,223 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
+
+use timely::communication::Allocate;
+use timely::dataflow::scopes::Child;
+use timely::dataflow::Scope;
+use timely::order::Product;
+use timely::worker::Worker as TimelyWorker;
+
+use mz_dataflow_types::*;
+use mz_expr::Id;
+use mz_ore::collections::CollectionExt as IteratorExt;
+use mz_repr::GlobalId;
+use mz_repr::Row;
+
+use crate::arrangement::manager::TraceBundle;
+use crate::compute_state::ComputeState;
+pub use crate::render::context::CollectionBundle;
+use crate::render::context::{ArrangementFlavor, Context};
+use mz_storage::boundary::ComputeReplay;
+
+use super::RenderTimestamp;
+
+/// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
+///
+/// This method imports sources from provided assets, and then builds the remaining
+/// dataflow using "compute-local" assets like shared arrangements, and producing
+/// both arrangements and sinks.
+pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
+    timely_worker: &mut TimelyWorker<A>,
+    compute_state: &mut ComputeState,
+    dataflow: DataflowDescription<mz_dataflow_types::plan::Plan>,
+    boundary: &mut B,
+) {
+    let worker_logging = timely_worker.log_register().get("timely");
+    let name = format!("Dataflow: {}", &dataflow.debug_name);
+
+    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
+        // The scope.clone() occurs to allow import in the region.
+        // We build a region here to establish a pattern of a scope inside the dataflow,
+        // so that other similar uses (e.g. with iterative scopes) do not require weird
+        // alternate type signatures.
+        scope.clone().iterative::<usize, _, _>(|region| {
+            let mut context = crate::render::context::Context::for_dataflow(
+                &dataflow,
+                scope.addr().into_element(),
+            );
+            let mut tokens = BTreeMap::new();
+
+            // Import declared sources into the rendering context.
+            for (source_id, source) in dataflow.source_imports.iter() {
+                let request = SourceInstanceRequest {
+                    source_id: *source_id,
+                    dataflow_id: dataflow.id,
+                    arguments: source.arguments.clone(),
+                    as_of: dataflow.as_of.clone().unwrap(),
+                };
+
+                let (mut ok, mut err, token) =
+                    boundary.replay(scope, &format!("{name}-{source_id}"), request);
+
+                // We do not trust `replay` to correctly advance times.
+                use differential_dataflow::lattice::Lattice;
+                use differential_dataflow::AsCollection;
+                use timely::dataflow::operators::Map;
+                let as_of_frontier1 = dataflow.as_of.clone().unwrap();
+                ok = ok
+                    .inner
+                    .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
+                    .as_collection();
+
+                let as_of_frontier2 = dataflow.as_of.clone().unwrap();
+                err = err
+                    .inner
+                    .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
+                    .as_collection();
+
+                let ok = ok.enter(region);
+                let err = err.enter(region);
+
+                // Associate collection bundle with the source identifier.
+                context.insert_id(
+                    mz_expr::Id::Global(*source_id),
+                    crate::render::CollectionBundle::from_collections(ok, err),
+                );
+                // Associate returned tokens with the source identifier.
+                tokens.insert(*source_id, token);
+            }
+
+            // Import declared indexes into the rendering context.
+            for (idx_id, idx) in &dataflow.index_imports {
+                context.import_index(compute_state, &mut tokens, scope, region, *idx_id, &idx.0);
+            }
+
+            // We first determine indexes and sinks to export, then build the declared object, and
+            // finally export indexes and sinks. The reason for this is that we want to avoid
+            // cloning the dataflow plan for `build_object`, which can be expensive.
+
+            // Determine indexes to export
+            let indexes = dataflow
+                .index_exports
+                .iter()
+                .map(|(idx_id, (idx, _typ))| (*idx_id, dataflow.depends_on(idx.on_id), idx.clone()))
+                .collect::<Vec<_>>();
+
+            // Determine sinks to export
+            let sinks = dataflow
+                .sink_exports
+                .iter()
+                .map(|(sink_id, sink)| (*sink_id, dataflow.depends_on(sink.from), sink.clone()))
+                .collect::<Vec<_>>();
+
+            // Build declared objects.
+            let mut variables = BTreeMap::new();
+            for object in dataflow.objects_to_build.iter() {
+                use differential_dataflow::operators::iterate::Variable;
+
+                let oks_v = Variable::new(region, Product::new(Default::default(), 1));
+                let err_v = Variable::new(region, Product::new(Default::default(), 1));
+
+                context.insert_id(
+                    Id::Global(object.id),
+                    CollectionBundle::from_collections(oks_v.clone(), err_v.clone()),
+                );
+                variables.insert(object.id, (oks_v, err_v));
+            }
+            for object in dataflow.objects_to_build {
+                let id = object.id;
+                let bundle = context.render_plan(object.plan, region, region.index());
+                let (oks_v, err_v) = variables.remove(&id).unwrap();
+                let (oks, err) = bundle.collection.clone().unwrap();
+                context.insert_id(Id::Global(object.id), bundle);
+                oks_v.set(&oks);
+                err_v.set(&err);
+            }
+
+            // Export declared indexes.
+            for (idx_id, imports, idx) in indexes {
+                context.export_index_recursive(compute_state, &mut tokens, imports, idx_id, &idx);
+            }
+
+            // Export declared sinks.
+            for (sink_id, imports, sink) in sinks {
+                context.export_sink(compute_state, &mut tokens, imports, sink_id, &sink);
+            }
+        });
+    })
+}
+
+// This implementation block requires the scopes have the same timestamp as the trace manager.
+// That makes some sense, because we are hoping to deposit an arrangement in the trace manager.
+impl<'g, G, T> Context<Child<'g, G, T>, Row>
+where
+    G: Scope<Timestamp = mz_repr::Timestamp>,
+    T: RenderTimestamp,
+{
+    pub(crate) fn export_index_recursive(
+        &mut self,
+        compute_state: &mut ComputeState,
+        tokens: &mut BTreeMap<GlobalId, Rc<dyn std::any::Any>>,
+        import_ids: BTreeSet<GlobalId>,
+        idx_id: GlobalId,
+        idx: &IndexDesc,
+    ) {
+        // put together tokens that belong to the export
+        let mut needed_tokens = Vec::new();
+        for import_id in import_ids {
+            if let Some(token) = tokens.get(&import_id) {
+                needed_tokens.push(Rc::clone(&token));
+            }
+        }
+        let bundle = self.lookup_id(Id::Global(idx_id)).unwrap_or_else(|| {
+            panic!(
+                "Arrangement alarmingly absent! id: {:?}",
+                Id::Global(idx_id)
+            )
+        });
+        match bundle.arrangement(&idx.key) {
+            Some(ArrangementFlavor::Local(oks, errs)) => {
+                use differential_dataflow::operators::arrange::Arrange;
+                let oks = oks
+                    .as_collection(|k, v| (k.clone(), v.clone()))
+                    .leave()
+                    .arrange();
+                let errs = errs
+                    .as_collection(|k, v| (k.clone(), v.clone()))
+                    .leave()
+                    .arrange();
+                compute_state.traces.set(
+                    idx_id,
+                    TraceBundle::new(oks.trace, errs.trace).with_drop(needed_tokens),
+                );
+            }
+            Some(ArrangementFlavor::Trace(gid, _, _)) => {
+                // Duplicate of existing arrangement with id `gid`, so
+                // just create another handle to that arrangement.
+                let trace = compute_state.traces.get(&gid).unwrap().clone();
+                compute_state.traces.set(idx_id, trace);
+            }
+            None => {
+                println!("collection available: {:?}", bundle.collection.is_none());
+                println!(
+                    "keys available: {:?}",
+                    bundle.arranged.keys().collect::<Vec<_>>()
+                );
+                panic!(
+                    "Arrangement alarmingly absent! id: {:?}, keys: {:?}",
+                    Id::Global(idx_id),
+                    &idx.key
+                );
+            }
+        };
+    }
+}

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -330,7 +330,13 @@ where
     }
 
     /// Like `depends_on`, but appends to an existing `BTreeSet`.
+    ///
+    /// This method includes identifiers for e.g. intermediate views, and should be filtered
+    /// if one only wants sources and indexes.
+    ///
+    /// This method is safe for mutually recursive view defintions.
     pub fn depends_on_into(&self, collection_id: GlobalId, out: &mut BTreeSet<GlobalId>) {
+        out.insert(collection_id);
         if self.source_imports.contains_key(&collection_id) {
             // The collection is provided by an imported source. Report the
             // dependency on the source.
@@ -358,7 +364,9 @@ where
         // It must be a collection whose plan we have handy. Recurse.
         let build = self.build_desc(collection_id);
         for id in build.plan.depends_on() {
-            self.depends_on_into(id, out)
+            if !out.contains(&id) {
+                self.depends_on_into(id, out)
+            }
         }
     }
 


### PR DESCRIPTION
This PR generalizes the `dataflow/render` code to be aware of "mutually recursive" dataflows, in which the constructed views may reference themselves, and any other identifiers in the `objects_to_build` list of the `DataflowDescription`.

The main technique is to 1. observe when this might happen (by looking at ids and dependencies) and then 2. in that case creating an iterative scope rather than a `Region`. Various actions are painful on the iterative scope, for example extracting arrangements to store. It is much harder to "borrow" an output arrangement, as the timestamps are not the same in the inner scope as we want to record. We usually just do more work, converting the data to a `Collection<(Row, Row)>`, extracting it from the scope, and re-arranging it.

The code has bugs at the moment. It will panic if a constructed object does not produce a `Collection` as part of its output. That is, if the object only produces arrangements, we are in a sticky spot of not having a collection to feed back through a `Variable`. We panic in this case. With some more forethought, we could have formed a `Variable<(Row, Row)>` corresponding to any one of the output arrangements, looped that data around, and then re-arranged it.

---

As far as I can tell, there is fairly little incidental fall out. Sinks have one additional operator they go through now to convert timestamps, that will be a no-op for conventional dataflows. We could copy/paste the whole method to remove that, I wouldn't mind should anyone be stressed by it. I also changed the behavior of `depends_on_into` to report intermediate identifiers (to converge in a fixed point); I documented it, and I don't know if it is in or out of spec.

### Motivation

Mutual recursion is cool. Not cool enough that we have to merge this, but it is really cool.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
