### PR TITLE
Fix panic on over-qualified names

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -389,12 +389,12 @@ impl<'a> NameResolver<'a> {
             UnresolvedDataType::Other { name, typ_mod } => {
                 let (name, item) = match name {
                     RawName::Name(name) => {
-                        let name = normalize::unresolved_object_name(name).unwrap();
+                        let name = normalize::unresolved_object_name(name)?;
                         let item = self.catalog.resolve_item(&name)?;
                         (item.name().clone().into(), item)
                     }
                     RawName::Id(id, name) => {
-                        let name = normalize::unresolved_object_name(name).unwrap();
+                        let name = normalize::unresolved_object_name(name)?;
                         let gid: GlobalId = id.parse()?;
                         let item = self.catalog.get_item_by_id(&gid);
                         (name, item)
@@ -475,22 +475,39 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
         &mut self,
         object_name: <Raw as AstInfo>::ObjectName,
     ) -> <Aug as AstInfo>::ObjectName {
+        let error_response = ResolvedObjectName {
+            id: Id::Global(GlobalId::System(0)),
+            raw_name: PartialName {
+                database: None,
+                schema: None,
+                item: "".to_string(),
+            },
+            print_id: false,
+        };
+
         match object_name {
             RawName::Name(raw_name) => {
+                let raw_name = match normalize::unresolved_object_name(raw_name) {
+                    Ok(raw_name) => raw_name,
+                    Err(e) => {
+                        self.status = Err(e.into());
+                        return error_response;
+                    }
+                };
+
                 // Check if unqualified name refers to a CTE.
-                if raw_name.0.len() == 1 {
-                    let norm_name = normalize::ident(raw_name.0[0].clone());
+                if raw_name.database.is_none() && raw_name.schema.is_none() {
+                    let norm_name = normalize::ident(Ident::new(&raw_name.item));
                     if let Some(id) = self.ctes.get(&norm_name) {
                         return ResolvedObjectName {
                             id: Id::Local(*id),
-                            raw_name: normalize::unresolved_object_name(raw_name).unwrap(),
+                            raw_name,
                             print_id: false,
                         };
                     }
                 }
 
-                let name = normalize::unresolved_object_name(raw_name).unwrap();
-                match self.catalog.resolve_item(&name) {
+                match self.catalog.resolve_item(&raw_name) {
                     Ok(item) => {
                         self.ids.insert(item.id());
                         let print_id = !matches!(
@@ -507,11 +524,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                         if self.status.is_ok() {
                             self.status = Err(e.into());
                         }
-                        ResolvedObjectName {
-                            id: Id::Local(LocalId::new(0)),
-                            raw_name: name,
-                            print_id: false,
-                        }
+                        error_response
                     }
                 }
             }
@@ -520,11 +533,12 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     Ok(id) => id,
                     Err(e) => {
                         self.status = Err(e.into());
-                        GlobalId::User(0)
+                        return error_response;
                     }
                 };
-                if self.status.is_ok() && self.catalog.try_get_item_by_id(&gid).is_none() {
+                if self.catalog.try_get_item_by_id(&gid).is_none() {
                     self.status = Err(PlanError::Unstructured(format!("invalid id {}", &gid)));
+                    return error_response;
                 }
                 self.ids.insert(gid.clone());
                 ResolvedObjectName {

--- a/test/sqllogictest/select.slt
+++ b/test/sqllogictest/select.slt
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE foo (a integer)
+
+statement ok
+INSERT INTO foo VALUES (42)
+
+query I
+SELECT * FROM foo
+----
+42
+
+# over qualified objects should return an error
+query error qualified name did not have between 1 and 3 components
+SELECT * FROM universe.db.schema.foo
+

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -1084,3 +1084,7 @@ SELECT 'table_with_id'::regclass
 # fully qualified names are not yet supported
 statement error object "test.table_with_id" does not exist
 SELECT 'test.table_with_id'::regclass
+
+# over qualified types should return an error
+query error qualified name did not have between 1 and 3 components
+SELECT 'true'::universe.database.schema.bool


### PR DESCRIPTION
Previously if an object or type was over-qualified, which means there
are more than 3 words separated by a '.', Materialize would panic. This
commit fixes that issue by catching the error and gracefully displaying
an error to the user instead of panicing.

Fixes #11349


### Motivation
This PR fixes a recognized bug.


### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - no user-facing changes
