### PR TITLE
Reenable testdrive retry cancelation timeout

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -621,6 +621,14 @@ default timeout, unless you specify `force=true`. Use this override with
 caution! It may cause the test to fail in test environments that introduce
 overhead and need a larger `--default-timeout` to succeed.
 
+#### `$ set-max-tries max-tries=N`
+
+Adjust the number of tries testdrive will perform while waiting for a SQL statement to arrive to the desired result.
+
+Set `max-tries` to `1` in order to ensure that statements are executed only once. If the desired result is not achieved on the first try, the test will fail. This is
+useful when testing operations that should return the right result immediately rather than eventually.
+
+
 ## Actions on Avro OCF files
 
 #### `$ avro-ocf-write path=... schema=... codec=(snapy|null) [repeat=N]`

--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -62,6 +62,7 @@ use std::thread;
 use futures::{ready, Stream, StreamExt};
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, ReadBuf};
+use tokio::time::error::Elapsed;
 use tokio::time::{self, Duration, Instant, Sleep};
 
 /// The state of a retry operation constructed with [`Retry`].
@@ -211,6 +212,36 @@ impl Retry {
             }
         }
         Err(err.expect("retry produces at least one element"))
+    }
+
+    /// Like [`Retry::retry_async`] but the operation will be canceled if the
+    /// maximum duration is reached.
+    ///
+    /// Specifically, if the maximum duration is reached, the operation `f` will
+    /// be forcibly canceled by dropping it, and an [`Elapsed`] error will be
+    /// returned. Canceling `f` can be surprising if the operation is not
+    /// programmed to expect the possibility of not resuming from an `await`
+    /// point; if you wish to always run `f` to completion, use
+    /// [`Retry::retry_async`] instead.
+    pub async fn retry_async_canceling<F, U, T, E>(self, mut f: F) -> Result<T, E>
+    where
+        F: FnMut(RetryState) -> U,
+        U: Future<Output = Result<T, E>>,
+        E: From<Elapsed>,
+    {
+        let start = Instant::now();
+        let max_duration = self.max_duration;
+        self.retry_async(|state| {
+            let fut = time::timeout(max_duration.saturating_sub(start.elapsed()), f(state));
+            async move {
+                match fut.await {
+                    Ok(Ok(t)) => Ok(t),
+                    Ok(Err(e)) => Err(e),
+                    Err(e) => Err(e.into()),
+                }
+            }
+        })
+        .await
     }
 
     /// Convert into [`RetryStream`]

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -282,7 +282,7 @@ impl State {
     async fn delete_bucket_objects(&self, bucket: String) -> Result<(), anyhow::Error> {
         Retry::default()
             .max_duration(self.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 // loop until error or response has no continuation token
                 let mut continuation_token = None;
                 loop {
@@ -321,7 +321,7 @@ impl State {
     pub async fn reset_sqs(&self) -> Result<(), anyhow::Error> {
         Retry::default()
             .max_duration(self.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 for queue_url in &self.sqs_queues_created {
                     self.sqs_client
                         .delete_queue()

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -78,6 +78,8 @@ pub struct Config {
     pub temp_dir: Option<String>,
     /// The default timeout for cancellable operations.
     pub default_timeout: Duration,
+    /// The default number of tries for retriable operations.
+    pub default_max_tries: usize,
     /// The initial backoff interval for retry operations.
     ///
     /// Set to 0 to retry immediately on failure.
@@ -138,6 +140,8 @@ pub struct State {
     _tempfile: Option<tempfile::TempDir>,
     default_timeout: Duration,
     timeout: Duration,
+    default_max_tries: usize,
+    max_tries: usize,
     initial_backoff: Duration,
     backoff_factor: f64,
     regex: Option<Regex>,
@@ -540,6 +544,7 @@ pub(crate) async fn build(
                     "set-sql-timeout" => {
                         Box::new(set::build_sql_timeout(builtin).map_err(wrap_err)?)
                     }
+                    "set-max-tries" => Box::new(set::build_max_tries(builtin).map_err(wrap_err)?),
                     "sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment" => {
                         Box::new(sleep::build_sleep(builtin).map_err(wrap_err)?)
                     }
@@ -780,6 +785,8 @@ pub async fn create_state(
         _tempfile,
         default_timeout: config.default_timeout,
         timeout: config.default_timeout,
+        default_max_tries: config.default_max_tries,
+        max_tries: config.default_max_tries,
         initial_backoff: config.initial_backoff,
         backoff_factor: config.backoff_factor,
         regex: None,

--- a/src/testdrive/src/action/avro_ocf.rs
+++ b/src/testdrive/src/action/avro_ocf.rs
@@ -155,7 +155,7 @@ impl Action for VerifyAction {
     async fn redo(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
         let path = Retry::default()
             .max_duration(state.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 let row = state
                     .pgclient
                     .query_one(

--- a/src/testdrive/src/action/kafka/add_partitions.rs
+++ b/src/testdrive/src/action/kafka/add_partitions.rs
@@ -87,7 +87,7 @@ impl Action for AddPartitionsAction {
 
         Retry::default()
             .max_duration(state.default_timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 let metadata = state.kafka_producer.client().fetch_metadata(
                     Some(&topic_name),
                     Some(cmp::max(state.default_timeout, Duration::from_secs(1))),

--- a/src/testdrive/src/action/kinesis/create_stream.rs
+++ b/src/testdrive/src/action/kinesis/create_stream.rs
@@ -57,7 +57,7 @@ impl Action for CreateStreamAction {
 
         Retry::default()
             .max_duration(cmp::max(state.default_timeout, Duration::from_secs(60)))
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 let description = state
                     .kinesis_client
                     .describe_stream()

--- a/src/testdrive/src/action/kinesis/ingest.rs
+++ b/src/testdrive/src/action/kinesis/ingest.rs
@@ -60,7 +60,7 @@ impl Action for IngestAction {
             // be prepared to back off.
             Retry::default()
                 .max_duration(state.default_timeout)
-                .retry_async(|_| async {
+                .retry_async_canceling(|_| async {
                     match state
                         .kinesis_client
                         .put_record()

--- a/src/testdrive/src/action/kinesis/update_shards.rs
+++ b/src/testdrive/src/action/kinesis/update_shards.rs
@@ -63,7 +63,7 @@ impl Action for UpdateShardCountAction {
         // Verify the current shard count.
         Retry::default()
             .max_duration(cmp::max(state.default_timeout, Duration::from_secs(60)))
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 // Wait for shards to stop updating.
                 let description = state
                     .kinesis_client

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -57,7 +57,7 @@ impl Action for VerifySlotAction {
         Retry::default()
             .initial_backoff(Duration::from_millis(50))
             .max_duration(cmp::max(state.default_timeout, Duration::from_secs(3)))
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 println!(">> checking for postgres replication slot {}", &self.slot);
                 let rows = client
                     .query(

--- a/src/testdrive/src/action/schema_registry.rs
+++ b/src/testdrive/src/action/schema_registry.rs
@@ -95,7 +95,7 @@ impl Action for WaitSchemaAction {
             .initial_backoff(Duration::from_millis(50))
             .factor(1.5)
             .max_duration(state.timeout)
-            .retry_async(|_| async {
+            .retry_async_canceling(|_| async {
                 state
                     .ccsr_client
                     .get_schema_by_subject(&self.schema)

--- a/src/testdrive/src/action/set.rs
+++ b/src/testdrive/src/action/set.rs
@@ -80,3 +80,26 @@ impl Action for SqlTimeoutAction {
         Ok(ControlFlow::Continue)
     }
 }
+
+pub struct MaxTriesAction {
+    max_tries: Option<usize>,
+}
+
+pub fn build_max_tries(mut cmd: BuiltinCommand) -> Result<MaxTriesAction, anyhow::Error> {
+    let max_tries = cmd.args.string("max-tries")?;
+    Ok(MaxTriesAction {
+        max_tries: Some(max_tries.parse::<usize>()?),
+    })
+}
+
+#[async_trait]
+impl Action for MaxTriesAction {
+    async fn undo(&self, _: &mut State) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
+        state.max_tries = self.max_tries.unwrap_or(state.default_max_tries);
+        Ok(ControlFlow::Continue)
+    }
+}

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -135,7 +135,8 @@ impl Action for SqlAction {
             true => Retry::default()
                 .initial_backoff(state.initial_backoff)
                 .factor(state.backoff_factor)
-                .max_duration(state.timeout),
+                .max_duration(state.timeout)
+                .max_tries(state.max_tries),
             false => Retry::default().max_tries(1),
         }
         .retry_async_canceling(|retry_state| async move {
@@ -389,7 +390,8 @@ impl Action for FailSqlAction {
             true => Retry::default()
                 .initial_backoff(state.initial_backoff)
                 .factor(state.backoff_factor)
-                .max_duration(state.timeout),
+                .max_duration(state.timeout)
+                .max_tries(state.max_tries),
             false => Retry::default().max_tries(1),
         }.retry_async(|retry_state| async move {
             match self.try_redo(state, &query).await {

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -138,7 +138,7 @@ impl Action for SqlAction {
                 .max_duration(state.timeout),
             false => Retry::default().max_tries(1),
         }
-        .retry_async(|retry_state| async move {
+        .retry_async_canceling(|retry_state| async move {
             match self.try_redo(state, &query).await {
                 Ok(()) => {
                     if retry_state.i != 0 {

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -57,7 +57,7 @@ impl Action for VerifyTimestampCompactionAction {
             Retry::default()
                 .initial_backoff(Duration::from_secs(1))
                 .max_duration(Duration::from_secs(30))
-                .retry_async(|retry_state| {
+                .retry_async_canceling(|retry_state| {
                     let initial_highest = Arc::clone(&initial_highest_base);
                     async move {
                         let mut catalog = Catalog::open_debug(path, NOW_ZERO.clone())

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -67,6 +67,9 @@ struct Args {
     /// Default timeout for cancellable operations.
     #[clap(long, parse(try_from_str = mz_repr::util::parse_duration), default_value = "10s", value_name = "DURATION")]
     default_timeout: Duration,
+    /// The default number of times to retry a query expecting it to converge to the desired result.
+    #[clap(long, default_value = "18446744073709551615", value_name = "N")]
+    default_max_tries: usize,
     /// Initial backoff interval for retry operations.
     ///
     /// Set to 0 to retry immediately on failure.
@@ -262,6 +265,7 @@ async fn main() {
         reset: !args.no_reset,
         temp_dir: args.temp_dir,
         default_timeout: args.default_timeout,
+        default_max_tries: args.default_max_tries,
         initial_backoff: args.initial_backoff,
         backoff_factor: args.backoff_factor,
 

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -29,7 +29,7 @@ SERVICES = [
     SchemaRegistry(kafka_servers=[("kafka", f"{KAFKA_SINK_PORT}")]),
     Materialized(),
     Toxiproxy(),
-    Testdrive(kafka_url="toxiproxy:9093"),
+    Testdrive(kafka_url="toxiproxy:9093", default_timeout="120s"),
 ]
 
 #

--- a/test/testdrive/github-10587.td
+++ b/test/testdrive/github-10587.td
@@ -134,7 +134,7 @@ count
 # in a row. Obviously, this test will not always catch the issue since the original
 # bug was nondeterministic, but this is a good best-effort smake test.
 
-$ set-sql-timeout duration=0s force=true
+$ set-max-tries max-tries=1
 
 > SELECT mz_internal.mz_sleep(0.2);
 <null>


### PR DESCRIPTION
```
commit 90262ee693c8235a0f25d7a4534192bd3dbe46f7 (HEAD -> reenable-testdrive-retry-cancelation-timeout, origin/reenable-testdrive-retry-cancelation-timeout)
Author: Philip Stoev <pstoev@materialize.io>
Date:   Mon Mar 28 09:42:12 2022 +0200

    testdrive: Control the number of tries for SQL queries
    
    Introduce a `$ set-max-tries` action that control the number of times
    a SQL statement is executed while waiting for it to return the expected
    result. Setting to 1 ensures that statement are only executed once.
    
    Fix github-10587.td to use the new functionality.

commit 15f18bad1663a19cfbd33f72199eb4f111d20b17
Author: Nikhil Benesch <nikhil.benesch@gmail.com>
Date:   Fri Mar 11 12:01:35 2022 -0500

    ore: introduce a canceling retry_async variant (re-introduction)
    
    [This commit re-introduces functionality that was previosuly backed out]
    
    It is often desirable to forcibly terminate the operation under retry
    when the max duration is reached. Add a `retry_async_canceling` variant
    that does this, and use this in testdrive.
    
    Alternative to #11172.

```

### Motivation

  * This PR fixes a previously unreported bug.

We introduced functionality that allowed testdrive to abort individual SQL statements if they executed for longer than the timeout. This broke `github-10587.td` as it was using `set-sql-timeout duration=0s`, which was causing immediate timeouts.

Introduce a `$ set-max-tries` functionality to get the test to do the right thing without timing out.


### Tips for reviewer

@benesch if you can take a quick look at the second commit that would be much appreciated. The first commit is the original one from your "canceling retry_async" PR.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

the testdrive.td file has been updated to include the new functionality.