### PR TITLE
persist: benchmarks for Consensus implementations

### DIFF
--- a/src/persist/benches/benches.rs
+++ b/src/persist/benches/benches.rs
@@ -10,6 +10,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use mz_persist::workload::DataGenerator;
 
+mod consensus;
 mod end_to_end;
 mod snapshot;
 mod writer;
@@ -20,6 +21,7 @@ pub fn bench_persist(c: &mut Criterion) {
     // being as spammy in these benchmarks.
     mz_ore::test::init_logging_default("warn");
     let data = DataGenerator::default();
+    let small_data = DataGenerator::small();
 
     end_to_end::bench_load(&data, &mut c.benchmark_group("end_to_end/load"));
     end_to_end::bench_replay(&data, &mut c.benchmark_group("end_to_end/replay"));
@@ -37,6 +39,11 @@ pub fn bench_persist(c: &mut Criterion) {
     );
     writer::bench_indexed_drain(&data, &mut c.benchmark_group("writer/indexed_drain"));
     writer::bench_compact_trace(&data, &mut c.benchmark_group("writer/compact_trace"));
+
+    consensus::bench_consensus_compare_and_set(
+        &small_data,
+        &mut c.benchmark_group("consensus/compare_and_set"),
+    );
 }
 
 // The grouping here is an artifact of criterion's interaction with the

--- a/src/persist/benches/consensus.rs
+++ b/src/persist/benches/consensus.rs
@@ -1,0 +1,89 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Benchmarks for different persistent Write implementations.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use criterion::measurement::WallTime;
+use criterion::{Bencher, BenchmarkGroup, BenchmarkId, Throughput};
+use rand::Rng;
+
+use mz_persist::location::{Consensus, SeqNo, VersionedData};
+use mz_persist::mem::MemConsensus;
+use mz_persist::sqlite::SqliteConsensus;
+use mz_persist::workload::{self, DataGenerator};
+
+fn new_sqlite_consensus(path: &Path) -> SqliteConsensus {
+    SqliteConsensus::open(&path.join("sqlite_consensus"))
+        .expect("creating a SqliteConsensus cannot fail")
+}
+
+// Benchmark the write throughput of Consensus::compare_and_set.
+fn bench_compare_and_set<C: Consensus>(consensus: &mut C, data: Vec<u8>, b: &mut Bencher) {
+    let deadline = Instant::now() + Duration::from_secs(3600);
+
+    // We need to pick random keys because Criterion likes to run this function
+    // many times as part of a warmup, and if we deterministically use the same
+    // keys we will overwrite previously set values.
+    let mut rng = rand::thread_rng();
+    let key = format!("{}", rng.gen::<usize>());
+    let mut current = SeqNo(0);
+    // Set an initial value in case that has different performance characteristics
+    // for some Consensus implementations.
+    futures_executor::block_on(consensus.compare_and_set(
+        &key,
+        deadline,
+        None,
+        VersionedData {
+            seqno: current,
+            data: data.clone(),
+        },
+    ))
+    .expect("gave invalid inputs")
+    .expect("failed to compare_and_set");
+
+    b.iter(|| {
+        let next = current.next();
+        futures_executor::block_on(consensus.compare_and_set(
+            &key,
+            deadline,
+            Some(current),
+            VersionedData {
+                seqno: next,
+                data: data.clone(),
+            },
+        ))
+        .expect("gave invalid inputs")
+        .expect("failed to compare_and_set");
+        current = next;
+    })
+}
+
+pub fn bench_consensus_compare_and_set(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
+    let blob_val = workload::flat_blob(&data);
+    g.throughput(Throughput::Bytes(data.goodput_bytes()));
+
+    let mut mem_consensus = MemConsensus::default();
+    g.bench_with_input(
+        BenchmarkId::new("mem", data.goodput_pretty()),
+        &blob_val,
+        |b, blob_val| bench_compare_and_set(&mut mem_consensus, blob_val.clone(), b),
+    );
+
+    // Create a directory that will automatically be dropped after the test finishes.
+    let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
+    let mut sqlite_consensus = new_sqlite_consensus(&temp_dir.path());
+    g.bench_with_input(
+        BenchmarkId::new("sqlite", data.goodput_pretty()),
+        &blob_val,
+        |b, blob_val| bench_compare_and_set(&mut sqlite_consensus, blob_val.clone(), b),
+    );
+}

