### PR TITLE
docs: fix reference to resolve_names

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -39,7 +39,7 @@ use crate::ast::{Expr, FunctionArgs, Ident, SqlOption, UnresolvedDataType, Unres
 // that it gets resolved to.
 //
 // Currently this process brings an Ast<Raw> to Ast<Aug>, and lives in
-// sql/src/plan/query.rs:resolve_names.
+// sql/src/names.rs:resolve_names.
 pub trait AstInfo: Clone {
     // The type used for table references.
     type ObjectName: AstDisplay + Clone + Hash + Debug + Eq;


### PR DESCRIPTION
realized this was pointing to the wrong thing
