### PR TITLE
doc/user: Add Click to Copy, Fix typos on Tools page

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -639,6 +639,31 @@ pre {
         background-color: $light-purple-v2;
     }
 }
+
+.copy_button {
+    display: none;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-family: "Inter", sans-serif;
+}
+
+pre {
+    position: relative;
+    transition: background-color 500ms ease-out;
+
+    &:hover {
+        .copy_button {
+            display: inline-block;
+        }
+    }
+
+    &.copy_success {
+        background-color: rgba($lime, 0.3);
+        transition: background-color 0s;
+    }
+}
+
 td > .default_button {
     margin-top: 6px;
 }

--- a/doc/user/content/third-party/supported-tools.md
+++ b/doc/user/content/third-party/supported-tools.md
@@ -32,7 +32,7 @@ Kafka is supported in Materialize as a [`SOURCE`](/sql/create-source/) of input
 | Confluent Cloud Kafka | 🟢 Production | Use SASL authentication, see [example here](/sql/create-source/kafka/#saslplain). The same config can be used to produce messages to Confluent Kafka via a [SINK](/sql/create-sink/). |  |
 | AWS MSK (Managed Streaming for Kafka) | 🟢 Production | Use SASL/SCRAM Authentication to securely connect to MSK clusters. [MSK SASL Docs](https://docs.aws.amazon.com/msk/latest/developerguide/msk-password.html) *(mTLS connections coming soon.)* |  |
 | Redpanda | 🟢 Beta | Repdanda works as a Kafka Source and Sink in Materialize. See [using Redpanda with Materialize](/third-party/redpanda/) for instructions and limitations. | [More Info](/third-party/redpanda/) [](#notify) |
-| Heroku Kafka | 🟢 Alpha | Use [SSL Authentication](https://materialize.com/docs/sql/create-source/kafka/#ssl) and the Heroku-provided certificates and keys for security. Use Heroku-provided `KAFKA_URL` for broker addresses (replace `kafka+ssl://` with `ssl://`). Heroku disables topic creation, [preventing SINKs from working](https://github.com/MaterializeInc/materialize/issues/8378). | [](#notify) |
+| Heroku Kafka | 🟡 Alpha | Use [SSL Authentication](https://materialize.com/docs/sql/create-source/kafka/#ssl) and the Heroku-provided certificates and keys for security. Use Heroku-provided `KAFKA_URL` for broker addresses (replace `kafka+ssl://` with `ssl://`). Heroku disables topic creation, [preventing SINKs from working](https://github.com/MaterializeInc/materialize/issues/8378). | [](#notify) |
 
 
 ### Other Message Brokers
@@ -66,7 +66,7 @@ Materialize has a [direct PostgreSQL source](/sql/create-source/postgres/) tha
 
 ### Other Databases
 
-Currently, it is only possible to use Materialize with other databases via an intermediary service like Debezium that can handle extracting change-data-capture events. This may change in the future
+Currently, it is only possible to use Materialize with other databases via an intermediary service like Debezium that can handle extracting change-data-capture events. This may change in the future.
 
 | Service | Materialize Support | Notes |  |
 | --- | --- | --- | --- |

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -60,7 +60,7 @@ by the Apache License, Version 2.0.  */}}
           $('pre.chroma span.copy_button').click(function(e) {
             var _this = $(this),
                 copyHex = document.createElement('textarea');
-            copyHex.value = _this.parent().text().trim();
+            copyHex.value = _this.parent().find('code').text().trim();
             document.body.appendChild(copyHex);
             copyHex.select();
             document.execCommand('copy');

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -53,6 +53,25 @@ by the Apache License, Version 2.0.  */}}
         /* Make external links open in new tabs */
         $('a[href*="//"]:not([href*="materialize.com"])').attr({target:"_blank", title:"External Link"});
 
+        /* Add "Click to Copy" button to code blocks */
+        $(document).ready(function() {
+          $('pre.chroma').append('<span class="default_button copy_button" title="Copy code to clipboard">Copy</span>');
+
+          $('pre.chroma span.copy_button').click(function(e) {
+            var _this = $(this),
+                copyHex = document.createElement('textarea');
+            copyHex.value = _this.parent().text().trim();
+            document.body.appendChild(copyHex);
+            copyHex.select();
+            document.execCommand('copy');
+            document.body.removeChild(copyHex);
+            _this.parent().addClass("copy_success");
+            setTimeout(function() {
+              _this.parent().removeClass("copy_success");
+            }, 1);
+          });
+        });
+
         /* s to search */
         document.addEventListener("keyup", e => {
           if (e.key !== "s" || e.ctrlKey || e.metaKey) return;


### PR DESCRIPTION

### Motivation
This adds a very basic "Click to Copy" function for `<pre class="chroma">` code blocks. And fixes a couple typos on the new tools page.  Fixes  #4592

#### Click to Copy
![Kapture 2022-03-14 at 18 20 49](https://user-images.githubusercontent.com/11527560/158270602-3274b643-1517-4ec0-9fdf-3dd81f8482ab.gif)
Here are some details about how it is supposed to work:
- Only works on codeblocks (not inline code) by filtering to `<pre class="chroma">` elements.
- The button is only visible when the mouse is hovered over the code block
- Clicking the button copies the code (stripped of trailing and leading newlines so that users aren't automatically executing code upon pasting into terminals)
- Repeated clicks repeatedly copy
- The user is alerted to the success by a brief flash of green on the copied codeblock.

#### Fixes to tools page
Fixing a couple issues with the tools page, namely Heroku Kafka's alpha status was incorrectly marked green and not yellow, and a sentence was missing a period.


### Tips for reviewer

Please vet that the copy functionality works as mentioned across chrome/firefox/safari