### PR TITLE
sql,coord: beginnings of ALTER CLUSTER

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -91,8 +91,9 @@ use uuid::Uuid;
 use mz_build_info::BuildInfo;
 use mz_dataflow_types::client::controller::ReadPolicy;
 use mz_dataflow_types::client::{
-    ComputeInstanceId, ComputeResponse, CreateSourceCommand, Response as DataflowResponse,
-    StorageResponse, TimestampBindingFeedback, DEFAULT_COMPUTE_INSTANCE_ID,
+    ComputeInstanceId, ComputeResponse, CreateSourceCommand, InstanceConfig,
+    Response as DataflowResponse, StorageResponse, TimestampBindingFeedback,
+    DEFAULT_COMPUTE_INSTANCE_ID,
 };
 use mz_dataflow_types::sinks::{SinkAsOf, SinkConnector, SinkDesc, TailSinkConnector};
 use mz_dataflow_types::sources::{
@@ -125,15 +126,15 @@ use mz_sql::catalog::{
 };
 use mz_sql::names::{DatabaseSpecifier, FullName};
 use mz_sql::plan::{
-    AlterIndexEnablePlan, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan,
-    AlterItemRenamePlan, ComputeInstanceIntrospectionConfig, CreateComputeInstancePlan,
-    CreateDatabasePlan, CreateIndexPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan,
-    CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan,
-    CreateViewsPlan, DropComputeInstancesPlan, DropDatabasePlan, DropItemsPlan, DropRolesPlan,
-    DropSchemaPlan, ExecutePlan, ExplainPlan, FetchPlan, HirRelationExpr, IndexOption,
-    IndexOptionName, InsertPlan, MutationKind, OptimizerConfig, Params, PeekPlan, Plan, QueryWhen,
-    RaisePlan, ReadThenWritePlan, SendDiffsPlan, SetVariablePlan, ShowVariablePlan, StatementDesc,
-    TailFrom, TailPlan, View,
+    AlterComputeInstancePlan, AlterIndexEnablePlan, AlterIndexResetOptionsPlan,
+    AlterIndexSetOptionsPlan, AlterItemRenamePlan, ComputeInstanceIntrospectionConfig,
+    CreateComputeInstancePlan, CreateDatabasePlan, CreateIndexPlan, CreateRolePlan,
+    CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan,
+    CreateTypePlan, CreateViewPlan, CreateViewsPlan, DropComputeInstancesPlan, DropDatabasePlan,
+    DropItemsPlan, DropRolesPlan, DropSchemaPlan, ExecutePlan, ExplainPlan, FetchPlan,
+    HirRelationExpr, IndexOption, IndexOptionName, InsertPlan, MutationKind, OptimizerConfig,
+    Params, PeekPlan, Plan, QueryWhen, RaisePlan, ReadThenWritePlan, SendDiffsPlan,
+    SetVariablePlan, ShowVariablePlan, StatementDesc, TailFrom, TailPlan, View,
 };
 use mz_sql_parser::ast::RawName;
 use mz_transform::Optimizer;
@@ -461,7 +462,11 @@ impl Coordinator {
     ) -> Result<(), CoordError> {
         for instance in self.catalog.compute_instances() {
             self.dataflow_client
-                .create_instance(instance.id, instance.config.clone())
+                .create_instance(
+                    instance.id,
+                    instance.config.clone(),
+                    instance.logging.clone(),
+                )
                 .await
                 .unwrap();
         }
@@ -1468,6 +1473,7 @@ impl Coordinator {
                     // Statements below must by run singly (in Started).
                     Statement::AlterIndex(_)
                     | Statement::AlterSecret(_)
+                    | Statement::AlterCluster(_)
                     | Statement::AlterObjectRename(_)
                     | Statement::CreateDatabase(_)
                     | Statement::CreateIndex(_)
@@ -1800,6 +1806,9 @@ impl Coordinator {
                     session,
                 );
             }
+            Plan::AlterComputeInstance(plan) => {
+                tx.send(self.sequence_alter_compute_instance(plan).await, session);
+            }
             Plan::AlterItemRename(plan) => {
                 tx.send(self.sequence_alter_item_rename(plan).await, session);
             }
@@ -2006,7 +2015,11 @@ impl Coordinator {
                     .resolve_compute_instance(&plan.name)
                     .expect("compute instance must exist after creation");
                 self.dataflow_client
-                    .create_instance(instance.id, instance.config.clone())
+                    .create_instance(
+                        instance.id,
+                        instance.config.clone(),
+                        instance.logging.clone(),
+                    )
                     .await
                     .unwrap();
                 Ok(ExecuteResponse::CreatedComputeInstance { existed: false })
@@ -2019,6 +2032,76 @@ impl Coordinator {
             }
             Err(err) => Err(err),
         }
+    }
+
+    async fn sequence_alter_compute_instance(
+        &mut self,
+        plan: AlterComputeInstancePlan,
+    ) -> Result<ExecuteResponse, CoordError> {
+        let instance = self.catalog.state().get_compute_instance(plan.id);
+        let old_config = instance.config.clone();
+
+        let ops = vec![catalog::Op::UpdateComputeInstanceConfig {
+            id: plan.id,
+            config: plan.config.clone(),
+        }];
+        let mut replicas_to_remove = vec![];
+        let mut replicas_to_add = vec![];
+        self.catalog_transact(ops, |tx| {
+            let new_config = &tx.catalog.get_compute_instance(plan.id).config;
+            match (old_config, new_config) {
+                (InstanceConfig::Virtual, InstanceConfig::Virtual) => Ok(()),
+                (
+                    InstanceConfig::Remote {
+                        replicas: old_replicas,
+                    },
+                    InstanceConfig::Remote {
+                        replicas: new_replicas,
+                    },
+                ) => {
+                    for (name, old_hosts) in &old_replicas {
+                        match new_replicas.get(name) {
+                            None => replicas_to_remove.push(name.clone()),
+                            Some(new_hosts) => {
+                                if old_hosts != new_hosts {
+                                    coord_bail!("cannot change definition of existing replica");
+                                }
+                            }
+                        }
+                    }
+                    for (name, new_hosts) in new_replicas {
+                        if !old_replicas.contains_key(name) {
+                            replicas_to_add.push((name.clone(), new_hosts.clone()));
+                        }
+                    }
+                    Ok(())
+                }
+                (
+                    InstanceConfig::Managed { size: old_size },
+                    InstanceConfig::Managed { size: new_size },
+                ) => {
+                    if old_size != *new_size {
+                        coord_bail!("cannot yet change size of cluster");
+                    }
+                    Ok(())
+                }
+                _ => coord_bail!("cannot change type of existing cluster"),
+            }
+        })
+        .await?;
+        // TODO(benesch,mcsherry): move this logic into the controller.
+        let mut compute_instance = self.dataflow_client.compute_mut(plan.id).unwrap();
+        for name in replicas_to_remove {
+            compute_instance.remove_replica(&name);
+        }
+        for (name, hosts) in replicas_to_add {
+            use mz_dataflow_types::client::{ComputeClient, ComputeWrapperClient, RemoteClient};
+            let client = RemoteClient::new(&hosts.into_iter().collect::<Vec<_>>());
+            let client = ComputeWrapperClient::new(client, plan.id);
+            let client: Box<dyn ComputeClient<_>> = Box::new(client);
+            compute_instance.add_replica(name, client).await;
+        }
+        Ok(ExecuteResponse::AlteredObject(ObjectType::Cluster))
     }
 
     async fn sequence_create_secret(

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -65,23 +65,16 @@ pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 1;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum InstanceConfig {
     /// In-process virtual instance, likely the default instance
-    Virtual {
-        /// Logging configuration.
-        logging: Option<LoggingConfig>,
-    },
+    Virtual,
     /// Out-of-process named instance
     Remote {
-        /// The hosts to connect to.
-        hosts: Vec<String>,
-        /// Logging configuration.
-        logging: Option<LoggingConfig>,
+        /// A map from replica name to hostnames.
+        replicas: BTreeMap<String, BTreeSet<String>>,
     },
     /// A remote but managed instance.
     Managed {
         /// The size of the cluster.
         size: String,
-        /// Logging configuration.
-        logging: Option<LoggingConfig>,
     },
 }
 

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -167,11 +167,11 @@ where
     }
 
     /// Adds a new instance replica, by name.
-    pub async fn add_replica(&mut self, id: uuid::Uuid, client: Box<dyn ComputeClient<T>>) {
+    pub async fn add_replica(&mut self, id: String, client: Box<dyn ComputeClient<T>>) {
         self.compute.client.add_replica(id, client).await;
     }
     /// Removes an existing instance replica, by name.
-    pub fn remove_replica(&mut self, id: &uuid::Uuid) {
+    pub fn remove_replica(&mut self, id: &str) {
         self.compute.client.remove_replica(id);
     }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -51,6 +51,7 @@ pub enum Statement<T: AstInfo> {
     AlterObjectRename(AlterObjectRenameStatement<T>),
     AlterIndex(AlterIndexStatement<T>),
     AlterSecret(AlterSecretStatement<T>),
+    AlterCluster(AlterClusterStatement),
     Discard(DiscardStatement),
     DropDatabase(DropDatabaseStatement),
     DropObjects(DropObjectsStatement),
@@ -103,6 +104,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::AlterObjectRename(stmt) => f.write_node(stmt),
             Statement::AlterIndex(stmt) => f.write_node(stmt),
             Statement::AlterSecret(stmt) => f.write_node(stmt),
+            Statement::AlterCluster(stmt) => f.write_node(stmt),
             Statement::Discard(stmt) => f.write_node(stmt),
             Statement::DropDatabase(stmt) => f.write_node(stmt),
             Statement::DropObjects(stmt) => f.write_node(stmt),
@@ -869,8 +871,13 @@ impl_display!(CreateClusterStatement);
 pub enum ClusterOption {
     /// The `VIRTUAL` option.
     Virtual,
-    /// The `REMOTE (<host> [, <host> ...])` option.
-    Remote(Vec<WithOptionValue>),
+    /// The `REMOTE <cluster> (<host> [, <host> ...])` option.
+    Remote {
+        /// The name.
+        name: Ident,
+        /// The hosts.
+        hosts: Vec<WithOptionValue>,
+    },
     /// The `SIZE [[=] <size>]` option.
     Size(WithOptionValue),
     /// The `INTROSPECTION GRANULARITY [[=] <interval>] option.
@@ -883,9 +890,11 @@ impl AstDisplay for ClusterOption {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             ClusterOption::Virtual => f.write_str("VIRTUAL"),
-            ClusterOption::Remote(hosts) => {
-                f.write_str("REMOTE (");
-                display::comma_separated(hosts);
+            ClusterOption::Remote { name, hosts } => {
+                f.write_str("REMOTE ");
+                f.write_node(name);
+                f.write_str(" (");
+                f.write_node(&display::comma_separated(hosts));
                 f.write_str(")");
             }
             ClusterOption::Size(size) => {
@@ -1010,6 +1019,33 @@ impl<T: AstInfo> AstDisplay for AlterSecretStatement<T> {
 }
 
 impl_display_t!(AlterSecretStatement);
+
+/// `ALTER CLUSTER ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AlterClusterStatement {
+    /// Name of the cluster to alter.
+    pub name: Ident,
+    /// Whether the `IF EXISTS` clause was specified.
+    pub if_exists: bool,
+    /// The comma-separated options.
+    pub options: Vec<ClusterOption>,
+}
+
+impl AstDisplay for AlterClusterStatement {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("ALTER CLUSTER ");
+        if self.if_exists {
+            f.write_str("IF EXISTS ");
+        }
+        f.write_node(&self.name);
+        if !self.options.is_empty() {
+            f.write_str(" ");
+            f.write_node(&display::comma_separated(&self.options));
+        }
+    }
+}
+
+impl_display!(AlterClusterStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DiscardStatement {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1311,6 +1311,34 @@ CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual, Virtual, Size(Value(String("small"))), Virtual, Size(Value(String("medium")))] })
 
 parse-statement
+CREATE CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
+----
+CREATE CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Remote { name: Ident("replica1"), hosts: [Value(String("host1")), Value(String("host2"))] }, Remote { name: Ident("replica2"), hosts: [Value(String("host3")), Value(String("host4"))] }] })
+
+parse-statement
+ALTER CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
+----
+ALTER CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
+=>
+AlterCluster(AlterClusterStatement { name: Ident("cluster"), if_exists: false, options: [Remote { name: Ident("replica1"), hosts: [Value(String("host1")), Value(String("host2"))] }, Remote { name: Ident("replica2"), hosts: [Value(String("host3")), Value(String("host4"))] }] })
+
+parse-statement
+ALTER CLUSTER cluster SIZE 'small'
+----
+ALTER CLUSTER cluster SIZE 'small'
+=>
+AlterCluster(AlterClusterStatement { name: Ident("cluster"), if_exists: false, options: [Size(Value(String("small")))] })
+
+parse-statement
+ALTER CLUSTER cluster RENAME TO cluster2
+----
+error: Expected one of VIRTUAL or REMOTE or SIZE or INTROSPECTION, found RENAME
+ALTER CLUSTER cluster RENAME TO cluster2
+                      ^
+
+parse-statement
 DROP CLUSTER cluster
 ----
 DROP CLUSTER cluster

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -26,7 +26,7 @@
 // `plan_root_query` and fanning out based on the contents of the `SELECT`
 // statement.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -104,6 +104,7 @@ pub enum Plan {
     SendDiffs(SendDiffsPlan),
     Insert(InsertPlan),
     AlterNoop(AlterNoopPlan),
+    AlterComputeInstance(AlterComputeInstancePlan),
     AlterIndexSetOptions(AlterIndexSetOptionsPlan),
     AlterIndexResetOptions(AlterIndexResetOptionsPlan),
     AlterIndexEnable(AlterIndexEnablePlan),
@@ -152,7 +153,8 @@ pub struct CreateComputeInstancePlan {
 pub enum ComputeInstanceConfig {
     Virtual,
     Remote {
-        hosts: Vec<String>,
+        /// A map from replica name to hostnames.
+        replicas: BTreeMap<String, BTreeSet<String>>,
         introspection: Option<ComputeInstanceIntrospectionConfig>,
     },
     Managed {
@@ -343,6 +345,12 @@ pub struct ReadThenWritePlan {
 #[derive(Debug)]
 pub struct AlterNoopPlan {
     pub object_type: ObjectType,
+}
+
+#[derive(Debug)]
+pub struct AlterComputeInstancePlan {
+    pub id: ComputeInstanceId,
+    pub config: ComputeInstanceConfig,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -141,6 +141,7 @@ pub fn describe(
         }
         (Statement::AlterIndex(stmt), None) => ddl::describe_alter_index_options(&scx, stmt)?,
         (Statement::AlterSecret(stmt), None) => ddl::describe_alter_secret_options(&scx, stmt)?,
+        (Statement::AlterCluster(stmt), None) => ddl::describe_alter_cluster(&scx, stmt)?,
 
         // `SHOW` statements.
         (Statement::ShowCreateTable(stmt), None) => show::describe_show_create_table(&scx, stmt)?,
@@ -248,6 +249,7 @@ pub fn plan(
         Statement::AlterIndex(stmt) => ddl::plan_alter_index_options(scx, stmt),
         Statement::AlterObjectRename(stmt) => ddl::plan_alter_object_rename(scx, stmt),
         Statement::AlterSecret(stmt) => ddl::plan_alter_secret(scx, stmt),
+        Statement::AlterCluster(stmt) => ddl::plan_alter_cluster(scx, stmt),
 
         // DML statements.
         Statement::Insert(stmt) => dml::plan_insert(scx, stmt, params),

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -35,6 +35,16 @@ SERVICES = [
         ports=[6876, 2101],
     ),
     Dataflowd(
+        name="dataflowd_compute_3",
+        options="--workers 2 --storage-workers 2 --processes 2 --process 0 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
+        ports=[6876, 2101],
+    ),
+    Dataflowd(
+        name="dataflowd_compute_4",
+        options="--workers 2 --storage-workers 2 --processes 2 --process 1 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
+        ports=[6876, 2101],
+    ),
+    Dataflowd(
         name="dataflowd_storage",
         options="--workers 2 --storage-addr dataflowd_storage:2102 --runtime storage",
         ports=[6876, 2102],
@@ -76,12 +86,25 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.up("dataflowd_storage")
     c.up("dataflowd_compute_1")
     c.up("dataflowd_compute_2")
+    c.sleep(5)  # TODO: make this unnecessary
     c.up("materialized")
     c.wait_for_materialized(service="materialized")
     # Dropping the `default` cluster lightly tests that `materialized` can run
     # and restart without any virtual clusters in the virtual cluster host.
     c.sql("DROP CLUSTER default")
     c.sql(
-        "CREATE CLUSTER default REMOTE ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876');"
+        "CREATE CLUSTER default REMOTE replica1 ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876');"
+    )
+    c.run("testdrive-svc", *glob)
+
+    c.up("dataflowd_compute_3")
+    c.up("dataflowd_compute_4")
+    c.sleep(5)  # TODO: make this unnecessary
+    c.sql(
+        """
+        ALTER CLUSTER default
+            REMOTE replica1 ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876'),
+            REMOTE replica2 ('dataflowd_compute_3:6876', 'dataflowd_compute_4:6876')
+        """
     )
     c.run("testdrive-svc", *glob)


### PR DESCRIPTION
ALTER CLUSTER is a possibly short-lived command to add and remove
replicas of clusters. Specifically, the syntax of CREATE CLUSTER ...
REMOTE is changed to

    CREATE CLUSTER <name> [REMOTE <name> (<host>, <host> ...) ...]

where multiple REMOTE clauses may now be specified to name multiple
replicas. A nearly identical ALTER CLUSTER command

    ALTER CLUSTER <name> [REMOTE <name> (<host>, <host> ...) ...]

can we used to wholesale replace the remote replica set of a cluster.
Replicas are identified by the user provided name. After alteration, any
new replicas are added and any unnamed replicas are removed. Changing
the host specification of an existing replica is not permitted.

Forthcoming work will make the concept of a replica more explicitly part
of the system (e.g., by allowing virtual and managed replicas). But for
now this unblocks the active replication work.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (Unstable feature; tests later.)

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A