### PR TITLE
dataflow: retry storage-compute boundary connections

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -1387,8 +1387,8 @@ pub mod tcp {
         pub async fn connect(&mut self) {
             if self.connection.is_none() {
                 let mut connection = TcpStream::connect(&self.addr).await;
-                while connection.is_err() {
-                    tracing::warn!("Connect error; reconnecting");
+                while let Err(e) = connection {
+                    tracing::warn!("Connect error: {e}; reconnecting");
                     time::sleep(Duration::from_secs(1)).await;
                     connection = TcpStream::connect(&self.addr).await;
                 }


### PR DESCRIPTION
Retry the initial connection attempt to remote storage boundary servers.
In Kubernetes, the storage instance and materialized are started at the
same time, and so materialized might try to connect before the storage
instance has booted.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
