### PR TITLE
storage: introduce Append command

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -175,13 +175,14 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// Each entry in the vector names a collection and provides a frontier after which
     /// accumulations must be correct.
     AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
-
-    /// Insert `updates` into the local input named `id`.
-    Insert {
+    /// Append `updates` into the local input named `id` and advance its upper to `upper`.
+    Append {
         /// Identifier of the local input.
         id: GlobalId,
         /// A list of updates to be introduced to the input.
         updates: Vec<Update<T>>,
+        /// The timestamp to advance to.
+        upper: T,
     },
     /// Update durability information for sources.
     ///
@@ -189,11 +190,6 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// be exactly replayed across restarts (i.e. we can assign the same timestamps to
     /// all the same data)
     DurabilityFrontierUpdates(Vec<(GlobalId, Antichain<T>)>),
-    /// Advance all local inputs to the given timestamp.
-    AdvanceAllLocalInputs {
-        /// The timestamp to advance to.
-        advance_to: T,
-    },
 }
 
 impl<T> ComputeCommand<T> {

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -175,15 +175,12 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// Each entry in the vector names a collection and provides a frontier after which
     /// accumulations must be correct.
     AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
-    /// Append `updates` into the local input named `id` and advance its upper to `upper`.
-    Append {
-        /// Identifier of the local input.
-        id: GlobalId,
-        /// A list of updates to be introduced to the input.
-        updates: Vec<Update<T>>,
-        /// The timestamp to advance to.
-        upper: T,
-    },
+    /// Append data and advance the frontier of the enumerated collections
+    ///
+    /// Each entry in the vector names a collection and provides a list of updates to insert and a
+    /// frontier that the collection must be advanced to. The times of the updates not be beyond
+    /// the given frontier.
+    Append(Vec<(GlobalId, Vec<Update<T>>, T)>),
     /// Update durability information for sources.
     ///
     /// Each entry names a source and provides a frontier before which the source can

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -77,9 +77,7 @@ pub trait StorageController: Debug + Send {
     // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
     async fn append(
         &mut self,
-        id: GlobalId,
-        updates: Vec<Update<Self::Timestamp>>,
-        upper: Self::Timestamp,
+        commands: Vec<(GlobalId, Vec<Update<Self::Timestamp>>, Self::Timestamp)>,
     ) -> Result<(), StorageError>;
 
     async fn update_durability_frontiers(
@@ -312,13 +310,11 @@ where
 
     async fn append(
         &mut self,
-        id: GlobalId,
-        updates: Vec<Update<Self::Timestamp>>,
-        upper: Self::Timestamp,
+        commands: Vec<(GlobalId, Vec<Update<Self::Timestamp>>, Self::Timestamp)>,
     ) -> Result<(), StorageError> {
         self.state
             .client
-            .send(StorageCommand::Append { id, updates, upper })
+            .send(StorageCommand::Append(commands))
             .await
             .map_err(StorageError::from)
     }

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -14,8 +14,9 @@
 //!
 //! The storage controller can be viewed as a partial map from `GlobalId` to collection. It is an error to
 //! use an identifier before it has been "created" with `create_source()`. Once created, the controller holds
-//! a read capability for each source, which is manipulated with `allow_compaction()`. Eventually, the source
-//! is dropped with either `drop_sources()` or by allowing compaction to the empty frontier.
+//! a read capability for each source, which is manipulated with `update_read_capabilities()`.
+//! Eventually, the source is dropped with either `drop_sources()` or by allowing compaction to the
+//! empty frontier.
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -72,20 +73,18 @@ pub trait StorageController: Debug + Send {
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
     async fn drop_sources(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError>;
 
-    async fn table_insert(
+    /// Append `updates` into the local input named `id` and advance its upper to `upper`.
+    // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
+    async fn append(
         &mut self,
         id: GlobalId,
         updates: Vec<Update<Self::Timestamp>>,
+        upper: Self::Timestamp,
     ) -> Result<(), StorageError>;
 
     async fn update_durability_frontiers(
         &mut self,
         updates: Vec<(GlobalId, Antichain<Self::Timestamp>)>,
-    ) -> Result<(), StorageError>;
-
-    async fn advance_all_table_timestamps(
-        &mut self,
-        advance_to: Self::Timestamp,
     ) -> Result<(), StorageError>;
 
     /// Persist timestamp bindings updates received from ingestion workers
@@ -311,14 +310,15 @@ where
         Ok(())
     }
 
-    async fn table_insert(
+    async fn append(
         &mut self,
         id: GlobalId,
-        updates: Vec<Update<T>>,
+        updates: Vec<Update<Self::Timestamp>>,
+        upper: Self::Timestamp,
     ) -> Result<(), StorageError> {
         self.state
             .client
-            .send(StorageCommand::Insert { id, updates })
+            .send(StorageCommand::Append { id, updates, upper })
             .await
             .map_err(StorageError::from)
     }
@@ -330,14 +330,6 @@ where
         self.state
             .client
             .send(StorageCommand::DurabilityFrontierUpdates(updates))
-            .await
-            .map_err(StorageError::from)
-    }
-
-    async fn advance_all_table_timestamps(&mut self, advance_to: T) -> Result<(), StorageError> {
-        self.state
-            .client
-            .send(StorageCommand::AdvanceAllLocalInputs { advance_to })
             .await
             .map_err(StorageError::from)
     }

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -193,7 +193,7 @@ where
         self.observe_command(&command);
 
         match command {
-            StorageCommand::Insert { id, updates } => {
+            StorageCommand::Append { id, updates, upper } => {
                 let mut updates_parts = vec![Vec::new(); self.parts];
                 for update in updates {
                     let part = usize::cast_from(update.row.hashed()) % self.parts;
@@ -201,7 +201,11 @@ where
                 }
                 updates_parts
                     .into_iter()
-                    .map(|updates| StorageCommand::Insert { id, updates })
+                    .map(|updates| StorageCommand::Append {
+                        id,
+                        updates,
+                        upper: upper.clone(),
+                    })
                     .collect()
             }
             command => vec![command; self.parts],


### PR DESCRIPTION
### Motivation

Change `coord` to make only `append` calls to storage that insert data into a collection and advance its upper as a single operation.

The changes to `coord` are the minimal possible, basically holding onto all the previous `table_insert` commands into an in-memory WAL and issuing them all at once at the place where `advance_all_local_inputs` was previously happening.

This PR should be followed up by two separate pieces of work. First, coord needs to think through if it needs a durable WAL or if it wants to call `append` at transaction commit time. Second, `storage` needs to absorb all the current `persister` calls in the coordinator and manage that internally. 

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
