### PR TITLE
Tidy logic for command compaction

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4624,8 +4624,7 @@ impl Coordinator {
         let mut output_ids = Vec::new();
         let mut dataflow_plans = Vec::with_capacity(dataflows.len());
         for dataflow in dataflows.into_iter() {
-            output_ids.extend(dataflow.index_exports.iter().map(|(id, _)| *id));
-            output_ids.extend(dataflow.sink_exports.iter().map(|(id, _)| *id));
+            output_ids.extend(dataflow.export_ids());
             dataflow_plans.push(self.finalize_dataflow(dataflow, instance));
         }
         self.dataflow_client
@@ -5284,9 +5283,7 @@ pub mod fast_path_peek {
                     permutation: index_permutation,
                     thinned_arity: index_thinned_arity,
                 }) => {
-                    let mut output_ids = Vec::new();
-                    output_ids.extend(dataflow.index_exports.iter().map(|(id, _)| *id));
-                    output_ids.extend(dataflow.sink_exports.iter().map(|(id, _)| *id));
+                    let output_ids = dataflow.export_ids().collect();
 
                     // Very important: actually create the dataflow (here, so we can destructure).
                     self.dataflow_client

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -307,6 +307,14 @@ impl<P, T> DataflowDescription<P, T>
 where
     P: CollectionPlan,
 {
+    /// Identifiers of exported objects (indexes and sinks).
+    pub fn export_ids(&self) -> impl Iterator<Item = GlobalId> + '_ {
+        self.index_exports
+            .keys()
+            .chain(self.sink_exports.keys())
+            .cloned()
+    }
+
     /// Returns the description of the object to build with the specified
     /// identifier.
     ///


### PR DESCRIPTION
This PR reorganizes command compaction to be imo clearer, first determining the appropriate `as_of` frontiers for each dataflow, and then discarding dataflows with empty frontiers. This also allows us to remove "redundant" compaction commands, those that would only compact up to the new `as_of` frontier (this is critical for empty frontiers, as the dataflow will no longer be present, and tidying for others).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
