### PR TITLE
Modify planner to work with augmented statements

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -40,12 +40,12 @@ use mz_pgrepr::oid::FIRST_USER_OID;
 use mz_repr::Timestamp;
 use mz_repr::{RelationDesc, ScalarType};
 use mz_sql::ast::display::AstDisplay;
-use mz_sql::ast::{Expr, Raw};
+use mz_sql::ast::Expr;
 use mz_sql::catalog::{
     CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
     CatalogItemType as SqlCatalogItemType, CatalogTypeDetails, SessionCatalog,
 };
-use mz_sql::names::{DatabaseSpecifier, FullName, PartialName, SchemaName};
+use mz_sql::names::{Aug, DatabaseSpecifier, FullName, PartialName, SchemaName};
 use mz_sql::plan::{
     CreateIndexPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan,
     CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
@@ -417,7 +417,7 @@ pub struct Table {
     pub create_sql: String,
     pub desc: RelationDesc,
     #[serde(skip)]
-    pub defaults: Vec<Expr<Raw>>,
+    pub defaults: Vec<Expr<Aug>>,
     pub conn_id: Option<u32>,
     pub depends_on: Vec<GlobalId>,
     pub persist_name: Option<String>,
@@ -2763,7 +2763,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
         }
     }
 
-    fn table_details(&self) -> Option<&[Expr<Raw>]> {
+    fn table_details(&self) -> Option<&[Expr<Aug>]> {
         if let CatalogItem::Table(Table { defaults, .. }) = self.item() {
             Some(defaults)
         } else {

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -35,6 +35,7 @@ use mz_sql::ast::{
     UnresolvedDataType, UnresolvedObjectName, Value, ViewDefinition, WithOption, WithOptionValue,
 };
 use mz_sql::names::resolve_names_stmt;
+use mz_sql::plan::StatementContext;
 use mz_sql_parser::ast::CreateTypeAs;
 
 use crate::catalog::storage::Transaction;
@@ -811,7 +812,7 @@ fn semantic_use_id_for_table_format_0_7_1(
     stmt: &mut mz_sql::ast::Statement<Raw>,
 ) -> Result<(), anyhow::Error> {
     // Resolve Statement<Raw> to Statement<Aug>
-    let resolved = resolve_names_stmt(cat, stmt.clone()).unwrap();
+    let resolved = resolve_names_stmt(&mut StatementContext::new(None, cat), stmt.clone()).unwrap();
     // Use consistent intermediary format between Aug and Raw.
     let create_sql = resolved.to_ast_string_stable();
     // Convert Statement<Aug> to Statement<Raw> (Aug is a subset of Raw's

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -136,6 +136,7 @@ use mz_sql::plan::{
     ShowVariablePlan, TailFrom, TailPlan,
 };
 use mz_sql::plan::{OptimizerConfig, StatementDesc, View};
+use mz_sql_parser::ast::RawName;
 use mz_transform::Optimizer;
 
 use self::prometheus::Scraper;
@@ -4588,9 +4589,11 @@ pub fn index_sql(
 ) -> String {
     use mz_sql::ast::{Expr, Value};
 
+    // TODO(jkosh44): we should be able to use CreateIndexStatement<Aug> since we always no the ID
+    // for view_name
     CreateIndexStatement::<Raw> {
         name: Some(Ident::new(index_name)),
-        on_name: mz_sql::normalize::unresolve(view_name),
+        on_name: RawName::Name(mz_sql::normalize::unresolve(view_name)),
         in_cluster: Some(RawIdent::Resolved(compute_instance.to_string())),
         key_parts: Some(
             keys.iter()

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -742,7 +742,7 @@ pub enum TableConstraint<T: AstInfo> {
     ForeignKey {
         name: Option<Ident>,
         columns: Vec<Ident>,
-        foreign_table: UnresolvedObjectName,
+        foreign_table: T::ObjectName,
         referred_columns: Vec<Ident>,
     },
     /// `[ CONSTRAINT <name> ] CHECK (<expr>)`

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -67,6 +67,13 @@ impl RawName {
             RawName::Id(_, name) => name,
         }
     }
+
+    pub fn name_mut(&mut self) -> &mut UnresolvedObjectName {
+        match self {
+            RawName::Name(name) => name,
+            RawName::Id(_, name) => name,
+        }
+    }
 }
 
 impl AstDisplay for RawName {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -48,8 +48,8 @@ pub enum Statement<T: AstInfo> {
     CreateRole(CreateRoleStatement),
     CreateCluster(CreateClusterStatement),
     CreateSecret(CreateSecretStatement<T>),
-    AlterObjectRename(AlterObjectRenameStatement),
-    AlterIndex(AlterIndexStatement),
+    AlterObjectRename(AlterObjectRenameStatement<T>),
+    AlterIndex(AlterIndexStatement<T>),
     Discard(DiscardStatement),
     DropDatabase(DropDatabaseStatement),
     DropObjects(DropObjectsStatement),
@@ -58,11 +58,11 @@ pub enum Statement<T: AstInfo> {
     ShowObjects(ShowObjectsStatement<T>),
     ShowIndexes(ShowIndexesStatement<T>),
     ShowColumns(ShowColumnsStatement<T>),
-    ShowCreateView(ShowCreateViewStatement),
-    ShowCreateSource(ShowCreateSourceStatement),
-    ShowCreateTable(ShowCreateTableStatement),
-    ShowCreateSink(ShowCreateSinkStatement),
-    ShowCreateIndex(ShowCreateIndexStatement),
+    ShowCreateView(ShowCreateViewStatement<T>),
+    ShowCreateSource(ShowCreateSourceStatement<T>),
+    ShowCreateTable(ShowCreateTableStatement<T>),
+    ShowCreateSink(ShowCreateSinkStatement<T>),
+    ShowCreateIndex(ShowCreateIndexStatement<T>),
     ShowVariable(ShowVariableStatement),
     StartTransaction(StartTransactionStatement),
     SetTransaction(SetTransactionStatement),
@@ -155,7 +155,7 @@ impl_display_t!(SelectStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InsertStatement<T: AstInfo> {
     /// TABLE
-    pub table_name: UnresolvedObjectName,
+    pub table_name: T::ObjectName,
     /// COLUMNS
     pub columns: Vec<Ident>,
     /// A SQL query that specifies what to insert.
@@ -180,7 +180,7 @@ impl_display_t!(InsertStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CopyRelation<T: AstInfo> {
     Table {
-        name: UnresolvedObjectName,
+        name: T::ObjectName,
         columns: Vec<Ident>,
     },
     Select(SelectStatement<T>),
@@ -237,7 +237,7 @@ impl<T: AstInfo> AstDisplay for CopyStatement<T> {
         f.write_str("COPY ");
         match &self.relation {
             CopyRelation::Table { name, columns } => {
-                f.write_node(&name);
+                f.write_node(name);
                 if !columns.is_empty() {
                     f.write_str("(");
                     f.write_node(&display::comma_separated(&columns));
@@ -433,7 +433,7 @@ impl_display_t!(CreateSourceStatement);
 pub struct CreateSinkStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub in_cluster: Option<T::ClusterName>,
-    pub from: UnresolvedObjectName,
+    pub from: T::ObjectName,
     pub connector: CreateSinkConnector<T>,
     pub with_options: Vec<SqlOption<T>>,
     pub format: Option<Format<T>>,
@@ -570,7 +570,7 @@ impl_display!(CreateViewsSourceTarget);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateViewsDefinitions<T: AstInfo> {
     Source {
-        name: UnresolvedObjectName,
+        name: T::ObjectName,
         targets: Option<Vec<CreateViewsSourceTarget>>,
     },
     Literal(Vec<ViewDefinition<T>>),
@@ -684,7 +684,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     pub name: Option<Ident>,
     pub in_cluster: Option<T::ClusterName>,
     /// `ON` table or view name
-    pub on_name: UnresolvedObjectName,
+    pub on_name: T::ObjectName,
     /// Expressions that form part of the index key. If not included, the
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
@@ -905,14 +905,14 @@ impl_display_t!(CreateTypeAs);
 
 /// `ALTER <OBJECT> ... RENAME TO`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AlterObjectRenameStatement {
+pub struct AlterObjectRenameStatement<T: AstInfo> {
     pub object_type: ObjectType,
     pub if_exists: bool,
-    pub name: UnresolvedObjectName,
+    pub name: T::ObjectName,
     pub to_item_name: Ident,
 }
 
-impl AstDisplay for AlterObjectRenameStatement {
+impl<T: AstInfo> AstDisplay for AlterObjectRenameStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER ");
         f.write_node(&self.object_type);
@@ -925,7 +925,7 @@ impl AstDisplay for AlterObjectRenameStatement {
         f.write_node(&self.to_item_name);
     }
 }
-impl_display!(AlterObjectRenameStatement);
+impl_display_t!(AlterObjectRenameStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterIndexAction {
@@ -936,13 +936,13 @@ pub enum AlterIndexAction {
 
 /// `ALTER INDEX ... {RESET, SET}`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AlterIndexStatement {
-    pub index_name: UnresolvedObjectName,
+pub struct AlterIndexStatement<T: AstInfo> {
+    pub index_name: T::ObjectName,
     pub if_exists: bool,
     pub action: AlterIndexAction,
 }
 
-impl AstDisplay for AlterIndexStatement {
+impl<T: AstInfo> AstDisplay for AlterIndexStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER INDEX ");
         if self.if_exists {
@@ -967,7 +967,7 @@ impl AstDisplay for AlterIndexStatement {
     }
 }
 
-impl_display!(AlterIndexStatement);
+impl_display_t!(AlterIndexStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DiscardStatement {
@@ -1170,7 +1170,7 @@ impl_display_t!(ShowObjectsStatement);
 /// `SHOW INDEX|INDEXES|KEYS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowIndexesStatement<T: AstInfo> {
-    pub table_name: UnresolvedObjectName,
+    pub table_name: T::ObjectName,
     pub extended: bool,
     pub filter: Option<ShowStatementFilter<T>>,
 }
@@ -1198,7 +1198,7 @@ impl_display_t!(ShowIndexesStatement);
 pub struct ShowColumnsStatement<T: AstInfo> {
     pub extended: bool,
     pub full: bool,
-    pub table_name: UnresolvedObjectName,
+    pub table_name: T::ObjectName,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
@@ -1223,73 +1223,73 @@ impl_display_t!(ShowColumnsStatement);
 
 /// `SHOW CREATE VIEW <view>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ShowCreateViewStatement {
-    pub view_name: UnresolvedObjectName,
+pub struct ShowCreateViewStatement<T: AstInfo> {
+    pub view_name: T::ObjectName,
 }
 
-impl AstDisplay for ShowCreateViewStatement {
+impl<T: AstInfo> AstDisplay for ShowCreateViewStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE VIEW ");
         f.write_node(&self.view_name);
     }
 }
-impl_display!(ShowCreateViewStatement);
+impl_display_t!(ShowCreateViewStatement);
 
 /// `SHOW CREATE SOURCE <source>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ShowCreateSourceStatement {
-    pub source_name: UnresolvedObjectName,
+pub struct ShowCreateSourceStatement<T: AstInfo> {
+    pub source_name: T::ObjectName,
 }
 
-impl AstDisplay for ShowCreateSourceStatement {
+impl<T: AstInfo> AstDisplay for ShowCreateSourceStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE SOURCE ");
         f.write_node(&self.source_name);
     }
 }
-impl_display!(ShowCreateSourceStatement);
+impl_display_t!(ShowCreateSourceStatement);
 
 /// `SHOW CREATE TABLE <table>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ShowCreateTableStatement {
-    pub table_name: UnresolvedObjectName,
+pub struct ShowCreateTableStatement<T: AstInfo> {
+    pub table_name: T::ObjectName,
 }
 
-impl AstDisplay for ShowCreateTableStatement {
+impl<T: AstInfo> AstDisplay for ShowCreateTableStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE TABLE ");
         f.write_node(&self.table_name);
     }
 }
-impl_display!(ShowCreateTableStatement);
+impl_display_t!(ShowCreateTableStatement);
 
 /// `SHOW CREATE SINK <sink>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ShowCreateSinkStatement {
-    pub sink_name: UnresolvedObjectName,
+pub struct ShowCreateSinkStatement<T: AstInfo> {
+    pub sink_name: T::ObjectName,
 }
 
-impl AstDisplay for ShowCreateSinkStatement {
+impl<T: AstInfo> AstDisplay for ShowCreateSinkStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE SINK ");
         f.write_node(&self.sink_name);
     }
 }
-impl_display!(ShowCreateSinkStatement);
+impl_display_t!(ShowCreateSinkStatement);
 
 /// `SHOW CREATE INDEX <index>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ShowCreateIndexStatement {
-    pub index_name: UnresolvedObjectName,
+pub struct ShowCreateIndexStatement<T: AstInfo> {
+    pub index_name: T::ObjectName,
 }
 
-impl AstDisplay for ShowCreateIndexStatement {
+impl<T: AstInfo> AstDisplay for ShowCreateIndexStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW CREATE INDEX ");
         f.write_node(&self.index_name);
     }
 }
-impl_display!(ShowCreateIndexStatement);
+impl_display_t!(ShowCreateIndexStatement);
 
 /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1384,14 +1384,14 @@ impl_display_t!(TailStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TailRelation<T: AstInfo> {
-    Name(UnresolvedObjectName),
+    Name(T::ObjectName),
     Query(Query<T>),
 }
 
 impl<T: AstInfo> AstDisplay for TailRelation<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            TailRelation::Name(name) => f.write_node(&name),
+            TailRelation::Name(name) => f.write_node(name),
             TailRelation::Query(query) => {
                 f.write_str("(");
                 f.write_node(query);
@@ -1708,7 +1708,7 @@ impl_display!(ExplainStage);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Explainee<T: AstInfo> {
-    View(UnresolvedObjectName),
+    View(T::ObjectName),
     Query(Query<T>),
 }
 
@@ -1721,11 +1721,11 @@ pub struct ExplainOptions {
 impl<T: AstInfo> AstDisplay for Explainee<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Explainee::View(name) => {
+            Self::View(name) => {
                 f.write_str("VIEW ");
-                f.write_node(&name);
+                f.write_node(name);
             }
-            Explainee::Query(query) => f.write_node(query),
+            Self::Query(query) => f.write_node(query),
         }
     }
 }

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -18,14 +18,14 @@ COPY t(a, b) FROM STDIN
 ----
 COPY t(a, b) FROM STDIN
 =>
-Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [Ident("a"), Ident("b")] }, direction: From, target: Stdin, options: [] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: From, target: Stdin, options: [] })
 
 parse-statement
 COPY t FROM STDIN
 ----
 COPY t FROM STDIN
 =>
-Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [] }, direction: From, target: Stdin, options: [] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [] })
 
 parse-statement
 COPY (select 1) TO STDOUT
@@ -39,28 +39,28 @@ COPY t(a, b) TO STDOUT
 ----
 COPY t(a, b) TO STDOUT
 =>
-Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [Ident("a"), Ident("b")] }, direction: To, target: Stdout, options: [] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [Ident("a"), Ident("b")] }, direction: To, target: Stdout, options: [] })
 
 parse-statement
 COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (format = text)
 =>
-Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMETER '|')
 ----
 COPY t FROM STDIN WITH (format = csv, delimeter = '|')
 =>
-Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [] }, direction: From, target: Stdin, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("csv")]))) }, WithOption { key: Ident("delimeter"), value: Some(Value(String("|"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("csv")]))) }, WithOption { key: Ident("delimeter"), value: Some(Value(String("|"))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (format = text)
 =>
-Copy(CopyStatement { relation: Table { name: UnresolvedObjectName([Ident("t")]), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
 
 parse-statement
 COPY t TO STDOUT ()

--- a/src/sql-parser/tests/testdata/cursor
+++ b/src/sql-parser/tests/testdata/cursor
@@ -25,7 +25,7 @@ DECLARE c CURSOR FOR TAIL t
 ----
 DECLARE c CURSOR FOR TAIL t
 =>
-Declare(DeclareStatement { name: Ident("c"), stmt: Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("t")])), options: [], as_of: None }) })
+Declare(DeclareStatement { name: Ident("c"), stmt: Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("t")]))), options: [], as_of: None }) })
 
 parse-statement
 CLOSE c

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -120,7 +120,7 @@ CREATE TABLE foo (id int, CONSTRAINT customer_address_id_fkey FOREIGN KEY (addre
 ----
 CREATE TABLE foo (id int4, CONSTRAINT customer_address_id_fkey FOREIGN KEY (address_id) REFERENCES public.address(address_id))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: UnresolvedObjectName([Ident("public"), Ident("address")]), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: Some(Ident("customer_address_id_fkey")), columns: [Ident("address_id")], foreign_table: Name(UnresolvedObjectName([Ident("public"), Ident("address")])), referred_columns: [Ident("address_id")] }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TEMPORARY TABLE foo (id int, CONSTRAINT ck CHECK (rtrim(ltrim(ref_code)) <> ''))
@@ -148,7 +148,7 @@ CREATE TABLE foo (id int, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, ba
 ----
 CREATE TABLE foo (id int4, FOREIGN KEY (foo, bar) REFERENCES anothertable(foo, bar))
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: UnresolvedObjectName([Ident("anothertable")]), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("foo")]), columns: [ColumnDef { name: Ident("id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [ForeignKey { name: None, columns: [Ident("foo"), Ident("bar")], foreign_table: Name(UnresolvedObjectName([Ident("anothertable")])), referred_columns: [Ident("foo"), Ident("bar")] }], with_options: [], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE foo (id int, CHECK (end_date > start_date OR end_date IS NULL))
@@ -351,14 +351,14 @@ CREATE VIEWS FROM SOURCE "foobar"
 ----
 CREATE VIEWS FROM SOURCE foobar
 =>
-CreateViews(CreateViewsStatement { if_exists: Error, temporary: false, materialized: false, definitions: Source { name: UnresolvedObjectName([Ident("foobar")]), targets: None } })
+CreateViews(CreateViewsStatement { if_exists: Error, temporary: false, materialized: false, definitions: Source { name: Name(UnresolvedObjectName([Ident("foobar")])), targets: None } })
 
 parse-statement
 CREATE OR REPLACE VIEWS FROM SOURCE "foobar"
 ----
 CREATE OR REPLACE VIEWS FROM SOURCE foobar
 =>
-CreateViews(CreateViewsStatement { if_exists: Replace, temporary: false, materialized: false, definitions: Source { name: UnresolvedObjectName([Ident("foobar")]), targets: None } })
+CreateViews(CreateViewsStatement { if_exists: Replace, temporary: false, materialized: false, definitions: Source { name: Name(UnresolvedObjectName([Ident("foobar")])), targets: None } })
 
 parse-statement
 CREATE VIEWS FROM SOURCE "foobar" ();
@@ -379,7 +379,7 @@ CREATE MATERIALIZED VIEWS FROM SOURCE "foobar" (t1, "t2" AS t3);
 ----
 CREATE MATERIALIZED VIEWS FROM SOURCE foobar (t1, t2 AS t3)
 =>
-CreateViews(CreateViewsStatement { if_exists: Error, temporary: false, materialized: true, definitions: Source { name: UnresolvedObjectName([Ident("foobar")]), targets: Some([CreateViewsSourceTarget { name: UnresolvedObjectName([Ident("t1")]), alias: None }, CreateViewsSourceTarget { name: UnresolvedObjectName([Ident("t2")]), alias: Some(UnresolvedObjectName([Ident("t3")])) }]) } })
+CreateViews(CreateViewsStatement { if_exists: Error, temporary: false, materialized: true, definitions: Source { name: Name(UnresolvedObjectName([Ident("foobar")])), targets: Some([CreateViewsSourceTarget { name: UnresolvedObjectName([Ident("t1")]), alias: None }, CreateViewsSourceTarget { name: UnresolvedObjectName([Ident("t2")]), alias: Some(UnresolvedObjectName([Ident("t3")])) }]) } })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING SCHEMA 'baz'
@@ -718,35 +718,35 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }, Value { name: Ident("retention_ms"), value: Number("10000") }, Value { name: Ident("retention_bytes"), value: Number("10000000000") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }, Value { name: Ident("retention_ms"), value: Number("10000") }, Value { name: Ident("retention_bytes"), value: Number("10000000000") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) NOT ENFORCED FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) NOT ENFORCED FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency') FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency') FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: None }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: None }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' CONSISTENCY FORMAT BYTES) FORMAT BYTES
@@ -760,14 +760,14 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSIS
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username=user)) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = user)) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { url: "http://localhost:8081", seed: None, with_options: [ObjectName { name: Ident("username"), object_name: UnresolvedObjectName([Ident("user")]) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { url: "http://localhost:8081", seed: None, with_options: [ObjectName { name: Ident("username"), object_name: UnresolvedObjectName([Ident("user")]) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
@@ -781,7 +781,7 @@ CREATE SINK foo FROM bar INTO AVRO OCF 'baz'
 ----
 CREATE SINK foo FROM bar INTO AVRO OCF 'baz' WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: UnresolvedObjectName([Ident("bar")]), connector: AvroOcf { path: "baz" }, with_options: [], format: None, envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: AvroOcf { path: "baz" }, with_options: [], format: None, envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES
@@ -844,70 +844,70 @@ CREATE INDEX foo ON myschema.bar (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: UnresolvedObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo ON myschema.bar USING arrangement (a, b)
 ----
 CREATE INDEX foo ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: UnresolvedObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo ON myschema.bar (a, b) WITH (baz = 'raz')
 ----
 CREATE INDEX foo ON myschema.bar (a, b) WITH (baz = 'raz')
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: UnresolvedObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [WithOption { key: Ident("baz"), value: Some(Value(String("raz"))) }], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [WithOption { key: Ident("baz"), value: Some(Value(String("raz"))) }], if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 ----
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), in_cluster: None, on_name: UnresolvedObjectName([Ident("baz")]), key_parts: Some([Function(Function { name: UnresolvedObjectName([Ident("ascii")]), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }), IsExpr { expr: Identifier([Ident("a")]), construct: Null, negated: true }, Nested(Exists(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("boop")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("fizz")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("baz")])), key_parts: Some([Function(Function { name: UnresolvedObjectName([Ident("ascii")]), args: Args { args: [Identifier([Ident("x")])], order_by: [] }, filter: None, over: None, distinct: false }), IsExpr { expr: Identifier([Ident("a")]), construct: Null, negated: true }, Nested(Exists(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("y")]), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("boop")])), alias: None }, joins: [] }], selection: Some(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("boop"), Ident("z")]), expr2: Some(Identifier([Ident("z")])) }), group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None })), Identifier([Ident("delta")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX ind ON tab ((col + 1))
 ----
 CREATE INDEX ind ON tab ((col + 1))
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), in_cluster: None, on_name: UnresolvedObjectName([Ident("tab")]), key_parts: Some([Nested(Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("col")]), expr2: Some(Value(Number("1"))) })]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("ind")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: Some([Nested(Op { op: Op { namespace: [], op: "+" }, expr1: Identifier([Ident("col")]), expr2: Some(Value(Number("1"))) })]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 ----
 CREATE INDEX qualifiers ON no_parentheses (alpha.omega)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), in_cluster: None, on_name: UnresolvedObjectName([Ident("no_parentheses")]), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("qualifiers")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("no_parentheses")])), key_parts: Some([Identifier([Ident("alpha"), Ident("omega")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo IN CLUSTER bar ON myschema.bar (a, b)
 ----
 CREATE INDEX foo IN CLUSTER bar ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Unresolved(Ident("bar"))), on_name: UnresolvedObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Unresolved(Ident("bar"))), on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX foo IN CLUSTER [1] ON myschema.bar (a, b)
 ----
 CREATE INDEX foo IN CLUSTER [1] ON myschema.bar (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Resolved("1")), on_name: UnresolvedObjectName([Ident("myschema"), Ident("bar")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: Some(Resolved("1")), on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab
 ----
 CREATE DEFAULT INDEX ON tab
 =>
-CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: UnresolvedObjectName([Ident("tab")]), key_parts: None, with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: None, with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 ----
 CREATE DEFAULT INDEX IF NOT EXISTS ON tab
 =>
-CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: UnresolvedObjectName([Ident("tab")]), key_parts: None, with_options: [], if_not_exists: true })
+CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: None, with_options: [], if_not_exists: true })
 
 parse-statement
 CREATE DEFAULT INDEX ON tab (a, b)
