### PR TITLE
Create introspect source indexes with unique name

### DIFF
--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -176,15 +176,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
     /// Finds a name like `name` that is not already in use.
     ///
     /// If `name` itself is available, it is returned unchanged.
-    fn find_available_name(&self, mut name: QualifiedObjectName) -> QualifiedObjectName {
-        let mut i = 0;
-        let orig_item_name = name.item.clone();
-        while self.item_exists(&name) {
-            i += 1;
-            name.item = format!("{}{}", orig_item_name, i);
-        }
-        name
-    }
+    fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName;
 
     /// Returns a fully qualified human readable name from fully qualified non-human readable name
     fn resolve_full_name(&self, name: &QualifiedObjectName) -> FullObjectName;
@@ -598,6 +590,10 @@ impl SessionCatalog for DummyCatalog {
 
     fn now(&self) -> EpochMillis {
         (self.config().now)()
+    }
+
+    fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
+        name
     }
 }
 

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -294,6 +294,10 @@ impl SessionCatalog for TestCatalog {
     fn now(&self) -> EpochMillis {
         (self.config().now)()
     }
+
+    fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
+        name
+    }
 }
 
 impl ExprHumanizer for TestCatalog {


### PR DESCRIPTION
Whenever a new compute instance is created, we create new introspection
source indexes for the new instances. However previously these would
all be created with the exact same name. This commit ensures that each
index has a unique name.

### Motivation

This PR fixes a previously unreported bug. Discovered in relation to #11435


### Tips for reviewer

* The vast majority of the PR is just shuffling functions around to different layers of the Catalog API (`SessionCatalog` -> `Catalog` -> `CatalogState`), so we can access the `find_available_name` function with a reference to `CatalogState`. The only interesting thing happening is in `src/coord/src/catalog.rs` lines 390-400 where we ensure the index name is unique.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered (There really isn't the testing infrastructure in place to test this functionality yet).

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes.
