### PR TITLE
dataflow: Make Peek a proper struct

### DIFF
--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -31,8 +31,8 @@ use uuid::Uuid;
 
 use crate::client::controller::storage::StorageController;
 use crate::client::replicated::ActiveReplication;
-use crate::client::GenericClient;
 use crate::client::{ComputeClient, ComputeCommand, ComputeInstanceId};
+use crate::client::{GenericClient, Peek};
 use crate::logging::LoggingConfig;
 use crate::DataflowDescription;
 use mz_expr::GlobalId;
@@ -332,14 +332,14 @@ where
 
         self.compute
             .client
-            .send(ComputeCommand::Peek {
+            .send(ComputeCommand::Peek(Peek {
                 id,
                 key,
                 uuid,
                 timestamp,
                 finishing,
                 map_filter_project,
-            })
+            }))
             .await
             .map_err(ComputeError::from)
     }

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -26,6 +26,7 @@ use std::collections::{HashMap, HashSet};
 
 use timely::progress::{frontier::MutableAntichain, Antichain};
 
+use crate::client::Peek;
 use mz_expr::GlobalId;
 
 use super::{ComputeClient, GenericClient};
@@ -126,7 +127,7 @@ where
 {
     async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         // Register an interest in the peek.
-        if let ComputeCommand::Peek { uuid, .. } = &cmd {
+        if let ComputeCommand::Peek(Peek { uuid, .. }) = &cmd {
             self.peeks.insert(*uuid);
         }
 


### PR DESCRIPTION
### Motivation

Turn `ComputeCommand::Peek` into a proper struct by extracting the inline struct.

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