@@ -928,7 +928,7 @@ CREATE INDEX ON tab (a, b)
 ----
 CREATE INDEX ON tab (a, b)
 =>
-CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: UnresolvedObjectName([Ident("tab")]), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: None, in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("tab")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
 CREATE INDEX IF NOT EXISTS ON tab (a, b)
@@ -1068,35 +1068,35 @@ TAIL foo.bar
 ----
 TAIL foo.bar
 =>
-Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [], as_of: None })
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: None })
 
 parse-statement
 TAIL foo.bar AS OF 123
 ----
 TAIL foo.bar AS OF 123
 =>
-Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [], as_of: Some(Value(Number("123"))) })
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(Value(Number("123"))) })
 
 parse-statement
 TAIL foo.bar AS OF now()
 ----
 TAIL foo.bar AS OF now()
 =>
-Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT) AS OF now()
 ----
 TAIL foo.bar WITH (snapshot) AS OF now()
 =>
-Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
 ----
 TAIL foo.bar WITH (snapshot = false, timestamps) AS OF now()
 =>
-Tail(TailStatement { relation: Name(UnresolvedObjectName([Ident("foo"), Ident("bar")])), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }, WithOption { key: Ident("timestamps"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }, WithOption { key: Ident("timestamps"), value: None }], as_of: Some(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT false)
@@ -1168,21 +1168,21 @@ ALTER INDEX name SET (property = true)
 ----
 ALTER INDEX name SET (property = true)
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
+AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
 
 parse-statement
 ALTER INDEX name RESET (property)
 ----
 ALTER INDEX name RESET (property)
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: ResetOptions([Ident("property")]) })
+AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: ResetOptions([Ident("property")]) })
 
 parse-statement
 ALTER INDEX IF EXISTS name SET (property = true)
 ----
 ALTER INDEX IF EXISTS name SET (property = true)
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: true, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
+AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: true, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
 
 parse-statement
 ALTER INDEX name SET ()
