### PR TITLE
antithesis: compile with -Cpasses=sancov-module

### DIFF
--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       antithesis-net:
         ipv4_address: 10.0.0.12
     command:
+      --listen-addr 0.0.0.0:6875
       --data-directory=/share/mzdata
       --workers 1
       --experimental

--- a/test/antithesis/materialized/mzbuild.yml
+++ b/test/antithesis/materialized/mzbuild.yml
@@ -14,7 +14,7 @@ pre-image:
     bin: materialized
     strip: false
     rustflags: [
-      "-Cpasses=sancov",
+      "-Cpasses=sancov-module",
       "-Cllvm-args=-sanitizer-coverage-level=3",
       "-Cllvm-args=-sanitizer-coverage-trace-pc-guard",
       "-Ccodegen-units=1",


### PR DESCRIPTION
'sancov' has been renamed to 'sancov-module' in LLVM, so adjust
the RUSTFLAGS used for building the antithesis container accordingly.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a previously unreported bug.

The Mz container for Antithesis could not be built