### PR TITLE
coord: disable SELECTing from non-table unmaterialized sources

### DIFF
--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -27,6 +27,13 @@ use crate::session::Var;
 /// Errors that can occur in the coordinator.
 #[derive(Debug)]
 pub enum CoordError {
+    /// Query needs AS OF <time> or indexes to succeed.
+    AutomaticTimestampFailure {
+        /// The names of any unmaterialized sources.
+        unmaterialized: Vec<String>,
+        /// Vec<(Objectname, Vec<Index names w/ enabled stats>)>.
+        disabled_indexes: Vec<(String, Vec<String>)>,
+    },
     /// An error occurred in a catalog operation.
     Catalog(catalog::Error),
     /// The cached plan or descriptor changed.
@@ -120,6 +127,41 @@ impl CoordError {
     /// Reports additional details about the error, if any are available.
     pub fn detail(&self) -> Option<String> {
         match self {
+            CoordError::AutomaticTimestampFailure {
+                unmaterialized,
+                disabled_indexes,
+            } => {
+                let unmaterialized_err = if unmaterialized.is_empty() {
+                    "".into()
+                } else {
+                    format!(
+                        "\nUnmaterialized sources:\n\t{}",
+                        itertools::join(unmaterialized, "\n\t")
+                    )
+                };
+
+                let disabled_indexes_err = if disabled_indexes.is_empty() {
+                    "".into()
+                } else {
+                    let d = disabled_indexes.iter().fold(
+                        String::default(),
+                        |acc, (object_name, disabled_indexes)| {
+                            format!(
+                                "{}\n\n\t{}\n\tDisabled indexes:\n\t\t{}",
+                                acc,
+                                object_name,
+                                itertools::join(disabled_indexes, "\n\t\t")
+                            )
+                        },
+                    );
+                    format!("\nSources w/ disabled indexes:{}", d)
+                };
+
+                Some(format!(
+                    "The query transitively depends on the following:{}{}",
+                    unmaterialized_err, disabled_indexes_err
+                ))
+            }
             CoordError::Catalog(c) => c.detail(),
             CoordError::Eval(e) => e.detail(),
             CoordError::RelationOutsideTimeDomain { relations, names } => Some(format!(
@@ -167,6 +209,33 @@ impl CoordError {
     /// Reports a hint for the user about how the error could be fixed.
     pub fn hint(&self) -> Option<String> {
         match self {
+            CoordError::AutomaticTimestampFailure {
+                unmaterialized,
+                disabled_indexes,
+            } => {
+                let unmaterialized_hint = if unmaterialized.is_empty() {
+                    ""
+                } else {
+                    "\n- Use `SELECT ... AS OF` to manually choose a timestamp for your query.
+- Create indexes on the listed unmaterialized sources or on the views derived from those sources"
+                };
+                let disabled_indexes_hint = if disabled_indexes.is_empty() {
+                    ""
+                } else {
+                    "ALTER INDEX ... SET ENABLED to enable indexes"
+                };
+
+                Some(format!(
+                    "{}{}{}",
+                    unmaterialized_hint,
+                    if !unmaterialized_hint.is_empty() {
+                        "\n-"
+                    } else {
+                        ""
+                    },
+                    disabled_indexes_hint
+                ))
+            }
             CoordError::Catalog(c) => c.hint(),
             CoordError::ConstrainedParameter {
                 valid_values: Some(valid_values),
@@ -213,6 +282,9 @@ impl CoordError {
 impl fmt::Display for CoordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            CoordError::AutomaticTimestampFailure { .. } => {
+                f.write_str("unable to automatically determine a query timestamp")
+            }
             CoordError::ChangedPlan => f.write_str("cached plan must not change result type"),
             CoordError::Catalog(e) => e.fmt(f),
             CoordError::ConstrainedParameter {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -367,6 +367,7 @@ impl ErrorResponse {
             CoordError::Catalog(_) => SqlState::INTERNAL_ERROR,
             CoordError::ChangedPlan => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::ConstrainedParameter { .. } => SqlState::INVALID_PARAMETER_VALUE,
+            CoordError::AutomaticTimestampFailure { .. } => SqlState::INTERNAL_ERROR,
             CoordError::DuplicateCursor(_) => SqlState::DUPLICATE_CURSOR,
             CoordError::Eval(EvalError::CharacterNotValidForEncoding(_)) => {
                 SqlState::PROGRAM_LIMIT_EXCEEDED

--- a/test/restart/user-indexes-disabled.td
+++ b/test/restart/user-indexes-disabled.td
@@ -45,9 +45,8 @@ default logging_derived_mat logging_derived_mat_primary_idx 1             count 
 # mat_view is not considered materialized
 > SHOW MATERIALIZED VIEWS
 
-# But it is still selectable.
-> SELECT * FROM mat_view
-1
+! SELECT * FROM mat_view
+contains:unable to automatically determine a query timestamp
 
 > SHOW INDEXES FROM mat_view;
 cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
@@ -71,9 +70,8 @@ contains:invalid ALTER on disabled index "materialize.public.mat_view_primary_id
 # mat_data is not considered materialized
 > SHOW MATERIALIZED SOURCES
 
-# But it is still selectable.
-> SELECT * FROM mat_data
-1
+! SELECT * FROM mat_data
+contains:unable to automatically determine a query timestamp
 
 > SHOW INDEXES FROM mat_data;
 cluster on_name   key_name              seq_in_index  column_name  expression  nullable enabled
@@ -90,8 +88,8 @@ default mat_data  mat_data_primary_idx  1             a            <null>      f
 
 # 🔬🔬🔬🔬 Non-materialized views
 
-> SELECT * FROM join_view
-1 a
+! SELECT * FROM join_view
+contains:unable to automatically determine a query timestamp
 
 # 🔬🔬 Sinks
 
@@ -183,10 +181,10 @@ mat_data
 
 # 🔬🔬🔬 Non-materialized views
 
-# Can seleect from `join_view` both with and without indexes enabled.
+# Still cannot select from non-materialized view because some of its indexes are disabled
 
-> SELECT * FROM join_view
-1 a
+! SELECT * FROM join_view
+contains:unable to automatically determine a query timestamp
 
 > ALTER INDEX join_data_primary_idx SET ENABLED
 

--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -234,22 +234,8 @@ names_num names_name mods_num mods_mod
 > CREATE VIEW test15 (names_num, names_name, mods_num, mods_mod) AS
   SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
 
-# TODO(guswynn|benesch): re-enable this test when we resolve
-# consistency unknowns
-#> SELECT * FROM test15;
-#names_num names_name mods_num mods_mod
-#--------------------------------------
-#1 one <null> <null>
-#2 two <null> <null>
-#3 three <null> <null>
-#<null> <null> 0 even
-#<null> <null> 1 odd
-#<null> <null> 2 even
-#
-#> SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
-#1 one <null> <null>
-#2 two <null> <null>
-#3 three <null> <null>
-#<null> <null> 0 even
-#<null> <null> 1 odd
-#<null> <null> 2 even
+! SELECT * FROM test15;
+contains:unable to automatically determine a query timestamp
+
+! SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
+contains:unable to automatically determine a query timestamp

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -25,11 +25,13 @@ $ kafka-create-topic topic=data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
-> SELECT * FROM data
+! SELECT * FROM data
+contains:unable to automatically determine a query timestamp
 
 > CREATE VIEW data_view as SELECT * from data
 
-> SELECT * FROM data_view
+! SELECT * FROM data_view
+contains:unable to automatically determine a query timestamp
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT b, sum(a) FROM data GROUP BY b
@@ -132,13 +134,9 @@ b  max
 ------
 2  1
 
-> SELECT * from data_view
-a  b
-----
-1  1
-2  1
-3  1
-1  2
+# Cannot select from unmaterialized view.
+! SELECT * from data_view
+contains:unable to automatically determine a query timestamp
 
 # Can create sink from unmaterialized view.
 > CREATE SINK not_mat_sink2 FROM data_view
@@ -186,12 +184,8 @@ b  c
 # Unmaterialize test5.
 > DROP INDEX idx1
 
-# Still works.
-> SELECT * from test5
-b  c
-------
-1  3
-2  1
+! SELECT * from test5
+contains:unable to automatically determine a query timestamp
 
 > SHOW FULL VIEWS LIKE 'test5'
 name        type     materialized  volatility
@@ -208,21 +202,13 @@ d
 -1
 3
 
-# Dependencies are still queryable after creating a dependent
+# Dependencies have not re-materialized as a result of creating a dependent
 # materialized view.
-> SELECT * from test5
-b  c
-------
-1  3
-2  1
+! SELECT * from test5
+contains:unable to automatically determine a query timestamp
 
-> SELECT * from data_view
-a  b
-----
-1  1
-2  1
-3  1
-1  2
+! SELECT * from data_view
+contains:unable to automatically determine a query timestamp
 
 # Rematerialize data_view creating an index on it.
 > CREATE INDEX data_view_idx on data_view(a)
@@ -379,27 +365,16 @@ c  d
 # Unmaterialize source.
 > DROP INDEX mat_data_primary_idx1
 
-# Still works.
-> SELECT * from mat_data
-a  b
-----
--1 0
--1 1
-3  4
-1  2
+! SELECT * from mat_data
+contains:unable to automatically determine a query timestamp
 
 > SELECT * from test7
 count
 -----
 4
 
-> SELECT * from test8
-c  d
------
-0  1
--1 1
--4 -3
--2 -1
+! SELECT * from test8
+contains:unable to automatically determine a query timestamp
 
 $ kafka-ingest format=avro topic=mat schema=${schema} timestamp=2
 {"a": -3, "b": 0}

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -30,13 +30,16 @@ $ file-append path=static.csv
 2
 4
 
-> SELECT c FROM unindexed
-1
-2
-4
+! SELECT * FROM unindexed
+contains:unable to automatically determine a query timestamp
 
-> SELECT * FROM v_unindexed
-3
+! SELECT * FROM v_unindexed
+contains:unable to automatically determine a query timestamp
+
+# Since sources aren't linearizable (see #11048), we need to wait out a
+# timestamp frequency interval to ensure the read timestamp for the timestamp
+# is not picked to a timestamp when the source is empty.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=1s
 
 > BEGIN
 
@@ -47,10 +50,8 @@ $ file-append path=static.csv
 2
 4
 
-> SELECT c FROM unindexed
-1
-2
-4
+! SELECT c FROM unindexed
+contains:unable to automatically determine a query timestamp
 
 > COMMIT
 
@@ -62,8 +63,8 @@ $ file-append path=static.csv
 2
 4
 
-> SELECT * FROM v_unindexed
-3
+! SELECT * FROM v_unindexed
+contains:unable to automatically determine a query timestamp
 
 > COMMIT
 
@@ -122,6 +123,10 @@ $ file-append path=static.csv
 # it returns a 0 timestamp error.
 > SELECT * FROM v_materialized
 3
+# Since sources aren't linearizable (see #11048), we need to wait out a
+# timestamp frequency interval to ensure the read timestamp for the timestamp
+# is not picked to a timestamp when the source is empty.
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=1s
 > BEGIN
 > SELECT * FROM v_materialized
 3


### PR DESCRIPTION
There are known semantic glitches with unmaterialized sources that can
cause them to present partial (or no) data when SELECTed. So, restore
the behavior that was present before #11037 by rejecting SELECTs that
reference unmaterialized sources.

The slight tweak in the new behavior is that tables are exempted from
this requirement. Tables are linearized by the coordinator, and so
SELECTing from an unmaterialized table does not have the same defect
that SELECTing from other types of unmaterialized sources do.

This makes #11072 and #11232 no longer release blockers. The underlying
issues are still visible via `AS OF now()`, but we're willing to live
with that now, to give us time to solve the semantic defects properly
(see #11048).

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
