### PR TITLE
sql: simplify typeconv::get_cast

### DIFF
--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -555,102 +555,11 @@ fn get_cast(
 ) -> Option<Cast> {
     use CastContext::*;
 
-    // Determines if types are equal in a way that does not require casting.
-    fn embedded_value_equality(ccx: &CastContext, l: &ScalarType, r: &ScalarType) -> bool {
-        use ScalarType::*;
-        match (l, r) {
-            (Array(l), Array(r)) => embedded_value_equality(&ccx, &l, &r),
-            (
-                List {
-                    element_type: l,
-                    custom_oid: oid_l,
-                },
-                List {
-                    element_type: r,
-                    custom_oid: oid_r,
-                },
-            )
-            | (
-                Map {
-                    value_type: l,
-                    custom_oid: oid_l,
-                },
-                Map {
-                    value_type: r,
-                    custom_oid: oid_r,
-                },
-            ) => oid_l == oid_r && embedded_value_equality(&ccx, &l, &r),
-            (
-                Record {
-                    fields: fields_l,
-                    custom_oid: oid_l,
-                    ..
-                },
-                Record {
-                    fields: fields_r,
-                    custom_oid: oid_r,
-                    ..
-                },
-            ) => {
-                oid_l == oid_r
-                    && fields_l.len() == fields_r.len()
-                    && fields_l
-                        .into_iter()
-                        .map(|(_, ColumnType { scalar_type: t, .. })| t)
-                        .zip(
-                            fields_r
-                                .into_iter()
-                                .map(|(_, ColumnType { scalar_type: t, .. })| t),
-                        )
-                        .all(|(l, r)| embedded_value_equality(&ccx, l, r))
-            }
-            (l, r) if ccx == &Implicit => l.base_eq(r),
-            (l, r) => l == r,
-        }
-    }
-
-    if embedded_value_equality(&ccx, &from, &to) {
+    if from == to || (ccx == Implicit && from.base_eq(to)) {
         return Some(Box::new(|expr| expr));
     }
 
-    // Determines if types are equal irrespective of any custom types.
-    fn structural_equality(l: &ScalarType, r: &ScalarType) -> bool {
-        use ScalarType::*;
-        match (l, r) {
-            (Array(l), Array(r))
-            | (
-                List {
-                    element_type: l, ..
-                },
-                List {
-                    element_type: r, ..
-                },
-            )
-            | (Map { value_type: l, .. }, Map { value_type: r, .. }) => structural_equality(&l, &r),
-            (
-                Record {
-                    fields: fields_l, ..
-                },
-                Record {
-                    fields: fields_r, ..
-                },
-            ) => {
-                fields_l.len() == fields_r.len()
-                    && fields_l
-                        .into_iter()
-                        .map(|(_, ColumnType { scalar_type: t, .. })| t)
-                        .zip(
-                            fields_r
-                                .into_iter()
-                                .map(|(_, ColumnType { scalar_type: t, .. })| t),
-                        )
-                        .all(|(l, r)| structural_equality(l, r))
-            }
-            (l, r) => l == r,
-        }
-    }
-
-    if (from.is_custom_type() || to.is_custom_type()) && structural_equality(&from, to) {
+    if (from.is_custom_type() || to.is_custom_type()) && from.structural_eq(to) {
         // CastInPlace allowed if going between custom and anonymous or if cast
         // explicitly requested.
         if from.is_custom_type() ^ to.is_custom_type() || ccx == CastContext::Explicit {


### PR DESCRIPTION
Realized these could be dramatically simplified

### Motivation

This PR refactors existing code.

In preparation of the work required to close #10935, I wanted to simplify the code in this function, making `structural_eq` a more broadly accessible function on `ScalarType`.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
