### PR TITLE
cluster: nerf the cluster smoke test

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -142,6 +142,9 @@ steps:
   - id: cluster-smoke
     label: Cluster smoke test
     depends_on: build-x86_64
+    timeout_in_minutes: 5
+    # https://github.com/MaterializeInc/materialize/issues/11390
+    soft_fail: true
     inputs: [test/cluster]
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
The cluster smoke test is hanging due to #11390 in a way that is not
being caught by existing timeout mechanisms. Set it to soft_fail and
set timeout_in_minutes to allow the CI to proceed in the face of hangs.


### Motivation


  * This PR fixes a previously unreported bug.

Sporadic failures in CI