### PR TITLE
docs: Recommend `--bin materialized` for building

### DIFF
--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -112,7 +112,7 @@ for the correct release.
 git clone https://github.com/MaterializeInc/materialize.git
 cd materialize
 git checkout {{< version >}}
-cargo build --release
+cargo build --release --bin materialized
 ```
 
 ## Run the binary


### PR DESCRIPTION
This PR changes the user docs slightly to recommend explicitly specifying `--bin materialized` when building from source. This has the effect that only the crates `materialized` actually depends on are compiled, instead of all creates in the Cargo workspace, which is beneficial for both the compile times and the size of the final `target/` folder.

Some data from my machine (MacBook Pro M1 Max):
* `cargo build --release`
  * built time: 8m 44s
  * `target/` size: 7.2GB
* `cargo build --release --bin materialized`
  * build time: 6m 51s
  * `target/` size: 4.8GB

Using `-p materialized` (or `-p materialized --bin materialized`) has a similar effect. In my tests the only difference was that with `-p materialized` the `libm` crate is not built. I assume that this happens because `--bin` switches on the feature flags of all crates in the workspace, even ones that are not compiled, whereas `-p` does not. But I didn't dig deeper into it. The one crate doesn't impact compile times/sizes much and using `--bin` ("build the `materialized` binary") seems more intuitive to me than `-p` ("build the `materialized` project, which *should* include the `materialized` binary"). 

### Motivation

  * This PR improves user experience when installing `materialized` from source according to the docs.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

I'm not sure if/how code from the user docs is tested. I confirmed that running the resulting `materialized` binary works as expected.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - 
