### PR TITLE
doc/user: patch JSON examples for Kafka and Kinesis sources

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -328,7 +328,7 @@ CREATE MATERIALIZED VIEW jsonified_kafka_source AS
     data->>'field1' AS field_1,
     data->>'field2' AS field_2,
     data->>'field3' AS field_3
-  FROM (SELECT text::jsonb AS data FROM json_source);
+  FROM (SELECT CONVERT_FROM(data, 'utf8')::jsonb AS data FROM json_source);
 ```
 
 {{< /tab >}}

--- a/doc/user/content/sql/create-source/kinesis.md
+++ b/doc/user/content/sql/create-source/kinesis.md
@@ -90,7 +90,7 @@ CREATE MATERIALIZED VIEW jsonified_kinesis_source AS
     data->>'field1' AS field_1,
     data->>'field2' AS field_2,
     data->>'field3' AS field_3
-  FROM (SELECT text::jsonb AS data FROM json_source);
+  FROM (SELECT CONVERT_FROM(data, 'utf8')::jsonb AS data FROM json_source);
 ```
 
 {{< /tab >}}


### PR DESCRIPTION
Fixes `CREATE SOURCE` examples for JSON sources, currently missing `CONVERT_FROM(data, 'utf8')::jsonb`.