### PR TITLE
design doc for connectors

### DIFF
--- a/doc/developer/design/20220203_connectors.md
+++ b/doc/developer/design/20220203_connectors.md
@@ -73,139 +73,88 @@ FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR schema_registry;
 
 ### SQL syntax and semantics
 
-Connector create syntax will come in type specific variants and will not include `with_options`, instead completely specifying the potential options in each variant. 
+The eventual goal is for connector create syntax to come in type specific variants and not include `WITH` options except in cases of client implementation specific details; however, the initial implementation will preserve existing syntax for connectors to avoid entangling separating connectors into their own objects from reworking the overall connection option syntax.
 
-Using connectors syntactically means replacing the source specific keyword such as BROKER or CONNECTION with CONNECTOR and supplying one or more connector names. 
+All Sources in the catalog will have a reference to their connector which will also indicate if the connector is implicit or explicit. Implicit connectors are created when a traditional `CREATE SOURCE` command is executed and are invisible unless the catalog is directly inspected, i.e. `SHOW CREATE SOURCE` for a source with an implicit connector will return the same output as if connectors did not exist. Explicit connectors are created with `CREATE CONNECTOR` commands and used by specifying the connector in the `CREATE SOURCE` statement. 
 
-Properties will be merged by applying values in the supplied order with the last write winning, this supports a usage pattern of supplying base values and then progressively more specific overrides while remaining easy to reason about.  
+## Implementation Phases 
 
-As long as connectors do not support ALTER then it is strictly not necessary to store the relationship between source and connector in the catalog, instead during planning of the CREATE SOURCE statement the values from the connector can be substituted into relevant places in the `CreateSourceConnector` without requiring any parsing changes for any part of the `CreateSourceStatement`. 
-
-While technically supporting ALTER does not have to require changing the catalog representation of sources, the utility of supporting ALTER without CASCADE is very small and supporting CASCADE requires that relations are discoverable.
-
-## Staged Implementation
-Since there is significant user experience value in the base feature without ALTER, not being able to ALTER is not a regression since sources are already immutable, and implementation is significantly less complex if connectors are only used during initial planning of a `CREATE SOURCE` statement I propose we break things into several distinct stages:
-
-1. Connectors as syntactic sugar during `CREATE SOURCE`
-2. Refactor Sources in the catalog such that connectors are referenced by relation (either implicitly or explicitly)
-    - unblock `ALTER ... CASCADE` behavior in the planner 
-    - unlocks other desirable features as well
-3. Determine exact semantics around `ALTER` and running sources once Platform has decoupled Sources into the STORAGE layer
-    - Upsert command?
-    - Consistency semantics between layers
-      - If eventual for running instance, how to convey progress to user   
-4. Implement `CASCADE` in planner/ADAPTER and source/STORAGE pieces according to the new semantics
+1. Support implicit and explicit connectors using otherwise identical syntax to now (`WITH` options, etc)
+2. Restructure syntax to remove as many `WITH` options as is reasonable, limiting them to client implementation details such as `librdkafka` options which are not generic Kafka options.
+3. Enable `ALTER CONNECTOR` with transactional consistency in the catalog but eventual consistency for existing Sources
+  - A `CREATE` which follows an `ALTER` will be created at the STORAGE layer with the values set in the `ALTER`
+  - An `ALTER` which follows a `CREATE` will take non-zero time to propagate to the STORAGE layer
+  - TBD exact semantics of assuring convergence
 
 ## Reference
-
+The longer term syntax for `CREATE CONNECTOR` is expected to look similar to these examples.
 ### Kafka connector
