### PR TITLE
Allow replica removal by name

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -513,7 +513,9 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         }
 
         // Reconstitute the commands as a compact history.
-        self.commands.push(create_command.unwrap());
+        if let Some(create_command) = create_command {
+            self.commands.push(create_command);
+        }
         self.commands
             .push(ComputeCommand::CreateDataflows(live_dataflows));
         self.commands.push(ComputeCommand::AllowCompaction(

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -87,8 +87,9 @@ where
             InstanceConfig::Remote { hosts, logging } => {
                 let client = RemoteClient::new(&hosts);
                 let client = ComputeWrapperClient::new(client, instance);
-                let client = crate::client::replicated::ActiveReplication::new(vec![client]);
-                (Box::new(client) as Box<dyn ComputeClient<T>>, logging)
+                let mut replicas = crate::client::replicated::ActiveReplication::default();
+                let _replica_id = replicas.add_replica(client).await;
+                (Box::new(replicas) as Box<dyn ComputeClient<T>>, logging)
             }
             InstanceConfig::Managed { size: _, logging } => {
                 let OrchestratorConfig {
@@ -131,8 +132,9 @@ where
                     .collect();
                 let client = RemoteClient::new(&addrs);
                 let client = ComputeWrapperClient::new(client, instance);
-                let client = crate::client::replicated::ActiveReplication::new(vec![client]);
-                (Box::new(client) as Box<dyn ComputeClient<T>>, logging)
+                let mut replicas = crate::client::replicated::ActiveReplication::default();
+                let _replica_id = replicas.add_replica(client).await;
+                (Box::new(replicas) as Box<dyn ComputeClient<T>>, logging)
             }
         };
         client


### PR DESCRIPTION
Introduce "names" for replicas (really `uuid::Uuid`) returned on addition of a replica, and usable to remove the replica.

### Motivation
 
We will want to be able to remove specific replicas, rather than just continually add them.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
