### PR TITLE
qgm: add `Union` support to `FromHir`

### DIFF
--- a/src/sql/src/query_model/hir/qgm_from_hir.rs
+++ b/src/sql/src/query_model/hir/qgm_from_hir.rs
@@ -60,6 +60,23 @@ impl FromHir {
     /// Generates a sub-graph representing the given expression.
     fn generate_internal(&mut self, expr: HirRelationExpr) -> Result<BoxId, QGMError> {
         match expr {
+            HirRelationExpr::Constant { rows, typ } => {
+                if typ.arity() == 0 && rows.len() == 1 {
+                    let values_box_id = self.model.make_box(BoxType::Values(Values {
+                        rows: rows.iter().map(|_| Vec::new()).collect_vec(),
+                    }));
+                    Ok(values_box_id)
+                } else {
+                    // The only expected constant collection is `{ () }` (the
+                    // singleton collection of a zero-arity tuple) and is handled above.
+                    // In theory, this should be `unreachable!(...)`, but we return an
+                    // `Err` in order to bubble up this to the user without panicking.
+                    Err(QGMError::from(UnsupportedHirRelationExpr {
+                        expr: HirRelationExpr::Constant { rows, typ },
+                        explanation: Some(String::from("Constant with arity > 0 or length != 1")),
+                    }))
+                }
+            }
             HirRelationExpr::Get { id, typ } => {
                 if let Some(box_id) = self.gets_seen.get(&id) {
                     return Ok(*box_id);
@@ -86,11 +103,9 @@ impl FromHir {
                     // Other id variants should not be present in the HirRelationExpr.
                     // In theory, this should be `unreachable!(...)`, but we return an
                     // `Err` in order to bubble up this to the user without panicking.
-                    let expr = HirRelationExpr::Get { id, typ };
-                    let explanation = Some(String::from("Unexpected Id variant in Get"));
                     Err(QGMError::from(UnsupportedHirRelationExpr {
-                        expr,
-                        explanation,
+                        expr: HirRelationExpr::Get { id, typ },
+                        explanation: Some(String::from("Unexpected Id variant in Get")),
                     }))
                 }
             }
@@ -111,24 +126,20 @@ impl FromHir {
                 }
                 Ok(body_box_id)
             }
-            HirRelationExpr::Constant { rows, typ } => {
-                if typ.arity() == 0 || rows.len() != 1 {
-                    let values_box_id = self.model.make_box(BoxType::Values(Values {
-                        rows: rows.iter().map(|_| Vec::new()).collect_vec(),
+            HirRelationExpr::Project { input, outputs } => {
+                let input_box_id = self.generate_internal(*input)?;
+                let select_id = self.model.make_select_box();
+                let quantifier_id =
+                    self.model
+                        .make_quantifier(QuantifierType::Foreach, input_box_id, select_id);
+                let mut select_box = self.model.get_mut_box(select_id);
+                for position in outputs {
+                    select_box.add_column(BoxScalarExpr::ColumnReference(ColumnReference {
+                        quantifier_id,
+                        position,
                     }));
-                    Ok(values_box_id)
-                } else {
-                    // The only expected constant collection is `{ () }` (the
-                    // singleton collection of a zero-arity tuple).
-                    // In theory, this should be `unreachable!(...)`, but we return an
-                    // `Err` in order to bubble up this to the user without panicking.
-                    let expr = HirRelationExpr::Constant { rows, typ };
-                    let explanation = String::from("Cannot convert Constant with arity > 0 to QGM");
-                    Err(QGMError::from(UnsupportedHirRelationExpr {
-                        expr,
-                        explanation: Some(explanation),
-                    }))
                 }
+                Ok(select_id)
             }
             HirRelationExpr::Map { input, mut scalars } => {
                 let mut box_id = self.generate_internal(*input)?;
@@ -174,11 +185,72 @@ impl FromHir {
                 }
                 Ok(box_id)
             }
-            HirRelationExpr::Distinct { input } => {
-                let select_id = self.generate_select(*input)?;
-                let mut select_box = self.model.get_mut_box(select_id);
-                select_box.distinct = DistinctOperation::Enforce;
+            // HirRelationExpr::CallTable { func, exprs } => todo!(),
+            HirRelationExpr::Filter { input, predicates } => {
+                let input_box = self.generate_internal(*input)?;
+                // We could install the predicates in `input_box` if it happened
+                // to be a `Select` box. However, that would require pushing down
+                // the predicates through its projection, since the predicates are
+                // written in terms of elements in `input`'s projection.
+                // Instead, we just install a new `Select` box for holding the
+                // predicate, and let normalization tranforms simplify the graph.
+                let select_id = self.wrap_within_select(input_box);
+                for predicate in predicates {
+                    let expr = self.generate_expr(predicate, select_id)?;
+                    self.add_predicate(select_id, expr);
+                }
                 Ok(select_id)
+            }
+            HirRelationExpr::Join {
+                left,
+                mut right,
+                on,
+                kind,
+            } => {
+                let (box_type, left_q_type, right_q_type) = match kind {
+                    JoinKind::Inner { .. } => (
+                        BoxType::Select(Select::default()),
+                        QuantifierType::Foreach,
+                        QuantifierType::Foreach,
+                    ),
+                    JoinKind::LeftOuter { .. } => (
+                        BoxType::OuterJoin(OuterJoin::default()),
+                        QuantifierType::PreservedForeach,
+                        QuantifierType::Foreach,
+                    ),
+                    JoinKind::RightOuter => (
+                        BoxType::OuterJoin(OuterJoin::default()),
+                        QuantifierType::Foreach,
+                        QuantifierType::PreservedForeach,
+                    ),
+                    JoinKind::FullOuter => (
+                        BoxType::OuterJoin(OuterJoin::default()),
+                        QuantifierType::PreservedForeach,
+                        QuantifierType::PreservedForeach,
+                    ),
+                };
+                let join_box = self.model.make_box(box_type);
+
+                // Left box
+                let left_box = self.generate_internal(*left)?;
+                self.model.make_quantifier(left_q_type, left_box, join_box);
+
+                // Right box
+                let right_box = self.within_context(join_box, &mut |generator| {
+                    let right = right.take();
+                    generator.generate_internal(right)
+                })?;
+                self.model
+                    .make_quantifier(right_q_type, right_box, join_box);
+
+                // ON clause
+                let predicate = self.generate_expr(on, join_box)?;
+                self.add_predicate(join_box, predicate);
+
+                // Default projection
+                self.model.get_mut_box(join_box).add_all_input_columns();
+
+                Ok(join_box)
             }
             HirRelationExpr::Reduce {
                 input,
@@ -252,88 +324,23 @@ impl FromHir {
                 }
                 Ok(group_box_id)
             }
-            HirRelationExpr::Filter { input, predicates } => {
-                let input_box = self.generate_internal(*input)?;
-                // We could install the predicates in `input_box` if it happened
-                // to be a `Select` box. However, that would require pushing down
-                // the predicates through its projection, since the predicates are
-                // written in terms of elements in `input`'s projection.
-                // Instead, we just install a new `Select` box for holding the
-                // predicate, and let normalization tranforms simplify the graph.
-                let select_id = self.wrap_within_select(input_box);
-                for predicate in predicates {
-                    let expr = self.generate_expr(predicate, select_id)?;
-                    self.add_predicate(select_id, expr);
-                }
-                Ok(select_id)
-            }
-
-            HirRelationExpr::Project { input, outputs } => {
-                let input_box_id = self.generate_internal(*input)?;
-                let select_id = self.model.make_select_box();
-                let quantifier_id =
-                    self.model
-                        .make_quantifier(QuantifierType::Foreach, input_box_id, select_id);
+            HirRelationExpr::Distinct { input } => {
+                let select_id = self.generate_select(*input)?;
                 let mut select_box = self.model.get_mut_box(select_id);
-                for position in outputs {
-                    select_box.add_column(BoxScalarExpr::ColumnReference(ColumnReference {
-                        quantifier_id,
-                        position,
-                    }));
-                }
+                select_box.distinct = DistinctOperation::Enforce;
                 Ok(select_id)
             }
-            HirRelationExpr::Join {
-                left,
-                mut right,
-                on,
-                kind,
-            } => {
-                let (box_type, left_q_type, right_q_type) = match kind {
-                    JoinKind::Inner { .. } => (
-                        BoxType::Select(Select::default()),
-                        QuantifierType::Foreach,
-                        QuantifierType::Foreach,
-                    ),
-                    JoinKind::LeftOuter { .. } => (
-                        BoxType::OuterJoin(OuterJoin::default()),
-                        QuantifierType::PreservedForeach,
-                        QuantifierType::Foreach,
-                    ),
-                    JoinKind::RightOuter => (
-                        BoxType::OuterJoin(OuterJoin::default()),
-                        QuantifierType::Foreach,
-                        QuantifierType::PreservedForeach,
-                    ),
-                    JoinKind::FullOuter => (
-                        BoxType::OuterJoin(OuterJoin::default()),
-                        QuantifierType::PreservedForeach,
-                        QuantifierType::PreservedForeach,
-                    ),
-                };
-                let join_box = self.model.make_box(box_type);
-
-                // Left box
-                let left_box = self.generate_internal(*left)?;
-                self.model.make_quantifier(left_q_type, left_box, join_box);
-
-                // Right box
-                let right_box = self.within_context(join_box, &mut |generator| {
-                    let right = right.take();
-                    generator.generate_internal(right)
-                })?;
-                self.model
-                    .make_quantifier(right_q_type, right_box, join_box);
-
-                // ON clause
-                let predicate = self.generate_expr(on, join_box)?;
-                self.add_predicate(join_box, predicate);
-
-                // Default projection
-                self.model.get_mut_box(join_box).add_all_input_columns();
-
-                Ok(join_box)
-            }
+            // HirRelationExpr::TopK {
+            //     input,
+            //     group_key,
+            //     order_key,
+            //     limit,
+            //     offset,
+            // } => todo!(),
+            // HirRelationExpr::Negate { input } => todo!(),
+            // HirRelationExpr::Threshold { input } => todo!(),
+            // HirRelationExpr::Union { base, inputs } => todo!(),
+            // HirRelationExpr::DeclareKeys { input, keys } => todo!(),
             expr => Err(QGMError::from(UnsupportedHirRelationExpr {
                 expr,
                 explanation: None,

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -222,7 +222,6 @@ pub(crate) enum BoxType {
     /// The invocation of table function from the catalog.
     TableFunction(TableFunction),
     /// SQL's union operator
-    #[allow(dead_code)]
     Union,
     /// Operator that produces a set of rows, with potentially
     /// correlated values.

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -1220,3 +1220,110 @@ digraph G {
     Q2 -> boxhead2 [ lhead = cluster2 ]
     Q1 -> boxhead1 [ lhead = cluster1 ]
 }
+
+build
+(select true as a) union (select false as b);
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "(select true as a) union (select false as b);"
+    node [ shape = box ]
+    subgraph cluster9 {
+        label = "Box9:Select"
+        boxhead9 [ shape = record, label = "{ Distinct: Enforce| 0: Q8.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q8 [ label = "Q8(F)" ]
+        }
+    }
+    subgraph cluster8 {
+        label = "Box8:Union"
+        boxhead8 [ shape = record, label = "{ Distinct: Preserve| 0: Q6.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q6 [ label = "Q6(F)" ]
+            Q7 [ label = "Q7(F)" ]
+        }
+    }
+    subgraph cluster3 {
+        label = "Box3:Select"
+        boxhead3 [ shape = record, label = "{ Distinct: Preserve| 0: Q2.C1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q2 [ label = "Q2(F)" ]
+        }
+    }
+    subgraph cluster2 {
+        label = "Box2:Select"
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C0| 1: Q1.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q1 [ label = "Q1(F)" ]
+        }
+    }
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: true }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:Values"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    subgraph cluster7 {
+        label = "Box7:Select"
+        boxhead7 [ shape = record, label = "{ Distinct: Preserve| 0: Q5.C1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q5 [ label = "Q5(F)" ]
+        }
+    }
+    subgraph cluster6 {
+        label = "Box6:Select"
+        boxhead6 [ shape = record, label = "{ Distinct: Preserve| 0: Q4.C0| 1: Q4.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q4 [ label = "Q4(F)" ]
+        }
+    }
+    subgraph cluster5 {
+        label = "Box5:Select"
+        boxhead5 [ shape = record, label = "{ Distinct: Preserve| 0: false }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q3 [ label = "Q3(F)" ]
+        }
+    }
+    subgraph cluster4 {
+        label = "Box4:Values"
+        boxhead4 [ shape = record, label = "{ Distinct: Preserve| ROW:  }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q8 -> boxhead8 [ lhead = cluster8 ]
+    Q6 -> boxhead3 [ lhead = cluster3 ]
+    Q7 -> boxhead7 [ lhead = cluster7 ]
+    Q2 -> boxhead2 [ lhead = cluster2 ]
+    Q1 -> boxhead1 [ lhead = cluster1 ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+    Q5 -> boxhead6 [ lhead = cluster6 ]
+    Q4 -> boxhead5 [ lhead = cluster5 ]
+    Q3 -> boxhead4 [ lhead = cluster4 ]
+}


### PR DESCRIPTION
Add support for translation of `HirRelationExpr::Union` nodes in the `FromHir` HIR ⇒ QGM conversion.

### Motivation

  * This PR adds a known-desirable feature. [#11227](11227)

### Tips for reviewer

The commits (in order of appending) change the code as follows:

1. Comment assumed unreachable error paths in `FromHir` so they can be clearly distinguished in the future.
1. Align the order in which the cases in `FromHir::generate_internal` are defined with the declaration order of `HirRelationExpr` variants and adds missing cases as code comments.
1. Add `Union` support to `FromHIR`. The new case is pretty-much a straight-forward 1:1 translation, with the columns of the new `Union` box projecting from the first quantifier.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A