### PR TITLE
Change default listen_addr to localhost

### DIFF
--- a/src/dataflowd/ci/Dockerfile
+++ b/src/dataflowd/ci/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update && apt-get -qy install ca-certificates curl tini
 
 COPY kdestroy kinit dataflowd /usr/local/bin/
 
-ENTRYPOINT ["tini", "--", "dataflowd"]
+ENTRYPOINT ["tini", "--", "dataflowd", "--listen-addr=0.0.0.0:6876"]

--- a/src/dataflowd/src/bin/dataflowd.rs
+++ b/src/dataflowd/src/bin/dataflowd.rs
@@ -42,7 +42,7 @@ struct Args {
         long,
         env = "DATAFLOWD_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "0.0.0.0:6876"
+        default_value = "127.0.0.1:6876"
     )]
     listen_addr: String,
     /// Number of dataflow worker threads.

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && apt-get -qy install ca-certificates curl sqlite3 tini
 
 COPY kdestroy kinit materialized /usr/local/bin/
 
-ENTRYPOINT ["tini", "--", "materialized", "--log-file=stderr"]
+ENTRYPOINT ["tini", "--", "materialized", "--log-file=stderr", "--listen-addr=0.0.0.0:6875"]

--- a/src/materialized/ci/coordd/Dockerfile
+++ b/src/materialized/ci/coordd/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && apt-get -qy install ca-certificates curl sqlite3 tini
 
 COPY kdestroy kinit coordd /usr/local/bin/
 
-ENTRYPOINT ["tini", "--", "coordd"]
+ENTRYPOINT ["tini", "--", "coordd", "--listen-addr=0.0.0.0:6875"]

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -37,7 +37,7 @@ struct Args {
         long,
         env = "COORDD_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "0.0.0.0:6875"
+        default_value = "127.0.0.1:6875"
     )]
     listen_addr: String,
     /// The address of the dataflowd servers to connect to.

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -252,7 +252,7 @@ pub struct Args {
         long,
         env = "MZ_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "0.0.0.0:6875"
+        default_value = "127.0.0.1:6875"
     )]
     listen_addr: SocketAddr,
     /// How stringently to demand TLS authentication and encryption.


### PR DESCRIPTION
This means that materialized by default won't be open to all network connections, but only to connections coming from the same machine.

This is a breaking change, and will require potentially some changes in the docs and some demos as well.

### Motivation

  * This PR fixes a previously unreported bug: Materialize defaulting to being open to all network connections with no authentication.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - **BREAKING**: Change the default `listen-addr` to `127.0.0.1:6875`: by default, Materialize will now listen to HTTP and SQL connections only from the local machine, instead of the entire Internet. To return to the old behavior, use `--listen-addr 0.0.0.0:6875`
