### PR TITLE
test: add test for linearizability of unmaterialized sources

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -612,9 +612,14 @@ Instructs Mz to sleep for the specified number of seconds. `mz_sleep()` returns 
 
 ## Controlling timeouts and retries
 
-#### `$ set-sql-timeout duration=N(ms|s|m)`
+#### `$ set-sql-timeout duration=N(ms|s|m) [force=true]`
 
 Adjusts the SQL timeout for tests that contain queries that may take a long time to run. Alternatively, the `--default-timeout` setting can be passed to `testdrive`.
+
+The command will be ignored if it sets a timeout that is smaller than the
+default timeout, unless you specify `force=true`. Use this override with
+caution! It may cause the test to fail in test environments that introduce
+overhead and need a larger `--default-timeout` to succeed.
 
 ## Actions on Avro OCF files
 

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -618,13 +618,19 @@ Adjusts the SQL timeout for tests that contain queries that may take a long time
 
 ## Actions on Avro OCF files
 
-#### `$ avro-ocf-write path=... schema=... codec=(snapy|null)`
+#### `$ avro-ocf-write path=... schema=... codec=(snapy|null) [repeat=N]`
 
 Writes the data following the action into the specified file using the specified schema. The schema is traditionally provided using a variable that is defined elsewhere in the test.
 
-#### `$ avro-ocf-append path=...`
+If the `repeat` parameter is provided, the data provided will be appended to the
+file the specified number of times, rather than just once.
+
+#### `$ avro-ocf-append path=... [repeat=N]`
 
 Appends the data provided to an already-existing file
+
+If the `repeat` parameter is provided, the data provided will be appended to the
+file the specified number of times, rather than just once.
 
 #### `$ avro-ocf-verify sink=...`
 
@@ -640,9 +646,12 @@ $ avro-ocf-verify sink=materialize.public.basic_sink_${testdrive.seed}
 
 ## Actions on local files
 
-#### `$ file-append path=file.name [compression=gzip]`
+#### `$ file-append path=file.name [compression=gzip] [repeat=N]`
 
 Writes the data provided to a file on disk. The file will be created inside the temporary directory of the test.
+
+If the `repeat` parameter is provided, the data provided will be appended to the
+file the specified number of times, rather than just once.
 
 #### `$ file-delete path=file.name`
 

--- a/test/testdrive/github-10587.td
+++ b/test/testdrive/github-10587.td
@@ -134,7 +134,7 @@ count
 # in a row. Obviously, this test will not always catch the issue since the original
 # bug was nondeterministic, but this is a good best-effort smake test.
 
-$ set-sql-timeout duration=0s
+$ set-sql-timeout duration=0s force=true
 
 > SELECT mz_internal.mz_sleep(0.2);
 <null>

--- a/test/testdrive/unmaterialized-sources.td
+++ b/test/testdrive/unmaterialized-sources.td
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that the first use of an unmaterialized source presents all data
+# that was available at the time the source was created.
+#
+# See #2310, #10587, #11048, and #11072.
+
+$ set-sql-timeout duration=0s force=true
+
+# Test with an unmaterialized file source.
+
+$ file-append path=file repeat=100000
+data
+
+> CREATE SOURCE file
+  FROM FILE '${testdrive.temp-dir}/file'
+  FORMAT TEXT
+
+> SELECT count(*) FROM file
+100000
+
+# Test with an unmaterialized Avro OCF source.
+
+$ avro-ocf-write path=file.ocf schema={"type": "string"} repeat=100000
+"data"
+
+> CREATE SOURCE file_ocf
+  FROM AVRO OCF '${testdrive.temp-dir}/file.ocf'
+
+> SELECT count(*) FROM file_ocf AS file_ocf (text)
+100000
+
+# Test with an unmaterialized Kafka source.
+
+$ kafka-create-topic topic=data
+
+$ kafka-ingest format=bytes topic=data repeat=100000
+1
+
+> CREATE SOURCE kafka
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT TEXT
+
+> SELECT text FROM kafka
+100000


### PR DESCRIPTION
Add a test that demonstrates the most obvious linearizability defect in
unmaterialized sources: that they don't promise to show you anything in
particular when you query them.

See https://github.com/MaterializeInc/materialize/issues/2310, https://github.com/MaterializeInc/materialize/issues/10587, https://github.com/MaterializeInc/materialize/issues/11048, and https://github.com/MaterializeInc/materialize/issues/11072.

### Motivation

  * This PR ~fixes~ adds a test for a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - TODO: if we fix the bug, maybe write a release note?
