### PR TITLE
dataflowd: Storage does not support reconciliation

### DIFF
--- a/src/dataflowd/src/bin/dataflowd.rs
+++ b/src/dataflowd/src/bin/dataflowd.rs
@@ -234,6 +234,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             serve(serve_config, server, client).await
         }
         RuntimeType::Storage => {
+            assert!(
+                !args.reconcile,
+                "Storage runtime does not support command reconciliation."
+            );
             let (storage_server, request_rx, _thread) =
                 mz_dataflow::tcp_boundary::server::serve(args.storage_addr).await?;
             let boundary = (0..config.workers)


### PR DESCRIPTION
Add an assert that reconciliation is not enabled with the storage runtime.
Unfortunately, there doesn't seem to be a way to express this as a
constraint on the command line parameters.

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
