### PR TITLE
sql: remove catalog from purification

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1091,172 +1091,8 @@ impl Coordinator {
                 session,
                 tx,
             } => {
-                let result = session
-                    .get_portal(&portal_name)
-                    .ok_or(CoordError::UnknownCursor(portal_name));
-                let portal = match result {
-                    Ok(portal) => portal,
-                    Err(e) => {
-                        let _ = tx.send(Response {
-                            result: Err(e),
-                            session,
-                        });
-                        return;
-                    }
-                };
-                let stmt = portal.stmt.clone();
-                let params = portal.parameters.clone();
-
-                match stmt {
-                    Some(stmt) => {
-                        // Verify that this statetement type can be executed in the current
-                        // transaction state.
-                        match session.transaction() {
-                            // By this point we should be in a running transaction.
-                            &TransactionStatus::Default => unreachable!(),
-
-                            // Started is almost always safe (started means there's a single statement
-                            // being executed). Failed transactions have already been checked in pgwire for
-                            // a safe statement (COMMIT, ROLLBACK, etc.) and can also proceed.
-                            &TransactionStatus::Started(_) | &TransactionStatus::Failed(_) => {
-                                if let Statement::Declare(_) = stmt {
-                                    // Declare is an exception. Although it's not against any spec to execute
-                                    // it, it will always result in nothing happening, since all portals will be
-                                    // immediately closed. Users don't know this detail, so this error helps them
-                                    // understand what's going wrong. Postgres does this too.
-                                    let _ = tx.send(Response {
-                                        result: Err(CoordError::OperationRequiresTransaction(
-                                            "DECLARE CURSOR".into(),
-                                        )),
-                                        session,
-                                    });
-                                    return;
-                                }
-                            }
-
-                            // Implicit or explicit transactions.
-                            //
-                            // Implicit transactions happen when a multi-statement query is executed
-                            // (a "simple query"). However if a "BEGIN" appears somewhere in there,
-                            // then the existing implicit transaction will be upgraded to an explicit
-                            // transaction. Thus, we should not separate what implicit and explicit
-                            // transactions can do unless there's some additional checking to make sure
-                            // something disallowed in explicit transactions did not previously take place
-                            // in the implicit portion.
-                            &TransactionStatus::InTransactionImplicit(_)
-                            | &TransactionStatus::InTransaction(_) => match stmt {
-                                // Statements that are safe in a transaction. We still need to verify that we
-                                // don't interleave reads and writes since we can't perform those serializably.
-                                Statement::Close(_)
-                                | Statement::Commit(_)
-                                | Statement::Copy(_)
-                                | Statement::Deallocate(_)
-                                | Statement::Declare(_)
-                                | Statement::Discard(_)
-                                | Statement::Execute(_)
-                                | Statement::Explain(_)
-                                | Statement::Fetch(_)
-                                | Statement::Prepare(_)
-                                | Statement::Rollback(_)
-                                | Statement::Select(_)
-                                | Statement::SetTransaction(_)
-                                | Statement::ShowColumns(_)
-                                | Statement::ShowCreateIndex(_)
-                                | Statement::ShowCreateSink(_)
-                                | Statement::ShowCreateSource(_)
-                                | Statement::ShowCreateTable(_)
-                                | Statement::ShowCreateView(_)
-                                | Statement::ShowDatabases(_)
-                                | Statement::ShowIndexes(_)
-                                | Statement::ShowObjects(_)
-                                | Statement::ShowVariable(_)
-                                | Statement::SetVariable(_)
-                                | Statement::StartTransaction(_)
-                                | Statement::Tail(_)
-                                | Statement::Raise(_) => {
-                                    // Always safe.
-                                }
-
-                                Statement::Insert(ref insert_statment)
-                                    if matches!(
-                                        insert_statment.source,
-                                        InsertSource::Query(Query {
-                                            body: SetExpr::Values(..),
-                                            ..
-                                        }) | InsertSource::DefaultValues
-                                    ) =>
-                                {
-                                    // Inserting from default? values statements
-                                    // is always safe.
-                                }
-
-                                // Statements below must by run singly (in Started).
-                                Statement::AlterIndex(_)
-                                | Statement::AlterObjectRename(_)
-                                | Statement::CreateDatabase(_)
-                                | Statement::CreateIndex(_)
-                                | Statement::CreateRole(_)
-                                | Statement::CreateCluster(_)
-                                | Statement::CreateSchema(_)
-                                | Statement::CreateSecret(_)
-                                | Statement::CreateSink(_)
-                                | Statement::CreateSource(_)
-                                | Statement::CreateTable(_)
-                                | Statement::CreateType(_)
-                                | Statement::CreateView(_)
-                                | Statement::CreateViews(_)
-                                | Statement::Delete(_)
-                                | Statement::DropDatabase(_)
-                                | Statement::DropObjects(_)
-                                | Statement::Insert(_)
-                                | Statement::Update(_) => {
-                                    let _ = tx.send(Response {
-                                        result: Err(CoordError::OperationProhibitsTransaction(
-                                            stmt.to_string(),
-                                        )),
-                                        session,
-                                    });
-                                    return;
-                                }
-                            },
-                        }
-
-                        if self.catalog.config().safe_mode {
-                            if let Err(e) = check_statement_safety(&stmt) {
-                                let _ = tx.send(Response {
-                                    result: Err(e),
-                                    session,
-                                });
-                                return;
-                            }
-                        }
-
-                        let internal_cmd_tx = self.internal_cmd_tx.clone();
-                        let purify_fut = mz_sql::pure::purify(
-                            self.now(),
-                            self.catalog.config().aws_external_id.clone(),
-                            stmt,
-                        );
-                        let conn_id = session.conn_id();
-                        task::spawn(|| format!("purify:{conn_id}"), async move {
-                            let result = purify_fut.await.map_err(|e| e.into());
-                            internal_cmd_tx
-                                .send(Message::StatementReady(StatementReady {
-                                    session,
-                                    tx: ClientTransmitter::new(tx, internal_cmd_tx.clone()),
-                                    result,
-                                    params,
-                                }))
-                                .expect("sending to internal_cmd_tx cannot fail");
-                        });
-                    }
-                    None => {
-                        let _ = tx.send(Response {
-                            result: Ok(ExecuteResponse::EmptyQuery),
-                            session,
-                        });
-                    }
-                }
+                let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
+                self.handle_execute(portal_name, session, tx).await;
             }
 
             Command::Declare {
@@ -1485,6 +1321,161 @@ impl Coordinator {
         } else {
             Ok(())
         }
+    }
+
+    /// Handles an execute command.
+    async fn handle_execute(
+        &mut self,
+        portal_name: String,
+        session: Session,
+        tx: ClientTransmitter<ExecuteResponse>,
+    ) {
+        let portal = match session.get_portal(&portal_name) {
+            Some(portal) => portal,
+            None => return tx.send(Err(CoordError::UnknownCursor(portal_name)), session),
+        };
+
+        let stmt = match &portal.stmt {
+            Some(stmt) => stmt,
+            None => return tx.send(Ok(ExecuteResponse::EmptyQuery), session),
+        };
+
+        // Verify that this statetement type can be executed in the current
+        // transaction state.
+        match session.transaction() {
+            // By this point we should be in a running transaction.
+            TransactionStatus::Default => unreachable!(),
+
+            // Started is almost always safe (started means there's a single statement
+            // being executed). Failed transactions have already been checked in pgwire for
+            // a safe statement (COMMIT, ROLLBACK, etc.) and can also proceed.
+            TransactionStatus::Started(_) | TransactionStatus::Failed(_) => {
+                if let Statement::Declare(_) = stmt {
+                    // Declare is an exception. Although it's not against any spec to execute
+                    // it, it will always result in nothing happening, since all portals will be
+                    // immediately closed. Users don't know this detail, so this error helps them
+                    // understand what's going wrong. Postgres does this too.
+                    return tx.send(
+                        Err(CoordError::OperationRequiresTransaction(
+                            "DECLARE CURSOR".into(),
+                        )),
+                        session,
+                    );
+                }
+            }
+
+            // Implicit or explicit transactions.
+            //
+            // Implicit transactions happen when a multi-statement query is executed
+            // (a "simple query"). However if a "BEGIN" appears somewhere in there,
+            // then the existing implicit transaction will be upgraded to an explicit
+            // transaction. Thus, we should not separate what implicit and explicit
+            // transactions can do unless there's some additional checking to make sure
+            // something disallowed in explicit transactions did not previously take place
+            // in the implicit portion.
+            TransactionStatus::InTransactionImplicit(_) | TransactionStatus::InTransaction(_) => {
+                match stmt {
+                    // Statements that are safe in a transaction. We still need to verify that we
+                    // don't interleave reads and writes since we can't perform those serializably.
+                    Statement::Close(_)
+                    | Statement::Commit(_)
+                    | Statement::Copy(_)
+                    | Statement::Deallocate(_)
+                    | Statement::Declare(_)
+                    | Statement::Discard(_)
+                    | Statement::Execute(_)
+                    | Statement::Explain(_)
+                    | Statement::Fetch(_)
+                    | Statement::Prepare(_)
+                    | Statement::Rollback(_)
+                    | Statement::Select(_)
+                    | Statement::SetTransaction(_)
+                    | Statement::ShowColumns(_)
+                    | Statement::ShowCreateIndex(_)
+                    | Statement::ShowCreateSink(_)
+                    | Statement::ShowCreateSource(_)
+                    | Statement::ShowCreateTable(_)
+                    | Statement::ShowCreateView(_)
+                    | Statement::ShowDatabases(_)
+                    | Statement::ShowIndexes(_)
+                    | Statement::ShowObjects(_)
+                    | Statement::ShowVariable(_)
+                    | Statement::SetVariable(_)
+                    | Statement::StartTransaction(_)
+                    | Statement::Tail(_)
+                    | Statement::Raise(_) => {
+                        // Always safe.
+                    }
+
+                    Statement::Insert(ref insert_statment)
+                        if matches!(
+                            insert_statment.source,
+                            InsertSource::Query(Query {
+                                body: SetExpr::Values(..),
+                                ..
+                            }) | InsertSource::DefaultValues
+                        ) =>
+                    {
+                        // Inserting from default? values statements
+                        // is always safe.
+                    }
+
+                    // Statements below must by run singly (in Started).
+                    Statement::AlterIndex(_)
+                    | Statement::AlterObjectRename(_)
+                    | Statement::CreateDatabase(_)
+                    | Statement::CreateIndex(_)
+                    | Statement::CreateRole(_)
+                    | Statement::CreateCluster(_)
+                    | Statement::CreateSchema(_)
+                    | Statement::CreateSecret(_)
+                    | Statement::CreateSink(_)
+                    | Statement::CreateSource(_)
+                    | Statement::CreateTable(_)
+                    | Statement::CreateType(_)
+                    | Statement::CreateView(_)
+                    | Statement::CreateViews(_)
+                    | Statement::Delete(_)
+                    | Statement::DropDatabase(_)
+                    | Statement::DropObjects(_)
+                    | Statement::Insert(_)
+                    | Statement::Update(_) => {
+                        return tx.send(
+                            Err(CoordError::OperationProhibitsTransaction(stmt.to_string())),
+                            session,
+                        )
+                    }
+                }
+            }
+        }
+
+        if self.catalog.config().safe_mode {
+            if let Err(e) = check_statement_safety(&stmt) {
+                return tx.send(Err(e), session);
+            }
+        }
+
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        let purify_fut = mz_sql::pure::purify(
+            self.now(),
+            self.catalog.config().aws_external_id.clone(),
+            stmt.clone(),
+        );
+        let params = portal.parameters.clone();
+        let conn_id = session.conn_id();
+        task::spawn(|| format!("purify:{conn_id}"), {
+            async move {
+                let result = purify_fut.err_into().await;
+                internal_cmd_tx
+                    .send(Message::StatementReady(StatementReady {
+                        session,
+                        tx,
+                        result,
+                        params,
+                    }))
+                    .expect("sending to internal_cmd_tx cannot fail");
+            }
+        });
     }
 
     /// Instruct the dataflow layer to cancel any ongoing, interactive work for

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1232,8 +1232,11 @@ impl Coordinator {
                         }
 
                         let internal_cmd_tx = self.internal_cmd_tx.clone();
