### PR TITLE
sql: limit `pg_catalog` views to the current database

### DIFF
--- a/test/lang/java/smoketest/SmokeTest.java
+++ b/test/lang/java/smoketest/SmokeTest.java
@@ -34,7 +34,7 @@ class SmokeTest {
         String port = System.getenv("PGPORT");
         if (port == null)
             port = "6875";
-        String url = String.format("jdbc:postgresql://%s:%s/", host, port);
+        String url = String.format("jdbc:postgresql://%s:%s/materialize", host, port);
         conn = DriverManager.getConnection(url, "materialize", null);
     }
 

--- a/test/sqllogictest/pg_catalog_class.slt
+++ b/test/sqllogictest/pg_catalog_class.slt
@@ -32,3 +32,45 @@ FROM pg_catalog.pg_class
 WHERE relname = (SELECT name FROM mz_indexes WHERE on_id = (SELECT id FROM mz_objects WHERE name = 'a'));
 ----
 0 0 0 0 false p i 0 false false false false d false false
+
+# Tables outside of the current database don't show up
+
+statement ok
+CREATE DATABASE kant;
+
+statement ok
+SET database = kant;
+
+statement ok
+CREATE TABLE c (b int);
+
+query TIIIIBTTIBBBBTBB
+SELECT relname, reloftype, relam, reltablespace, reltoastrelid, relhasindex, relpersistence, relkind, relchecks,
+    relhasrules, relhastriggers, relrowsecurity, relforcerowsecurity, relreplident, relispartition, relhasoids
+FROM pg_catalog.pg_class
+WHERE relname = 'c';
+----
+c 0 0 0 0 false p r 0 false false false false d false false
+
+
+statement ok
+SET database = test;
+
+query TIIIIBTTIBBBBTBB
+SELECT relname, reloftype, relam, reltablespace, reltoastrelid, relhasindex, relpersistence, relkind, relchecks,
+    relhasrules, relhastriggers, relrowsecurity, relforcerowsecurity, relreplident, relispartition, relhasoids
+FROM pg_catalog.pg_class
+WHERE relname = 'c';
+----
+
+
+# statement ok
+# SET database = kant;
+
+# query TIIIIBTTIBBBBTBB
+# SELECT relname, reloftype, relam, reltablespace, reltoastrelid, relhasindex, relpersistence, relkind, relchecks,
+#     relhasrules, relhastriggers, relrowsecurity, relforcerowsecurity, relreplident, relispartition, relhasoids
+# FROM pg_catalog.pg_class
+# WHERE relname = 'c';
+# ----
+# c 0 0 0 0 false p r 0 false false false false d false false


### PR DESCRIPTION
Add `JOIN`s to the `mz_databases` view that limit `pg_catalog` views to the current database. Fixes #10391

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - **TODO**:  this will probably require a release note