@@ -1203,7 +1203,7 @@ ALTER INDEX name SET (property)
 ----
 ALTER INDEX name SET (property)
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: None }]) })
+AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: None }]) })
 
 parse-statement
 ALTER INDEX name RESET (property = true)
@@ -1238,14 +1238,14 @@ ALTER INDEX name RENAME TO name2
 ----
 ALTER INDEX name RENAME TO name2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: Index, if_exists: false, name: UnresolvedObjectName([Ident("name")]), to_item_name: Ident("name2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: Index, if_exists: false, name: Name(UnresolvedObjectName([Ident("name")])), to_item_name: Ident("name2") })
 
 parse-statement
 ALTER INDEX name SET ENABLED
 ----
 ALTER INDEX name SET ENABLED
 =>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: Enable })
+AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: Enable })
 
 parse-statement
 ALTER INDEX name SET (property = true) ENABLED

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -58,14 +58,14 @@ EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(UnresolvedObjectName([Ident("foo")])), options: ExplainOptions { typed: false, timing: false } })
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: false } })
 
 parse-statement
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(UnresolvedObjectName([Ident("foo")])), options: ExplainOptions { typed: true, timing: false } })
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: true, timing: false } })
 
 parse-statement
 EXPLAIN (TIMING false) TYPED OPTIMIZED PLAN FOR VIEW foo
