### PR TITLE
Prefer to use btree keys/values over iter

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4707,13 +4707,13 @@ impl Coordinator {
 
         let storage_ids = dataflow
             .source_imports
-            .iter()
-            .map(|(id, _)| *id)
+            .keys()
+            .copied()
             .collect::<BTreeSet<_>>();
         let compute_ids = dataflow
             .index_imports
-            .iter()
-            .map(|(id, _)| *id)
+            .keys()
+            .copied()
             .collect::<BTreeSet<_>>();
 
         let since = self.least_valid_read(

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -198,7 +198,7 @@ where
             let mut compute_dependencies = Vec::new();
 
             // Validate sources have `since.less_equal(as_of)`.
-            for (source_id, _) in dataflow.source_imports.iter() {
+            for source_id in dataflow.source_imports.keys() {
                 let since = &self
                     .storage_controller
                     .collection(*source_id)
@@ -214,7 +214,7 @@ where
 
             // Validate indexes have `since.less_equal(as_of)`.
             // TODO(mcsherry): Instead, return an error from the constructing method.
-            for (index_id, _) in dataflow.index_imports.iter() {
+            for index_id in dataflow.index_imports.keys() {
                 let collection = self.as_ref().collection(*index_id)?;
                 let since = collection.read_capabilities.frontier();
                 if !(<_ as timely::order::PartialOrder>::less_equal(&since, &as_of.borrow())) {
@@ -254,7 +254,7 @@ where
                 .await;
 
             // Install collection state for each of the exports.
-            for (sink_id, _) in dataflow.sink_exports.iter() {
+            for sink_id in dataflow.sink_exports.keys() {
                 self.compute.collections.insert(
                     *sink_id,
                     CollectionState::new(
@@ -264,7 +264,7 @@ where
                     ),
                 );
             }
-            for (index_id, _) in dataflow.index_exports.iter() {
+            for index_id in dataflow.index_exports.keys() {
                 self.compute.collections.insert(
                     *index_id,
                     CollectionState::new(

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -252,7 +252,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
     /// Returns true iff `id` is already imported.
     pub fn is_imported(&self, id: &GlobalId) -> bool {
         self.objects_to_build.iter().any(|bd| &bd.id == id)
-            || self.source_imports.iter().any(|(i, _)| i == id)
+            || self.source_imports.keys().any(|i| i == id)
     }
 
     /// Assigns the `as_of` frontier to the supplied argument.
@@ -289,7 +289,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
                 return source.description.desc.arity();
             }
         }
-        for (_index_id, (desc, typ)) in self.index_imports.iter() {
+        for (desc, typ) in self.index_imports.values() {
             if &desc.on_id == id {
                 return typ.arity();
             }


### PR DESCRIPTION
### Motivation

Instead of iterating `BTreeMap` elements, only iterate over keys/values if sufficient.

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
