### PR TITLE
mock_telemetry_server: fix bug in cert generation

### DIFF
--- a/misc/python/materialize/cli/mock_telemetry_server.py
+++ b/misc/python/materialize/cli/mock_telemetry_server.py
@@ -22,11 +22,15 @@ First, launch the server:
     $ bin/pyactivate -m materialize.cli.mock_telemetry_server
 
 This generates a self-signed SSL certificate named "localhost.crt" in the
-current directory.
+current directory. You'll need to tell your system to trust this certificate.
+On macOS, add the certificate to the "login" keychain and mark the certificate
+as always trusted. On Linux, set the `SSL_CERT_FILE` environment variable:
+
+    $ export SSL_CERT_FILE=localhost.crt
 
 In another terminal, launch Materialize:
 
-    $ SSL_CERT_FILE=localhost.crt cargo run -- --dev --telemetry-domain localhost:4000 --telemetry-interval 5s
+    $ cargo run -- --dev --telemetry-domain localhost:4000 --telemetry-interval 5s
 
 Notice how we configure Materialize to target the mock telemetry server. The
 SSL_CERT_FILE environment variable instructs OpenSSL to trust the self-signed
@@ -85,7 +89,7 @@ if __name__ == "__main__":
     else:
         print("Generating self-signed cert for localhost...")
         os.system(
-            "openssl req -nodes -x509 -keyout localhost.crt -out localhost.crt -subj '/CN=localhost'"
+            "openssl req -nodes -x509 -newkey rsa:4096 -keyout localhost.crt -out localhost.crt -subj '/CN=localhost'"
         )
 
     cargo_workspace = Workspace(ROOT)


### PR DESCRIPTION
Without specifying the `-newkey` parameter, certificate generation hangs
forever.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
