### PR TITLE
coord,dataflow,sql: remove virtual clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6059,7 +6059,7 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#c4145f0ab5c3830f08d1fd8158a441503554de7b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6f5057355305e54a36774aa805ec1c625cf8532e"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -6077,12 +6077,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#c4145f0ab5c3830f08d1fd8158a441503554de7b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6f5057355305e54a36774aa805ec1c625cf8532e"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#c4145f0ab5c3830f08d1fd8158a441503554de7b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6f5057355305e54a36774aa805ec1c625cf8532e"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -6098,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#c4145f0ab5c3830f08d1fd8158a441503554de7b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6f5057355305e54a36774aa805ec1c625cf8532e"
 dependencies = [
  "columnation",
  "serde",
@@ -6107,7 +6107,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#c4145f0ab5c3830f08d1fd8158a441503554de7b"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#6f5057355305e54a36774aa805ec1c625cf8532e"
 
 [[package]]
 name = "tinytemplate"

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -26,8 +26,8 @@ pub struct Config<'a> {
     pub experimental_mode: Option<bool>,
     /// Whether to enable safe mode.
     pub safe_mode: bool,
-    /// Whether to enable introspection for the virtual compute host.
-    pub virtual_compute_host_introspection: Option<ComputeInstanceIntrospectionConfig>,
+    /// Whether to enable introspection for the local compute instance.
+    pub local_compute_introspection: Option<ComputeInstanceIntrospectionConfig>,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
     /// An [External ID][] to use for all AWS AssumeRole operations.

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -384,7 +384,7 @@ impl Connection {
                 let name: String = row.get(1)?;
                 let config: Option<String> = row.get(2)?;
                 let config: ComputeInstanceConfig = match config {
-                    None => ComputeInstanceConfig::Virtual,
+                    None => ComputeInstanceConfig::Local,
                     Some(config) => serde_json::from_str(&config)
                         .map_err(|err| rusqlite::Error::from(FromSqlError::Other(Box::new(err))))?,
                 };

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -25,9 +25,7 @@
 //! for the previous instance. The implementation currently does not distinguish between buffering
 //! messages for a disconnected controller and talking to a live controller.
 
-use crate::client::{
-    Command, ComputeCommand, ComputeInstanceId, ComputeResponse, GenericClient, Response,
-};
+use crate::client::{Command, ComputeCommand, ComputeResponse, GenericClient, Response};
 use crate::{DataflowDescription, Plan};
 use async_trait::async_trait;
 use mz_expr::GlobalId;
@@ -44,8 +42,9 @@ use tracing::warn;
 pub struct ComputeCommandReconcile<T, C> {
     /// The client wrapped by this struct.
     client: C,
-    /// The known compute instances we're responsible for.
-    created: HashSet<ComputeInstanceId>,
+    /// Whether we've seen a `CreateInstance` command without a corresponding
+    /// `DropInstance` command.
+    created: bool,
     /// Dataflows by ID.
     dataflows: HashMap<GlobalId, DataflowDescription<Plan>>,
     /// Outstanding peek identifiers, to guide responses (and which to suppress).
@@ -53,7 +52,7 @@ pub struct ComputeCommandReconcile<T, C> {
     /// Stash of responses to send back to the controller.
     responses: VecDeque<Response>,
     /// Upper frontiers for indexes, sources, and sinks.
-    uppers: HashMap<(GlobalId, ComputeInstanceId), MutableAntichain<T>>,
+    uppers: HashMap<GlobalId, MutableAntichain<T>>,
 }
 
 #[async_trait]
@@ -99,11 +98,11 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
     ///
     /// If we're already tracking this ID, it means that the controller lost connection and
     /// reconnected (or has a bug). We're updating the controller's upper to match the local state.
-    fn start_tracking(&mut self, id: GlobalId, instance: ComputeInstanceId) {
+    fn start_tracking(&mut self, id: GlobalId) {
         let frontier = timely::progress::frontier::MutableAntichain::new_bottom(
             <mz_repr::Timestamp as timely::progress::Timestamp>::minimum(),
         );
-        match self.uppers.entry((id, instance)) {
+        match self.uppers.entry(id) {
             Entry::Occupied(entry) => {
                 // We're about to start tracking an already-bound ID. This means that the controller
                 // needs to be informed about the `upper`.
@@ -112,10 +111,11 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
                     -1,
                 );
                 change_batch.extend(entry.get().frontier().iter().copied().map(|t| (t, 1)));
-                self.responses.push_back(Response::Compute(
-                    ComputeResponse::FrontierUppers(vec![(id, change_batch)]),
-                    instance,
-                ));
+                self.responses
+                    .push_back(Response::Compute(ComputeResponse::FrontierUppers(vec![(
+                        id,
+                        change_batch,
+                    )])));
             }
             Entry::Vacant(entry) => {
                 entry.insert(frontier);
@@ -124,8 +124,8 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
     }
 
     /// Stop tracking the id within an instance.
-    fn stop_tracking(&mut self, id: GlobalId, instance: ComputeInstanceId) {
-        let previous = self.uppers.remove(&(id, instance));
+    fn stop_tracking(&mut self, id: GlobalId) {
+        let previous = self.uppers.remove(&id);
         if previous.is_none() {
             warn!("Protocol error: ceasing frontier tracking for absent identifier {id:?}");
         }
@@ -136,7 +136,7 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
     async fn absorb_command(&mut self, command: Command) -> Result<(), anyhow::Error> {
         use Command::*;
         match command {
-            Compute(command, instance) => self.absorb_compute_command(command, instance).await,
+            Compute(command) => self.absorb_compute_command(command).await,
             Storage(_) => panic!("ComputeCommandReconcile cannot handle Storage commands"),
         }
     }
@@ -144,9 +144,9 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
     /// Absorbs a response, and produces response that should be emitted.
     pub fn absorb_response(&mut self, message: Response) {
         match message {
-            Response::Compute(ComputeResponse::FrontierUppers(mut list), instance) => {
+            Response::Compute(ComputeResponse::FrontierUppers(mut list)) => {
                 for (id, changes) in list.iter_mut() {
-                    if let Some(frontier) = self.uppers.get_mut(&(*id, instance)) {
+                    if let Some(frontier) = self.uppers.get_mut(id) {
                         let iter = frontier.update_iter(changes.drain());
                         changes.extend(iter);
                     } else {
@@ -154,24 +154,22 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
                     }
                 }
 
-                self.responses.push_back(Response::Compute(
-                    ComputeResponse::FrontierUppers(list),
-                    instance,
-                ));
+                self.responses
+                    .push_back(Response::Compute(ComputeResponse::FrontierUppers(list)));
             }
-            Response::Compute(ComputeResponse::PeekResponse(uuid, response), instance) => {
+            Response::Compute(ComputeResponse::PeekResponse(uuid, response)) => {
                 if self.peeks.remove(&uuid) {
-                    self.responses.push_back(Response::Compute(
-                        ComputeResponse::PeekResponse(uuid, response),
-                        instance,
-                    ));
+                    self.responses
+                        .push_back(Response::Compute(ComputeResponse::PeekResponse(
+                            uuid, response,
+                        )));
                 }
             }
-            Response::Compute(ComputeResponse::TailResponse(id, response), instance) => {
-                self.responses.push_back(Response::Compute(
-                    ComputeResponse::TailResponse(id, response),
-                    instance,
-                ));
+            Response::Compute(ComputeResponse::TailResponse(id, response)) => {
+                self.responses
+                    .push_back(Response::Compute(ComputeResponse::TailResponse(
+                        id, response,
+                    )));
             }
             Response::Storage(_) => {
                 panic!("ComputeCommandReconcile cannot handle Storage responses")
@@ -182,7 +180,6 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
     async fn absorb_compute_command(
         &mut self,
         command: ComputeCommand,
-        instance: ComputeInstanceId,
     ) -> Result<(), anyhow::Error> {
         use Command::Compute;
         use ComputeCommand::*;
@@ -190,24 +187,24 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
             CreateInstance(config) => {
                 // TODO: Handle `logging` correctly when reconnecting. We currently assume that the
                 // logging config stays the same.
-                if self.created.insert(instance) {
+                if !self.created {
                     if let Some(logging) = &config {
                         for id in logging.log_identifiers() {
-                            if !self.uppers.contains_key(&(id, instance)) {
-                                self.start_tracking(id, instance);
+                            if !self.uppers.contains_key(&id) {
+                                self.start_tracking(id);
                             }
                         }
                     }
-                    self.client
-                        .send(Compute(CreateInstance(config), instance))
-                        .await?;
+                    self.client.send(Compute(CreateInstance(config))).await?;
+                    self.created = true;
                 }
                 Ok(())
             }
             cmd @ DropInstance => {
-                if self.created.remove(&instance) {
-                    self.uppers.retain(|(_, i), _| i != &instance);
-                    self.client.send(Compute(cmd, instance)).await
+                if self.created {
+                    self.created = false;
+                    self.uppers.clear();
+                    self.client.send(Compute(cmd)).await
                 } else {
                     Ok(())
                 }
@@ -216,7 +213,7 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
                 let mut create = Vec::new();
                 for dataflow in dataflows {
                     for id in dataflow.export_ids() {
-                        self.start_tracking(id, instance);
+                        self.start_tracking(id);
                     }
                     match self.dataflows.entry(dataflow.global_id().unwrap()) {
                         Entry::Vacant(entry) => {
@@ -233,35 +230,27 @@ impl<C: GenericClient<Command<mz_repr::Timestamp>, Response<mz_repr::Timestamp>>
                     }
                 }
                 if !create.is_empty() {
-                    self.client
-                        .send(Compute(CreateDataflows(create), instance))
-                        .await?
+                    self.client.send(Compute(CreateDataflows(create))).await?
                 }
                 Ok(())
             }
             AllowCompaction(frontiers) => {
                 for (id, frontier) in &frontiers {
                     if frontier.is_empty() {
-                        self.stop_tracking(*id, instance);
+                        self.stop_tracking(*id);
                     }
                 }
-                self.client
-                    .send(Compute(AllowCompaction(frontiers), instance))
-                    .await
+                self.client.send(Compute(AllowCompaction(frontiers))).await
             }
             Peek(peek) => {
                 self.peeks.insert(peek.uuid);
-                self.client
-                    .send(Compute(ComputeCommand::Peek(peek), instance))
-                    .await
+                self.client.send(Compute(ComputeCommand::Peek(peek))).await
             }
             CancelPeeks { uuids } => {
                 for uuid in &uuids {
                     self.peeks.remove(uuid);
                 }
-                self.client
-                    .send(Compute(CancelPeeks { uuids }, instance))
-                    .await
+                self.client.send(Compute(CancelPeeks { uuids })).await
             }
         }
     }

--- a/src/dataflow/src/server/compute_state.rs
+++ b/src/dataflow/src/server/compute_state.rs
@@ -21,7 +21,7 @@ use timely::progress::ChangeBatch;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 
-use mz_dataflow_types::client::{ComputeCommand, ComputeInstanceId, ComputeResponse, Response};
+use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, Response};
 use mz_dataflow_types::logging::LoggingConfig;
 use mz_dataflow_types::{DataflowError, PeekResponse, TailResponse};
 use mz_expr::GlobalId;
@@ -70,8 +70,6 @@ pub struct ActiveComputeState<'a, A: Allocate, B: ComputeReplay> {
     pub timely_worker: &'a mut TimelyWorker<A>,
     /// The compute state itself.
     pub compute_state: &'a mut ComputeState,
-    /// The identifier of the compute instance, for forming responses.
-    pub instance_id: ComputeInstanceId,
     /// The channel over which frontier information is reported.
     pub response_tx: &'a mut mpsc::UnboundedSender<Response>,
     /// The boundary with the Storage layer
@@ -585,8 +583,6 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
     fn send_compute_response(&self, response: ComputeResponse) {
         // Ignore send errors because the coordinator is free to ignore our
         // responses. This happens during shutdown.
-        let _ = self
-            .response_tx
-            .send(Response::Compute(response, self.instance_id));
+        let _ = self.response_tx.send(Response::Compute(response));
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -877,8 +877,6 @@ impl_display!(CreateClusterStatement);
 /// An option in a `CREATE CLUSTER` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ClusterOption {
-    /// The `VIRTUAL` option.
-    Virtual,
     /// The `REMOTE <cluster> (<host> [, <host> ...])` option.
     Remote {
         /// The name.
@@ -897,7 +895,6 @@ pub enum ClusterOption {
 impl AstDisplay for ClusterOption {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            ClusterOption::Virtual => f.write_str("VIRTUAL"),
             ClusterOption::Remote { name, hosts } => {
                 f.write_str("REMOTE ");
                 f.write_node(name);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -305,7 +305,6 @@ Varchar
 Varying
 View
 Views
-Virtual
 Warning
 When
 Where

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2476,8 +2476,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_cluster_option(&mut self) -> Result<ClusterOption, ParserError> {
-        match self.expect_one_of_keywords(&[VIRTUAL, REMOTE, SIZE, INTROSPECTION])? {
-            VIRTUAL => Ok(ClusterOption::Virtual),
+        match self.expect_one_of_keywords(&[REMOTE, SIZE, INTROSPECTION])? {
             REMOTE => {
                 let name = self.parse_identifier()?;
                 self.expect_token(&Token::LParen)?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1285,9 +1285,9 @@ CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: fa
 parse-statement
 CREATE CLUSTER cluster VIRTUAL
 ----
+error: Expected one of REMOTE or SIZE or INTROSPECTION, found identifier "virtual"
 CREATE CLUSTER cluster VIRTUAL
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual] })
+                       ^
 
 parse-statement
 CREATE CLUSTER cluster SIZE 'small'
@@ -1304,11 +1304,11 @@ CREATE CLUSTER cluster SIZE 'small'
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small")))] })
 
 parse-statement
-CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
+CREATE CLUSTER cluster SIZE 'small', REMOTE replica1 ('host1'), SIZE 'medium', REMOTE replica2 ('host2')
 ----
-CREATE CLUSTER cluster VIRTUAL, VIRTUAL, SIZE 'small', VIRTUAL, SIZE 'medium'
+CREATE CLUSTER cluster SIZE 'small', REMOTE replica1 ('host1'), SIZE 'medium', REMOTE replica2 ('host2')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Virtual, Virtual, Size(Value(String("small"))), Virtual, Size(Value(String("medium")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small"))), Remote { name: Ident("replica1"), hosts: [Value(String("host1"))] }, Size(Value(String("medium"))), Remote { name: Ident("replica2"), hosts: [Value(String("host2"))] }] })
 
 parse-statement
 CREATE CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
@@ -1334,7 +1334,7 @@ AlterCluster(AlterClusterStatement { name: Ident("cluster"), if_exists: false, o
 parse-statement
 ALTER CLUSTER cluster RENAME TO cluster2
 ----
-error: Expected one of VIRTUAL or REMOTE or SIZE or INTROSPECTION, found RENAME
+error: Expected one of REMOTE or SIZE or INTROSPECTION, found RENAME
 ALTER CLUSTER cluster RENAME TO cluster2
                       ^
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -153,7 +153,7 @@ pub struct CreateComputeInstancePlan {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ComputeInstanceConfig {
-    Virtual,
+    Local,
     Remote {
         /// A map from replica name to hostnames.
         replicas: BTreeMap<String, BTreeSet<String>>,

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -11,16 +11,19 @@
 
 mode cockroach
 
-# Creating a cluster without any options works.
-statement ok
+# Creating a cluster without any options does not work.
+statement error one of REMOTE or SIZE must be specified
 CREATE CLUSTER foo
+
+# Creating a remote cluster works.
+statement ok
+CREATE CLUSTER foo REMOTE r1 ('localhost:1234')
 
 statement error cluster 'foo' already exists
-CREATE CLUSTER foo
+CREATE CLUSTER foo REMOTE r1 ('localhost:1234')
 
-# Creating a virtual cluster works.
 statement ok
-CREATE CLUSTER bar VIRTUAL
+CREATE CLUSTER bar REMOTE r1 ('localhost:1235'), REMOTE r2 ('localhost:1236')
 
 query TT rowsort
 SELECT * FROM mz_clusters
@@ -48,14 +51,11 @@ default
 
 # Test invalid option combinations.
 
-statement error VIRTUAL specified more than once
-CREATE CLUSTER baz VIRTUAL, VIRTUAL
-
 statement error SIZE specified more than once
 CREATE CLUSTER baz SIZE 'small', SIZE 'medium'
 
-statement error only one of VIRTUAL, REMOTE, and SIZE may be specified
-CREATE CLUSTER baz VIRTUAL, SIZE 'small'
+statement error only one of REMOTE or SIZE may be specified
+CREATE CLUSTER baz REMOTE r1 ('localhost:1234'), SIZE 'small'
 
 # Test `cluster` session variable.
 
@@ -74,6 +74,9 @@ bar
 
 statement ok
 CREATE MATERIALIZED VIEW v AS SELECT 1
+
+statement ok
+SET cluster = 'default'
 
 query T
 SELECT * FROM v
@@ -147,6 +150,9 @@ DROP CLUSTER baz
 statement error cannot drop cluster with active indexes or sinks
 DROP CLUSTER bar
 
+statement error cannot drop the default cluster
+DROP CLUSTER default CASCADE
+
 query TTTTTTTT
 SHOW INDEXES IN CLUSTER bar;
 ----
@@ -168,7 +174,7 @@ statement ok
 DROP CLUSTER foo
 
 statement ok
-CREATE CLUSTER baz
+CREATE CLUSTER baz REMOTE r1 ('localhost:1234')
 
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -232,7 +232,7 @@ contains:unknown catalog item 'nonexistent'
 ! SHOW INDEX FROM foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
 
-> CREATE CLUSTER clstr
+> CREATE CLUSTER clstr REMOTE r1 ('localhost:1234')
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
 > SHOW INDEXES IN CLUSTER clstr
 clstr foo  foo_primary_idx1   1  a       <null>                     false  true

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -233,7 +233,7 @@ default    sink10      user  nonvolatile
   WITH (partition_count=-1, replication_factor=-1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE CLUSTER clstr
+> CREATE CLUSTER clstr REMOTE r1 ('localhost:1234')
 
 > CREATE SINK clstr_sink
   IN CLUSTER clstr FROM src


### PR DESCRIPTION
This commit removes the concept of virtual clusters. They were useful as
a way to plumb compute instance IDs throughout the codebase before we
had remote and managed clusters. But now that we have these real types
of clusters, virtual clusters are getting in the way.

Specifically, virtual clusters required that a single timely instance could
host multiple compute instances, which meant that large swaths of the
system needed to be multi-cluster aware. By removing virtual clusters,
only the coordinator and controller need to be multi-cluster aware, and
the downstream components only need to be aware of a single cluster.

To preserve the behavior of the binary, the `default` cluster is now
special cased as a "local" cluster. It always exists, is always
connected to the local timely instance, and cannot be dropped. It is not
possible to create another local cluster: you only get the one.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
