### PR TITLE
dataflow-types: teach PartitionedClient to absorb errors

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -142,9 +142,7 @@ steps:
   - id: cluster-smoke
     label: Cluster smoke test
     depends_on: build-x86_64
-    timeout_in_minutes: 5
-    # https://github.com/MaterializeInc/materialize/issues/11390
-    soft_fail: true
+    timeout_in_minutes: 10
     inputs: [test/cluster]
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
The PartitionedClient is meant to abstract away the details of
communicating with a multi-process timely cluster. Previously the
multi-process nature leaked out when errors occurred: one error was
returned for each process.

This commit teaches PartitionedClient to instead suppress all but the
Nth error, where N is the number of parts. This ensures that the caller
observes each error only once.

Notably, this PR, along with the already merged #11405, fixes #11390.
The issue was that the `ActiveReplication` client would observe *two*
errors on initial connection, for the reason mentioned above,  and
attempt to hydrate the replica twice, which is not yet safe. #11103 will
one day make hydrating the same replica twice safe, but we're not there
yet.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
