### PR TITLE
expr, sql: add dense_rank window function

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -630,6 +630,8 @@
 - type: Window
   description: Window functions compute values across sets of rows related to the current query.
   functions:
+  - signature: 'dense_rank() -> int'
+    description: Returns the rank of the current row within its partition without gaps, counting from 1.
   - signature: 'row_number() -> int'
     description: Returns the number of the current row within its partition, counting from 1.
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1471,7 +1471,8 @@ pub mod monoids {
             | AggregateFunc::ArrayConcat { .. }
             | AggregateFunc::ListConcat { .. }
             | AggregateFunc::StringAgg { .. }
-            | AggregateFunc::RowNumber { .. } => None,
+            | AggregateFunc::RowNumber { .. }
+            | AggregateFunc::DenseRank { .. } => None,
         }
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -571,6 +571,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::ArrayConcat { .. }
         | AggregateFunc::ListConcat { .. }
         | AggregateFunc::StringAgg { .. }
-        | AggregateFunc::RowNumber { .. } => ReductionType::Basic,
+        | AggregateFunc::RowNumber { .. }
+        | AggregateFunc::DenseRank { .. } => ReductionType::Basic,
     }
 }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2458,6 +2458,9 @@ lazy_static! {
             "row_number" => ScalarWindow {
                 params!() => ScalarWindowFunc::RowNumber, 3100;
             },
+            "dense_rank" => ScalarWindow {
+                params!() => ScalarWindowFunc::DenseRank, 3102;
+            },
 
             // Table functions.
             "generate_series" => Table {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -262,6 +262,7 @@ impl ScalarWindowExpr {
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
+            ScalarWindowFunc::DenseRank => {}
         }
         Ok(())
     }
@@ -272,6 +273,7 @@ impl ScalarWindowExpr {
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
+            ScalarWindowFunc::DenseRank => {}
         }
         Ok(())
     }
@@ -290,6 +292,9 @@ impl ScalarWindowExpr {
             ScalarWindowFunc::RowNumber => mz_expr::AggregateFunc::RowNumber {
                 order_by: self.order_by,
             },
+            ScalarWindowFunc::DenseRank => mz_expr::AggregateFunc::DenseRank {
+                order_by: self.order_by,
+            },
         }
     }
 }
@@ -298,12 +303,14 @@ impl ScalarWindowExpr {
 /// Scalar Window functions
 pub enum ScalarWindowFunc {
     RowNumber,
+    DenseRank,
 }
 
 impl ScalarWindowFunc {
     pub fn output_type(&self) -> ColumnType {
         match self {
             ScalarWindowFunc::RowNumber => ScalarType::Int64.nullable(false),
+            ScalarWindowFunc::DenseRank => ScalarType::Int64.nullable(false),
         }
     }
 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -469,3 +469,163 @@ ORDER BY row_number() OVER ()
 a
 b
 c
+
+# dense_rank
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+3  a
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+2  b
+3  a
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+1  c
+2  b
+2  b
+3  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  a
+1  a
+2  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY dense_rank, x
+----
+1  b
+1  c
+2  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  b
+1  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+1  c
+1  c
+1  c
+1  b
+1  b
+1  b
+1  a
+1  a
+1  a
+
+# Make sure a non-column expression following the window function is correctly
+# handled.
+query ITT
+WITH t (x) AS (VALUES ('a'))
+SELECT dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
+FROM t
+----
+1 a b
+
+
+query IITT
+WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
+FROM t
+ORDER BY y, x DESC, z
+----
+1  3  a    1
+2  2  a    1
+2  2  a    1
+3  1  a    1
+1  4  b    0
+2  4  b    1
+1  3  c    1
+2  2  c  NaN
+3  1  c  NaN
+
+
+# NaNs have the same rank
+query IITT
+WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
+FROM t
+ORDER BY y, z DESC, x
+----
+1  1  a    1
+1  2  a    1
+1  2  a    1
+1  3  a    1
+1  4  b    1
+2  4  b    0
+1  1  c  NaN
+1  2  c  NaN
+2  3  c    1


### PR DESCRIPTION
Add `dense_rank` window function, with mostly the same performance characteristics of `row_number()`, as it shares most of the implementation.
All other nullary window functions (`rank`, `percent_rank`,`cume_dist`) should follow the same pattern.
Done mostly as an exercise to get more acquainted with how window functions are implemented, since we have active requests for `lag`, `lead` and `last_value` (MaterializeInc/product#139).

### Motivation

  * This PR adds a feature that has not yet been specified: add a window function from Postgres, which has been sporadically asked by users and internally.

### Tips for reviewer
  * Tests will come later, but the logic here should work and be correct.
  * Would love for some feedback in the implementation of `dense_rank`: it looks really ugly to me, and I feel there's probably an idiom or two I could be using here instead.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Support the `dense_rank` window function.
