### PR TITLE
doc/user: make COPY button consistent with docs style

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -717,10 +717,12 @@ td > .default_button {
     position: absolute;
     top: 10px;
     right: 10px;
-    font-family: "Inter", sans-serif;
-    line-height: 1.75;
+    font-family: 'Encode Sans Expanded';
+    font-size: 0.8rem;
+    line-height: 2;
     &.success {
-        background: $lime;
+        opacity:0.8;
+        background: #70F2A3;
     }
 }
 


### PR DESCRIPTION
Small adjustments to the recently added copy button (#11305 🎉) to make it blend in a bit better into the docs style:

<img width="794" alt="Screenshot 2022-03-19 at 18 21 02" src="https://user-images.githubusercontent.com/23521087/159131529-21699f34-fc63-4430-981a-0cef06f24af7.png">

Noticed that we have a couple of code blocks that include results, which can be annoying when copying code. Should we give a pass to separate these from the core commands or can we live with it, @ruf-io? I can take care of it, can use some mindless work as I ease back into it.