### PR TITLE
coord: run coordd in experimental mode

### DIFF
--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -115,7 +115,7 @@ pub struct CoordTest {
 
 impl CoordTest {
     pub async fn new() -> anyhow::Result<Self> {
-        let experimental_mode = false;
+        let experimental_mode = true;
         let timestamp = Arc::new(Mutex::new(0));
         let now = {
             let timestamp = Arc::clone(&timestamp);

--- a/src/materialized/src/bin/coordd.rs
+++ b/src/materialized/src/bin/coordd.rs
@@ -95,7 +95,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             (Box::new(client), config)
         };
 
-    let experimental_mode = false;
+    let experimental_mode = true;
     let mut metrics_registry = MetricsRegistry::new();
     let coord_storage = mz_coord::catalog::storage::Connection::open(
         &args.data_directory.join("catalog"),


### PR DESCRIPTION
`coordd` needs to be run in experimental mode to support testing clusters. In the near-term this could/should move to an arg to `coordd`, but this suffices to fix #11259.

### Motivation

This PR fixes a recognized bug.

Fixes #11259

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
