### PR TITLE
doc/user: Add "click to copy" on docs codeblocks

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -719,20 +719,17 @@ td > .default_button {
     right: 10px;
     font-family: "Inter", sans-serif;
     line-height: 1.75;
+    &.success {
+        background: $lime;
+    }
 }
 
 pre {
     position: relative;
-    transition: background-color 500ms ease-out;
 
     &:hover {
         .copy_button {
             display: inline-block;
         }
-    }
-
-    &.copy_success {
-        background-color: rgba($lime, 0.3);
-        transition: background-color 0s;
     }
 }

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -711,3 +711,28 @@ td > .default_button {
         color: $danger;
     }
 }
+
+.copy_button {
+    display: none;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-family: "Inter", sans-serif;
+    line-height: 1.75;
+}
+
+pre {
+    position: relative;
+    transition: background-color 500ms ease-out;
+
+    &:hover {
+        .copy_button {
+            display: inline-block;
+        }
+    }
+
+    &.copy_success {
+        background-color: rgba($lime, 0.3);
+        transition: background-color 0s;
+    }
+}

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -65,6 +65,25 @@ by the Apache License, Version 2.0.  */}}
           e.preventDefault();
           document.getElementById("search-input").focus();
         });
+
+        /* Add "Click to Copy" button to code blocks */
+        $(document).ready(function() {
+          $('pre.chroma').append('<span class="default_button copy_button" title="Copy code to clipboard">Copy</span>');
+
+          $('pre.chroma span.copy_button').click(function(e) {
+            var _this = $(this),
+                copyHex = document.createElement('textarea');
+            copyHex.value = _this.parent().find('code').text().trim();
+            document.body.appendChild(copyHex);
+            copyHex.select();
+            document.execCommand('copy');
+            document.body.removeChild(copyHex);
+            _this.parent().addClass("copy_success");
+            setTimeout(function() {
+              _this.parent().removeClass("copy_success");
+            }, 1);
+          });
+        });
     </script>
 </body>
 

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -78,10 +78,10 @@ by the Apache License, Version 2.0.  */}}
             copyHex.select();
             document.execCommand('copy');
             document.body.removeChild(copyHex);
-            _this.parent().addClass("copy_success");
+            _this.addClass("success").text('Copied');
             setTimeout(function() {
-              _this.parent().removeClass("copy_success");
-            }, 1);
+              _this.removeClass("success").text('Copy');
+            }, 1000);
           });
         });
     </script>


### PR DESCRIPTION
_Second attempt with proper forked branch_

### Motivation
This adds a very basic "Click to Copy" function for `<pre class="chroma">` code blocks.   Fixes  #4592

#### Click to Copy
![Kapture 2022-03-18 at 15 27 36](https://user-images.githubusercontent.com/11527560/159071347-8c4afa56-abfd-418b-acd0-ca3004c16d54.gif)


Here are some details about how it is supposed to work:
- Only works on codeblocks (not inline code) by filtering to `<pre class="chroma">` elements.
- The button is only visible when the mouse is hovered over the code block
- Clicking the button copies the code (stripped of trailing and leading newlines so that users aren't automatically executing code upon pasting into terminals)
- Repeated clicks repeatedly copy
- The user is alerted to the success by a brief flash of green on the copied codeblock.



### Tips for reviewer

Please vet that the copy functionality works as mentioned across chrome/firefox/safari