### PR TITLE
persist: implement Consensus on top of sqlite.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,6 +3713,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand",
+ "rusqlite",
  "semver",
  "serde",
  "serde_json",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -46,6 +46,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["metrics", "ta
 mz-persist-types = { path = "../persist-types" }
 parquet2 = { version = "0.8.1", default-features = false }
 prost = "0.9.0"
+rusqlite = { version = "0.27.0", features = ["bundled"] }
 semver = "1.0.7"
 serde = { version = "1.0.136", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/persist/src/error.rs
+++ b/src/persist/src/error.rs
@@ -101,6 +101,12 @@ impl<T> From<sync::PoisonError<T>> for Error {
     }
 }
 
+impl From<rusqlite::Error> for Error {
+    fn from(e: rusqlite::Error) -> Self {
+        Error::String(format!("sqlite: {}", e))
+    }
+}
+
 /// A stub implementation of [Log] that always returns errors.
 ///
 /// This exists to let us keep the (surprisingly non-trivial) Log plumbing while

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -30,6 +30,7 @@ pub mod operators;
 pub mod pfuture;
 pub mod runtime;
 pub mod s3;
+pub mod sqlite;
 pub mod storage;
 pub mod unreliable;
 pub mod workload;

--- a/src/persist/src/sqlite.rs
+++ b/src/persist/src/sqlite.rs
@@ -1,0 +1,173 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Implementation of [Consensus] backed by sqlite.
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use rusqlite::{named_params, params, Connection, OptionalExtension};
+use tokio::sync::Mutex;
+
+use crate::error::Error;
+use crate::storage::{Consensus, SeqNo, VersionedData};
+
+const APPLICATION_ID: i32 = 0x0678_ef32; // chosen randomly
+
+const SCHEMA: &str = "
+CREATE TABLE consensus (
+    shard text NOT NULL,
+    sequence_number integer NOT NULL,
+    data blob NOT NULL,
+    PRIMARY KEY(shard, sequence_number)
+);
+";
+
+/// Implementation of [Consensus] over a sqlite database.
+#[derive(Debug)]
+pub struct SqliteConsensus {
+    conn: Arc<Mutex<Connection>>,
+    shard: String,
+}
+
+impl SqliteConsensus {
+    /// Open a sqlite-backed [Consensus] instance at `path`, for the collection
+    /// named `shard`.
+    pub fn open<P: AsRef<Path>>(path: P, shard: String) -> Result<Self, Error> {
+        let mut conn = Connection::open(path)?;
+        let tx = conn.transaction()?;
+        let app_id: i32 = tx.query_row("PRAGMA application_id", params![], |row| row.get(0))?;
+        if app_id == 0 {
+            tx.execute_batch(&format!(
+                "PRAGMA application_id = {APPLICATION_ID};
+                 PRAGMA user_version = 1;"
+            ))?;
+            tx.execute_batch(SCHEMA)?;
+        } else if app_id != APPLICATION_ID {
+            return Err(Error::from(format!("invalid application id: {}", app_id)));
+        }
+        tx.commit()?;
+        Ok(SqliteConsensus {
+            conn: Arc::new(Mutex::new(conn)),
+            shard,
+        })
+    }
+}
+
+#[async_trait]
+impl Consensus for SqliteConsensus {
+    async fn head(&self, _deadline: Instant) -> Result<Option<VersionedData>, Error> {
+        let conn = self.conn.lock().await;
+        let mut stmt = conn.prepare(
+            "SELECT sequence_number, data FROM consensus
+                 WHERE shard = $shard ORDER BY sequence_number DESC LIMIT 1",
+        )?;
+        stmt.query_row(named_params! {"$shard": self.shard}, |row| {
+            let sequence_number = row.get("sequence_number")?;
+            let data: Vec<_> = row.get("data")?;
+            Ok(VersionedData {
+                seqno: SeqNo(sequence_number),
+                data,
+            })
+        })
+        .optional()
+        .map_err(|e| e.into())
+    }
+
+    async fn compare_and_set(
+        &mut self,
+        deadline: Instant,
+        expected: Option<SeqNo>,
+        new: VersionedData,
+    ) -> Result<Result<(), Option<VersionedData>>, Error> {
+        if let Some(expected) = expected {
+            if new.seqno <= expected {
+                return Err(Error::from(
+                        format!("new seqno must be strictly greater than expected. Got new: {:?} expected: {:?}",
+                                 new.seqno, expected)));
+            }
+        }
+
+        let result = if let Some(expected) = expected {
+            let conn = self.conn.lock().await;
+
+            // Only insert the new row if:
+            // - sequence number expected is already present
+            // - expected corresponds to the most recent sequence number
+            //   i.e. there is no other sequence number > expected already
+            //   present.
+            let mut stmt = conn
+                .prepare_cached(
+                    "INSERT INTO consensus SELECT $shard, $sequence_number, $data WHERE
+                     EXISTS (
+                        SELECT * FROM consensus WHERE shard = $shard AND sequence_number = $expected
+                     )
+                     AND NOT EXISTS (
+                         SELECT * FROM consensus WHERE shard = $shard AND sequence_number > $expected
+                     )
+                     ON CONFLICT DO NOTHING",
+                )?;
+
+            stmt.execute(named_params! {
+                "$shard": self.shard,
+                "$sequence_number": new.seqno.0,
+                "$data": new.data,
+                "$expected": expected.0,
+            })?
+        } else {
+            let conn = self.conn.lock().await;
+
+            // Insert the new row as long as no other row exists for the same shard.
+            let mut stmt = conn.prepare_cached(
+                "INSERT INTO consensus SELECT $shard, $sequence_number, $data WHERE
+                     NOT EXISTS (
+                         SELECT * FROM consensus WHERE shard = $shard
+                     )
+                     ON CONFLICT DO NOTHING",
+            )?;
+            stmt.execute(named_params! {
+                "$shard": self.shard,
+                "$sequence_number": new.seqno.0,
+                "$data": new.data,
+            })?
+        };
+
+        if result == 1 {
+            Ok(Ok(()))
+        } else {
+            // It's safe to call head in a subsequent transaction rather than doing
+            // so directly in the same transaction because, once a given (seqno, data)
+            // pair exists for our shard, we enforce the invariants that
+            // 1. Our shard will always have _some_ data mapped to it.
+            // 2. All operations that modify the (seqno, data) can only increase
+            //    the sequence number.
+            let current = self.head(deadline).await?;
+            Ok(Err(current))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::tests::consensus_impl_test;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn sqlite_consensus() -> Result<(), Error> {
+        let temp_dir = tempfile::tempdir()?;
+        consensus_impl_test(|| {
+            let path = temp_dir.path().join("sqlite_consensus");
+            SqliteConsensus::open(&path, "test_shard".to_string())
+        })
+        .await
+    }
+}

--- a/src/persist/src/storage.rs
+++ b/src/persist/src/storage.rs
@@ -242,7 +242,8 @@ pub trait Consensus: std::fmt::Debug {
     ///
     /// Returns a recent version and data from this location iff the current sequence
     /// number does not equal `expected` or if `new`'s sequence number is less than or
-    /// equal to the current sequence number.
+    /// equal to the current sequence number. It is invalid to call this function with
+    /// a `new` and `expected` such that `new`'s sequence number is <= `expected`.
     ///
     /// This data is initialized to None, and the first call to compare_and_set needs to
     /// happen with None as the expected value to set the state.
@@ -733,7 +734,7 @@ pub mod tests {
             consensus
                 .compare_and_set(deadline, Some(state.seqno), invalid_constant_seqno)
                 .await,
-            Ok(Err(Some(state.clone())))
+            Err(Error::from("new seqno must be strictly greater than expected. Got new: SeqNo(5) expected: SeqNo(5)"))
         );
 
         let invalid_regressing_seqno = VersionedData {
@@ -747,7 +748,7 @@ pub mod tests {
             consensus
                 .compare_and_set(deadline, Some(state.seqno), invalid_regressing_seqno)
                 .await,
-            Ok(Err(Some(state.clone())))
+            Err(Error::from("new seqno must be strictly greater than expected. Got new: SeqNo(3) expected: SeqNo(5)"))
         );
 
         // Can correctly update to a new state if we provide the right expected seqno


### PR DESCRIPTION
This commit adds a new Consensus built on top of sqlite, which will be the
Consensus implementation while we are prototyping, and most likely also the
Consensus implementation used for on-prem deployments.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
