### PR TITLE
Hold compaction for peeks

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -165,6 +165,12 @@ where
                         .update_write_frontiers(updates)
                         .await;
                 }
+                Response::Compute(ComputeResponse::PeekResponse(uuid, _response), instance) => {
+                    self.compute_mut(*instance)
+                        .expect("Reference to absent instance")
+                        .remove_peeks(std::iter::once(*uuid))
+                        .await;
+                }
                 Response::Storage(StorageResponse::TimestampBindings(feedback)) => {
                     self.storage_mut()
                         .update_write_frontiers(&feedback.changes)


### PR DESCRIPTION
This PR changes the `Controller` to hold back compaction for outstanding `Peek` requests. Previously, compaction would be allowed to overtake peeks that had not yet returned. In principle, the dataflow layer would not compact their indexes until the peek was complete, but in a world where we may have to restart such dataflows from their inputs, we need to hold back compaction if we want to avoid erroring on that reconstruction.

On insertion, the peeks register a compaction hold for their collection, and if cancelled or if a response comes back, that hold is removed (at most once).

### Motivation

  * This PR adds a feature that has not yet been specified.

Restarting compute instances have as yet undefined behavior related to peek commands, but it seems appropriate to make sure that we can answer a peek request that has been accepted. This does not seem likely to have a deleterious effect on compaction, and generally it seems better not to two classes of commands.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
