### PR TITLE
antithesis: Run Mz in the Antithesis environment with --workers 2

### DIFF
--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command:
       --listen-addr 0.0.0.0:6875
       --data-directory=/share/mzdata
-      --workers 1
+      --workers 2
       --experimental
       --timestamp-frequency 100ms
       --disable-telemetry


### PR DESCRIPTION
Previously, we ran it with --workers 1 because the docker-compose.yml
file was created eons ago, which did not provide any concurrency on the
timely/dataflow level.

Unfortunately, running with --workers 4 causes too many queries to never
complete, so --workers 2 is currently the only viable settings to get
at least some concurrency going.

### Motivation
  * This PR adds a known-desirable feature.
  * This PR fixes a previously unreported bug.


Mz was running in the Antithesis environment with --workers 1, so without any concurrency on the timely/dataflow level. 