### PR TITLE
Restartable sources groundwork

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3125,7 +3125,7 @@ impl Coordinator {
         let view_id = self.allocate_transient_id()?;
         let index_id = self.allocate_transient_id()?;
         // The assembled dataflow contains a view and an index of that view.
-        let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id), view_id);
+        let mut dataflow = DataflowDesc::new(format!("temp-view-{}", view_id));
         dataflow.set_as_of(Antichain::from_elem(timestamp));
         let mut builder = self.dataflow_builder(compute_instance);
         builder.import_view_into_dataflow(&view_id, &source, &mut dataflow)?;
@@ -3252,7 +3252,7 @@ impl Coordinator {
                 let expr = self.view_optimizer.optimize(expr)?;
                 let desc = RelationDesc::new(expr.typ(), desc.iter_names());
                 let sink_desc = make_sink_desc(self, id, desc, &depends_on)?;
-                let mut dataflow = DataflowDesc::new(format!("tail-{}", id), id);
+                let mut dataflow = DataflowDesc::new(format!("tail-{}", id));
                 let mut dataflow_builder = self.dataflow_builder(compute_instance);
                 dataflow_builder.import_view_into_dataflow(&id, &expr, &mut dataflow)?;
                 dataflow_builder.build_sink_dataflow_into(&mut dataflow, id, sink_desc)?;
@@ -3556,7 +3556,7 @@ impl Coordinator {
              -> Result<DataflowDescription<OptimizedMirRelationExpr>, CoordError> {
                 let start = Instant::now();
                 let optimized_plan = coord.view_optimizer.optimize(decorrelated_plan)?;
-                let mut dataflow = DataflowDesc::new(format!("explanation"), GlobalId::Explain);
+                let mut dataflow = DataflowDesc::new(format!("explanation"));
                 coord
                     .dataflow_builder(compute_instance)
                     .import_view_into_dataflow(
@@ -5358,7 +5358,7 @@ impl Coordinator {
         // prevent us from incorrectly teaching those functions how to return errors
         // (which has happened twice and is the motivation for this test).
 
-        let df = DataflowDesc::new("".into(), GlobalId::Explain);
+        let df = DataflowDesc::new("".into());
         let _: () = self
             .ship_dataflow(df.clone(), DEFAULT_COMPUTE_INSTANCE_ID)
             .await;

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -225,7 +225,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
         let on_entry = self.catalog.get_by_id(&index.on);
         let on_type = on_entry.desc().unwrap().typ().clone();
         let name = index_entry.name().to_string();
-        let mut dataflow = DataflowDesc::new(name, id);
+        let mut dataflow = DataflowDesc::new(name);
         self.import_into_dataflow(&index.on, &mut dataflow)?;
         for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
             self.prep_relation_expr(plan, ExprPrepStyle::Index)?;
@@ -256,7 +256,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
         id: GlobalId,
         sink_description: SinkDesc,
     ) -> Result<DataflowDesc, CoordError> {
-        let mut dataflow = DataflowDesc::new(name, id);
+        let mut dataflow = DataflowDesc::new(name);
         self.build_sink_dataflow_into(&mut dataflow, id, sink_description)?;
         Ok(dataflow)
     }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -411,6 +411,16 @@ pub trait Client<T = mz_repr::Timestamp>: std::fmt::Debug {
 }
 
 #[async_trait(?Send)]
+impl Client for Box<dyn Client + Send> {
+    async fn send(&mut self, cmd: Command) -> Result<(), anyhow::Error> {
+        (**self).send(cmd).await
+    }
+    async fn recv(&mut self) -> Option<Response> {
+        (**self).recv().await
+    }
+}
+
+#[async_trait(?Send)]
 impl Client for Box<dyn Client> {
     async fn send(&mut self, cmd: Command) -> Result<(), anyhow::Error> {
         (**self).send(cmd).await

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -179,7 +179,7 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     RenderSources(
         Vec<(
             /* debug_name */ String,
-            /* dataflow_id */ GlobalId,
+            /* dataflow_id */ uuid::Uuid,
             /* as_of */ Option<Antichain<T>>,
             /* source_imports*/ BTreeMap<GlobalId, SourceInstanceDesc<T>>,
         )>,

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -29,7 +29,7 @@ use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
 use uuid::Uuid;
 
-use crate::client::{Client, Command, ComputeCommand, ComputeInstanceId, StorageCommand};
+use crate::client::{Client, Command, ComputeCommand, ComputeInstanceId};
 use crate::logging::LoggingConfig;
 use crate::DataflowDescription;
 use mz_expr::GlobalId;
@@ -245,22 +245,6 @@ impl<'a, C: Client<T>, T: Timestamp + Lattice> ComputeControllerMut<'a, C, T> {
             }
         }
 
-        let sources = dataflows
-            .iter()
-            .map(|dataflow| {
-                (
-                    dataflow.debug_name.clone(),
-                    dataflow.id,
-                    dataflow.as_of.clone(),
-                    dataflow.source_imports.clone(),
-                )
-            })
-            .collect();
-
-        self.client
-            .send(Command::Storage(StorageCommand::RenderSources(sources)))
-            .await
-            .expect("Storage command failed; unrecoverable");
         self.client
             .send(Command::Compute(
                 ComputeCommand::CreateDataflows(dataflows),

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -91,7 +91,7 @@ where
             .source_imports
             .iter()
             .filter_map(|(id, source)| {
-                if let Some(operator) = &source.operators {
+                if let Some(operator) = &source.arguments.operators {
                     Some((*id, operator))
                 } else {
                     None

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -143,12 +143,12 @@ pub struct DataflowDescription<P, T = mz_repr::Timestamp> {
     /// Human readable name
     pub debug_name: String,
     /// Unique ID of the dataflow
-    pub id: GlobalId,
+    pub id: uuid::Uuid,
 }
 
 impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
     /// Creates a new dataflow description with a human-readable name.
-    pub fn new(name: String, id: GlobalId) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             source_imports: Default::default(),
             index_imports: Default::default(),
@@ -157,7 +157,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
             sink_exports: Default::default(),
             as_of: Default::default(),
             debug_name: name,
-            id,
+            id: uuid::Uuid::new_v4(),
         }
     }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -100,21 +100,40 @@ pub struct BuildDesc<P> {
 pub struct SourceInstanceDesc<T = mz_repr::Timestamp> {
     /// A description of the source to construct.
     pub description: crate::types::sources::SourceDesc,
-    /// Optional linear operators that can be applied record-by-record.
-    pub operators: Option<crate::types::LinearOperator>,
-    /// A description of how to persist the source.
-    pub persist: Option<sources::persistence::SourcePersistDesc<T>>,
+    /// Arguments for this instantiation of the source.
+    pub arguments: SourceInstanceArguments<T>,
 }
 
-/// A representation of `SourceInstanceDesc` which elides the source details.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-pub struct SourceInstanceKey<T = mz_repr::Timestamp> {
-    /// The globally unique identifier of the source.
-    pub identifier: GlobalId,
+/// Per-source construction arguments.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SourceInstanceArguments<T = mz_repr::Timestamp> {
     /// Optional linear operators that can be applied record-by-record.
-    pub operators: Option<crate::types::LinearOperator>,
+    pub operators: Option<crate::LinearOperator>,
     /// A description of how to persist the source.
-    pub persist: Option<sources::persistence::SourcePersistDesc<T>>,
+    pub persist: Option<crate::sources::persistence::SourcePersistDesc<T>>,
+}
+
+/// Type alias for source subscriptions, (dataflow_id, source_id).
+pub type SourceInstanceId = (uuid::Uuid, mz_expr::GlobalId);
+
+/// A formed request for source instantiation.
+#[derive(Debug, Clone, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SourceInstanceRequest<T = mz_repr::Timestamp> {
+    /// The source's own identifier.
+    pub source_id: mz_expr::GlobalId,
+    /// A dataflow identifier that should be unique across dataflows.
+    pub dataflow_id: uuid::Uuid,
+    /// Arguments to the source instantiation.
+    pub arguments: SourceInstanceArguments<T>,
+    /// Frontier beyond which updates must be correct.
+    pub as_of: Antichain<T>,
+}
+
+impl<T> SourceInstanceRequest<T> {
+    /// Source identifier uniquely identifing this instantation.
+    pub fn unique_id(&self) -> SourceInstanceId {
+        (self.dataflow_id, self.source_id)
+    }
 }
 
 /// A description of a dataflow to construct and results to surface.
@@ -186,8 +205,10 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
             id,
             SourceInstanceDesc {
                 description,
-                operators: None,
-                persist,
+                arguments: SourceInstanceArguments {
+                    operators: None,
+                    persist,
+                },
             },
         );
     }
@@ -335,17 +356,6 @@ where
         let build = self.build_desc(collection_id);
         for id in build.plan.depends_on() {
             self.depends_on_into(id, out)
-        }
-    }
-}
-
-impl SourceInstanceDesc {
-    /// Converts the description to an instance key.
-    pub fn with_id(&self, identifier: GlobalId) -> SourceInstanceKey {
-        SourceInstanceKey {
-            identifier,
-            operators: self.operators.clone(),
-            persist: self.persist.clone(),
         }
     }
 }

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -27,5 +27,6 @@ pub mod source;
 
 pub use server::{
     boundary::ComputeReplay, boundary::DummyBoundary, boundary::EventLinkBoundary,
-    boundary::StorageCapture, serve, serve_boundary, tcp_boundary, Config, Server,
+    boundary::StorageCapture, serve, serve_boundary, serve_boundary_requests, tcp_boundary, Config,
+    Server,
 };

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -244,6 +244,7 @@ pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
                     region,
                     &format!("{name}-{source_id}"),
                     dataflow.id,
+                    dataflow.as_of.clone().unwrap(),
                 );
 
                 // We do not trust `replay` to correctly advance times.

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -144,7 +144,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
     debug_name: &str,
     as_of: Option<Antichain<mz_repr::Timestamp>>,
     source_imports: BTreeMap<GlobalId, SourceInstanceDesc>,
-    dataflow_id: GlobalId,
+    dataflow_id: uuid::Uuid,
     boundary: &mut B,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -151,8 +151,11 @@ pub(crate) fn import_source<G>(
     as_of_frontier: &timely::progress::Antichain<mz_repr::Timestamp>,
     SourceInstanceDesc {
         description: src,
-        operators: mut linear_operators,
-        persist,
+        arguments:
+            SourceInstanceArguments {
+                operators: mut linear_operators,
+                persist,
+            },
     }: SourceInstanceDesc,
     storage_state: &mut crate::server::StorageState,
     scope: &mut G,

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -111,7 +111,7 @@ pub fn serve_boundary_requests<
     B: Fn(usize) -> (SC, CR) + Send + Sync + 'static,
 >(
     config: Config,
-    requests: tokio::sync::mpsc::UnboundedReceiver<crate::server::boundary::SourceRequest>,
+    requests: tokio::sync::mpsc::UnboundedReceiver<mz_dataflow_types::SourceInstanceRequest>,
     create_boundary: B,
 ) -> Result<(Server, BoundaryHook<LocalClient>), anyhow::Error> {
     let workers = config.workers as u64;

--- a/src/dataflow/src/server.rs
+++ b/src/dataflow/src/server.rs
@@ -111,7 +111,7 @@ pub fn serve_boundary_requests<
     B: Fn(usize) -> (SC, CR) + Send + Sync + 'static,
 >(
     config: Config,
-    requests: tokio::sync::mpsc::UnboundedReceiver<(uuid::Uuid, GlobalId)>,
+    requests: tokio::sync::mpsc::UnboundedReceiver<crate::server::boundary::SourceRequest>,
     create_boundary: B,
 ) -> Result<(Server, BoundaryHook<LocalClient>), anyhow::Error> {
     let workers = config.workers as u64;

--- a/src/dataflow/src/server/boundary.rs
+++ b/src/dataflow/src/server/boundary.rs
@@ -13,7 +13,6 @@ use timely::dataflow::Scope;
 
 use mz_dataflow_types::DataflowError;
 use mz_dataflow_types::SourceInstanceKey;
-use mz_expr::GlobalId;
 use mz_repr::{Diff, Row};
 
 /// A type that can capture a specific source.
@@ -26,7 +25,7 @@ pub trait StorageCapture {
         err: Collection<G, DataflowError, Diff>,
         token: Rc<dyn Any>,
         name: &str,
-        dataflow_id: GlobalId,
+        dataflow_id: uuid::Uuid,
     );
 }
 
@@ -38,7 +37,7 @@ impl<SC: StorageCapture> StorageCapture for Rc<RefCell<SC>> {
         err: Collection<G, DataflowError, Diff>,
         token: Rc<dyn Any>,
         name: &str,
-        dataflow_id: GlobalId,
+        dataflow_id: uuid::Uuid,
     ) {
         self.borrow_mut()
             .capture(id, ok, err, token, name, dataflow_id)
@@ -51,7 +50,7 @@ impl<CR: ComputeReplay> ComputeReplay for Rc<RefCell<CR>> {
         id: SourceInstanceKey,
         scope: &mut G,
         name: &str,
-        dataflow_id: GlobalId,
+        dataflow_id: uuid::Uuid,
     ) -> (
         Collection<G, Row, Diff>,
         Collection<G, DataflowError, Diff>,
@@ -73,7 +72,7 @@ pub trait ComputeReplay {
         id: SourceInstanceKey,
         scope: &mut G,
         name: &str,
-        dataflow_id: GlobalId,
+        dataflow_id: uuid::Uuid,
     ) -> (
         Collection<G, Row, Diff>,
         Collection<G, DataflowError, Diff>,
@@ -90,7 +89,7 @@ impl ComputeReplay for DummyBoundary {
         _id: SourceInstanceKey,
         _scope: &mut G,
         _name: &str,
-        _dataflow_id: GlobalId,
+        _dataflow_id: uuid::Uuid,
     ) -> (
         Collection<G, Row, Diff>,
         Collection<G, DataflowError, Diff>,
@@ -108,7 +107,7 @@ impl StorageCapture for DummyBoundary {
         _err: Collection<G, DataflowError, Diff>,
         _token: Rc<dyn Any>,
         _name: &str,
-        _dataflow_id: GlobalId,
+        _dataflow_id: uuid::Uuid,
     ) {
         panic!("DummyBoundary cannot capture")
     }
@@ -131,7 +130,6 @@ mod event_link {
 
     use mz_dataflow_types::DataflowError;
     use mz_dataflow_types::SourceInstanceKey;
-    use mz_expr::GlobalId;
     use mz_repr::{Diff, Row};
 
     use crate::activator::RcActivator;
@@ -164,7 +162,7 @@ mod event_link {
             err: Collection<G, DataflowError, Diff>,
             token: Rc<dyn Any>,
             name: &str,
-            _dataflow_id: GlobalId,
+            _dataflow_id: uuid::Uuid,
         ) {
             let boundary = SourceBoundary::new(name, token);
 
@@ -191,7 +189,7 @@ mod event_link {
             id: SourceInstanceKey,
             scope: &mut G,
             name: &str,
-            _dataflow_id: GlobalId,
+            _dataflow_id: uuid::Uuid,
         ) -> (
             Collection<G, Row, Diff>,
             Collection<G, DataflowError, Diff>,

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -346,7 +346,7 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
         &mut self,
         dataflows: Vec<(
             String,
-            GlobalId,
+            uuid::Uuid,
             Option<Antichain<Timestamp>>,
             BTreeMap<GlobalId, SourceInstanceDesc>,
         )>,

--- a/src/dataflow/src/server/tcp_boundary.rs
+++ b/src/dataflow/src/server/tcp_boundary.rs
@@ -15,7 +15,7 @@ use mz_dataflow_types::DataflowError;
 use mz_expr::GlobalId;
 
 /// Type alias for source subscriptions, (dataflow_id, source_id).
-pub type SourceId = (GlobalId, GlobalId);
+pub type SourceId = (uuid::Uuid, GlobalId);
 /// Type alias for a source subscription including a source worker.
 pub type SubscriptionId = (SourceId, WorkerIdentifier);
 
@@ -27,7 +27,6 @@ pub mod server {
     use differential_dataflow::Collection;
     use futures::{SinkExt, TryStreamExt};
     use mz_dataflow_types::{DataflowError, SourceInstanceKey};
-    use mz_expr::GlobalId;
     use mz_repr::{Diff, Row, Timestamp};
     use std::any::Any;
     use std::collections::{HashMap, HashSet};
@@ -245,7 +244,7 @@ pub mod server {
             err: Collection<G, DataflowError, Diff>,
             token: Rc<dyn Any>,
             _name: &str,
-            dataflow_id: GlobalId,
+            dataflow_id: uuid::Uuid,
         ) {
             let subscription_id = ((dataflow_id, id.identifier), ok.inner.scope().index());
             let client_token = Arc::new(());
@@ -341,7 +340,6 @@ pub mod client {
     use differential_dataflow::{AsCollection, Collection};
     use futures::{Sink, SinkExt, TryStreamExt};
     use mz_dataflow_types::{DataflowError, SourceInstanceKey};
-    use mz_expr::GlobalId;
     use mz_repr::{Diff, Row, Timestamp};
     use std::any::Any;
     use std::collections::HashMap;
@@ -592,7 +590,7 @@ pub mod client {
             id: SourceInstanceKey,
             scope: &mut G,
             name: &str,
-            dataflow_id: GlobalId,
+            dataflow_id: uuid::Uuid,
         ) -> (
             Collection<G, Row, Diff>,
             Collection<G, DataflowError, Diff>,

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -220,14 +220,14 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) -> Result<(), Transform
     for (source_id, source) in dataflow.source_imports.iter_mut() {
         if let Some(columns) = demand.get(&Id::Global(*source_id)).clone() {
             // Install no-op demand information if none exists.
-            if source.operators.is_none() {
-                source.operators = Some(LinearOperator {
+            if source.arguments.operators.is_none() {
+                source.arguments.operators = Some(LinearOperator {
                     predicates: Vec::new(),
                     projection: (0..source.description.desc.arity()).collect(),
                 })
             }
             // Restrict required columns by those identified as demanded.
-            if let Some(operator) = &mut source.operators {
+            if let Some(operator) = &mut source.arguments.operators {
                 operator.projection.retain(|col| columns.contains(col));
             }
         }
@@ -304,14 +304,14 @@ fn optimize_dataflow_filters(dataflow: &mut DataflowDesc) -> Result<(), Transfor
     for (source_id, source) in dataflow.source_imports.iter_mut() {
         if let Some(list) = predicates.get(&Id::Global(*source_id)).clone() {
             // Install no-op predicate information if none exists.
-            if source.operators.is_none() {
-                source.operators = Some(LinearOperator {
+            if source.arguments.operators.is_none() {
+                source.arguments.operators = Some(LinearOperator {
                     predicates: Vec::new(),
                     projection: (0..source.description.desc.arity()).collect(),
                 })
             }
             // Add any predicates that can be pushed to the source.
-            if let Some(operator) = &mut source.operators {
+            if let Some(operator) = &mut source.arguments.operators {
                 operator.predicates.extend(list.iter().cloned());
                 operator.predicates.sort();
             }


### PR DESCRIPTION
Groundwork for restartable sources. Fundamentally, the stack of PRs makes it so that `ComputeReplay::replay` commands prompt the instantiation of a source to connect to, rather than rely on the `RenderSources` being produced by a third party. This means that e.g. a dataflow could somewhat autonomously restart and get data, without requiring `Controller` intervention.

Independent of the application, I think we eventually do want dataflows to be able to attach to STORAGE without per-dataflow pre-negotiation. At the moment it is complicated because we have to build a new dataflow for each source we want to read, but in the future it should just be "sure; read out of this queue" and STORAGE might be surprised to be pro-actively involved in that.

### Motivation

  * This PR adds a feature that has not yet been specified.

    Dataflow source instantiation previously requires pre-announcement of the intent to STORAGE. This change alters the behavior to track what I believe is the intended architecture, that COMPUTE can connect directly to STORAGE without mediation.

### Tips for reviewer

The commits should each make sense. First some clean-up, then a pile of work, then some more clean-up.

This has not been tested with multiple processes, and we should do that before merging.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
