### PR TITLE
qgm: add `CallTable` support to `FromHir`

### DIFF
--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -20,6 +20,7 @@
 use super::super::attribute::core::Attributes;
 use super::scalar::*;
 use itertools::Itertools;
+use mz_expr::TableFunc;
 use mz_ore::id_gen::Gen;
 use mz_sql_parser::ast::Ident;
 use std::cell::{Ref, RefCell, RefMut};
@@ -200,6 +201,12 @@ pub(crate) const ARBITRARY_QUANTIFIER: usize = 0b00000000
     | (QuantifierType::PreservedForeach as usize)
     | (QuantifierType::Scalar as usize);
 
+/// A bitmask that matches the discriminant of a subquery [`QuantifierType`].
+pub(crate) const SUBQUERY_QUANTIFIER: usize = 0b00000000
+    | (QuantifierType::All as usize)
+    | (QuantifierType::Existential as usize)
+    | (QuantifierType::Scalar as usize);
+
 #[derive(Debug, Clone)]
 pub(crate) enum BoxType {
     /// A table from the catalog.
@@ -220,7 +227,7 @@ pub(crate) enum BoxType {
     /// that order.
     Select(Select),
     /// The invocation of table function from the catalog.
-    TableFunction(TableFunction),
+    CallTable(CallTable),
     /// SQL's union operator
     Union,
     /// Operator that produces a set of rows, with potentially
@@ -295,15 +302,21 @@ impl Select {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub(crate) struct TableFunction {
-    pub parameters: Vec<BoxScalarExpr>,
-    // @todo function metadata from the catalog
+#[derive(Debug, Clone)]
+pub(crate) struct CallTable {
+    pub func: TableFunc,
+    pub exprs: Vec<BoxScalarExpr>,
 }
 
-impl From<TableFunction> for BoxType {
-    fn from(table_function: TableFunction) -> Self {
-        BoxType::TableFunction(table_function)
+impl CallTable {
+    pub fn new(func: TableFunc, exprs: Vec<BoxScalarExpr>) -> CallTable {
+        CallTable { func, exprs }
+    }
+}
+
+impl From<CallTable> for BoxType {
+    fn from(table_funct: CallTable) -> Self {
+        BoxType::CallTable(table_funct)
     }
 }
 
@@ -683,8 +696,8 @@ impl QueryBox {
                     }
                 }
             }
-            BoxType::TableFunction(table_function) => {
-                for p in table_function.parameters.iter() {
+            BoxType::CallTable(table_function) => {
+                for p in table_function.exprs.iter() {
                     f(p)?;
                 }
             }
@@ -735,8 +748,8 @@ impl QueryBox {
                     }
                 }
             }
-            BoxType::TableFunction(table_function) => {
-                for p in table_function.parameters.iter_mut() {
+            BoxType::CallTable(table_function) => {
+                for p in table_function.exprs.iter_mut() {
                     f(p)?;
                 }
             }
@@ -933,7 +946,7 @@ impl BoxType {
             BoxType::Intersect => "Intersect",
             BoxType::OuterJoin(..) => "OuterJoin",
             BoxType::Select(..) => "Select",
-            BoxType::TableFunction(..) => "TableFunction",
+            BoxType::CallTable(..) => "CallTable",
             BoxType::Union => "Union",
             BoxType::Values(..) => "Values",
         }

--- a/src/sql/src/query_model/validator/quantifier.rs
+++ b/src/sql/src/query_model/validator/quantifier.rs
@@ -107,6 +107,14 @@ mod constants {
         select_parent: false,
     };
 
+    pub(crate) const ZERO_NOT_SUBQUERY: QuantifierConstraint = QuantifierConstraint {
+        min: Bound::Included(0),
+        max: Bound::Included(0),
+        allowed_types: ARBITRARY_QUANTIFIER & !(SUBQUERY_QUANTIFIER as usize),
+        select_input: false,
+        select_parent: false,
+    };
+
     pub(crate) const ZERO_NOT_FOREACH: QuantifierConstraint = QuantifierConstraint {
         min: Bound::Included(0),
         max: Bound::Included(0),
@@ -189,8 +197,9 @@ mod constants {
 }
 
 /// A [`Validator`] that checks the following quantifier constraints:
-/// - `Get`, `TableFunction` and `Values` boxes cannot have input
+/// - `Get` and `Values` boxes cannot have input
 ///    quantifiers.
+/// - `TableFunction` boxes can only have subquery input quantifiers.
 /// - `Union`, `Except` and `Intersect` boxes can only have input
 ///    quantifiers of type `Foreach`.
 /// - A `Grouping` box must have a single input quantifier of type
@@ -216,8 +225,14 @@ impl Validator for QuantifierConstraintValidator {
             use constants::*;
             use BoxType::*;
             match b.box_type {
-                Get(..) | TableFunction(..) | Values(..) => {
+                Get(..) | Values(..) => {
                     let constraints = [ZERO_ARBITRARY];
+                    check_constraints(&constraints, b.input_quantifiers(), model, |c| {
+                        errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
+                    })
+                }
+                CallTable(..) => {
+                    let constraints = [ZERO_NOT_SUBQUERY];
                     check_constraints(&constraints, b.input_quantifiers(), model, |c| {
                         errors.push(ValidationError::InvalidInputQuantifiers(b.id, c.clone()))
                     })
@@ -268,43 +283,41 @@ impl Validator for QuantifierConstraintValidator {
 
 #[cfg(test)]
 mod tests {
+    use mz_expr::TableFunc;
+
     use super::constants::*;
     use super::*;
     use crate::query_model::test::util::*;
     use std::collections::HashSet;
 
-    /// Tests constraints for quantifiers incident with [`BoxType::Get`],
-    /// [`BoxType::TableFunction`], and [`BoxType::Values`] boxes (happy case).
+    /// Tests constraints for quantifiers incident with [`BoxType::Get`]
+    /// and [`BoxType::Values`] boxes (happy case).
     #[test]
-    fn test_invalid_get_table_fn_values_ok() {
+    fn test_invalid_get_values_ok() {
         let mut model = Model::default();
 
         let box_get = model.make_box(qgm::get(1).into());
-        let box_table_fn = model.make_box(TableFunction::default().into());
         let box_values = model.make_box(Values::default().into());
         let box_tgt = model.make_box(Select::default().into());
 
         model.make_quantifier(QuantifierType::Foreach, box_get, box_tgt);
-        model.make_quantifier(QuantifierType::Foreach, box_table_fn, box_tgt);
         model.make_quantifier(QuantifierType::Foreach, box_values, box_tgt);
 
         let result = QuantifierConstraintValidator::default().validate(&model);
         assert!(result.is_ok());
     }
 
-    /// Tests constraints for quantifiers incident with [`BoxType::Get`],
-    /// [`BoxType::TableFunction`], and [`BoxType::Values`] boxes (bad case).
+    /// Tests constraints for quantifiers incident with [`BoxType::Get`]
+    /// and [`BoxType::Values`] boxes (bad case).
     #[test]
-    fn test_invalid_get_table_fn_values_not_ok() {
+    fn test_invalid_get_values_not_ok() {
         let mut model = Model::default();
 
         let box_src = model.make_box(qgm::get(0).into());
         let box_get = model.make_box(qgm::get(1).into());
-        let box_table_fn = model.make_box(TableFunction::default().into());
         let box_values = model.make_box(Values::default().into());
 
         model.make_quantifier(QuantifierType::Foreach, box_src, box_get);
-        model.make_quantifier(QuantifierType::Foreach, box_src, box_table_fn);
         model.make_quantifier(QuantifierType::Foreach, box_src, box_values);
 
         let result = QuantifierConstraintValidator::default().validate(&model);
@@ -313,9 +326,54 @@ mod tests {
         let errors_act: HashSet<_> = result.unwrap_err().drain(..).collect();
         let errors_exp = HashSet::from([
             ValidationError::InvalidInputQuantifiers(box_get, ZERO_ARBITRARY),
-            ValidationError::InvalidInputQuantifiers(box_table_fn, ZERO_ARBITRARY),
             ValidationError::InvalidInputQuantifiers(box_values, ZERO_ARBITRARY),
         ]);
+        assert_eq!(errors_act, errors_exp);
+    }
+
+    /// Tests constraints for quantifiers incident with [`BoxType::CallTable`]
+    /// boxes (happy case).
+    #[test]
+    fn test_invalid_call_table_ok() {
+        use TableFunc::GenerateSeriesInt32;
+
+        let mut model = Model::default();
+
+        let box_src = model.make_box(qgm::get(0).into());
+        let call_table = CallTable::new(GenerateSeriesInt32, vec![]);
+        let box_table_fn = model.make_box(call_table.into());
+        let box_tgt = model.make_box(Select::default().into());
+
+        model.make_quantifier(QuantifierType::Scalar, box_src, box_table_fn);
+        model.make_quantifier(QuantifierType::Foreach, box_table_fn, box_tgt);
+
+        let result = QuantifierConstraintValidator::default().validate(&model);
+        assert!(result.is_ok());
+    }
+
+    /// Tests constraints for quantifiers incident with [`BoxType::CallTable`]
+    /// boxes (bad case).
+    #[test]
+    fn test_invalid_call_table_not_ok() {
+        use TableFunc::GenerateSeriesInt32;
+
+        let mut model = Model::default();
+
+        let box_src = model.make_box(qgm::get(0).into());
+        let call_table = CallTable::new(GenerateSeriesInt32, vec![]);
+        let box_table_fn = model.make_box(call_table.into());
+
+        model.make_quantifier(QuantifierType::Scalar, box_src, box_table_fn);
+        model.make_quantifier(QuantifierType::Foreach, box_src, box_table_fn);
+
+        let result = QuantifierConstraintValidator::default().validate(&model);
+        assert!(result.is_err());
+
+        let errors_act: HashSet<_> = result.unwrap_err().drain(..).collect();
+        let errors_exp = HashSet::from([ValidationError::InvalidInputQuantifiers(
+            box_table_fn,
+            ZERO_NOT_SUBQUERY,
+        )]);
         assert_eq!(errors_act, errors_exp);
     }
 

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -1327,3 +1327,60 @@ digraph G {
     Q4 -> boxhead5 [ lhead = cluster5 ]
     Q3 -> boxhead4 [ lhead = cluster4 ]
 }
+
+build
+select * from generate_series(0, 10, 2);
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from generate_series(0, 10, 2);"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:CallTable"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0| CALL: generate_series(0, 10, 2)| UNIQUE KEY: C0 }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}
+
+
+build
+select * from (values (1, 2), (3, 4));
+----
+digraph G {
+    compound = true
+    labeljust = l
+    label = "select * from (values (1, 2), (3, 4));"
+    node [ shape = box ]
+    subgraph cluster1 {
+        label = "Box1:Select"
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0| 1: Q0.C1 }" ]
+        {
+            rank = same
+            node [ shape = circle ]
+            Q0 [ label = "Q0(F)" ]
+        }
+    }
+    subgraph cluster0 {
+        label = "Box0:CallTable"
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0| 1: C1| CALL: wrap2(1, 2, 3, 4) }" ]
+        {
+            rank = same
+        }
+    }
+    edge [ arrowhead = none, style = dashed ]
+    Q0 -> boxhead0 [ lhead = cluster0 ]
+}

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -571,7 +571,7 @@ digraph G {
     }
     subgraph cluster0 {
         label = "Box0:Get"
-        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0| 1: C1| 2: C2| UNIQUE KEY [0] [1, 2] }" ]
+        boxhead0 [ shape = record, label = "{ Distinct: Preserve| 0: C0| 1: C1| 2: C2| UNIQUE KEY: C0| UNIQUE KEY: C1, C2 }" ]
         {
             rank = same
         }
@@ -609,7 +609,7 @@ digraph G {
     }
     subgraph cluster1 {
         label = "Box1:Get"
-        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: C0| 1: C1| 2: C2| UNIQUE KEY [0] [1, 2] }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: C0| 1: C1| 2: C2| UNIQUE KEY: C0| UNIQUE KEY: C1, C2 }" ]
         {
             rank = same
         }


### PR DESCRIPTION
Add support for translation of `HirRelationExpr::CallTable` nodes in the `FromHir` HIR ⇒ QGM conversion.

### Motivation

  * This PR adds a known-desirable feature. [#9130](9130)

### Tips for reviewer

The first two commits are part of [#11253](11253) and are included here as some of the newly added tests assume they have present.

The rest of the commits change the code as follows:

1. Refactor the `TableFunction` box type.
    - Rename and align the structure of the `TableFunction` box type with the `CallTable` HIR variant.
    - Allow subquery quantifiers to appear in the outputs of the refactored `CallTable` box type.
1. Add `CallTable` specifics to the DOT output.
    - `CallTable` boxes now contain the applied function and the unique keys generated by the output.
    - Both `CallTable` and `Get` report unique keys in a slightly different format (one row per key).
1. Add `CallTable` support to `FromHir`.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A