### PR TITLE
coord: limit transactions to a single cluster

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2989,6 +2989,7 @@ impl Coordinator {
         uses_ids: I,
         timeline: &Option<Timeline>,
         conn_id: u32,
+        compute_instance: mz_dataflow_types::client::ComputeInstanceId,
     ) -> Result<CollectionIdBundle, CoordError>
     where
         I: IntoIterator<Item = &'a GlobalId>,
@@ -3029,17 +3030,9 @@ impl Coordinator {
         }
 
         // Gather the indexes and unmaterialized sources used by those items.
-        //
-        // NOTE: there is surely a more efficient way to do this than to call
-        // sufficient_collections per cluster.
-        let mut id_bundle = CollectionIdBundle::default();
-        for compute_instance in self.catalog.compute_instances() {
-            id_bundle.extend(
-                &self
-                    .index_oracle(compute_instance.id())
-                    .sufficient_collections(item_ids.iter()),
-            );
-        }
+        let mut id_bundle: CollectionIdBundle = self
+            .index_oracle(compute_instance)
+            .sufficient_collections(item_ids.iter());
 
         // Filter out ids from different timelines.
         for ids in [&mut id_bundle.storage_ids, &mut id_bundle.compute_ids] {
@@ -3167,7 +3160,8 @@ impl Coordinator {
                 _ => {
                     // Determine a timestamp that will be valid for anything in any schema
                     // referenced by the first query.
-                    let id_bundle = self.timedomain_for(&source_ids, &timeline, conn_id)?;
+                    let id_bundle =
+                        self.timedomain_for(&source_ids, &timeline, conn_id, compute_instance)?;
 
                     // We want to prevent compaction of the indexes consulted by
                     // determine_timestamp, not the ones listed in the query.

--- a/src/coord/src/coord/id_bundle.rs
+++ b/src/coord/src/coord/id_bundle.rs
@@ -26,12 +26,6 @@ impl CollectionIdBundle {
         self.storage_ids.is_empty() && self.compute_ids.is_empty()
     }
 
-    /// Extends the bundle with the identifiers from `other`.
-    pub fn extend(&mut self, other: &CollectionIdBundle) {
-        self.storage_ids.extend(&other.storage_ids);
-        self.compute_ids.extend(&other.compute_ids);
-    }
-
     /// Returns a new bundle without the identifiers from `other`.
     pub fn difference(&self, other: &CollectionIdBundle) -> CollectionIdBundle {
         CollectionIdBundle {

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/11568.
+
+mode cockroach
+
+statement ok
+create cluster c remote r1 ('1.0:1234')
+
+statement ok
+set cluster = c
+
+statement ok
+create table t1 (f1 integer, f2 integer)
+
+statement ok
+create index i1 on t1 (f2)
+
+statement ok
+set cluster = default
+
+statement ok
+begin;
+
+# The original github issue would panic here.
+query II
+select * from t1
+----
+
+# Additionally, verify that changing cluster mid transaction causes the indexes
+# to be unavailable.
+statement ok
+set cluster = c
+
+query error Transactions can only reference objects in the same timedomain.
+select * from t1


### PR DESCRIPTION
Read transactions now limit their used indexes to those on the current
cluster. The remaining transaction machinery knows how to complain should
those indexes no longer be available due to an active cluster change.

Fixes #11568

### Motivation

  * This PR fixes a recognized bug. #11568

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - NA
