### PR TITLE
feature-benchmark: Add scenarios around concurrency

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -16,7 +16,9 @@ from typing import List, Type
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
 sys.path.append(os.path.dirname(__file__))
-from scenarios import *
+from scenarios import *  # noqa: F401 F403
+from scenarios import Scenario
+from scenarios_concurrency import *  # noqa: F401 F403
 
 from materialize.feature_benchmark.aggregation import Aggregation, MinAggregation
 from materialize.feature_benchmark.benchmark import Benchmark, Report

--- a/test/feature-benchmark/scenarios_concurrency.py
+++ b/test/feature-benchmark/scenarios_concurrency.py
@@ -1,0 +1,149 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.feature_benchmark.action import Action, TdAction
+from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
+from materialize.feature_benchmark.scenario import Scenario
+
+
+class Concurrency(Scenario):
+    """Feature benchmarks related to testing concurrency aspects of the system"""
+
+
+class ParallelIngestion(Concurrency):
+    """Measure the time it takes to ingest multiple sources concurrently."""
+
+    SOURCES = 10
+
+    def shared(self) -> Action:
+        return TdAction(
+            self.schema()
+            + self.keyschema()
+            + f"""
+$ kafka-create-topic topic=kafka-parallel-ingestion partitions=4
+
+$ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()} publish=true
+{{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
+"""
+        )
+
+    def benchmark(self) -> MeasurementSource:
+        sources = range(1, ParallelIngestion.SOURCES + 1)
+        drop_sources = "\n".join(
+            [
+                f"""
+> DROP SOURCE IF EXISTS s{s}
+"""
+                for s in sources
+            ]
+        )
+
+        create_sources = "\n".join(
+            [
+                f"""
+> CREATE SOURCE s{s}
+  FROM KAFKA BROKER '${{testdrive.kafka-addr}}' TOPIC 'testdrive-kafka-parallel-ingestion-${{testdrive.seed}}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
+"""
+                for s in sources
+            ]
+        )
+
+        create_indexes = "\n".join(
+            [
+                f"""
+> CREATE DEFAULT INDEX ON s{s}
+"""
+                for s in sources
+            ]
+        )
+
+        selects = "\n".join(
+            [
+                f"""
+> SELECT * FROM s{s} WHERE f2 = {self.n()-1}
+{self.n()-1}
+"""
+                for s in sources
+            ]
+        )
+
+        return Td(
+            self.schema()
+            + f"""
+{drop_sources}
+
+{create_sources}
+
+> SELECT 1
+  /* A */
+1
+
+{create_indexes}
+
+{selects}
+
+> SELECT 1
+  /* B */
+1
+"""
+        )
+
+
+class ParallelDataflows(Concurrency):
+    """Measure the time it takes to compute multiple parallel dataflows."""
+
+    SCALE = 5
+    VIEWS = 100
+
+    def benchmark(self) -> MeasurementSource:
+        views = range(1, ParallelDataflows.VIEWS + 1)
+
+        create_views = "\n".join(
+            [
+                f"""
+> CREATE MATERIALIZED VIEW v{v} AS
+  SELECT COUNT(DISTINCT f1) + {v} - {v} AS f1
+  FROM t1
+"""
+                for v in views
+            ]
+        )
+
+        selects = "\n".join(
+            [
+                f"""
+> SELECT * FROM v{v}
+{self.n()}
+"""
+                for v in views
+            ]
+        )
+
+        return Td(
+            f"""
+> DROP TABLE IF EXISTS t1 CASCADE
+
+> CREATE TABLE t1 (f1 INTEGER)
+
+{create_views}
+
+> SELECT 1
+  /* A */
+1
+
+> INSERT INTO t1 SELECT * FROM generate_series(1,{self.n()})
+
+{selects}
+
+> SELECT 1
+  /* B */
+1
+"""
+        )


### PR DESCRIPTION
Even though the feature benchmark is not the right tool to measure
performance under concurrency, we are adding a couple of scenarios
in other to detect regressions where:

 - a piece of code (such as a global lock or other serialization
   mechanism) on a critical path prevents multi-core processing

 - the presence of many souces or dataflows causes non-linear
   behaviors to show up

The scenarios are as follows:

 - Multiple sources ingesting from the same topic

 - Multiple dataflows against the same base table

### Motivation
  * This PR fixes a previously unreported bug.
  * This PR adds a feature that has not yet been specified.

We do not have much in a way of benchmarks that exercise any form of parallelism or concurrency, so add some as a stop-gap measure.