### PR TITLE
Restore timely config to `materialized`

### DIFF
--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -273,7 +273,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         workers,
         timely_config: timely::Config {
             communication: timely::CommunicationConfig::Process(workers),
-            worker: timely::WorkerConfig::default(),
+            worker: config.timely_worker,
         },
         experimental_mode: config.experimental_mode,
         now: config.now.clone(),


### PR DESCRIPTION
This PR undoes what I think was an unintended regression in which timely configuration arguments are discarded and replaced by defaults, essentially disabling user control over the progress mode and eager compaction.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
