### PR TITLE
materialized: exclude SIGPIPE from termination signal handling

### DIFF
--- a/src/materialized/src/bin/materialized/sys.rs
+++ b/src/materialized/src/bin/materialized/sys.rs
@@ -219,7 +219,6 @@ pub fn enable_termination_signal_cleanup() -> Result<(), anyhow::Error> {
     for signum in &[
         signal::SIGHUP,
         signal::SIGINT,
-        signal::SIGPIPE,
         signal::SIGALRM,
         signal::SIGTERM,
         signal::SIGUSR1,


### PR DESCRIPTION
The Rust runtime ignores SIGPIPE automatically (rust-lang/rust#62569)
and returns EPIPE from the failed system call instead. `materialized`
was accidentally overriding this behavior by installing its own
termination signal handler. This was causing code that sent into a
closed TCP stream to cause the process to exit, rather than simply
returning an error.

This commit changes `materialized` to just stop doing this. The
termination signal handler exists only to ensure that we emit LLVM
profiling information before a signal causes `materialized` to exit;
since SIGPIPE does *not* actually cause the process to exit by default,
we don't need to handle the signal specially.

Fix #11447.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