--- a/src/persist/src/workload.rs
+++ b/src/persist/src/workload.rs
@@ -38,6 +38,10 @@ const RECORD_SIZE_BYTES_KEY: &'static str = "MZ_PERSIST_RECORD_SIZE_BYTES";
 const RECORD_COUNT_KEY: &'static str = "MZ_PERSIST_RECORD_COUNT";
 const BATCH_MAX_COUNT_KEY: &'static str = "MZ_PERSIST_BATCH_MAX_COUNT";
 
+const RECORD_SIZE_BYTES_KEY_SMALL: &'static str = "MZ_PERSIST_RECORD_SIZE_BYTES_SMALL";
+const RECORD_COUNT_KEY_SMALL: &'static str = "MZ_PERSIST_RECORD_COUNT_SMALL";
+const BATCH_MAX_COUNT_KEY_SMALL: &'static str = "MZ_PERSIST_BATCH_MAX_COUNT_SMALL";
+
 // Selected arbitrarily as representative of production record sizes.
 const DEFAULT_RECORD_SIZE_BYTES: usize = 64;
 // Selected arbitrarily to make ~8MiB batches.
@@ -46,6 +50,13 @@ const DEFAULT_BATCH_MAX_COUNT: usize = (8 * 1024 * 1024) / DEFAULT_RECORD_SIZE_B
 // throughput on the end_to_end benchmark and (2) goodput_pretty produces a
 // round-ish number.
 const DEFAULT_RECORD_COUNT: usize = 819_200;
+
+// Selected arbitrarily as representative of production record sizes.
+const DEFAULT_RECORD_SIZE_BYTES_SMALL: usize = 64;
+// Selected arbitrarily to make ~64KiB batches.
+const DEFAULT_BATCH_MAX_COUNT_SMALL: usize = (64 * 1024) / DEFAULT_RECORD_SIZE_BYTES_SMALL;
+// Selected to produce exactly one small batch with default settings.
+const DEFAULT_RECORD_COUNT_SMALL: usize = DEFAULT_BATCH_MAX_COUNT_SMALL;
 
 const TS_DIFF_GOODPUT_SIZE: usize = size_of::<u64>() + size_of::<i64>();
 
@@ -92,6 +103,30 @@ impl DataGenerator {
             key_buf: Vec::new(),
             val_buf: Vec::new(),
         }
+    }
+
+    /// Returns a new [DataGenerator] specifically for testing small data volumes.
+    pub fn small() -> Self {
+        let record_count_small = read_env_usize(RECORD_COUNT_KEY_SMALL, DEFAULT_RECORD_COUNT_SMALL);
+        let record_size_bytes_small =
+            read_env_usize(RECORD_SIZE_BYTES_KEY_SMALL, DEFAULT_RECORD_SIZE_BYTES_SMALL);
+        let batch_max_count_small =
+            read_env_usize(BATCH_MAX_COUNT_KEY_SMALL, DEFAULT_BATCH_MAX_COUNT_SMALL);
+
+        eprintln!(
+            "{}={} {}={} {}={}",
+            RECORD_COUNT_KEY_SMALL,
+            record_count_small,
+            RECORD_SIZE_BYTES_KEY_SMALL,
+            record_size_bytes_small,
+            BATCH_MAX_COUNT_KEY_SMALL,
+            batch_max_count_small,
+        );
+        DataGenerator::new(
+            record_count_small,
+            record_size_bytes_small,
+            batch_max_count_small,
+        )
     }
 
     /// Returns the number of "goodput" bytes represented by the entire dataset


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation



    This commit adds benchmarks for the two currently available Consensus implementations:
    in-memory and sqlite. The benchmarks sequentially compare_and_set the same data to the
    same location, with increasing version numbers, in order to measure the expected
    latency for uncontended compare_and_set.

    Testing the latency of compare and set with contention is left for future work.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
