### PR TITLE
scratch: Print the region that instances are in

### DIFF
--- a/ci/load/periodic.py
+++ b/ci/load/periodic.py
@@ -9,6 +9,8 @@
 
 import datetime
 
+import boto3
+
 from materialize import scratch
 
 
@@ -29,11 +31,13 @@ def main() -> None:
         size_gb=64,
     )
     now = datetime.datetime.utcnow()
+    region = boto3.Session().region_name
     scratch.launch_cluster(
         [desc],
         nonce=now.replace(tzinfo=datetime.timezone.utc).isoformat(),
         # Keep alive for at least a day.
         delete_after=datetime.datetime.utcnow() + datetime.timedelta(days=1),
+        region=region,
     )
 
 

--- a/misc/python/materialize/cli/cloudbench.py
+++ b/misc/python/materialize/cli/cloudbench.py
@@ -273,6 +273,7 @@ sudo systemctl start confluent-schema-registry
 
     # TODO - Do these in parallel
     launched = []
+    region = boto3.Session().region_name
     for (i, rev) in clusters:
         launched += scratch.launch_cluster(
             descs=descs,
@@ -291,6 +292,7 @@ sudo systemctl start confluent-schema-registry
             },
             delete_after=datetime.datetime.utcnow() + datetime.timedelta(days=1),
             git_rev=rev,
+            region=region,
         )
 
     print("Launched instances:")

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -13,6 +13,8 @@ import json
 import sys
 from typing import Any, Dict, List
 
+import boto3
+
 from materialize.cli.scratch import check_required_vars
 from materialize.scratch import (
     DEFAULT_INSTANCE_PROFILE_NAME,
@@ -144,6 +146,8 @@ def run(args: argparse.Namespace) -> None:
         raise RuntimeError(f"max_age_days must be positive, got {args.max_age_days}")
     max_age = datetime.timedelta(days=args.max_age_days)
 
+    region = boto3.Session().region_name
+
     instances = launch_cluster(
         descs,
         subnet_id=args.subnet_id,
@@ -154,9 +158,10 @@ def run(args: argparse.Namespace) -> None:
         delete_after=datetime.datetime.utcnow() + max_age,
         git_rev=args.git_rev,
         extra_env={},
+        region=region,
     )
 
-    print("Launched instances:")
+    print(f"Launched instances in {region}:")
     print_instances(instances, args.output_format)
 
     if args.ssh:

--- a/misc/python/materialize/cli/scratch/destroy.py
+++ b/misc/python/materialize/cli/scratch/destroy.py
@@ -70,7 +70,9 @@ def run(args: argparse.Namespace) -> None:
         )
     )
 
-    print("Destroying instances:")
+    region = boto3.Session().region_name
+
+    print(f"Destroying instances in {region}:")
     print_instances(instances, args.output_format)
 
     if not args.yes and not ui.confirm("Would you like to continue?"):

--- a/misc/python/materialize/cli/scratch/mine.py
+++ b/misc/python/materialize/cli/scratch/mine.py
@@ -32,6 +32,8 @@ def run(args: argparse.Namespace) -> None:
     filters: List[FilterTypeDef] = []
     if not args.all:
         filters.append({"Name": "tag:LaunchedBy", "Values": args.who or [whoami()]})
+    region = boto3.Session().region_name
+    print(f"Instances in {region}:")
     print_instances(
         list(boto3.resource("ec2").instances.filter(Filters=filters)),
         args.output_format,

--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -16,6 +16,7 @@ import os
 import shlex
 import subprocess
 import sys
+from collections import defaultdict
 from subprocess import CalledProcessError
 from typing import Dict, List, NamedTuple, Optional, cast
 
@@ -128,6 +129,7 @@ def launch(
     instance_profile: Optional[str],
     nonce: str,
     delete_after: datetime.datetime,
+    region: str,
 ) -> Instance:
     """Launch and configure an ec2 instance with the given properties."""
 
@@ -146,7 +148,7 @@ def launch(
     if subnet_id:
         network_interface["SubnetId"] = subnet_id
 
-    say(f"launching instance {display_name or '(unnamed)'}")
+    say(f"launching instance {display_name or '(unnamed)'} in {region}")
     with open(ROOT / "misc" / "scratch" / "provision.bash") as f:
         provisioning_script = f.read()
     kwargs: RunInstancesRequestRequestTypeDef = {
@@ -272,6 +274,7 @@ class MachineDesc(BaseModel):
 def launch_cluster(
     descs: List[MachineDesc],
     *,
+    region: str,
     nonce: Optional[str] = None,
     subnet_id: str = DEFAULT_SUBNET_ID,
     key_name: Optional[str] = None,
@@ -301,6 +304,7 @@ def launch_cluster(
             instance_profile=instance_profile,
             nonce=nonce,
             delete_after=delete_after,
+            region=region,
         )
         for d in descs
     ]


### PR DESCRIPTION
Because of AWS UX, knowing the exact region is pretty important -- trying to
operate in the wrong region will just turn up "not found" or even worse
responses (e.g. for aws ssm it will say that the ssm client on the vm did
not start, not that the vm does not exist).

### Motivation

* This PR adds a feature that has not yet been specified.

### Checklist

- [n/a] This PR has adequate test coverage / QA involvement has been duly considered.
- [n/a] This PR adds a release note for any [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/user/content/release-notes.md#what-changes-require-a-release-note).