### PR TITLE
doc/user: Fix typo in custom types

### DIFF
--- a/doc/user/content/sql/types/_index.md
+++ b/doc/user/content/sql/types/_index.md
@@ -50,7 +50,7 @@ Value | Description
 ## Custom types
 
 Custom types, in general, provide a mechanism to create names for specific
-instances of  anonymous types to suite users' needs.
+instances of anonymous types to suit users' needs.
 
 However, types are considered custom if the type:
 - Was created through [`CREATE TYPE`][create-type].


### PR DESCRIPTION
Fix types typo

Before:
![image](https://user-images.githubusercontent.com/11527560/161757069-7d0e40c2-bd24-4a4d-a444-c5c131637f42.png)
After:
![image](https://user-images.githubusercontent.com/11527560/161757167-135e09b4-d1d2-49d2-adcf-4dc8dc40a301.png)