-```ebnf
-create_connector_kafka ::=
-  'CREATE' 'CONNECTOR' ('IF NOT EXISTS')? connector_name
-  'FOR' 'KAFKA BROKER' host ('USING AUTH' (ssl_security_protocol_options | sasl_plain_protocol_options | sasl_gssapi_protocol_option) )?
-ssl_security_protocol_options ::=
-  '(' 'security_protocol' '=' ('ssl' | 'sasl_ssl') ','
-  'ssl_key_location' '=' ssl_key_location ','
-  'ssl_certificate_location' '=' ssl_certificate_location ','?
-  ('ssl_ca_location' '=' ssl_ca_location ','
-  'ssl_key_password' '=' ssl_key_password)? ')'
-sasl_plain_protocol_options ::=
-  '(' 'security_protocol' '=' ('sasl_plaintext' | 'plaintext') ','
-  'sasl_mechanisms' '=' ('PLAIN' | 'SCRAM-SHA-256' | 'SCRAM-SHA-512') ','
-  'sasl_username' '=' sasl_username ','
-  ( ('sasl_password' '=' sasl_password) | ('sasl_password_env' '=' sasl_password_env) ) ')'
-sasl_gssapi_protocol_option ::=
-  '(' 'security_protocol' '=' ('sasl_plaintext' | 'plaintext') ','
-  'sasl_mechanisms' '=' 'GSSAPI' ','
-  'sasl_kerberos_keytab' '=' sasl_kerberos_keytab ','
-  'sasl_kerberos_kinit_cmd' '=' sasl_kerberos_kinit_cmd ','
-  'sasl_kerberos_min_time_before_relogin' '=' sasl_kerberos_min_time_before_relogin ','
-  'sasl_kerberos_principal' '=' sasl_kerberos_principal ','
-  'sasl_kerberos_service_name' '=' sasl_kerberos_service_name ')'
 ```
+CREATE CONNECTOR <connector_name>
+FOR KAFKA 
+  BROKER <value>
+  SECURITY [=] <security_options>
+
+security_options ::=
+  SSL (
+    KEY FILE [[=] <value>]
+    CERTIFICATE FILE [[=] <value>]
+    KEY PASSWORD [[=] <value>] )
+| SASL (
+    MECHANISMS <value>
+    USERNAME [[=] <value> ]
+    PASSOWRD [[=] <value> ]
+    PASSWORD ENV [[=] <value> ] )
+| GSSAPI (
+    KEYTAB [=] <value>
+    KINIT CMD [=] <value>
+    RELOGIN TIME [=] <value>
+    PRINCIPAL [=] <value>
+    SERVICE [=] <value> )
+```
+
 ### Confluent Schema Registry connector
-```ebnf
-create_connector_confluent_schema_registry ::=
-  'CREATE' 'CONNECTOR' connector_name 'FOR'
-  'CONFLUENT SCHEMA REGISTRY' registry_url 'WITH' '('
-  'username' '=' username ',' 
-  'password' '=' password ','
-  ( 'ssl_certificate_location' '=' ssl_certificate_location ',')?
-  ( 'ssl_key_location' '=' ssl_key_location ',')?
-  ( 'ssl_ca_location' '=' ssl_ca_location)? ')'
 ```
+CREATE CONNETOR <connector_name>
+FOR CONFLUENT SCHEMA REGISTRY
+  <registry_url>
+  SECURITY [[=] <security_options>]
+
+security_options ::=
+  USERNAME [=] <value>
+  PASSWORD [=] <value>
+  SSL (
+    CERTIFICATE FILE [[=] <value> ]
+    KEY FILE [[=] <value> ]
+    CA FILE [[=] <value> ] )
+```
+
 ### PostgreSQL connector
-```ebnf
-create_connector_postgres ::=
-  ( ('host' '=' hostname) | ('hostaddr' '=' hostaddr) ) ','
-  'port' '=' port_number ','
-  ( 'dbname' '=' dbname ',')?
-  'user' '=' username ','
-  ('password' '=' password ',')?
-  ('application_name' '=' application_name ',')?
-  ('keepalives' '=' keepalives ',')?
-  (postgres_ssl_options)?
-postgres_ssl_options ::=
-  ('sslmode' '=' ( 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full' ) ',')?
-  ('sslcert' '=' ssl_certificate_location ',')?
-  ('sslkey' '=' ssl_key_location (',' 'sslpassword' '=' ssl_key_password )? ',')?
-  ('sslsni' '=' ssl_sni ',')?
 ```
