### PR TITLE
[kafka eos] [testdrive] Reenable compaction verification

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -411,12 +411,8 @@ $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key key=true
 $ kafka-verify format=json sink=materialize.public.json_avro_upsert_key_2 key=true
 {"b": 2} {"a": 1, "b": 2, "c": 3, "transaction": {"id": "0"}}
 
-# Temporarily disabled due to flakiness.
-# See: https://github.com/MaterializeInc/materialize/issues/10927
 # Verify compaction of exactly once sinks.
-# $ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
+$ verify-timestamp-compaction source=input_csv max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=rt_binding_consistency_test_source max-size=3 permit-progress=true
 $ verify-timestamp-compaction source=input_kafka_dbz max-size=3 permit-progress=true
-
-# TODO: enable when possible
-# $ verify-timestamp-compaction source=input_kafka_cdcv2 max-size=3 permit-progress=true
+$ verify-timestamp-compaction source=input_kafka_cdcv2 max-size=3 permit-progress=true


### PR DESCRIPTION
After #11223 was merged, we can re-enable these!

Fixes #10927

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] this _is_ the test coverage!

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
