### PR TITLE
coord: rename dataflow_client to dataflow_controller

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -63,7 +63,7 @@ impl Coordinator {
         &self,
         instance: ComputeInstanceId,
     ) -> DataflowBuilder<mz_repr::Timestamp> {
-        let compute = self.dataflow_client.compute(instance).unwrap();
+        let compute = self.dataflow_controller.compute(instance).unwrap();
         DataflowBuilder {
             catalog: self.catalog.state(),
             persister: &self.persister,
@@ -78,7 +78,7 @@ impl CatalogTxn<'_, mz_repr::Timestamp> {
         &self,
         instance: ComputeInstanceId,
     ) -> DataflowBuilder<mz_repr::Timestamp> {
-        let compute = self.dataflow_client.compute(instance).unwrap();
+        let compute = self.dataflow_controller.compute(instance).unwrap();
         DataflowBuilder {
             catalog: self.catalog,
             persister: &self.persister,

--- a/src/coord/src/coord/indexes.rs
+++ b/src/coord/src/coord/indexes.rs
@@ -35,7 +35,7 @@ impl Coordinator {
     ) -> ComputeInstanceIndexOracle<mz_repr::Timestamp> {
         ComputeInstanceIndexOracle {
             catalog: self.catalog.state(),
-            compute: self.dataflow_client.compute(instance).unwrap(),
+            compute: self.dataflow_controller.compute(instance).unwrap(),
         }
     }
 }


### PR DESCRIPTION
The controller *contains* a client, which is responsible for the
lower-level details of transporting requests to the dataflow servers.
But the coordinator was calling the controller the client, which was
awfully confusing.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


   * This PR refactors existing code to use more consistent naming.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
