### PR TITLE
Start TcpClient in disconnected state; connect for storage clients

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -85,7 +85,7 @@ where
                 (client, logging)
             }
             InstanceConfig::Remote { hosts, logging } => {
-                let client = RemoteClient::connect(&hosts).await?;
+                let client = RemoteClient::new(&hosts);
                 let client = ComputeWrapperClient::new(client, instance);
                 let client = crate::client::replicated::ActiveReplication::new(vec![client]);
                 (Box::new(client) as Box<dyn ComputeClient<T>>, logging)
@@ -129,7 +129,7 @@ where
                     .iter()
                     .map(|h| format!("{h}:6876"))
                     .collect();
-                let client = RemoteClient::connect(&addrs).await?;
+                let client = RemoteClient::new(&addrs);
                 let client: Box<dyn ComputeClient<T>> =
                     Box::new(ComputeWrapperClient::new(client, instance));
                 (client, logging)

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -162,10 +162,10 @@ where
                     dataflow.id = uuid::Uuid::new_v4();
                 }
             }
-            let mut result = self.replicas[index].send(command).await;
-            while result.is_err() {
-                result = self.hydrate_replica(index).await;
-            }
+
+            // Errors are suppressed by this client, which awaits a reconnection in `recv` and
+            // will rehydrate the client when that happens.
+            let _ = self.replicas[index].send(command).await;
         }
 
         Ok(())


### PR DESCRIPTION
Our `TcpClient` is able to recover from connection errors by reconnecting, and communicating this through a `recv` error. This communication is used by our restartable client.

This PR changes the tcp client to *start* in this disconnected state, and rely on `recv` calls to initiate the connection. This takes the connection out of the critical path for client construction. In the case of the storage server, we force the connection to happen, as this client is not wrapped in a restartable harness (it would just lose messages before it was connected).

The restartable client is also changed to only watch for errors on `recv`, and the `TcpClient` changed to report all errors (including a new "disconnected" error) on `send`. This allows non-restarting users to correctly catch on fire if they would like to do so.

### Motivation

Our network connection initialization was on the critical path, and it did not have to be (except for the storage instance). Also, our `TcpClient` implementation would secretly lose data if you stopped and restarted a storage instance, presenting the appearance of correct behavior when instead someone should have panicked.

### Tips for reviewer

This has not yet been tested; just putting it up for discussion.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
