### PR TITLE
antithesis: Update the Antithesis container to new realities

### DIFF
--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       antithesis-net:
         ipv4_address: 10.0.0.12
     command:
+      --listen-addr 0.0.0.0:6875
       --data-directory=/share/mzdata
       --workers 1
       --experimental

--- a/test/antithesis/materialized/mzbuild.yml
+++ b/test/antithesis/materialized/mzbuild.yml
@@ -14,7 +14,7 @@ pre-image:
     bin: materialized
     strip: false
     rustflags: [
-      "-Cpasses=sancov",
+      "-Cpasses=sancov-module",
       "-Cllvm-args=-sanitizer-coverage-level=3",
       "-Cllvm-args=-sanitizer-coverage-trace-pc-guard",
       "-Ccodegen-units=1",


### PR DESCRIPTION
- compile with -Cpasses=sancov-module

'sancov' has been renamed to 'sancov-module' in LLVM, so adjust
the RUSTFLAGS used for building the antithesis container accordingly.

- run with --listen-addr=0.0.0.0:...

Otherwise by default the other containers in the Antithesis environment
Mz container will be unable to contact the Mz instance

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

Antithesis builds were failing.