### PR TITLE
dataflow: Better error log for SplitClient

### DIFF
--- a/src/coordtest/src/lib.rs
+++ b/src/coordtest/src/lib.rs
@@ -560,6 +560,7 @@ pub async fn run_test(mut tf: datadriven::TestFile) -> datadriven::TestFile {
 /// `recv`, however, only presents the responses that have been explicitly
 /// forwarded via `forward_response`. To access the actual responses from
 /// the underlying dataflow client, call `try_intercepting_recv`.
+#[derive(Debug)]
 struct InterceptingDataflowClient<C> {
     inner: Arc<TokioMutex<C>>,
     feedback_tx: mpsc::UnboundedSender<mz_dataflow_types::client::Response>,


### PR DESCRIPTION
### Motivation

Make `Client` implement `Debug`. This needs to be encoded in the trait
itself because we can't have a boxed `Client + Debug` due to Rust's
limitations.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A