### PR TITLE
Advance write frontier for `TAIL`

### DIFF
--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -110,7 +110,7 @@ impl PendingTail {
                 }
                 upper.is_empty()
             }
-            TailResponse::Dropped => {
+            TailResponse::DroppedAt(_frontier) => {
                 // TODO: Could perhaps do this earlier, in response to DROP SINK.
                 true
             }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -1201,10 +1201,13 @@ pub mod partitioned {
                                 None
                             }
                         }
-                        TailResponse::Dropped => {
+                        TailResponse::DroppedAt(frontier) => {
                             *maybe_entry = None;
                             Some(Ok(Response::Compute(
-                                ComputeResponse::TailResponse(id, TailResponse::Dropped),
+                                ComputeResponse::TailResponse(
+                                    id,
+                                    TailResponse::DroppedAt(frontier),
+                                ),
                                 instance,
                             )))
                         }

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -272,7 +272,7 @@ where
                                         )));
                                     }
                                 }
-                                TailResponse::Dropped => {
+                                TailResponse::DroppedAt(frontier) => {
                                     // Introduce a new terminal frontier to suppress all future responses.
                                     // We cannot simply remove the entry, as we currently create new entries in response
                                     // to observed responses; if we pre-load the entries in response to commands we can
@@ -280,7 +280,7 @@ where
                                     self.tails.insert(id, Antichain::new());
                                     return Ok(Some(ComputeResponse::TailResponse(
                                         id,
-                                        TailResponse::Dropped,
+                                        TailResponse::DroppedAt(frontier),
                                     )));
                                 }
                             }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -64,7 +64,7 @@ impl PeekResponse {
 pub enum TailResponse<T = mz_repr::Timestamp> {
     /// A batch of updates over a non-empty interval of time.
     Batch(TailBatch<T>),
-    /// The TAIL dataflow was dropped before completing. Indicates the end.
+    /// The TAIL dataflow was dropped, leaving updates from this frontier onward unspecified.
     DroppedAt(Antichain<T>),
 }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -65,7 +65,7 @@ pub enum TailResponse<T = mz_repr::Timestamp> {
     /// A batch of updates over a non-empty interval of time.
     Batch(TailBatch<T>),
     /// The TAIL dataflow was dropped before completing. Indicates the end.
-    Dropped,
+    DroppedAt(Antichain<T>),
 }
 
 /// A batch of updates for the interval `[lower, upper)`.

--- a/src/dataflow/src/sink/tail.rs
+++ b/src/dataflow/src/sink/tail.rs
@@ -158,7 +158,7 @@ impl TailProtocol {
             self.prev_upper = upper;
             if input_exhausted {
                 // The dataflow's input has been exhausted; clear the channel,
-                // to avoid sending `TailResponse::Dropped`.
+                // to avoid sending `TailResponse::DroppedAt`.
                 self.tail_response_buffer = None;
             }
         }
@@ -168,9 +168,10 @@ impl TailProtocol {
 impl Drop for TailProtocol {
     fn drop(&mut self) {
         if let Some(buffer) = self.tail_response_buffer.take() {
-            buffer
-                .borrow_mut()
-                .push((self.sink_id, TailResponse::Dropped));
+            buffer.borrow_mut().push((
+                self.sink_id,
+                TailResponse::DroppedAt(self.prev_upper.clone()),
+            ));
         }
     }
 }


### PR DESCRIPTION
TAIL (and some other sinks) were not communicating their "write frontiers" back from compute instances to the compute controller, as e.g. indexes and Kafka sinks do with the `ComputeResponse::FrontierUppers` variant. This led to TAIL use disallowing compaction on their inputs, both immediate (indexes) and transitive (sources).

There seem to be two plausible fixes for this:
1. Have TAIL communicate via `FrontierUppers` information that is redundant with `TailResponse`.
2. Respond to `TailResponse` with behavior that would be redundant with `FrontierUppers` response.

I went with the latter in this one, under the theory that our plan is to eventually migrate TAIL out of "sink" territory and into a concept managed by COMPUTE. It would be the wrong call if someone does a blanket implementation of `FrontierUppers` for all sinks, as we would be providing twice the information (in a non-idempotent representation). 

### Motivation

  * This PR addresses a recognized bug (https://github.com/MaterializeInc/materialize/issues/11522). 

It does not close this issue, but addresses it for TAIL which is the primary other sink of consequence (as AvroOcf sinks were not even remembered to exist until recenly).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
