### PR TITLE
Try adding wait on bucket

### DIFF
--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -21,7 +21,6 @@ psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.
 pydantic==1.9.0
 pytest==7.1.1
-retry==0.9.2
 scipy==1.7.3
 shtab==1.5.3
 sqlparse==0.4.2

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -21,6 +21,7 @@ psutil==5.9.0
 # psycopg2 intentionally omitted. Use pg8000 from requirements-core.txt instead.
 pydantic==1.9.0
 pytest==7.1.1
+retry==0.9.2
 scipy==1.7.3
 shtab==1.5.3
 sqlparse==0.4.2

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -185,7 +185,8 @@ def workflow_default(c: Composition) -> None:
 def create_bucket(session: boto3.Session) -> None:
     try:
         s3 = session.resource('s3')
-        bucket = s3.create_bucket(Bucket=BUCKET_NAME)
+        constraint = {'LocationConstraint': session.region_name } if session.region_name != "us-east-1" else None
+        bucket = s3.create_bucket(Bucket=BUCKET_NAME, CreateBucketConfiguration=constraint)
         bucket.wait_until_exists()
     except Exception as e:
         raise UIError("Unable to create s3 bucket")

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -351,6 +351,8 @@ def wait_for_bucket(sts: STSClient, role_arn: str, has_access: bool) -> None:
     for i in range(30, 0, -1):
         try:
             client.list_objects_v2(Bucket=BUCKET_NAME, MaxKeys=1)
+            print("Allow access permission successfully tested")
+            return
         except botocore.exceptions.ClientError:
             if not has_access:
                 print("Deny permission successfully enforced")

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -351,7 +351,7 @@ def wait_for_bucket(sts: STSClient, role_arn: str, has_access: bool) -> None:
     for i in range(30, 0, -1):
         try:
             client.list_objects_v2(Bucket=BUCKET_NAME, MaxKeys=1)
-        except botocore.exceptions.AccessDeniedException:
+        except botocore.exceptions.ClientError:
             if not has_access:
                 print("Deny permission successfully enforced")
                 return

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -202,7 +202,6 @@ def create_role(
     iam: IAMClient,
     effect: str,
     current_user: str,
-    bucket_location: str,
     created: List[CreatedRole],
     external_id: Optional[str] = None,
 ) -> CreatedRole:
