### PR TITLE
Modify SCL planning to use augmented statements

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -796,7 +796,8 @@ fn semantic_use_id_for_table_format_0_7_1(
     stmt: &mut mz_sql::ast::Statement<Raw>,
 ) -> Result<(), anyhow::Error> {
     // Resolve Statement<Raw> to Statement<Aug>
-    let resolved = resolve_names_stmt(&mut StatementContext::new(None, cat), stmt.clone()).unwrap();
+    let (resolved, _) =
+        resolve_names_stmt(&mut StatementContext::new(None, cat), stmt.clone()).unwrap();
     // Use consistent intermediary format between Aug and Raw.
     let create_sql = resolved.to_ast_string_stable();
     // Convert Statement<Aug> to Statement<Raw> (Aug is a subset of Raw's

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -573,7 +573,7 @@ mod tests {
         )?
         .into_element();
 
-        let stmt = resolve_names_stmt(scx, parsed)?;
+        let (stmt, _) = resolve_names_stmt(scx, parsed)?;
 
         // Ensure that all identifiers are quoted.
         assert_eq!(

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4625,7 +4625,6 @@ impl<'a> QueryContext<'a> {
             outer_scopes: vec![],
             outer_relation_types: vec![],
             ctes: HashMap::new(),
-            ids: HashSet::new(),
             recursion_guard: RecursionGuard::with_limit(1024), // chosen arbitrarily
         }
     }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -12,7 +12,7 @@
 //! This module houses the entry points for planning a SQL statement.
 
 use std::cell::RefCell;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use anyhow::bail;
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -47,7 +47,7 @@ use mz_dataflow_types::{
         UnplannedSourceEnvelope, UpsertStyle,
     },
 };
-use mz_expr::{CollectionPlan, GlobalId};
+use mz_expr::{CollectionPlan, GlobalId, Id};
 use mz_interchange::avro::{self, AvroSchemaGenerator};
 use mz_interchange::envelopes;
 use mz_ore::collections::CollectionExt;
@@ -60,6 +60,7 @@ use mz_sql_parser::ast::{
 };
 
 use crate::ast::display::AstDisplay;
