### PR TITLE
coord: initialize table since to the timeline write ts, not 0

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -487,7 +487,7 @@ impl Coordinator {
                         .load_source_persist_desc(&source)
                         .map_err(CoordError::Persistence)?
                         .map(|p| p.since_ts)
-                        .unwrap_or(0);
+                        .unwrap_or_else(Timestamp::minimum);
 
                     // Re-announce the source description.
                     let source_description = self
@@ -527,7 +527,7 @@ impl Coordinator {
                         .table_details
                         .get(&entry.id())
                         .map(|td| td.since_ts)
-                        .unwrap_or(0);
+                        .unwrap_or_else(|| self.get_local_write_ts());
 
                     // Re-announce the source description.
                     let source_description = self
@@ -2065,7 +2065,7 @@ impl Coordinator {
                     .table_details
                     .get(&table_id)
                     .map(|td| td.since_ts)
-                    .unwrap_or(0);
+                    .unwrap_or_else(|| self.get_local_write_ts());
 
                 // Announce the creation of the table source.
                 let source_description = self
@@ -2181,7 +2181,7 @@ impl Coordinator {
                     .load_source_persist_desc(&source)
                     .map_err(CoordError::Persistence)?
                     .map(|p| p.since_ts)
-                    .unwrap_or(0);
+                    .unwrap_or_else(Timestamp::minimum);
 
                 let ts_bindings = self
                     .catalog

--- a/src/dataflow-types/src/explain.rs
+++ b/src/dataflow-types/src/explain.rs
@@ -256,12 +256,12 @@ pub struct TimestampSource<T> {
 
 impl<T: fmt::Display + fmt::Debug> fmt::Display for TimestampExplanation<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "     timestamp: {}", self.timestamp)?;
+        writeln!(f, "     timestamp: {:13}", self.timestamp)?;
         writeln!(f, "         since:{:13?}", self.since)?;
         writeln!(f, "         upper:{:13?}", self.upper)?;
         writeln!(f, "     has table: {}", self.has_table)?;
         if let Some(ts) = &self.table_read_ts {
-            writeln!(f, " table read ts: {ts}")?;
+            writeln!(f, " table read ts: {:13}", ts)?;
         }
         for source in &self.sources {
             writeln!(f, "")?;

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -223,7 +223,7 @@ db error: ERROR: transaction in read-only mode
 # Using an AS OF in the SELECT or TAIL allows lifting that restriction.
 
 simple
-DECLARE c CURSOR FOR TAIL t AS OF 1;
+DECLARE c CURSOR FOR TAIL t AS OF 18446744073709551615;
 FETCH 0 c;
 DECLARE d CURSOR FOR TAIL t;
 FETCH 0 d;
@@ -234,7 +234,7 @@ COMPLETE 0
 COMPLETE 0
 
 simple
-DECLARE c CURSOR FOR TAIL t AS OF 1;
+DECLARE c CURSOR FOR TAIL t AS OF 18446744073709551615;
 FETCH 0 c;
 SELECT * FROM t LIMIT 0;
 ----
@@ -244,24 +244,26 @@ COMPLETE 0
 
 simple
 SELECT * FROM t LIMIT 0;
-DECLARE c CURSOR FOR TAIL t AS OF 1;
+DECLARE c CURSOR FOR TAIL t AS OF 18446744073709551615;
 FETCH 0 c;
 ----
 COMPLETE 0
 COMPLETE 0
 COMPLETE 0
 
+# Use AS OF now()+'1s' because now() has problems with tables (#11188), so
+# adding a second will probably always work.
 simple
 DECLARE c CURSOR FOR TAIL t;
 FETCH 0 c;
-SELECT * FROM t LIMIT 0 AS OF 1;
+SELECT * FROM t LIMIT 0 AS OF now()+'1s';
 ----
 COMPLETE 0
 COMPLETE 0
 COMPLETE 0
 
 simple
-SELECT * FROM t LIMIT 0 AS OF 1;
+SELECT * FROM t LIMIT 0 AS OF now()+'1s';
 DECLARE c CURSOR FOR TAIL t;
 FETCH 0 c;
 ----


### PR DESCRIPTION
Table sinces were initializing to 0, even though we knew that their first possible data is the global write time. This would only show up on first interaction with a table, which would quickly catch up. But it makes running EXPLAIN TIMESTAMP on new tables make more sense.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user-facing changes.