@@ -239,12 +238,12 @@ def create_role(
                     {
                         "Effect": effect,
                         "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
-                        "Resource": bucket_location,
+                        "Resource": BUCKET_ARN,
                     },
                     {
                         "Effect": effect,
                         "Action": ["s3:GetObject", "s3:GetObjectAcl"],
-                        "Resource": f"{bucket_location}*/*",
+                        "Resource": f"{BUCKET_ARN}*/*",
                     },
                 ],
             }

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -338,10 +338,16 @@ def wait_for_bucket(sts: STSClient, role_arn: str, has_access: bool) -> None:
     Much like wait_for_role this is not expected to take long but
     it does require waiting to eliminate flakes
     """
-    sts.assume_role(
+    resp = sts.assume_role(
             RoleArn=role_arn, RoleSessionName="mzcomposevalidates3access"
         )
-    client = boto3.client('s3')
+    
+    client = boto3.client(
+        's3',
+        aws_access_key_id=resp["Credentials"]["AccessKeyId"],
+        aws_secret_access_key=resp["Credentials"]["SecretAccessKey"],
+        aws_session_token=resp["Credentials"]["SessionToken"]
+    )
     for i in range(30, 0, -1):
         try:
             client.list_objects_v2(Bucket=BUCKET_NAME, MaxKeys=1)

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -187,7 +187,7 @@ class CreatedBucket:
 def create_bucket() -> CreatedBucket:
     try:
         client = boto3.client('s3')
-        resp = client.create_bucket(Bucket=BUCKET_NAME)
+        resp = client.create_bucket(Bucket=BUCKET_NAME, CreateBucketConfiguration={'LocationConstraint': 'us-east-1'})
         return CreatedBucket(location=resp['Location'])
     except Exception as e:
         raise UIError("Unable to create s3 bucket")

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -320,7 +320,7 @@ def wait_for_role(sts: STSClient, role_arn: str) -> None:
         )
     try:
         assume()
-    finally:
+    except Exception as e:
         raise UIError("Never able to assume role")
 
     

--- a/test/aws-config/test-externalid-missing.td
+++ b/test/aws-config/test-externalid-missing.td
@@ -11,8 +11,6 @@
 
 $ set td-bucket=testdrive-noeid-${testdrive.seed}
 
-$ s3-create-bucket bucket=noeid
-
 $ s3-put-object bucket=noeid key=a
 a1
 

--- a/test/aws-config/test-restart-with-creds.td
+++ b/test/aws-config/test-restart-with-creds.td
@@ -12,7 +12,6 @@
 
 $ set td-bucket=testdrive-testrestart-${testdrive.seed}
 
-$ s3-create-bucket bucket=testrestart
 
 $ s3-put-object bucket=testrestart key=a
 a1

--- a/test/aws-config/test.td
+++ b/test/aws-config/test.td
@@ -90,16 +90,6 @@ $ set-sql-timeout duration=1m
   FORMAT TEXT;
 contains: Unable to validate AWS credentials
 
-> CREATE MATERIALIZED SOURCE s3_profile_denied
-  FROM S3 DISCOVER OBJECTS USING BUCKET SCAN '${td-bucket}'
-  WITH (
-    profile = 'denied'
-  )
-  FORMAT TEXT;
-
-! SELECT text FROM s3_profile_denied
-regex: Unable to list S3 bucket.*Access Denied
-
 # check credentials from profile, but using a role that denies access
 > CREATE MATERIALIZED SOURCE s3_role_denied
   FROM S3 DISCOVER OBJECTS USING BUCKET SCAN '${td-bucket}'
@@ -112,3 +102,15 @@ regex: Unable to list S3 bucket.*Access Denied
 
 ! SELECT text FROM s3_role_denied
 regex: Unable to list S3 bucket.*Access Denied
+
+
+> CREATE MATERIALIZED SOURCE s3_profile_denied
+  FROM S3 DISCOVER OBJECTS USING BUCKET SCAN '${td-bucket}'
+  WITH (
+    profile = 'denied'
+  )
+  FORMAT TEXT;
+
+! SELECT text FROM s3_profile_denied
+regex: Unable to list S3 bucket.*Access Denied
+

--- a/test/aws-config/test.td
+++ b/test/aws-config/test.td
@@ -113,4 +113,3 @@ regex: Unable to list S3 bucket.*Access Denied
 
 ! SELECT text FROM s3_profile_denied
 regex: Unable to list S3 bucket.*Access Denied
-

--- a/test/aws-config/test.td
+++ b/test/aws-config/test.td
@@ -12,8 +12,6 @@
 
 $ set td-bucket=testdrive-test-${testdrive.seed}
 
-$ s3-create-bucket bucket=test
-
 $ s3-put-object bucket=test key=a
 a1
 


### PR DESCRIPTION
The aws credential test was thought to be a little flaky because IAM propagation sometimes takes longer than expected for bucket policies, this PR adds some logic in the mz_compose workflow to wait for the bucket policy to apply as expected before running test drive.

It turns out that there was a separate change which removed a timeout but the mzcompose changes are still a net positive IMO since it is now fully deterministic that the testdrive stages will not run until they can be expected to succeed.
### Motivation


  * This PR fixes a previously unreported bug.

    AWS infra is eventually consistent and sometimes that was taking longer than tests accounted for

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
Passing section of the nightlies: https://buildkite.com/materialize/nightlies/builds/778

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No user facing changes, test stuff only.
