### PR TITLE
dbt-materialize: error on incremental model

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,15 +1,19 @@
 # dbt-materialize Changelog
 
-## 1.0.3 - 2021-02-27
+## 1.0.4 - 2022-03-16
+
+* Produce a proper error message when attempting to use an incremental materialization.
+
+## 1.0.3 - 2022-02-27
 
 * Upgrade to `dbt-postgres` v1.0.3.
 
-## 1.0.1.post3 - 2021-02-17
+## 1.0.1.post3 - 2022-02-17
 
 * Fix a bug introduced in v1.0.1.post1 that prevented use of the custom
   materialization types (`sink`, `source`, `index`, and `materializedview`).
 
-## 1.0.1.post2 - 2021-02-14
+## 1.0.1.post2 - 2022-02-14
 
 * Execute hooks that specify `transaction: true` ([#7675]). In particular, this
   includes hooks that are configured as a simple string.
@@ -21,7 +25,7 @@
 
 [#7675]: https://github.com/MaterializeInc/materialize/issues/7675
 
-## 1.0.1.post1 - 2021-02-14
+## 1.0.1.post1 - 2022-02-14
 
 * Disable transactions. This avoids errors of the form "CREATE ... must be
   executed outside of a transaction block" ([materialize-dbt-utils#11]).
@@ -37,7 +41,7 @@
 
 [materialize-dbt-utils#11]: https://github.com/MaterializeInc/materialize-dbt-utils/issues/11
 
-## 1.0.1 - 2021-01-03
+## 1.0.1 - 2022-01-03
 
 * Upgrade to `dbt-postgres` v1.0.1.
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.0.3"
+version = "1.0.4"

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/incremental.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/incremental.sql
@@ -15,8 +15,6 @@
 -- limitations under the License.
 
 {% materialization incremental, adapter='materialize' %}
-   -- Todo@jldlaughlin: Fail in a useful way!
-
    -- TL;DR: dbt-materialize does not support incremental models, use materializedview
    -- models instead.
 
@@ -27,4 +25,15 @@
    -- in, Materialize only performs work on that new data. And, all this happens without
    -- extra configurations or scheduled refreshes.
    -- For more information, please visit: https://materialize.com/docs/
+    {{ exceptions.raise_compiler_error(
+        """
+        dbt-materialize does not support incremental models, because all views in
+        Materialize are natively maintained incrementally.
+
+        Use the `materializedview` custom materialization instead.
+
+        See: https://materialize.com/docs/overview/api-components/#materialized-views
+        See: https://docs.getdbt.com/reference/warehouse-profiles/materialize-profile#materializations
+        """
+    )}}
 {% endmaterialization %}

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,7 +26,7 @@ setup(
     # dbt-postgres version, change version_suffix to ".post1", ".post2", etc.
     #
     # If you bump this version, bump it in __version__.py too.
-    version="1.0.3",
+    version="1.0.4",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
dbt-materialize does not support incremental models. Adjust the adaptor to error when a user tries to implement one. 

### Motivation

  * This PR tackles the first task in https://github.com/MaterializeInc/materialize/issues/10600

### Testing

Running `test_dbt_incremental` fails in the expected way:
```
FAILED dbt-materialize/test/materialize.dbtspec::test_dbt_incremental
18:24:45.176170 [error] [MainThread]: Compilation Error in model incremental (models/incremental.sql)
18:24:45.176263 [error] [MainThread]:
18:24:45.176427 [error] [MainThread]:           dbt-materialize does not support incremental models, because all views in
18:24:45.176510 [error] [MainThread]:           Materialize are natively maintained incrementally.
18:24:45.176585 [error] [MainThread]:
18:24:45.176662 [error] [MainThread]:           Use the `materializedview` custom materialization instead.
18:24:45.176745 [error] [MainThread]:
18:24:45.176826 [error] [MainThread]:           See: https://materialize.com/docs/overview/api-components/#materialized-views
18:24:45.176902 [error] [MainThread]:           See: https://docs.getdbt.com/reference/warehouse-profiles/materialize-profile#materializations
18:24:45.176978 [error] [MainThread]:
18:24:45.177057 [error] [MainThread]:
18:24:45.177120 [error] [MainThread]:   > in macro materialization_incremental_materialize (macros/materializations/incremental.sql)
18:24:45.177194 [error] [MainThread]:   > called by model incremental (models/incremental.sql)
```
- [x] This PR has adequate test coverage / QA involvement has been duly considered.