### PR TITLE
Fix error message to be human readable

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -80,7 +80,7 @@ pub use crate::catalog::config::Config;
 pub use crate::catalog::error::Error;
 pub use crate::catalog::error::ErrorKind;
 
-pub const SYSTEM_CONN_ID: u32 = 0;
+const SYSTEM_CONN_ID: u32 = 0;
 const SYSTEM_USER: &str = "mz_system";
 
 /// A `Catalog` keeps track of the SQL objects known to the planner.
@@ -210,7 +210,13 @@ impl CatalogState {
         }
     }
 
-    pub fn resolve_full_name(&self, name: &QualifiedObjectName, conn_id: u32) -> FullObjectName {
+    pub fn resolve_full_name(
+        &self,
+        name: &QualifiedObjectName,
+        conn_id: Option<u32>,
+    ) -> FullObjectName {
+        let conn_id = conn_id.unwrap_or(SYSTEM_CONN_ID);
+
         let database = match &name.qualifiers.database_spec {
             ResolvedDatabaseSpecifier::Ambient => RawDatabaseSpecifier::Ambient,
             ResolvedDatabaseSpecifier::Id(id) => {
@@ -292,7 +298,8 @@ impl CatalogState {
                 Some(metadata) => metadata.used_by.push(entry.id),
                 None => panic!(
                     "Catalog: missing dependent catalog item {} while installing {}",
-                    &u, entry.name
+                    &u,
+                    self.resolve_full_name(&entry.name, entry.conn_id())
                 ),
             }
         }
@@ -1619,7 +1626,11 @@ impl Catalog {
         &self.state
     }
 
-    pub fn resolve_full_name(&self, name: &QualifiedObjectName, conn_id: u32) -> FullObjectName {
+    pub fn resolve_full_name(
+        &self,
+        name: &QualifiedObjectName,
+        conn_id: Option<u32>,
+    ) -> FullObjectName {
         self.state.resolve_full_name(name, conn_id)
     }
 
@@ -2165,8 +2176,12 @@ impl Catalog {
                         )
                         .map_err(|e| {
                             Error::new(ErrorKind::AmbiguousRename {
-                                depender: entry.name.to_string(),
-                                dependee: entry.name.to_string(),
+                                depender: self
+                                    .resolve_full_name(&entry.name, entry.conn_id())
+                                    .to_string(),
+                                dependee: self
+                                    .resolve_full_name(&entry.name, entry.conn_id())
+                                    .to_string(),
                                 message: e,
                             })
                         })?;
@@ -2183,8 +2198,15 @@ impl Catalog {
                             )
                             .map_err(|e| {
                                 Error::new(ErrorKind::AmbiguousRename {
-                                    depender: dependent_item.name.to_string(),
-                                    dependee: entry.name.to_string(),
+                                    depender: self
+                                        .resolve_full_name(
+                                            &dependent_item.name,
+                                            dependent_item.conn_id(),
+                                        )
+                                        .to_string(),
+                                    dependee: self
+                                        .resolve_full_name(&entry.name, entry.conn_id())
+                                        .to_string(),
                                     message: e,
                                 })
                             })?;
@@ -2381,7 +2403,12 @@ impl Catalog {
                 Action::DropItem(id) => {
                     let metadata = state.entry_by_id.remove(&id).unwrap();
                     if !metadata.item.is_placeholder() {
-                        info!("drop {} {} ({})", metadata.item_type(), metadata.name, id);
+                        info!(
+                            "drop {} {} ({})",
+                            metadata.item_type(),
+                            state.resolve_full_name(&metadata.name, metadata.conn_id()),
+                            id
+                        );
                     }
                     for u in metadata.uses() {
                         if let Some(dep_metadata) = state.entry_by_id.get_mut(&u) {
@@ -2428,7 +2455,7 @@ impl Catalog {
                     info!(
                         "update {} {} ({})",
                         old_entry.item_type(),
-                        old_entry.name,
+                        state.resolve_full_name(&old_entry.name, old_entry.conn_id()),
                         id
                     );
                     assert_eq!(old_entry.uses(), to_item.uses());
@@ -3065,7 +3092,7 @@ impl SessionCatalog for ConnCatalog<'_> {
     }
 
     fn resolve_full_name(&self, name: &QualifiedObjectName) -> FullObjectName {
-        self.catalog.resolve_full_name(name, self.conn_id)
+        self.catalog.resolve_full_name(name, Some(self.conn_id))
     }
 
     fn config(&self) -> &mz_sql::catalog::CatalogConfig {

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -134,9 +134,7 @@ impl CatalogState {
             CatalogItem::Secret(_) => self.pack_secret_update(id, schema_id, name, diff),
         };
 
-        if let Ok(desc) = entry
-            .desc(&self.resolve_full_name(entry.name(), entry.conn_id().unwrap_or(SYSTEM_CONN_ID)))
-        {
+        if let Ok(desc) = entry.desc(&self.resolve_full_name(entry.name(), entry.conn_id())) {
             let defaults = match entry.item() {
                 CatalogItem::Table(table) => Some(&table.defaults),
                 _ => None,
@@ -338,10 +336,7 @@ impl CatalogState {
             let nullable = key
                 .typ(
                     on_entry
-                        .desc(&self.resolve_full_name(
-                            on_entry.name(),
-                            on_entry.conn_id().unwrap_or(SYSTEM_CONN_ID),
-                        ))
+                        .desc(&self.resolve_full_name(on_entry.name(), on_entry.conn_id()))
                         .unwrap()
                         .typ(),
                 )

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -27,7 +27,7 @@ use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{Datum, Row};
 
-use crate::catalog::{CatalogItem, CatalogState, SYSTEM_CONN_ID};
+use crate::catalog::{CatalogItem, CatalogState};
 use crate::coord::{CatalogTxn, Coordinator};
 use crate::error::RematerializedSourceType;
 use crate::session::{Session, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION};
@@ -123,10 +123,11 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                     };
                     let entry = self.catalog.get_entry(id);
                     let desc = entry
-                        .desc(&self.catalog.resolve_full_name(
-                            entry.name(),
-                            entry.conn_id().unwrap_or(SYSTEM_CONN_ID),
-                        ))
+                        .desc(
+                            &self
+                                .catalog
+                                .resolve_full_name(entry.name(), entry.conn_id()),
+                        )
                         .expect("indexes can only be built on items with descs");
                     dataflow.import_index(index_id, index_desc, desc.typ().clone());
                 }
@@ -226,10 +227,11 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
         }
         let on_entry = self.catalog.get_entry(&index.on);
         let on_type = on_entry
-            .desc(&self.catalog.resolve_full_name(
-                on_entry.name(),
-                on_entry.conn_id().unwrap_or(SYSTEM_CONN_ID),
-            ))
+            .desc(
+                &self
+                    .catalog
+                    .resolve_full_name(on_entry.name(), on_entry.conn_id()),
+            )
             .unwrap()
             .typ()
             .clone();

--- a/test/sqllogictest/ambiguous_rename.slt
+++ b/test/sqllogictest/ambiguous_rename.slt
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE DATABASE d1
+
+statement ok
+CREATE DATABASE d2
+
+statement ok
+CREATE TABLE d1.public.foo(a int)
+
+statement ok
+CREATE TABLE d2.public.bar(b int)
+
+statement ok
+CREATE VIEW v AS SELECT foo.a, bar.b FROM d1.public.foo, d2.public.bar
+
+statement error renaming conflict: in materialize.public.v, which uses d1.public.foo, found reference to "bar"; cannot rename "foo" to any identity used in any existing view definitions
+ALTER TABLE d1.public.foo RENAME TO bar


### PR DESCRIPTION
Previously ambiguous rename error messages (and other log messages) contained schema and
database ids instead of human readable names. This commit changes
the error message to have human readable names.

### Motivation
This PR fixes a previously unreported bug.

### Tips for reviewer
- Instead of every call to `resolve_full_name` having to call `unwrap_or(SYSTEM_CONN_ID)`, I just pushed `unwrap_or(SYSTEM_CONN_ID)` inside of `resolve_full_name` which is where most of the diff comes from.


### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes.
