### PR TITLE
ore: compensate for missing default max duration

### DIFF
--- a/demo/billing/src/bin/billing-demo/mz.rs
+++ b/demo/billing/src/bin/billing-demo/mz.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use csv::Writer;
@@ -156,6 +157,7 @@ pub async fn validate_sink(
     let count_input_view_query = format!("SELECT count(*) from {}", input_view);
 
     Retry::default()
+        .max_duration(Duration::from_secs(30))
         .retry_async(|_| async {
             let count_check_sink: i64 = mz_client
                 .query_one(&*count_check_sink_query, &[])

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4491,6 +4491,7 @@ impl Coordinator {
                     for (conn, slot_names) in replication_slots_to_drop {
                         // Try to drop the replication slots, but give up after a while.
                         let _ = Retry::default()
+                            .max_duration(Duration::from_secs(30))
                             .retry_async(|_state| {
                                 mz_postgres_util::drop_replication_slots(&conn, &slot_names)
                             })

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -595,7 +595,6 @@ impl KafkaSinkState {
                         let self_self_producer = self_producer.clone();
                         // Only actually used for retriable errors.
                         let should_shutdown = Retry::default()
-                            .max_tries(usize::MAX)
                             .clamp_backoff(Duration::from_secs(60 * 10))
                             .retry_async(|_| async {
                                 match self_self_producer.abort_transaction().await {
@@ -708,7 +707,6 @@ impl KafkaSinkState {
         let self_producer = self.producer.clone();
         // Only actually used for retriable errors.
         Retry::default()
-            .max_tries(usize::MAX)
             // Because we only expect to receive timeout errors, we should clamp fairly low.
             .clamp_backoff(Duration::from_secs(60))
             .retry_async(|_| self_producer.flush())
@@ -874,7 +872,6 @@ impl KafkaSinkState {
         {
             // Only actually used for retriable errors.
             return Retry::default()
-                .max_tries(usize::MAX)
                 .clamp_backoff(Duration::from_secs(60 * 10))
                 .retry_async(|_| async {
                     let topic = topic.clone();

--- a/src/dataflow/src/source/s3.rs
+++ b/src/dataflow/src/source/s3.rs
@@ -290,6 +290,7 @@ async fn scan_bucket_task(
     let mut continuation_token = None;
     loop {
         let response = Retry::default()
+            .max_duration(Duration::from_secs(30))
             .retry_async(|_| {
                 client
                     .list_objects_v2()

--- a/src/kafka-util/src/admin.rs
+++ b/src/kafka-util/src/admin.rs
@@ -85,6 +85,7 @@ where
     // created with the default number partitions, and not the number of
     // partitions requested in `new_topic`.
     Retry::default()
+        .max_duration(Duration::from_secs(30))
         .retry_async(|_| async {
             let metadata = client
                 .inner()

--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -257,8 +257,8 @@ impl Retry {
 }
 
 impl Default for Retry {
-    /// Constructs a retry operation with defaults that are reasonable for a
-    /// fallible network operation.
+    /// Constructs a retry operation that will retry forever with backoff
+    /// defaults that are reasonable for a fallible network operation.
     fn default() -> Self {
         Retry {
             initial_backoff: Duration::from_millis(125),


### PR DESCRIPTION
PR #11425 somewhat inadvertently changed `Retry::default()` so that it
produces a retry operation that retries forever, rather than a retry
operation that has a maximum duration of 30s.

This is actually a better default, because the default is the *least*
constrained retry operation, and each caller can choose whether to add a
max try constraint, a max duration constraint, or both. Previously
callers that wanted to retry forever had to know to call
`max_tries(usize::MAX)` to remove the max duration constraint.

So, this commit keeps the new default, but updates all callers to
account for the new default. Callers that want a 30s max duration need
to install it explicitly; callers that want an infinite retry loop no
longer need to call `max_tries(usize::MAX)`.

h/t @nharring-adjacent for spotting this.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
