### PR TITLE
doc: Add Python psycopg2 guide

### DIFF
--- a/doc/user/content/guides/php-pdo.md
+++ b/doc/user/content/guides/php-pdo.md
@@ -139,7 +139,7 @@ Query a view `my_view` with a select statement:
 // Include the Postgres connection details
 require 'connect.php';
 
-$sql = 'SELECT * FROM my_view LIMIT';
+$sql = 'SELECT * FROM my_view';
 $statement = $connection->query($sql);
 
 while (($row = $statement->fetch(PDO::FETCH_ASSOC)) !== false) {
@@ -147,7 +147,7 @@ while (($row = $statement->fetch(PDO::FETCH_ASSOC)) !== false) {
 }
 ```
 
-For more details, see the  [PHP `PDOStatement`](https://www.php.net/manual/en/pdostatement.fetch.php) documentation.
+For more details, see the [PHP `PDOStatement`](https://www.php.net/manual/en/pdostatement.fetch.php) documentation.
 
 ## Insert data into tables
 
@@ -227,4 +227,4 @@ For more information, see [`CREATE VIEW`](/sql/create-view/).
 
 ## PHP ORMs
 
-Materialize doesn't currently support the full catalog of PostgreSQL system metadata API endpoints, including the system calls that object relational mapping systems (ORMs) like **Eloquent** use to introspect databases and do extra work behind the scenes. This means that some ORM system attempts to interact with Materialize will currently fail. Once [full `pg_catalog` support](https://github.com/MaterializeInc/materialize/issues/2157) is implemented, the features that depend on  `pg_catalog` may work properly.
+Materialize doesn't currently support the full catalog of PostgreSQL system metadata API endpoints, including the system calls that object relational mapping systems (ORMs) like **Eloquent** use to introspect databases and do extra work behind the scenes. This means that some ORM system attempts to interact with Materialize will currently fail. Once [full `pg_catalog` support](https://github.com/MaterializeInc/materialize/issues/2157) is implemented, the features that depend on `pg_catalog` may work properly.

--- a/doc/user/content/guides/python.md
+++ b/doc/user/content/guides/python.md
@@ -96,7 +96,7 @@ dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
 conn = psycopg2.connect(dsn)
 
 with conn.cursor() as cur:
-    cur.execute("SELECT * FROM my_view")
+    cur.execute("SELECT * FROM my_view;")
     for row in cur:
         print(row)
 ```

--- a/doc/user/content/guides/python.md
+++ b/doc/user/content/guides/python.md
@@ -78,6 +78,30 @@ The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view up
 
 A `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a deletion (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same `mz_timestamp`.
 
+### Streaming with psycopg3
+
+{{< warning >}}
+psycopg3 is not yet stable.
+The example here could break if their API changes.
+{{< /warning >}}
+
+Although psycopg3 can function identically as the psycopg2 example above,
+it also has a `stream` feature where rows are not buffered and we can thus use `TAIL` directly.
+
+```python
+#!/usr/bin/env python3
+
+import psycopg3
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg3.connect(dsn)
+
+conn = psycopg3.connect(dsn)
+with conn.cursor() as cur:
+    for row in cur.stream("TAIL t"):
+        print(row)
+```
 ## Query
 
 Querying Materialize is identical to querying a traditional PostgreSQL database: Python executes the query, and Materialize returns the state of the view, source, or table at that point in time.

--- a/doc/user/content/guides/python.md
+++ b/doc/user/content/guides/python.md
@@ -127,7 +127,7 @@ conn.commit()
 cur.close()
 
 with conn.cursor() as cur:
-    cur.execute("SELECT COUNT(*) FROM countries")
+    cur.execute("SELECT COUNT(*) FROM countries;")
     print(cur.fetchone())
 
 conn.close()

--- a/doc/user/content/guides/python.md
+++ b/doc/user/content/guides/python.md
@@ -1,0 +1,196 @@
+---
+title: "Python and Materialize"
+description: "Use Python to connect, insert, manage, query and stream from Materialize."
+weight:
+menu:
+  main:
+    parent: guides
+---
+
+Materialize is **PostgreSQL-compatible**, which means that Python applications can use any existing PostgreSQL client to interact with Materialize as if it were a PostgreSQL database. In this guide, we'll use [psycopg2 PostgreSQL database adapter](https://pypi.org/project/psycopg2/) to connect to Materialize and issue PostgreSQL commands.
+
+## Connect
+
+You connect to Materialize the same way you [connect to PostgreSQL with `psycopg2`](https://www.psycopg.org/docs/usage.html).
+
+### Local Instance
+
+You can connect to a local Materialize instance just as you would connect to a PostgreSQL instance:
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg2.connect(dsn)
+```
+
+### Materialize Cloud Instance
+
+Download your instance's certificate files from the Materialize Cloud [Connect](/cloud/connect-to-cloud/) dialog and specify the path to each file in the [connection string parameters](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING). Replace `MY_INSTANCE_ID` in the connection string property with your Materialize Cloud instance ID.
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@MY_INSTANCE_ID:6875/materialize?sslmode=verify-full&sslcert=materialize.crt&sslkey=materialize.key&sslrootcert=ca.crt"
+conn = psycopg2.connect(dsn)
+```
+
+## Stream
+
+To take full advantage of incrementally updated materialized views from a Python application, instead of [querying](#query) Materialize for the state of a view at a point in time, use [a `TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
+
+To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query.
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg2.connect(dsn)
+
+with conn.cursor() as cur:
+    cur.execute("DECLARE c CURSOR FOR TAIL my_view")
+    while True:
+        cur.execute("FETCH ALL c")
+        for row in cur:
+            print(row)
+```
+
+The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view update objects. When a row of a tailed view is **updated,** two objects will show up in the `rows` array:
+
+```python
+    ...
+(Decimal('1648737001490'), 1, 'my_value_1')
+(Decimal('1648737001490'), 1, 'my_value_2')
+(Decimal('1648737001490'), 1, 'my_value_3')
+(Decimal('1648737065479'), -1, 'my_value_3')
+(Decimal('1648737065479'), 1, 'my_value_4')
+    ...
+```
+
+A `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a deletion (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same `mz_timestamp`.
+
+## Query
+
+Querying Materialize is identical to querying a traditional PostgreSQL database: Python executes the query, and Materialize returns the state of the view, source, or table at that point in time.
+
+Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
+
+Query a view `my_view` with a select statement:
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg2.connect(dsn)
+
+with conn.cursor() as cur:
+    cur.execute("SELECT * FROM my_view")
+    for row in cur:
+        print(row)
+```
+
+For more details, see the [Psycopg](https://www.psycopg.org/docs/usage.html) documentation.
+
+## Insert data into tables
+
+Most data in Materialize will stream in via a `SOURCE`, but a [`TABLE` in Materialize](https://materialize.com/docs/sql/create-table/) can be helpful for supplementary data. For example, use a table to join slower-moving reference or lookup data with a stream.
+
+**Basic Example:** [Insert a row](https://materialize.com/docs/sql/insert/) of data into a table named `countries` in Materialize.
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg2.connect(dsn)
+
+cur = conn.cursor()
+cur.execute("INSERT INTO countries (name, code) VALUES (%s, %s)", ('United States', 'US'))
+cur.execute("INSERT INTO countries (name, code) VALUES (%s, %s)", ('Canada', 'CA'))
+cur.execute("INSERT INTO countries (name, code) VALUES (%s, %s)", ('Mexico', 'MX'))
+cur.execute("INSERT INTO countries (name, code) VALUES (%s, %s)", ('Germany', 'DE'))
+conn.commit()
+cur.close()
+
+with conn.cursor() as cur:
+    cur.execute("SELECT COUNT(*) FROM countries")
+    print(cur.fetchone())
+
+conn.close()
+```
+
+## Manage sources, views, and indexes
+
+Typically, you create sources, views, and indexes when deploying Materialize, although it is possible to use a Python app to execute common DDL statements.
+
+### Create a source from Python
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg2.connect(dsn)
+conn.autocommit = True
+
+cur = conn.cursor()
+
+with conn.cursor() as cur:
+    cur.execute("CREATE SOURCE market_orders_raw_2 FROM PUBNUB " \
+            "SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe' " \
+            "CHANNEL 'pubnub-market-orders'")
+
+with conn.cursor() as cur:
+    cur.execute("SHOW SOURCES")
+    print(cur.fetchone())
+```
+
+For more information, see [`CREATE SOURCE`](/sql/create-source/).
+
+### Create a view from Python
+
+```python
+#!/usr/bin/env python3
+
+import psycopg2
+import sys
+
+dsn = "postgresql://materialize@localhost:6875/materialize?sslmode=disable"
+conn = psycopg2.connect(dsn)
+conn.autocommit = True
+
+cur = conn.cursor()
+
+with conn.cursor() as cur:
+    cur.execute("CREATE VIEW market_orders_2 AS " \
+            "SELECT " \
+                "val->>'symbol' AS symbol, " \
+                "(val->'bid_price')::float AS bid_price " \
+            "FROM (SELECT text::jsonb AS val FROM market_orders_raw_2)")
+
+with conn.cursor() as cur:
+    cur.execute("SHOW VIEWS")
+    print(cur.fetchone())
+```
+
+For more information, see [`CREATE VIEW`](/sql/create-view/).
+
+## Python ORMs
+
+Materialize doesn't currently support the full catalog of PostgreSQL system metadata API endpoints, including the system calls that object relational mapping systems (ORMs) like **SQLAlchemy** use to introspect databases and do extra work behind the scenes. This means that some ORM system attempts to interact with Materialize will currently fail. Once [full `pg_catalog` support](https://github.com/MaterializeInc/materialize/issues/2157) is implemented, the features that depend on `pg_catalog` may work properly.


### PR DESCRIPTION
### Motivation

This adds a Python guide that follows the format of the [Node.JS](https://materialize.com/docs/guides/node-js/) and [PHP](https://materialize.com/docs/guides/php-pdo/) and Golang guides that we already have.