@@ -93,28 +93,28 @@ EXPLAIN (TIMING false) VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(UnresolvedObjectName([Ident("foo")])), options: ExplainOptions { typed: false, timing: false } })
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: false } })
 
 parse-statement
 EXPLAIN (TIMING false, TIMING true) VIEW foo
 ----
 EXPLAIN (TIMING true) OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(UnresolvedObjectName([Ident("foo")])), options: ExplainOptions { typed: false, timing: true } })
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: true } })
 
 parse-statement
 EXPLAIN (TIMING false, TIMING true) DECORRELATED PLAN FOR VIEW foo
 ----
 EXPLAIN (TIMING true) DECORRELATED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: DecorrelatedPlan, explainee: View(UnresolvedObjectName([Ident("foo")])), options: ExplainOptions { typed: false, timing: true } })
+Explain(ExplainStatement { stage: DecorrelatedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: true } })
 
 parse-statement
 EXPLAIN TYPED (TIMING false) OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(UnresolvedObjectName([Ident("foo")])), options: ExplainOptions { typed: true, timing: false } })
+Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: true, timing: false } })
 
 parse-statement
 EXPLAIN ((SELECT 1))

--- a/src/sql-parser/tests/testdata/insert
+++ b/src/sql-parser/tests/testdata/insert
@@ -23,49 +23,49 @@ INSERT INTO customer VALUES (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 ----
 INSERT INTO customer VALUES (1, 2, 3), (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))], [Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 INSERT INTO public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("public"), Ident("customer")])), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 ----
 INSERT INTO db.public.customer VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("db"), Ident("public"), Ident("customer")]), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("db"), Ident("public"), Ident("customer")])), columns: [], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 ----
 INSERT INTO public.customer (id, name, active) VALUES (1, 2, 3)
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("public"), Ident("customer")])), columns: [Ident("id"), Ident("name"), Ident("active")], source: Query(Query { ctes: [], body: Values(Values([[Value(Number("1")), Value(Number("2")), Value(Number("3"))]])), order_by: [], limit: None, offset: None }) })
 
 parse-statement
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 ----
 INSERT INTO customer WITH foo AS (SELECT 1) SELECT * FROM foo UNION VALUES (1)
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("customer")]), columns: [], source: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: SetOperation { op: Union, all: false, left: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None }) })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("foo"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: SetOperation { op: Union, all: false, left: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), right: Values(Values([[Value(Number("1"))]])) }, order_by: [], limit: None, offset: None }) })
 
 parse-statement
 INSERT INTO customer DEFAULT VALUES
 ----
 INSERT INTO customer DEFAULT VALUES
 =>
-Insert(InsertStatement { table_name: UnresolvedObjectName([Ident("customer")]), columns: [], source: DefaultValues })
+Insert(InsertStatement { table_name: Name(UnresolvedObjectName([Ident("customer")])), columns: [], source: DefaultValues })
 
 parse-statement
 INSERT INTO customer DEFAULT VALUES, DEFAULT VALUES

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -163,119 +163,119 @@ SHOW INDEXES FROM foo
 ----
 SHOW INDEXES FROM foo
 =>
-ShowIndexes(ShowIndexesStatement { table_name: UnresolvedObjectName([Ident("foo")]), extended: false, filter: None })
+ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: false, filter: None })
 
 parse-statement
 SHOW INDEXES IN foo
 ----
 SHOW INDEXES FROM foo
 =>
-ShowIndexes(ShowIndexesStatement { table_name: UnresolvedObjectName([Ident("foo")]), extended: false, filter: None })
+ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: false, filter: None })
 
 parse-statement
 SHOW EXTENDED INDEXES FROM foo
 ----
 SHOW EXTENDED INDEXES FROM foo
 =>
-ShowIndexes(ShowIndexesStatement { table_name: UnresolvedObjectName([Ident("foo")]), extended: true, filter: None })
+ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: true, filter: None })
 
 parse-statement
 SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 ----
 SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 =>
-ShowIndexes(ShowIndexesStatement { table_name: UnresolvedObjectName([Ident("foo")]), extended: true, filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("index_name")]), expr2: Some(Value(String("bar"))) })) })
+ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: true, filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("index_name")]), expr2: Some(Value(String("bar"))) })) })
 
 parse-statement
 SHOW CREATE VIEW foo
 ----
 SHOW CREATE VIEW foo
 =>
-ShowCreateView(ShowCreateViewStatement { view_name: UnresolvedObjectName([Ident("foo")]) })
+ShowCreateView(ShowCreateViewStatement { view_name: Name(UnresolvedObjectName([Ident("foo")])) })
 
 parse-statement
 SHOW CREATE SINK foo
 ----
 SHOW CREATE SINK foo
 =>
-ShowCreateSink(ShowCreateSinkStatement { sink_name: UnresolvedObjectName([Ident("foo")]) })
+ShowCreateSink(ShowCreateSinkStatement { sink_name: Name(UnresolvedObjectName([Ident("foo")])) })
 
 parse-statement
 SHOW CREATE INDEX foo
 ----
 SHOW CREATE INDEX foo
 =>
-ShowCreateIndex(ShowCreateIndexStatement { index_name: UnresolvedObjectName([Ident("foo")]) })
+ShowCreateIndex(ShowCreateIndexStatement { index_name: Name(UnresolvedObjectName([Ident("foo")])) })
 
 parse-statement
 SHOW COLUMNS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW COLUMNS FROM mydb.mytable
 ----
 SHOW COLUMNS FROM mydb.mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mydb"), Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mydb"), Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW EXTENDED COLUMNS FROM mytable
 ----
 SHOW EXTENDED COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: true, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: true, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW FULL COLUMNS FROM mytable
 ----
 SHOW FULL COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: true, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: false, full: true, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW EXTENDED FULL COLUMNS FROM mytable
 ----
 SHOW EXTENDED FULL COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: true, full: true, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: true, full: true, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 ----
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: Some(Like("pattern")) })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Like("pattern")) })
 
 parse-statement
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 ----
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) })) })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) })) })
 
 parse-statement
 SHOW FIELDS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW COLUMNS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW FIELDS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: UnresolvedObjectName([Ident("mytable")]), filter: None })
+ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None })
 
 parse-statement
 SHOW a

