### PR TITLE
sql+coord: propagate index, sink relationship to clusters to system tables

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2248,7 +2248,7 @@ impl Catalog {
                 conn_id: None,
                 depends_on: index.depends_on,
                 enabled: self.index_enabled_by_default(&id),
-                compute_instance: DEFAULT_COMPUTE_INSTANCE_ID,
+                compute_instance: index.compute_instance,
             }),
             Plan::CreateSink(CreateSinkPlan {
                 sink,
@@ -2261,7 +2261,7 @@ impl Catalog {
                 envelope: sink.envelope,
                 with_snapshot,
                 depends_on: sink.depends_on,
-                compute_instance: DEFAULT_COMPUTE_INSTANCE_ID,
+                compute_instance: sink.compute_instance,
             }),
             Plan::CreateType(CreateTypePlan { typ, .. }) => CatalogItem::Type(Type {
                 create_sql: typ.create_sql,

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1048,7 +1048,8 @@ lazy_static! {
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("on_id", ScalarType::String.nullable(false))
             .with_column("volatility", ScalarType::String.nullable(false))
-            .with_column("enabled", ScalarType::Bool.nullable(false)),
+            .with_column("enabled", ScalarType::Bool.nullable(false))
+            .with_column("cluster_id", ScalarType::Int64.nullable(false)),
         id: GlobalId::System(4015),
         persistent: false,
     };
@@ -1099,7 +1100,8 @@ lazy_static! {
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("name", ScalarType::String.nullable(false))
             .with_column("connector_type", ScalarType::String.nullable(false))
-            .with_column("volatility", ScalarType::String.nullable(false)),
+            .with_column("volatility", ScalarType::String.nullable(false))
+            .with_column("cluster_id", ScalarType::Int64.nullable(false)),
         id: GlobalId::System(4023),
         persistent: false,
     };

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -286,6 +286,7 @@ impl CatalogState {
                     Datum::String(name),
                     Datum::String(connector.name()),
                     Datum::String(self.is_volatile(id).as_str()),
+                    Datum::Int64(sink.compute_instance),
                 ]),
                 diff,
             });
@@ -320,6 +321,7 @@ impl CatalogState {
                 Datum::String(&index.on.to_string()),
                 Datum::String(self.is_volatile(id).as_str()),
                 Datum::from(index.enabled),
+                Datum::Int64(index.compute_instance),
             ]),
             diff,
         });

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -192,31 +192,15 @@ fn ast_rewrite_index_sink_cluster_default_0_23_0(
 ) -> Result<(), anyhow::Error> {
     match stmt {
         Statement::CreateIndex(CreateIndexStatement {
-            name: _,
-            in_cluster,
-            on_name: _,
-            key_parts: _,
-            with_options: _,
-            if_not_exists: _,
+            in_cluster: in_cluster @ None,
+            ..
+        })
+        | Statement::CreateSink(CreateSinkStatement {
+            in_cluster: in_cluster @ None,
+            ..
         }) => {
             *in_cluster = Some(RawIdent::Resolved(DEFAULT_COMPUTE_INSTANCE_ID.to_string()));
         }
-
-        Statement::CreateSink(CreateSinkStatement {
-            name: _,
-            in_cluster,
-            from: _,
-            connector: _,
-            with_options: _,
-            format: _,
-            envelope: _,
-            with_snapshot: _,
-            as_of: _,
-            if_not_exists: _,
-        }) => {
-            *in_cluster = Some(RawIdent::Resolved(DEFAULT_COMPUTE_INSTANCE_ID.to_string()));
-        }
-
         _ => (),
     };
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1123,6 +1123,7 @@ impl_display_t!(ShowDatabasesStatement);
 pub struct ShowObjectsStatement<T: AstInfo> {
     pub object_type: ObjectType,
     pub from: Option<UnresolvedObjectName>,
+    pub in_cluster: Option<T::ClusterName>,
     pub extended: bool,
     pub full: bool,
     pub materialized: bool,
@@ -1170,7 +1171,8 @@ impl_display_t!(ShowObjectsStatement);
 /// `SHOW INDEX|INDEXES|KEYS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowIndexesStatement<T: AstInfo> {
-    pub table_name: T::ObjectName,
+    pub table_name: Option<T::ObjectName>,
+    pub in_cluster: Option<T::ClusterName>,
     pub extended: bool,
     pub filter: Option<ShowStatementFilter<T>>,
 }
@@ -1181,8 +1183,15 @@ impl<T: AstInfo> AstDisplay for ShowIndexesStatement<T> {
         if self.extended {
             f.write_str("EXTENDED ");
         }
-        f.write_str("INDEXES FROM ");
-        f.write_node(&self.table_name);
+        f.write_str("INDEXES ");
+        if let Some(table_name) = &self.table_name {
+            f.write_str("FROM ");
+            f.write_node(table_name);
+        }
+        if let Some(in_cluster) = &self.in_cluster {
+            f.write_str("IN CLUSTER ");
+            f.write_node(in_cluster);
+        }
         if let Some(filter) = &self.filter {
             f.write_str(" ");
             f.write_node(filter);

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -37,154 +37,168 @@ SHOW ROLES
 ----
 SHOW ROLES
 =>
-ShowObjects(ShowObjectsStatement { object_type: Role, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW CLUSTERS
 ----
 SHOW CLUSTERS
 =>
-ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW USERS
 ----
 SHOW ROLES
 =>
-ShowObjects(ShowObjectsStatement { object_type: Role, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SCHEMAS
 ----
 SHOW SCHEMAS
 =>
-ShowObjects(ShowObjectsStatement { object_type: Schema, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Schema, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SCHEMAS FROM foo.bar
 ----
 SHOW SCHEMAS FROM foo.bar
 =>
-ShowObjects(ShowObjectsStatement { object_type: Schema, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Schema, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-ShowObjects(ShowObjectsStatement { object_type: Source, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SOURCES FROM foo.bar
 ----
 SHOW SOURCES FROM foo.bar
 =>
-ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW VIEWS
 ----
 SHOW VIEWS
 =>
-ShowObjects(ShowObjectsStatement { object_type: View, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: View, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW VIEWS FROM foo.bar
 ----
 SHOW VIEWS FROM foo.bar
 =>
-ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW TABLES
 ----
 SHOW TABLES
 =>
-ShowObjects(ShowObjectsStatement { object_type: Table, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW TABLES FROM foo.bar
 ----
 SHOW TABLES FROM foo.bar
 =>
-ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SINKS
 ----
 SHOW SINKS
 =>
-ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SINKS FROM foo.bar
 ----
 SHOW SINKS FROM foo.bar
 =>
-ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, materialized: false, filter: None })
+
+parse-statement
+SHOW SINKS FROM foo.bar IN CLUSTER baz
+----
+SHOW SINKS FROM foo.bar
+=>
+ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedObjectName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, materialized: false, filter: None })
+
+parse-statement
+SHOW SINKS IN CLUSTER baz
+----
+SHOW SINKS
+=>
+ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW TABLES LIKE '%foo%'
 ----
 SHOW TABLES LIKE '%foo%'
 =>
-ShowObjects(ShowObjectsStatement { object_type: Table, from: None, extended: false, full: false, materialized: false, filter: Some(Like("%foo%")) })
+ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: Some(Like("%foo%")) })
 
 parse-statement
 SHOW FULL VIEWS
 ----
 SHOW FULL VIEWS
 =>
-ShowObjects(ShowObjectsStatement { object_type: View, from: None, extended: false, full: true, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: View, from: None, in_cluster: None, extended: false, full: true, materialized: false, filter: None })
 
 parse-statement
 SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-ShowObjects(ShowObjectsStatement { object_type: Source, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW MATERIALIZED SOURCES FROM foo
 ----
 SHOW MATERIALIZED SOURCES FROM foo
 =>
-ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedObjectName([Ident("foo")])), extended: false, full: false, materialized: true, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedObjectName([Ident("foo")])), in_cluster: None, extended: false, full: false, materialized: true, filter: None })
 
 parse-statement
 SHOW MATERIALIZED VIEWS FROM foo LIKE '%foo%'
 ----
 SHOW MATERIALIZED VIEWS FROM foo LIKE '%foo%'
 =>
-ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedObjectName([Ident("foo")])), extended: false, full: false, materialized: true, filter: Some(Like("%foo%")) })
+ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedObjectName([Ident("foo")])), in_cluster: None, extended: false, full: false, materialized: true, filter: Some(Like("%foo%")) })
 
 parse-statement
 SHOW INDEXES FROM foo
 ----
 SHOW INDEXES FROM foo
 =>
-ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: false, filter: None })
+ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: false, filter: None })
 
 parse-statement
 SHOW INDEXES IN foo
 ----
 SHOW INDEXES FROM foo
 =>
-ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: false, filter: None })
+ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: false, filter: None })
 
 parse-statement
 SHOW EXTENDED INDEXES FROM foo
 ----
 SHOW EXTENDED INDEXES FROM foo
 =>
-ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: true, filter: None })
+ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: true, filter: None })
 
 parse-statement
 SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 ----
 SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 =>
-ShowIndexes(ShowIndexesStatement { table_name: Name(UnresolvedObjectName([Ident("foo")])), extended: true, filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("index_name")]), expr2: Some(Value(String("bar"))) })) })
+ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: true, filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("index_name")]), expr2: Some(Value(String("bar"))) })) })
 
 parse-statement
 SHOW CREATE VIEW foo
@@ -289,7 +303,7 @@ SHOW CLUSTERS
 ----
 SHOW CLUSTERS
 =>
-ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, extended: false, full: false, materialized: false, filter: None })
+ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, extended: false, full: false, materialized: false, filter: None })
 
 # TODO(justin): "all" here should be its own token so that it doesn't get
 # downcased.

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -28,7 +28,9 @@ use crate::ast::{
     ShowStatementFilter, Statement, Value,
 };
 use crate::catalog::CatalogItemType;
-use crate::names::{resolve_names_stmt, resolve_names_stmt_show, Aug, NameSimplifier};
+use crate::names::{
+    resolve_names_stmt, resolve_names_stmt_show, Aug, NameSimplifier, ResolvedClusterName,
+};
 use crate::parse;
 use crate::plan::statement::{dml, StatementContext, StatementDesc};
 use crate::plan::{Params, Plan, SendRowsPlan};
@@ -206,6 +208,7 @@ pub fn show_objects<'a>(
         materialized,
         object_type,
         from,
+        in_cluster,
         filter,
     }: ShowObjectsStatement<Aug>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
@@ -214,7 +217,7 @@ pub fn show_objects<'a>(
         ObjectType::Table => show_tables(scx, extended, full, from, filter),
         ObjectType::Source => show_sources(scx, full, materialized, from, filter),
         ObjectType::View => show_views(scx, full, materialized, from, filter),
-        ObjectType::Sink => show_sinks(scx, full, from, filter),
+        ObjectType::Sink => show_sinks(scx, full, from, in_cluster, filter),
         ObjectType::Type => show_types(scx, extended, full, from, filter),
         ObjectType::Object => show_all_objects(scx, extended, full, from, filter),
         ObjectType::Role => bail_unsupported!("SHOW ROLES"),
@@ -409,33 +412,48 @@ fn show_sinks<'a>(
     scx: &'a StatementContext<'a>,
     full: bool,
     from: Option<UnresolvedObjectName>,
