### PR TITLE
dataflow: failpoints in Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,9 +2342,12 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.6"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "integer-encoding"
@@ -3188,6 +3191,7 @@ dependencies = [
  "differential-dataflow",
  "enum-iterator",
  "enum-kinds",
+ "fail",
  "futures",
  "globset",
  "http",
@@ -4353,13 +4357,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.3",
+ "parking_lot_core 0.8.5",
 ]
 
 [[package]]
@@ -4374,9 +4378,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if",
  "instant",
@@ -4786,7 +4790,7 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "regex",
  "thiserror",
 ]
@@ -5983,7 +5987,7 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "log",
- "parking_lot 0.11.1",
+ "parking_lot 0.11.2",
  "percent-encoding",
  "phf",
  "pin-project-lite",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -19,6 +19,7 @@ derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 enum-iterator = "0.7.0"
 enum-kinds = "0.5.1"
+fail = { version = "0.5.0", features = ["failpoints"]}
 futures = "0.3.21"
 globset = { version = "0.4.8", features = ["serde1"] }
 http = "0.2.6"

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -32,6 +32,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 
 use mz_build_info::BuildInfo;
 use mz_coord::LoggingConfig;
+use mz_dataflow_types::client::test_clients::DuplicatingClient;
 use mz_dataflow_types::client::InstanceConfig;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
@@ -281,6 +282,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         persister: persister.runtime.clone(),
         aws_external_id: config.aws_external_id.clone(),
     })?;
+
+    let dataflow_client = DuplicatingClient::new(dataflow_client);
 
     // Initialize coordinator.
     let (coord_handle, coord_client) = mz_coord::serve(mz_coord::Config {


### PR DESCRIPTION
### Motivation

Introduce fail points into the dataflow client. This would add the following fail points:
* `client-response-duplicate`: Duplicate responses.
* `client-command-duplicate`: Duplicate commands.

Currently, enabling either and issuing a query will crash Materialize.

Example: `set failpoints = 'client-response-duplicate=return';`

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