--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -80,10 +80,10 @@ pub fn create_stmt_rename_refs(
     // TODO(sploiselle): Support renaming schemas and databases.
     match create_stmt {
         Statement::CreateIndex(CreateIndexStatement { on_name, .. }) => {
-            maybe_update_object_name(on_name);
+            maybe_update_object_name(on_name.name_mut());
         }
         Statement::CreateSink(CreateSinkStatement { from, .. }) => {
-            maybe_update_object_name(from);
+            maybe_update_object_name(from.name_mut());
         }
         Statement::CreateView(CreateViewStatement {
             definition: ViewDefinition { query, .. },

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -24,11 +24,11 @@ use mz_dataflow_types::client::ComputeInstanceId;
 use mz_expr::{DummyHumanizer, ExprHumanizer, GlobalId, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, RelationDesc, ScalarType};
-use mz_sql_parser::ast::{Expr, Raw};
+use mz_sql_parser::ast::Expr;
 use uuid::Uuid;
 
 use crate::func::Func;
-use crate::names::{FullName, PartialName, SchemaName};
+use crate::names::{Aug, FullName, PartialName, SchemaName};
 use crate::plan::statement::StatementDesc;
 
 /// A catalog keeps track of SQL objects and session state available to the
@@ -287,7 +287,7 @@ pub trait CatalogItem {
 
     /// Returns the column defaults associated with the catalog item, if the
     /// catalog item is a table.
-    fn table_details(&self) -> Option<&[Expr<Raw>]>;
+    fn table_details(&self) -> Option<&[Expr<Aug>]>;
 
     /// Returns the type information associated with the catalog item, if the
     /// catalog item is a type.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -286,11 +286,9 @@ pub fn sql_impl(
         );
         let mut qcx = QueryContext::root(&scx, qcx.lifetime);
 
+        let mut expr = resolve_names_expr(&mut qcx, expr.clone())?;
         // Desugar the expression
-        let mut expr = expr.clone();
         transform_ast::transform_expr(&scx, &mut expr)?;
-
-        let expr = resolve_names_expr(&mut qcx, expr)?;
 
         let ecx = ExprContext {
             qcx: &qcx,
@@ -366,10 +364,9 @@ fn sql_impl_table_func_inner(
         );
         let mut qcx = QueryContext::root(&scx, qcx.lifetime);
 
-        let mut query = query.clone();
+        let query = query.clone();
+        let mut query = resolve_names(&mut qcx, query)?;
         transform_ast::transform_query(&scx, &mut query)?;
-
-        let query = resolve_names(&mut qcx, query)?;
 
         query::plan_nested_query(&mut qcx, &query)
     };

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -26,11 +26,11 @@ use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
     AstInfo, CreateIndexStatement, CreateSinkStatement, CreateSourceStatement,
     CreateTableStatement, CreateTypeAs, CreateTypeStatement, CreateViewStatement, Function,
-    FunctionArgs, Ident, IfExistsBehavior, Op, Query, Raw, SqlOption, Statement, TableFactor,
+    FunctionArgs, Ident, IfExistsBehavior, Op, Query, SqlOption, Statement, TableFactor,
     TableFunction, UnresolvedObjectName, Value, ViewDefinition,
 };
 
-use crate::names::{resolve_names_stmt, Aug, DatabaseSpecifier, FullName, PartialName};
+use crate::names::{Aug, DatabaseSpecifier, FullName, PartialName};
 use crate::plan::error::PlanError;
 use crate::plan::statement::StatementContext;
 
@@ -98,7 +98,7 @@ pub fn options<T: AstInfo>(options: &[SqlOption<T>]) -> BTreeMap<String, Value> 
 
 /// Normalizes `WITH` option keys without normalizing their corresponding
 /// values.
-pub fn option_objects(options: &[SqlOption<Raw>]) -> BTreeMap<String, SqlOption<Raw>> {
+pub fn option_objects(options: &[SqlOption<Aug>]) -> BTreeMap<String, SqlOption<Aug>> {
     options
         .iter()
         .map(|o| (ident(o.name().clone()), o.clone()))
@@ -128,10 +128,8 @@ pub fn unresolve(name: FullName) -> UnresolvedObjectName {
 /// objects that are persisted in the catalog.
 pub fn create_statement(
     scx: &StatementContext,
-    stmt: Statement<Raw>,
+    mut stmt: Statement<Aug>,
 ) -> Result<String, anyhow::Error> {
-    let mut stmt = resolve_names_stmt(scx.catalog, stmt)?;
-
     let allocate_name = |name: &UnresolvedObjectName| -> Result<_, PlanError> {
         Ok(unresolve(
             scx.allocate_name(unresolved_object_name(name.clone())?),
@@ -142,11 +140,6 @@ pub fn create_statement(
         Ok(unresolve(scx.allocate_temporary_name(
             unresolved_object_name(name.clone())?,
         )))
-    };
-
-    let resolve_item = |name: &UnresolvedObjectName| -> Result<_, PlanError> {
-        let item = scx.resolve_item(name.clone())?;
-        Ok(unresolve(item.name().clone()))
     };
 
     fn normalize_function_name(
@@ -238,23 +231,6 @@ pub fn create_statement(
                 _ => visit_mut::visit_table_factor_mut(self, table_factor),
             }
         }
-
-        fn visit_unresolved_object_name_mut(
-            &mut self,
-            unresolved_object_name: &'ast mut UnresolvedObjectName,
-        ) {
-            // Single-part object names can refer to CTEs in addition to
-            // catalog objects.
-            if let [ident] = unresolved_object_name.0.as_slice() {
-                if self.ctes.contains(ident) {
-                    return;
-                }
-            }
-            match self.scx.resolve_item(unresolved_object_name.clone()) {
-                Ok(full_name) => *unresolved_object_name = unresolve(full_name.name().clone()),
-                Err(e) => self.err = Some(e),
-            };
-        }
     }
 
     // Think very hard before changing any of the branches in this match
@@ -310,7 +286,6 @@ pub fn create_statement(
 
         Statement::CreateSink(CreateSinkStatement {
             name,
-            from,
             connector: _,
             with_options: _,
             in_cluster: _,
@@ -319,9 +294,9 @@ pub fn create_statement(
             with_snapshot: _,
             as_of: _,
             if_not_exists,
+            ..
         }) => {
             *name = allocate_name(name)?;
-            *from = resolve_item(from)?;
             *if_not_exists = false;
         }
 
@@ -355,13 +330,12 @@ pub fn create_statement(
 
         Statement::CreateIndex(CreateIndexStatement {
             name: _,
-            on_name,
             in_cluster: _,
             key_parts,
             with_options: _,
             if_not_exists,
+            ..
         }) => {
-            *on_name = resolve_item(on_name)?;
             let mut normalizer = QueryNormalizer::new(scx);
             if let Some(key_parts) = key_parts {
                 for key_part in key_parts {
@@ -588,20 +562,23 @@ mod tests {
 
     use super::*;
     use crate::catalog::DummyCatalog;
+    use crate::names::resolve_names_stmt;
 
     #[test]
     fn normalized_create() -> Result<(), Box<dyn Error>> {
-        let scx = &StatementContext::new(None, &DummyCatalog);
+        let scx = &mut StatementContext::new(None, &DummyCatalog);
 
         let parsed = mz_sql_parser::parser::parse_statements(
             "create materialized view foo as select 1 as bar",
         )?
         .into_element();
 
+        let stmt = resolve_names_stmt(scx, parsed)?;
+
         // Ensure that all identifiers are quoted.
         assert_eq!(
             r#"CREATE VIEW "dummy"."public"."foo" AS SELECT 1 AS "bar""#,
-            create_statement(scx, parsed)?,
+            create_statement(scx, stmt)?,
         );
 
         Ok(())

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -46,7 +46,7 @@ use crate::ast::{
     TransactionAccessMode,
 };
 use crate::catalog::CatalogType;
-use crate::names::{DatabaseSpecifier, FullName, SchemaName};
+use crate::names::{Aug, DatabaseSpecifier, FullName, SchemaName};
 
 pub(crate) mod error;
 pub(crate) mod explain;
@@ -391,7 +391,7 @@ pub struct RaisePlan {
 pub struct Table {
     pub create_sql: String,
     pub desc: RelationDesc,
-    pub defaults: Vec<Expr<Raw>>,
+    pub defaults: Vec<Expr<Aug>>,
     pub temporary: bool,
     pub depends_on: Vec<GlobalId>,
 }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -41,7 +41,6 @@ use mz_repr::{
     strconv, ColumnName, ColumnType, Datum, RelationDesc, RelationType, Row, RowArena, ScalarType,
 };
 
-use mz_sql_parser::ast::fold::Fold;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
     Assignment, DeleteStatement, Distinct, Expr, Function, FunctionArgs, HomogenizingFunction,
@@ -53,10 +52,7 @@ use mz_sql_parser::ast::{
 
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
-use crate::names::{
-    resolve_names, resolve_names_expr, resolve_names_extend_qcx_ids, Aug, NameResolver,
-    PartialName, ResolvedDataType, ResolvedObjectName,
-};
+use crate::names::{resolve_names_expr, Aug, PartialName, ResolvedDataType, ResolvedObjectName};
 use crate::normalize;
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
@@ -88,13 +84,12 @@ pub struct PlannedQuery<E> {
 /// applying the returned `RowSetFinishing`.
 pub fn plan_root_query(
     scx: &StatementContext,
-    mut query: Query<Raw>,
+    mut query: Query<Aug>,
     lifetime: QueryLifetime,
 ) -> Result<PlannedQuery<HirRelationExpr>, PlanError> {
     transform_ast::transform_query(scx, &mut query)?;
     let mut qcx = QueryContext::root(scx, lifetime);
-    let resolved_query = resolve_names(&mut qcx, query)?;
-    let (mut expr, scope, mut finishing) = plan_query(&mut qcx, &resolved_query)?;
+    let (mut expr, scope, mut finishing) = plan_query(&mut qcx, &query)?;
 
     // Attempt to push the finishing's ordering past its projection. This allows
     // data to be projected down on the workers rather than the coordinator. It
@@ -112,7 +107,7 @@ pub fn plan_root_query(
             .collect(),
     );
     let desc = RelationDesc::new(typ, scope.column_names());
-    let depends_on = qcx.ids.into_iter().collect();
+    let depends_on = qcx.ids().into_iter().collect();
 
     Ok(PlannedQuery {
         expr,
@@ -158,12 +153,12 @@ fn try_push_projection_order_by(
 
 pub fn plan_insert_query(
     scx: &StatementContext,
-    table_name: UnresolvedObjectName,
+    table_name: ResolvedObjectName,
     columns: Vec<Ident>,
-    source: InsertSource<Raw>,
+    source: InsertSource<Aug>,
 ) -> Result<(GlobalId, HirRelationExpr), PlanError> {
     let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
-    let table = scx.resolve_item(table_name)?;
+    let table = scx.get_item_by_name(&table_name)?;
 
     // Validate the target of the insert.
     if table.item_type() != CatalogItemType::Table {
@@ -221,7 +216,6 @@ pub fn plan_insert_query(
     let expr = match source {
         InsertSource::Query(mut query) => {
             transform_ast::transform_query(scx, &mut query)?;
-            let query = resolve_names(&mut qcx, query)?;
 
             match query {
                 // Special-case simple VALUES clauses as PostgreSQL does.
@@ -301,10 +295,10 @@ pub fn plan_insert_query(
 
 pub fn plan_copy_from(
     scx: &StatementContext,
-    table_name: UnresolvedObjectName,
+    table_name: ResolvedObjectName,
     columns: Vec<Ident>,
 ) -> Result<(GlobalId, RelationDesc, Vec<usize>), PlanError> {
-    let table = scx.resolve_item(table_name)?;
+    let table = scx.get_item_by_name(&table_name)?;
 
     // Validate the target of the insert.
     if table.item_type() != CatalogItemType::Table {
@@ -438,7 +432,7 @@ pub struct ReadThenWritePlan {
 
 pub fn plan_delete_query(
     scx: &StatementContext,
-    mut delete_stmt: DeleteStatement<Raw>,
+    mut delete_stmt: DeleteStatement<Aug>,
 ) -> Result<ReadThenWritePlan, PlanError> {
     transform_ast::run_transforms(
         scx,
@@ -446,22 +440,20 @@ pub fn plan_delete_query(
         &mut delete_stmt,
     )?;
 
-    let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
-    let DeleteStatement {
-        table_name,
-        alias,
-        using,
-        selection,
-    } = resolve_names_extend_qcx_ids(&mut qcx, move |n: &mut NameResolver| {
-        n.fold_delete_statement(delete_stmt)
-    })?;
-
-    plan_mutation_query_inner(qcx, table_name, alias, using, vec![], selection)
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
+    plan_mutation_query_inner(
+        qcx,
+        delete_stmt.table_name,
+        delete_stmt.alias,
+        delete_stmt.using,
+        vec![],
+        delete_stmt.selection,
+    )
 }
 
 pub fn plan_update_query(
     scx: &StatementContext,
-    mut update_stmt: UpdateStatement<Raw>,
+    mut update_stmt: UpdateStatement<Aug>,
 ) -> Result<ReadThenWritePlan, PlanError> {
     transform_ast::run_transforms(
         scx,
@@ -469,16 +461,16 @@ pub fn plan_update_query(
         &mut update_stmt,
     )?;
 
-    let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
-    let UpdateStatement {
-        table_name,
-        assignments,
-        selection,
-    } = resolve_names_extend_qcx_ids(&mut qcx, move |n: &mut NameResolver| {
-        n.fold_update_statement(update_stmt)
-    })?;
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
 
-    plan_mutation_query_inner(qcx, table_name, None, vec![], assignments, selection)
+    plan_mutation_query_inner(
+        qcx,
+        update_stmt.table_name,
+        None,
+        vec![],
+        update_stmt.assignments,
+        update_stmt.selection,
+    )
 }
 
 pub fn plan_mutation_query_inner(
@@ -729,7 +721,7 @@ where
 }
 
 /// Plans an expression in the AS OF position of a `SELECT` or `TAIL` statement.
-pub fn plan_as_of(scx: &StatementContext, expr: Option<Expr<Raw>>) -> Result<QueryWhen, PlanError> {
+pub fn plan_as_of(scx: &StatementContext, expr: Option<Expr<Aug>>) -> Result<QueryWhen, PlanError> {
     let mut expr = match expr {
         None => return Ok(QueryWhen::Immediately),
         Some(expr) => expr,
@@ -737,11 +729,9 @@ pub fn plan_as_of(scx: &StatementContext, expr: Option<Expr<Raw>>) -> Result<Que
 
     let scope = Scope::empty();
     let desc = RelationDesc::empty();
-    let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
 
     transform_ast::transform_expr(scx, &mut expr)?;
-
-    let expr = resolve_names_expr(&mut qcx, expr)?;
 
     let ecx = &ExprContext {
         qcx: &qcx,
@@ -760,11 +750,10 @@ pub fn plan_as_of(scx: &StatementContext, expr: Option<Expr<Raw>>) -> Result<Que
 
 pub fn plan_default_expr(
     scx: &StatementContext,
-    expr: &Expr<Raw>,
+    expr: &Expr<Aug>,
     target_ty: &ScalarType,
 ) -> Result<(HirScalarExpr, Vec<GlobalId>), PlanError> {
-    let mut qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
-    let expr = resolve_names_expr(&mut qcx, expr.clone())?;
+    let qcx = QueryContext::root(scx, QueryLifetime::OneShot(scx.pcx()?));
     let ecx = &ExprContext {
         qcx: &qcx,
         name: "DEFAULT expression",
@@ -775,7 +764,7 @@ pub fn plan_default_expr(
         allow_windows: false,
     };
     let hir = plan_expr(ecx, &expr)?.cast_to(ecx, CastContext::Assignment, target_ty)?;
-    Ok((hir, qcx.ids.into_iter().collect()))
+    Ok((hir, qcx.ids().into_iter().collect()))
 }
 
 pub fn plan_params<'a>(
@@ -799,9 +788,9 @@ pub fn plan_params<'a>(
     let mut packer = datums.packer();
     let mut types = Vec::new();
     let temp_storage = &RowArena::new();
-    for (mut param, ty) in params.into_iter().zip(&desc.param_types) {
-        transform_ast::transform_expr(scx, &mut param)?;
-        let expr = resolve_names_expr(&mut qcx, param)?;
+    for (param, ty) in params.into_iter().zip(&desc.param_types) {
+        let mut expr = resolve_names_expr(&mut qcx, param)?;
+        transform_ast::transform_expr(scx, &mut expr)?;
 
         let ecx = &ExprContext {
             qcx: &qcx,
@@ -832,18 +821,10 @@ pub fn plan_params<'a>(
 pub fn plan_index_exprs<'a>(
     scx: &'a StatementContext,
     on_desc: &RelationDesc,
-    exprs: Vec<Expr<Raw>>,
+    exprs: Vec<Expr<Aug>>,
 ) -> Result<(Vec<mz_expr::MirScalarExpr>, Vec<GlobalId>), PlanError> {
     let scope = Scope::from_source(None, on_desc.iter_names());
-    let mut qcx = QueryContext::root(scx, QueryLifetime::Static);
-
-    let resolved_exprs = exprs
-        .into_iter()
-        .map(|mut e| {
-            transform_ast::transform_expr(scx, &mut e)?;
-            resolve_names_expr(&mut qcx, e)
-        })
-        .collect::<Result<Vec<Expr<Aug>>, _>>()?;
+    let qcx = QueryContext::root(scx, QueryLifetime::Static);
 
     let ecx = &ExprContext {
         qcx: &qcx,
@@ -855,11 +836,12 @@ pub fn plan_index_exprs<'a>(
         allow_windows: false,
     };
     let mut out = vec![];
-    for expr in resolved_exprs {
+    for mut expr in exprs {
+        transform_ast::transform_expr(scx, &mut expr)?;
         let expr = plan_expr_or_col_index(ecx, &expr)?;
         out.push(expr.lower_uncorrelated()?);
     }
-    Ok((out, qcx.ids.into_iter().collect()))
+    Ok((out, qcx.ids().into_iter().collect()))
 }
 
 fn plan_expr_or_col_index(ecx: &ExprContext, e: &Expr<Aug>) -> Result<HirScalarExpr, PlanError> {
@@ -4632,7 +4614,7 @@ pub struct QueryContext<'a> {
     /// CTEs for this query, mapping their assigned LocalIds to their definition.
     pub ctes: HashMap<LocalId, CteDesc>,
     /// The GlobalIds of the items the `Query` is dependent upon.
-    pub ids: HashSet<GlobalId>,
+    ids: HashSet<GlobalId>,
     pub recursion_guard: RecursionGuard,
 }
 
@@ -4726,6 +4708,16 @@ impl<'a> QueryContext<'a> {
 
     pub fn humanize_scalar_type(&self, typ: &ScalarType) -> String {
         self.scx.humanize_scalar_type(typ)
+    }
+
+    pub fn ids(&self) -> HashSet<GlobalId> {
+        let mut ids = self.ids.clone();
+        ids.extend(self.scx.ids.iter());
+        ids
+    }
+
+    pub fn extend_ids(&mut self, ids: &HashSet<GlobalId>) {
+        self.ids.extend(ids.iter());
     }
 }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -20,16 +20,18 @@ use mz_expr::MirRelationExpr;
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::numeric::NumericMaxScale;
 use mz_repr::{RelationDesc, ScalarType};
+use mz_sql_parser::ast::AstInfo;
 
 use crate::ast::{
     CopyDirection, CopyRelation, CopyStatement, CopyTarget, CreateViewStatement, DeleteStatement,
-    ExplainStage, ExplainStatement, Explainee, Ident, InsertStatement, Query, Raw, SelectStatement,
-    Statement, TailRelation, TailStatement, UnresolvedObjectName, UpdateStatement, ViewDefinition,
+    ExplainStage, ExplainStatement, Explainee, Ident, InsertStatement, Query, SelectStatement,
+    Statement, TailRelation, TailStatement, UpdateStatement, ViewDefinition,
 };
 use crate::catalog::CatalogItemType;
-use crate::plan::query;
+use crate::names::{resolve_names, Aug, ResolvedObjectName};
 use crate::plan::query::QueryLifetime;
 use crate::plan::statement::{StatementContext, StatementDesc};
+use crate::plan::{query, QueryContext};
 use crate::plan::{
     CopyFormat, CopyFromPlan, CopyParams, ExplainPlan, InsertPlan, MutationKind, Params, PeekPlan,
     Plan, ReadThenWritePlan, TailFrom, TailPlan,
@@ -48,7 +50,7 @@ pub fn describe_insert(
         columns,
         source,
         ..
-    }: InsertStatement<Raw>,
+    }: InsertStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     query::plan_insert_query(scx, table_name, columns, source)?;
     Ok(StatementDesc::new(None))
@@ -60,7 +62,7 @@ pub fn plan_insert(
         table_name,
         columns,
         source,
-    }: InsertStatement<Raw>,
+    }: InsertStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let (id, mut expr) = query::plan_insert_query(scx, table_name, columns, source)?;
@@ -72,7 +74,7 @@ pub fn plan_insert(
 
 pub fn describe_delete(
     scx: &StatementContext,
-    stmt: DeleteStatement<Raw>,
+    stmt: DeleteStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     query::plan_delete_query(scx, stmt)?;
     Ok(StatementDesc::new(None))
@@ -80,7 +82,7 @@ pub fn describe_delete(
 
 pub fn plan_delete(
     scx: &StatementContext,
-    stmt: DeleteStatement<Raw>,
+    stmt: DeleteStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let rtw_plan = query::plan_delete_query(scx, stmt)?;
@@ -89,7 +91,7 @@ pub fn plan_delete(
 
 pub fn describe_update(
     scx: &StatementContext,
-    stmt: UpdateStatement<Raw>,
+    stmt: UpdateStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     query::plan_update_query(scx, stmt)?;
     Ok(StatementDesc::new(None))
@@ -97,7 +99,7 @@ pub fn describe_update(
 
 pub fn plan_update(
     scx: &StatementContext,
-    stmt: UpdateStatement<Raw>,
+    stmt: UpdateStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let rtw_plan = query::plan_update_query(scx, stmt)?;
@@ -135,16 +137,16 @@ pub fn plan_read_then_write(
 
 pub fn describe_select(
     scx: &StatementContext,
-    SelectStatement { query, .. }: SelectStatement<Raw>,
+    stmt: SelectStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     let query::PlannedQuery { desc, .. } =
-        query::plan_root_query(scx, query, QueryLifetime::OneShot(scx.pcx()?))?;
+        query::plan_root_query(scx, stmt.query, QueryLifetime::OneShot(scx.pcx()?))?;
     Ok(StatementDesc::new(Some(desc)))
 }
 
 pub fn plan_select(
     scx: &StatementContext,
-    SelectStatement { query, as_of }: SelectStatement<Raw>,
+    SelectStatement { query, as_of }: SelectStatement<Aug>,
     params: &Params,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, anyhow::Error> {
@@ -164,7 +166,7 @@ pub fn describe_explain(
     scx: &StatementContext,
     ExplainStatement {
         stage, explainee, ..
-    }: ExplainStatement<Raw>,
+    }: ExplainStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(RelationDesc::empty().with_column(
         match stage {
@@ -198,13 +200,13 @@ pub fn plan_explain(
         stage,
         explainee,
         options,
-    }: ExplainStatement<Raw>,
+    }: ExplainStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, anyhow::Error> {
     let is_view = matches!(explainee, Explainee::View(_));
     let query = match explainee {
         Explainee::View(name) => {
-            let view = scx.resolve_item(name.clone())?;
+            let view = scx.get_item_by_name(&name)?;
             if view.item_type() != CatalogItemType::View {
                 bail!("Expected {} to be a view, not a {}", name, view.item_type());
             }
@@ -217,11 +219,12 @@ pub fn plan_explain(
                 }) => query,
                 _ => panic!("Sql for existing view should parse as a view"),
             };
-            query
+            let mut qcx = QueryContext::root(&scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
+            resolve_names(&mut qcx, query)?
         }
         Explainee::Query(query) => query,
     };
-    // Previouly we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
+    // Previously we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
     // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
     let query::PlannedQuery {
         mut expr,
@@ -251,7 +254,7 @@ pub fn plan_explain(
 /// an `mz_expr::MirRelationExpr`, which cannot include correlated expressions.
 pub fn plan_query(
     scx: &StatementContext,
-    query: Query<Raw>,
+    query: Query<Aug>,
     params: &Params,
     lifetime: QueryLifetime,
 ) -> Result<query::PlannedQuery<MirRelationExpr>, anyhow::Error> {
@@ -279,19 +282,17 @@ with_options! {
 
 pub fn describe_tail(
     scx: &StatementContext,
-    TailStatement {
-        relation, options, ..
-    }: TailStatement<Raw>,
+    stmt: TailStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
-    let relation_desc = match relation {
-        TailRelation::Name(name) => scx.resolve_item(name)?.desc()?.clone(),
+    let relation_desc = match stmt.relation {
+        TailRelation::Name(name) => scx.get_item_by_name(&name)?.desc()?.clone(),
         TailRelation::Query(query) => {
             let query::PlannedQuery { desc, .. } =
                 query::plan_root_query(scx, query, QueryLifetime::OneShot(scx.pcx()?))?;
             desc
         }
     };
-    let options = TailOptions::try_from(options)?;
+    let options = TailOptions::try_from(stmt.options)?;
     let progress = options.progress.unwrap_or(false);
     let mut desc = RelationDesc::empty().with_column(
         "mz_timestamp",
@@ -310,7 +311,7 @@ pub fn describe_tail(
         }
         desc = desc.with_column(name, ty);
     }
-    Ok(StatementDesc::new(Some(desc)))
+    return Ok(StatementDesc::new(Some(desc)));
 }
 
 pub fn plan_tail(
@@ -319,12 +320,12 @@ pub fn plan_tail(
         relation,
         options,
         as_of,
-    }: TailStatement<Raw>,
+    }: TailStatement<Aug>,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, anyhow::Error> {
     let from = match relation {
         TailRelation::Name(name) => {
-            let entry = scx.resolve_item(name)?;
+            let entry = scx.get_item_by_name(&name)?;
             match entry.item_type() {
                 CatalogItemType::Table | CatalogItemType::Source | CatalogItemType::View => {
                     TailFrom::Id(entry.id())
@@ -373,7 +374,7 @@ pub fn plan_tail(
 
 pub fn describe_table(
     scx: &StatementContext,
-    table_name: UnresolvedObjectName,
+    table_name: <Aug as AstInfo>::ObjectName,
     columns: Vec<Ident>,
 ) -> Result<StatementDesc, anyhow::Error> {
     let (_, desc, _) = query::plan_copy_from(scx, table_name, columns)?;
@@ -393,7 +394,7 @@ with_options! {
 
 pub fn describe_copy(
     scx: &StatementContext,
-    CopyStatement { relation, .. }: CopyStatement<Raw>,
+    CopyStatement { relation, .. }: CopyStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(match relation {
         CopyRelation::Table { name, columns } => describe_table(scx, name, columns)?,
@@ -405,7 +406,7 @@ pub fn describe_copy(
 
 fn plan_copy_from(
     scx: &StatementContext,
-    table_name: UnresolvedObjectName,
+    table_name: ResolvedObjectName,
     columns: Vec<Ident>,
     params: CopyParams,
 ) -> Result<Plan, anyhow::Error> {
@@ -424,7 +425,7 @@ pub fn plan_copy(
         direction,
         target,
         options,
-    }: CopyStatement<Raw>,
+    }: CopyStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     let options = CopyOptions::try_from(options)?;
     let mut copy_params = CopyParams {

--- a/src/sql/src/plan/transform_ast.rs
+++ b/src/sql/src/plan/transform_ast.rs
@@ -15,11 +15,12 @@
 
 use uuid::Uuid;
 
+use crate::names::Aug;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
-    Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Raw, Select, SelectItem,
-    TableAlias, TableFactor, TableFunction, TableWithJoins, UnresolvedObjectName, Value,
+    Expr, Function, FunctionArgs, Ident, Op, OrderByExpr, Query, Select, SelectItem, TableAlias,
+    TableFactor, TableFunction, TableWithJoins, UnresolvedObjectName, Value,
 };
 
 use crate::normalize;
@@ -27,12 +28,12 @@ use crate::plan::{PlanError, StatementContext};
 
 pub fn transform_query<'a>(
     scx: &StatementContext,
-    query: &'a mut Query<Raw>,
+    query: &'a mut Query<Aug>,
 ) -> Result<(), PlanError> {
     run_transforms(scx, |t, query| t.visit_query_mut(query), query)
 }
 
-pub fn transform_expr(scx: &StatementContext, expr: &mut Expr<Raw>) -> Result<(), PlanError> {
+pub fn transform_expr(scx: &StatementContext, expr: &mut Expr<Aug>) -> Result<(), PlanError> {
     run_transforms(scx, |t, expr| t.visit_expr_mut(expr), expr)
 }
 
@@ -42,7 +43,7 @@ pub(crate) fn run_transforms<F, A>(
     ast: &mut A,
 ) -> Result<(), PlanError>
 where
-    F: for<'ast> FnMut(&mut dyn VisitMut<'ast, Raw>, &'ast mut A),
+    F: for<'ast> FnMut(&mut dyn VisitMut<'ast, Aug>, &'ast mut A),
 {
     let mut func_rewriter = FuncRewriter::new(scx);
     f(&mut func_rewriter, ast);
@@ -88,7 +89,7 @@ impl<'a> FuncRewriter<'a> {
 
     // Divides `lhs` by `rhs` but replaces division-by-zero errors with NULL;
     // note that this is semantically equivalent to `NULLIF(rhs, 0)`.
-    fn plan_divide(lhs: Expr<Raw>, rhs: Expr<Raw>) -> Expr<Raw> {
+    fn plan_divide(lhs: Expr<Aug>, rhs: Expr<Aug>) -> Expr<Aug> {
         lhs.divide(Expr::Case {
             operand: None,
             conditions: vec![rhs.clone().equals(Expr::number("0"))],
@@ -99,11 +100,11 @@ impl<'a> FuncRewriter<'a> {
 
     fn plan_agg(
         name: UnresolvedObjectName,
-        expr: Expr<Raw>,
-        order_by: Vec<OrderByExpr<Raw>>,
-        filter: Option<Box<Expr<Raw>>>,
+        expr: Expr<Aug>,
+        order_by: Vec<OrderByExpr<Aug>>,
+        filter: Option<Box<Expr<Aug>>>,
         distinct: bool,
-    ) -> Expr<Raw> {
+    ) -> Expr<Aug> {
         Expr::Function(Function {
             name,
             args: FunctionArgs::Args {
@@ -116,7 +117,7 @@ impl<'a> FuncRewriter<'a> {
         })
     }
 
-    fn plan_avg(expr: Expr<Raw>, filter: Option<Box<Expr<Raw>>>, distinct: bool) -> Expr<Raw> {
+    fn plan_avg(expr: Expr<Aug>, filter: Option<Box<Expr<Aug>>>, distinct: bool) -> Expr<Aug> {
         let sum = Self::plan_agg(
             UnresolvedObjectName::qualified(&["pg_catalog", "sum"]),
             expr.clone(),
@@ -136,11 +137,11 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn plan_variance(
-        expr: Expr<Raw>,
-        filter: Option<Box<Expr<Raw>>>,
+        expr: Expr<Aug>,
+        filter: Option<Box<Expr<Aug>>>,
         distinct: bool,
         sample: bool,
-    ) -> Expr<Raw> {
+    ) -> Expr<Aug> {
         // N.B. this variance calculation uses the "textbook" algorithm, which
         // is known to accumulate problematic amounts of error. The numerically
         // stable variants, the most well-known of which is Welford's, are
@@ -190,15 +191,15 @@ impl<'a> FuncRewriter<'a> {
     }
 
     fn plan_stddev(
-        expr: Expr<Raw>,
-        filter: Option<Box<Expr<Raw>>>,
+        expr: Expr<Aug>,
+        filter: Option<Box<Expr<Aug>>>,
         distinct: bool,
         sample: bool,
-    ) -> Expr<Raw> {
+    ) -> Expr<Aug> {
         Self::plan_variance(expr, filter, distinct, sample).call_unary(vec!["sqrt"])
     }
 
-    fn rewrite_expr(&mut self, expr: &Expr<Raw>) -> Option<(Ident, Expr<Raw>)> {
+    fn rewrite_expr(&mut self, expr: &Expr<Aug>) -> Option<(Ident, Expr<Aug>)> {
         match expr {
             Expr::Function(Function {
                 name,
@@ -268,8 +269,8 @@ impl<'a> FuncRewriter<'a> {
     }
 }
 
-impl<'ast> VisitMut<'ast, Raw> for FuncRewriter<'_> {
-    fn visit_select_item_mut(&mut self, item: &'ast mut SelectItem<Raw>) {
+impl<'ast> VisitMut<'ast, Aug> for FuncRewriter<'_> {
+    fn visit_select_item_mut(&mut self, item: &'ast mut SelectItem<Aug>) {
         if let SelectItem::Expr { expr, alias: None } = item {
             visit_mut::visit_expr_mut(self, expr);
             if let Some((alias, expr)) = self.rewrite_expr(expr) {
@@ -283,7 +284,7 @@ impl<'ast> VisitMut<'ast, Raw> for FuncRewriter<'_> {
         }
     }
 
-    fn visit_expr_mut(&mut self, expr: &'ast mut Expr<Raw>) {
+    fn visit_expr_mut(&mut self, expr: &'ast mut Expr<Aug>) {
         visit_mut::visit_expr_mut(self, expr);
         if let Some((_name, new_expr)) = self.rewrite_expr(expr) {
             *expr = new_expr;
@@ -306,8 +307,8 @@ impl CheckedRecursion for Desugarer {
     }
 }
 
-impl<'ast> VisitMut<'ast, Raw> for Desugarer {
-    fn visit_expr_mut(&mut self, expr: &'ast mut Expr<Raw>) {
+impl<'ast> VisitMut<'ast, Aug> for Desugarer {
+    fn visit_expr_mut(&mut self, expr: &'ast mut Expr<Aug>) {
         self.visit_internal(Self::visit_expr_mut_internal, expr);
     }
 }
@@ -334,7 +335,7 @@ impl Desugarer {
         }
     }
 
-    fn visit_expr_mut_internal(&mut self, expr: &mut Expr<Raw>) -> Result<(), PlanError> {
+    fn visit_expr_mut_internal(&mut self, expr: &mut Expr<Aug>) -> Result<(), PlanError> {
         // `($expr)` => `$expr`
         while let Expr::Nested(e) = expr {
             *expr = e.take();

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, ensure, Context};
 use aws_arn::ARN;
 use csv::ReaderBuilder;
+use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
 use protobuf_native::MessageLite;
 use reqwest::Url;
@@ -32,8 +33,6 @@ use mz_ccsr::{Client, GetBySubjectError};
 use mz_dataflow_types::postgres_source::PostgresSourceDetails;
 use mz_dataflow_types::sources::{AwsConfig, AwsExternalId};
 use mz_repr::strconv;
-
-use prost::Message;
 
 use crate::ast::{
     AvroSchema, CreateSourceConnector, CreateSourceFormat, CreateSourceStatement, CsrConnectorAvro,

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -7,13 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::ast::{Expr, Raw};
+use crate::ast::Expr;
 use crate::catalog::{
     CatalogComputeInstance, CatalogConfig, CatalogDatabase, CatalogError, CatalogItem,
     CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, SessionCatalog,
 };
 use crate::func::{Func, MZ_CATALOG_BUILTINS, MZ_INTERNAL_BUILTINS, PG_CATALOG_BUILTINS};
-use crate::names::{DatabaseSpecifier, FullName, PartialName};
+use crate::names::{Aug, DatabaseSpecifier, FullName, PartialName};
 use crate::plan::StatementDesc;
 use chrono::MIN_DATETIME;
 use lazy_static::lazy_static;
@@ -131,7 +131,7 @@ impl CatalogItem for TestCatalogItem {
         unimplemented!()
     }
 
-    fn table_details(&self) -> Option<&[Expr<Raw>]> {
+    fn table_details(&self) -> Option<&[Expr<Aug>]> {
         unimplemented!()
     }
 

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -18,6 +18,7 @@ use mz_lowertest::*;
 use crate::query_model::Model;
 use catalog::TestCatalog;
 
+use crate::names::resolve_names_stmt;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -62,7 +63,11 @@ fn convert_input_to_model(input: &str, catalog: &TestCatalog) -> Result<Model, S
         Ok(mut stmts) => {
             assert!(stmts.len() == 1);
             let stmt = stmts.pop().unwrap();
-            let scx = &StatementContext::new(None, catalog);
+            let scx = &mut StatementContext::new(None, catalog);
+            let stmt = match resolve_names_stmt(scx, stmt) {
+                Ok(stmt) => stmt,
+                Err(e) => return Err(format!("unable to resolve statement {}", e)),
+            };
             if let mz_sql_parser::ast::Statement::Select(query) = stmt {
                 let planned_query = match crate::plan::query::plan_root_query(
                     scx,

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -189,7 +189,7 @@ materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"de
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [u244 AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -7,8 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ set-regex match=u\d+ replacement=UID
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER [1] FROM [u38 AS \"materialize\".\"public\".\"static_view\"] INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER [1] FROM [UID AS \"materialize\".\"public\".\"static_view\"] INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
 
 $ kafka-verify format=avro sink=materialize.public.upgrade_kafka_sink sort-messages=true
 {"before": null, "after": {"row": {"f1": 1}}}

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -7,13 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# v0.22.X version broke backwards compatibility by separating the day
-# and microsecond fields in Intervals.
-$ skip-if
-select split_part(ltrim(mz_version(), 'v'), '.', 1)::int = 0 and split_part(ltrim(mz_version(), 'v'), '.', 2)::int >= 22;
-
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER [1] FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER [1] FROM [u38 AS \"materialize\".\"public\".\"static_view\"] INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
 
 $ kafka-verify format=avro sink=materialize.public.upgrade_kafka_sink sort-messages=true
 {"before": null, "after": {"row": {"f1": 1}}}


### PR DESCRIPTION
Previously all planner functions would take in raw statements and
resolve names on an ad hoc basis as needed. This commit updates this
behavior so that the planner resolves all names as it's first step and
the planner functions take augmented statements. There are two
exceptions to this:
  * SCL planner functions still work with raw statements
  * SHOW and DROP statements use augmented statements, but the
  augmented statements contain unresolved names.

These exceptions exist not for any logical reason but to try and break
up the work into multiple smaller commits.

These changes gets us closer to removing some of the limitations on our
ALTER statements, by starting to allow us to represent dependencies
with IDs instead of names.

Works towards resolving #5302

### Motivation
This PR refactors existing code.

### Tips for reviewer
* There's still a lot to be done, but I thought this was a good stopping point for one PR.
* Pay close attention to how `depends_on: HashSet<GlobalId>` are collected and used during planning. They are stashed in the `StatementContext`/`QueryContext` during name resolution and then later retrieved when constructing a plan.  I'm not in love with this approach because it wasn't very obvious to me and it was one of the bigger pain points when trying to fix errors. One idea I had was to explicitly return a set of `GlobalIds` from the name resolution functions, though they would still need to be carried around until the end of planning.
* I don't think I understand the full ramifications of including `GlobalIds` in the create statements or switching from `parse_object_name` to `parse_raw_name` (which allows names to look like `[<global-id> AS <actual-name>]`). If these statements are being used to take a snapshot it definitely seems a bit fragile because all the statements would need to be re-executed in the correct order to try and re-create the same IDs.
* I have to fix the upgrades tests, but that in itself shouldn't require any non-test code changes.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds global ids to `SHOW CREATE` statements for the from field for `CREATE SINK` statements, source name field for `CREATE VIEW` statements, on field for `CREATE INDEX` statements.