+    in_cluster: Option<ResolvedClusterName>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
-    let schema = if let Some(from) = from {
-        scx.resolve_schema(from)?
-    } else {
-        scx.resolve_active_schema()?
+    let mut query_filters = vec![];
+
+    if let Some(from) = from {
+        query_filters.push(format!("schema_id = {}", scx.resolve_schema(from)?.id()));
+    } else if in_cluster.is_none() {
+        query_filters.push(format!("schema_id = {}", scx.resolve_active_schema()?.id()));
     };
+
+    if let Some(cluster) = in_cluster {
+        scx.require_experimental_mode("SHOW SINKS...IN CLUSTER")?;
+        query_filters.push(format!("clusters.id = {}", cluster.0));
+    }
+
+    let query_filters = itertools::join(query_filters.iter(), " AND ");
 
     let query = if full {
         format!(
             "SELECT
-            clusters.name AS in_cluster,
+            clusters.name AS cluster,
             sinks.name,
-            mz_internal.mz_classify_object_id(id) AS type,
+            mz_internal.mz_classify_object_id(sinks.id) AS type,
             sinks.volatility
         FROM
             mz_catalog.mz_sinks AS sinks
             JOIN mz_catalog.mz_clusters AS clusters ON
                     clusters.id = sinks.cluster_id
-        WHERE
-            schema_id = {}",
-            schema.id(),
+        WHERE {}",
+            query_filters
         )
     } else {
         format!(
-            "SELECT name FROM mz_catalog.mz_sinks WHERE schema_id = {}",
-            schema.id(),
+            "SELECT
+            sinks.name
+        FROM
+            mz_catalog.mz_sinks AS sinks
+            JOIN mz_catalog.mz_clusters AS clusters ON
+                    clusters.id = sinks.cluster_id
+        WHERE {}",
+            query_filters
         )
     };
     ShowSelect::new(scx, query, filter, None, None)
@@ -505,6 +523,7 @@ pub fn show_indexes<'a>(
     scx: &'a StatementContext<'a>,
     ShowIndexesStatement {
         extended,
+        in_cluster,
         table_name,
         filter,
     }: ShowIndexesStatement<Aug>,
@@ -512,21 +531,37 @@ pub fn show_indexes<'a>(
     if extended {
         bail_unsupported!("SHOW EXTENDED INDEXES")
     }
-    let from = scx.get_item_by_name(&table_name)?;
-    if from.item_type() != CatalogItemType::View
-        && from.item_type() != CatalogItemType::Source
-        && from.item_type() != CatalogItemType::Table
-    {
-        bail!(
-            "cannot show indexes on {} because it is a {}",
-            from.name(),
-            from.item_type(),
-        );
+
+    let mut query_filter = vec![];
+
+    if let Some(table_name) = table_name {
+        let from = scx.get_item_by_name(&table_name)?;
+        if from.item_type() != CatalogItemType::View
+            && from.item_type() != CatalogItemType::Source
+            && from.item_type() != CatalogItemType::Table
+        {
+            bail!(
+                "cannot show indexes on {} because it is a {}",
+                from.name(),
+                from.item_type(),
+            );
+        }
+        query_filter.push(format!("objs.id = '{}'", from.id()));
     }
+
+    if let Some(cluster) = in_cluster {
+        scx.require_experimental_mode("SHOW INDEXES...IN CLUSTER")?;
+        query_filter.push(format!("clusters.id = {}", cluster.0))
+    };
+
+    assert!(
+        !query_filter.is_empty(),
+        "parsing failed to enforce either table_name or in_cluster's presence"
+    );
 
     let query = format!(
         "SELECT
-            clusters.name AS in_cluster,
+            clusters.name AS cluster,
             objs.name AS on_name,
             idxs.name AS key_name,
             idx_cols.index_position AS seq_in_index,
@@ -542,9 +577,10 @@ pub fn show_indexes<'a>(
             LEFT JOIN mz_catalog.mz_columns AS obj_cols
                 ON idxs.on_id = obj_cols.id AND idx_cols.on_position = obj_cols.position
         WHERE
-            objs.id = '{}'",
-        from.id(),
+            {}",
+        itertools::join(query_filter.iter(), " AND ")
     );
+
     ShowSelect::new(scx, query, filter, None, None)
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -419,9 +419,17 @@ fn show_sinks<'a>(
 
     let query = if full {
         format!(
-            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility
-            FROM mz_catalog.mz_sinks
-            WHERE schema_id = {}",
+            "SELECT
+            clusters.name AS in_cluster,
+            sinks.name,
+            mz_internal.mz_classify_object_id(id) AS type,
+            sinks.volatility
+        FROM
+            mz_catalog.mz_sinks AS sinks
+            JOIN mz_catalog.mz_clusters AS clusters ON
+                    clusters.id = sinks.cluster_id
+        WHERE
+            schema_id = {}",
             schema.id(),
         )
     } else {
@@ -518,6 +526,7 @@ pub fn show_indexes<'a>(
 
     let query = format!(
         "SELECT
+            clusters.name AS in_cluster,
             objs.name AS on_name,
             idxs.name AS key_name,
             idx_cols.index_position AS seq_in_index,
@@ -529,6 +538,7 @@ pub fn show_indexes<'a>(
             mz_catalog.mz_indexes AS idxs
             JOIN mz_catalog.mz_index_columns AS idx_cols ON idxs.id = idx_cols.index_id
             JOIN mz_catalog.mz_objects AS objs ON idxs.on_id = objs.id
+            JOIN mz_catalog.mz_clusters AS clusters ON clusters.id = idxs.cluster_id
             LEFT JOIN mz_catalog.mz_columns AS obj_cols
                 ON idxs.on_id = obj_cols.id AND idx_cols.on_position = obj_cols.position
         WHERE

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -28,8 +28,8 @@ use mz_ore::now::NOW_ZERO;
 use mz_ore::retry::Retry;
 use mz_pgrepr::{Interval, Jsonb, Numeric};
 use mz_sql_parser::ast::{
-    CreateDatabaseStatement, CreateSchemaStatement, CreateSourceStatement, CreateTableStatement,
-    CreateViewStatement, Raw, Statement, ViewDefinition,
+    CreateClusterStatement, CreateDatabaseStatement, CreateSchemaStatement, CreateSourceStatement,
+    CreateTableStatement, CreateViewStatement, Raw, Statement, ViewDefinition,
 };
 
 use crate::action::{Action, ControlFlow, State};
@@ -95,6 +95,13 @@ impl Action for SqlAction {
                 self.try_drop(
                     &mut state.pgclient,
                     &format!("DROP TABLE IF EXISTS {} CASCADE", name),
+                )
+                .await
+            }
+            Statement::CreateCluster(CreateClusterStatement { name, .. }) => {
+                self.try_drop(
+                    &mut state.pgclient,
+                    &format!("DROP CLUSTER IF EXISTS {} CASCADE", name),
                 )
                 .await
             }

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -30,9 +30,9 @@
 1
 
 > SHOW INDEXES FROM logging_derived_mat;
-on_name             key_name                        seq_in_index  column_name expression  nullable enabled
-----------------------------------------------------------------------------------------------------------
-logging_derived_mat logging_derived_mat_primary_idx 1             count       <null>      false    false
+cluster on_name             key_name                        seq_in_index  column_name expression  nullable enabled
+------------------------------------------------------------------------------------------------------------------
+default logging_derived_mat logging_derived_mat_primary_idx 1             count       <null>      false    false
 
 # Views that embed a constant are selectable
 > SELECT * FROM constant
@@ -50,17 +50,17 @@ logging_derived_mat logging_derived_mat_primary_idx 1             count       <n
 1
 
 > SHOW INDEXES FROM mat_view;
-on_name   key_name              seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
-mat_view  mat_view_primary_idx  1             sum          <null>      true     false
-mat_view  mv_drop_idx           1             sum          <null>      true     false
+cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+default mat_view  mat_view_primary_idx  1             sum          <null>      true     false
+default mat_view  mv_drop_idx           1             sum          <null>      true     false
 
 > DROP INDEX mv_drop_idx;
 
 > SHOW INDEXES FROM mat_view;
-on_name   key_name              seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
-mat_view  mat_view_primary_idx  1             sum          <null>      true     false
+cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+default mat_view  mat_view_primary_idx  1             sum          <null>      true     false
 
 # Cannot alter disabled index
 ! ALTER INDEX mat_view_primary_idx RESET (logical_compaction_window)
@@ -76,17 +76,17 @@ contains:invalid ALTER on disabled index "materialize.public.mat_view_primary_id
 1
 
 > SHOW INDEXES FROM mat_data;
-on_name   key_name              seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
-mat_data  mat_data_primary_idx  1             a            <null>      false    false
-mat_data  ms_drop_idx           1             a            <null>      false    false
+cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+default mat_data  mat_data_primary_idx  1             a            <null>      false    false
+default mat_data  ms_drop_idx           1             a            <null>      false    false
 
 > DROP INDEX ms_drop_idx;
 
 > SHOW INDEXES FROM mat_data;
-on_name   key_name              seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
-mat_data  mat_data_primary_idx  1             a            <null>      false    false
+cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+default mat_data  mat_data_primary_idx  1             a            <null>      false    false
 
 # 🔬🔬🔬🔬 Non-materialized views
 
@@ -108,9 +108,9 @@ mat_data  mat_data_primary_idx  1             a            <null>      false    
 1
 
 > SHOW INDEXES FROM t;
-on_name   key_name      seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------
-t         t_drop_idx    1             a            <null>      true     false
+cluster on_name   key_name      seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+default t         t_drop_idx    1             a            <null>      true     false
 
 # 🔬🔬 Indexes
 
@@ -118,17 +118,17 @@ t         t_drop_idx    1             a            <null>      true     false
 > CREATE INDEX t_secondary_idx ON t(a+a);
 
 > SHOW INDEXES FROM t;
-on_name   key_name        seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------
-t         t_drop_idx      1             a            <null>      true     false
-t         t_secondary_idx 1             <null>       "a + a"     true     false
+cluster on_name   key_name        seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+default t         t_drop_idx      1             a            <null>      true     false
+default t         t_secondary_idx 1             <null>       "a + a"     true     false
 
 > DROP INDEX t_drop_idx;
 
 > SHOW INDEXES FROM t;
-on_name   key_name        seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------
-t         t_secondary_idx 1             <null>       "a + a"     true     false
+cluster on_name   key_name        seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+default t         t_secondary_idx 1             <null>       "a + a"     true     false
 
 # 🔬 Enabling indexes
 
@@ -140,9 +140,9 @@ t         t_secondary_idx 1             <null>       "a + a"     true     false
 1
 
 > SHOW INDEXES FROM logging_derived_mat;
-on_name             key_name                        seq_in_index  column_name expression  nullable enabled
-----------------------------------------------------------------------------------------------------------
-logging_derived_mat logging_derived_mat_primary_idx 1             count       <null>      false    true
+cluster on_name             key_name                        seq_in_index  column_name expression  nullable enabled
+------------------------------------------------------------------------------------------------------------------
+default logging_derived_mat logging_derived_mat_primary_idx 1             count       <null>      false    true
 
 # Alter index is functionally idempotent
 > ALTER INDEX logging_derived_mat_primary_idx SET ENABLED;
@@ -155,9 +155,9 @@ logging_derived_mat logging_derived_mat_primary_idx 1             count       <n
 > ALTER INDEX mat_view_primary_idx  SET ENABLED;
 
 > SHOW INDEXES FROM mat_view;
-on_name   key_name              seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
-mat_view  mat_view_primary_idx  1             sum          <null>      true     true
+cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+default mat_view  mat_view_primary_idx  1             sum          <null>      true     true
 
 > SHOW MATERIALIZED VIEWS
 logging_derived_mat
@@ -171,9 +171,9 @@ mat_view
 > ALTER INDEX mat_data_primary_idx  SET ENABLED;
 
 > SHOW INDEXES FROM mat_data;
-on_name   key_name              seq_in_index  column_name  expression  nullable enabled
----------------------------------------------------------------------------------------
-mat_data  mat_data_primary_idx  1             a            <null>      false    true
+cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
+-----------------------------------------------------------------------------------------------
+default mat_data  mat_data_primary_idx  1             a            <null>      false    true
 
 > SHOW MATERIALIZED SOURCES
 mat_data
@@ -203,9 +203,9 @@ $ kafka-verify format=avro sink=materialize.public.snk_indexes_disabled sort-mes
 
 # Tables still work with non-primary indexes enabled because all indexes are covering
 > SHOW INDEXES FROM t;
-on_name   key_name        seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------
-t         t_secondary_idx 1             <null>       "a + a"     true     false
+cluster on_name   key_name        seq_in_index  column_name  expression  nullable enabled
+-------------------------------------------------------------------------------------
+default t         t_secondary_idx 1             <null>       "a + a"     true     false
 
 > INSERT INTO t VALUES (2)
 

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -71,8 +71,6 @@ SHOW cluster
 ----
 bar
 
-#TODO(clusters): show cluster is on bar
-
 statement ok
 CREATE MATERIALIZED VIEW v AS SELECT 1
 
@@ -80,6 +78,21 @@ query T
 SELECT * FROM v
 ----
 1
+
+query TTTTTTTT
+SHOW INDEXES ON v IN CLUSTER bar;
+----
+bar v v_primary_idx 1 ?column? NULL false true
+
+query T
+SELECT
+	mz_clusters.name
+FROM
+	mz_clusters JOIN mz_indexes ON mz_clusters.id = mz_indexes.cluster_id
+WHERE
+	mz_indexes.name = 'v_primary_idx';
+----
+bar
 
 # Test invalid setting of `cluster`.
 
@@ -111,10 +124,21 @@ v_primary_idx
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER bar ON v
 
+query TTTTTTTT
+SHOW INDEXES ON v IN CLUSTER bar;
+----
+bar v v_primary_idx 1 ?column? NULL false true
+bar v v_primary_idx1 1 ?column? NULL false true
+
 statement error unknown cluster 'noexist'
 CREATE DEFAULT INDEX IN CLUSTER noexist ON v
 
 # Test invalid DROPs.
+
+query T
+SHOW cluster
+----
+default
 
 statement error active cluster cannot be dropped
 DROP CLUSTER default
@@ -124,6 +148,12 @@ DROP CLUSTER baz
 
 statement error cannot drop cluster with active indexes or sinks
 DROP CLUSTER bar
+
+query TTTTTTTT
+SHOW INDEXES IN CLUSTER bar;
+----
+bar v v_primary_idx 1 ?column? NULL false true
+bar v v_primary_idx1 1 ?column? NULL false true
 
 statement ok
 DROP INDEX v_primary_idx
@@ -154,5 +184,3 @@ DROP CLUSTER baz CASCADE
 query T
 SELECT name FROM mz_indexes;
 ----
-
-# TODO(clusters): write tests for SHOW CREATE INDEX and mz_indexes.

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -151,17 +151,17 @@ contains:catalog item 'materialize.public.i1' is an index and so cannot be depen
 
 > CREATE INDEX i2 ON v2a(x*2);
 
-> SHOW INDEX in v2a;
-on_name   key_name         seq_in_index column_name expression  nullable  enabled
----------------------------------------------------------------------------------
-v2a       i2               1            <null>      "x * 2"     false     true
-v2a       v2a_primary_idx  1            x           <null>      false     true
+> SHOW INDEXES FROM v2a;
+cluster on_name   key_name         seq_in_index column_name expression  nullable  enabled
+-----------------------------------------------------------------------------------------
+default v2a       i2               1            <null>      "x * 2"     false     true
+default v2a       v2a_primary_idx  1            x           <null>      false     true
 
-> SHOW INDEX in v2;
-on_name  key_name        seq_in_index column_name expression nullable enabled
------------------------------------------------------------------------------
-v2       i1              1            x           <null>     false    true
-v2       v2_primary_idx  1            x           <null>     false    true
+> SHOW INDEXES FROM v2;
+cluster on_name  key_name        seq_in_index column_name expression nullable enabled
+-------------------------------------------------------------------------------------
+default v2       i1              1            x           <null>     false    true
+default v2       v2_primary_idx  1            x           <null>     false    true
 
 # Test that dependent indexes do not prevent view deletion when restrict is specified
 # but do not cause deletion of dependent views
@@ -170,11 +170,11 @@ v2       v2_primary_idx  1            x           <null>     false    true
 ! DROP VIEW v2a;
 contains:unknown catalog item 'v2a'
 
-> SHOW INDEX in v2;
-on_name  key_name        seq_in_index   column_name expression nullable enabled
--------------------------------------------------------------------------------
-v2       i1              1              x           <null>     false    true
-v2       v2_primary_idx  1              x           <null>     false    true
+> SHOW INDEXES FROM v2;
+cluster on_name  key_name        seq_in_index   column_name expression nullable enabled
+---------------------------------------------------------------------------------------
+default v2       i1              1              x           <null>     false    true
+default v2       v2_primary_idx  1              x           <null>     false    true
 
 ! DROP INDEX i2;
 contains:unknown catalog item 'i2'
@@ -185,20 +185,20 @@ contains:unknown catalog item 'i2'
 
 > CREATE INDEX i3 ON v4a(y);
 
-> SHOW INDEX in v4a;
-on_name  key_name         seq_in_index   column_name expression nullable  enabled
----------------------------------------------------------------------------------
-v4a      i3               1              y           <null>     false     true
-v4a      v4a_primary_idx  1              y           <null>     false     true
+> SHOW INDEXES FROM v4a;
+cluster on_name  key_name         seq_in_index   column_name expression nullable  enabled
+-----------------------------------------------------------------------------------------
+default v4a      i3               1              y           <null>     false     true
+default v4a      v4a_primary_idx  1              y           <null>     false     true
 
 > CREATE INDEX i4 ON v4(x);
 
-> SHOW INDEX in v4;
-on_name  key_name        seq_in_index  column_name expression nullable  enabled
--------------------------------------------------------------------------------
-v4       i4              1             x           <null>     false     true
-v4       v4_primary_idx  1             x           <null>     false     true
-v4       v4_primary_idx  2             y           <null>     false     true
+> SHOW INDEXES FROM v4;
+cluster on_name  key_name        seq_in_index  column_name expression nullable  enabled
+---------------------------------------------------------------------------------------
+default v4       i4              1             x           <null>     false     true
+default v4       v4_primary_idx  1             x           <null>     false     true
+default v4       v4_primary_idx  2             y           <null>     false     true
 
 # Test cascade deletes associated indexes as well
 > DROP VIEW v4a CASCADE;
@@ -209,36 +209,36 @@ contains:unknown catalog item 'v4a'
 ! DROP INDEX i3;
 contains:unknown catalog item 'i3'
 
-> SHOW INDEX in v4;
-on_name  key_name        seq_in_index  column_name expression nullable  enabled
--------------------------------------------------------------------------------
-v4       i4              1             x           <null>     false     true
-v4       v4_primary_idx  1             x           <null>     false     true
-v4       v4_primary_idx  2             y           <null>     false     true
+> SHOW INDEXES FROM v4;
+cluster on_name  key_name        seq_in_index  column_name expression nullable  enabled
+---------------------------------------------------------------------------------------
+default v4       i4              1             x           <null>     false     true
+default v4       v4_primary_idx  1             x           <null>     false     true
+default v4       v4_primary_idx  2             y           <null>     false     true
 
 > CREATE MATERIALIZED VIEW v5 AS SELECT substr(y, 3, 2) as substr from v4;
 
 > CREATE INDEX i5 ON v5(substr);
 
-> SHOW INDEX in v5;
-on_name   key_name        seq_in_index  column_name expression nullable enabled
--------------------------------------------------------------------------------
-v5        i5              1             substr      <null>     true     true
-v5        v5_primary_idx  1             substr      <null>     true     true
+> SHOW INDEXES FROM v5;
+cluster on_name   key_name        seq_in_index  column_name expression nullable enabled
+---------------------------------------------------------------------------------------
+default v5        i5              1             substr      <null>     true     true
+default v5        v5_primary_idx  1             substr      <null>     true     true
 
 > CREATE VIEW multicol AS SELECT 'a' AS a, 'b' AS b, 'c' AS c, 'd' AS d
 > CREATE INDEX i6 ON multicol (2, a, 4)
-> SHOW INDEX IN multicol
-on_name   key_name  seq_in_index column_name  expression   nullable enabled
----------------------------------------------------------------------------
-multicol  i6        1            b            <null>       false     true
-multicol  i6        2            a            <null>       false     true
-multicol  i6        3            d            <null>       false     true
+> SHOW INDEXES FROM multicol
+cluster on_name   key_name  seq_in_index column_name  expression   nullable enabled
+-----------------------------------------------------------------------------------
+default multicol  i6        1            b            <null>       false     true
+default multicol  i6        2            a            <null>       false     true
+default multicol  i6        3            d            <null>       false     true
 
-> SHOW INDEX IN multicol WHERE column_name = 'a'
-on_name   key_name  seq_in_index column_name  expression   nullable enabled
----------------------------------------------------------------------------
-multicol  i6        2            a            <null>       false    true
+> SHOW INDEXES FROM multicol WHERE column_name = 'a'
+cluster on_name   key_name  seq_in_index column_name  expression   nullable enabled
+-----------------------------------------------------------------------------------
+default multicol  i6        2            a            <null>       false    true
 
 # Test cascade deletes all indexes associated with cascaded views
 > DROP VIEW v4 CASCADE;
@@ -271,12 +271,12 @@ contains:unknown catalog item 'i4'
 # Test that dependent indexes do not prevent source deletion when restrict is specified
 > CREATE INDEX j1 on s3(ascii(y))
 
-> SHOW INDEX in s3;
-on_name  key_name        seq_in_index  column_name expression             nullable  enabled
--------------------------------------------------------------------------------------------
-s3       j1              1             <null>      "pg_catalog.ascii(y)"  false     true
-s3       s3_primary_idx  1             x           <null>                 false     true
-s3       s3_primary_idx  2             y           <null>                 false     true
+> SHOW INDEXES FROM s3;
+cluster on_name  key_name        seq_in_index  column_name expression             nullable  enabled
+---------------------------------------------------------------------------------------------------
+default s3       j1              1             <null>      "pg_catalog.ascii(y)"  false     true
+default s3       s3_primary_idx  1             x           <null>                 false     true
+default s3       s3_primary_idx  2             y           <null>                 false     true
 
 > DROP SOURCE s3;
 
@@ -299,17 +299,17 @@ contains:unknown catalog item 'j1'
 
 > CREATE INDEX j3 on w(z);
 
-> SHOW INDEX in s4;
-on_name  key_name        seq_in_index   column_name expression  nullable  enabled
----------------------------------------------------------------------------------
-s4       j2              1               <null>      "x + 2"    false     true
-s4       s4_primary_idx  1               x           <null>     false     true
-s4       s4_primary_idx  2               y           <null>     false     true
+> SHOW INDEXES FROM s4;
+cluster on_name  key_name        seq_in_index   column_name expression  nullable  enabled
+-----------------------------------------------------------------------------------------
+default s4       j2              1               <null>      "x + 2"    false     true
+default s4       s4_primary_idx  1               x           <null>     false     true
+default s4       s4_primary_idx  2               y           <null>     false     true
 
-> SHOW INDEX in w;
-on_name  key_name   seq_in_index  column_name expression nullable enabled
--------------------------------------------------------------------------
-w        j3         1             z           <null>     false    true
+> SHOW INDEXES FROM w;
+cluster on_name  key_name   seq_in_index  column_name expression nullable enabled
+---------------------------------------------------------------------------------
+default w        j3         1             z           <null>     false    true
 
 > DROP SOURCE s4 CASCADE;
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -38,117 +38,117 @@ position         name
 3                mz_obj_no
 
 > SHOW INDEXES FROM mz_data
-on_name  key_name             seq_in_index  column_name  expression  nullable enabled
--------------------------------------------------------------------------------------
-mz_data  mz_data_primary_idx  1             a            <null>      false    true
-mz_data  mz_data_primary_idx  2             b            <null>      false    true
-mz_data  mz_data_primary_idx  3             mz_obj_no    <null>      false    true
+cluster on_name  key_name             seq_in_index  column_name  expression  nullable enabled
+--------------------------------------------------------------------------------------------------
+default mz_data  mz_data_primary_idx  1             a            <null>      false    true
+default mz_data  mz_data_primary_idx  2             b            <null>      false    true
+default mz_data  mz_data_primary_idx  3             mz_obj_no    <null>      false    true
 
 # Non-materialized views do not have indexes automatically created
 > CREATE SOURCE data
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
 
 > SHOW INDEXES FROM data
-on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
----------------------------------------------------------------------------
+cluster on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
+--------------------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
 > SHOW INDEXES FROM data
-on_name  key_name          seq_in_index column_name  expression  nullable enabled
----------------------------------------------------------------------------------
-data     data_primary_idx  1            a            <null>      false    true
-data     data_primary_idx  2            b            <null>      false    true
-data     data_primary_idx  3            mz_obj_no    <null>      false    true
+cluster on_name  key_name          seq_in_index column_name  expression  nullable enabled
+----------------------------------------------------------------------------------------------
+default data     data_primary_idx  1            a            <null>      false    true
+default data     data_primary_idx  2            b            <null>      false    true
+default data     data_primary_idx  3            mz_obj_no    <null>      false    true
 
 > CREATE DEFAULT INDEX ON mz_data
 
 > SHOW INDEXES FROM mz_data
-on_name  key_name              seq_in_index  column_name  expression  nullable  enabled
----------------------------------------------------------------------------------------
-mz_data  mz_data_primary_idx   1             a            <null>      false     true
-mz_data  mz_data_primary_idx   2             b            <null>      false     true
-mz_data  mz_data_primary_idx   3             mz_obj_no    <null>      false     true
-mz_data  mz_data_primary_idx1  1             a            <null>      false     true
-mz_data  mz_data_primary_idx1  2             b            <null>      false     true
-mz_data  mz_data_primary_idx1  3             mz_obj_no    <null>      false     true
+cluster on_name  key_name              seq_in_index  column_name  expression  nullable  enabled
+----------------------------------------------------------------------------------------------------
+default mz_data  mz_data_primary_idx   1             a            <null>      false     true
+default mz_data  mz_data_primary_idx   2             b            <null>      false     true
+default mz_data  mz_data_primary_idx   3             mz_obj_no    <null>      false     true
+default mz_data  mz_data_primary_idx1  1             a            <null>      false     true
+default mz_data  mz_data_primary_idx1  2             b            <null>      false     true
+default mz_data  mz_data_primary_idx1  3             mz_obj_no    <null>      false     true
 
 # Materialized views are synonymous with having an index automatically created
 > CREATE MATERIALIZED VIEW matv AS
   SELECT b, sum(a) FROM data GROUP BY b
 
 > SHOW INDEXES FROM matv
-on_name   key_name          seq_in_index column_name  expression  nullable  enabled
------------------------------------------------------------------------------------
-matv      matv_primary_idx  1            b            <null>      false     true
+cluster on_name   key_name          seq_in_index column_name  expression  nullable  enabled
+----------------------------------------------------------------------------------------------
+default matv      matv_primary_idx  1            b            <null>      false     true
 
 # Non-materialized views do not have indexes automatically created
 > CREATE VIEW data_view as SELECT * from data
 
 > SHOW INDEXES FROM data_view
-on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
----------------------------------------------------------------------------
+cluster on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
+--------------------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------------------
-data_view  data_view_primary_idx  1             a            <null>      false    true
-data_view  data_view_primary_idx  2             b            <null>      false    true
-data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
+cluster on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+----------------------------------------------------------------------------------------------------
+default data_view  data_view_primary_idx  1             a            <null>      false    true
+default data_view  data_view_primary_idx  2             b            <null>      false    true
+default data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # Default indexes are equivalent in structure to indexes added automatically with the "MATERIALIZED" keyword
 > CREATE MATERIALIZED VIEW mz_data_view as SELECT * from data
 
 > SHOW INDEXES FROM mz_data_view
-on_name       key_name                  seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------------------------
-mz_data_view  mz_data_view_primary_idx  1             a            <null>      false    true
-mz_data_view  mz_data_view_primary_idx  2             b            <null>      false    true
-mz_data_view  mz_data_view_primary_idx  3             mz_obj_no    <null>      false    true
+cluster on_name       key_name                  seq_in_index  column_name  expression  nullable enabled
+------------------------------------------------------------------------------------------------------------
+default mz_data_view  mz_data_view_primary_idx  1             a            <null>      false    true
+default mz_data_view  mz_data_view_primary_idx  2             b            <null>      false    true
+default mz_data_view  mz_data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------------------
-data_view  data_view_primary_idx  1             a            <null>      false    true
-data_view  data_view_primary_idx  2             b            <null>      false    true
-data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
+cluster on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+------------------------------------------------------------------------------------------------------
+default data_view  data_view_primary_idx  1             a            <null>      false    true
+default data_view  data_view_primary_idx  2             b            <null>      false    true
+default data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # IF NOT EXISTS works for both automatically and explicitly created default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON matv
 
 > SHOW INDEXES FROM matv
-on_name  key_name          seq_in_index  column_name  expression  nullable  enabled
------------------------------------------------------------------------------------
-matv     matv_primary_idx  1             b            <null>      false     true
+cluster on_name  key_name          seq_in_index  column_name  expression  nullable  enabled
+----------------------------------------------------------------------------------------------
+default matv     matv_primary_idx  1             b            <null>      false     true
 
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
 
 > SHOW INDEXES FROM matv
-on_name  key_name           seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------------
-matv     matv_primary_idx   1             b            <null>      false    true
-matv     matv_primary_idx1  1             b            <null>      false    true
+cluster on_name  key_name           seq_in_index  column_name  expression  nullable enabled
+------------------------------------------------------------------------------------------------
+default matv     matv_primary_idx   1             b            <null>      false    true
+default matv     matv_primary_idx1  1             b            <null>      false    true
 
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------------------
-data_view  data_view_primary_idx  1             a            <null>      false    true
-data_view  data_view_primary_idx  2             b            <null>      false    true
-data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
-data_view  named_idx              1             a            <null>      false    true
-data_view  named_idx              2             b            <null>      false    true
-data_view  named_idx              3             mz_obj_no    <null>      false    true
+cluster on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+----------------------------------------------------------------------------------------------------
+default data_view  data_view_primary_idx  1             a            <null>      false    true
+default data_view  data_view_primary_idx  2             b            <null>      false    true
+default data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
+default data_view  named_idx              1             a            <null>      false    true
+default data_view  named_idx              2             b            <null>      false    true
+default data_view  named_idx              3             mz_obj_no    <null>      false    true
 
 > DROP INDEX data_view_primary_idx
 > DROP INDEX named_idx
@@ -157,9 +157,9 @@ data_view  named_idx              3             mz_obj_no    <null>      false  
 > CREATE INDEX ON data_view(a)
 
 > SHOW INDEXES FROM data_view
-on_name    key_name           seq_in_index  column_name  expression  nullable enabled
--------------------------------------------------------------------------------------
-data_view  data_view_a_idx    1             a            <null>      false    true
+cluster on_name    key_name           seq_in_index  column_name  expression  nullable enabled
+------------------------------------------------------------------------------------------------
+default data_view  data_view_a_idx    1             a            <null>      false    true
 
 > DROP INDEX data_view_a_idx
 
@@ -168,12 +168,12 @@ data_view  data_view_a_idx    1             a            <null>      false    tr
 > CREATE INDEX ON data_view(b - a, a)
 
 > SHOW INDEXES FROM data_view
-on_name    key_name               seq_in_index  column_name  expression  nullable enabled
------------------------------------------------------------------------------------------
-data_view  data_view_b_a_idx      2             a            <null>      false    true
-data_view  data_view_b_a_idx      1             b            <null>      false    true
-data_view  data_view_expr_a_idx   1             <null>       "b - a"     false    true
-data_view  data_view_expr_a_idx   2             a            <null>      false    true
+cluster on_name    key_name               seq_in_index  column_name  expression  nullable enabled
+----------------------------------------------------------------------------------------------------
+default data_view  data_view_b_a_idx      2             a            <null>      false    true
+default data_view  data_view_b_a_idx      1             b            <null>      false    true
+default data_view  data_view_expr_a_idx   1             <null>       "b - a"     false    true
+default data_view  data_view_expr_a_idx   2             a            <null>      false    true
 
 > DROP INDEX data_view_b_a_idx
 > DROP INDEX data_view_expr_a_idx
@@ -182,10 +182,10 @@ data_view  data_view_expr_a_idx   2             a            <null>      false  
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
 > SHOW INDEXES FROM data_view
-on_name    key_name    seq_in_index  column_name  expression  nullable  enabled
--------------------------------------------------------------------------------
-data_view  named_idx   1             <null>       "b - a"     false     true
-data_view  named_idx   2             a            <null>      false     true
+cluster on_name    key_name    seq_in_index  column_name  expression  nullable  enabled
+-----------------------------------------------------------------------------------------
+default data_view  named_idx   1             <null>       "b - a"     false     true
+default data_view  named_idx   2             a            <null>      false     true
 
 > DROP INDEX named_idx
 
@@ -194,10 +194,10 @@ data_view  named_idx   2             a            <null>      false     true
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-on_name    key_name                seq_in_index  column_name  expression  nullable  enabled
--------------------------------------------------------------------------------------------
-data_view  data_view_primary_idx   1             <null>       "b - a"     false     true
-data_view  data_view_primary_idx   2             a            <null>      false     true
+cluster on_name    key_name                seq_in_index  column_name  expression  nullable  enabled
+------------------------------------------------------------------------------------------------------
+default data_view  data_view_primary_idx   1             <null>       "b - a"     false     true
+default data_view  data_view_primary_idx   2             a            <null>      false     true
 
 > SHOW CREATE INDEX data_view_primary_idx
 Index                                    "Create Index"
@@ -213,16 +213,16 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
 > SHOW INDEXES FROM foo
-foo  foo_primary_idx   1  a       <null>                     false  true
-foo  foo_primary_idx   2  b       <null>                     true   true
-foo  foo_primary_idx   3  z       <null>                     true   true
-foo  foo_expr_idx      1  <null>  "a + b"                    true   true
-foo  foo_expr_idx1     1  <null>  "pg_catalog.substr(z, 3)"  true   true
+default foo  foo_primary_idx   1  a       <null>                     false  true
+default foo  foo_primary_idx   2  b       <null>                     true   true
+default foo  foo_primary_idx   3  z       <null>                     true   true
+default foo  foo_expr_idx      1  <null>  "a + b"                    true   true
+default foo  foo_expr_idx1     1  <null>  "pg_catalog.substr(z, 3)"  true   true
 > SHOW INDEXES FROM foo WHERE Column_name = 'b'
-foo  foo_primary_idx   2  b       <null>          true  true
+default foo  foo_primary_idx   2  b       <null>          true  true
 > SHOW INDEXES FROM foo WHERE Column_name = 'noexist'
 > SHOW INDEXES FROM foo WHERE Key_name = 'foo_expr_idx'
-foo  foo_expr_idx      1  <null>  "a + b"         true  true
+default foo  foo_expr_idx      1  <null>  "a + b"         true  true
 # TODO(justin): not handled in parser yet:
 #   SHOW INDEXES FROM v LIKE '%v'
 
@@ -231,3 +231,10 @@ contains:unknown catalog item 'nonexistent'
 
 ! SHOW INDEX FROM foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
+
+> CREATE CLUSTER clstr
+> CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
+> SHOW INDEXES IN CLUSTER clstr
+clstr foo  foo_primary_idx1   1  a       <null>                     false  true
+clstr foo  foo_primary_idx1   2  b       <null>                     true   true
+clstr foo  foo_primary_idx1   3  z       <null>                     true   true

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -31,11 +31,11 @@ $ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
     SELECT * FROM mz_data
 
 > SHOW INDEXES FROM mz_view
-on_name  key_name             seq_in_index  column_name  expression  nullable enabled
--------------------------------------------------------------------------------------
-mz_view  mz_view_primary_idx  1             a            <null>      false    true
-mz_view  mz_view_primary_idx  2             b            <null>      false    true
-mz_view  mz_view_primary_idx  3             mz_obj_no    <null>      false    true
+cluster on_name  key_name             seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------------
+default mz_view  mz_view_primary_idx  1             a            <null>      false    true
+default mz_view  mz_view_primary_idx  2             b            <null>      false    true
+default mz_view  mz_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 > CREATE VIEW dependent_view AS
     SELECT * FROM mz_view;
@@ -169,11 +169,11 @@ materialize.public.renamed_mz_view  "CREATE VIEW \"materialize\".\"public\".\"re
 
 # Item's indexes are properly re-attributed
 > SHOW INDEXES FROM renamed_mz_view
-on_name          key_name       seq_in_index  column_name expression nullable enabled
--------------------------------------------------------------------------------------
-renamed_mz_view  renamed_index  1             a           <null>     false    true
-renamed_mz_view  renamed_index  2             b           <null>     false    true
-renamed_mz_view  renamed_index  3             mz_obj_no   <null>     false    true
+cluster on_name          key_name       seq_in_index  column_name expression nullable enabled
+---------------------------------------------------------------------------------------------
+default renamed_mz_view  renamed_index  1             a           <null>     false    true
+default renamed_mz_view  renamed_index  2             b           <null>     false    true
+default renamed_mz_view  renamed_index  3             mz_obj_no   <null>     false    true
 
 > SHOW CREATE INDEX renamed_index
 Index               "Create Index"
@@ -186,10 +186,12 @@ View                                "Create View"
 ------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"dependent_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\""
 
+$ set-regex match=u\d+ replacement=UID
+
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [u244 AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [UID AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -98,13 +98,13 @@ snk4
 snk5
 
 > SHOW FULL SINKS
-name   type  volatility
+cluster name   type  volatility
 -----------------------
-snk1   user  unknown
-snk2   user  unknown
-snk3   user  unknown
-snk4   user  unknown
-snk5   user  unknown
+default snk1   user  unknown
+default snk2   user  unknown
+default snk3   user  unknown
+default snk4   user  unknown
+default snk5   user  unknown
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
@@ -191,18 +191,18 @@ $ kafka-verify format=avro sink=materialize.public.sink10 sort-messages=true
 {"before": null, "after": {"row":{"column1": 3}}}
 
 > SHOW FULL SINKS
-name        type  volatility
-----------------------------
-snk1        user  unknown
-snk2        user  unknown
-snk3        user  unknown
-snk4        user  unknown
-snk5        user  unknown
-snk6        user  unknown
-snk7        user  unknown
-snk8        user  unknown
-sink9       user  nonvolatile
-sink10      user  nonvolatile
+cluster    name        type  volatility
+-----------------------------------------
+default    snk1        user  unknown
+default    snk2        user  unknown
+default    snk3        user  unknown
+default    snk4        user  unknown
+default    snk5        user  unknown
+default    snk6        user  unknown
+default    snk7        user  unknown
+default    snk8        user  unknown
+default    sink9       user  nonvolatile
+default    sink10      user  nonvolatile
 
 # test explicit partition count
 > CREATE SINK sink11 FROM foo
@@ -232,3 +232,13 @@ sink10      user  nonvolatile
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink15'
   WITH (partition_count=-1, replication_factor=-1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE CLUSTER clstr
+
+> CREATE SINK clstr_sink
+  IN CLUSTER clstr FROM src
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'clstr_sink'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> SHOW SINKS IN CLUSTER clstr
+clstr_sink

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -57,10 +57,10 @@ name
 > CREATE DEFAULT INDEX on t
 
 > SHOW INDEXES FROM t
-on_name  key_name       seq_in_index  column_name  expression  nullable enabled
--------------------------------------------------------------------------------
-t        t_primary_idx  1             a            <null>      true     true
-t        t_primary_idx  2             b            <null>      false    true
+cluster on_name  key_name       seq_in_index  column_name  expression  nullable enabled
+---------------------------------------------------------------------------------------
+default t        t_primary_idx  1             a            <null>      true     true
+default t        t_primary_idx  2             b            <null>      false    true
 
 > DROP INDEX t_primary_idx
 

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -57,10 +57,10 @@ contains:non-temporary items cannot depend on temporary item
 > CREATE TEMPORARY MATERIALIZED VIEW foo AS SELECT * FROM v
 
 > SHOW INDEXES FROM foo
- on_name    key_name         seq_in_index  column_name  expression  nullable  enabled
--------------------------------------------------------------------------------------
- foo        foo_primary_idx  1             column1      <null>      false     true
- foo        foo_primary_idx  2             column2      <null>      false     true
+cluster on_name    key_name         seq_in_index  column_name  expression  nullable  enabled
+--------------------------------------------------------------------------------------------
+default foo        foo_primary_idx  1             column1      <null>      false     true
+default foo        foo_primary_idx  2             column2      <null>      false     true
 
 ! CREATE TEMP MATERIALIZED VIEW foo AS SELECT * FROM v
 contains:catalog item 'foo' already exists


### PR DESCRIPTION
@benesch The proposed grammar of:

```
SHOW SINKS [(FROM | IN) <schema>]
[IN CLUSTER <cluster_name>]
{ LIKE 'pattern | EXPR <expr> }
```

is ambiguous, so we have to do some back pedaling to figure out if it's a `CLUSTER` branch or not. Because I was doing that, I propagated the same change to `SHOW INDEX` to let you find indexes on a cluster, not necessarily only those on an identified table.

### Motivation

This PR adds a known-desirable feature. Closes #11129

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Include information about the [experimental](/cli/#experimental-mode) cluster feature in [`SHOW INDEXES`](/sql/show-indexes) and [`SHOW SINKS`](/sql/show-sinks).
