### PR TITLE
ci/builder: bump python dependencies

### DIFF
--- a/ci/builder/requirements-core.txt
+++ b/ci/builder/requirements-core.txt
@@ -4,4 +4,4 @@
 # add to this list without consulting with @benesch!
 
 pip==22.0.4
-setuptools==61.2.0
+setuptools==61.3.1

--- a/ci/builder/requirements-dev.txt
+++ b/ci/builder/requirements-dev.txt
@@ -5,16 +5,16 @@
 # psycopg2) tend to be troublesome unless they ship binary wheels for a wide
 # variety of platforms, including M1 Macs.
 
-black==22.1.0
-boto3-stubs[ec2,iam,kinesis,s3,sqs,ssm,sts]==1.21.27
-boto3==1.21.27
+black==22.3.0
+boto3-stubs[ec2,iam,kinesis,s3,sqs,ssm,sts]==1.21.32
+boto3==1.21.32
 docker==5.0.3
 ec2instanceconnectcli==1.0.2
 flake8==4.0.1
 isort==5.10.1
 mypy==0.942
 numpy==1.22.3
-pandas==1.4.1
+pandas==1.4.2
 parameterized==0.8.1
 pdoc3==0.10.0
 psutil==5.9.0
@@ -24,12 +24,12 @@ pytest==7.1.1
 scipy==1.7.3
 shtab==1.5.3
 sqlparse==0.4.2
-twine==3.8.0
+twine==4.0.0
 types-prettytable==2.1.2
 types-psutil==5.8.20
-types-PyMYSQL==1.0.14
+types-PyMYSQL==1.0.15
 types-PyYAML==6.0.5
-types-requests==2.27.15
+types-requests==2.27.16
 types-setuptools==57.4.11
 types-toml==0.10.4
 types-pkg-resources==0.1.3

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -4,7 +4,7 @@
 # Strictly no packages that require compiling native code. Do not add to this
 # list without consulting with @benesch!
 
-click==8.0.4
+click==8.1.2
 colored==1.4.3
 humanize==4.0.0
 junit-xml==1.9


### PR DESCRIPTION
Amalgamates Python dependency bump PRs from this week.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Weekly Python dependency bump.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
