### PR TITLE
Storage: Discover storage workers in tcp_boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,7 @@ dependencies = [
  "tempfile",
  "timely",
  "tokio",
+ "tokio-byteorder",
  "tokio-postgres",
  "tokio-serde",
  "tokio-util 0.7.1",
@@ -6148,6 +6149,16 @@ dependencies = [
  "tokio-macros",
  "tracing",
  "winapi",
+]
+
+[[package]]
+name = "tokio-byteorder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf347e8ae1d1ffd16c8aed569172a71bd81098a001d0f4964d476c0097aba4a"
+dependencies = [
+ "byteorder",
+ "tokio",
 ]
 
 [[package]]

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -54,11 +54,6 @@ pub struct OrchestratorConfig {
     pub dataflowd_image: String,
     /// The storage address that compute instances should connect to.
     pub storage_addr: String,
-    /// The number of storage workers in the storage instance.
-    ///
-    /// TODO(benesch,antiguru): make this something that is discovered in the
-    /// handshake between compute and storage.
-    pub storage_workers: usize,
 }
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
@@ -116,7 +111,6 @@ where
                 let OrchestratorConfig {
                     orchestrator,
                     storage_addr,
-                    storage_workers,
                     dataflowd_image,
                 } = match &mut self.orchestrator {
                     Some(orchestrator) => orchestrator,
@@ -133,7 +127,6 @@ where
                             image: dataflowd_image.clone(),
                             args: vec![
                                 "--runtime=compute".into(),
-                                format!("--storage-workers={storage_workers}"),
                                 format!("--storage-addr={storage_addr}"),
                                 "0.0.0.0:2101".into(),
                             ],

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -57,6 +57,7 @@ serde_json = "1.0.79"
 tempfile = "3.2.0"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.17.0", features = ["fs", "rt", "sync"] }
+tokio-byteorder = "0.3.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-util = { version = "0.7.1", features = ["codec", "io"] }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -26,22 +26,22 @@ SERVICES = [
     SchemaRegistry(),
     Dataflowd(
         name="dataflowd_compute_1",
-        options="--workers 2 --storage-workers 2 --processes 2 --process 0 dataflowd_compute_1:2101 dataflowd_compute_2:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
+        options="--workers 2 --processes 2 --process 0 dataflowd_compute_1:2101 dataflowd_compute_2:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
         ports=[6876, 2101],
     ),
     Dataflowd(
         name="dataflowd_compute_2",
-        options="--workers 2 --storage-workers 2 --processes 2 --process 1 dataflowd_compute_1:2101 dataflowd_compute_2:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
+        options="--workers 2 --processes 2 --process 1 dataflowd_compute_1:2101 dataflowd_compute_2:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
         ports=[6876, 2101],
     ),
     Dataflowd(
         name="dataflowd_compute_3",
-        options="--workers 2 --storage-workers 2 --processes 2 --process 0 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute --linger --reconcile",
+        options="--workers 2 --processes 2 --process 0 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute --linger --reconcile",
         ports=[6876, 2101],
     ),
     Dataflowd(
         name="dataflowd_compute_4",
-        options="--workers 2 --storage-workers 2 --processes 2 --process 1 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute --linger --reconcile",
+        options="--workers 2 --processes 2 --process 1 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute --linger --reconcile",
         ports=[6876, 2101],
     ),
     Dataflowd(
@@ -50,7 +50,7 @@ SERVICES = [
         ports=[6876, 2102],
     ),
     Materialized(
-        options="--storage-workers=2 --storage-compute-addr=dataflowd_storage:2102 --storage-controller-addr=dataflowd_storage:6876",
+        options="--storage-compute-addr=dataflowd_storage:2102 --storage-controller-addr=dataflowd_storage:6876",
     ),
     Testdrive(
         volumes=[


### PR DESCRIPTION
### Motivation

Discover the number of storage workers as part of the `tcp_boundary` initialization instead of passing it as a command-line parameter. It sends the number of workers as a raw number before initializing the framed protocol. This is not the nicest implementation, but should serve its purpose until the `tcp_boundary` switches to a more expressive transport.

  * This PR adds a known-desirable feature: #11355

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
