### PR TITLE
Use correct datum type (i32) in array_length implementations

### DIFF
--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1877,7 +1877,7 @@ lazy_static! {
                 params!(Bytes, Bytes, String) => VariadicFunc::HmacBytes, 44157;
             },
             "jsonb_array_length" => Scalar {
-                params!(Jsonb) => UnaryFunc::JsonbArrayLength, 3207;
+                params!(Jsonb) => UnaryFunc::JsonbArrayLength => Int32, 3207;
             },
             "jsonb_build_array" => Scalar {
                 params!() => VariadicFunc::JsonbBuildArray, 3272;


### PR DESCRIPTION
As mentioned in https://github.com/MaterializeInc/materialize/pull/11515

This changes various implementations to match the declared types for https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/func.rs#L1712

Fix #11527.

### Motivation

  * This PR fixes a previously unreported bug.

See above

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

- **Breaking change.** Change the return type of the `array_length`, `array_upper`, and `array_lower` functions from `bigint` to `integer` to match PostgreSQL.

