### PR TITLE
sql: remove CastInPlace

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -3400,9 +3400,6 @@ pub enum UnaryFunc {
     CastMapToString {
         ty: ScalarType,
     },
-    CastInPlace {
-        return_ty: ScalarType,
-    },
     CastInt2VectorToString,
     CeilFloat32(CeilFloat32),
     CeilFloat64(CeilFloat64),
@@ -3843,7 +3840,6 @@ impl UnaryFunc {
             CastRecord1ToRecord2 { cast_exprs, .. } => {
                 cast_record1_to_record2(a, cast_exprs, temp_storage)
             }
-            CastInPlace { .. } => Ok(a),
             Ascii => Ok(ascii(a)),
             BitLengthString => bit_length(a.unwrap_str()),
             BitLengthBytes => bit_length(a.unwrap_bytes()),
@@ -4101,8 +4097,6 @@ impl UnaryFunc {
             CastJsonbToFloat64 => ScalarType::Float64.nullable(nullable),
             CastJsonbToBool => ScalarType::Bool.nullable(nullable),
 
-            CastInPlace { return_ty } => (return_ty.clone()).nullable(nullable),
-
             CastRecord1ToRecord2 { return_ty, .. } => {
                 return_ty.without_modifiers().nullable(nullable)
             }
@@ -4353,7 +4347,7 @@ impl UnaryFunc {
             TimezoneTime { .. } => false,
             TimezoneTimestampTz(_) => false,
             TimezoneTimestamp(_) => false,
-            CastList1ToList2 { .. } | CastRecord1ToRecord2 { .. } | CastInPlace { .. } => false,
+            CastList1ToList2 { .. } | CastRecord1ToRecord2 { .. } => false,
             JsonbTypeof | JsonbStripNulls | JsonbPretty | ListLength => false,
             ExtractInterval(_)
             | ExtractTime(_)
@@ -4624,7 +4618,6 @@ impl UnaryFunc {
             CastListToString { .. } => f.write_str("listtostr"),
             CastList1ToList2 { .. } => f.write_str("list1tolist2"),
             CastMapToString { .. } => f.write_str("maptostr"),
-            CastInPlace { .. } => f.write_str("castinplace"),
             Ascii => f.write_str("ascii"),
             CharLength => f.write_str("char_length"),
             BitLengthBytes => f.write_str("bit_length"),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -559,17 +559,6 @@ fn get_cast(
         return Some(Box::new(|expr| expr));
     }
 
-    if (from.is_custom_type() || to.is_custom_type()) && from.structural_eq(to) {
-        // CastInPlace allowed if going between custom and anonymous or if cast
-        // explicitly requested.
-        if from.is_custom_type() ^ to.is_custom_type() || ccx == CastContext::Explicit {
-            let return_ty = to.clone();
-            return Some(Box::new(move |expr| {
-                expr.call_unary(UnaryFunc::CastInPlace { return_ty })
-            }));
-        }
-    }
-
     let imp = VALID_CASTS.get(&(from.into(), to.into()))?;
     let template = match (ccx, imp.context) {
         (Explicit, Implicit) | (Explicit, Assignment) | (Explicit, Explicit) => Some(&imp.template),


### PR DESCRIPTION
### Motivation

This PR refactors existing code.

`CastInPlace` seems more like an optimization than a semantic concern, so trying to remove it from SQL planning.

For some context, I added this alongside some change related to custom types--the idea being that the only thing those casts needed to do was change the return type. However, this was not semantically meaningful in any way and was just my attempt at building cleaner dataflows.

In refactoring polymorphic type resolution, I realized that this call made the type conversion code harder to read about and I'm now more dubious about its upside (or if this should even be a concern for SQL planning). So, I removed it. As you can see, nothing broke with the change so I think it's better left in the optimizer if we're going to do this kind of work at all.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
