### PR TITLE
feature-benchmark: stabilize and shorten the KafkaRestart scenario

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -728,9 +728,7 @@ $ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{key
         )
 
 
-class KafkaRecovery(Kafka):
-    SCALE = 7
-
+class KafkaRestart(Kafka):
     def shared(self) -> Action:
         return TdAction(
             self.keyschema()
@@ -761,25 +759,21 @@ $ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${{ke
 """
         )
 
-    def before(self) -> Action:
-        return LambdaAction(lambda e: e.RestartMz())
-
-    def benchmark(self) -> MeasurementSource:
-        return Td(
-            f"""
-> SELECT 1;
-  /* A */
-1
-
-> SELECT COUNT(*) FROM s1;
+    def benchmark(self) -> BenchmarkingSequence:
+        return [
+            Lambda(lambda e: e.RestartMz()),
+            Td(
+                f"""
+> SELECT COUNT(*) /* {self.n()} */ FROM s1;
   /* B */
 {self.n()}
 """
-        )
+            ),
+        ]
 
 
-class KafkaRecoveryBig(ScenarioBig):
-    """Benchmark the ingestion of 100M records without constructing
+class KafkaRestartBig(ScenarioBig):
+    """Ingest 100M records without constructing
     a dataflow that would keep all of them in memory. For the purpose, we
     emit a bunch of "EOF" records after the primary ingestion is complete
     and consider that the source has caught up when all the EOF records have
@@ -835,21 +829,17 @@ true
 """
         )
 
-    def before(self) -> Action:
-        return LambdaAction(lambda e: e.RestartMz())
-
-    def benchmark(self) -> MeasurementSource:
-        return Td(
-            """
-> SELECT 1;
-  /* A */
-1
-
+    def benchmark(self) -> BenchmarkingSequence:
+        return [
+            Lambda(lambda e: e.RestartMz()),
+            Td(
+                """
 > SELECT * FROM s1_is_complete
   /* B */
 true
 """
-        )
+            ),
+        ]
 
 
 @parameterized_class(


### PR DESCRIPTION
The KafkaRestart scenario was running with SCALE=7 due to extreme
variability of the results. This caused it to consume ~25% of the
execution time of the entire suite of benchmarks.

- rename the scenarios from "Recovery" to "Restart" to better reflect
  what is being measured, which is Mz restart time in the presence of
  a Kafka source. It may not involve recovery at all, but rather re-ingestion,
  depending on whether persistence is enabled.

- refactor the Recovery scenarios to better measure the time between
  Mz restart and the time the materialized source becomes fully hydrated

- use the default SCALE=6 for KafkaRestart

### Motivation

  * This PR fixes a previously unreported bug.

The KafkaRecovery/Restart scenario was taking too much time to run.
