### PR TITLE
materialized: disable persistent system tables test by default

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -123,7 +123,7 @@ pub struct Args {
     /// variety of deployments, but setting this flag to true to opt out of the
     /// test is always safe.
     #[clap(long)]
-    disable_persistent_system_tables_test: bool,
+    disable_persistent_system_tables_test: Option<bool>,
 
     /// An S3 location used to persist data, specified as s3://<bucket>/<path>.
     ///
@@ -681,7 +681,8 @@ dataflow workers: {workers}",
         } else {
             false
         };
-        let mut system_table_enabled = !args.disable_persistent_system_tables_test;
+        let system_table_disabled = args.disable_persistent_system_tables_test.unwrap_or(true);
+        let mut system_table_enabled = !system_table_disabled;
         if system_table_enabled && args.logical_compaction_window.is_none() {
             ::tracing::warn!("--logical-compaction-window is off; disabling background persistence test to prevent unbounded disk usage");
             system_table_enabled = false;

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -146,7 +146,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         options = [
             "--persistent-user-tables",
             "--persistent-kafka-sources",
-            "--disable-persistent-system-tables-test",
+            "--disable-persistent-system-tables-test=true",
         ]
 
     if args.s3_storage == "":

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -19,7 +19,7 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 
-mz_options = "--persistent-user-tables --persistent-kafka-sources --disable-persistent-system-tables-test"
+mz_options = "--persistent-user-tables --persistent-kafka-sources --disable-persistent-system-tables-test=true"
 
 mz_default = Materialized(options=mz_options)
 


### PR DESCRIPTION
As things are rapidly changing in the transition to platform, it was
assumed that we'd accidentally break this test along the way. We could
fix it, but the value we'd get from keeping the test working during the
transition (some value) is not worth the work (dunno exactly, but it's
too much work) compared to disabling the test and re-enabling it once
things have settled down.

Today is that day. Philip found #11332, which is sufficiently worrisome
that it's no longer worth keeping this test on in the short-term. This
changes the default for the flag to disable the test.

### Motivation

  * This PR ~fixes~ works around a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

**Breaking change.** Materialize no longer runs a file-based test of persistence in the background. This test may be re-enabled at some point in the future. To enable this, the `--disable-persistent-system-tables-test` flag no longer accepts the value-less variant: `=false` and `=true` still work.
