### PR TITLE
Organize dataflow exports as BTreeMaps

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3364,7 +3364,7 @@ impl Coordinator {
             }
         };
 
-        let (sink_id, sink_desc) = &dataflow.sink_exports[0];
+        let (sink_id, sink_desc) = dataflow.sink_exports.iter().next().unwrap();
         session.add_drop_sink(compute_instance, *sink_id);
         let arity = sink_desc.from_desc.arity();
         let (tx, rx) = mpsc::unbounded_channel();
@@ -4526,7 +4526,7 @@ impl Coordinator {
         let mut output_ids = Vec::new();
         let mut dataflow_plans = Vec::with_capacity(dataflows.len());
         for dataflow in dataflows.into_iter() {
-            output_ids.extend(dataflow.index_exports.iter().map(|(id, _, _)| *id));
+            output_ids.extend(dataflow.index_exports.iter().map(|(id, _)| *id));
             output_ids.extend(dataflow.sink_exports.iter().map(|(id, _)| *id));
             dataflow_plans.push(self.finalize_dataflow(dataflow, instance));
         }
@@ -5189,7 +5189,7 @@ pub mod fast_path_peek {
                     thinned_arity: index_thinned_arity,
                 }) => {
                     let mut output_ids = Vec::new();
-                    output_ids.extend(dataflow.index_exports.iter().map(|(id, _, _)| *id));
+                    output_ids.extend(dataflow.index_exports.iter().map(|(id, _)| *id));
                     output_ids.extend(dataflow.sink_exports.iter().map(|(id, _)| *id));
 
                     // Very important: actually create the dataflow (here, so we can destructure).

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -354,7 +354,7 @@ impl<T> ComputeCommand<T> {
                     for (sink_id, _) in dataflow.sink_exports.iter() {
                         start.push(*sink_id)
                     }
-                    for (index_id, _, _) in dataflow.index_exports.iter() {
+                    for (index_id, _) in dataflow.index_exports.iter() {
                         start.push(*index_id);
                     }
                 }
@@ -449,7 +449,7 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
             let index_active = dataflow
                 .index_exports
                 .iter()
-                .any(|(id, _, _)| final_frontiers.get(id) != Some(Antichain::new()).as_ref());
+                .any(|(id, _)| final_frontiers.get(id) != Some(Antichain::new()).as_ref());
             let sink_active = dataflow
                 .sink_exports
                 .iter()
@@ -460,7 +460,7 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
             // If we are going to drop the dataflow, we should remove the frontier information so that we
             // do not instruct anyone to compact a frontier they have not heard of.
             if !retain {
-                for (id, _, _) in dataflow.index_exports.iter() {
+                for (id, _) in dataflow.index_exports.iter() {
                     final_frontiers.remove(id);
                 }
                 for (id, _) in dataflow.sink_exports.iter() {
@@ -475,7 +475,7 @@ impl<T: timely::progress::Timestamp> ComputeCommandHistory<T> {
         for dataflow in live_dataflows.iter_mut() {
             let mut same_as_of = false;
             let mut as_of = Antichain::new();
-            for (id, _, _) in dataflow.index_exports.iter() {
+            for (id, _) in dataflow.index_exports.iter() {
                 if let Some(frontier) = final_frontiers.get(id) {
                     as_of.extend(frontier.clone());
                 } else {

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -266,7 +266,7 @@ where
                     ),
                 );
             }
-            for (index_id, _, _) in dataflow.index_exports.iter() {
+            for (index_id, _) in dataflow.index_exports.iter() {
                 self.compute.collections.insert(
                     *index_id,
                     CollectionState::new(

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -155,10 +155,10 @@ pub struct DataflowDescription<P, T = mz_repr::Timestamp> {
     pub objects_to_build: Vec<BuildDesc<P>>,
     /// Indexes to be made available to be shared with other dataflows
     /// (id of new index, description of index, relationtype of base source/view)
-    pub index_exports: Vec<(GlobalId, IndexDesc, RelationType)>,
+    pub index_exports: BTreeMap<GlobalId, (IndexDesc, RelationType)>,
     /// sinks to be created
     /// (id of new sink, description of sink)
-    pub sink_exports: Vec<(GlobalId, crate::types::sinks::SinkDesc<T>)>,
+    pub sink_exports: BTreeMap<GlobalId, crate::types::sinks::SinkDesc<T>>,
     /// An optional frontier to which inputs should be advanced.
     ///
     /// If this is set, it should override the default setting determined by
@@ -241,12 +241,12 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
                 keys: vec![description.key.clone()],
             }),
         );
-        self.index_exports.push((id, description, on_type));
+        self.index_exports.insert(id, (description, on_type));
     }
 
     /// Exports as `id` a sink described by `description`.
     pub fn export_sink(&mut self, id: GlobalId, description: SinkDesc<T>) {
-        self.sink_exports.push((id, description));
+        self.sink_exports.insert(id, description);
     }
 
     /// Returns true iff `id` is already imported.

--- a/src/dataflow/src/render/mod.rs
+++ b/src/dataflow/src/render/mod.rs
@@ -283,16 +283,14 @@ pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
             let indexes = dataflow
                 .index_exports
                 .iter()
-                .cloned()
-                .map(|(idx_id, idx, _typ)| (idx_id, dataflow.depends_on(idx.on_id), idx))
+                .map(|(idx_id, (idx, _typ))| (*idx_id, dataflow.depends_on(idx.on_id), idx.clone()))
                 .collect::<Vec<_>>();
 
             // Determine sinks to export
             let sinks = dataflow
                 .sink_exports
                 .iter()
-                .cloned()
-                .map(|(sink_id, sink)| (sink_id, dataflow.depends_on(sink.from), sink))
+                .map(|(sink_id, sink)| (*sink_id, dataflow.depends_on(sink.from), sink.clone()))
                 .collect::<Vec<_>>();
 
             // Build declared objects.

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -100,7 +100,7 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                     let index_ids = dataflow
                         .index_exports
                         .iter()
-                        .map(|(idx_id, idx, _)| (*idx_id, idx.on_id));
+                        .map(|(idx_id, (idx, _))| (*idx_id, idx.on_id));
                     let exported_ids = index_ids.chain(sink_ids);
 
                     // Initialize frontiers for each object, and optionally log their construction.

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -81,7 +81,7 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
                 occurs_in_export = true;
             }
         }
-        for (_, index_desc, _) in dataflow.index_exports.iter() {
+        for (_, (index_desc, _)) in dataflow.index_exports.iter() {
             if index_desc.on_id == global_id {
                 occurs_in_export = true;
             }
@@ -199,7 +199,7 @@ fn optimize_dataflow_demand(dataflow: &mut DataflowDesc) -> Result<(), Transform
     }
 
     // Demand all columns of inputs to exported indexes.
-    for (_id, desc, _typ) in dataflow.index_exports.iter() {
+    for (_id, (desc, _typ)) in dataflow.index_exports.iter() {
         let input_id = desc.on_id;
         demand
             .entry(Id::Global(input_id))


### PR DESCRIPTION
Dataflow exports were previously flat lists of paired keys and values. This dates back to not wanting to use `HashMap` because of the nondeterminism, but not knowing about `BTreeMap`. The change makes it clearer that there is at most one entry for each key.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
