### PR TITLE
Dataflowd: Correct logging env symbol

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -135,7 +135,7 @@ class Dataflowd(Service):
 
         if environment is None:
             environment = [
-                "MZ_LOG_FILTER",
+                "DATAFLOWD_LOG_FILTER",
                 "MZ_SOFT_ASSERTIONS=1",
             ]
 


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug: We didn't expose the correct environment symbol to enable `dataflowd` logging in Docker.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
