### PR TITLE
mzcompose: drop "svc" from the name of the testdrive svc

### DIFF
--- a/doc/developer/mzcompose.md
+++ b/doc/developer/mzcompose.md
@@ -68,7 +68,7 @@ def workflow_test(c: Composition):
     c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry", "materialized"])
     c.wait_for_materialized()
 
-    c.run("testdrive-svc", "*.td")
+    c.run("testdrive", "*.td")
 ```
 
 Additional examples can be found here:
@@ -200,6 +200,6 @@ To run a Testdrive test or tests:
 ```python
 def workflow_simple_test(c: Composition):
    ...
-   w.run("testdrive-svc", "*.td")
+   w.run("testdrive", "*.td")
    ...
 ```

--- a/misc/python/materialize/feature_benchmark/executor.py
+++ b/misc/python/materialize/feature_benchmark/executor.py
@@ -72,7 +72,7 @@ class Docker(Executor):
             td_file.flush()
             dirname, basename = os.path.split(td_file.name)
             return self._composition.run(
-                "testdrive-svc",
+                "testdrive",
                 "--no-reset",
                 f"--seed={self._seed}",
                 "--initial-backoff=10ms",

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -476,7 +476,7 @@ class Localstack(Service):
 class Testdrive(Service):
     def __init__(
         self,
-        name: str = "testdrive-svc",
+        name: str = "testdrive",
         mzbuild: str = "testdrive",
         materialized_url: str = "postgres://materialize@materialized:6875",
         materialized_params: Dict[str, str] = {},

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -101,12 +101,12 @@ def workflow_default(c: Composition) -> None:
 
         c.wait_for_materialized("materialized")
         c.run(
-            "testdrive-svc",
+            "testdrive",
             *td_args,
             "test.td",
         )
         c.run(
-            "testdrive-svc",
+            "testdrive",
             *td_args,
             # no reset because the next test wants to validate behavior with
             # the previous catalog
@@ -128,14 +128,14 @@ def workflow_default(c: Composition) -> None:
         c.up("materialized")
 
         c.run(
-            "testdrive-svc",
+            "testdrive",
             "--no-reset",
             "test-restart-no-creds.td",
         )
 
         # now test that with added credentials things can be done
         write_aws_config(LOCAL_DIR, profile_contents)
-        c.run("testdrive-svc", *td_args, "test-restart-with-creds.td")
+        c.run("testdrive", *td_args, "test-restart-with-creds.td")
 
         # == Test that requires --aws-external-id has been supplied ==
         print("+++ Test AWS External IDs")
@@ -146,7 +146,7 @@ def workflow_default(c: Composition) -> None:
             c.up("materialized")
             c.wait_for_materialized("materialized")
             write_aws_config(LOCAL_DIR, profile_contents)
-            c.run("testdrive-svc", *td_args, "test-externalid-present.td")
+            c.run("testdrive", *td_args, "test-externalid-present.td")
     finally:
         errored = False
         for role in created_roles:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -94,7 +94,7 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.sql(
         "CREATE CLUSTER c REMOTE replica1 ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876');"
     )
-    c.run("testdrive-svc", *glob)
+    c.run("testdrive", *glob)
 
     # Add a replica to that remote cluster and verify that tests still pass.
     c.up("dataflowd_compute_3")
@@ -106,12 +106,12 @@ def test_cluster(c: Composition, *glob: str) -> None:
             REMOTE replica2 ('dataflowd_compute_3:6876', 'dataflowd_compute_4:6876')
         """
     )
-    c.run("testdrive-svc", *glob)
+    c.run("testdrive", *glob)
 
     # Kill one of the nodes in the first replica of the compute cluster and
     # verify that tests still pass.
     c.kill("dataflowd_compute_1")
-    c.run("testdrive-svc", *glob)
+    c.run("testdrive", *glob)
 
     # Kill one of the nodes in the first replica of the compute cluster and
     # verify that tests still pass.
@@ -127,4 +127,4 @@ def test_cluster(c: Composition, *glob: str) -> None:
             REMOTE replica2 ('dataflowd_compute_3:6876', 'dataflowd_compute_4:6876')
         """
     )
-    c.run("testdrive-svc", "smoke/insert-select.td")
+    c.run("testdrive", "smoke/insert-select.td")

--- a/test/debezium/mzcompose.py
+++ b/test/debezium/mzcompose.py
@@ -49,19 +49,19 @@ def workflow_postgres(c: Composition) -> None:
     c.wait_for_postgres(service="postgres")
     c.wait_for_materialized("materialized")
 
-    c.run("testdrive-svc", "postgres/debezium-postgres.td.initialize")
-    c.run("testdrive-svc", "postgres/*.td")
+    c.run("testdrive", "postgres/debezium-postgres.td.initialize")
+    c.run("testdrive", "postgres/*.td")
 
 
 def workflow_sql_server(c: Composition) -> None:
     c.start_and_wait_for_tcp(services=prerequisites)
     c.start_and_wait_for_tcp(services=["sql-server"])
 
-    c.run("testdrive-svc", f"--var=sa-password={password}", "sql-server/*.td")
+    c.run("testdrive", f"--var=sa-password={password}", "sql-server/*.td")
 
 
 def workflow_mysql(c: Composition) -> None:
     c.start_and_wait_for_tcp(services=prerequisites)
     c.start_and_wait_for_tcp(services=["mysql"])
 
-    c.run("testdrive-svc", f"--var=mysql-root-password={password}", "mysql/*.td")
+    c.run("testdrive", f"--var=mysql-root-password={password}", "mysql/*.td")

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -141,7 +141,7 @@ def run_one_scenario(
             comparator.append(outcome)
 
             c.kill("materialized")
-            c.rm("materialized", "testdrive-svc")
+            c.rm("materialized", "testdrive")
             c.rm_volumes("mzdata")
 
     return comparator

--- a/test/kafka-exactly-once/mzcompose.py
+++ b/test/kafka-exactly-once/mzcompose.py
@@ -38,7 +38,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         services=["zookeeper", "kafka", "schema-registry", "materialized"]
     )
     c.run(
-        "testdrive-svc",
+        "testdrive",
         f"--seed={args.seed}",
         "--kafka-option=group.id=group1",
         "before-restart.td",
@@ -47,7 +47,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.up("materialized")
     c.wait_for_materialized()
     c.run(
-        "testdrive-svc",
+        "testdrive",
         f"--seed={args.seed}",
         "--no-reset",
         "--kafka-option=group.id=group2",

--- a/test/kafka-ingest-open-loop/mzcompose.py
+++ b/test/kafka-ingest-open-loop/mzcompose.py
@@ -181,7 +181,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.wait_for_materialized("materialized")
 
         c.run(
-            "testdrive-svc",
+            "testdrive",
             f"--var=envelope={envelope}",
             "setup.td",
         )
@@ -245,5 +245,5 @@ def workflow_smoke_test(c: Composition) -> None:
             arg,
         )
         c.kill("materialized")
-        c.rm("materialized", "testdrive-svc", "kafka", destroy_volumes=True)
+        c.rm("materialized", "testdrive", "kafka", destroy_volumes=True)
         c.rm_volumes("mzdata")

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -47,7 +47,7 @@ def workflow_default(c: Composition) -> None:
                 services=["zookeeper", "kafka", "schema-registry", "materialized"]
             )
             c.wait_for_materialized()
-            c.run("testdrive-svc", "kafka-matrix.td", "testdrive/kafka-*.td")
+            c.run("testdrive", "kafka-matrix.td", "testdrive/kafka-*.td")
             c.rm(
                 "zookeeper",
                 "kafka",

--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -50,13 +50,11 @@ def workflow_default(c: Composition) -> None:
             "materialized",
         ]
     )
-    c.run("testdrive-svc", "--kafka-addr=kafka2", "01-init.td")
+    c.run("testdrive", "--kafka-addr=kafka2", "01-init.td")
     time.sleep(10)
     c.kill("kafka1")
     time.sleep(10)
-    c.run(
-        "testdrive-svc", "--kafka-addr=kafka2,kafka3", "--no-reset", "02-after-leave.td"
-    )
+    c.run("testdrive", "--kafka-addr=kafka2,kafka3", "--no-reset", "02-after-leave.td")
     c.up("kafka1")
     time.sleep(10)
-    c.run("testdrive-svc", "--kafka-addr=kafka1", "--no-reset", "03-after-join.td")
+    c.run("testdrive", "--kafka-addr=kafka1", "--no-reset", "03-after-join.td")

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -53,7 +53,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     ):
         c.start_and_wait_for_tcp(["toxiproxy"])
         c.run(
-            "testdrive-svc",
+            "testdrive",
             "--no-reset",
             "--max-errors=1",
             f"--seed={seed}{i}",

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -121,4 +121,4 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "materialized",
         ]
     )
-    c.run("testdrive-svc", *args.files)
+    c.run("testdrive", *args.files)

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1039,4 +1039,4 @@ def workflow_default(c: Composition) -> None:
         with contextlib.redirect_stdout(tmp):
             [cls.generate() for cls in Generator.__subclasses__()]
             sys.stdout.flush()
-            c.run("testdrive-svc", os.path.basename(tmp.name))
+            c.run("testdrive", os.path.basename(tmp.name))

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -69,7 +69,7 @@ def workflow_versioned_mz(c: Composition) -> None:
 
         c.wait_for_materialized(mz.name)
 
-        c.run("testdrive-svc", "test*.td")
+        c.run("testdrive", "test*.td")
 
         c.kill(mz.name)
 

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -98,7 +98,7 @@ def workflow_kafka_sources(
     c.up("materialized")
     c.wait_for_materialized("materialized")
 
-    c.run("testdrive-svc", f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
+    c.run("testdrive", f"--seed={seed}", f"kafka-sources/*{td_test}*-before.td")
 
     c.kill("materialized")
     c.up("materialized")
@@ -109,7 +109,7 @@ def workflow_kafka_sources(
     c.up("materialized")
     c.wait_for_materialized("materialized")
 
-    c.run("testdrive-svc", f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
+    c.run("testdrive", f"--seed={seed}", f"kafka-sources/*{td_test}*-after.td")
 
     # Do one more restart, just in case and just confirm that Mz is able to come up
     c.kill("materialized")
@@ -117,7 +117,7 @@ def workflow_kafka_sources(
     c.wait_for_materialized("materialized")
 
     c.kill("materialized")
-    c.rm("materialized", "testdrive-svc", destroy_volumes=True)
+    c.rm("materialized", "testdrive", destroy_volumes=True)
     c.rm_volumes("mzdata")
 
 
@@ -128,7 +128,7 @@ def workflow_user_tables(c: Composition) -> None:
     c.wait_for_materialized()
 
     c.run(
-        "testdrive-svc",
+        "testdrive",
         f"--seed={seed}",
         f"user-tables/table-persistence-before-{td_test}.td",
     )
@@ -137,13 +137,13 @@ def workflow_user_tables(c: Composition) -> None:
     c.up("materialized")
 
     c.run(
-        "testdrive-svc",
+        "testdrive",
         f"--seed={seed}",
         f"user-tables/table-persistence-after-{td_test}.td",
     )
 
     c.kill("materialized")
-    c.rm("materialized", "testdrive-svc", destroy_volumes=True)
+    c.rm("materialized", "testdrive", destroy_volumes=True)
     c.rm_volumes("mzdata")
 
 
@@ -172,7 +172,7 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
     c.wait_for_materialized()
 
     c.run(
-        "testdrive-svc",
+        "testdrive",
         f"--seed={seed}",
         f"--var=failpoint={failpoint}",
         f"--var=action={action}",
@@ -185,10 +185,10 @@ def run_one_failpoint(c: Composition, failpoint: str, action: str) -> None:
     c.up("materialized")
     c.wait_for_materialized()
 
-    c.run("testdrive-svc", f"--seed={seed}", "failpoints/after.td")
+    c.run("testdrive", f"--seed={seed}", "failpoints/after.td")
 
     c.kill("materialized")
-    c.rm("materialized", "testdrive-svc", destroy_volumes=True)
+    c.rm("materialized", "testdrive", destroy_volumes=True)
     c.rm_volumes("mzdata")
 
 
@@ -201,7 +201,7 @@ def workflow_disable_user_indexes(
     c.up("materialized")
     c.wait_for_materialized()
 
-    c.run("testdrive-svc", f"--seed={seed}", "disable-user-indexes/before.td")
+    c.run("testdrive", f"--seed={seed}", "disable-user-indexes/before.td")
 
     c.kill("materialized")
 
@@ -213,11 +213,11 @@ def workflow_disable_user_indexes(
         c.up("materialized")
         c.wait_for_materialized()
 
-        c.run("testdrive-svc", f"--seed={seed}", "disable-user-indexes/after.td")
+        c.run("testdrive", f"--seed={seed}", "disable-user-indexes/after.td")
 
         c.kill("materialized")
 
-    c.rm("materialized", "testdrive-svc", destroy_volumes=True)
+    c.rm("materialized", "testdrive", destroy_volumes=True)
 
     c.rm_volumes("mzdata")
 
@@ -231,10 +231,10 @@ def workflow_compaction(c: Composition) -> None:
         c.up("materialized")
         c.wait_for_materialized()
 
-        c.run("testdrive-svc", "compaction/compaction.td")
+        c.run("testdrive", "compaction/compaction.td")
 
         c.kill("materialized")
 
-    c.rm("materialized", "testdrive-svc", destroy_volumes=True)
+    c.rm("materialized", "testdrive", destroy_volumes=True)
 
     c.rm_volumes("mzdata")

--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -49,7 +49,7 @@ def initialize(c: Composition) -> None:
     # We run configure-postgres.td only once for all workflows as
     # it contains CREATE USER that is not indempotent
 
-    c.run("testdrive-svc", "configure-postgres.td")
+    c.run("testdrive", "configure-postgres.td")
 
 
 def restart_pg(c: Composition) -> None:
@@ -68,7 +68,7 @@ def begin(c: Composition) -> None:
     """Configure Toxiproxy and Mz and populate initial data"""
 
     c.run(
-        "testdrive-svc",
+        "testdrive",
         "configure-toxiproxy.td",
         "populate-tables.td",
         "configure-materalize.td",
@@ -77,12 +77,12 @@ def begin(c: Composition) -> None:
 
 def end(c: Composition) -> None:
     """Validate the data at the end and reset Toxiproxy"""
-    c.run("testdrive-svc", "verify-data.td", "toxiproxy-remove.td")
+    c.run("testdrive", "verify-data.td", "toxiproxy-remove.td")
 
 
 def disconnect_pg_during_snapshot(c: Composition) -> None:
     c.run(
-        "testdrive-svc",
+        "testdrive",
         "toxiproxy-close-connection.td",
         "toxiproxy-restore-connection.td",
         "delete-rows-t1.td",
@@ -94,18 +94,18 @@ def disconnect_pg_during_snapshot(c: Composition) -> None:
 def restart_pg_during_snapshot(c: Composition) -> None:
     restart_pg(c)
 
-    c.run("testdrive-svc", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
+    c.run("testdrive", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
 
 
 def restart_mz_during_snapshot(c: Composition) -> None:
     restart_mz(c)
 
-    c.run("testdrive-svc", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
+    c.run("testdrive", "delete-rows-t1.td", "delete-rows-t2.td", "alter-table.td")
 
 
 def disconnect_pg_during_replication(c: Composition) -> None:
     c.run(
-        "testdrive-svc",
+        "testdrive",
         "wait-for-snapshot.td",
         "delete-rows-t1.td",
         "delete-rows-t2.td",
@@ -116,20 +116,16 @@ def disconnect_pg_during_replication(c: Composition) -> None:
 
 
 def restart_pg_during_replication(c: Composition) -> None:
-    c.run(
-        "testdrive-svc", "wait-for-snapshot.td", "delete-rows-t1.td", "alter-table.td"
-    )
+    c.run("testdrive", "wait-for-snapshot.td", "delete-rows-t1.td", "alter-table.td")
 
     restart_pg(c)
 
-    c.run("testdrive-svc", "delete-rows-t2.td")
+    c.run("testdrive", "delete-rows-t2.td")
 
 
 def restart_mz_during_replication(c: Composition) -> None:
-    c.run(
-        "testdrive-svc", "wait-for-snapshot.td", "delete-rows-t1.td", "alter-table.td"
-    )
+    c.run("testdrive", "wait-for-snapshot.td", "delete-rows-t1.td", "alter-table.td")
 
     restart_mz(c)
 
-    c.run("testdrive-svc", "delete-rows-t2.td")
+    c.run("testdrive", "delete-rows-t2.td")

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -27,7 +27,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    c.up("materialized", "test-certs", "testdrive-svc", "postgres")
+    c.up("materialized", "test-certs", "testdrive", "postgres")
     c.wait_for_materialized()
     c.wait_for_postgres()
-    c.run("testdrive-svc", *args.filter)
+    c.run("testdrive", *args.filter)

--- a/test/proxy/mzcompose.py
+++ b/test/proxy/mzcompose.py
@@ -105,4 +105,4 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             with c.override(Materialized(environment_extra=test_case.env)):
                 c.up("materialized")
                 c.wait_for_materialized("materialized")
-                c.run("testdrive-svc", aws_arg, *test_case.files)
+                c.run("testdrive", aws_arg, *test_case.files)

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -41,7 +41,7 @@ def workflow_disable_user_indexes(c: Composition) -> None:
     # Create catalog with vanilla MZ
     c.up("materialized")
     c.wait_for_materialized("materialized")
-    c.run("testdrive-svc", "user-indexes-enabled.td")
+    c.run("testdrive", "user-indexes-enabled.td")
     c.kill("materialized")
 
     # Test semantics of disabling user indexes
@@ -54,7 +54,7 @@ def workflow_disable_user_indexes(c: Composition) -> None:
 def workflow_github_8021(c: Composition) -> None:
     c.up("materialized")
     c.wait_for_materialized("materialized")
-    c.run("testdrive-svc", "github-8021.td")
+    c.run("testdrive", "github-8021.td")
 
     # Ensure MZ can boot
     c.kill("materialized")

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -62,7 +62,7 @@ def workflow_default(c: Composition) -> None:
         )
 
         c.run(
-            "testdrive-svc",
+            "testdrive",
             "--no-reset",
             "--max-errors=1",
             f"--seed={toxiproxy_bytes_allowed}",

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -100,7 +100,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.wait_for_materialized("materialized")
         try:
             junit_report = ci_util.junit_report_filename(c.name)
-            c.run("testdrive-svc", f"--junit-report={junit_report}", *args.files)
+            c.run("testdrive", f"--junit-report={junit_report}", *args.files)
         finally:
             ci_util.upload_junit_report(
                 "testdrive", Path(__file__).parent / junit_report

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -138,7 +138,7 @@ def test_upgrade_from_version(
     version_glob = "{" + ",".join(["any_version", *priors, from_version]) + "}"
     print(">>> Version glob pattern: " + version_glob)
 
-    c.rm("materialized", "testdrive-svc", stop=True)
+    c.rm("materialized", "testdrive", stop=True)
     c.rm_volumes("mzdata", "tmp")
 
     if from_version != "current_source":
@@ -164,7 +164,7 @@ def test_upgrade_from_version(
     temp_dir = f"--temp-dir=/share/tmp/upgrade-from-{from_version}"
     seed = f"--seed={random.getrandbits(32)}"
     c.run(
-        "testdrive-svc",
+        "testdrive",
         "--no-reset",
         f"--var=upgrade-from-version={from_version}",
         temp_dir,
@@ -173,13 +173,13 @@ def test_upgrade_from_version(
     )
 
     c.kill("materialized")
-    c.rm("materialized", "testdrive-svc")
+    c.rm("materialized", "testdrive")
 
     c.up("materialized")
     c.wait_for_materialized("materialized")
 
     c.run(
-        "testdrive-svc",
+        "testdrive",
         "--no-reset",
         f"--var=upgrade-from-version={from_version}",
         temp_dir,


### PR DESCRIPTION
Now that "testdrive" is never used as a workflow name, we can change the
name of the testdrive service from "testdrive-svc" to "testdrive". This
brings it in line with all other mzcompose services.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
