### PR TITLE
doc/user: add temporary note to demos

### DIFF
--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -6,6 +6,8 @@ menu:
         parent: "demos"
 ---
 
+{{% demos-warning %}}
+
 **tl;dr** Materialize can enable real-time monitoring within business
 intelligence tools, and we have a [demo](#run-the-demo) showing you that it's
 feasible.

--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -6,7 +6,7 @@ menu:
         parent: "demos"
 ---
 
-{{% demos-warning %}} 
+{{% demos-warning %}}
 
 **tl;dr** Materialize can enable real-time monitoring within business
 intelligence tools, and we have a [demo](#run-the-demo) showing you that it's

--- a/doc/user/content/demos/business-intelligence.md
+++ b/doc/user/content/demos/business-intelligence.md
@@ -6,7 +6,7 @@ menu:
         parent: "demos"
 ---
 
-{{% demos-warning %}}
+{{% demos-warning %}} 
 
 **tl;dr** Materialize can enable real-time monitoring within business
 intelligence tools, and we have a [demo](#run-the-demo) showing you that it's

--- a/doc/user/content/demos/log-parsing.md
+++ b/doc/user/content/demos/log-parsing.md
@@ -6,6 +6,8 @@ menu:
     parent: 'demos'
 ---
 
+{{% demos-warning %}}
+
 **tl;dr** Materialize can extract meaningful data from logs in real time.
 
 Servers, especially busy ones, can emit a vast amount of logging data. Given

--- a/doc/user/content/demos/microservice.md
+++ b/doc/user/content/demos/microservice.md
@@ -6,6 +6,8 @@ menu:
     parent: 'demos'
 ---
 
+{{% demos-warning %}}
+
 **tl;dr** Using Materialize, you can easily create transformation-oriented
 microservices.
 

--- a/doc/user/layouts/shortcodes/demos-warning.html
+++ b/doc/user/layouts/shortcodes/demos-warning.html
@@ -1,0 +1,3 @@
+<div class="warning">
+  <strong class="gutter">WARNING!</strong> This demo uses Docker images that <b>are not compatible</b> with ARM architectures. We are working on refactoring it to use multi-arch images.
+</div>


### PR DESCRIPTION
The demos in our documentation use Docker images that don't provide ARM-compatible builds (namely, Kafka and Metabase). While we work on the demo repo, we should add a disclaimer to existing demos so users don't just assume they're broken.