### PR TITLE
coord,sql: untangle cluster logging

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -97,8 +97,6 @@ pub struct BuiltinView {
     pub schema: &'static str,
     pub sql: &'static str,
     pub id: GlobalId,
-    // TODO(benesch): auto-derive the needs_logs property.
-    pub needs_logs: bool,
 }
 
 pub struct BuiltinType {
@@ -1262,7 +1260,6 @@ pub const MZ_RELATIONS: BuiltinView = BuiltinView {
 UNION SELECT id, oid, schema_id, name, 'source' FROM mz_catalog.mz_sources
 UNION SELECT id, oid, schema_id, name, 'view' FROM mz_catalog.mz_views",
     id: GlobalId::System(5000),
-    needs_logs: false,
 };
 
 pub const MZ_OBJECTS: BuiltinView = BuiltinView {
@@ -1277,7 +1274,6 @@ UNION
     FROM mz_catalog.mz_indexes
     JOIN mz_catalog.mz_relations ON mz_indexes.on_id = mz_relations.id",
     id: GlobalId::System(5001),
-    needs_logs: false,
 };
 
 // For historical reasons, this view does not properly escape identifiers. For
@@ -1300,7 +1296,6 @@ FROM mz_catalog.mz_objects o
 JOIN mz_catalog.mz_schemas s ON s.id = o.schema_id
 LEFT JOIN mz_catalog.mz_databases d ON d.id = s.database_id",
     id: GlobalId::System(5002),
-    needs_logs: false,
 };
 
 pub const MZ_DATAFLOW_NAMES: BuiltinView = BuiltinView {
@@ -1319,7 +1314,6 @@ WHERE
     mz_dataflow_operator_addresses.worker = mz_dataflow_operators.worker AND
     mz_catalog.list_length(mz_dataflow_operator_addresses.address) = 1",
     id: GlobalId::System(5003),
-    needs_logs: true,
 };
 
 pub const MZ_DATAFLOW_OPERATOR_DATAFLOWS: BuiltinView = BuiltinView {
@@ -1341,7 +1335,6 @@ WHERE
     mz_dataflow_names.local_id = mz_dataflow_operator_addresses.address[1] AND
     mz_dataflow_names.worker = mz_dataflow_operator_addresses.worker",
     id: GlobalId::System(5004),
-    needs_logs: true,
 };
 
 pub const MZ_MATERIALIZATION_FRONTIERS: BuiltinView = BuiltinView {
@@ -1352,7 +1345,6 @@ pub const MZ_MATERIALIZATION_FRONTIERS: BuiltinView = BuiltinView {
 FROM mz_catalog.mz_worker_materialization_frontiers
 GROUP BY global_id",
     id: GlobalId::System(5005),
-    needs_logs: true,
 };
 
 pub const MZ_RECORDS_PER_DATAFLOW_OPERATOR: BuiltinView = BuiltinView {
@@ -1382,7 +1374,6 @@ WHERE
     mz_dataflow_operator_dataflows.id = records_cte.operator AND
     mz_dataflow_operator_dataflows.worker = records_cte.worker",
     id: GlobalId::System(5006),
-    needs_logs: true,
 };
 
 pub const MZ_RECORDS_PER_DATAFLOW: BuiltinView = BuiltinView {
@@ -1404,7 +1395,6 @@ GROUP BY
     mz_dataflow_names.name,
     mz_records_per_dataflow_operator.worker",
     id: GlobalId::System(5007),
-    needs_logs: true,
 };
 
 pub const MZ_RECORDS_PER_DATAFLOW_GLOBAL: BuiltinView = BuiltinView {
@@ -1420,7 +1410,6 @@ GROUP BY
     mz_records_per_dataflow.id,
     mz_records_per_dataflow.name",
     id: GlobalId::System(5008),
-    needs_logs: true,
 };
 
 pub const MZ_PERF_ARRANGEMENT_RECORDS: BuiltinView = BuiltinView {
@@ -1442,7 +1431,6 @@ FROM
     records_cte mas LEFT JOIN mz_catalog.mz_dataflow_operators mdo
         ON mdo.id = mas.operator AND mdo.worker = mas.worker",
     id: GlobalId::System(5009),
-    needs_logs: true,
 };
 
 pub const MZ_PERF_PEEK_DURATIONS_CORE: BuiltinView = BuiltinView {
@@ -1460,7 +1448,6 @@ WHERE
     d_upper.duration_ns >= d_summed.duration_ns
 GROUP BY d_upper.worker, d_upper.duration_ns",
     id: GlobalId::System(5010),
-    needs_logs: true,
 };
 
 pub const MZ_PERF_PEEK_DURATIONS_BUCKET: BuiltinView = BuiltinView {
@@ -1474,7 +1461,6 @@ pub const MZ_PERF_PEEK_DURATIONS_BUCKET: BuiltinView = BuiltinView {
     GROUP BY worker
 )",
     id: GlobalId::System(5011),
-    needs_logs: true,
 };
 
 pub const MZ_PERF_PEEK_DURATIONS_AGGREGATES: BuiltinView = BuiltinView {
@@ -1484,7 +1470,6 @@ pub const MZ_PERF_PEEK_DURATIONS_AGGREGATES: BuiltinView = BuiltinView {
 FROM mz_catalog.mz_peek_durations lpd
 GROUP BY worker",
     id: GlobalId::System(5012),
-    needs_logs: true,
 };
 
 pub const MZ_PERF_DEPENDENCY_FRONTIERS: BuiltinView = BuiltinView {
@@ -1510,7 +1495,6 @@ JOIN mz_catalog.mz_materialization_frontiers frontier_df ON index_deps.dataflow 
 JOIN mz_catalog.mz_catalog_names mcn ON mcn.global_id = index_deps.dataflow
 JOIN mz_catalog.mz_catalog_names mcn_source ON mcn_source.global_id = source_info.source_id",
     id: GlobalId::System(5013),
-    needs_logs: true,
 };
 
 pub const PG_NAMESPACE: BuiltinView = BuiltinView {
@@ -1523,7 +1507,6 @@ NULL::pg_catalog.oid AS nspowner,
 NULL::pg_catalog.text[] AS nspacl
 FROM mz_catalog.mz_schemas",
     id: GlobalId::System(5014),
-    needs_logs: false,
 };
 
 pub const PG_CLASS: BuiltinView = BuiltinView {
@@ -1572,7 +1555,6 @@ pub const PG_CLASS: BuiltinView = BuiltinView {
 FROM mz_catalog.mz_objects
 JOIN mz_catalog.mz_schemas ON mz_schemas.id = mz_objects.schema_id",
     id: GlobalId::System(5015),
-    needs_logs: false,
 };
 
 pub const PG_DATABASE: BuiltinView = BuiltinView {
@@ -1588,7 +1570,6 @@ pub const PG_DATABASE: BuiltinView = BuiltinView {
     NULL::pg_catalog.text[] as datacl
 FROM mz_catalog.mz_databases",
     id: GlobalId::System(5016),
-    needs_logs: false,
 };
 
 pub const PG_INDEX: BuiltinView = BuiltinView {
@@ -1622,7 +1603,6 @@ JOIN mz_catalog.mz_objects ON mz_indexes.on_id = mz_objects.id
 JOIN mz_catalog.mz_index_columns ON mz_index_columns.index_id = mz_indexes.id
 GROUP BY mz_indexes.oid, mz_objects.oid",
     id: GlobalId::System(5017),
-    needs_logs: false,
 };
 
 pub const PG_DESCRIPTION: BuiltinView = BuiltinView {
@@ -1635,7 +1615,6 @@ pub const PG_DESCRIPTION: BuiltinView = BuiltinView {
     NULL::pg_catalog.text as description
 FROM pg_catalog.pg_class",
     id: GlobalId::System(5018),
-    needs_logs: false,
 };
 
 pub const PG_TYPE: BuiltinView = BuiltinView {
@@ -1686,7 +1665,6 @@ FROM
         )
             AS t ON mz_types.id = t.type_id",
     id: GlobalId::System(5019),
-    needs_logs: false,
 };
 
 pub const PG_ATTRIBUTE: BuiltinView = BuiltinView {
@@ -1713,7 +1691,6 @@ JOIN pg_catalog.pg_type ON pg_type.oid = mz_columns.type_oid",
     // Since this depends on pg_type, its id must be higher due to initialization
     // ordering.
     id: GlobalId::System(5020),
-    needs_logs: false,
 };
 
 pub const PG_PROC: BuiltinView = BuiltinView {
@@ -1727,7 +1704,6 @@ pub const PG_PROC: BuiltinView = BuiltinView {
 FROM mz_catalog.mz_functions
 JOIN mz_catalog.mz_schemas ON mz_functions.schema_id = mz_schemas.id",
     id: GlobalId::System(5021),
-    needs_logs: false,
 };
 
 pub const PG_RANGE: BuiltinView = BuiltinView {
@@ -1738,7 +1714,6 @@ pub const PG_RANGE: BuiltinView = BuiltinView {
     NULL::pg_catalog.oid AS rngsubtype
     WHERE false",
     id: GlobalId::System(5022),
-    needs_logs: false,
 };
 
 pub const PG_ENUM: BuiltinView = BuiltinView {
@@ -1751,7 +1726,6 @@ pub const PG_ENUM: BuiltinView = BuiltinView {
     NULL::pg_catalog.text AS enumlabel
     WHERE false",
     id: GlobalId::System(5023),
-    needs_logs: false,
 };
 
 pub const PG_ATTRDEF: BuiltinView = BuiltinView {
@@ -1769,7 +1743,6 @@ FROM
 WHERE
     default IS NOT NULL",
     id: GlobalId::System(5025),
-    needs_logs: false,
 };
 
 pub const PG_SETTINGS: BuiltinView = BuiltinView {
@@ -1781,7 +1754,6 @@ FROM (VALUES
     ('max_index_keys'::pg_catalog.text, '1000'::pg_catalog.text)
 ) AS _ (name, setting)",
     id: GlobalId::System(5026),
-    needs_logs: false,
 };
 
 pub const MZ_SCHEDULING_ELAPSED: BuiltinView = BuiltinView {
@@ -1794,7 +1766,6 @@ FROM
 GROUP BY
     id, worker",
     id: GlobalId::System(5027),
-    needs_logs: true,
 };
 
 pub const MZ_SCHEDULING_HISTOGRAM: BuiltinView = BuiltinView {
@@ -1807,7 +1778,6 @@ FROM
 GROUP BY
     id, worker, duration_ns",
     id: GlobalId::System(5028),
-    needs_logs: true,
 };
 
 pub const MZ_SCHEDULING_PARKS: BuiltinView = BuiltinView {
@@ -1820,7 +1790,6 @@ FROM
 GROUP BY
     worker, slept_for, requested",
     id: GlobalId::System(5029),
-    needs_logs: true,
 };
 
 pub const MZ_MESSAGE_COUNTS: BuiltinView = BuiltinView {
@@ -1857,7 +1826,6 @@ SELECT
     received_cte.received
 FROM sent_cte JOIN received_cte USING (channel, source_worker, target_worker)",
     id: GlobalId::System(5030),
-    needs_logs: true,
 };
 
 pub const MZ_DATAFLOW_OPERATOR_REACHABILITY: BuiltinView = BuiltinView {
@@ -1874,7 +1842,6 @@ FROM
     mz_catalog.mz_dataflow_operator_reachability_internal
 GROUP BY address, port, worker, update_type, timestamp",
     id: GlobalId::System(5031),
-    needs_logs: true,
 };
 
 pub const MZ_ARRANGEMENT_SIZES: BuiltinView = BuiltinView {
@@ -1908,7 +1875,6 @@ SELECT
     batches_cte.batches
 FROM batches_cte JOIN records_cte USING (operator, worker)",
     id: GlobalId::System(5032),
-    needs_logs: true,
 };
 
 pub const MZ_ARRANGEMENT_SHARING: BuiltinView = BuiltinView {
@@ -1922,7 +1888,6 @@ SELECT
 FROM mz_catalog.mz_arrangement_sharing_internal
 GROUP BY operator, worker",
     id: GlobalId::System(5033),
-    needs_logs: true,
 };
 
 // NOTE: If you add real data to this implementation, then please update
@@ -1958,7 +1923,6 @@ pub const PG_CONSTRAINT: BuiltinView = BuiltinView {
     NULL::pg_catalog.text as conbin
     WHERE false",
     id: GlobalId::System(5034),
-    needs_logs: false,
 };
 
 pub const PG_TABLES: BuiltinView = BuiltinView {
@@ -1972,7 +1936,6 @@ FROM pg_catalog.pg_class c
 LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
 WHERE c.relkind = ANY (ARRAY['r','p'])",
     id: GlobalId::System(5035),
-    needs_logs: false,
 };
 
 pub const PG_ACCESS_METHODS: BuiltinView = BuiltinView {
@@ -1985,7 +1948,6 @@ SELECT NULL::pg_catalog.oid AS oid,
     NULL::pg_catalog.\"char\" AS amtype
 WHERE false",
     id: GlobalId::System(5036),
-    needs_logs: false,
 };
 
 pub const PG_ROLES: BuiltinView = BuiltinView {
@@ -1997,7 +1959,6 @@ pub const PG_ROLES: BuiltinView = BuiltinView {
     oid AS oid
 FROM mz_catalog.mz_roles",
     id: GlobalId::System(5037),
-    needs_logs: false,
 };
 
 pub const PG_VIEWS: BuiltinView = BuiltinView {
@@ -2011,7 +1972,6 @@ FROM mz_catalog.mz_views v
 LEFT JOIN mz_catalog.mz_schemas s ON s.id = v.schema_id
 LEFT JOIN mz_catalog.mz_databases d ON d.id = s.database_id",
     id: GlobalId::System(5038),
-    needs_logs: false,
 };
 
 pub const INFORMATION_SCHEMA_COLUMNS: BuiltinView = BuiltinView {
@@ -2033,7 +1993,6 @@ JOIN mz_catalog.mz_objects o ON o.id = c.id
 JOIN mz_catalog.mz_schemas s ON s.id = o.schema_id
 JOIN mz_catalog.mz_databases d on s.database_id = d.id",
     id: GlobalId::System(5039),
-    needs_logs: false,
 };
 
 pub const INFORMATION_SCHEMA_TABLES: BuiltinView = BuiltinView {
@@ -2051,7 +2010,6 @@ FROM mz_catalog.mz_relations r
 JOIN mz_catalog.mz_schemas s ON s.id = r.schema_id
 JOIN mz_catalog.mz_databases d on s.database_id = d.id",
     id: GlobalId::System(5040),
-    needs_logs: false,
 };
 
 // MZ doesn't support COLLATE so the table is filled with NULLs and made empty. pg_database hard
@@ -2073,7 +2031,6 @@ AS SELECT
     NULL::pg_catalog.text AS collversion
 WHERE false",
     id: GlobalId::System(5041),
-    needs_logs: false,
 };
 
 // MZ doesn't support row level security policies so the table is filled in with NULLs and made empty.
@@ -2092,7 +2049,6 @@ AS SELECT
     NULL::pg_catalog.text AS polwithcheck
 WHERE false",
     id: GlobalId::System(5042),
-    needs_logs: false,
 };
 
 // MZ doesn't support table inheritance so the table is filled in with NULLs and made empty.
@@ -2107,7 +2063,6 @@ AS SELECT
     NULL::pg_catalog.bool AS inhdetachpending
 WHERE false",
     id: GlobalId::System(5043),
-    needs_logs: false,
 };
 
 // Next id BuiltinView: 5044

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -97,7 +97,7 @@ impl CatalogState {
         name: &str,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        let compute_instance_id = &self.compute_instance_names[name];
+        let compute_instance_id = &self.compute_instances_by_name[name];
         BuiltinTableUpdate {
             id: MZ_CLUSTERS.id,
             row: Row::pack_slice(&[Datum::Int64(*compute_instance_id), Datum::String(&name)]),

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use mz_build_info::BuildInfo;
 use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
+use mz_sql::plan::ComputeInstanceIntrospectionConfig;
 
 use crate::catalog::storage;
 use crate::persistcfg::PersisterWithConfig;
@@ -25,9 +26,8 @@ pub struct Config<'a> {
     pub experimental_mode: Option<bool>,
     /// Whether to enable safe mode.
     pub safe_mode: bool,
-    /// Whether to enable logging sources and the views that depend upon them
-    /// for the default cluster.
-    pub default_compute_instance_logging: Option<LoggingConfig>,
+    /// Whether to enable introspection for the virtual compute host.
+    pub virtual_compute_host_introspection: Option<ComputeInstanceIntrospectionConfig>,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// An [External ID][] to use for all AWS AssumeRole operations.
@@ -46,13 +46,4 @@ pub struct Config<'a> {
     pub disable_user_indexes: bool,
     /// A runtime for the `persist` crate alongside its configuration.
     pub persister: &'a PersisterWithConfig,
-}
-
-/// Configuration of logging for a compute instance.
-#[derive(Debug)]
-pub struct LoggingConfig {
-    /// The interval at which to update logging sources.
-    pub granularity: Duration,
-    // Whether to report logs for the log-processing dataflows.
-    pub log_logging: bool,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -126,15 +126,14 @@ use mz_sql::catalog::{
 use mz_sql::names::{DatabaseSpecifier, FullName};
 use mz_sql::plan::{
     AlterIndexEnablePlan, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan,
-    AlterItemRenamePlan, CreateComputeInstancePlan, CreateDatabasePlan, CreateIndexPlan,
-    CreateRolePlan, CreateSchemaPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan,
-    CreateTypePlan, CreateViewPlan, CreateViewsPlan, DropComputeInstancesPlan, DropDatabasePlan,
-    DropItemsPlan, DropRolesPlan, DropSchemaPlan, ExecutePlan, ExplainPlan, FetchPlan,
-    HirRelationExpr, IndexOption, IndexOptionName, InsertPlan, MutationKind, Params, PeekPlan,
-    Plan, QueryWhen, RaisePlan, ReadThenWritePlan, SendDiffsPlan, SetVariablePlan,
-    ShowVariablePlan, TailFrom, TailPlan,
+    AlterItemRenamePlan, ComputeInstanceIntrospectionConfig, CreateComputeInstancePlan,
+    CreateDatabasePlan, CreateIndexPlan, CreateRolePlan, CreateSchemaPlan, CreateSinkPlan,
+    CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, CreateViewsPlan,
+    DropComputeInstancesPlan, DropDatabasePlan, DropItemsPlan, DropRolesPlan, DropSchemaPlan,
+    ExecutePlan, ExplainPlan, FetchPlan, HirRelationExpr, IndexOption, IndexOptionName, InsertPlan,
+    MutationKind, OptimizerConfig, Params, PeekPlan, Plan, QueryWhen, RaisePlan, ReadThenWritePlan,
+    SendDiffsPlan, SetVariablePlan, ShowVariablePlan, StatementDesc, TailFrom, TailPlan, View,
 };
-use mz_sql::plan::{OptimizerConfig, StatementDesc, View};
 use mz_sql_parser::ast::RawName;
 use mz_transform::Optimizer;
 
@@ -461,11 +460,7 @@ impl Coordinator {
     ) -> Result<(), CoordError> {
         for instance in self.catalog.compute_instances() {
             self.dataflow_client
-                .create_instance(
-                    instance.id,
-                    instance.config.clone(),
-                    instance.logging.clone(),
-                )
+                .create_instance(instance.id, instance.config.clone())
                 .await
                 .unwrap();
         }
@@ -1997,13 +1992,12 @@ impl Coordinator {
         let r = self.catalog_transact(vec![op], |_| Ok(())).await;
         match r {
             Ok(()) => {
-                let id = self
+                let instance = self
                     .catalog
                     .resolve_compute_instance(&plan.name)
-                    .expect("compute instance must exist after creation")
-                    .id;
+                    .expect("compute instance must exist after creation");
                 self.dataflow_client
-                    .create_instance(id, plan.config, None)
+                    .create_instance(instance.id, instance.config.clone())
                     .await
                     .unwrap();
                 Ok(ExecuteResponse::CreatedComputeInstance { existed: false })
@@ -4632,9 +4626,11 @@ pub async fn serve(
         storage,
         experimental_mode: Some(experimental_mode),
         safe_mode,
-        default_compute_instance_logging: logging.as_ref().map(|logging| catalog::LoggingConfig {
-            granularity: logging.granularity,
-            log_logging: logging.log_logging,
+        virtual_compute_host_introspection: logging.as_ref().map(|logging| {
+            ComputeInstanceIntrospectionConfig {
+                granularity: logging.granularity,
+                debugging: logging.log_logging,
+            }
         }),
         build_info,
         aws_external_id,

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -64,9 +64,17 @@ pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 1;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum InstanceConfig {
     /// In-process virtual instance, likely the default instance
-    Virtual,
+    Virtual {
+        /// Logging configuration.
+        logging: Option<LoggingConfig>,
+    },
     /// Out-of-process named instance
-    Remote(Vec<String>),
+    Remote {
+        /// The hosts to connect to.
+        hosts: Vec<String>,
+        /// Logging configuration.
+        logging: Option<LoggingConfig>,
+    },
 }
 
 /// Commands related to the computation and maintenance of views.

--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -49,8 +49,8 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
         client.batch_execute("CREATE VIEW d.s.v AS SELECT 1")?;
     }
 
-    {
-        let server = util::start_server(config.clone())?;
+    for config in [config.clone(), config.logging_granularity(None)] {
+        let server = util::start_server(config)?;
         let mut client = server.connect(postgres::NoTls)?;
         assert_eq!(
             client
@@ -94,13 +94,6 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
                 .collect::<Vec<String>>(),
             vec!["u1", "u2", "u3", "u4", "u5", "u6"]
         );
-    }
-
-    {
-        let config = config.logging_granularity(None);
-        if util::start_server(config).is_ok() {
-            panic!("server unexpectedly booted with corrupted catalog")
-        };
     }
 
     Ok(())

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -869,10 +869,14 @@ impl_display!(CreateClusterStatement);
 pub enum ClusterOption {
     /// The `VIRTUAL` option.
     Virtual,
-    /// The `REMOTE` option.
-    Remote(Vec<String>),
-    /// The `SIZE [[=] 'size']` option.
-    Size(String),
+    /// The `REMOTE (<host> [, <host> ...])` option.
+    Remote(Vec<WithOptionValue>),
+    /// The `SIZE [[=] <size>]` option.
+    Size(WithOptionValue),
+    /// The `INTROSPECTION GRANULARITY [[=] <interval>] option.
+    IntrospectionGranularity(WithOptionValue),
+    /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
+    IntrospectionDebugging(WithOptionValue),
 }
 
 impl AstDisplay for ClusterOption {
@@ -880,20 +884,21 @@ impl AstDisplay for ClusterOption {
         match self {
             ClusterOption::Virtual => f.write_str("VIRTUAL"),
             ClusterOption::Remote(hosts) => {
-                f.write_str("REMOTE ");
-                for (i, host) in hosts.iter().enumerate() {
-                    if i > 0 {
-                        f.write_str(", ");
-                    }
-                    f.write_str("'");
-                    f.write_node(&display::escape_single_quote_string(host));
-                    f.write_str("'");
-                }
+                f.write_str("REMOTE (");
+                display::comma_separated(hosts);
+                f.write_str(")");
             }
             ClusterOption::Size(size) => {
-                f.write_str("SIZE '");
-                f.write_node(&display::escape_single_quote_string(size));
-                f.write_str("'");
+                f.write_str("SIZE ");
+                f.write_node(size);
+            }
+            ClusterOption::IntrospectionGranularity(granularity) => {
+                f.write_str("INTROSPECTION GRANULARITY ");
+                f.write_node(granularity);
+            }
+            ClusterOption::IntrospectionDebugging(debugging) => {
+                f.write_str("INTROSPECTION DEBUGGING ");
+                f.write_node(debugging);
             }
         }
     }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -80,6 +80,7 @@ Days
 Deallocate
 Debezium
 Debug
+Debugging
 Dec
 Decimal
 Declare
@@ -120,6 +121,7 @@ Format
 Forward
 From
 Full
+Granularity
 Graph
 Greatest
 Group
@@ -145,6 +147,7 @@ Integer
 Intersect
 Interval
 Into
+Introspection
 Is
 Isnull
 Isolation

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1294,21 +1294,21 @@ CREATE CLUSTER cluster SIZE 'small'
 ----
 CREATE CLUSTER cluster SIZE 'small'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size("small")] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small")))] })
 
 parse-statement
 CREATE CLUSTER cluster SIZE = 'small'
 ----
 CREATE CLUSTER cluster SIZE 'small'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size("small")] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small")))] })
 
 parse-statement
 CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
 ----
 CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual, Virtual, Size("small"), Virtual, Size("medium")] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual, Virtual, Size(Value(String("small"))), Virtual, Size(Value(String("medium")))] })
 
 parse-statement
 DROP CLUSTER cluster

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -382,7 +382,7 @@ pub fn create_statement(
 }
 
 macro_rules! with_option_type {
-    ($name:ident, String) => {
+    ($name:expr, String) => {
         match $name {
             Some(crate::ast::WithOptionValue::Value(crate::ast::Value::String(value))) => value,
             Some(crate::ast::WithOptionValue::ObjectName(name)) => {
@@ -391,7 +391,7 @@ macro_rules! with_option_type {
             _ => ::anyhow::bail!("expected String"),
         }
     };
-    ($name:ident, bool) => {
+    ($name:expr, bool) => {
         match $name {
             Some(crate::ast::WithOptionValue::Value(crate::ast::Value::Boolean(value))) => value,
             // Bools, if they have no '= value', are true.
@@ -399,7 +399,7 @@ macro_rules! with_option_type {
             _ => ::anyhow::bail!("expected bool"),
         }
     };
-    ($name:ident, Interval) => {
+    ($name:expr, Interval) => {
         match $name {
             Some(crate::ast::WithOptionValue::Value(Value::String(value))) => {
                 mz_repr::strconv::parse_interval(&value)?

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -33,7 +33,7 @@ use chrono::{DateTime, Utc};
 use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
-use mz_dataflow_types::client::{ComputeInstanceId, InstanceConfig};
+use mz_dataflow_types::client::ComputeInstanceId;
 use mz_dataflow_types::sinks::{SinkConnectorBuilder, SinkEnvelope};
 use mz_dataflow_types::sources::SourceConnector;
 use mz_expr::{GlobalId, MirRelationExpr, MirScalarExpr, RowSetFinishing};
@@ -144,7 +144,25 @@ pub struct CreateRolePlan {
 pub struct CreateComputeInstancePlan {
     pub name: String,
     pub if_not_exists: bool,
-    pub config: InstanceConfig,
+    pub config: ComputeInstanceConfig,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ComputeInstanceConfig {
+    Virtual,
+    Remote {
+        hosts: Vec<String>,
+        introspection: Option<ComputeInstanceIntrospectionConfig>,
+    },
+}
+
+/// Configuration of introspection for a compute instance.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ComputeInstanceIntrospectionConfig {
+    /// Whether to introspect the introspection.
+    pub debugging: bool,
+    /// The interval at which to introspect.
+    pub granularity: Duration,
 }
 
 #[derive(Debug)]

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -43,7 +43,6 @@ SERVICES = [
         options="--storage-workers=2 --storage-compute-addr=dataflowd_storage:2102 --storage-controller-addr=dataflowd_storage:6876",
     ),
     Testdrive(
-        materialized_params={"cluster": "c"},
         volumes=[
             "mzdata:/share/mzdata",
             "tmp:/share/tmp",
@@ -79,7 +78,10 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.up("dataflowd_compute_2")
     c.up("materialized")
     c.wait_for_materialized(service="materialized")
+    # Dropping the `default` cluster lightly tests that `materialized` can run
+    # and restart without any virtual clusters in the virtual cluster host.
+    c.sql("DROP CLUSTER default")
     c.sql(
-        "CREATE CLUSTER c REMOTE 'dataflowd_compute_1:6876', 'dataflowd_compute_2:6876'"
+        "CREATE CLUSTER default REMOTE ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876');"
     )
     c.run("testdrive-svc", *glob)

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -140,9 +140,6 @@ SHOW cluster
 ----
 default
 
-statement error active cluster cannot be dropped
-DROP CLUSTER default
-
 statement error unknown cluster 'baz'
 DROP CLUSTER baz
 


### PR DESCRIPTION
Make cluster logging configurable per cluster by extending the CREATE
CLUSTER syntax like so:

    CREATE CLUSTER <name>
      [INTROSPECTION GRANULARITY <interval>]
      [INTROSPECTION DEBUGGING <enabled>]

These new clauses correspond to the `--introspection-frequency` and
`--debug-introspection` command-line arguments.

The command-line arguments now control the logging configuration for the
virtual compute host. Logging of virtual compute instances in the
virtual compute host is a bit funny, because only one of them is allowed
to configure logging. To avoid special casing things too much, we now
arbitrarily declare that the first virtual cluster loaded from the
catalog configures logging; if you drop this virtual cluster, you lose
access to logging until you restart `materialized`. This seems fine
enough, as it preserves the existing behavior of `materialized` unless
you start mucking with `DROP CLUSTER`.

The upshot is that the plumbing of `InstanceConfig` has nearly reached
its final form. Virtual clusters excepted, `InstanceConfig` is fully
determined by a `CREATE CLUSTER` statement, and flows through the SQL
parser, planner, catalog, coordinator, and controller in a straight
line.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (It's good enough for an experimental feature.)

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A (experimental mode)
