### PR TITLE
zippy: First draft of the new testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ node_modules
 coverage
 **/*.swp
 test/feature-benchmark/tmp/*.td
+test/zippy/tmp/*.td
 junit_*.xml

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -33,6 +33,7 @@ steps:
           - { value: feature-benchmark }
           - { value: feature-benchmark-persistence }
           - { value: aws-config }
+          - { value: zippy }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -198,3 +199,10 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: aws-config
+
+  - id: zippy
+    label: "Zippy"
+    timeout_in_minutes: 30
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -1,0 +1,110 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import List, Set, Type, TypeVar
+
+from materialize.mzcompose import Composition
+
+
+class Capability:
+    """Base class for a Zippy capability.
+
+    A capability represents a condition that is true about a Zippy test context,
+    like "a table with name 'foo' exists".
+    """
+
+    pass
+
+
+T = TypeVar("T", bound="Capability")
+
+
+class Capabilities:
+    """A set of `Capability`s."""
+
+    def __init__(self) -> None:
+        self._capabilities: List[Capability] = []
+
+    def _extend(self, capabilities: List[Capability]) -> None:
+        """Add new capabilities."""
+        self._capabilities.extend(capabilities)
+
+    def _remove(self, capabilities: Set[Type[T]]) -> None:
+        """Remove all existing capabilities of the specified types."""
+        self._capabilities = [
+            cap for cap in self._capabilities if type(cap) not in capabilities
+        ]
+
+    def provides(self, capability: Type[T]) -> bool:
+        """Report whether any capability of the specified type exists."""
+        return len(self.get(capability)) > 0
+
+    def get(self, capability: Type[T]) -> List[T]:
+        """Get all capabilities of the specified type."""
+        return [cap for cap in self._capabilities if type(cap) == capability]
+
+
+class Action:
+    """Base class for an action that a Zippy test can take."""
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        """Construct a new action, possibly conditioning on the available
+        capabilities."""
+        pass
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        """Compute the capability classes that this action requires."""
+        return set()
+
+    def removes(self) -> Set[Type[Capability]]:
+        """Compute the capability classes that this action will make unavailable."""
+        return set()
+
+    def provides(self) -> List[Capability]:
+        """Compute the capabilities that this action will make available."""
+        return []
+
+    def run(self, c: Composition) -> None:
+        """Run this action on the provided copmosition."""
+        assert False
+
+
+class Test:
+    """A Zippy test, consisting of a sequence of actions."""
+
+    def __init__(
+        self, action_classes: List[Type[Action]], max_actions: int = 20
+    ) -> None:
+        """Generate a new Zippy test.
+
+        Args:
+            action_classes: The set of actions to choose from.
+            max_actions: The number of actions to generate.
+        """
+        self._actions: List[Action] = []
+        capabilities = Capabilities()
+        for i in range(0, max_actions):
+            action_class = random.choice(
+                [
+                    action
+                    for action in action_classes
+                    if all(capabilities.provides(req) for req in action.requires())
+                ]
+            )
+            action = action_class(capabilities)
+            self._actions.append(action)
+            capabilities._extend(action.provides())
+            capabilities._remove(action.removes())
+
+    def run(self, c: Composition) -> None:
+        """Run the Zippy test."""
+        for action in self._actions:
+            action.run(c)

--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -1,0 +1,160 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
+from materialize.zippy.mz_capabilities import MzIsRunning
+
+SCHEMA = """
+$ set keyschema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"long"}
+        ]
+    }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f2", "type":"long"}
+        ]
+    }
+"""
+
+
+class KafkaStart(Action):
+    def provides(self) -> List[Capability]:
+        return [KafkaRunning()]
+
+    def run(self, c: Composition) -> None:
+        c.start_and_wait_for_tcp(services=["kafka"])
+
+
+class KafkaStop(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {KafkaRunning}
+
+    def removes(self) -> Set[Type[Capability]]:
+        return {KafkaRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("kafka")
+
+
+class CreateTopic(Action):
+    @classmethod
+    def requires(cls) -> Set[Type[Capability]]:
+        return {MzIsRunning, KafkaRunning}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        this_topic = TopicExists(name="topic" + str(random.randint(1, 10)))
+        existing_topics = [
+            t for t in capabilities.get(TopicExists) if t.name == this_topic.name
+        ]
+
+        if len(existing_topics) == 0:
+            self.new_topic = True
+            self.topic = this_topic
+        elif len(existing_topics) == 1:
+            self.new_topic = False
+            self.topic = existing_topics[0]
+        else:
+            assert False
+
+    def provides(self) -> List[Capability]:
+        return [self.topic] if self.new_topic else []
+
+    def run(self, c: Composition) -> None:
+        if self.new_topic:
+            c.testdrive(
+                f"""
+$ kafka-create-topic topic={self.topic.name}
+
+{SCHEMA}
+
+$ kafka-ingest format=avro key-format=avro topic={self.topic.name} schema=${{schema}} key-schema=${{keyschema}} publish=true repeat=1
+{{"f1": 0}} {{"f2": 0}}
+"""
+            )
+
+
+class Ingest(Action):
+    @classmethod
+    def requires(cls) -> Set[Type[Capability]]:
+        return {MzIsRunning, KafkaRunning, TopicExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        self.topic = random.choice(capabilities.get(TopicExists))
+        self.delta = random.randint(1, 100000)
+
+
+class KafkaInsert(Ingest):
+    def run(self, c: Composition) -> None:
+        prev_high = self.topic.watermarks.high
+        self.topic.watermarks.high = prev_high + self.delta
+        assert self.topic.watermarks.high >= 0
+        assert self.topic.watermarks.low >= 0
+        c.testdrive(
+            f"""
+{SCHEMA}
+
+$ kafka-ingest format=avro key-format=avro topic={self.topic.name} schema=${{schema}} key-schema=${{keyschema}} start-iteration={prev_high + 1} publish=true repeat={self.delta}
+{{"f1": ${{kafka-ingest.iteration}}}} {{"f2": ${{kafka-ingest.iteration}}}}
+"""
+        )
+
+
+class KafkaDeleteFromHead(Ingest):
+    def run(self, c: Composition) -> None:
+        prev_high = self.topic.watermarks.high
+        self.topic.watermarks.high = max(
+            prev_high - self.delta, self.topic.watermarks.low
+        )
+        assert self.topic.watermarks.high >= 0
+        assert self.topic.watermarks.low >= 0
+
+        actual_delta = prev_high - self.topic.watermarks.high
+
+        if actual_delta > 0:
+            c.testdrive(
+                f"""
+{SCHEMA}
+
+$ kafka-ingest format=avro topic={self.topic.name} key-format=avro key-schema=${{keyschema}} schema=${{schema}} start-iteration={self.topic.watermarks.high + 1} publish=true repeat={actual_delta}
+{{"f1": ${{kafka-ingest.iteration}}}}
+"""
+            )
+
+
+class KafkaDeleteFromTail(Ingest):
+    def run(self, c: Composition) -> None:
+        prev_low = self.topic.watermarks.low
+        self.topic.watermarks.low = min(
+            prev_low + self.delta, self.topic.watermarks.high
+        )
+        assert self.topic.watermarks.high >= 0
+        assert self.topic.watermarks.low >= 0
+        actual_delta = self.topic.watermarks.low - prev_low
+
+        if actual_delta > 0:
+            c.testdrive(
+                f"""
+{SCHEMA}
+
+$ kafka-ingest format=avro topic={self.topic.name} key-format=avro key-schema=${{keyschema}} schema=${{schema}} start-iteration={prev_low} publish=true repeat={actual_delta}
+{{"f1": ${{kafka-ingest.iteration}}}}
+"""
+            )

--- a/misc/python/materialize/zippy/kafka_capabilities.py
+++ b/misc/python/materialize/zippy/kafka_capabilities.py
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.watermarks import Watermarks
+
+
+class KafkaRunning(Capability):
+    pass
+
+
+class TopicExists(Capability):
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.watermarks = Watermarks()

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -1,0 +1,35 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+
+
+class MzStart(Action):
+    def run(self, c: Composition) -> None:
+        c.up("materialized")
+        c.wait_for_materialized()
+
+    def provides(self) -> List[Capability]:
+        return [MzIsRunning()]
+
+
+class MzStop(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("materialized")
+
+    def removes(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}

--- a/misc/python/materialize/zippy/mz_capabilities.py
+++ b/misc/python/materialize/zippy/mz_capabilities.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+
+
+class MzIsRunning(Capability):
+    pass

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.source_capabilities import SourceExists
+
+
+class CreateSource(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, KafkaRunning, TopicExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        source_name = "source" + str(random.randint(1, 10))
+        this_source = SourceExists(name=source_name)
+
+        existing_sources = [
+            s for s in capabilities.get(SourceExists) if s.name == this_source.name
+        ]
+
+        if len(existing_sources) == 0:
+            self.new_source = True
+
+            self.source = this_source
+            self.topic = random.choice(capabilities.get(TopicExists))
+            self.source.topic = self.topic
+        elif len(existing_sources) == 1:
+            self.new_source = False
+
+            self.source = existing_sources[0]
+            assert self.source.topic is not None
+            self.topic = self.source.topic
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if self.new_source:
+            c.testdrive(
+                f"""
+> CREATE MATERIALIZED SOURCE {self.source.name}
+  FROM KAFKA BROKER '${{testdrive.kafka-addr}}'
+  TOPIC 'testdrive-{self.topic.name}-${{testdrive.seed}}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
+  ENVELOPE UPSERT
+"""
+            )
+
+    def provides(self) -> List[Capability]:
+        return [self.source] if self.new_source else []

--- a/misc/python/materialize/zippy/source_capabilities.py
+++ b/misc/python/materialize/zippy/source_capabilities.py
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Optional
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.kafka_capabilities import TopicExists
+from materialize.zippy.watermarks import Watermarks
+
+
+class SourceExists(Capability):
+    def __init__(self, name: str, topic: Optional[TopicExists] = None) -> None:
+        self.name = name
+        self.topic = topic
+
+    def get_watermarks(self) -> Watermarks:
+        assert self.topic is not None
+        return self.topic.watermarks

--- a/misc/python/materialize/zippy/table_actions.py
+++ b/misc/python/materialize/zippy/table_actions.py
@@ -1,0 +1,118 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.table_capabilities import TableExists
+
+
+class CreateTable(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        this_table = TableExists(name="table" + str(random.randint(1, 10)))
+
+        existing_tables = [
+            t for t in capabilities.get(TableExists) if t.name == this_table.name
+        ]
+
+        if len(existing_tables) == 0:
+            self.new_table = True
+            self.table = this_table
+        elif len(existing_tables) == 1:
+            self.new_table = False
+            self.table = existing_tables[0]
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if self.new_table:
+            c.testdrive(
+                f"""
+> CREATE TABLE {self.table.name} (f1 INTEGER);
+> INSERT INTO {self.table.name} VALUES ({self.table.watermarks.high});
+"""
+            )
+
+    def provides(self) -> List[Capability]:
+        return [self.table] if self.new_table else []
+
+
+class ValidateTable(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, TableExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        self.table = random.choice(capabilities.get(TableExists))
+
+    def run(self, c: Composition) -> None:
+        c.testdrive(
+            f"""
+> SELECT MIN(f1), MAX(f1), COUNT(f1), COUNT(DISTINCT f1) FROM {self.table.name};
+{self.table.watermarks.low} {self.table.watermarks.high} {(self.table.watermarks.high-self.table.watermarks.low)+1} {(self.table.watermarks.high-self.table.watermarks.low)+1}
+"""
+        )
+
+
+class DML(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, TableExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        self.table = random.choice(capabilities.get(TableExists))
+        self.delta = random.randint(1, 100000)
+
+
+class Insert(DML):
+    def run(self, c: Composition) -> None:
+        prev_high = self.table.watermarks.high
+        self.table.watermarks.high = prev_high + self.delta
+        c.testdrive(
+            f"> INSERT INTO {self.table.name} SELECT * FROM generate_series({prev_high + 1}, {self.table.watermarks.high});"
+        )
+
+
+class ShiftForward(DML):
+    def run(self, c: Composition) -> None:
+        self.table.watermarks.shift(self.delta)
+        c.testdrive(f"> UPDATE {self.table.name} SET f1 = f1 + {self.delta};")
+
+
+class ShiftBackward(DML):
+    def run(self, c: Composition) -> None:
+        self.table.watermarks.shift(-self.delta)
+        c.testdrive(f"> UPDATE {self.table.name} SET f1 = f1 - {self.delta};")
+
+
+class DeleteFromHead(DML):
+    def run(self, c: Composition) -> None:
+        self.table.watermarks.high = max(
+            self.table.watermarks.high - self.delta, self.table.watermarks.low
+        )
+        c.testdrive(
+            f"> DELETE FROM {self.table.name} WHERE f1 > {self.table.watermarks.high};"
+        )
+
+
+class DeleteFromTail(DML):
+    def run(self, c: Composition) -> None:
+        self.table.watermarks.low = min(
+            self.table.watermarks.low + self.delta, self.table.watermarks.high
+        )
+        c.testdrive(
+            f"> DELETE FROM {self.table.name} WHERE f1 < {self.table.watermarks.low};"
+        )

--- a/misc/python/materialize/zippy/table_capabilities.py
+++ b/misc/python/materialize/zippy/table_capabilities.py
@@ -1,0 +1,20 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.watermarks import Watermarks
+
+
+class TableExists(Capability):
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.watermarks = Watermarks()
+
+    def get_watermarks(self) -> Watermarks:
+        return self.watermarks

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -1,0 +1,100 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import List, Set, Type, Union
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.source_capabilities import SourceExists
+from materialize.zippy.table_capabilities import TableExists
+from materialize.zippy.view_capabilities import ViewExists
+
+WatermarkedObjects = List[Union[TableExists, SourceExists]]
+
+
+class CreateView(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, SourceExists, TableExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        view_name = "view" + str(random.randint(1, 10))
+
+        this_view = ViewExists(name=view_name)
+        existing_views = [
+            v for v in capabilities.get(ViewExists) if v.name == this_view.name
+        ]
+        self.view = this_view
+
+        if len(existing_views) == 0:
+            self.new_view = True
+            sources: WatermarkedObjects = capabilities.get(SourceExists)
+            tables: WatermarkedObjects = capabilities.get(TableExists)
+
+            potential_froms = sources + tables
+            this_view.froms = random.sample(
+                potential_froms, min(len(potential_froms), random.randint(1, 5))
+            )
+
+            self.view = this_view
+            assert len(self.view.froms) > 0
+        elif len(existing_views) == 1:
+            self.new_view = False
+            self.view = existing_views[0]
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if not self.new_view:
+            return
+
+        some_from = random.sample(self.view.froms, 1)[0]
+        outer_join = "\n  ".join(
+            f"JOIN {f.name} USING (f1)" for f in self.view.froms[1:]
+        )
+
+        c.testdrive(
+            f"""
+> CREATE MATERIALIZED VIEW {self.view.name} AS
+  SELECT
+    MIN({some_from.name}.f1),
+    MAX({some_from.name}.f1),
+    COUNT({some_from.name}.f1) AS c1,
+    COUNT(DISTINCT {some_from.name}.f1) AS c2
+  FROM {self.view.froms[0].name}
+  {outer_join};
+"""
+        )
+
+    def provides(self) -> List[Capability]:
+        return [self.view] if self.new_view else []
+
+
+class ValidateView(Action):
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, ViewExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        self.view = random.choice(capabilities.get(ViewExists))
+
+    def run(self, c: Composition) -> None:
+        froms: WatermarkedObjects = self.view.froms
+        low = max([f.get_watermarks().low for f in froms])
+        high = min([f.get_watermarks().high for f in froms])
+
+        if low <= high:
+            c.testdrive(
+                f"""
+> SELECT * FROM {self.view.name};
+{low} {high} {(high-low)+1} {(high-low)+1}
+"""
+            )

--- a/misc/python/materialize/zippy/view_capabilities.py
+++ b/misc/python/materialize/zippy/view_capabilities.py
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List, Union
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.source_capabilities import SourceExists
+from materialize.zippy.table_capabilities import TableExists
+
+WatermarkedObjects = List[Union[TableExists, SourceExists]]
+
+
+class ViewExists(Capability):
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.froms: WatermarkedObjects = []

--- a/misc/python/materialize/zippy/watermarks.py
+++ b/misc/python/materialize/zippy/watermarks.py
@@ -1,0 +1,18 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+class Watermarks:
+    def __init__(self) -> None:
+        self.low = 0
+        self.high = 0
+
+    def shift(self, delta: int) -> None:
+        self.low = self.low + delta
+        self.high = self.high + delta

--- a/test/zippy/mzcompose
+++ b/test/zippy/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate --dev -m materialize.cli.mzcompose "$@"

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -1,0 +1,66 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import (
+    Kafka,
+    Materialized,
+    SchemaRegistry,
+    Testdrive,
+    Zookeeper,
+)
+from materialize.zippy.framework import Test
+from materialize.zippy.kafka_actions import *
+from materialize.zippy.mz_actions import *
+from materialize.zippy.source_actions import *
+from materialize.zippy.table_actions import *
+from materialize.zippy.view_actions import *
+
+SERVICES = [
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
+    # --persistent-kafka-sources can not be enabled due to gh#11711 , gh#11506
+    Materialized(options="--persistent-user-tables"),
+    Testdrive(validate_data_dir=False, no_reset=True, seed=1),
+]
+
+all_action_classes = [
+    MzStart,
+    MzStop,
+    KafkaStart,
+    #   KafkaStop,
+    CreateTopic,
+    CreateSource,
+    CreateSource,
+    CreateTable,
+    CreateView,
+    ValidateView,
+    ValidateView,
+    Insert,
+    ShiftForward,
+    ShiftBackward,
+    DeleteFromTail,
+    DeleteFromHead,
+    KafkaInsert,
+    KafkaDeleteFromHead,
+    KafkaDeleteFromTail,
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.up("testdrive", persistent=True)
+
+    random.seed(1)
+
+    print("Generating test...")
+    test = Test(action_classes=all_action_classes, max_actions=500)
+    print("Running test...")
+    test.run(c)


### PR DESCRIPTION
A first draft of the new testing framework, including some ability
to create topics, sinks, tables, views on top of them and then
validate the results from those views.


### Motivation

See design document:

https://github.com/philip-stoev/materialize/blob/0119667cea45c9b6551e9c920e75982d21e23010/doc/developer/design/2022-02-28_zippy_testing_framework.md

And presentation:

https://docs.google.com/presentation/d/19BTAhmpedIS4uQT0wtSTNMqjeia04_4-9EXXcKUUR6A/edit?usp=sharing

### Tips for reviewer

@benesch  if you could review [misc/python/materialize/mzcompose/__init__.py](https://github.com/MaterializeInc/materialize/compare/main...philip-stoev:zippy?expand=1#diff-969f91d1842251eb0957ef5efffb8b9f7d1f56af63d4cd3dd9c3cd4889d1650d) that would be much appreciated. Basically I am looking for an idiomatic way to run in-lined testdrive commands.

At some point I will stop using testdrive to communicate with Kafka and Mz, I promise ... but not having to implement in python any of the stuff testdrive does internally has been a productivity godsend.