### PR TITLE
[storage] Render invalid sources

### DIFF
--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -354,12 +354,6 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
         )>,
     ) {
         for (debug_name, dataflow_id, as_of, source_imports) in dataflows {
-            for (source_id, instance) in source_imports.iter() {
-                assert_eq!(
-                    self.storage_state.source_descriptions[source_id],
-                    instance.description
-                );
-            }
             crate::render::build_storage_dataflow(
                 self.timely_worker,
                 &mut self.storage_state,

--- a/test/testdrive/frank.td
+++ b/test/testdrive/frank.td
@@ -1,0 +1,21 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that a dependency chain with multiple links is properly maintained
+# across creation and deletion.
+
+> CREATE MATERIALIZED VIEW test1 AS SELECT * FROM generate_series(1, 100000);
+
+> CREATE TABLE foo (a int);
+
+> CREATE INDEX baz ON foo (a);
+
+> DROP INDEX baz;
+
+> DROP TABLE foo;

--- a/test/testdrive/github-11563.td
+++ b/test/testdrive/github-11563.td
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Test that a dependency chain with multiple links is properly maintained
-# across creation and deletion.
+# Test that a distracted compute instance will not panic if asked to construct
+# an index for a now-invalid source.
 
 > CREATE MATERIALIZED VIEW test1 AS SELECT * FROM generate_series(1, 100000);
 


### PR DESCRIPTION
This PR causes us to not panic when requested to render an storage collection that is "invalid" in the sense that it is no longer installed. Ideally, we would extend this to "storage collections whose `since` is not less or equal to the requested `as_of`", although this PR does not yet do that.

This PR exists because of a race between dataflow start up, dataflow shut down, and source shut down. A source can be shut down before a dataflow is started, in the case that the dataflow has since been shut down. In such a case, we deem it harmless to start up a non-source that produces no data and does not advance its capability (marking no times as complete). Ideally STORAGE could optimize this to not involve a dataflow at all, but this seems to require some careful tweaking of the boundary implementations.

We should do the same thing for storage collections that are not valid for the requested `as_of`, as feeding incorrect data may result in a negative accumulation error and crash the compute instance. 

### Motivation

  * This PR fixes a previously unreported bug.

These commands can cause MZ to crash in a setting where the STORAGE and COMPUTE instances are concurrent.
```
> CREATE MATERIALIZED VIEW test1 AS SELECT * FROM generate_series(1, 1000000);
> CREATE TABLE foo (a int);
> CREATE INDEX baz ON foo (a);
> DROP INDEX baz;
> DROP TABLE foo;
```
The first command distracts the compute instance for a moment, and the other commands create and drop a table and an index on it. The storage instance will complete all commands, and the compute instance will attempt to create the index dataflow and .. panic the storage instance at the moment.

The above should be added as a test as part of this PR before merging. @philip-stoev for any tips on where this should live.

### Tips for reviewer

This PR is meant to remove the current potential for `materialized` to crash in single-process mode. It is not otherwise something to be proud of, but if you have any tips for how to make it less sad, I'm all ears! I think perhaps also the PR should be updated to track `since` for each storage collection, and do the validation using that frontier.

Suppress whitespace. Also, I didn't mean to add `frank.td` though that is the test to add somewhere.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
