### PR TITLE
doc/user: compile release notes for v0.23

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -102,12 +102,15 @@ recommended worker setting on this VM is `7`.
 
 ### Listen address
 
-By default, `materialized` binds to `0.0.0.0:6875`. This means that Materialize
-will accept any incoming SQL connection to port 6875 from anywhere. It is the
-responsibility of the network firewall to limit incoming connections. If you
-wish to configure `materialized` to only listen to, e.g. localhost connections,
-you can set `--listen-addr` to `localhost:6875`. You can also use this to change
-the port that Materialize listens on from the default `6875`.
+By default, `materialized` binds to `127.0.0.1:6875`. This means that
+Materialize will accept any incoming SQL connection to port 6875 from only the
+local machine. If you wish to configure `materialized` to accept connections
+from anywhere, you can set `--listen-addr` to `0.0.0.0:6875`. You can
+also use this to change the port that Materialize listens on from the default
+`6875`.
+
+The `materialized` [Docker image](/install/#docker) instead uses a listen
+address of `0.0.0.0:6875` by default, in accordance with Docker conventions.
 
 ### Compaction window
 

--- a/doc/user/content/overview/api-components.md
+++ b/doc/user/content/overview/api-components.md
@@ -186,6 +186,23 @@ change data capture (CDC) producers for the given source or view.
 Currently, Materialize only supports sending sink data to Kafka or Avro OCFs,
 encoded in Avro with the [Debezium diff envelope](/sql/create-sink#debezium-envelope-details).
 
+## Clusters
+
+{{< experimental >}}
+The concept of a cluster
+{{< /experimental >}}
+
+A cluster is a set of compute resources that have been allocated to maintain
+indexes and sinks. The `materialized` process provides one virtual cluster named
+`default` that represents the compute resources of the local machine. In
+a forthcoming version of [Materialize Cloud](/cloud), you will be able to
+dynamically create and drop clusters to allocate and deallocate compute
+resources on demand.
+
+Clusters are still under active development and are not yet meant for general
+use. They are described here because some non-experimental features (e.g.,
+[`SHOW INDEX`](/sql/show-indexes)) already make reference to clusters.
+
 ## Related pages
 
 - [`CREATE SOURCE`](/sql/create-source)

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -19,6 +19,61 @@ the PR description instead. They will be migrated here during the release
 process by the release notes team.
 {{< /comment >}}
 
+{{% version-header v0.23.0 %}}
+
+- **Breaking change.** Change the default [listen address](/cli/#listen-address)
+  to `127.0.0.1:6875`.
+
+  Previously, Materialize would accept HTTP and SQL connections from any machine
+  on the network by default; now it accepts HTTP and SQL connections from only
+  the local machine by default. To return to the old behavior, specify the
+  command line flag `--listen-addr=0.0.0.0:6875`.
+
+  The `materialized` [Docker image](/install/#docker) continues to use a
+  listen address of `0.0.0.0:6875` by default.
+
+- Improve PostgreSQL compatibility:
+
+  - Add the `pg_collation`, `pg_inherits`, and `pg_policy` relations to the
+    [`pg_catalog`](/sql/system-catalog#pg_catalog) schema.
+
+  - Add several columns to the existing `pg_attribute`, `pg_class`, `pg_index`,
+    and `pg_type` relations in the
+    [`pg_catalog`](/sql/system-catalog#pg_catalog) schema.
+
+  - Add the [`pg_get_indexdef`](/sql/functions/#pg_get_indexdef) function.
+
+  - Change the [`pg_get_constraintdef`](/sql/functions/#pg_get_constraintdef)
+    function to always return `NULL` instead of raising an error.
+
+  - Add a `USING <method>` clause to [`CREATE INDEX`], with
+    [`arrangement`](/overview/arrangements) as the only valid method.
+
+  Together these changes enable support for [Apache Superset] and the
+  `\d <object>` command in the  [psql terminal](/connect/cli).
+
+- Support calling [`date_trunc`](/sql/functions/#date_trunc) with
+  [`interval`](/sql/types/interval) values {{% gh 9871 %}}.
+
+- Remove the mandatory default index on [tables](/sql/create-table/#memory-usage).
+
+- Fix a crash when calling [`array_to_string`](/sql/functions/#array_to_string)
+  with an empty array {{% gh 11073 %}}.
+
+- Fix an error when calling [`string_agg`](/sql/functions/#string_agg) with
+  all `NULL` inputs {{% gh 11139 %}}.
+
+- Include information about the experimental
+  [cluster feature](/overview/api-components/#clusters) in
+  [`SHOW INDEX`](/sql/show-index) and [`SHOW SINKS`](/sql/show-sinks).
+
+- Improve recovery of [Postgres sources](/sql/create-source/postgres) when
+  errors occur during initial data loading {{% gh 10938 %}}.
+
+- Make [`CREATE VIEWS`](/sql/create-views) on a [Postgres
+  source](/sql/create-source/postgres) resilient to changes to the upstream
+  publication that are made after the the source is created. {{% gh 11083 %}}
+
 {{% version-header v0.22.0 %}}
 
 - **Breaking change.** Standardize handling of the following [unmaterializable
@@ -2057,6 +2112,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 [`time`]: /sql/types/time
 [`timestamp`]: /sql/types/timestamp
 [`timestamp with time zone`]: /sql/types/timestamptz
+[Apache Superset]: https://superset.apache.org
 [Postgres sources]: /sql/create-source/postgres
 [pg-copy]: https://www.postgresql.org/docs/current/sql-copy.html
 [pgwire-simple]: https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -40,6 +40,7 @@ Field | Use
 **DEFAULT** | Creates a default index with the same structure as the index automatically created with [**CREATE MATERIALIZED VIEW**](/sql/create-materialized-view). This provides a simple method to convert a non-materialized object to a materialized one.
 _index&lowbar;name_ | A name for the index.
 _obj&lowbar;name_ | The name of the source or view on which you want to create an index.
+_method_ | The name of the index method to use. The only supported method is [`arrangement`](/overview/arrangements).
 _col&lowbar;expr_**...** | The expressions to use as the key for the index.
 _field_ | The name of the option you want to set.
 _val_ | The value for the option.
@@ -48,6 +49,10 @@ _val_ | The value for the option.
 The `WITH (field = val, ...)` clause was added to allow setting index options
 when creating the index.
 {{</ version-changed >}}
+
+{{< version-added v0.23.0 >}}
+The `USING` clause.
+{{</ version-added >}}
 
 ### `WITH` options
 

--- a/doc/user/content/sql/create-table.md
+++ b/doc/user/content/sql/create-table.md
@@ -6,7 +6,7 @@ menu:
     parent: 'sql'
 ---
 
-{{< version-added v0.5.0 >}}
+{{< version-added v0.5.0 />}}
 
 `CREATE TABLE` creates an in-memory table.
 
@@ -85,17 +85,19 @@ tables may not depend on temporary objects.
 
 ### Memory usage
 
-Every table is backed by an [index](/overview/api-components/#indexes) that
-materializes all of the data in the table. Unlike sources, tables cannot be
-"unmaterialized". Therefore you must ensure that the data you store in tables
-fits in the amount of memory you have available on your system. Remember that
-any additional indexes or derived materialized views will count against your
-memory budget.
+Tables presently store their data in memory. Therefore you must ensure that the
+data you store in tables fits in the amount of memory you have available on your
+system. Remember that any additional indexes or derived materialized views will
+count against your memory budget.
 
 If your dataset is too large to fit in memory, consider using an unmaterialized
 [source](/sql/create-source) instead. This lets you defer materialization to
 views derived from this source, which can aggregate or filter the data down to a
 manageable size.
+
+{{< version-changed v0.23.0 >}}
+Tables no longer have a mandatory default [index](/overview/api-components/#indexes).
+{{< /version-changed >}}
 
 ## Examples
 

--- a/doc/user/content/sql/show-index.md
+++ b/doc/user/content/sql/show-index.md
@@ -26,13 +26,14 @@ _on&lowbar;name_ | The name of the object whose indexes you want to show. This c
 `SHOW INDEX`'s output is a table, with this structure:
 
 ```nofmt
- on_name | key_name | seq_in_index | column_name | expression | nullable | enabled
----------+----------+--------------+-------------+------------+----------+--------
- ...     | ...      | ...          | ...         | ...        | ...      | ...
+cluster | on_name | key_name | seq_in_index | column_name | expression | nullable | enabled
+--------+---------+----------+--------------+-------------+------------+----------+--------
+ ...    | ...     | ...      | ...          | ...         | ...        | ...      | ...
 ```
 
 Field | Meaning
 ------|--------
+**cluster** | The name of the [cluster](/overview/api-components/#clusters) containing the index.
 **on_name** | The name of the table, source, or view the index belongs to.
 **key_name** | The name of the index.
 **seq_in_index** | The column's position in the index.
@@ -46,6 +47,10 @@ The output columns are renamed from `On_name`, `Key_name`, `Column_name`,
 `Expression`, `Null`, and `Seq_in_index` to `on_name`, `key_name`,
 `column_name`, `expression`, `nullable`, and `seq_in_index`, respectively.
 {{< /version-changed >}}
+
+{{< version-added v0.23.0 >}}
+The `cluster` column.
+{{< /version-added >}}
 
 ### Determine which views have indexes
 

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -26,15 +26,16 @@ _schema&lowbar;name_ | The schema to show sinks from. Defaults to `public` in th
 `SHOW FULL SINKS`'s output is a table, with this structure:
 
 ```nofmt
- name  | type | volatile
--------+------+---------
- ...   | ...  | ...
+cluster | name  | type | volatile
+--------+-------+------+---------
+...     | ...   | ...  | ...
 ```
 
 Field | Meaning
 ------|--------
-**name** | The name of the sink
-**type** | Whether the sink was created by the `user` or the `system`
+**cluster** | The name of the [cluster](/overview/api-components/#clusters) containing the sink.
+**name** | The name of the sink.
+**type** | Whether the sink was created by the `user` or the `system`.
 **volatility** | Whether the sink is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
 
 {{< version-changed v0.5.0 >}}
@@ -43,6 +44,10 @@ The output column is renamed from `SINKS` to `name`.
 
 {{< version-added v0.7.2 >}}
 The `volatile` column.
+{{< /version-added >}}
+
+{{< version-added v0.23.0 >}}
+The `cluster` column.
 {{< /version-added >}}
 
 ## Examples

--- a/doc/user/layouts/partials/sql-grammar/create-index.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-index.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="655" height="317">
+<svg xmlns="http://www.w3.org/2000/svg" width="869" height="381">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -31,92 +31,114 @@
    <rect x="305" y="113" width="82" height="32"/>
    <rect x="303" y="111" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="313" y="131">obj_name</text>
-   <rect x="407" y="113" width="26" height="32" rx="10"/>
-   <rect x="405"
+   <rect x="427" y="145" width="64" height="32" rx="10"/>
+   <rect x="425"
+         y="143"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="435" y="163">USING</text>
+   <rect x="511" y="145" width="70" height="32"/>
+   <rect x="509" y="143" width="70" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="519" y="163">method</text>
+   <rect x="621" y="113" width="26" height="32" rx="10"/>
+   <rect x="619"
          y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="415" y="131">(</text>
-   <rect x="473" y="113" width="74" height="32"/>
-   <rect x="471" y="111" width="74" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="481" y="131">col_expr</text>
-   <rect x="473" y="69" width="24" height="32" rx="10"/>
-   <rect x="471"
+   <text class="terminal" x="629" y="131">(</text>
+   <rect x="687" y="113" width="74" height="32"/>
+   <rect x="685" y="111" width="74" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="695" y="131">col_expr</text>
+   <rect x="687" y="69" width="24" height="32" rx="10"/>
+   <rect x="685"
          y="67"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="481" y="87">,</text>
-   <rect x="587" y="113" width="26" height="32" rx="10"/>
-   <rect x="585"
+   <text class="terminal" x="695" y="87">,</text>
+   <rect x="801" y="113" width="26" height="32" rx="10"/>
+   <rect x="799"
          y="111"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="595" y="131">)</text>
-   <rect x="45" y="157" width="158" height="32" rx="10"/>
+   <text class="terminal" x="809" y="131">)</text>
+   <rect x="45" y="189" width="158" height="32" rx="10"/>
    <rect x="43"
-         y="155"
+         y="187"
          width="158"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="175">DEFAULT INDEX ON</text>
-   <rect x="223" y="157" width="82" height="32"/>
-   <rect x="221" y="155" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="231" y="175">obj_name</text>
-   <rect x="243" y="267" width="58" height="32" rx="10"/>
-   <rect x="241"
-         y="265"
+   <text class="terminal" x="53" y="207">DEFAULT INDEX ON</text>
+   <rect x="223" y="189" width="82" height="32"/>
+   <rect x="221" y="187" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="231" y="207">obj_name</text>
+   <rect x="345" y="221" width="64" height="32" rx="10"/>
+   <rect x="343"
+         y="219"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="239">USING</text>
+   <rect x="429" y="221" width="70" height="32"/>
+   <rect x="427" y="219" width="70" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="437" y="239">method</text>
+   <rect x="457" y="331" width="58" height="32" rx="10"/>
+   <rect x="455"
+         y="329"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="251" y="285">WITH</text>
-   <rect x="321" y="267" width="26" height="32" rx="10"/>
-   <rect x="319"
-         y="265"
+   <text class="terminal" x="465" y="349">WITH</text>
+   <rect x="535" y="331" width="26" height="32" rx="10"/>
+   <rect x="533"
+         y="329"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="329" y="285">(</text>
-   <rect x="387" y="267" width="48" height="32"/>
-   <rect x="385" y="265" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="395" y="285">field</text>
-   <rect x="455" y="267" width="28" height="32" rx="10"/>
-   <rect x="453"
-         y="265"
+   <text class="terminal" x="543" y="349">(</text>
+   <rect x="601" y="331" width="48" height="32"/>
+   <rect x="599" y="329" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="609" y="349">field</text>
+   <rect x="669" y="331" width="28" height="32" rx="10"/>
+   <rect x="667"
+         y="329"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="463" y="285">=</text>
-   <rect x="503" y="267" width="38" height="32"/>
-   <rect x="501" y="265" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="511" y="285">val</text>
-   <rect x="387" y="223" width="24" height="32" rx="10"/>
-   <rect x="385"
-         y="221"
+   <text class="terminal" x="677" y="349">=</text>
+   <rect x="717" y="331" width="38" height="32"/>
+   <rect x="715" y="329" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="725" y="349">val</text>
+   <rect x="601" y="287" width="24" height="32" rx="10"/>
+   <rect x="599"
+         y="285"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="395" y="241">,</text>
-   <rect x="581" y="267" width="26" height="32" rx="10"/>
-   <rect x="579"
-         y="265"
+   <text class="terminal" x="609" y="305">,</text>
+   <rect x="795" y="331" width="26" height="32" rx="10"/>
+   <rect x="793"
+         y="329"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="589" y="285">)</text>
+   <text class="terminal" x="803" y="349">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-126 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m20 44 h10 m26 0 h10 m-608 0 h20 m588 0 h20 m-628 0 q10 0 10 10 m608 0 q0 -10 10 -10 m-618 10 v24 m608 0 v-24 m-608 24 q0 10 10 10 m588 0 q10 0 10 -10 m-598 10 h10 m158 0 h10 m0 0 h10 m82 0 h10 m0 0 h308 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="645 281 653 277 653 285"/>
-   <polygon points="645 281 637 277 637 285"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-126 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m20 44 h10 m26 0 h10 m-822 0 h20 m802 0 h20 m-842 0 q10 0 10 10 m822 0 q0 -10 10 -10 m-832 10 v56 m822 0 v-56 m-822 56 q0 10 10 10 m802 0 q10 0 10 -10 m-812 10 h10 m158 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 -32 h308 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="859 345 867 341 867 349"/>
+   <polygon points="859 345 851 341 851 349"/>
 </svg>

--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -24,9 +24,10 @@
   </tr>
   {{ range .functions }}
   <tr>
-    {{/*  Print an ID and class that can be used to index in docsearch
-            and deeplink.  */}}
-    <td class="docsearch_l4" id="{{ .signature | urlize }}">
+    {{/*  Extract the function's name from its signature and use it as the ID
+          to facilitate deeplinking. The `docsearch_l4` class is a special
+          class that is scraped by our Algolia DocSearch configuration.  */}}
+    <td class="docsearch_l4" id="{{ index (split .signature "(") 0 | urlize }}">
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -33,8 +33,8 @@ create_database ::=
     'CREATE' 'DATABASE' ('IF NOT EXISTS')? database_name
 create_index ::=
     'CREATE' (
-        'INDEX' index_name 'ON' obj_name '(' ( ( col_expr ) ( ( ',' col_expr ) )* ) ')'
-        | 'DEFAULT INDEX ON' obj_name
+        'INDEX' index_name 'ON' obj_name ('USING' method)? '(' ( ( col_expr ) ( ( ',' col_expr ) )* ) ')'
+        | 'DEFAULT INDEX ON' obj_name ('USING' method)?
     )
     ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_materialized_view ::=


### PR DESCRIPTION
Compile the release notes for v0.23.0.

@sploiselle, could you look at the cluster-related changes? I updated the docs for `SHOW INDEX` and `SHOW SINKS`, since the `cluster` columns there are not experimental, and then added a smidge of text about clusters just so I had something to link to.

@ruf-io, could you look at the changes to function deeplinking? I made a tweak so that it's possible to link to the functions by name, rather than the signature. E.g., the hash is `array_to_string`, rather than `array_to_stringa-anyarray-sep-text-ifnull-text-text`.

### Motivation

* Standard release notes PR.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
