### PR TITLE
persist: flesh out an in-mem placeholder implementation of the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,10 +3731,14 @@ dependencies = [
  "bytes",
  "crossbeam-channel",
  "differential-dataflow",
+ "futures-executor",
  "futures-util",
+ "mz-ore",
  "mz-persist-types",
  "serde",
  "timely",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -12,8 +12,14 @@ bincode = "1.3.3"
 bytes = "1.1.0"
 crossbeam-channel = "0.5.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+futures-executor = "0.3.21"
 futures-util = "0.3.19"
 mz-persist-types = { path = "../persist-types" }
 serde = { version = "1.0.136", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
+tokio = { version = "1.17.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
+tracing = "0.1.31"
 uuid = { version = "0.8.2", features = ["v4"] }
+
+[dev-dependencies]
+mz-ore = { path = "../ore", default-features = false, features = ["test"] }

--- a/src/persist-client/src/impl/shard.rs
+++ b/src/persist-client/src/impl/shard.rs
@@ -1,0 +1,232 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist_types::{Codec, Codec64};
+use timely::progress::{Antichain, Timestamp};
+use timely::PartialOrder;
+use tokio::sync::Mutex;
+
+use crate::error::InvalidUsage;
+use crate::read::{ReadHandle, ReaderId};
+use crate::write::{WriteHandle, WriterId};
+use crate::Id;
+
+#[derive(Debug)]
+pub struct State {
+    pub(crate) shard_id: Id,
+    pub(crate) key_codec: String,
+    pub(crate) val_codec: String,
+    pub(crate) ts_codec: String,
+    pub(crate) diff_codec: String,
+
+    pub(crate) writers: HashMap<WriterId, Vec<[u8; 8]>>,
+    pub(crate) since: Vec<[u8; 8]>,
+    pub(crate) readers: HashMap<ReaderId, Vec<[u8; 8]>>,
+
+    pub(crate) upper: Vec<[u8; 8]>,
+    pub(crate) contents: Vec<(Vec<u8>, Vec<u8>, [u8; 8], [u8; 8])>,
+}
+
+pub struct Shard<K, V, T, D> {
+    state: Arc<Mutex<State>>,
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+// Impl Clone regardless of the type params.
+impl<K, V, T, D> Clone for Shard<K, V, T, D> {
+    fn clone(&self) -> Self {
+        Self {
+            state: Arc::clone(&self.state),
+            _phantom: self._phantom.clone(),
+        }
+    }
+}
+
+// Impl Debug regardless of the type params.
+impl<K, V, T, D> std::fmt::Debug for Shard<K, V, T, D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Shard").field("state", &self.state).finish()
+    }
+}
+
+impl<K, V, T, D> Shard<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    pub fn new(shard_id: Id) -> Self {
+        let state = State {
+            shard_id,
+            key_codec: K::codec_name(),
+            val_codec: V::codec_name(),
+            ts_codec: T::codec_name(),
+            diff_codec: D::codec_name(),
+
+            upper: Antichain::from_elem(T::minimum())
+                .iter()
+                .map(|x| T::encode(x))
+                .collect(),
+            writers: HashMap::new(),
+            since: Antichain::from_elem(T::minimum())
+                .iter()
+                .map(|x| T::encode(x))
+                .collect(),
+            readers: HashMap::new(),
+
+            contents: Vec::new(),
+        };
+        Shard {
+            state: Arc::new(Mutex::new(state)),
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn into_inner(self) -> Arc<Mutex<State>> {
+        self.state
+    }
+
+    pub async fn decode(state: Arc<Mutex<State>>) -> Result<Self, InvalidUsage> {
+        {
+            let state = state.lock().await;
+            if K::codec_name() != state.key_codec {
+                return Err(InvalidUsage(anyhow!(
+                    "key_codec {} doesn't match original: {}",
+                    K::codec_name(),
+                    state.key_codec
+                )));
+            }
+            if V::codec_name() != state.val_codec {
+                return Err(InvalidUsage(anyhow!(
+                    "val_codec {} doesn't match original: {}",
+                    V::codec_name(),
+                    state.val_codec
+                )));
+            }
+            if T::codec_name() != state.ts_codec {
+                return Err(InvalidUsage(anyhow!(
+                    "ts_codec {} doesn't match original: {}",
+                    T::codec_name(),
+                    state.ts_codec
+                )));
+            }
+            if D::codec_name() != state.diff_codec {
+                return Err(InvalidUsage(anyhow!(
+                    "diff_codec {} doesn't match original: {}",
+                    D::codec_name(),
+                    state.diff_codec
+                )));
+            }
+        }
+
+        Ok(Shard {
+            state,
+            _phantom: PhantomData,
+        })
+    }
+
+    fn decode_antichain(elements: &Vec<[u8; 8]>) -> Antichain<T> {
+        Antichain::from(elements.iter().map(|x| T::decode(*x)).collect::<Vec<_>>())
+    }
+
+    pub async fn recover_capabilities(&self) -> (WriteHandle<K, V, T, D>, ReadHandle<K, V, T, D>) {
+        let mut state = self.state.lock().await;
+
+        let upper = state.upper.clone();
+        let since = state.since.clone();
+
+        let writer_id = WriterId::new();
+        let reader_id = ReaderId::new();
+        assert_eq!(state.writers.contains_key(&writer_id), false);
+        assert_eq!(state.readers.contains_key(&reader_id), false);
+        state.writers.insert(writer_id.clone(), upper.clone());
+        state.readers.insert(reader_id.clone(), since.clone());
+
+        let writer = WriteHandle {
+            writer_id,
+            shard: self.clone(),
+            upper: Self::decode_antichain(&upper),
+        };
+        let reader = ReadHandle {
+            reader_id,
+            state: self.clone(),
+            since: Self::decode_antichain(&since),
+        };
+        (writer, reader)
+    }
+
+    pub async fn write_batch<'i, I: IntoIterator<Item = ((&'i K, &'i V), &'i T, &'i D)>>(
+        &self,
+        writer_id: &WriterId,
+        updates: I,
+        new_upper: Antichain<T>,
+    ) -> Result<Antichain<T>, InvalidUsage> {
+        let mut state = self.state.lock().await;
+
+        let writer_lower = match state.writers.get(writer_id) {
+            Some(x) => Self::decode_antichain(x),
+            // TODO: This is more likely an expired lease.
+            None => return Err(InvalidUsage(anyhow!("unknown writer: {:?}", writer_id))),
+        };
+
+        let lower = Self::decode_antichain(&state.upper);
+        if PartialOrder::less_than(&new_upper, &lower) {
+            return Err(InvalidUsage(anyhow!(
+                "new upper {:?} not in advance of current {:?}",
+                new_upper,
+                lower
+            )));
+        }
+        for ((k, v), t, d) in updates {
+            debug_assert!(writer_lower.less_equal(t));
+            debug_assert!(!new_upper.less_equal(t));
+            let (mut key_buf, mut val_buf) = (Vec::new(), Vec::new());
+            K::encode(k, &mut key_buf);
+            V::encode(v, &mut val_buf);
+            state
+                .contents
+                .push((key_buf, val_buf, T::encode(t), D::encode(d)));
+        }
+        state.upper = new_upper.elements().iter().map(|x| T::encode(x)).collect();
+        Ok(new_upper)
+    }
+
+    pub async fn clone_reader(&self, reader_id: &ReaderId) -> Result<ReaderId, InvalidUsage> {
+        let mut state = self.state.lock().await;
+        let since = match state.readers.get(reader_id) {
+            Some(x) => x.clone(),
+            // TODO: This is more likely an expired lease.
+            None => return Err(InvalidUsage(anyhow!("unknown reader: {}", reader_id))),
+        };
+        let new_reader_id = ReaderId::new();
+        state.readers.insert(new_reader_id.clone(), since);
+        Ok(new_reader_id)
+    }
+}
+
+impl<K, V, T, D> Shard<K, V, T, D> {
+    pub async fn deregister_writer(&self, writer_id: &WriterId) {
+        // TODO: Move this id to a graveyard?
+        self.state.lock().await.writers.remove(writer_id);
+    }
+
+    pub async fn deregister_reader(&self, reader_id: &ReaderId) {
+        // TODO: Move this id to a graveyard?
+        self.state.lock().await.readers.remove(reader_id);
+    }
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -7,19 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![warn(missing_docs)]
+#![warn(missing_docs, missing_debug_implementations)]
 #![warn(
     clippy::cast_possible_truncation,
     clippy::cast_precision_loss,
     clippy::cast_sign_loss
 )]
-// TODO: Remove this once we've got at least a placeholder implementation.
-#![allow(clippy::todo)]
 
 //! An abstraction presenting as a durable time-varying collection (aka shard)
 
+use std::collections::HashMap;
 use std::fmt::Debug;
-use std::marker::PhantomData;
+use std::sync::Arc;
 use std::time::Duration;
 
 use differential_dataflow::difference::Semigroup;
@@ -27,15 +26,25 @@ use differential_dataflow::lattice::Lattice;
 use mz_persist_types::{Codec, Codec64};
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp;
+use tokio::sync::Mutex;
+use tracing::trace;
 use uuid::Uuid;
 
 use crate::error::LocationError;
+use crate::r#impl::shard::{Shard, State};
 use crate::read::ReadHandle;
 use crate::write::WriteHandle;
 
 pub mod error;
 pub mod read;
 pub mod write;
+
+/// An implementation of the public crate interface.
+///
+/// TODO: Move this to another crate.
+pub(crate) mod r#impl {
+    pub mod shard;
+}
 
 // Notes
 // - Pretend that everything marked with Serialize and Deserialize instead has
