### PR TITLE
Get rid of DeclareKeys

### DIFF
--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -218,7 +218,6 @@ Operator | Meaning | Example
 **Threshold** | Removes any rows with negative counts. | `Threshold`
 **Union** | Sums the rows counts of both inputs | `Union %2 %3`
 **ArrangeBy** | Indicates a point that will become an arrangement in the dataflow engine | `ArrangeBy (#0) (#3)`
-**DeclareKeys**  | Contains any manually declared primary keys.    | `DeclareKeys`
 **Let**  | Marks a branch of computation whose result is used later by other branches with `%0`. |  `%0 = Let 10 =`
 
 
@@ -271,4 +270,3 @@ Operator | Meaning | Example
 **Negate** | Negates the row counts of the input. This is usually used in combination with union to remove rows from the other union input. | `Negate`
 **Threshold** | Removes any rows with negative counts. | `Threshold`
 **Union** | Sums the rows counts of both inputs | `Union %2 %3`
-**DeclareKeys**  | Contains any manually declared primary keys.    | `DeclareKeys`

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -812,7 +812,6 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     input_keys,
                 )
             }
-            MirRelationExpr::DeclareKeys { input, keys: _ } => Self::from_mir(input, arrangements)?,
         };
 
         // If the plan stage did not absorb all linear operators, introduce a new stage to implement them.

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -114,7 +114,6 @@ impl<'a> ViewExplanation<'a> {
                 | TopK { input, .. }
                 | Negate { input, .. }
                 | Threshold { input, .. }
-                | DeclareKeys { input, .. }
                 | ArrangeBy { input, .. } => walk(input, explanation),
                 // For join and union, each input may need to go in its own
                 // chain.
@@ -320,15 +319,6 @@ impl<'a> ViewExplanation<'a> {
             }
             Negate { .. } => writeln!(f, "| Negate")?,
             Threshold { .. } => writeln!(f, "| Threshold")?,
-            DeclareKeys { input: _, keys } => writeln!(
-                f,
-                "| Declare primary keys {}",
-                separated(
-                    " ",
-                    keys.iter()
-                        .map(|key| bracketed("(", ")", separated(", ", key)))
-                )
-            )?,
             Union { base, inputs } => writeln!(
                 f,
                 "| Union %{} {}",

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -142,7 +142,6 @@ impl<'a> Explanation<'a> {
                 | Distinct { input }
                 | TopK { input, .. }
                 | Negate { input, .. }
-                | DeclareKeys { input, .. }
                 | Threshold { input, .. } => walk(input, explanation, id_gen),
                 // For join and union, each input needs to go in its own chain.
                 Join { left, right, .. } => walk_many(
@@ -187,7 +186,6 @@ impl<'a> Explanation<'a> {
                 | Negate { .. }
                 | Threshold { .. }
                 | Union { .. }
-                | DeclareKeys { .. }
                 | TopK { .. } => (),
                 Map { scalars: exprs, .. }
                 | Filter {
@@ -413,15 +411,6 @@ impl<'a> Explanation<'a> {
             }
             Negate { .. } => writeln!(f, "| Negate")?,
             Threshold { .. } => write!(f, "| Threshold")?,
-            DeclareKeys { input: _, keys } => write!(
-                f,
-                "| Declare primary keys {}",
-                separated(
-                    " ",
-                    keys.iter()
-                        .map(|key| bracketed("(", ")", separated(", ", key)))
-                )
-            )?,
             Union { base, inputs } => writeln!(
                 f,
                 "| Union %{} {}",

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -120,10 +120,6 @@ pub enum HirRelationExpr {
         base: Box<HirRelationExpr>,
         inputs: Vec<HirRelationExpr>,
     },
-    DeclareKeys {
-        input: Box<HirRelationExpr>,
-        keys: Vec<Vec<usize>>,
-    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -767,9 +763,6 @@ impl HirRelationExpr {
                 }
                 RelationType::new(base_cols)
             }
-            HirRelationExpr::DeclareKeys { input, keys } => {
-                input.typ(outers, params).with_keys(keys.clone())
-            }
         })
     }
 
@@ -785,7 +778,6 @@ impl HirRelationExpr {
             | HirRelationExpr::TopK { input, .. }
             | HirRelationExpr::Distinct { input }
             | HirRelationExpr::Negate { input }
-            | HirRelationExpr::DeclareKeys { input, .. }
             | HirRelationExpr::Threshold { input } => input.arity(),
             HirRelationExpr::Join { left, right, .. } => left.arity() + right.arity(),
             HirRelationExpr::Union { base, .. } => base.arity(),
@@ -857,13 +849,6 @@ impl HirRelationExpr {
         HirRelationExpr::Filter {
             input: Box::new(self),
             predicates,
-        }
-    }
-
-    pub fn declare_keys(self, keys: Vec<Vec<usize>>) -> Self {
-        HirRelationExpr::DeclareKeys {
-            input: Box::new(self),
-            keys,
         }
     }
 
@@ -1032,9 +1017,6 @@ impl HirRelationExpr {
             HirRelationExpr::Threshold { input } => {
                 f(input, depth)?;
             }
-            HirRelationExpr::DeclareKeys { input, .. } => {
-                f(input, depth)?;
-            }
             HirRelationExpr::Union { base, inputs } => {
                 f(base, depth)?;
                 for input in inputs {
@@ -1107,9 +1089,6 @@ impl HirRelationExpr {
             HirRelationExpr::Threshold { input } => {
                 f(input, depth)?;
             }
-            HirRelationExpr::DeclareKeys { input, .. } => {
-                f(input, depth)?;
-            }
             HirRelationExpr::Union { base, inputs } => {
                 f(base, depth)?;
                 for input in inputs {
@@ -1162,7 +1141,6 @@ impl HirRelationExpr {
                 | HirRelationExpr::Distinct { .. }
                 | HirRelationExpr::TopK { .. }
                 | HirRelationExpr::Negate { .. }
-                | HirRelationExpr::DeclareKeys { .. }
                 | HirRelationExpr::Threshold { .. }
                 | HirRelationExpr::Constant { .. }
                 | HirRelationExpr::Get { .. } => (),
@@ -1209,7 +1187,6 @@ impl HirRelationExpr {
                 | HirRelationExpr::Distinct { .. }
                 | HirRelationExpr::TopK { .. }
                 | HirRelationExpr::Negate { .. }
-                | HirRelationExpr::DeclareKeys { .. }
                 | HirRelationExpr::Threshold { .. }
                 | HirRelationExpr::Constant { .. }
                 | HirRelationExpr::Get { .. } => (),

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -661,9 +661,6 @@ impl HirRelationExpr {
                         .applied_to(id_gen, get_outer, col_map, cte_map)
                         .threshold()
                 }
-                DeclareKeys { input, keys } => input
-                    .applied_to(id_gen, get_outer, col_map, cte_map)
-                    .declare_keys(keys),
             }
         })
     }

--- a/src/sql/src/query_model/hir/qgm_from_hir.rs
+++ b/src/sql/src/query_model/hir/qgm_from_hir.rs
@@ -389,7 +389,6 @@ impl FromHir {
 
                 Ok(union_id)
             }
-            // HirRelationExpr::DeclareKeys { input, keys } => todo!(),
             expr => Err(QGMError::from(UnsupportedHirRelationExpr {
                 expr,
                 explanation: None,

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -299,9 +299,6 @@ impl ColumnKnowledge {
                 MirRelationExpr::Threshold { input } => {
                     self.harvest(input, knowledge, knowledge_stack)
                 }
-                MirRelationExpr::DeclareKeys { input, .. } => {
-                    self.harvest(input, knowledge, knowledge_stack)
-                }
                 MirRelationExpr::Union { base, inputs } => {
                     let mut know = self.harvest(base, knowledge, knowledge_stack)?;
                     for input in inputs {

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -265,11 +265,6 @@ impl Demand {
                     self.action(input, columns, gets)
                 }
                 MirRelationExpr::Negate { input } => self.action(input, columns, gets),
-                MirRelationExpr::DeclareKeys { input, keys: _ } => {
-                    // TODO[btv] - If and when we add a "debug mode" that asserts whether this is truly a key,
-                    // we will probably need to add the key to the set of demanded columns.
-                    self.action(input, columns, gets)
-                }
                 MirRelationExpr::Threshold { input } => {
                     // Threshold requires all columns, as collapsing any distinct values
                     // has the potential to change how it thresholds counts. This could

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -622,7 +622,6 @@ impl LiteralLifting {
                     // Literals can just be lifted out of threshold.
                     self.action(input, gets)
                 }
-                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
                 MirRelationExpr::Union { base, inputs } => {
                     let mut base_literals = self.action(base, gets)?;
 

--- a/src/transform/src/monotonic.rs
+++ b/src/transform/src/monotonic.rs
@@ -84,10 +84,7 @@ impl MonotonicFlag {
                     }
                     monotonic
                 }
-                MirRelationExpr::ArrangeBy { input, .. }
-                | MirRelationExpr::DeclareKeys { input, .. } => {
-                    self.apply(input, sources, locals)?
-                }
+                MirRelationExpr::ArrangeBy { input, .. } => self.apply(input, sources, locals)?,
                 MirRelationExpr::FlatMap { input, func, .. } => {
                     let is_monotonic = self.apply(input, sources, locals)?;
                     is_monotonic && func.preserves_monotonicity()

--- a/src/transform/src/nonnull_requirements.rs
+++ b/src/transform/src/nonnull_requirements.rs
@@ -279,7 +279,6 @@ impl NonNullRequirements {
                 }
                 MirRelationExpr::Negate { input } => self.action(input, columns, gets),
                 MirRelationExpr::Threshold { input } => self.action(input, columns, gets),
-                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, columns, gets),
                 MirRelationExpr::Union { base, inputs } => {
                     self.action(base, columns.clone(), gets)?;
                     for input in inputs {

--- a/src/transform/src/projection_lifting.rs
+++ b/src/transform/src/projection_lifting.rs
@@ -279,7 +279,6 @@ impl ProjectionLifting {
                     // action on weights need to accumulate the restricted rows.
                     self.action(input, gets)
                 }
-                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, gets),
                 MirRelationExpr::Union { base, inputs } => {
                     // We cannot, in general, lift projections out of unions.
                     self.action(base, gets)?;

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -322,21 +322,6 @@ impl ProjectionPushdown {
                 self.action(input, &(0..arity).collect(), gets);
                 (0..arity).collect()
             }
-            MirRelationExpr::DeclareKeys { input, keys } => {
-                // TODO[btv] - If and when we add a "debug mode" that asserts whether this is truly a key,
-                // we will probably need to add the key to the set of demanded
-                // columns.
-
-                // Current behavior is that if a key is not contained with the
-                // desired_projection, then it is not relevant to the query plan
-                // and can be removed.
-                keys.retain(|key_set| key_set.iter().all(|k| desired_projection.contains(k)));
-                self.action(input, desired_projection, gets);
-                if keys.is_empty() {
-                    *relation = input.take_dangerous();
-                }
-                desired_projection.clone()
-            }
         };
         let add_project = desired_projection != &actual_projection;
         if add_project {

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -127,11 +127,6 @@ impl FoldConstants {
                     *relation = input.take_dangerous();
                 }
             }
-            MirRelationExpr::DeclareKeys { input, keys: _ } => {
-                if let MirRelationExpr::Constant { rows: _, .. } = &mut **input {
-                    *relation = input.take_dangerous();
-                }
-            }
             MirRelationExpr::Threshold { input } => {
                 if let MirRelationExpr::Constant { rows, .. } = &mut **input {
                     if let Ok(rows) = rows {

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -250,7 +250,6 @@ impl RedundantJoin {
                     }
                     Ok(result)
                 }
-                MirRelationExpr::DeclareKeys { input, .. } => self.action(input, lets),
 
                 MirRelationExpr::Union { base, inputs } => {
                     let mut prov = self.action(base, lets)?;

--- a/src/transform/tests/testdata/projection-pushdown
+++ b/src/transform/tests/testdata/projection-pushdown
@@ -250,23 +250,6 @@ build apply=ProjectionPushdown
 ----
 ----
 
-# Project around a DeclareKeys
-
-build apply=ProjectionPushdown
-(project (declare_keys (get x) [[#0] [#1]]) [#1])
-----
-%0 =
-| Get x (u0)
-| Project (#1)
-| Declare primary keys (1)
-
-build apply=ProjectionPushdown
-(project (declare_keys (get x) [[#0]]) [#1])
-----
-%0 =
-| Get x (u0)
-| Project (#1)
-
 # Project around an ArrangeBy
 
 build apply=ProjectionPushdown


### PR DESCRIPTION
### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/11255

### Tips for reviewer

The important thing is just to note that HIR/MIR DeclareKeys were never being instantiated. Everything else is just mechanical deleting of code

### Testing

Dead code removal, should be safe.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
