### PR TITLE
ci: increase the testdrive timeout to 60s

### DIFF
--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -88,6 +88,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     testdrive = Testdrive(
+        default_timeout="60s",
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         entrypoint_extra=[f"--aws-region={args.aws_region}"]


### PR DESCRIPTION
test/testdrive/mzcompose.py is called by the CI using various options,
some of which put Mz under considerable stress, such as --workers 1 or
--workers 32. The default testdrive timeout of 30s was not large enough
to accomodate all the individual configurations being tested.

In particular, introspection information was not processed quickly enough
to allow queries against the mz_* tables to converge to the expected
result within 30s.

### Motivation

  * This PR fixes a previously unreported bug.

Failiures in Nightly across the board.