+use crate::ast::visit::Visit;
 use crate::ast::{
     AlterIndexAction, AlterIndexStatement, AlterObjectRenameStatement, AvroSchema, ClusterOption,
     ColumnOption, Compression, CreateDatabaseStatement, CreateIndexStatement, CreateRoleOption,
@@ -76,7 +77,7 @@ use crate::catalog::{CatalogItem, CatalogItemType, CatalogType, CatalogTypeDetai
 use crate::kafka_util;
 use crate::names::{
     resolve_names_data_type, resolve_object_name, Aug, DatabaseSpecifier, FullName,
-    ResolvedClusterName, ResolvedDataType, SchemaName,
+    ResolvedClusterName, ResolvedDataType, ResolvedObjectName, SchemaName,
 };
 use crate::normalize;
 use crate::normalize::ident;
@@ -157,6 +158,7 @@ pub fn describe_create_table(
 pub fn plan_create_table(
     scx: &StatementContext,
     stmt: CreateTableStatement<Aug>,
+    depends_on: HashSet<GlobalId>,
 ) -> Result<Plan, anyhow::Error> {
     let CreateTableStatement {
         name,
@@ -184,7 +186,6 @@ pub fn plan_create_table(
     // and NOT NULL constraints.
     let mut column_types = Vec::with_capacity(columns.len());
     let mut defaults = Vec::with_capacity(columns.len());
-    let mut depends_on = Vec::new();
     let mut keys = Vec::new();
 
     for (i, c) in columns.into_iter().enumerate() {
@@ -198,8 +199,7 @@ pub fn plan_create_table(
                 ColumnOption::Default(expr) => {
                     // Ensure expression can be planned and yields the correct
                     // type.
-                    let (_, expr_depends_on) = query::plan_default_expr(scx, expr, &ty)?;
-                    depends_on.extend(expr_depends_on);
+                    let _ = query::plan_default_expr(scx, expr, &ty)?;
                     default = expr.clone();
                 }
                 ColumnOption::Unique { is_primary } => {
@@ -215,7 +215,6 @@ pub fn plan_create_table(
         }
         column_types.push(ty.nullable(nullable));
         defaults.push(default);
-        depends_on.extend(aug_data_type.get_ids());
     }
 
     for constraint in constraints {
@@ -270,6 +269,7 @@ pub fn plan_create_table(
     let desc = RelationDesc::new(typ, names);
 
     let create_sql = normalize::create_statement(&scx, Statement::CreateTable(stmt.clone()))?;
+    let depends_on = depends_on.into_iter().collect();
     let table = Table {
         create_sql,
         desc,
@@ -1288,6 +1288,7 @@ pub fn plan_view(
     def: &mut ViewDefinition<Aug>,
     params: &Params,
     temporary: bool,
+    depends_on: HashSet<GlobalId>,
 ) -> Result<(FullName, View), anyhow::Error> {
     let create_sql = normalize::create_statement(
         scx,
@@ -1313,7 +1314,6 @@ pub fn plan_view(
         mut expr,
         mut desc,
         finishing,
-        depends_on,
     } = query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
 
     expr.bind_parameters(&params)?;
@@ -1334,6 +1334,7 @@ pub fn plan_view(
         bail!("column {} specified more than once", dup.as_str().quoted());
     }
 
+    let depends_on = depends_on.into_iter().collect();
     let view = View {
         create_sql,
         expr: relation_expr,
@@ -1349,6 +1350,7 @@ pub fn plan_create_view(
     scx: &StatementContext,
     mut stmt: CreateViewStatement<Aug>,
     params: &Params,
+    depends_on: HashSet<GlobalId>,
 ) -> Result<Plan, anyhow::Error> {
     let CreateViewStatement {
         temporary,
@@ -1356,7 +1358,7 @@ pub fn plan_create_view(
         if_exists,
         definition,
     } = &mut stmt;
-    let (name, view) = plan_view(scx, definition, params, *temporary)?;
+    let (name, view) = plan_view(scx, definition, params, *temporary, depends_on)?;
     let replace = if *if_exists == IfExistsBehavior::Replace {
         if let Ok(item) = scx.catalog.resolve_item(&name.clone().into()) {
             if view.expr.depends_on().contains(&item.id()) {
@@ -1402,7 +1404,16 @@ pub fn plan_create_views(
         CreateViewsDefinitions::Literal(view_definitions) => {
             let mut views = Vec::with_capacity(view_definitions.len());
             for mut definition in view_definitions {
-                let view = plan_view(scx, &mut definition, &Params::empty(), temporary)?;
+                let mut depends_on_collector = DependsOnCollector::new();
+                depends_on_collector.visit_view_definition(&definition);
+                let depends_on = depends_on_collector.get_ids().clone();
+                let view = plan_view(
+                    scx,
+                    &mut definition,
+                    &Params::empty(),
+                    temporary,
+                    depends_on,
+                )?;
                 views.push(view);
             }
             Ok(Plan::CreateViews(CreateViewsPlan {
@@ -1555,7 +1566,16 @@ pub fn plan_create_views(
                             with_options: vec![],
                             query,
                         };
-                        views.push(plan_view(scx, &mut viewdef, &Params::empty(), temporary)?);
+                        let mut depends_on_collector = DependsOnCollector::new();
+                        depends_on_collector.visit_view_definition(&viewdef);
+                        let depends_on = depends_on_collector.get_ids().clone();
+                        views.push(plan_view(
+                            scx,
+                            &mut viewdef,
+                            &Params::empty(),
+                            temporary,
+                            depends_on,
+                        )?);
                     }
                     Ok(Plan::CreateViews(CreateViewsPlan {
                         views,
@@ -1918,6 +1938,7 @@ pub fn describe_create_sink(
 pub fn plan_create_sink(
     scx: &StatementContext,
     mut stmt: CreateSinkStatement<Aug>,
+    depends_on: HashSet<GlobalId>,
 ) -> Result<Plan, anyhow::Error> {
     let compute_instance = match &stmt.in_cluster {
         None => scx.resolve_compute_instance(None)?.id(),
@@ -2034,9 +2055,6 @@ pub fn plan_create_sink(
         bail!("CREATE SINK ... AS OF is no longer supported");
     }
 
-    let mut depends_on = vec![from.id()];
-    depends_on.extend(from.uses());
-
     let root_user_dependencies = get_root_dependencies(scx, &depends_on);
 
     let connector_builder = match connector {
@@ -2064,6 +2082,7 @@ pub fn plan_create_sink(
 
     normalize::ensure_empty_options(&with_options, "CREATE SINK")?;
 
+    let depends_on = depends_on.into_iter().collect();
     Ok(Plan::CreateSink(CreateSinkPlan {
         name,
         sink: Sink {
@@ -2131,7 +2150,7 @@ fn key_constraint_err(desc: &RelationDesc, user_keys: &[ColumnName]) -> anyhow::
 /// dependencies. Those are the root dependencies.
 fn get_root_dependencies<'a>(
     scx: &'a StatementContext,
-    depends_on: &[GlobalId],
+    depends_on: &HashSet<GlobalId>,
 ) -> Vec<&'a dyn CatalogItem> {
     let mut result = Vec::new();
     let mut work_queue: Vec<&GlobalId> = Vec::new();
@@ -2166,6 +2185,7 @@ pub fn describe_create_index(
 pub fn plan_create_index(
     scx: &StatementContext,
     mut stmt: CreateIndexStatement<Aug>,
+    depends_on: HashSet<GlobalId>,
 ) -> Result<Plan, anyhow::Error> {
     let CreateIndexStatement {
         name,
@@ -2207,7 +2227,7 @@ pub fn plan_create_index(
                 .collect()
         }
     };
-    let (keys, exprs_depend_on) = query::plan_index_exprs(scx, on_desc, filled_key_parts.clone())?;
+    let keys = query::plan_index_exprs(scx, on_desc, filled_key_parts.clone())?;
 
     let index_name = if let Some(name) = name {
         FullName {
@@ -2250,15 +2270,13 @@ pub fn plan_create_index(
     };
     *in_cluster = Some(ResolvedClusterName(compute_instance));
 
-    let mut depends_on = vec![on.id()];
-    depends_on.extend(exprs_depend_on);
-
     // Normalize `stmt`.
     *name = Some(Ident::new(index_name.item.clone()));
     *key_parts = Some(filled_key_parts);
     let if_not_exists = *if_not_exists;
     stmt.on_name.print_id = false;
     let create_sql = normalize::create_statement(scx, Statement::CreateIndex(stmt))?;
+    let depends_on = depends_on.into_iter().collect();
 
     Ok(Plan::CreateIndex(CreateIndexPlan {
         name: index_name,
@@ -2385,10 +2403,13 @@ pub fn plan_create_type(
 
     let inner = match as_type {
         CreateTypeAs::List { .. } => CatalogType::List {
+            // works because you can't create a nested List without intermediate custom types
             element_id: *depends_on.get(0).expect("custom type to have element id"),
         },
         CreateTypeAs::Map { .. } => {
+            // works because you can't create a nested Map without intermediate custom types
             let key_id = *depends_on.get(0).expect("key");
+            let value_id = *depends_on.get(1).expect("value");
             let entry = scx.catalog.get_item_by_id(&key_id);
             match entry.type_details() {
                 Some(CatalogTypeDetails {
@@ -2399,10 +2420,7 @@ pub fn plan_create_type(
                 None => unreachable!("already guaranteed id correlates to a type"),
             }
 
-            CatalogType::Map {
-                key_id,
-                value_id: *depends_on.get(1).expect("value"),
-            }
+            CatalogType::Map { key_id, value_id }
         }
         CreateTypeAs::Record { .. } => CatalogType::Record {
             fields: record_fields,
@@ -2917,4 +2935,31 @@ pub fn plan_alter_object_rename(
         to_name: normalize::ident(to_item_name),
         object_type,
     }))
+}
+
+struct DependsOnCollector {
+    ids: HashSet<GlobalId>,
+}
+
+impl<'a, 'ast> Visit<'ast, Aug> for DependsOnCollector {
+    fn visit_object_name(&mut self, name: &ResolvedObjectName) {
+        if let Id::Global(id) = name.id {
+            self.ids.insert(id);
+        }
+    }
+
+    fn visit_data_type(&mut self, typ: &ResolvedDataType) {
+        self.ids.extend(typ.get_ids().iter());
+    }
+}
+
+impl DependsOnCollector {
+    fn new() -> Self {
+        DependsOnCollector {
+            ids: HashSet::default(),
+        }
+    }
+    fn get_ids(&self) -> &HashSet<GlobalId> {
+        &self.ids
+    }
 }

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -23,6 +23,7 @@ use crate::ast::{
     ExecuteStatement, FetchStatement, PrepareStatement, Raw, SetVariableStatement,
     SetVariableValue, ShowVariableStatement, Value,
 };
+use crate::names::Aug;
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{
     describe, query, ClosePlan, DeallocatePlan, DeclarePlan, ExecutePlan, ExecuteTimeout,
@@ -202,7 +203,7 @@ pub fn plan_prepare(
 
 pub fn describe_execute(
     scx: &StatementContext,
-    stmt: ExecuteStatement<Raw>,
+    stmt: ExecuteStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     // The evaluation of the statement doesn't happen until it gets to coord. That
     // means if the statement is now invalid due to an object having been dropped,
@@ -214,14 +215,14 @@ pub fn describe_execute(
 
 pub fn plan_execute(
     scx: &StatementContext,
-    stmt: ExecuteStatement<Raw>,
+    stmt: ExecuteStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     Ok(plan_execute_desc(scx, stmt)?.1)
 }
 
 fn plan_execute_desc<'a>(
     scx: &'a StatementContext,
-    ExecuteStatement { name, params }: ExecuteStatement<Raw>,
+    ExecuteStatement { name, params }: ExecuteStatement<Aug>,
 ) -> Result<(&'a StatementDesc, Plan), anyhow::Error> {
     let name = name.to_string();
     let desc = match scx.catalog.get_prepared_statement_desc(&name) {

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -56,7 +56,7 @@ pub fn plan_show_create_view(
         let view_sql = view.create_sql();
         let parsed = parse::parse(view_sql)?;
         let parsed = parsed[0].clone();
-        let mut resolved = resolve_names_stmt(scx, parsed)?;
+        let (mut resolved, _) = resolve_names_stmt(scx, parsed)?;
         let mut s = NameSimplifier {
             catalog: scx.catalog,
         };
@@ -92,7 +92,7 @@ pub fn plan_show_create_table(
     if let CatalogItemType::Table = table.item_type() {
         let name = table.name().to_string();
         let parsed = parse::parse(table.create_sql())?.into_element();
-        let mut resolved = resolve_names_stmt(scx, parsed)?;
+        let (mut resolved, _) = resolve_names_stmt(scx, parsed)?;
         let mut s = NameSimplifier {
             catalog: scx.catalog,
         };

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -65,7 +65,7 @@ fn convert_input_to_model(input: &str, catalog: &TestCatalog) -> Result<Model, S
             let stmt = stmts.pop().unwrap();
             let scx = &mut StatementContext::new(None, catalog);
             let stmt = match resolve_names_stmt(scx, stmt) {
-                Ok(stmt) => stmt,
+                Ok((stmt, _)) => stmt,
                 Err(e) => return Err(format!("unable to resolve statement {}", e)),
             };
             if let mz_sql_parser::ast::Statement::Select(query) = stmt {


### PR DESCRIPTION
This commit updates the majority of SCL planning functions to use
augmented statements. The two exceptions are DECLARE and PREPARE
planning which delay name resolution until the provided queries are
actually executed.

These changes gets us closer to removing some of the limitations on our
ALTER statements, by starting to allow us to represent dependencies
with IDs instead of names.

Additionally the logic around gathering global id dependencies for
create statements has been cleaned up.

Works towards resolving #5302

### Motivation
This PR refactors existing code.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user facing changes
