### PR TITLE
Attempt to simplify TAIL responses

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -830,7 +830,6 @@ where
 /// Clients whose implementation is partitioned across a set of subclients (e.g. timely workers).
 pub mod partitioned {
 
-    use std::collections::hash_map::Entry;
     use std::collections::HashMap;
     use std::iter::Fuse;
 
@@ -839,8 +838,6 @@ pub mod partitioned {
 
     use mz_expr::GlobalId;
     use mz_repr::{Diff, Row};
-    use timely::order::PartialOrder;
-    use timely::progress::{Antichain, ChangeBatch};
     use tokio_stream::StreamMap;
     use tracing::debug;
 
@@ -918,95 +915,6 @@ pub mod partitioned {
     use timely::progress::frontier::MutableAntichain;
     use uuid::Uuid;
 
-    /// Buffer for partial results for a `TAIL`.
-    /// This exists so we can consolidate rows and
-    /// sort them by timestamp before passing them to the consumer
-    /// (currently, coord.rs).
-    #[derive(Debug)]
-    struct PendingTail<T> {
-        /// `frontiers[i]` is an antichain representing the times at which we may
-        /// still receive results from worker `i`.
-        frontiers: HashMap<usize, Antichain<T>>,
-        /// Consolidated frontiers
-        change_batch: ChangeBatch<T>,
-        /// The results (possibly unsorted) which have not yet been delivered.
-        buffer: Vec<(T, Row, Diff)>,
-        /// The number of unique shard IDs expected.
-        parts: usize,
-        /// The last progress message that has been reported to the consumer.
-        reported_frontier: Antichain<T>,
-    }
-
-    impl<T: timely::progress::Timestamp + Copy> PendingTail<T> {
-        /// Return all the updates with time less than `upper`,
-        /// in sorted and consolidated representation.
-        pub fn consolidate_up_to(&mut self, upper: Antichain<T>) -> Vec<(T, Row, Diff)> {
-            differential_dataflow::consolidation::consolidate_updates(&mut self.buffer);
-            let split_point = self
-                .buffer
-                .partition_point(|(t, _, _)| !upper.less_equal(t));
-            self.buffer.drain(0..split_point).collect()
-        }
-
-        pub fn push_data<I: IntoIterator<Item = (T, Row, Diff)>>(&mut self, data: I) {
-            self.buffer.extend(data);
-        }
-
-        pub fn record_progress(
-            &mut self,
-            shard_id: usize,
-            progress: Antichain<T>,
-        ) -> Option<Antichain<T>> {
-            // In the future, we can probably replace all this logic with the use of a `MutableAntichain`.
-            // We would need to have the tail workers report both their old frontier and their new frontier, rather
-            // than just the latter. But this will all be subsumed anyway by the proposed refactor to make TAILs
-            // behave like PEEKs.
-            match self.frontiers.entry(shard_id) {
-                Entry::Occupied(mut oe) => {
-                    for element in oe.get().elements() {
-                        self.change_batch.update(*element, -1);
-                    }
-                    assert!(
-                        PartialOrder::less_than(oe.get(), &progress),
-                        "Timestamps should advance"
-                    );
-                    for element in progress.elements() {
-                        self.change_batch.update(*element, 1);
-                    }
-                    oe.insert(progress);
-                }
-                Entry::Vacant(ve) => {
-                    for element in progress.elements() {
-                        self.change_batch.update(*element, 1);
-                    }
-                    ve.insert(progress);
-                }
-            }
-            assert!(self.frontiers.len() <= self.parts);
-            if self.frontiers.len() == self.parts {
-                self.change_batch.compact();
-                let mut min_frontier = Antichain::new();
-                if let Some(time) = self.change_batch.iter().next().map(|(time, _)| *time) {
-                    min_frontier.insert(time);
-                }
-
-                // assert!(self.reported_frontier.less_equal(&min_frontier));
-                assert!(PartialOrder::less_equal(
-                    &self.reported_frontier,
-                    &min_frontier
-                ));
-                if PartialOrder::less_than(&self.reported_frontier, &min_frontier) {
-                    self.reported_frontier = min_frontier.clone();
-                    Some(min_frontier)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        }
-    }
-
     /// Maintained state for sharded dataflow clients.
     ///
     /// This helper type unifies the responses of multiple partitioned
@@ -1022,12 +930,10 @@ pub mod partitioned {
         parts: usize,
         /// Tracks in-progress `TAIL`s, and the stashed rows we are holding
         /// back until their timestamps are complete.
-        ///
-        /// `None` is a sentinel value indicating that the tail has been dropped and no
-        /// further messages should be forwarded.
-        ///
-        /// The `Option<ComputeInstanceId>` uses `None` to represent Storage.
-        pending_tails: HashMap<(GlobalId, Option<ComputeInstanceId>), Option<PendingTail<T>>>,
+        pending_tails: HashMap<
+            (GlobalId, Option<ComputeInstanceId>),
+            Option<(MutableAntichain<T>, Vec<(T, Row, Diff)>)>,
+        >,
         /// The next responses to return immediately, if any
         stashed_responses: Fuse<Box<dyn Iterator<Item = Response<T>> + Send>>,
     }
@@ -1199,13 +1105,10 @@ pub mod partitioned {
                         .pending_tails
                         .entry((id, Some(instance)))
                         .or_insert_with(|| {
-                            Some(PendingTail {
-                                frontiers: HashMap::new(),
-                                change_batch: Default::default(),
-                                buffer: Vec::new(),
-                                parts: self.parts,
-                                reported_frontier: Antichain::from_elem(T::minimum()),
-                            })
+                            let mut frontier = MutableAntichain::new();
+                            frontier
+                                .update_iter(std::iter::once((T::minimum(), self.parts as i64)));
+                            Some((frontier, Vec::new()))
                         });
 
                     let entry = match maybe_entry {
@@ -1218,48 +1121,48 @@ pub mod partitioned {
                         Some(entry) => entry,
                     };
 
+                    use crate::TailBatch;
+                    use differential_dataflow::consolidation::consolidate_updates;
                     let responses: Box<dyn Iterator<Item = Response<T>> + Send> = match response {
-                        TailResponse::Progress(frontier) => {
-                            if let Some(new_frontier) = entry.record_progress(shard_id, frontier) {
-                                let data = entry.consolidate_up_to(new_frontier.clone());
-                                let progress_response = TailResponse::Progress(new_frontier);
-                                if data.is_empty() {
-                                    Box::new(
-                                        Some(Response::Compute(
-                                            ComputeResponse::TailResponse(id, progress_response),
-                                            instance,
-                                        ))
-                                        .into_iter(),
-                                    )
-                                } else {
-                                    // Return the data first, then the progress message.
-                                    Box::new(
-                                        [
-                                            Response::Compute(
-                                                ComputeResponse::TailResponse(
-                                                    id,
-                                                    TailResponse::Rows(data),
-                                                ),
-                                                instance,
-                                            ),
-                                            Response::Compute(
-                                                ComputeResponse::TailResponse(
-                                                    id,
-                                                    progress_response,
-                                                ),
-                                                instance,
-                                            ),
-                                        ]
-                                        .into_iter(),
-                                    )
+                        TailResponse::Batch(TailBatch {
+                            lower,
+                            upper,
+                            mut updates,
+                        }) => {
+                            let old_frontier = entry.0.frontier().to_owned();
+                            entry.0.update_iter(lower.iter().map(|t| (t.clone(), -1)));
+                            entry.0.update_iter(upper.iter().map(|t| (t.clone(), 1)));
+                            entry.1.append(&mut updates);
+                            let new_frontier = entry.0.frontier().to_owned();
+                            if old_frontier != new_frontier {
+                                consolidate_updates(&mut entry.1);
+                                let mut ship = Vec::new();
+                                let mut keep = Vec::new();
+                                for (time, data, diff) in entry.1.drain(..) {
+                                    if new_frontier.less_equal(&time) {
+                                        keep.push((time, data, diff));
+                                    } else {
+                                        ship.push((time, data, diff));
+                                    }
                                 }
+                                entry.1 = keep;
+                                Box::new(
+                                    Some(Response::Compute(
+                                        ComputeResponse::TailResponse(
+                                            id,
+                                            TailResponse::Batch(TailBatch {
+                                                lower: old_frontier,
+                                                upper: new_frontier,
+                                                updates: ship,
+                                            }),
+                                        ),
+                                        instance,
+                                    ))
+                                    .into_iter(),
+                                )
                             } else {
                                 Box::new(None.into_iter())
                             }
-                        }
-                        TailResponse::Rows(rows) => {
-                            entry.push_data(rows);
-                            Box::new(None.into_iter())
                         }
                         TailResponse::Dropped => {
                             *maybe_entry = None;

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -62,15 +62,21 @@ impl PeekResponse {
 /// Various responses that can be communicated about the progress of a TAIL command.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum TailResponse<T = mz_repr::Timestamp> {
-    /// Progress information. Subsequent messages from this worker will only contain timestamps
-    /// greater or equal to an element of this frontier.
-    ///
-    /// An empty antichain indicates the end.
-    Progress(Antichain<T>),
-    /// Rows that should be returned in order to the client.
-    Rows(Vec<(T, Row, Diff)>),
+    /// A batch of updates over a non-empty interval of time.
+    Batch(TailBatch<T>),
     /// The TAIL dataflow was dropped before completing. Indicates the end.
     Dropped,
+}
+
+/// A batch of updates for the interval `[lower, upper)`.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TailBatch<T> {
+    /// The lower frontier of the batch of updates.
+    pub lower: Antichain<T>,
+    /// The upper frontier of the batch of updates.
+    pub upper: Antichain<T>,
+    /// All updates greater than `lower` and not greater than `upper`.
+    pub updates: Vec<(T, Row, Diff)>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This is an attempt to simplify TAIL responses, by merging the `Progress` and `Rows` variants into one `Batch` variant. This removes various moments where we would need "state machine" logic to respond to a rows and then progress, to not accept rows after progress, stuff like that.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

No rush yet (will edit if that changes). Mostly posting to get a look at it.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
