### PR TITLE
expr: add protobuf for global and local id

### DIFF
--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Id {
 
 /// The identifier for a local component of a dataflow.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub struct LocalId(pub u64);
+pub struct LocalId(pub(crate) u64);
 
 impl LocalId {
     /// Constructs a new local identifier. It is the caller's responsibility

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -34,7 +34,7 @@ impl fmt::Display for Id {
 
 /// The identifier for a local component of a dataflow.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-pub struct LocalId(u64);
+pub struct LocalId(pub u64);
 
 impl LocalId {
     /// Constructs a new local identifier. It is the caller's responsibility

--- a/src/expr/src/proto/id.proto
+++ b/src/expr/src/proto/id.proto
@@ -22,6 +22,13 @@ message ProtoGlobalId {
     }
 }
 
+message ProtoId {
+    oneof kind {
+        ProtoGlobalId global = 1;
+        ProtoLocalId local = 2;
+    }
+}
+
 message ProtoLocalId {
     uint64 value = 1;
 }

--- a/src/expr/src/proto/id.proto
+++ b/src/expr/src/proto/id.proto
@@ -13,6 +13,19 @@ import "google/protobuf/empty.proto";
 
 package id;
 
+message ProtoGlobalId {
+    oneof kind {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        google.protobuf.Empty explain = 4;
+    }
+}
+
+message ProtoLocalId {
+    uint64 value = 1;
+}
+
 message ProtoPartitionId {
     oneof kind {
         int32 kafka = 1;


### PR DESCRIPTION
### Motivation

This is a follow up for PR #11489 and adds Protobuf (de-) serialization for `Id`, `GlobalId`, `LocalId` .

### Tips for reviewer

 * I had add `pub` to the member of LocalId such that I can access it from `src/proto/id.rs`.

### Testing

We will add protobuf tests in a later PR.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
