### PR TITLE
[sql] Make normalize::full_name take mut instead of mut ref

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -698,10 +698,10 @@ impl<'a> NameResolver<'a> {
                         let full_name = self.catalog.resolve_full_name(item.name());
                         (full_name, item)
                     }
-                    RawObjectName::Id(id, mut name) => {
+                    RawObjectName::Id(id, name) => {
                         let gid: GlobalId = id.parse()?;
                         let item = self.catalog.get_item(&gid);
-                        let full_name = normalize::full_name(&mut name)?;
+                        let full_name = normalize::full_name(name)?;
                         (full_name, item)
                     }
                 };
@@ -826,7 +826,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                     }
                 }
             }
-            RawObjectName::Id(id, mut raw_name) => {
+            RawObjectName::Id(id, raw_name) => {
                 let gid: GlobalId = match id.parse() {
                     Ok(id) => id,
                     Err(e) => {
@@ -848,7 +848,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                 };
 
                 self.ids.insert(gid.clone());
-                let full_name = match normalize::full_name(&mut raw_name) {
+                let full_name = match normalize::full_name(raw_name) {
                     Ok(full_name) => full_name,
                     Err(e) => {
                         if self.status.is_ok() {

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -149,7 +149,7 @@ pub fn unresolve(name: FullObjectName) -> UnresolvedObjectName {
 
 /// Converts an `UnresolvedObjectName` to a `FullObjectName` if the
 /// `UnresolvedObjectName` is fully specified. Otherwise returns an error.
-pub fn full_name(raw_name: &mut UnresolvedObjectName) -> Result<FullObjectName, anyhow::Error> {
+pub fn full_name(mut raw_name: UnresolvedObjectName) -> Result<FullObjectName, anyhow::Error> {
     match raw_name.0.len() {
         3 => Ok(FullObjectName {
             item: ident(raw_name.0.pop().unwrap()),


### PR DESCRIPTION
As title

### Motivation
I was using this function in a different PR and was slightly confused by the signature

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