@@ -74,8 +83,9 @@ impl Id {
 
 /// A handle for interacting with the set of persist shard made durable at a
 /// single [Location].
+#[derive(Debug)]
 pub struct Client {
-    _phantom: PhantomData<()>,
+    shards: Arc<Mutex<HashMap<Id, Arc<Mutex<State>>>>>,
 }
 
 impl Client {
@@ -90,7 +100,15 @@ impl Client {
         location: Location,
         role_arn: Option<String>,
     ) -> Result<Self, LocationError> {
-        todo!("{:?}{:?}{:?}", timeout, location, role_arn)
+        trace!(
+            "Client::new timeout={:?} location={:?} role_arn={:?}",
+            timeout,
+            location,
+            role_arn
+        );
+        Ok(Client {
+            shards: Arc::new(Mutex::new(HashMap::new())),
+        })
     }
 
     /// Provides capabilities for the durable TVC identified by `id` at its
@@ -117,6 +135,94 @@ impl Client {
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64,
     {
-        todo!("{:?}{:?}", timeout, id)
+        trace!("Client::open timeout={:?} id={:?}", timeout, id);
+        let mut shards = self.shards.lock().await;
+        let state = shards
+            .entry(id)
+            .or_insert_with(|| Shard::<K, V, T, D>::new(id.clone()).into_inner());
+        let state = Shard::decode(Arc::clone(state))
+            .await
+            .expect("internal error: newly created shard's codecs don't match");
+        Ok(state.recover_capabilities().await)
+    }
+}
+
+#[cfg(test)]
+const NO_TIMEOUT: Duration = Duration::from_secs(1_000_000);
+
+#[cfg(test)]
+mod tests {
+    use timely::progress::Antichain;
+
+    use crate::read::ListenEvent;
+
+    use super::*;
+
+    async fn new_test_client() -> Result<Client, LocationError> {
+        let location = Location {
+            bucket: "unused".into(),
+            prefix: "unused".into(),
+        };
+        Client::new(NO_TIMEOUT, location, None).await
+    }
+
+    fn all_ok<'a, K, V, T, D, I>(iter: I) -> Vec<((Result<K, String>, Result<V, String>), T, D)>
+    where
+        K: Clone + 'a,
+        V: Clone + 'a,
+        T: Clone + 'a,
+        D: Clone + 'a,
+        I: IntoIterator<Item = &'a ((K, V), T, D)>,
+    {
+        iter.into_iter()
+            .map(|((k, v), t, d)| ((Ok(k.clone()), Ok(v.clone())), t.clone(), d.clone()))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn sanity_check() -> Result<(), Box<dyn std::error::Error>> {
+        mz_ore::test::init_logging_default("warn");
+
+        let data = vec![
+            (("1".to_owned(), "one".to_owned()), 1, 1),
+            (("2".to_owned(), "two".to_owned()), 2, 1),
+            (("3".to_owned(), "three".to_owned()), 3, 1),
+        ];
+
+        let (mut write, mut read) = new_test_client()
+            .await?
+            .open::<String, String, u64, i64>(NO_TIMEOUT, Id::new())
+            .await?;
+        assert_eq!(write.upper(), &Antichain::from_elem(u64::minimum()));
+        assert_eq!(read.since(), &Antichain::from_elem(u64::minimum()));
+
+        // Write a [0,3) batch.
+        write.write_batch_slice(&data[..2], 3).await??;
+        assert_eq!(write.upper(), &Antichain::from_elem(3));
+
+        // Grab a snapshot and listener as_of 2.
+        let mut snap = read.snapshot_one(1).await??;
+        let mut listen = read.listen(NO_TIMEOUT, Antichain::from_elem(1)).await??;
+
+        // Snapshot should only have part of what we wrote.
+        assert_eq!(snap.read_all().await?, all_ok(&data[..1]));
+
+        // Write a [3,4) batch.
+        write.write_batch_slice(&data[2..], 4).await??;
+        assert_eq!(write.upper(), &Antichain::from_elem(4));
+
+        // Listen should have part of the initial write plus the new one.
+        let expected_events = vec![
+            ListenEvent::Updates(all_ok(&data[1..])),
+            ListenEvent::Progress(Antichain::from_elem(4)),
+        ];
+        assert_eq!(listen.poll_next(NO_TIMEOUT).await?, expected_events);
+
+        // Downgrading the since is tracked locally (but otherwise is a no-op).
+        read.downgrade_since(NO_TIMEOUT, Antichain::from_elem(2))
+            .await??;
+        assert_eq!(read.since(), &Antichain::from_elem(2));
+
+        Ok(())
     }
 }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -10,7 +10,6 @@
 //! Read capabilities and handles
 
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 
@@ -19,9 +18,13 @@ use differential_dataflow::lattice::Lattice;
 use mz_persist_types::{Codec, Codec64};
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
+use timely::PartialOrder;
+use tracing::trace;
 use uuid::Uuid;
 
 use crate::error::{InvalidUsage, LocationError};
+use crate::r#impl::shard::Shard;
+use crate::Id;
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -33,8 +36,14 @@ impl std::fmt::Display for ReaderId {
     }
 }
 
-/// A token representing one split of a "snapshot" (the contents of a shard as
-/// of some frontier).
+impl ReaderId {
+    pub(crate) fn new() -> Self {
+        ReaderId(*Uuid::new_v4().as_bytes())
+    }
+}
+
+/// A token representing one split of a "snapshot" (the contents of a shard
+/// as of some frontier).
 ///
 /// This may be exchanged (including over the network). It is tradeable via
 /// [ReadHandle::snapshot_iter] for a [SnapshotIter], which can be used to
@@ -42,13 +51,21 @@ impl std::fmt::Display for ReaderId {
 ///
 /// See [ReadHandle::snapshot] for details.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SnapshotSplit(PhantomData<()>);
+pub struct SnapshotSplit {
+    id: Id,
+    as_of: Vec<[u8; 8]>,
+    contents: Vec<(Vec<u8>, Vec<u8>, [u8; 8], [u8; 8])>,
+}
 
 /// An iterator over one split of a "snapshot" (the contents of a shard as of
 /// some frontier).
 ///
 /// See [ReadHandle::snapshot] for details.
-pub struct SnapshotIter<K, V, T, D>(PhantomData<(K, V, T, D)>);
+#[derive(Debug)]
+pub struct SnapshotIter<K, V, T, D> {
+    as_of: Antichain<T>,
+    contents: Vec<((Result<K, String>, Result<V, String>), T, D)>,
+}
 
 impl<K, V, T, D> SnapshotIter<K, V, T, D>
 where
@@ -59,7 +76,7 @@ where
 {
     /// The frontier at which we're outputting the contents of the shard.
     pub fn as_of(&self) -> &Antichain<T> {
-        todo!()
+        &self.as_of
     }
 
     /// Attempt to pull out the next values of this iterator.
@@ -69,7 +86,26 @@ where
         &mut self,
         timeout: Duration,
     ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, LocationError> {
-        todo!("{:?}", timeout)
+        trace!("SnapshotIter::poll_next timeout={:?}", timeout);
+        let contents = std::mem::take(&mut self.contents);
+        Ok(contents)
+    }
+
+    /// Test helper to read all data in the snapshot.
+    #[cfg(test)]
+    pub async fn read_all(
+        &mut self,
+    ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, LocationError> {
+        use crate::NO_TIMEOUT;
+
+        let mut ret = Vec::new();
+        loop {
+            let mut next = self.poll_next(NO_TIMEOUT).await?;
+            if next.is_empty() {
+                return Ok(ret);
+            }
+            ret.append(&mut next)
+        }
     }
 }
 
@@ -77,6 +113,7 @@ where
 ///
 /// TODO: Unify this with [timely::dataflow::operators::to_stream::Event] or
 /// [timely::dataflow::operators::capture::event::Event].
+#[derive(Debug, PartialEq)]
 pub enum ListenEvent<K, V, T, D> {
     /// Progress of the shard.
     Progress(Antichain<T>),
@@ -85,7 +122,12 @@ pub enum ListenEvent<K, V, T, D> {
 }
 
 /// An ongoing subscription of updates to a shard.
-pub struct Listen<K, V, T, D>(PhantomData<(K, V, T, D)>);
+#[derive(Debug)]
+pub struct Listen<K, V, T, D> {
+    as_of: Antichain<T>,
+    pub(crate) upper: Antichain<T>,
+    shard: Shard<K, V, T, D>,
+}
 
 impl<K, V, T, D> Listen<K, V, T, D>
 where
@@ -98,18 +140,57 @@ where
     pub async fn poll_next(
         &mut self,
         timeout: Duration,
-    ) -> Result<ListenEvent<K, V, T, D>, LocationError> {
-        todo!("{:?}", timeout)
+    ) -> Result<Vec<ListenEvent<K, V, T, D>>, LocationError> {
+        trace!("Listen::poll_next timeout={:?}", timeout);
+        let mut ret = Vec::new();
+        loop {
+            let state = self.shard.clone().into_inner();
+            let state = state.lock().await;
+            let new_upper = Antichain::from(
+                state
+                    .upper
+                    .iter()
+                    .map(|x| T::decode(*x))
+                    .collect::<Vec<_>>(),
+            );
+            if PartialOrder::less_than(&self.upper, &new_upper) {
+                // TODO: We could order contents to avoid scanning the entire
+                // thing every time, but this impl is meant as a placeholder, so
+                // let's see how far we get without that.
+                let mut updates = Vec::new();
+                for (k, v, t, d) in state.contents.iter() {
+                    let t = T::decode(*t);
+                    if self.as_of.less_than(&t) && self.upper.less_equal(&t) {
+                        debug_assert_eq!(new_upper.less_equal(&t), false);
+                        let k = K::decode(&k);
+                        let v = V::decode(&v);
+                        let d = D::decode(*d);
+                        updates.push(((k, v), t, d));
+                    }
+                }
+                if !updates.is_empty() {
+                    ret.push(ListenEvent::Updates(updates));
+                }
+                self.upper = new_upper;
+                ret.push(ListenEvent::Progress(self.upper.clone()));
+                return Ok(ret);
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
     }
 }
 
 /// A "capability" granting the ability to read the state of some shard at times
 /// greater or equal to `self.since()`.
+#[derive(Debug)]
 pub struct ReadHandle<K, V, T, D>
 where
     T: Timestamp + Lattice + Codec64,
 {
-    _phantom: PhantomData<(K, V, T, D)>,
+    pub(crate) reader_id: ReaderId,
+    pub(crate) state: Shard<K, V, T, D>,
+
+    pub(crate) since: Antichain<T>,
 }
 
 impl<K, V, T, D> ReadHandle<K, V, T, D>
@@ -123,7 +204,7 @@ where
     ///
     /// This will always be greater or equal to the shard-global `since`.
     pub fn since(&self) -> &Antichain<T> {
-        todo!()
+        &self.since
     }
 
     /// Forwards the since frontier of this handle, giving up the ability to
@@ -140,7 +221,14 @@ where
         timeout: Duration,
         new_since: Antichain<T>,
     ) -> Result<Result<(), InvalidUsage>, LocationError> {
-        todo!("{:?}{:?}", timeout, new_since)
+        trace!(
+            "ReadHandle::downgrade_since timeout={:?} new_since={:?}",
+            timeout,
+            new_since
+        );
+        // TODO: No-op for now.
+        self.since = new_since;
+        Ok(Ok(()))
     }
 
     /// Returns an ongoing subscription of updates to a shard.
@@ -163,7 +251,12 @@ where
         timeout: Duration,
         as_of: Antichain<T>,
     ) -> Result<Result<Listen<K, V, T, D>, InvalidUsage>, LocationError> {
-        todo!("{:?}{:?}", timeout, as_of);
+        trace!("ReadHandle::listen timeout={:?} as_of={:?}", timeout, as_of);
+        Ok(Ok(Listen {
+            upper: as_of.clone(),
+            as_of,
+            shard: self.state.clone(),
+        }))
     }
 
     /// Returns a snapshot of the contents of the shard TVC at `as_of`.
@@ -194,7 +287,32 @@ where
         as_of: Antichain<T>,
         num_splits: NonZeroUsize,
     ) -> Result<Result<Vec<SnapshotSplit>, InvalidUsage>, LocationError> {
-        todo!("{:?}{:?}{:?}", timeout, as_of, num_splits);
+        trace!(
+            "ReadHandle::snapshot timeout={:?} as_of={:?} num_splits={:?}",
+            timeout,
+            as_of,
+            num_splits
+        );
+        let state = self.state.clone().into_inner();
+        let state = state.lock().await;
+        let mut splits = (0..num_splits.get())
+            .map(|_| SnapshotSplit {
+                id: state.shard_id,
+                as_of: as_of.iter().map(|x| T::encode(x)).collect(),
+                contents: Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        for (idx, (k, v, t, d)) in state.contents.iter().enumerate() {
+            let mut t = T::decode(*t);
+            if as_of.less_than(&t) {
+                continue;
+            }
+            t.advance_by(as_of.borrow());
+            splits[idx % num_splits.get()]
+                .contents
+                .push((k.clone(), v.clone(), T::encode(&t), *d));
+        }
+        return Ok(Ok(splits));
     }
 
     /// Trade in an exchange-able [SnapshotSplit] for an iterator over the data
@@ -204,13 +322,71 @@ where
         timeout: Duration,
         split: SnapshotSplit,
     ) -> Result<SnapshotIter<K, V, T, D>, LocationError> {
-        todo!("{:?}{:?}", timeout, split);
+        trace!(
+            "ReadHandle::snapshot timeout={:?} split={:?}",
+            timeout,
+            split
+        );
+        // TODO: Each part should have a read capability attached to it and then
+        // we should use that here instead of the handle's capability.
+        let contents = split
+            .contents
+            .into_iter()
+            .map(|(k, v, t, d)| ((K::decode(&k), V::decode(&v)), T::decode(t), D::decode(d)))
+            .collect();
+        let iter = SnapshotIter {
+            as_of: Antichain::from(
+                split
+                    .as_of
+                    .iter()
+                    .map(|x| T::decode(*x))
+                    .collect::<Vec<_>>(),
+            ),
+            contents,
+        };
+        Ok(iter)
     }
 
     /// Returns an independent [ReadHandle] with a new [ReaderId] but the same
     /// `since`.
     pub async fn clone(&self, timeout: Duration) -> Result<Self, LocationError> {
-        todo!("{:?}", timeout);
+        trace!("ReadHandle::clone timeout={:?}", timeout);
+        let new_reader_id = self
+            .state
+            .clone_reader(&self.reader_id)
+            .await
+            .expect("TODO: return a lease expired error instead");
+        let new_reader = ReadHandle {
+            reader_id: new_reader_id,
+            state: self.state.clone(),
+            since: self.since.clone(),
+        };
+        Ok(new_reader)
+    }
+
+    /// Test helper for creating a single part snapshot.
+    #[cfg(test)]
+    pub async fn snapshot_one(
+        &self,
+        as_of: T,
+    ) -> Result<Result<SnapshotIter<K, V, T, D>, InvalidUsage>, LocationError> {
+        use crate::NO_TIMEOUT;
+
+        let splits = self
+            .snapshot(
+                NO_TIMEOUT,
+                Antichain::from_elem(as_of),
+                NonZeroUsize::new(1).unwrap(),
+            )
+            .await?;
+        let mut splits = match splits {
+            Ok(x) => x,
+            Err(err) => return Ok(Err(err)),
+        };
+        assert_eq!(splits.len(), 1);
+        let split = splits.pop().unwrap();
+        let iter = self.snapshot_iter(NO_TIMEOUT, split).await?;
+        Ok(Ok(iter))
     }
 }
 
@@ -219,6 +395,7 @@ where
     T: Timestamp + Lattice + Codec64,
 {
     fn drop(&mut self) {
-        todo!()
+        // TODO: Use tokio instead of futures_executor.
+        futures_executor::block_on(self.state.deregister_reader(&self.reader_id));
     }
 }


### PR DESCRIPTION
Nothing fancy and under-tested. This is just to unblock STORAGE
prototyping for the next few weeks while we work on a more permanent
impl.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Tips for reviewer

Don't bother looking at this too hard, it's going to get ripped out for something entirely different for the end of march deliverable. The bar we have to clear here is really just "better than todo!()".

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
