### PR TITLE
Match uid regex in testdrive rename testcase

### DIFF
--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -186,10 +186,11 @@ View                                "Create View"
 ------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"dependent_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\""
 
+$ set-regex match=u\d+ replacement=UID
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [u244 AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [(UID) AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -190,7 +190,7 @@ $ set-regex match=u\d+ replacement=UID
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [(UID) AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [UID AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -19,6 +19,8 @@ $ set writer-schema={
 $ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
 {"a": 1, "b": "dog"}
 
+$ set-regex match=u\d+ replacement=UID
+
 # Create library of objects and verify names
 > CREATE MATERIALIZED SOURCE mz_data
   FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
@@ -186,7 +188,6 @@ View                                "Create View"
 ------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"dependent_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\""
 
-$ set-regex match=u\d+ replacement=UID
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This testcase became fragile when it was updated to look for a specific global_id in the output, this PR adds a [regex match](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/testdrive.md#dealing-with-variable-output) for UID to make it non-flaky.

### Motivation

  * This PR fixes a previously unreported bug.

      - test flakiness because the global_id is sensitive to workload the instance under test has performed prior to this case


### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user facing changes, just fixing a test case.
