### PR TITLE
doc/user: use long form for `materialized` commands

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -261,7 +261,7 @@ The following example demonstrates how to configure a server in `verify-full`
 mode:
 
 ```shell
-$ materialized -w1 --tls-cert=server.crt --tls-key=server.key --tls-ca=root.crt
+$ materialized --workers 1 --tls-cert=server.crt --tls-key=server.key --tls-ca=root.crt
 ```
 
 Materialize statically links against a vendored copy of [OpenSSL]. It does *not*

--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -28,15 +28,15 @@ Select an environment and follow the instructions to get the latest stable relea
     docker run -p 6875:6875 materialize/materialized:{{< version >}} --workers 1
     ```
 
-    This starts a process using one [worker thread]({{< ref "cli#worker-threads" >}}) and listening on port 6875 by default.
+    This starts a process using one [worker thread](/cli#worker-threads) and listening on port 6875 by default.
 
-1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI]({{< ref "connect/cli" >}}), like `psql` or `mzcli`. If you already have `psql` installed on your machine, connect using:
+1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI](/connect/cli), like `psql` or `mzcli`. If you already have `psql` installed on your machine, connect using:
 
     ```shell
     psql -U materialize -h localhost -p 6875 materialize
     ```
 
-    Otherwise, you can find the steps to install and use your CLI of choice under [Install]({{< ref "install#cli-connections" >}}).
+    Otherwise, you can find the steps to install and use your CLI of choice under [Install](/install#cli-connections).
 
 {{< /tab >}}
 {{< tab "macOS">}}
@@ -47,7 +47,7 @@ Select an environment and follow the instructions to get the latest stable relea
     brew install MaterializeInc/materialize/materialized
     ```
 
-    **Note:** For a `curl`-based alternative, see [Install]({{< ref "install#curl" >}}).
+    **Note:** For a `curl`-based alternative, see [Install](/install#curl).
 
 1. Once the installation is complete, you can start the `materialized` process:
 
@@ -55,15 +55,15 @@ Select an environment and follow the instructions to get the latest stable relea
     materialized --workers 1
     ```
 
-    This starts a process using one [worker thread]({{< ref "cli#worker-threads" >}}) and listening on port 6875 by default.
+    This starts a process using one [worker thread](/cli#worker-threads) and listening on port 6875 by default.
 
-1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI]({{< ref "connect/cli" >}}), like `psql` or `mzcli`. If you have `psql` installed on your machine, connect using:
+1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI](/connect/cli), like `psql` or `mzcli`. If you have `psql` installed on your machine, connect using:
 
     ```shell
     psql -U materialize -h localhost -p 6875 materialize
     ```
 
-    Otherwise, you can find the steps to install and use your CLI of choice under [Install]({{< ref "install#cli-connections" >}}).
+    Otherwise, you can find the steps to install and use your CLI of choice under [Install](/install#cli-connections).
 
 {{< /tab >}}
 
@@ -81,7 +81,7 @@ Select an environment and follow the instructions to get the latest stable relea
     apt install materialized
     ```
 
-    **Note:** For a `curl`-based alternative, see [Install]({{< ref "install#curl-1" >}}).
+    **Note:** For a `curl`-based alternative, see [Install](/install#curl-1).
 
 1. Once the installation is complete, you can start the `materialized` process:
 
@@ -89,15 +89,15 @@ Select an environment and follow the instructions to get the latest stable relea
     materialized --workers 1
     ```
 
-    This starts a process using one [worker thread]({{< ref "cli#worker-threads" >}}) and listening on port 6875 by default.
+    This starts a process using one [worker thread](/cli#worker-threads) and listening on port 6875 by default.
 
-1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI]({{< ref "connect/cli" >}}), like `psql` or `mzcli`. If you have `psql` installed on your machine, connect using:
+1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI](/connect/cli), like `psql` or `mzcli`. If you have `psql` installed on your machine, connect using:
 
     ```shell
     psql -U materialize -h localhost -p 6875 materialize
     ```
 
-    Otherwise, you can find the steps to install and use your CLI of choice under [Install]({{< ref "install#cli-connections" >}}).
+    Otherwise, you can find the steps to install and use your CLI of choice under [Install](/install#cli-connections).
 
 {{< /tab >}}
 

--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -52,7 +52,7 @@ Select an environment and follow the instructions to get the latest stable relea
 1. Once the installation is complete, you can start the `materialized` process:
 
     ```shell
-    materialized -w 1
+    materialized --workers 1
     ```
 
     This starts a process using one [worker thread]({{< ref "cli#worker-threads" >}}) and listening on port 6875 by default.
@@ -86,7 +86,7 @@ Select an environment and follow the instructions to get the latest stable relea
 1. Once the installation is complete, you can start the `materialized` process:
 
     ```shell
-    materialized -w 1
+    materialized --workers 1
     ```
 
     This starts a process using one [worker thread]({{< ref "cli#worker-threads" >}}) and listening on port 6875 by default.

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -1,6 +1,6 @@
 ---
 title: "Install"
-description: "Get started with Materialize"
+description: "Install the Materialize binary"
 menu: "main"
 weight: 2
 ---
@@ -54,8 +54,11 @@ curl -L https://binaries.materialize.com/materialized-{{< version >}}-$(uname -m
 
 ### apt (Ubuntu, Debian, or variants)
 
-**Note!** These instructions changed between versions 0.8.0 and 0.8.1. If you ran them
+{{< note >}}
+These instructions changed between versions 0.8.0 and 0.8.1. If you ran them
 previously, you may need to do so again to continue receiving updates.
+{{</ note >}}
+
 
 ```shell
 # Add the signing key for the Materialize apt repository
@@ -77,8 +80,7 @@ curl -L https://binaries.materialize.com/materialized-{{< version >}}-$(uname -m
 ## Build from source
 
 Materialize is written primarily in Rust, but incorporates several components
-written in C. To build Materialize, you will need to acquire the following
-tools:
+written in C. To build Materialize, you will need the following tools:
 
   * A recent version of Git
 
@@ -118,10 +120,10 @@ cargo build --release
 You can start the `materialized` process by simply running the binary, e.g.
 
 ```nofmt
-./materialized -w 1
+./materialized --workers 1
 ```
 
-`-w 1` specifies that the process will use 1 worker. You can also find more detail
+`--workers 1` specifies that the process will use 1 worker. You can also find more detail
 about our [command line flags](/cli/#command-line-flags).
 
 By default `materialized` uses:


### PR DESCRIPTION
Fixes #11215.

Also patches the special `ref` syntax for links inside tabs, which is no longer needed since #10943 landed.
