### PR TITLE
Allow `GenericClient::recv` to produce errors; reset TCP connections

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -705,7 +705,12 @@ impl Coordinator {
                 biased;
 
                 Some(m) = internal_cmd_rx.recv() => m,
-                Some(m) = self.dataflow_client.recv() => Message::Worker(m),
+                m = self.dataflow_client.recv() => {
+                    match m.unwrap() {
+                        None => break,
+                        Some(r) => Message::Worker(r),
+                    }
+                },
                 Some(m) = metric_scraper_stream.next() => m,
                 m = cmd_rx.recv() => match m {
                     None => break,

--- a/src/dataflow/src/server/boundary.rs
+++ b/src/dataflow/src/server/boundary.rs
@@ -201,7 +201,7 @@ mod boundary_hook {
             }
             Ok(())
         }
-        async fn recv(&mut self) -> Option<Response<T>> {
+        async fn recv(&mut self) -> Result<Option<Response<T>>, anyhow::Error> {
             // The receive logic draws from either the responses of the client, or requests for source instantiation.
             let mut response = None;
             while response.is_none() {
@@ -234,11 +234,11 @@ mod boundary_hook {
                         },
                     },
                     resp = self.client.recv() => {
-                        response = resp;
+                        response = resp?;
                     }
                 }
             }
-            response
+            Ok(response)
         }
     }
 }

--- a/src/dataflowd/src/bin/dataflowd.rs
+++ b/src/dataflowd/src/bin/dataflowd.rs
@@ -239,9 +239,14 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         select! {
             cmd = conn.try_next() => match cmd? {
                 None => break,
-                Some(cmd) => client.send(cmd).await.unwrap(),
+                Some(cmd) => { client.send(cmd).await.unwrap(); },
             },
-            Some(response) = client.recv() => conn.send(response).await?,
+            res = client.recv() => {
+                match res.unwrap() {
+                    None => break,
+                    Some(response) => { conn.send(response).await?; }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The `recv` method use to either produce nothing or a `Response`. In addition, the result could be an error, e.g. corresponding to a TCP connection reset. Propagate this information upwards.

In addition, the actual motivation here was to support TCP reconnections, while still communicating the connection reset. So, in addition, reconnect TCP connections. The behavior is intended to be as it was before, where such a reconnection results in an error, as the ultimate consumer of the client still doesn't know what to do with such an error.

### Motivation

  * This PR adds a feature that has not yet been specified.

Various `Client` implementations may experience non-fatal errors that can be recovered by restarting the connection. Rather than have the implementations panic, have them communicate upwards that they experienced such an error.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
