### PR TITLE
coord: add EXPLAIN TIMESTAMP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,7 @@ dependencies = [
  "prometheus",
  "rand",
  "rdkafka-sys",
+ "regex",
  "reqwest",
  "rlimit",
  "semver",

--- a/src/dataflow-types/src/lib.rs
+++ b/src/dataflow-types/src/lib.rs
@@ -26,6 +26,8 @@ pub use errors::*;
 pub use explain::DataflowGraphFormatter;
 pub use explain::Explanation;
 pub use explain::JsonViewFormatter;
+pub use explain::TimestampExplanation;
+pub use explain::TimestampSource;
 pub use gen::*;
 pub use plan::Plan;
 pub use types::*;

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -130,6 +130,7 @@ postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres", b
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array", branch = "mz-0.7.2" }
 predicates = "2.1.1"
 rand = "0.8.5"
+regex = "1.5.4"
 reqwest = { version = "0.11.9", features = ["blocking"] }
 serde_json = "1.0.79"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4"] }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1690,6 +1690,8 @@ pub enum ExplainStage {
     OptimizedPlan,
     /// The render::plan::Plan
     PhysicalPlan,
+    /// The dependent and selected timestamps
+    Timestamp,
 }
 
 impl AstDisplay for ExplainStage {
@@ -1701,6 +1703,7 @@ impl AstDisplay for ExplainStage {
             ExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
             ExplainStage::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
             ExplainStage::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
+            ExplainStage::Timestamp => f.write_str("TIMESTAMP"),
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4460,6 +4460,7 @@ impl<'a> Parser<'a> {
             PHYSICAL,
             PLAN,
             QUERY,
+            TIMESTAMP,
         ]) {
             Some(RAW) => {
                 self.expect_keywords(&[PLAN, FOR])?;
@@ -4489,6 +4490,10 @@ impl<'a> Parser<'a> {
             Some(PHYSICAL) => {
                 self.expect_keywords(&[PLAN, FOR])?;
                 ExplainStage::PhysicalPlan
+            }
+            Some(TIMESTAMP) => {
+                self.expect_keywords(&[FOR])?;
+                ExplainStage::Timestamp
             }
             None => ExplainStage::OptimizedPlan,
             _ => unreachable!(),

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -129,3 +129,10 @@ EXPLAIN (WITH A AS (SELECT 1) SELECT * from A)
 EXPLAIN OPTIMIZED PLAN FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
 Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+
+parse-statement
+EXPLAIN TIMESTAMP FOR SELECT 1
+----
+EXPLAIN TIMESTAMP FOR SELECT 1
+=>
+Explain(ExplainStatement { stage: Timestamp, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -174,6 +174,7 @@ pub fn describe_explain(
             ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
             ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
             ExplainStage::PhysicalPlan => "Physical Plan",
+            ExplainStage::Timestamp => "Timestamp",
         },
         ScalarType::String.nullable(false),
     )))


### PR DESCRIPTION
This mode outputs a description of all data that were used when choosing
a timestamp for a query.

This PR does not update the documentation or list a release note because it is currently mostly useful during internal debugging.

### Motivation

  * This PR adds a feature that has not yet been specified.

When debugging, it is sometimes useful to have detailed timestamp information. Historically we have generated this by adding various printlns.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing changes.