### PR TITLE
Add OS and arch to telemetry data

### DIFF
--- a/doc/user/content/cli/_index.md
+++ b/doc/user/content/cli/_index.md
@@ -348,6 +348,8 @@ We record the following data:
 * Number of worker threads
 * Uptime
 * Count of sinks, sources, and views by type
+* System architecture (ARM or x86_64)
+* Operating system type (Linux or macOS)
 
 We use this data to guide our product roadmap. Unless you are using [Materialize
 Cloud](/cloud/), we do not and cannot correlate this

--- a/src/materialized/src/telemetry.rs
+++ b/src/materialized/src/telemetry.rs
@@ -87,6 +87,8 @@ pub async fn report_loop(config: Config) {
 // telemetry docs in doc/user/cli/_index.md#telemetry accordingly, and be sure
 // the data is not identifiable.
 fn make_telemetry_query(config: &Config) -> String {
+    let architecture = std::env::consts::ARCH;
+    let os = std::env::consts::OS;
     format!("
         SELECT jsonb_build_object(
             'version', mz_version(),
@@ -94,6 +96,8 @@ fn make_telemetry_query(config: &Config) -> String {
                 'session_id', mz_internal.mz_session_id(),
                 'uptime_seconds', extract(epoch FROM mz_uptime()),
                 'num_workers', {workers},
+                'architecture', '{architecture}',
+                'os', '{os}',
                 'sources', (
                     SELECT jsonb_object_agg(connector_type, jsonb_build_object('count', count))
                     FROM (SELECT connector_type, count(*) FROM mz_sources WHERE id LIKE 'u%' GROUP BY connector_type)


### PR DESCRIPTION
Using the standard Rust definitions of OS and arch, so that we'll be
able to distinguish between Mac and Linux, and ARM and x64, but not
specific OS versions.

### Motivation

  * This PR adds a feature that has not yet been specified: provides a way to understand how many ARM + Mac users we have, which will help with future planning and prioritisation.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

  - Start tracking OS type (Mac or Linux) and system architecture on telemetry data.
