### PR TITLE
doc/user: Make function names searchable in docs

### DIFF
--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -54,5 +54,5 @@
 <script type="text/javascript">
   $(function() {
     $(location.hash).parents('tr').css('background-color', '#FFFF5522');
-   });
+  });
 </script>

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -24,7 +24,9 @@
   </tr>
   {{ range .functions }}
   <tr>
-    <td>
+    {{/*  Print an ID and class that can be used to index in docsearch
+            and deeplink.  */}}
+    <td class="docsearch_l4" id="{{ .signature | urlize }}">
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -49,3 +49,10 @@
 {{end}}
 
 {{ end }}{{/*  {{ range $.Site.Data.sql_funcs }} */}}
+
+{{/*  When someone is deeplinked to a td on the page, highlight the tr  */}}
+<script type="text/javascript">
+  $(function() {
+    $(location.hash).parents('tr').css('background-color', '#FFFF5522');
+   });
+</script>


### PR DESCRIPTION
This is long overdue. Certain functions (e.g. `stddev` only appear in the large table of functions on https://materialize.com/docs/sql/functions/  This means Algolia DocSearch doesn't pick them up. So searching for `stddev` returns nothing valuable:

![image](https://user-images.githubusercontent.com/11527560/157991066-ac903984-04f9-45ab-bda7-5a468296513c.png)

This PR is step one of two, it does the following:
1. Adds an anchor (ID) attribute to the `td` around the function signature, by urlizing the signature.
2. Adds a line of javascript that highlights the entire row of a deeplinked function.

There is a second step we need to do in Algolia DocSearch config to ensure that docsearch is looking for `docsearch_l4` tags.

If there are other fragments in docs that are important to search and NOT currently printed in headers, we can use this same approach.

## Review Criteria:

1. We can deeplink to functions https://preview.materialize.com/11184/sql/functions/#stddevx-t-u
   - It's in your scroll window
   - The row is highlighted yellow
2. This doesn't break other deeplinks on the page https://preview.materialize.com/11184/sql/functions/#array-func

We won't be able to test search until it's in production.

## Algolia Config Edit

My next step will be to change the record extractor in docsearch to first try for `main .docsearch_l4` and [fallback](https://docsearch.algolia.com/docs/record-extractor#handling-fallback-dom-selectors) to `main h4`:
```js
recordExtractor: ({ $, helpers }) => {
        return helpers.docsearch({
          recordProps: {
            lvl1: "main h2",
            content: "main p, main li",
            lvl0: {
              selectors: "main h1",
            },
            lvl2: "main h3",
            lvl3: ["main .docsearch_l4", "main h4"],
            lvl4: "main h5",
            lvl5: "main h6",
          },
          indexHeadings: true,
        });
```