-### AWS connector
-```ebnf
-create_connector_aws ::=
-  ( ('access_key_id' '=' access_key_id ',' 'secret_access_key' '=' secret_access_key (',' 'token' '=' token)?) | 'profile' '=' profile ) 
-  ('role_arn' '=' role_arn)?
-  ('region' '=' region)?
-```
-
-## Alter Table complexities
-Catalog support for these relations would require more extensive changes to properly disentangle the shareable portions of a source description from the elements which are expected to be unique. This may be a desirable evolution of these structures anyhow to organize them more modularly, primarily along boundaries of responsibility such as authentication.
-
-This would need to be done with some care to avoid leaking unnecessary implementation details into the grammar, while still avoiding `WITH options` wherever possible. The initial connector specification would provide a solid baseline of moving all Source but not implementation specific details out of `WITH options` and into the grammar. 
-
-Creating a more universal abstraction of authentication for sources is valuable beyond just the potential for Connector usage, since several source types support distinctly different auth modes when using cloud hosted versions;  Kafka and Postgres in AWS supporting IAM authentication are the most obvious example where the current representation of the source effectively disallows representing this auth method in any way.
-
-#### CASCADE specific complexities
-
-While allowing ALTER to CASCADE to all sources which reference the connector makes certain operational tasks for users easier, such as changing rotating authentication certificates or passwords, updating broker host names, or even completely changing auth methods. Implementation brings with it a significant amount of essential complexity to ensure robust, correct behavior even with eventually consistent updates of running sources.
-
-Before considering the transactional consistency required to communicate changes from ADAPTER to STORAGE, the first added complexity comes in ensuring that only ALTERs which actually change the value in a specific source are propagated which requires re-evaluating the entire set of connectors involved in specifying a source.s 
-
-Upsert would be simplest way to extend this; however, this introduces distributed coordination requirements in any mode of operation. By making Upsert semantically fallible STORAGE can incrementally support live ALTER on a source by source and property by property basis.
-
-- Eventually consistent changes would involve Adapter and Storage participating in 2 phase commit
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Adapter
-    participant Storage
-    participant SI as Source Instance
-
-    Client->>+Adapter: ALTER CONNECTOR
-    Adapter->>+Storage: UPSERT SOURCE
-    Storage->>-Adapter: ACK UPSERT
-    Adapter->>-Client: ACK ALTER
-    Storage->>+SI: UPSERT SOURCE
-    SI->>-Storage: ACK UPSERT
-```
-
-- Strongly consistent changes would require Adapter, Storage and the Instantiated Source to participate in a 3 phase commit
-
-
-```mermaid
-sequenceDiagram
-    participant Client
-    participant Adapter
-    participant Storage
-    participant SI as Source Instance
-
-    Client->>+Adapter: ALTER CONNECTOR
-    Adapter->>+Storage: UPSERT SOURCE
-    Storage->>+SI: UPSERT SOURCE
-    SI->>-Storage: ACK UPSERT
-    Storage->>-Adapter: ACK UPSERT
-    Adapter->>-Client: ACK ALTER
+CREATE CONNECTOR <connector_name>
+FOR POSTGRES
+  CONNECTION (
+    ( HOST [=] <value>
+      PORT [=] <value> )
+  | HOST ADDR [[=] <value> ] )
+  DB  [[=] <value> ]
+  USER  [=] <value>
+  SSL (
+    MODE [[=] <value>]
+    CERTIFICATE FILE [[=] <value>]
+    KEY FILE [[=] <value>]
+    SNI [[=] <value>] )
     
 ```
 
+### AWS connector
+```
+CREATE CONNECTOR <connector_name>
+FOR AWS
+  ACCESS KEY ID [[=] <value>]
+  SECRET ACCESS KEY [[=] <value>]
+  TOKEN [[=] <value>]
+  PROFILE [[=] <value>]
+  ROLE ARN [[=] <value>]
+  REGION [[=] <value>]
+```

--- a/doc/developer/design/20220203_connectors.md
+++ b/doc/developer/design/20220203_connectors.md
@@ -1,0 +1,211 @@
+# Connectors
+
+## Summary
+
+This document proposes a design for **connectors**, a new type of catalog object
+that allows common configuration parameters to be shared across sources and
+sinks.
+
+## Overview
+
+Many users of Materialize create families of sources and sinks that share many
+configuration parameters. The current design of `CREATE SOURCE` and `CREATE
+SINK` make this a verbose affair. The problem is particularly acute with
+Avro-formatted Kafka sources that configure authentication:
+
+```sql
+CREATE SOURCE kafka1
+FROM KAFKA BROKER 'kafka:9092' TOPIC 'top1' WITH (
+    security_protocol = 'SASL_SSL',
+    sasl_mechanisms = 'PLAIN',
+    sasl_username = 'username',
+    sasl_password = 'password',
+)
+FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://schema-registry' WITH (
+    username = 'username',
+    password = 'password'
+);
+
+CREATE SOURCE kafka2
+FROM KAFKA BROKER 'kafka:9092' TOPIC 'top2' WITH (
+    security_protocol = 'SASL_SSL',
+    sasl_mechanisms = 'PLAIN',
+    sasl_username = 'username',
+    sasl_password = 'password'
+)
+FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://schema-registry' WITH (
+    username = 'username',
+    password = 'password'
+);
+```
+
+These two source definition differ only in their topic specification, but
+must duplicate eight other configuration parameters.
+
+With the connectors proposed in this document, the `CREATE SOURCE` can instead
+share all the relevant configuration:
+
+```sql
+CREATE CONNECTOR kafka FOR
+KAFKA BROKER 'kafka:9092' WITH (
+    security_protocol = 'SASL_SSL',
+    sasl_mechanisms = 'PLAIN',
+    sasl_username = 'username',
+    sasl_password = 'password'
+);
+
+CREATE CONNECTOR schema_registry FOR
+CONFLUENT SCHEMA REGISTRY 'https://schema-registry' WITH (
+    username = 'username',
+    password = 'password'
+);
+
+CREATE SOURCE kafka1
+FROM KAFKA CONNECTOR kafka TOPIC 'top1'
+FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR schema_registry;
+
+CREATE SOURCE kafka2
+FROM KAFKA CONNECTOR kafka TOPIC 'top2'
+FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR schema_registry;
+```
+
+## Design
+
+### SQL syntax and semantics
+
+Connector create syntax will come in type specific variants and will not include `with_options`, instead completely specifying the potential options in each variant. 
+
+Using connectors syntactically means replacing the source specific keyword such as BROKER or CONNECTION with CONNECTOR and supplying one or more connector names. 
+
+Properties will be merged by applying values in the supplied order with the last write winning, this supports a usage pattern of supplying base values and then progressively more specific overrides while remaining easy to reason about.  
+
+As long as connectors do not support ALTER then it is strictly not necessary to store the relationship between source and connector in the catalog, instead during planning of the CREATE SOURCE statement the values from the connector can be substituted into relevant places in the `CreateSourceConnector` without requiring any parsing changes for any part of the `CreateSourceStatement`. 
+
+While technically supporting ALTER does not have to require changing the catalog representation of sources, the utility of supporting ALTER without CASCADE is very small and supporting CASCADE requires that relations are discoverable.
+
+## Staged Implementation
+Since there is significant user experience value in the base feature without ALTER, not being able to ALTER is not a regression since sources are already immutable, and implementation is significantly less complex if connectors are only used during initial planning of a `CREATE SOURCE` statement I propose we break things into several distinct stages:
+
+1. Connectors as syntactic sugar during `CREATE SOURCE`
+2. Refactor Sources in the catalog such that connectors are referenced by relation (either implicitly or explicitly)
+    - unblock `ALTER ... CASCADE` behavior in the planner 
+    - unlocks other desirable features as well
+3. Determine exact semantics around `ALTER` and running sources once Platform has decoupled Sources into the STORAGE layer
+    - Upsert command?
+    - Consistency semantics between layers
+      - If eventual for running instance, how to convey progress to user   
+4. Implement `CASCADE` in planner/ADAPTER and source/STORAGE pieces according to the new semantics
+
+## Reference
+
+### Kafka connector
+```ebnf
+create_connector_kafka ::=
+  'CREATE' 'CONNECTOR' ('IF NOT EXISTS')? connector_name
+  'FOR' 'KAFKA BROKER' host ('USING AUTH' (ssl_security_protocol_options | sasl_plain_protocol_options | sasl_gssapi_protocol_option) )?
+ssl_security_protocol_options ::=
+  '(' 'security_protocol' '=' ('ssl' | 'sasl_ssl') ','
+  'ssl_key_location' '=' ssl_key_location ','
+  'ssl_certificate_location' '=' ssl_certificate_location ','?
+  ('ssl_ca_location' '=' ssl_ca_location ','
+  'ssl_key_password' '=' ssl_key_password)? ')'
+sasl_plain_protocol_options ::=
+  '(' 'security_protocol' '=' ('sasl_plaintext' | 'plaintext') ','
+  'sasl_mechanisms' '=' ('PLAIN' | 'SCRAM-SHA-256' | 'SCRAM-SHA-512') ','
+  'sasl_username' '=' sasl_username ','
+  ( ('sasl_password' '=' sasl_password) | ('sasl_password_env' '=' sasl_password_env) ) ')'
+sasl_gssapi_protocol_option ::=
+  '(' 'security_protocol' '=' ('sasl_plaintext' | 'plaintext') ','
+  'sasl_mechanisms' '=' 'GSSAPI' ','
+  'sasl_kerberos_keytab' '=' sasl_kerberos_keytab ','
+  'sasl_kerberos_kinit_cmd' '=' sasl_kerberos_kinit_cmd ','
+  'sasl_kerberos_min_time_before_relogin' '=' sasl_kerberos_min_time_before_relogin ','
+  'sasl_kerberos_principal' '=' sasl_kerberos_principal ','
+  'sasl_kerberos_service_name' '=' sasl_kerberos_service_name ')'
+```
+### Confluent Schema Registry connector
+```ebnf
+create_connector_confluent_schema_registry ::=
+  'CREATE' 'CONNECTOR' connector_name 'FOR'
+  'CONFLUENT SCHEMA REGISTRY' registry_url 'WITH' '('
+  'username' '=' username ',' 
+  'password' '=' password ','
+  ( 'ssl_certificate_location' '=' ssl_certificate_location ',')?
+  ( 'ssl_key_location' '=' ssl_key_location ',')?
+  ( 'ssl_ca_location' '=' ssl_ca_location)? ')'
+```
+### PostgreSQL connector
+```ebnf
+create_connector_postgres ::=
+  ( ('host' '=' hostname) | ('hostaddr' '=' hostaddr) ) ','
+  'port' '=' port_number ','
+  ( 'dbname' '=' dbname ',')?
+  'user' '=' username ','
+  ('password' '=' password ',')?
+  ('application_name' '=' application_name ',')?
+  ('keepalives' '=' keepalives ',')?
+  (postgres_ssl_options)?
+postgres_ssl_options ::=
+  ('sslmode' '=' ( 'disable' | 'allow' | 'prefer' | 'require' | 'verify-ca' | 'verify-full' ) ',')?
+  ('sslcert' '=' ssl_certificate_location ',')?
+  ('sslkey' '=' ssl_key_location (',' 'sslpassword' '=' ssl_key_password )? ',')?
+  ('sslsni' '=' ssl_sni ',')?
+```
+### AWS connector
+```ebnf
+create_connector_aws ::=
+  ( ('access_key_id' '=' access_key_id ',' 'secret_access_key' '=' secret_access_key (',' 'token' '=' token)?) | 'profile' '=' profile ) 
+  ('role_arn' '=' role_arn)?
+  ('region' '=' region)?
+```
+
+## Alter Table complexities
+Catalog support for these relations would require more extensive changes to properly disentangle the shareable portions of a source description from the elements which are expected to be unique. This may be a desirable evolution of these structures anyhow to organize them more modularly, primarily along boundaries of responsibility such as authentication.
+
+This would need to be done with some care to avoid leaking unnecessary implementation details into the grammar, while still avoiding `WITH options` wherever possible. The initial connector specification would provide a solid baseline of moving all Source but not implementation specific details out of `WITH options` and into the grammar. 
+
+Creating a more universal abstraction of authentication for sources is valuable beyond just the potential for Connector usage, since several source types support distinctly different auth modes when using cloud hosted versions;  Kafka and Postgres in AWS supporting IAM authentication are the most obvious example where the current representation of the source effectively disallows representing this auth method in any way.
+
+#### CASCADE specific complexities
+
+While allowing ALTER to CASCADE to all sources which reference the connector makes certain operational tasks for users easier, such as changing rotating authentication certificates or passwords, updating broker host names, or even completely changing auth methods. Implementation brings with it a significant amount of essential complexity to ensure robust, correct behavior even with eventually consistent updates of running sources.
+
+Before considering the transactional consistency required to communicate changes from ADAPTER to STORAGE, the first added complexity comes in ensuring that only ALTERs which actually change the value in a specific source are propagated which requires re-evaluating the entire set of connectors involved in specifying a source.s 
+
+Upsert would be simplest way to extend this; however, this introduces distributed coordination requirements in any mode of operation. By making Upsert semantically fallible STORAGE can incrementally support live ALTER on a source by source and property by property basis.
+
+- Eventually consistent changes would involve Adapter and Storage participating in 2 phase commit
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Adapter
+    participant Storage
+    participant SI as Source Instance
+
+    Client->>+Adapter: ALTER CONNECTOR
+    Adapter->>+Storage: UPSERT SOURCE
+    Storage->>-Adapter: ACK UPSERT
+    Adapter->>-Client: ACK ALTER
+    Storage->>+SI: UPSERT SOURCE
+    SI->>-Storage: ACK UPSERT
+```
+
+- Strongly consistent changes would require Adapter, Storage and the Instantiated Source to participate in a 3 phase commit
+
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Adapter
+    participant Storage
+    participant SI as Source Instance
+
+    Client->>+Adapter: ALTER CONNECTOR
+    Adapter->>+Storage: UPSERT SOURCE
+    Storage->>+SI: UPSERT SOURCE
+    SI->>-Storage: ACK UPSERT
+    Storage->>-Adapter: ACK UPSERT
+    Adapter->>-Client: ACK ALTER
+    
+```
+

--- a/doc/developer/design/20220404_connectors.md
+++ b/doc/developer/design/20220404_connectors.md
@@ -79,12 +79,14 @@ All Sources in the catalog will have a reference to their connector which will a
 
 ## Implementation Phases 
 
-1. Support implicit and explicit connectors using otherwise identical syntax to now (`WITH` options, etc)
-2. Restructure syntax to remove as many `WITH` options as is reasonable, limiting them to client implementation details such as `librdkafka` options which are not generic Kafka options.
-3. Enable `ALTER CONNECTOR` with transactional consistency in the catalog but eventual consistency for existing Sources
+1. Connectors marked `experimental` with support for implicit and explicit connectors using otherwise identical syntax to now (`WITH` options, etc) in `CREATE SOURCE` statements when enabled and when reading from the catalog in all cases
+2. During `experimental` phase evaluate restructuring the syntax to remove as many `WITH` options as is reasonable, limiting them to client implementation details such as `librdkafka` options which are not generic Kafka options.
+3. Finalize syntax and determine necessary migrations, if any, to allow for removing `experimental` status.
+4. Enable `ALTER CONNECTOR` with transactional consistency in the catalog but eventual consistency for existing Sources as `experimental` feature
   - A `CREATE` which follows an `ALTER` will be created at the STORAGE layer with the values set in the `ALTER`
   - An `ALTER` which follows a `CREATE` will take non-zero time to propagate to the STORAGE layer
   - TBD exact semantics of assuring convergence
+5. Make `ALTER CONNECTOR` stable once semantics and implementation are stable
 
 ## Reference
 The longer term syntax for `CREATE CONNECTOR` is expected to look similar to these examples.
@@ -103,7 +105,7 @@ security_options ::=
 | SASL (
     MECHANISMS <value>
     USERNAME [[=] <value> ]
-    PASSOWRD [[=] <value> ]
+    PASSWORD [[=] <value> ]
     PASSWORD ENV [[=] <value> ] )
 | GSSAPI (
     KEYTAB [=] <value>

--- a/doc/developer/design/20220404_connectors.md
+++ b/doc/developer/design/20220404_connectors.md
@@ -75,9 +75,9 @@ FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR schema_registry;
 
 The eventual goal is for connector create syntax to come in type specific variants and not include `WITH` options except in cases of client implementation specific details; however, the initial implementation will preserve existing syntax for connectors to avoid entangling separating connectors into their own objects from reworking the overall connection option syntax.
 
-All Sources in the catalog will have a reference to their connector which will also indicate if the connector is implicit or explicit. Implicit connectors are created when a traditional `CREATE SOURCE` command is executed and are invisible unless the catalog is directly inspected, i.e. `SHOW CREATE SOURCE` for a source with an implicit connector will return the same output as if connectors did not exist. Explicit connectors are created with `CREATE CONNECTOR` commands and used by specifying the connector in the `CREATE SOURCE` statement. 
+All Sources in the catalog will have a reference to their connector which will also indicate if the connector is implicit or explicit. Implicit connectors are created when a traditional `CREATE SOURCE` command is executed and are invisible unless the catalog is directly inspected, i.e. `SHOW CREATE SOURCE` for a source with an implicit connector will return the same output as if connectors did not exist. Explicit connectors are created with `CREATE CONNECTOR` commands and used by specifying the connector in the `CREATE SOURCE` statement.
 
-## Implementation Phases 
+## Implementation Phases
 
 1. Connectors marked `experimental` with support for implicit and explicit connectors using otherwise identical syntax to now (`WITH` options, etc) in `CREATE SOURCE` statements when enabled and when reading from the catalog in all cases
 2. During `experimental` phase evaluate restructuring the syntax to remove as many `WITH` options as is reasonable, limiting them to client implementation details such as `librdkafka` options which are not generic Kafka options.
@@ -93,7 +93,7 @@ The longer term syntax for `CREATE CONNECTOR` is expected to look similar to the
 ### Kafka connector
 ```
 CREATE CONNECTOR <connector_name>
