### PR TITLE
feature-benchmark: Add scenario for measuring startup performance

### DIFF
--- a/misc/python/materialize/feature_benchmark/action.py
+++ b/misc/python/materialize/feature_benchmark/action.py
@@ -33,7 +33,7 @@ class Action:
         assert False
 
 
-class Lambda(Action):
+class LambdaAction(Action):
     def __init__(self, _lambda: Callable) -> None:
         self._lambda = _lambda
 

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -56,10 +56,10 @@ class Docker(Executor):
         self._composition = composition
         self._seed = seed
 
-    def RestartMz(self) -> Any:
+    def RestartMz(self) -> None:
         self._composition.kill("materialized")
         self._composition.up("materialized")
-        return 0.0
+        return None
 
     def Td(self, input: str) -> Any:
         with NamedTemporaryFile(

--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -13,6 +13,8 @@ from typing import Dict, List, Optional, Type, Union
 from materialize.feature_benchmark.action import Action, DummyAction, TdAction
 from materialize.feature_benchmark.measurement_source import MeasurementSource
 
+BenchmarkingSequence = Union[MeasurementSource, List[Union[Action, MeasurementSource]]]
+
 
 class RootScenario:
     SCALE: float = 6
@@ -31,7 +33,7 @@ class RootScenario:
     def before(self) -> Action:
         return DummyAction()
 
-    def benchmark(self) -> MeasurementSource:
+    def benchmark(self) -> BenchmarkingSequence:
         assert False
 
     def name(self) -> str:


### PR DESCRIPTION
A new scenario is hereby added that creates various Mz objects and
then checks the time between restarting Mz and the objects becoming
queryable.

By default 100 materialized sources, 100 sinks , 100 tables and
100 3-table materialized views are created.

In addition:
- it is now possible to have mzcompose operations as part of the workload
  being benchmarked, not just in the init() or before() phases as it was previously.
- the feature-benchmark has been extended to operate on timestamps
rather than measurements. This way, one part of the workload can provide
the start timestamp and another part can provide the end timestamp.
The framework will then calculate the elapsed time.
- the measurement_source.py no longer supports an Iterator interface
- various dead code and debugging aides have been removed

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
