### PR TITLE
Proposal: unban 'thiserror'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,6 @@ name = "mz-coord"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "backtrace",
  "bincode",
  "byteorder",
  "chrono",
@@ -3240,6 +3239,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "timely",
  "tokio",
  "tokio-postgres",
@@ -3303,6 +3303,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "timely",
  "tokio",
  "tokio-byteorder",
@@ -3561,6 +3562,7 @@ dependencies = [
  "rdkafka",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "url",

--- a/deny.toml
+++ b/deny.toml
@@ -64,40 +64,6 @@ name = "strum"
 [[bans.deny]]
 name = "strum-macros"
 
-# `thiserror` requires everyone to learn a special DSL. Our current position is
-# that it is clearer to require manual implementations of the `Error` trait.
-[[bans.deny]]
-name = "thiserror"
-wrappers = [
-    # Only list third-party crates here.
-    "async-native-tls",
-    "aws-http",
-    "aws-smithy-xml",
-    "aws-sig-auth",
-    "flatbuffers",
-    "junit-report",
-    "kube-client",
-    "kube-core",
-    "mysql_async",
-    "mysql_common",
-    "opentelemetry",
-    "opentelemetry-otlp",
-    "pprof",
-    "proc-macro-crate",
-    "prometheus",
-    "protoc",
-    "protobuf-codegen",
-    "protobuf-codegen-pure",
-    "protobuf-parse",
-    "pubnub-core",
-    "pubnub-hyper",
-    "simple_asn1",
-    "sysctl",
-    "tiberius",
-    "tungstenite",
-    "zip",
-]
-
 [[bans.deny]]
 name = "log"
 wrappers = [

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.56"
-backtrace = "0.3.64"
+# backtrace = "0.3.64"
 bincode = { version = "1.3.3", optional = true }
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
@@ -56,6 +56,7 @@ tokio = { version = "1.17.0", features = ["rt"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-stream = "0.1.8"
 tracing = "0.1.32"
+thiserror = "1.0.30"
 uncased = "0.9.6"
 url = "2.2.2"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.56"
-# backtrace = "0.3.64"
 bincode = { version = "1.3.3", optional = true }
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -74,6 +74,7 @@ pub mod storage;
 
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
 pub use crate::catalog::config::Config;
+pub use crate::catalog::error::AmbiguousRename;
 pub use crate::catalog::error::Error;
 pub use crate::catalog::error::ErrorKind;
 
@@ -2248,7 +2249,7 @@ impl Catalog {
                             true,
                         )
                         .map_err(|e| {
-                            Error::new(ErrorKind::AmbiguousRename {
+                            Error::new(ErrorKind::from(AmbiguousRename {
                                 depender: self
                                     .resolve_full_name(&entry.name, entry.conn_id())
                                     .to_string(),
@@ -2256,7 +2257,7 @@ impl Catalog {
                                     .resolve_full_name(&entry.name, entry.conn_id())
                                     .to_string(),
                                 message: e,
-                            })
+                            }))
                         })?;
                     let serialized_item = self.serialize_item(&item);
 
@@ -2270,7 +2271,7 @@ impl Catalog {
                                 false,
                             )
                             .map_err(|e| {
-                                Error::new(ErrorKind::AmbiguousRename {
+                                Error::new(ErrorKind::from(AmbiguousRename {
                                     depender: self
                                         .resolve_full_name(
                                             &dependent_item.name,
@@ -2281,7 +2282,7 @@ impl Catalog {
                                         .resolve_full_name(&entry.name, entry.conn_id())
                                         .to_string(),
                                     message: e,
-                                })
+                                }))
                             })?;
 
                         if !item.is_temporary() {

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -17,8 +17,6 @@ use mz_sql::catalog::CatalogError as SqlCatalogError;
 pub struct Error {
     #[from]
     pub(crate) kind: ErrorKind,
-    // #[backtrace] TODO(guswynn): when its stable
-    // pub(crate) _backtrace: Backtrace,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -64,7 +62,7 @@ pub enum ErrorKind {
     #[error("persistence error: {0}")]
     Persistence(#[from] mz_persist::error::Error),
     #[error(transparent)]
-    AmbiguousRenamed(#[from] AmbiguousRename),
+    AmbiguousRename(#[from] AmbiguousRename),
     #[error("cannot rename type: {0}")]
     TypeRename(String),
     #[error(
@@ -91,10 +89,7 @@ more details, see https://materialize.com/docs/cli#experimental-mode"#
 
 impl Error {
     pub(crate) fn new(kind: ErrorKind) -> Error {
-        Error {
-            kind,
-            // _backtrace: Backtrace::new_unresolved(),
-        }
+        Error { kind }
     }
 
     /// Reports additional details about the error, if any are available.

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -7,58 +7,95 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-
-use backtrace::Backtrace;
-
 use mz_ore::str::StrExt;
 use mz_sql::catalog::CatalogError as SqlCatalogError;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
 pub struct Error {
+    #[from]
     pub(crate) kind: ErrorKind,
-    pub(crate) _backtrace: Backtrace,
+    // #[backtrace] TODO(guswynn): when its stable
+    // pub(crate) _backtrace: Backtrace,
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    Corruption {
-        detail: String,
-    },
+    #[error("corrupt catalog: {detail}")]
+    Corruption { detail: String },
+    #[error("id counter overflows i64")]
     IdExhaustion,
+    #[error("oid counter overflows i64")]
     OidExhaustion,
-    Sql(SqlCatalogError),
+    #[error(transparent)]
+    Sql(#[from] SqlCatalogError),
+    #[error("database '{0}' already exists")]
     DatabaseAlreadyExists(String),
+    #[error("schema '{0}' already exists")]
     SchemaAlreadyExists(String),
+    #[error("role '{0}' already exists")]
     RoleAlreadyExists(String),
+    #[error("cluster '{0}' already exists")]
     ClusterAlreadyExists(String),
+    #[error("catalog item '{0}' already exists")]
     ItemAlreadyExists(String),
+    #[error("unacceptable schema name '{0}'")]
     ReservedSchemaName(String),
+    #[error("role name {} is reserved", .0.quoted())]
     ReservedRoleName(String),
+    #[error("cluster name {} is reserved", .0.quoted())]
     ReservedClusterName(String),
+    #[error("system schema '{0}' cannot be modified")]
     ReadOnlySystemSchema(String),
+    #[error("system item '{0}' cannot be modified")]
     ReadOnlyItem(String),
+    #[error("cannot drop non-empty schema '{0}'")]
     SchemaNotEmpty(String),
+    #[error("non-temporary items cannot depend on temporary item '{0}'")]
     InvalidTemporaryDependency(String),
+    #[error("cannot create temporary item in non-temporary schema")]
     InvalidTemporarySchema,
-    UnsatisfiableLoggingDependency {
-        depender_name: String,
-    },
-    Storage(rusqlite::Error),
-    Persistence(mz_persist::error::Error),
+    #[error("catalog item '{depender_name}' depends on system logging, but logging is disabled")]
+    UnsatisfiableLoggingDependency { depender_name: String },
+    #[error("sqlite error: {0}")]
+    Storage(#[from] rusqlite::Error),
+    #[error("persistence error: {0}")]
+    Persistence(#[from] mz_persist::error::Error),
+    #[error("{}",
+        if depender == dependee {
+            format!("renaming conflict: in {}, {}", dependee, message)
+        } else {
+            format!("renaming conflict: in {}, which uses {}, {}",
+                depender, dependee, message
+            )
+        }
+    )]
     AmbiguousRename {
         depender: String,
         dependee: String,
         message: String,
     },
+    #[error("cannot rename type: {0}")]
     TypeRename(String),
+    #[error(
+        r#"Materialize previously started with --experimental to
+enable experimental features, so now must be started in experimental
+mode. For more details, see
+https://materialize.com/docs/cli#experimental-mode"#
+    )]
     ExperimentalModeRequired,
+    #[error(
+        r#"Experimental mode is only available on new nodes. For
+more details, see https://materialize.com/docs/cli#experimental-mode"#
+    )]
     ExperimentalModeUnavailable,
+    #[error("cannot migrate from catalog version {last_seen_version} to version {this_version} (earlier versions might still work): {cause}")]
     FailedMigration {
         last_seen_version: String,
         this_version: &'static str,
         cause: String,
     },
+    #[error("failpoint {0} reached)")]
     FailpointReached(String),
 }
 
@@ -66,7 +103,7 @@ impl Error {
     pub(crate) fn new(kind: ErrorKind) -> Error {
         Error {
             kind,
-            _backtrace: Backtrace::new_unresolved(),
+            // _backtrace: Backtrace::new_unresolved(),
         }
     }
 
@@ -94,146 +131,18 @@ impl Error {
 
 impl From<rusqlite::Error> for Error {
     fn from(e: rusqlite::Error) -> Error {
-        Error::new(ErrorKind::Storage(e))
+        Error::new(ErrorKind::from(e))
     }
 }
 
 impl From<SqlCatalogError> for Error {
     fn from(e: SqlCatalogError) -> Error {
-        Error::new(ErrorKind::Sql(e))
+        Error::new(ErrorKind::from(e))
     }
 }
 
 impl From<mz_persist::error::Error> for Error {
     fn from(e: mz_persist::error::Error) -> Error {
-        Error::new(ErrorKind::Persistence(e))
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.kind {
-            ErrorKind::Corruption { .. }
-            | ErrorKind::IdExhaustion
-            | ErrorKind::OidExhaustion
-            | ErrorKind::DatabaseAlreadyExists(_)
-            | ErrorKind::SchemaAlreadyExists(_)
-            | ErrorKind::RoleAlreadyExists(_)
-            | ErrorKind::ClusterAlreadyExists(_)
-            | ErrorKind::ItemAlreadyExists(_)
-            | ErrorKind::ReservedSchemaName(_)
-            | ErrorKind::ReservedRoleName(_)
-            | ErrorKind::ReservedClusterName(_)
-            | ErrorKind::ReadOnlySystemSchema(_)
-            | ErrorKind::ReadOnlyItem(_)
-            | ErrorKind::SchemaNotEmpty(_)
-            | ErrorKind::InvalidTemporaryDependency(_)
-            | ErrorKind::InvalidTemporarySchema
-            | ErrorKind::UnsatisfiableLoggingDependency { .. }
-            | ErrorKind::AmbiguousRename { .. }
-            | ErrorKind::TypeRename(_)
-            | ErrorKind::ExperimentalModeRequired
-            | ErrorKind::ExperimentalModeUnavailable
-            | ErrorKind::FailedMigration { .. }
-            | ErrorKind::FailpointReached(_) => None,
-            ErrorKind::Sql(e) => Some(e),
-            ErrorKind::Storage(e) => Some(e),
-            ErrorKind::Persistence(e) => Some(e),
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match &self.kind {
-            ErrorKind::Corruption { detail } => write!(f, "corrupt catalog: {}", detail),
-            ErrorKind::IdExhaustion => write!(f, "id counter overflows i64"),
-            ErrorKind::OidExhaustion => write!(f, "oid counter overflows u32"),
-            ErrorKind::Sql(e) => write!(f, "{}", e),
-            ErrorKind::DatabaseAlreadyExists(name) => {
-                write!(f, "database '{}' already exists", name)
-            }
-            ErrorKind::SchemaAlreadyExists(name) => write!(f, "schema '{}' already exists", name),
-            ErrorKind::RoleAlreadyExists(name) => {
-                write!(f, "role '{}' already exists", name)
-            }
-            ErrorKind::ClusterAlreadyExists(name) => {
-                write!(f, "cluster '{}' already exists", name)
-            }
-            ErrorKind::ItemAlreadyExists(name) => {
-                write!(f, "catalog item '{}' already exists", name)
-            }
-            ErrorKind::ReservedSchemaName(name) => {
-                write!(f, "unacceptable schema name '{}'", name)
-            }
-            ErrorKind::ReservedRoleName(name) => {
-                write!(f, "role name {} is reserved", name.quoted())
-            }
-            ErrorKind::ReservedClusterName(name) => {
-                write!(f, "cluster name {} is reserved", name.quoted())
-            }
-            ErrorKind::ReadOnlySystemSchema(name) => {
-                write!(f, "system schema '{}' cannot be modified", name)
-            }
-            ErrorKind::ReadOnlyItem(name) => write!(f, "system item '{}' cannot be modified", name),
-            ErrorKind::SchemaNotEmpty(name) => write!(f, "cannot drop non-empty schema '{}'", name),
-            ErrorKind::InvalidTemporaryDependency(name) => write!(
-                f,
-                "non-temporary items cannot depend on temporary item '{}'",
-                name
-            ),
-            ErrorKind::InvalidTemporarySchema => {
-                write!(f, "cannot create temporary item in non-temporary schema")
-            }
-            ErrorKind::UnsatisfiableLoggingDependency { depender_name } => write!(
-                f,
-                "catalog item '{}' depends on system logging, but logging is disabled",
-                depender_name
-            ),
-            ErrorKind::Storage(e) => write!(f, "sqlite error: {}", e),
-            ErrorKind::Persistence(e) => write!(f, "persistence error: {}", e),
-            ErrorKind::AmbiguousRename {
-                depender,
-                dependee,
-                message,
-            } => {
-                if depender == dependee {
-                    write!(f, "renaming conflict: in {}, {}", dependee, message)
-                } else {
-                    write!(
-                        f,
-                        "renaming conflict: in {}, which uses {}, {}",
-                        depender, dependee, message
-                    )
-                }
-            }
-            ErrorKind::TypeRename(typ) => write!(f, "cannot rename type: {}", typ),
-            ErrorKind::ExperimentalModeRequired => write!(
-                f,
-                r#"Materialize previously started with --experimental to
-enable experimental features, so now must be started in experimental
-mode. For more details, see
-https://materialize.com/docs/cli#experimental-mode"#
-            ),
-            ErrorKind::ExperimentalModeUnavailable => write!(
-                f,
-                r#"Experimental mode is only available on new nodes. For
-more details, see https://materialize.com/docs/cli#experimental-mode"#
-            ),
-            ErrorKind::FailedMigration {
-                last_seen_version,
-                this_version,
-                cause,
-            } => {
-                write!(
-                    f,
-                    "cannot migrate from catalog version {} to version {} (earlier versions might still work): {}",
-                    last_seen_version, this_version, cause
-                )
-            }
-            ErrorKind::FailpointReached(failpoint) => {
-                write!(f, "failpoint {} reached", failpoint)
-            }
-        }
+        Error::new(ErrorKind::from(e))
     }
 }

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -62,6 +62,7 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", bran
 tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-util = { version = "0.7.1", features = ["codec", "io"] }
 tracing = "0.1.32"
+thiserror = "1.0.30"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -21,5 +21,6 @@ rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["c
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["macros"] }
+thiserror = "1.0.30"
 tracing = "0.1.32"
 url = "2.2.2"


### PR DESCRIPTION
There is a reason why we have so many exceptions for the use of `thiserror` in our `deny.toml`. Here are some reasons why we should unban it:

- It is well-loved, well-tested, and there are plenty of examples of how to use it DSL in its docs and in the greater rust community
- It reduces boilerplate, and localizes information about errors. (see `CreateTopicError` in the attached code) The `Display` impl, the `From` impls, and the `Error` impls are all in 1 place.
- It is flexible enough for complex errors (See the `ErrorKind` wrapper for the coord catalog `Error` in the attached pr, and the display string for the `AmbiguousRename` variant)
- It reduces the prevalence of subtle bugs, like missing a correct `source` impl (see `S3Error` in the attached pr)

Additionally:
- It will make using `backtrace`'s trivial when they are stabilized (just `#[backtrace]`)
- Reduces the strain and boilerplate of writing a custom error, and will reduce our use of just `String` for `Err`'s in the codebase, producing more structured code.
- Works well with our use of `anyhow`. `thiserror` makes it easy to just add a:
```
#[error(transparent)]
Other(#[from] anyhow::Error)
```
to error enums, making `?` work very nicely!