### PR TITLE
storage: introduce StorageController trait

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5342,9 +5342,9 @@ pub mod read_holds {
         ) {
             // Update STORAGE read policies.
             let mut policy_changes = Vec::new();
-            let mut storage = self.dataflow_client.storage_mut();
+            let storage = self.dataflow_client.storage_mut();
             for id in read_holds.id_bundle.storage_ids.iter() {
-                let collection = storage.as_ref().collection(*id).unwrap();
+                let collection = storage.collection(*id).unwrap();
                 assert!(collection
                     .read_capabilities
                     .frontier()

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -382,9 +382,11 @@ pub async fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
             let (dataflow_server, dataflow_client) = mz_dataflow::serve(dataflow_config)?;
             let (storage_client, virtual_compute_host) =
                 mz_dataflow_types::client::split_client(dataflow_client);
+            let storage_controller =
+                mz_dataflow_types::client::controller::storage::Controller::new(storage_client);
             let dataflow_controller = mz_dataflow_types::client::Controller::new(
                 orchestrator,
-                storage_client,
+                storage_controller,
                 virtual_compute_host,
             );
             (dataflow_server, dataflow_controller)
@@ -413,9 +415,11 @@ pub async fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
                 client.connect().await;
                 client
             }));
+            let storage_controller =
+                mz_dataflow_types::client::controller::storage::Controller::new(storage_client);
             let dataflow_controller = mz_dataflow_types::client::Controller::new(
                 orchestrator,
-                storage_client,
+                storage_controller,
                 virtual_compute_host,
             );
             (compute_server, dataflow_controller)


### PR DESCRIPTION
Allow other compontents to abstract over an implementation of a
`StorageController`. This allows controller implementations that for one
reason or another have extra constraints on their types and we don't
necessarily want those constraints to contaminate the components that
generically interact with a `StorageController`.

This came up as part of #11223 where the `StorageController`
implementation became specific over `i64`/`u64` timestamps and those
constraints contaminated COMPUTE.