### PR TITLE
QGM => HIR

### DIFF
--- a/src/sql/src/query_model/error.rs
+++ b/src/sql/src/query_model/error.rs
@@ -139,6 +139,8 @@ impl fmt::Display for UnsupportedBoxType {
 #[derive(Debug, Clone)]
 pub struct UnsupportedQuantifierType {
     pub(crate) quantifier_type: QuantifierType,
+    /// Context where error is being thrown.
+    pub(crate) context: String,
 }
 
 impl From<UnsupportedQuantifierType> for QGMError {
@@ -151,8 +153,8 @@ impl fmt::Display for UnsupportedQuantifierType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Unsupported quantifier type in MIR conversion: {}.",
-            self.quantifier_type
+            "Unsupported quantifier type in {}: {}.",
+            self.context, self.quantifier_type
         )
     }
 }
@@ -160,6 +162,9 @@ impl fmt::Display for UnsupportedQuantifierType {
 #[derive(Debug, Clone)]
 pub struct UnsupportedBoxScalarExpr {
     pub(crate) scalar: BoxScalarExpr,
+    /// Context where error is being thrown.
+    pub(crate) context: String,
+    pub(crate) explanation: Option<String>,
 }
 
 impl From<UnsupportedBoxScalarExpr> for QGMError {
@@ -172,9 +177,13 @@ impl fmt::Display for UnsupportedBoxScalarExpr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Unsupported QGM scalar expression in MIR conversion: {}.",
-            self.scalar
-        )
+            "Unsupported QGM scalar expression in {}: {}.",
+            self.context, self.scalar
+        )?;
+        if let Some(explanation) = &self.explanation {
+            write!(f, " Explanation: {}", explanation)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/sql/src/query_model/hir/hir_from_qgm.rs
+++ b/src/sql/src/query_model/hir/hir_from_qgm.rs
@@ -12,10 +12,17 @@
 //! The public interface consists of the [`From<Model>`]
 //! implementation for [`HirRelationExpr`].
 
-use mz_repr::RelationType;
+use std::collections::{HashMap, HashSet};
 
-use crate::plan::expr::HirRelationExpr;
-use crate::query_model::{Model, QGMError};
+use crate::plan::expr::{ColumnRef, JoinKind};
+use crate::plan::{HirRelationExpr, HirScalarExpr};
+use crate::query_model::attribute::relation_type::RelationType as BoxRelationType;
+use crate::query_model::model::*;
+use crate::query_model::{BoxId, Model, QGMError, QuantifierId};
+
+use itertools::Itertools;
+
+use mz_ore::id_gen::IdGen;
 
 impl From<Model> for HirRelationExpr {
     fn from(model: Model) -> Self {
@@ -24,23 +31,373 @@ impl From<Model> for HirRelationExpr {
 }
 
 #[derive(Default)]
-struct FromModel;
+struct FromModel {
+    /// Generates [`mz_expr::LocalId`] as an alias for common expressions.
+    id_gen: IdGen,
+    // TODO: Add the current correlation information.
+    // Inspired by FromHir::context_stack. Subject to change.
+    // context_stack: Vec<QuantifierId>,
+    /// Stack of [HirRelationExpr] that have been created through visiting nodes
+    /// of QGM in post-order.
+    converted: Vec<HirRelationExpr>,
+    /// Common expressions that have been given a [`mz_expr::LocalId`], from
+    /// oldest to most recently identified.
+    lets: Vec<(mz_expr::LocalId, HirRelationExpr, mz_repr::RelationType)>,
+    /// Map of ([BoxId]s whose HIR representation has been given a
+    /// [`mz_expr::LocalId`]) -> (position of its HIR representation in `lets`)
+    common_subgraphs: HashMap<BoxId, usize>,
+}
+
+/// Tracks the column ranges in a [HirRelationExpr] in corresponding the
+/// quantifiers in a box.
+struct ColumnMap {
+    quantifier_to_input: HashMap<QuantifierId, usize>,
+    input_mapper: mz_expr::JoinInputMapper,
+}
 
 impl FromModel {
-    #[allow(dead_code, unused_variables, unused_mut)]
-    fn generate(mut self, model: Model) -> HirRelationExpr {
+    #[allow(dead_code)]
+    fn generate(mut self, mut model: Model) -> HirRelationExpr {
+        // Derive the RelationType of each box.
+        use crate::query_model::attribute::core::{Attribute, RequiredAttributes};
+        let attributes = HashSet::from_iter(std::iter::once(
+            Box::new(BoxRelationType) as Box<dyn Attribute>
+        ));
+        let root = model.top_box;
+        RequiredAttributes::from(attributes).derive(&mut model, root);
+
+        // Convert QGM to HIR.
         let _ = model.try_visit_pre_post(
-            &mut |model, box_id| -> Result<(), QGMError> {
-                println!("pre-visit");
+            &mut |_, _| -> Result<(), QGMError> {
+                // TODO: add to the context stack
                 Ok(())
             },
             &mut |model, box_id| -> Result<(), QGMError> {
-                println!("post-visit");
+                self.convert_subgraph(model, box_id);
                 Ok(())
             },
         );
-        // this should be todo!(), but we cannot merge to main code
-        // with todo!() statements
-        HirRelationExpr::constant(vec![vec![]], RelationType::empty())
+
+        // Retrieve the HIR and put `let`s around it.
+        let mut result = self.converted.pop().unwrap();
+        while let Some((id, value, _)) = self.lets.pop() {
+            if !matches!(value, HirRelationExpr::Get { .. }) {
+                result = HirRelationExpr::Let {
+                    name: "".to_string(),
+                    id,
+                    value: Box::new(value),
+                    body: Box::new(result),
+                }
+            }
+        }
+        result
+    }
+
+    /// Convert subgraph rooted at `box_id` to [HirRelationExpr].
+    ///
+    /// If the box corresponding to `box_id` has multiple ranging quantifiers,
+    /// the [HirRelationExpr] will be in `self.lets`, and it can be looked up in
+    /// `self.common_subgraphs`. Otherwise, it will be pushed to `self.converted`.
+    fn convert_subgraph(&mut self, model: &Model, box_id: &BoxId) {
+        let r#box = model.get_box(*box_id);
+        if self.common_subgraphs.get(&box_id).is_some() {
+            // Subgraph has already been converted.
+            return;
+        }
+        let hir = match &r#box.box_type {
+            BoxType::Get(Get { id, unique_keys }) => {
+                let typ = mz_repr::RelationType::new(
+                    r#box
+                        .columns
+                        .iter()
+                        .map(|c| {
+                            if let BoxScalarExpr::BaseColumn(BaseColumn { column_type, .. }) =
+                                &c.expr
+                            {
+                                column_type.clone()
+                            } else {
+                                // TODO: the validator should make this branch unreachable.
+                                panic!("expected all columns in Get BoxType to be BaseColumn");
+                            }
+                        })
+                        .collect::<Vec<_>>(),
+                )
+                .with_keys(unique_keys.clone());
+                HirRelationExpr::Get {
+                    id: mz_expr::Id::Global(*id),
+                    typ,
+                }
+            }
+            BoxType::Values(_) => {
+                HirRelationExpr::constant(vec![vec![]], mz_repr::RelationType::new(vec![]))
+            }
+            BoxType::Select(select) => {
+                let (rels, scalars) = self.convert_quantifiers(&r#box);
+                let (join_q_ids, mut join_inputs): (Vec<_>, Vec<_>) = rels.into_iter().unzip();
+                let (map_q_ids, maps): (Vec<_>, Vec<_>) = scalars.into_iter().unzip();
+
+                let mut result = if let Some(first) = join_inputs.pop() {
+                    first
+                } else {
+                    HirRelationExpr::constant(vec![vec![]], mz_repr::RelationType::new(vec![]))
+                };
+
+                while let Some(join_input) = join_inputs.pop() {
+                    result = HirRelationExpr::Join {
+                        left: Box::new(result),
+                        right: Box::new(join_input),
+                        kind: JoinKind::Inner,
+                        on: HirScalarExpr::literal_true(),
+                    }
+                }
+                if !maps.is_empty() {
+                    result = result.map(maps);
+                }
+                let column_map = ColumnMap::new(
+                    join_q_ids
+                        .into_iter()
+                        .rev()
+                        .chain(map_q_ids.into_iter().rev()),
+                    model,
+                );
+                if !select.predicates.is_empty() {
+                    let filter = select
+                        .predicates
+                        .iter()
+                        .map(|pred| self.convert_scalar(pred, &column_map))
+                        .filter(|pred| pred != &HirScalarExpr::literal_true())
+                        .collect_vec();
+                    if !filter.is_empty() {
+                        result = result.filter(filter);
+                    }
+                }
+                let result = self.convert_projection(&r#box, &column_map, result);
+                if select.limit.is_some() || select.offset.is_some() || select.order_key.is_some() {
+                    // TODO: put a TopK around the result
+                    unimplemented!()
+                }
+                result
+            }
+            BoxType::OuterJoin(outer_join) => {
+                let (mut rels, _) = self.convert_quantifiers(&r#box);
+                let (_, left) = rels.pop().unwrap();
+                let (_, right) = rels.pop().unwrap();
+                let mut quantifier_iter = r#box.input_quantifiers();
+                let left_preserved = matches!(
+                    quantifier_iter.next().unwrap().quantifier_type,
+                    QuantifierType::PreservedForeach
+                );
+                let right_preserved = matches!(
+                    quantifier_iter.next().unwrap().quantifier_type,
+                    QuantifierType::PreservedForeach
+                );
+                let kind = if left_preserved {
+                    if right_preserved {
+                        JoinKind::FullOuter
+                    } else {
+                        JoinKind::LeftOuter
+                    }
+                } else if right_preserved {
+                    JoinKind::RightOuter
+                } else {
+                    JoinKind::Inner
+                };
+                let column_map = ColumnMap::new(r#box.input_quantifiers().map(|q| q.id), model);
+                let mut converted_predicates = outer_join
+                    .predicates
+                    .iter()
+                    .map(|pred| self.convert_scalar(pred, &column_map))
+                    .collect_vec();
+                let on = if let Some(start) = converted_predicates.pop() {
+                    converted_predicates.into_iter().fold(start, |acc, pred| {
+                        HirScalarExpr::CallBinary {
+                            func: mz_expr::BinaryFunc::And,
+                            expr1: Box::new(acc),
+                            expr2: Box::new(pred),
+                        }
+                    })
+                } else {
+                    HirScalarExpr::literal_true()
+                };
+                let result = HirRelationExpr::Join {
+                    left: Box::new(left),
+                    right: Box::new(right),
+                    kind,
+                    on,
+                };
+                self.convert_projection(&r#box, &column_map, result)
+            }
+            _ => unimplemented!(),
+        };
+
+        if r#box.ranging_quantifiers().count() > 1 {
+            let id = mz_expr::LocalId::new(self.id_gen.allocate_id());
+            let typ =
+                mz_repr::RelationType::new(r#box.attributes.get::<BoxRelationType>().to_owned());
+            self.common_subgraphs.insert(r#box.id, self.lets.len());
+            self.lets.push((id, hir, typ));
+        } else {
+            self.converted.push(hir);
+        }
+    }
+
+    /// Convert the quantifiers of `box` into [HirRelationExpr] and [HirScalarExpr].
+    ///
+    /// Results are returned in reverse quantifier order; the last entry in the
+    /// second vector corresponds to the first subquery quantifier in the box.
+    fn convert_quantifiers<'a>(
+        &mut self,
+        r#box: &BoundRef<'a, QueryBox>,
+    ) -> (
+        Vec<(QuantifierId, HirRelationExpr)>,
+        Vec<(QuantifierId, HirScalarExpr)>,
+    ) {
+        let mut rels = Vec::new();
+        let mut scalars = Vec::new();
+        for q in r#box.input_quantifiers().rev() {
+            // Retrive the HIR corresponding to the input box of the quantifier
+            let inner_relation = if let Some(let_pos) = self.common_subgraphs.get(&q.input_box) {
+                if matches!(self.lets[*let_pos].1, HirRelationExpr::Get { .. }) {
+                    self.lets[*let_pos].1.clone()
+                } else {
+                    HirRelationExpr::Get {
+                        id: mz_expr::Id::Local(self.lets[*let_pos].0),
+                        typ: self.lets[*let_pos].2.clone(),
+                    }
+                }
+            } else {
+                self.converted.pop().unwrap()
+            };
+
+            match q.quantifier_type {
+                QuantifierType::Foreach | QuantifierType::PreservedForeach => {
+                    rels.push((q.id, inner_relation))
+                }
+                QuantifierType::Existential => {
+                    scalars.push((q.id, HirScalarExpr::Exists(Box::new(inner_relation))))
+                }
+                QuantifierType::Scalar => {
+                    scalars.push((q.id, HirScalarExpr::Select(Box::new(inner_relation))))
+                }
+                QuantifierType::All => {
+                    // TODO: Shouldn't QuantifierType::Any also exist?
+                    unimplemented!()
+                }
+            }
+        }
+        (rels, scalars)
+    }
+
+    /// Convert the projection of a box into a Map + Project around the
+    /// [HirRelationExpr] representing the rest of the box.
+    fn convert_projection<'a>(
+        &mut self,
+        r#box: &BoundRef<'a, QueryBox>,
+        column_map: &ColumnMap,
+        mut result: HirRelationExpr,
+    ) -> HirRelationExpr {
+        let mut map = Vec::new();
+        let mut project = Vec::new();
+        let mut total_columns = column_map.arity();
+
+        for column in &r#box.columns {
+            let hir_scalar = self.convert_scalar(&column.expr, column_map);
+            if let HirScalarExpr::Column(ColumnRef { level: 0, column }) = hir_scalar {
+                // We can skip making a copy of the column.
+                project.push(column);
+            } else {
+                map.push(hir_scalar);
+                project.push(total_columns);
+                total_columns += 1;
+            }
+        }
+
+        if !map.is_empty() {
+            result = result.map(map);
+        }
+        result.project(project)
+    }
+
+    /// Convert a BoxScalarExpr to [HirScalarExpr].
+    fn convert_scalar(&mut self, expr: &BoxScalarExpr, column_map: &ColumnMap) -> HirScalarExpr {
+        match expr {
+            BoxScalarExpr::BaseColumn(BaseColumn { position, .. }) => {
+                HirScalarExpr::Column(ColumnRef {
+                    level: 0,
+                    column: *position,
+                })
+            }
+            BoxScalarExpr::ColumnReference(ColumnReference {
+                quantifier_id,
+                position,
+            }) => {
+                if let Some(column) = column_map.lookup_level_0_col(*quantifier_id, *position) {
+                    HirScalarExpr::Column(ColumnRef { level: 0, column })
+                } else {
+                    // TODO: calculate the level for a correlated subquery.
+                    unimplemented!()
+                }
+            }
+            BoxScalarExpr::Literal(row, typ) => HirScalarExpr::Literal(row.clone(), typ.clone()),
+            BoxScalarExpr::CallUnmaterializable(func) => {
+                HirScalarExpr::CallUnmaterializable(func.clone())
+            }
+            BoxScalarExpr::CallUnary { func, expr } => HirScalarExpr::CallUnary {
+                func: func.clone(),
+                expr: Box::new(self.convert_scalar(expr, column_map)),
+            },
+            BoxScalarExpr::CallBinary { func, expr1, expr2 } => HirScalarExpr::CallBinary {
+                func: func.clone(),
+                expr1: Box::new(self.convert_scalar(expr1, column_map)),
+                expr2: Box::new(self.convert_scalar(expr2, column_map)),
+            },
+            BoxScalarExpr::CallVariadic { func, exprs } => HirScalarExpr::CallVariadic {
+                func: func.clone(),
+                exprs: exprs
+                    .iter()
+                    .map(|expr| self.convert_scalar(expr, column_map))
+                    .collect_vec(),
+            },
+            BoxScalarExpr::If { cond, then, els } => HirScalarExpr::If {
+                cond: Box::new(self.convert_scalar(cond, column_map)),
+                then: Box::new(self.convert_scalar(then, column_map)),
+                els: Box::new(self.convert_scalar(els, column_map)),
+            },
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl ColumnMap {
+    fn new<I>(quantifiers: I, model: &Model) -> Self
+    where
+        I: Iterator<Item = QuantifierId>,
+    {
+        let (quantifier_to_input, arities): (HashMap<_, _>, Vec<_>) = quantifiers
+            .enumerate()
+            .map(|(index, q_id)| {
+                let q_input_box = model.get_quantifier(q_id).input_box;
+                let input_arity = model.get_box(q_input_box).columns.iter().count();
+                ((q_id, index), input_arity)
+            })
+            .unzip();
+        let input_mapper = mz_expr::JoinInputMapper::new_from_input_arities(arities.into_iter());
+        Self {
+            quantifier_to_input,
+            input_mapper,
+        }
+    }
+
+    fn lookup_level_0_col(&self, q_id: QuantifierId, position: usize) -> Option<usize> {
+        if let Some(input) = self.quantifier_to_input.get(&q_id) {
+            Some(self.input_mapper.map_column_to_global(position, *input))
+        } else {
+            None
+        }
+    }
+
+    #[inline(always)]
+    fn arity(&self) -> usize {
+        self.input_mapper.total_columns()
     }
 }

--- a/src/sql/src/query_model/hir/hir_from_qgm.rs
+++ b/src/sql/src/query_model/hir/hir_from_qgm.rs
@@ -188,7 +188,10 @@ impl FromModel {
                         result = result.filter(filter);
                     }
                 }
-                let result = self.convert_projection(&r#box, &column_map, result);
+                let mut result = self.convert_projection(&r#box, &column_map, result);
+                if r#box.distinct == DistinctOperation::Enforce {
+                    result = result.distinct();
+                }
                 if select.limit.is_some() || select.offset.is_some() || select.order_key.is_some() {
                     // TODO: put a TopK around the result
                     unimplemented!()

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -639,6 +639,7 @@ impl<'a> Lowerer<'a> {
             other => {
                 return Err(QGMError::from(UnsupportedQuantifierType {
                     quantifier_type: other.clone(),
+                    context: "MIR conversion".to_string(),
                 }))
             }
         }
@@ -766,7 +767,9 @@ impl<'a> Lowerer<'a> {
             },
             other => {
                 return Err(QGMError::from(UnsupportedBoxScalarExpr {
+                    context: "MIR conversion".to_string(),
                     scalar: other.clone(),
+                    explanation: None,
                 }))
             }
         };

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -911,6 +911,20 @@ impl<'a> BoundRef<'a, Quantifier> {
     pub fn parent_box(&self) -> BoundRef<'_, QueryBox> {
         self.model.get_box(self.parent_box)
     }
+
+    /// The arity of the quantifier from the perspective of the parent box.
+    ///
+    /// Note that this is distinct from the arity of the input box of the
+    /// quantifier. For example, an existential subquery may have any number of
+    /// input columns, but its output is always a single boolean not null
+    /// column.
+    pub fn output_arity(&self) -> usize {
+        if self.quantifier_type.is_subquery() {
+            return 1;
+        } else {
+            self.model.get_box(self.input_box).columns.len()
+        }
+    }
 }
 
 /// Mutable [`Quantifier`] methods that depend on their enclosing [`Model`].

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -826,7 +826,7 @@ impl QueryBox {
     fn input_quantifiers<'a>(
         &'a self,
         model: &'a Model,
-    ) -> impl Iterator<Item = BoundRef<'a, Quantifier>> {
+    ) -> impl DoubleEndedIterator<Item = BoundRef<'a, Quantifier>> {
         self.quantifiers
             .iter()
             .map(|q_id| model.get_quantifier(*q_id))
@@ -837,7 +837,7 @@ impl QueryBox {
     fn ranging_quantifiers<'a>(
         &'a self,
         model: &'a Model,
-    ) -> impl Iterator<Item = BoundRef<'a, Quantifier>> {
+    ) -> impl DoubleEndedIterator<Item = BoundRef<'a, Quantifier>> {
         self.ranging_quantifiers
             .iter()
             .map(|q_id| model.get_quantifier(*q_id))
@@ -847,12 +847,12 @@ impl QueryBox {
 /// Immutable [`QueryBox`] methods that depend on their enclosing [`Model`].
 impl<'a> BoundRef<'a, QueryBox> {
     /// Delegate to `QueryBox::input_quantifiers` with the enclosing model.
-    pub fn input_quantifiers(&self) -> impl Iterator<Item = BoundRef<'_, Quantifier>> {
+    pub fn input_quantifiers(&self) -> impl DoubleEndedIterator<Item = BoundRef<'_, Quantifier>> {
         self.deref().input_quantifiers(self.model)
     }
 
     /// Delegate to `QueryBox::ranging_quantifiers` with the enclosing model.
-    pub fn ranging_quantifiers(&self) -> impl Iterator<Item = BoundRef<'_, Quantifier>> {
+    pub fn ranging_quantifiers(&self) -> impl DoubleEndedIterator<Item = BoundRef<'_, Quantifier>> {
         self.deref().ranging_quantifiers(self.model)
     }
 

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod catalog;
 pub(crate) mod util;
 
 use crate::plan::query::QueryLifetime;
-use crate::plan::StatementContext;
+use crate::plan::{HirRelationExpr, StatementContext};
 use mz_expr_test_util::generate_explanation;
 use mz_lowertest::*;
 
@@ -35,6 +35,8 @@ enum Directive {
     Opt,
     /// Optimize and decorrelate the model. Then convert it to a `MirRelationExpr`.
     EndToEnd,
+    /// Build the model and convert it back to a `HirRelationExpr`.
+    RoundTrip,
 }
 
 lazy_static! {
@@ -114,6 +116,19 @@ fn run_command(
         match model.try_into() {
             Ok(mir) => Ok(generate_explanation(catalog, &mir, args.get("format"))),
             Err(err) => Err(err.to_string()),
+        }
+    } else if matches!(directive, Directive::RoundTrip) {
+        let hir = HirRelationExpr::from(model);
+        let model2 = Model::try_from(hir.clone())?;
+        let hir2 = HirRelationExpr::from(model2);
+        if !hir.eq(&hir2) {
+            Err(format!(
+                "HirRelationExpr is not same after round-trip.\nOld:\n{}\nNew:\n{}\n",
+                hir.pretty(),
+                hir2.pretty()
+            ))
+        } else {
+            Ok(hir2.pretty())
         }
     } else {
         match model.as_dot(input, catalog, false) {

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -118,9 +118,9 @@ fn run_command(
             Err(err) => Err(err.to_string()),
         }
     } else if matches!(directive, Directive::RoundTrip) {
-        let hir = HirRelationExpr::from(model);
+        let hir = HirRelationExpr::try_from(model)?;
         let model2 = Model::try_from(hir.clone())?;
-        let hir2 = HirRelationExpr::from(model2);
+        let hir2 = HirRelationExpr::try_from(model2)?;
         if !hir.eq(&hir2) {
             Err(format!(
                 "HirRelationExpr is not same after round-trip.\nOld:\n{}\nNew:\n{}\n",

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -35,7 +35,7 @@ enum Directive {
     Opt,
     /// Optimize and decorrelate the model. Then convert it to a `MirRelationExpr`.
     EndToEnd,
-    /// Build the model and convert it back to a `HirRelationExpr`.
+    /// Ensure that the HIR ⇒ QGM ⇒ HIR round trip reaches a fixpoint after one iteration.
     RoundTrip,
 }
 

--- a/src/sql/tests/querymodel/hirroundtrip
+++ b/src/sql/tests/querymodel/hirroundtrip
@@ -1,0 +1,191 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+round_trip
+select;
+----
+%0 =
+| Constant ()
+
+round_trip
+select 1;
+----
+%0 =
+| Constant ()
+| Map 1
+
+round_trip
+select a, a from (select 1 as a);
+----
+%0 =
+| Constant ()
+| Map 1
+| Project (#0, #0)
+
+round_trip
+select a, b, a from (select 1 as a, 2 as b);
+----
+%0 =
+| Constant ()
+| Map 1, 2
+| Project (#0, #1, #0)
+
+round_trip
+select a from (select 1 as a, true as b) where b;
+----
+%0 =
+| Constant ()
+| Map 1, true
+| Filter #1
+| Project (#0)
+
+round_trip
+select case when not x.a then ltrim('e', x.b) else substr(x.c, 3, 4) end, mz_logical_timestamp()
+from (select false as a, null as b, null as c) x
+----
+%0 =
+| Constant ()
+| Map false, null
+| Project (#0, #1, #1)
+| Map if !(#0) then {ltrim("e", #1)} els {substr(#2, i32toi64(3), i32toi64(4))}, mz_logical_timestamp()
+| Project (#3, #4)
+
+round_trip
+select c from (select b, a + 1 as c from (select 1 as a, true as b));
+----
+%0 =
+| Constant ()
+| Map 1, true, (#0 + 1)
+| Project (#1, #2)
+| Project (#1)
+
+round_trip
+select x.a from (select true as a) x join (select false as b) y on x.a;
+----
+----
+%0 =
+| Constant ()
+| Map true
+
+%1 =
+| Constant ()
+| Map false
+
+%2 =
+| InnerJoin %0 %1 on true
+| Filter #0
+| Project (#0)
+----
+----
+
+round_trip
+select x.a from (select true as a) x left join (select false as b) y on x.a;
+----
+----
+%0 =
+| Constant ()
+| Map true
+
+%1 =
+| Constant ()
+| Map false
+
+%2 =
+| LeftOuterJoin %0 %1 on #0
+| Project (#0)
+----
+----
+
+cat
+(defsource x [int32 int64 int32] [a b c])
+(defsource y [int32 int64 int32] [a b c])
+----
+ok
+
+round_trip
+select x.b + 1 as d from x right join y on x.a = y.a;
+----
+----
+%0 =
+| Get ? (u0)
+
+%1 =
+| Get ? (u1)
+
+%2 =
+| RightOuterJoin %0 %1 on (#0 = #3)
+| Map (#1 + i32toi64(1))
+| Project (#6)
+----
+----
+
+round_trip
+select coalesce(x.b, 0) from x full join y on x.a = y.a and x.c is not null;
+----
+----
+%0 =
+| Get ? (u0)
+
+%1 =
+| Get ? (u1)
+
+%2 =
+| FullOuterJoin %0 %1 on ((#0 = #3) && !(isnull(#2)))
+| Map coalesce(#1, i32toi64(0))
+| Project (#6)
+----
+----
+
+round_trip
+with a(a, b) as (select 1, 2) select case when x.c > 5 then 1 else 0 end from a
+cross join x
+----
+----
+%0 =
+| Constant ()
+| Map 1, 2
+
+%1 =
+| Get ? (u0)
+
+%2 =
+| InnerJoin %0 %1 on true
+| Map if (#4 > 5) then {1} els {0}
+| Project (#5)
+----
+----
+
+round_trip
+with a(a, b) as (select 1, 2) select a.a from a cross join a as b
+----
+----
+%0 = Let  (l0) =
+| Constant ()
+| Map 1, 2
+
+%1 =
+| InnerJoin %0 %0 on true
+| Project (#0)
+----
+----
+
+round_trip
+select * from x, x as y;
+----
+----
+%0 =
+| Get ? (u0)
+
+%1 =
+| Get ? (u0)
+
+%2 =
+| InnerJoin %0 %1 on true
+----
+----

--- a/src/sql/tests/querymodel/hirroundtrip
+++ b/src/sql/tests/querymodel/hirroundtrip
@@ -189,3 +189,11 @@ select * from x, x as y;
 | InnerJoin %0 %1 on true
 ----
 ----
+
+round_trip
+select distinct a from x
+----
+%0 =
+| Get ? (u0)
+| Project (#0)
+| Distinct

--- a/src/sql/tests/querymodel/hirroundtrip
+++ b/src/sql/tests/querymodel/hirroundtrip
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+## Basic MFP over a constant or a get
+
 round_trip
 select;
 ----
@@ -64,6 +66,8 @@ select c from (select b, a + 1 as c from (select 1 as a, true as b));
 | Map 1, true, (#0 + 1)
 | Project (#1, #2)
 | Project (#1)
+
+## Different variations of joins
 
 round_trip
 select x.a from (select true as a) x join (select false as b) y on x.a;
@@ -143,6 +147,55 @@ select coalesce(x.b, 0) from x full join y on x.a = y.a and x.c is not null;
 ----
 
 round_trip
+select * from x inner join y on x.a = y.a;
+----
+----
+%0 =
+| Get ? (u0)
+
+%1 =
+| Get ? (u1)
+
+%2 =
+| InnerJoin %0 %1 on true
+| Filter (#0 = #3)
+----
+----
+
+round_trip
+select * from x inner join y using(a);
+----
+----
+%0 =
+| Get ? (u0)
+
+%1 =
+| Get ? (u1)
+
+%2 =
+| InnerJoin %0 %1 on true
+| Filter (true && (#0 = #3))
+| Project (#0..=#2, #4, #5)
+----
+----
+
+round_trip
+select * from x, y where x.a = y.a;
+----
+----
+%0 =
+| Get ? (u0)
+
+%1 =
+| Get ? (u1)
+
+%2 =
+| InnerJoin %0 %1 on true
+| Filter (#0 = #3)
+----
+----
+
+round_trip
 with a(a, b) as (select 1, 2) select case when x.c > 5 then 1 else 0 end from a
 cross join x
 ----
@@ -160,6 +213,8 @@ cross join x
 | Project (#5)
 ----
 ----
+
+## CSE tests
 
 round_trip
 with a(a, b) as (select 1, 2) select a.a from a cross join a as b
@@ -190,6 +245,8 @@ select * from x, x as y;
 ----
 ----
 
+## Distinct test
+
 round_trip
 select distinct a from x
 ----
@@ -197,3 +254,78 @@ select distinct a from x
 | Get ? (u0)
 | Project (#0)
 | Distinct
+
+## Subqueries
+
+round_trip
+select (select true from x), true
+----
+----
+%0 =
+| Constant ()
+| Map select(%1), true
+| |
+| | %1 =
+| | | Get ? (u0)
+| | | Map true
+| | | Project (#3)
+| |
+----
+----
+
+round_trip
+select y.b, y.c + 1 from y where (select a from x) = y.a
+----
+%0 =
+| Get ? (u1)
+| Map select(%1)
+| |
+| | %1 =
+| | | Get ? (u0)
+| | | Project (#0)
+| |
+| Filter (#3 = #0)
+| Project (#0..=#2)
+| Map (#2 + 1)
+| Project (#1, #3)
+
+round_trip
+select y.a - 1, y.b, (select a from x), y.c + 1 from y
+----
+%0 =
+| Get ? (u1)
+| Map select(%1), (#0 - 1), (#2 + 1)
+| |
+| | %1 =
+| | | Get ? (u0)
+| | | Project (#0)
+| |
+| Project (#0..=#2, #4, #3, #5)
+| Project (#3, #1, #4, #5)
+
+round_trip
+select
+  *
+from
+  x
+where
+  exists(select z.a, z.b from x as z where z.a != 5) and
+  exists(select z.a, z.b from x as z where z.a != 5);
+----
+%0 =
+| Get ? (u0)
+| Map exists(%1), exists(%2)
+| |
+| | %1 =
+| | | Get ? (u0)
+| | | Filter (#0 != 5)
+| | | Project (#0, #1)
+| |
+| |
+| | %2 =
+| | | Get ? (u0)
+| | | Filter (#0 != 5)
+| | | Project (#0, #1)
+| |
+| Filter (#3 && #4)
+| Project (#0..=#2)


### PR DESCRIPTION
### Motivation

Converts QGM back to HIR so we can use the existing decorrelation mechanism.

So far the following types of boxes are supported.
* outer join
* select w/o limit/order-by/offset. (I should probably amend this PR and put in a TODO for limit/order-by-offset.)
* get
* constant

Correlated subqueries are not yet supported.

I don't think anywhere in the code calls the QGM => HIR function.

I figured out how to get rid of all the roundtrip inconsistency issues shown at the daily sync today, though I would not be surprised if more stringent future testing uncovers more issues.

### Tips for reviewer

First commit is just the testing framework.
Second commit is just changing input/ranging_quantifiers() to return double-ended iterators.
Third commit is the bulk of the code. `Let`s are handled in a very similar to way to the QGM=>MIR converter.
Fourth commit adds support for values boxes that are not join identities.
Fifth commit adds support for distinct.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
