### PR TITLE
dataflow-types: avoid unsafe stream generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3180,6 +3180,7 @@ name = "mz-dataflow-types"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-smithy-http",
@@ -3215,6 +3216,7 @@ dependencies = [
  "serde_regex",
  "timely",
  "tokio",
+ "tokio-stream",
  "tracing",
  "url",
  "uuid",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.55"
+async-stream = "0.3.3"
 async-trait = "0.1.52"
 aws-config = { version = "0.8.0", default-features = false, features = ["native-tls"] }
 aws-smithy-http = "0.38.0"
@@ -42,6 +43,7 @@ serde_json = "1.0.79"
 serde_regex = "1.1.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.17.0"
+tokio-stream = " 0.1.8"
 tracing = "0.1.32"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }


### PR DESCRIPTION
As spotted by @petrosagg in #11223, the `SelectStream` incorrectly
converts `Client`s to `Stream`s by constructing new futures on every
call to `poll_next`. The code happens to work with the current stack of
futures/streams, but might break at any point in the future.

The solution here involves many allocations on each call to `recv()`
but avoids the defect. If these allocations become a performance
problem, we can look into a more invasive refactor like #11314.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported by @petrosagg leaving a TODO comment in #11314.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
