### PR TITLE
Clean up error msg for unsupported call

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4068,7 +4068,7 @@ impl Coordinator {
                 if selection.contains_temporal() {
                     tx.send(
                         Err(CoordError::Unsupported(
-                            "calls to mz_logical_timestamp in write statements are not supported",
+                            "calls to mz_logical_timestamp in write statements",
                         )),
                         session,
                     );


### PR DESCRIPTION
### Motivation
This PR fixes a previously unreported bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Clean up error message from calling `mz_logical_timestamp` in write statements to be grammatically correct