-                        let catalog = self.catalog.for_session(&session);
-                        let purify_fut = mz_sql::pure::purify(&catalog, stmt);
+                        let purify_fut = mz_sql::pure::purify(
+                            self.now(),
+                            self.catalog.config().aws_external_id.clone(),
+                            stmt,
+                        );
                         let conn_id = session.conn_id();
                         task::spawn(|| format!("purify:{conn_id}"), async move {
                             let result = purify_fut.await.map_err(|e| e.into());

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -168,8 +168,9 @@ pub fn describe(
 /// Produces a [`Plan`] from the purified statement `stmt`.
 ///
 /// Planning is a pure, synchronous function and so requires that the provided
-/// `stmt` does does not depend on any external state. To purify a statement,
-/// use [`crate::pure::purify`].
+/// `stmt` does does not depend on any external state. Only `CREATE SOURCE`
+/// statements can depend on external state; remove that state prior to calling
+/// this function via [`crate::pure::purify_create_source`].
 ///
 /// The returned plan is tied to the state of the provided catalog. If the state
 /// of the catalog changes after planning, the validity of the plan is not

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -37,7 +37,7 @@ use prost::Message;
 use crate::ast::{
     AvroSchema, CreateSourceConnector, CreateSourceFormat, CreateSourceStatement, CsrConnectorAvro,
     CsrConnectorProto, CsrSeed, CsrSeedCompiled, CsrSeedCompiledEncoding, CsrSeedCompiledOrLegacy,
-    CsvColumns, DbzMode, Envelope, Format, Ident, ProtobufSchema, Raw, SqlOption, Statement, Value,
+    CsvColumns, DbzMode, Envelope, Format, Ident, ProtobufSchema, Raw, SqlOption, Value,
     WithOption, WithOptionValue,
 };
 use crate::kafka_util;
@@ -52,142 +52,142 @@ use crate::normalize;
 /// time to complete. As a result purification does *not* have access to a
 /// [`SessionCatalog`](crate::catalog::SessionCatalog), as that would require
 /// locking access to the catalog for an unbounded amount of time.
-pub async fn purify(
+pub async fn purify_create_source(
     now: u64,
     aws_external_id: AwsExternalId,
-    mut stmt: Statement<Raw>,
-) -> Result<Statement<Raw>, anyhow::Error> {
-    if let Statement::CreateSource(CreateSourceStatement {
+    mut stmt: CreateSourceStatement<Raw>,
+) -> Result<CreateSourceStatement<Raw>, anyhow::Error> {
+    let CreateSourceStatement {
         connector,
         format,
         envelope,
         with_options,
         include_metadata: _,
         ..
-    }) = &mut stmt
-    {
-        let mut with_options_map = normalize::options(with_options);
-        let mut config_options = BTreeMap::new();
+    } = &mut stmt;
 
-        let mut file = None;
-        match connector {
-            CreateSourceConnector::Kafka { broker, topic, .. } => {
-                if !broker.contains(':') {
-                    *broker += ":9092";
+    let mut with_options_map = normalize::options(with_options);
+    let mut config_options = BTreeMap::new();
+
+    let mut file = None;
+    match connector {
+        CreateSourceConnector::Kafka { broker, topic, .. } => {
+            if !broker.contains(':') {
+                *broker += ":9092";
+            }
+
+            // Verify that the provided security options are valid and then test them.
+            config_options = kafka_util::extract_config(&mut with_options_map)?;
+            let consumer = kafka_util::create_consumer(&broker, &topic, &config_options)
+                .await
+                .map_err(|e| anyhow!("Failed to create and connect Kafka consumer: {}", e))?;
+
+            // Translate `kafka_time_offset` to `start_offset`.
+            match kafka_util::lookup_start_offsets(
+                Arc::clone(&consumer),
+                &topic,
+                &with_options_map,
+                now,
+            )
+            .await?
+            {
+                Some(start_offsets) => {
+                    // Drop `kafka_time_offset`
+                    with_options.retain(|val| match val {
+                        mz_sql_parser::ast::SqlOption::Value { name, .. } => {
+                            name.as_str() != "kafka_time_offset"
+                        }
+                        _ => true,
+                    });
+
+                    // Add `start_offset`
+                    with_options.push(mz_sql_parser::ast::SqlOption::Value {
+                        name: mz_sql_parser::ast::Ident::new("start_offset"),
+                        value: mz_sql_parser::ast::Value::Array(
+                            start_offsets
+                                .iter()
+                                .map(|offset| Value::Number(offset.to_string()))
+                                .collect(),
+                        ),
+                    });
                 }
-
-                // Verify that the provided security options are valid and then test them.
-                config_options = kafka_util::extract_config(&mut with_options_map)?;
-                let consumer = kafka_util::create_consumer(&broker, &topic, &config_options)
-                    .await
-                    .map_err(|e| anyhow!("Failed to create and connect Kafka consumer: {}", e))?;
-
-                // Translate `kafka_time_offset` to `start_offset`.
-                match kafka_util::lookup_start_offsets(
-                    Arc::clone(&consumer),
-                    &topic,
-                    &with_options_map,
-                    now,
-                )
-                .await?
-                {
-                    Some(start_offsets) => {
-                        // Drop `kafka_time_offset`
-                        with_options.retain(|val| match val {
-                            mz_sql_parser::ast::SqlOption::Value { name, .. } => {
-                                name.as_str() != "kafka_time_offset"
-                            }
-                            _ => true,
-                        });
-
-                        // Add `start_offset`
-                        with_options.push(mz_sql_parser::ast::SqlOption::Value {
-                            name: mz_sql_parser::ast::Ident::new("start_offset"),
-                            value: mz_sql_parser::ast::Value::Array(
-                                start_offsets
-                                    .iter()
-                                    .map(|offset| Value::Number(offset.to_string()))
-                                    .collect(),
-                            ),
-                        });
-                    }
-                    _ => {}
-                }
+                _ => {}
             }
-            CreateSourceConnector::AvroOcf { path, .. } => {
-                let path = path.clone();
-                task::block_in_place(|| {
-                    // mz_avro::Reader has no async equivalent, so we're stuck
-                    // using blocking calls here.
-                    let f = std::fs::File::open(path)?;
-                    let r = mz_avro::Reader::new(f)?;
-                    if !with_options_map.contains_key("reader_schema") {
-                        let schema = serde_json::to_string(r.writer_schema()).unwrap();
-                        with_options.push(mz_sql_parser::ast::SqlOption::Value {
-                            name: mz_sql_parser::ast::Ident::new("reader_schema"),
-                            value: mz_sql_parser::ast::Value::String(schema),
-                        });
-                    }
-                    Ok::<_, anyhow::Error>(())
-                })?;
-            }
-            // Report an error if a file cannot be opened, or if it is a directory.
-            CreateSourceConnector::File { path, .. } => {
-                let f = File::open(&path).await?;
-                if f.metadata().await?.is_dir() {
-                    bail!("Expected a regular file, but {} is a directory.", path);
-                }
-                file = Some(f);
-            }
-            CreateSourceConnector::S3 { .. } => {
-                let aws_config = normalize::aws_config(&mut with_options_map, None)?;
-                validate_aws_credentials(&aws_config, aws_external_id).await?;
-            }
-            CreateSourceConnector::Kinesis { arn } => {
-                let region = arn
-                    .parse::<ARN>()
-                    .context("Unable to parse provided ARN")?
-                    .region
-                    .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
-
-                let aws_config = normalize::aws_config(&mut with_options_map, Some(region.into()))?;
-                validate_aws_credentials(&aws_config, aws_external_id).await?;
-            }
-            CreateSourceConnector::Postgres {
-                conn,
-                publication,
-                slot,
-                details,
-            } => {
-                slot.get_or_insert_with(|| {
-                    format!(
-                        "materialize_{}",
-                        Uuid::new_v4().to_string().replace('-', "")
-                    )
-                });
-
-                // verify that we can connect upstream and snapshot publication metadata
-                let tables = mz_postgres_util::publication_info(&conn, &publication).await?;
-
-                let details_proto = PostgresSourceDetails {
-                    tables: tables.into_iter().map(|t| t.into()).collect(),
-                    slot: slot.clone().expect("slot must exist"),
-                };
-                *details = Some(hex::encode(details_proto.encode_to_vec()));
-            }
-            CreateSourceConnector::PubNub { .. } => (),
         }
+        CreateSourceConnector::AvroOcf { path, .. } => {
+            let path = path.clone();
+            task::block_in_place(|| {
+                // mz_avro::Reader has no async equivalent, so we're stuck
+                // using blocking calls here.
+                let f = std::fs::File::open(path)?;
+                let r = mz_avro::Reader::new(f)?;
+                if !with_options_map.contains_key("reader_schema") {
+                    let schema = serde_json::to_string(r.writer_schema()).unwrap();
+                    with_options.push(mz_sql_parser::ast::SqlOption::Value {
+                        name: mz_sql_parser::ast::Ident::new("reader_schema"),
+                        value: mz_sql_parser::ast::Value::String(schema),
+                    });
+                }
+                Ok::<_, anyhow::Error>(())
+            })?;
+        }
+        // Report an error if a file cannot be opened, or if it is a directory.
+        CreateSourceConnector::File { path, .. } => {
+            let f = File::open(&path).await?;
+            if f.metadata().await?.is_dir() {
+                bail!("Expected a regular file, but {} is a directory.", path);
+            }
+            file = Some(f);
+        }
+        CreateSourceConnector::S3 { .. } => {
+            let aws_config = normalize::aws_config(&mut with_options_map, None)?;
+            validate_aws_credentials(&aws_config, aws_external_id).await?;
+        }
+        CreateSourceConnector::Kinesis { arn } => {
+            let region = arn
+                .parse::<ARN>()
+                .context("Unable to parse provided ARN")?
+                .region
+                .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
 
-        purify_source_format(
-            format,
-            connector,
-            &envelope,
-            file,
-            &config_options,
-            with_options,
-        )
-        .await?;
+            let aws_config = normalize::aws_config(&mut with_options_map, Some(region.into()))?;
+            validate_aws_credentials(&aws_config, aws_external_id).await?;
+        }
+        CreateSourceConnector::Postgres {
+            conn,
+            publication,
+            slot,
+            details,
+        } => {
+            slot.get_or_insert_with(|| {
+                format!(
+                    "materialize_{}",
+                    Uuid::new_v4().to_string().replace('-', "")
+                )
+            });
+
+            // verify that we can connect upstream and snapshot publication metadata
+            let tables = mz_postgres_util::publication_info(&conn, &publication).await?;
+
+            let details_proto = PostgresSourceDetails {
+                tables: tables.into_iter().map(|t| t.into()).collect(),
+                slot: slot.clone().expect("slot must exist"),
+            };
+            *details = Some(hex::encode(details_proto.encode_to_vec()));
+        }
+        CreateSourceConnector::PubNub { .. } => (),
     }
+
+    purify_source_format(
+        format,
+        connector,
+        &envelope,
+        file,
+        &config_options,
+        with_options,
+    )
+    .await?;
+
     Ok(stmt)
 }
 


### PR DESCRIPTION
This brings the signature of the `purify` function back in line with its
documentation. Purification is meant to be an operation that does not
depend on the catalog at all; we corrupted this to support `CREATE VIEWS
FROM SOURCE` in a hurry. Fortunately the refactor in #11083 allows us to
restore `purify` to its original ... purity.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Go commit by commit with whitespace suppressed.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
