### PR TITLE
add 'linearize_sources' API to `StorageController`

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -916,7 +916,10 @@ impl Coordinator {
                 }
             }
             DataflowResponse::Storage(StorageResponse::LinearizedTimestamps(
-                LinearizedTimestampBindingFeedback { bindings: _ },
+                LinearizedTimestampBindingFeedback {
+                    timestamp: _,
+                    peek_id: _,
+                },
             )) => {
                 // TODO(guswynn): communicate `bindings` to `sequence_peek`
             }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -558,8 +558,10 @@ impl<T> Default for ComputeCommandHistory<T> {
 /// of a specific "linearized" read request
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LinearizedTimestampBindingFeedback<T = mz_repr::Timestamp> {
-    /// Timestamp bindings that are adequate for "linearized" reads
-    pub bindings: Vec<(GlobalId, PartitionId, T)>,
+    /// The _minimum_ viable timestamp that will produce a "linearized" read...
+    pub timestamp: T,
+    /// ... for this peek
+    pub peek_id: Uuid,
 }
 
 /// Data about timestamp bindings that dataflow workers send to the coordinator

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -220,16 +220,6 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
         /// The timestamp to advance to.
         advance_to: T,
     },
-
-    /// "Linearize" the listed sources.
-    ///
-    /// If these sources are valid and "linearizable", then the response
-    /// will respond with timestamps that are guaranteed to be up-to-date
-    /// with the max offset found at the time of the command issuance.
-    ///
-    /// Note: "linearizable" in this context may not represent
-    /// true linearizability in all cases.
-    LinearizeSources(Vec<GlobalId>),
 }
 
 impl StorageCommandKind {
@@ -244,7 +234,6 @@ impl StorageCommandKind {
             StorageCommandKind::DurabilityFrontierUpdates => "durability_frontier_updates",
             StorageCommandKind::Insert => "insert",
             StorageCommandKind::RenderSources => "render_sources",
-            StorageCommandKind::LinearizeSources => "linearize_sources",
         }
     }
 }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -220,6 +220,16 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
         /// The timestamp to advance to.
         advance_to: T,
     },
+
+    /// "Linearize" the listed sources.
+    ///
+    /// If these sources are valid and "linearizable", then the response
+    /// will respond with timestamps that are guaranteed to be up-to-date
+    /// with the max offset found at the time of the command issuance.
+    ///
+    /// Note: "linearizable" in this context may not represent
+    /// true linearizability in all cases.
+    LinearizeSources(Vec<GlobalId>),
 }
 
 impl StorageCommandKind {
@@ -234,6 +244,7 @@ impl StorageCommandKind {
             StorageCommandKind::DurabilityFrontierUpdates => "durability_frontier_updates",
             StorageCommandKind::Insert => "insert",
             StorageCommandKind::RenderSources => "render_sources",
+            StorageCommandKind::LinearizeSources => "linearize_sources",
         }
     }
 }
@@ -554,6 +565,14 @@ impl<T> Default for ComputeCommandHistory<T> {
     }
 }
 
+/// Data about timestamp bindings, sent to the coordinator, in service
+/// of a specific "linearized" read request
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LinearizedTimestampBindingFeedback<T = mz_repr::Timestamp> {
+    /// Timestamp bindings that are adequate for "linearized" reads
+    pub bindings: Vec<(GlobalId, PartitionId, T)>,
+}
+
 /// Data about timestamp bindings that dataflow workers send to the coordinator
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimestampBindingFeedback<T = mz_repr::Timestamp> {
@@ -599,6 +618,10 @@ pub enum StorageResponse<T = mz_repr::Timestamp> {
     /// Timestamp bindings and prior and new frontiers for those bindings for all
     /// sources
     TimestampBindings(TimestampBindingFeedback<T>),
+
+    /// Data about timestamp bindings, sent to the coordinator, in service
+    /// of a specific "linearized" read request
+    LinearizedTimestamps(LinearizedTimestampBindingFeedback<T>),
 }
 
 /// A client to a running dataflow server.
@@ -1111,6 +1134,10 @@ pub mod partitioned {
                         feedback,
                     ))))
                 }
