### PR TITLE
stash: lighten the load on SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4059,6 +4059,7 @@ name = "mz-stash"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "criterion",
  "differential-dataflow",
  "mz-persist-types",
  "rusqlite",

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2021"
 rust-version = "1.59.0"
 publish = false
 
+[[bench]]
+name = "sqlite"
+harness = false
+
+# [[bench]]
+# name = "consolidation"
+# harness = false
+
 [dependencies]
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 mz-persist-types = { path = "../persist-types" }
@@ -15,3 +23,4 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 [dev-dependencies]
 anyhow = "1.0.56"
 tempfile = "3.3.0"
+criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = [ "html_reports" ] }

--- a/src/stash/benches/sqlite.rs
+++ b/src/stash/benches/sqlite.rs
@@ -1,0 +1,127 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::iter::{repeat, repeat_with};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use tempfile::NamedTempFile;
+use timely::progress::Antichain;
+
+use mz_stash::{Sqlite, Stash};
+
+fn bench_update(c: &mut Criterion) {
+    let file = NamedTempFile::new().unwrap();
+    let mut stash = Sqlite::open(file.path()).unwrap();
+
+    let orders = stash.collection::<String, String>("orders").unwrap();
+    let mut ts = 1;
+    c.bench_function("update", |b| {
+        b.iter(|| {
+            let data = ("widgets".into(), "1".into());
+            stash.update(orders, data, ts, 1).unwrap();
+            ts += 1;
+        })
+    });
+}
+
+fn bench_update_many(c: &mut Criterion) {
+    let file = NamedTempFile::new().unwrap();
+    let stash = Sqlite::open(file.path()).unwrap();
+
+    let orders = stash.collection::<String, String>("orders").unwrap();
+    let mut ts = 1;
+    c.bench_function("update_many", |b| {
+        b.iter(|| {
+            let data = ("widgets".into(), "1".into());
+            stash
+                .update_many(orders, repeat((data, ts, 1)).take(10))
+                .unwrap();
+            ts += 1;
+        })
+    });
+}
+
+fn bench_consolidation(c: &mut Criterion) {
+    let file = NamedTempFile::new().unwrap();
+    let mut stash = Sqlite::open(file.path()).unwrap();
+
+    let orders = stash.collection::<String, String>("orders").unwrap();
+    let mut ts = 1;
+    c.bench_function("consolidation", |b| {
+        b.iter(|| {
+            let data = ("widgets".into(), "1".into());
+            stash.update(orders, data.clone(), ts, 1).unwrap();
+            stash.update(orders, data, ts + 1, -1).unwrap();
+            let frontier = Antichain::from_elem(ts + 2);
+            stash.seal(orders, frontier.borrow()).unwrap();
+            stash.compact(orders, frontier.borrow()).unwrap();
+            stash.consolidate(orders).unwrap();
+            ts += 2;
+        })
+    });
+}
+
+fn bench_consolidation_large(c: &mut Criterion) {
+    let file = NamedTempFile::new().unwrap();
+    let stash = Sqlite::open(file.path()).unwrap();
+
+    let orders = stash.collection::<String, String>("orders").unwrap();
+    let mut ts = 0;
+
+    // Prepopulate the database with 100k records
+    let kv = ("widgets".into(), "1".into());
+    stash
+        .update_many(
+            orders,
+            repeat_with(|| {
+                let update = (kv.clone(), ts, 1);
+                ts += 1;
+                update
+            })
+            .take(100_000),
+        )
+        .unwrap();
+    let frontier = Antichain::from_elem(ts);
+    stash.seal(orders, frontier.borrow()).unwrap();
+
+    let mut compact_ts = 0;
+    c.bench_function("consolidation large", |b| {
+        b.iter(|| {
+            ts += 1;
+            // add 10k records
+            stash
+                .update_many(
+                    orders,
+                    repeat_with(|| {
+                        let update = (kv.clone(), ts, 1);
+                        ts += 1;
+                        update
+                    })
+                    .take(10_000),
+                )
+                .unwrap();
+            let frontier = Antichain::from_elem(ts);
+            stash.seal(orders, frontier.borrow()).unwrap();
+            // compact + consolidate
+            compact_ts += 10_000;
+            let compact_frontier = Antichain::from_elem(compact_ts);
+            stash.compact(orders, compact_frontier.borrow()).unwrap();
+            stash.consolidate(orders).unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_update,
+    bench_update_many,
+    bench_consolidation,
+    bench_consolidation_large
+);
+criterion_main!(benches);


### PR DESCRIPTION
### Motivation

This patch simplifies the schema of the SQLite backend of stash by
foregoing consolidation on insert which involved a DELETE statement and
a unique index.

The external API remains unchagned since we were consolidating the
result of the stash implementation anyway.

Consolidation logic has been adapted too to account for the lack of
unique index which was driving the logic before.

Attempts to fix the performance regression reported in #11596


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
