### PR TITLE
doc/user: polish release notes for v0.25.0

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -19,6 +19,12 @@ the PR description instead. They will be migrated here during the release
 process by the release notes team.
 {{< /comment >}}
 
+{{% version-header v0.25.0 %}}
+
+- Improve `base64` decoding to support numerals in encoded strings. Previously, if the encoded string contained a numeral, decoding would fail.
+
+- Fix a panic that would occur if an object or type was over-qualified (i.e., the fully qualified object name consisted of more than three identifiers separated by a `.`).
+
 {{% version-header v0.24.0 %}}
 
 - Restore the documented behavior of the

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -21,7 +21,7 @@ process by the release notes team.
 
 {{% version-header v0.25.0 %}}
 
-- Improve `base64` decoding to support numerals in encoded strings. Previously, if the encoded string contained a numeral, decoding would fail.
+- Fix `base64` decoding to support numerals in encoded strings. Previously, if the encoded string contained a numeral, decoding would fail.
 
 - Fix a panic that would occur if an object or type was over-qualified (i.e., the fully qualified object name consisted of more than three identifiers separated by a `.`).
 


### PR DESCRIPTION
### Motivation

Weekly release notes PR.

### Tips for reviewer

* Added a release note for #11352, since we usually document panic fixes:

  > Fix a panic that would occur if an object or type was over-qualified (i.e., the fully qualified object name consisted of more than three identifiers separated by a `.`).

* Double checked with @jkosh44 how to phrase #11313 as a single release note, and it turns out that the first point is no longer true. I don't think that the remaining point grants a release note:

  > Name resolution errors are returned before all other types of errors, except for parsing errors.

  , but let me know if you feel differently @benesch.