+                // TODO(guswynn): is this the correct implementation?
+                Response::Storage(StorageResponse::LinearizedTimestamps(feedback)) => Some(Ok(
+                    Response::Storage(StorageResponse::LinearizedTimestamps(feedback)),
+                )),
                 Response::Compute(ComputeResponse::PeekResponse(uuid, response), instance) => {
                     // Incorporate new peek responses; awaiting all responses.
                     let entry = self

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
+use uuid::Uuid;
 
 use crate::client::controller::ReadPolicy;
 use crate::client::{CreateSourceCommand, StorageClient, StorageCommand, StorageResponse};
@@ -100,7 +101,11 @@ pub trait StorageController: Debug + Send {
     );
 
     /// Send a request to obtain "linearized" timestamps for the given sources.
-    async fn linearize_sources(&mut self, source_ids: Vec<GlobalId>) -> Result<(), anyhow::Error>;
+    async fn linearize_sources(
+        &mut self,
+        peek_id: Uuid,
+        source_ids: Vec<GlobalId>,
+    ) -> Result<(), anyhow::Error>;
 
     async fn recv(&mut self) -> Result<Option<StorageResponse<Self::Timestamp>>, anyhow::Error>;
 }
@@ -360,7 +365,11 @@ impl<T: Timestamp + Lattice> StorageController for Controller<T> {
     ///
     /// Note: "linearizable" in this context may not represent
     /// true linearizability in all cases.
-    async fn linearize_sources(&mut self, _source_ids: Vec<GlobalId>) -> Result<(), anyhow::Error> {
+    async fn linearize_sources(
+        &mut self,
+        _peek_id: Uuid,
+        _source_ids: Vec<GlobalId>,
+    ) -> Result<(), anyhow::Error> {
         // TODO(guswynn): implement this function
         Ok(())
     }

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -352,13 +352,16 @@ impl<T: Timestamp + Lattice> StorageController for Controller<T> {
         self.state.client.recv().await
     }
 
-    async fn linearize_sources(&mut self, source_ids: Vec<GlobalId>) -> Result<(), anyhow::Error> {
-        self.state
-            .client
-            .send(StorageCommand::LinearizeSources(source_ids))
-            .await
-            .expect("Storage command failed; unrecoverable");
-
+    /// "Linearize" the listed sources.
+    ///
+    /// If these sources are valid and "linearizable", then the response
+    /// will respond with timestamps that are guaranteed to be up-to-date
+    /// with the max offset found at the time of the command issuance.
+    ///
+    /// Note: "linearizable" in this context may not represent
+    /// true linearizability in all cases.
+    async fn linearize_sources(&mut self, _source_ids: Vec<GlobalId>) -> Result<(), anyhow::Error> {
+        // TODO(guswynn): implement this function
         Ok(())
     }
 }

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -339,6 +339,7 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                     }
                 }
             }
+            StorageCommand::LinearizeSources(_source_ids) => {}
         }
     }
 

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -339,7 +339,6 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                     }
                 }
             }
-            StorageCommand::LinearizeSources(_source_ids) => {}
         }
     }
 


### PR DESCRIPTION
This PR adds the `LinearizeSources` and `LinearizedTimestamps` variants to `StorageCommand` and `StorageResponse` respectively. This is the main api boundary between the coordinator and the `STORAGE` layer that allows the coordinator, once the logic is implemented, to "wait" on storage to catch a source up to a specific set of timestamps, giving the illusion of linearized reads for certain scenarios (and up-to-date ones for others).

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

This PR intentionally leaves out a thorough implementation, as its intended to iterate, through review, on the storage API itself

### Testing

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
