### PR TITLE
Surface replica manipulation operations on compute instance controller

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -660,6 +660,16 @@ where
     }
 }
 
+#[async_trait]
+impl<T: Send> GenericClient<ComputeCommand<T>, ComputeResponse<T>> for Box<dyn ComputeClient<T>> {
+    async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+        (**self).send(cmd).await
+    }
+    async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {
+        (**self).recv().await
+    }
+}
+
 /// A convenience type for compatibility.
 #[derive(Debug)]
 pub struct LocalClient<T = mz_repr::Timestamp> {

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -29,6 +29,8 @@ use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
 use uuid::Uuid;
 
+use crate::client::replicated::ActiveReplication;
+use crate::client::GenericClient;
 use crate::client::{ComputeClient, ComputeCommand, ComputeInstanceId};
 use crate::logging::LoggingConfig;
 use crate::DataflowDescription;
@@ -41,7 +43,7 @@ use super::ReadPolicy;
 /// Controller state maintained for each compute instance.
 #[derive(Debug)]
 pub(super) struct ComputeControllerState<T> {
-    pub(super) client: Box<dyn ComputeClient<T>>,
+    pub(super) client: ActiveReplication<Box<dyn ComputeClient<T>>, T>,
     /// Tracks expressed `since` and received `upper` frontiers for indexes and sinks.
     pub(super) collections: BTreeMap<GlobalId, CollectionState<T>>,
     /// Currently outstanding peeks: identifiers and timestamps.
@@ -91,7 +93,10 @@ impl<T> ComputeControllerState<T>
 where
     T: Timestamp + Lattice,
 {
-    pub(super) fn new(client: Box<dyn ComputeClient<T>>, logging: &Option<LoggingConfig>) -> Self {
+    pub(super) async fn new(
+        // client: ActiveReplication<Box<dyn ComputeClient<T>>, T>,
+        logging: &Option<LoggingConfig>,
+    ) -> Result<Self, anyhow::Error> {
         let mut collections = BTreeMap::default();
         if let Some(logging_config) = logging.as_ref() {
             for id in logging_config.log_identifiers() {
@@ -105,11 +110,16 @@ where
                 );
             }
         }
-        Self {
+        let mut client = crate::client::replicated::ActiveReplication::default();
+        client
+            .send(ComputeCommand::CreateInstance(logging.clone()))
+            .await?;
+
+        Ok(Self {
             client,
             collections,
             peeks: Default::default(),
-        }
+        })
     }
 }
 
@@ -154,6 +164,15 @@ where
         crate::client::controller::StorageControllerMut {
             storage: &mut self.storage,
         }
+    }
+
+    /// Adds a new instance replica, by name.
+    pub async fn add_replica(&mut self, id: uuid::Uuid, client: Box<dyn ComputeClient<T>>) {
+        self.compute.client.add_replica(id, client).await;
+    }
+    /// Removes an existing instance replica, by name.
+    pub fn remove_replica(&mut self, id: &uuid::Uuid) {
+        self.compute.client.remove_replica(id);
     }
 
     /// Creates and maintains the described dataflows, and initializes state for their output.

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -68,8 +68,7 @@ where
     /// Introduce a new replica, and catch it up to the commands of other replicas.
     ///
     /// It is not yet clear under which circumstances a replica can be removed.
-    pub async fn add_replica(&mut self, client: C) -> uuid::Uuid {
-        let identifier = uuid::Uuid::new_v4();
+    pub async fn add_replica(&mut self, identifier: uuid::Uuid, client: C) {
         for (_, frontiers) in self.uppers.values_mut() {
             frontiers.insert(identifier, {
                 let mut frontier = timely::progress::frontier::MutableAntichain::new();
@@ -79,14 +78,13 @@ where
         }
         self.replicas.insert(identifier, client);
         self.hydrate_replica(&identifier).await;
-        identifier
     }
 
     /// Remove a replica by its identifier.
-    pub fn remove_replica(&mut self, id: uuid::Uuid) {
-        self.replicas.remove(&id);
+    pub fn remove_replica(&mut self, id: &uuid::Uuid) {
+        self.replicas.remove(id);
         for (_frontier, frontiers) in self.uppers.iter_mut() {
-            frontiers.1.remove(&id);
+            frontiers.1.remove(id);
         }
     }
 


### PR DESCRIPTION
This PR adds methods `add_replica` and `remove_replica` to `ComputeControllerMut`, the controller for a compute instance. These methods allow manipulation of the replicas backing the compute instance.

The client type of a compute instance changes from `Box<dyn ComputeClient<T>>` to `ActiveReplication<Box<dyn ComputeClient<T>>, T>`, which is a bit odd for virtual clusters but is probably harmless. It might even be interesting eventually. Anyhow, it was less painful than runtime reflection on the type, which we could certainly go to if we want to.

### Motivation

Although the actively replicated client exposed these verbs, the compute controller did not, as its clients were behind an abstraction boundary. 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