-FOR KAFKA 
+FOR KAFKA
   BROKER <value>
   SECURITY [=] <security_options>
 
@@ -146,7 +146,7 @@ FOR POSTGRES
     CERTIFICATE FILE [[=] <value>]
     KEY FILE [[=] <value>]
     SNI [[=] <value>] )
-    
+
 ```
 
 ### AWS connector


### PR DESCRIPTION
Design doc for connectors which proposes a multi-phase implementation starting with behavior where connectors act like a copy/paste from the catalogue during source creation, this offers the largest user experience improvement and has the lowest complexity to implement. 

Working on this design also reinforced the evidence that source definitions could use some amount of revamping to more cleanly abstract concepts like authentication or transport encryption to not only enable expressing a source with a relation to one or more connectors but also to more easily enable adding authentication methods such as AWS IAM to sources which currently do not support them but could. Doing this refactor of the source types and figuring if we should always use them, and if so figuring out the details of implicitly creating connectors and using them transparently to users, is the proposed second phase since it is pretty much mandatory to some extent to support any reasonable design for allowing `ALTER CONNECTOR ... CASCADE` which is the main use case that would justify supporting `ALTER CONNETOR` at all since otherwise it is just syntactic sugar for a delete/create cycle.

The final stages would be done after the transition to platform is further along or complete, by nailing down the design of an `UpsertSource` command or equivalent and what consistency and transactional semantics would be required. The design doc goes into less depth on these issues but does sketch out the basic sequence for eventual vs. strong consistency all the way to the running instance level.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user facing changes, just a design doc
