### PR TITLE
expr: decode numeral values in base64

### DIFF
--- a/src/expr/src/scalar/func/encoding.rs
+++ b/src/expr/src/scalar/func/encoding.rs
@@ -48,6 +48,7 @@ impl Base64Format {
         match b {
             b'A'..=b'Z' => Ok(b - b'A'),
             b'a'..=b'z' => Ok(b - b'a' + 26),
+            b'0'..=b'9' => Ok(b + 4),
             b'+' => Ok(62),
             b'/' => Ok(63),
             _ => Err(EvalError::InvalidBase64Symbol(char::from(b))),

--- a/test/sqllogictest/encode.slt
+++ b/test/sqllogictest/encode.slt
@@ -99,3 +99,14 @@ NULL           NULL
 
 query error invalid input syntax for type bytea
 SELECT decode('\9', 'escape')
+
+# checks https://github.com/MaterializeInc/materialize/issues/11369
+query T
+SELECT encode('se', 'base64')
+----
+c2U=
+
+query T
+SELECT decode(encode('se', 'base64'), 'base64')
+----
+se


### PR DESCRIPTION
Our base64 decoding routine refused to decode numerals, despite their validity as base64 encoded values.

### Motivation

This PR fixes a recognized bug. Fixes #11369

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Improve base64 [decoding](https://materialize.com/docs/sql/functions/encode/) to support numerals in encoded strings. Previously, if the encoded string contained a numeral, decoding would fail.
