### PR TITLE
sql: Make "item exists" error messages consistent

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2404,8 +2404,8 @@ pub fn plan_create_type(
     };
 
     let name = scx.allocate_qualified_name(normalize::unresolved_object_name(name)?)?;
-    if scx.catalog.item_exists(&name) {
-        bail!("catalog item {} already exists", name.to_string().quoted());
+    if scx.item_exists(&name) {
+        bail!("catalog item '{}' already exists", name);
     }
 
     let inner = match as_type {
@@ -3036,7 +3036,7 @@ pub fn plan_alter_object_rename(
                 item: to_item_name.clone().into_string(),
             };
             if scx.item_exists(&proposed_name) {
-                bail!("{} is already taken by item in schema", to_item_name)
+                bail!("catalog item '{}' already exists", to_item_name);
             }
             Ok(Plan::AlterItemRename(AlterItemRenamePlan {
                 id: entry.id(),

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -85,10 +85,10 @@ secret
 statement OK
 CREATE SECRET existing AS decode('c2VjcmV0Cg==', 'base64');
 
-statement error existing is already taken by item in schema
+statement error catalog item 'existing' already exists
 ALTER SECRET certificate RENAME TO existing
 
-statement error t1 is already taken by item in schema
+statement error catalog item 't1' already exists
 ALTER SECRET certificate RENAME TO t1
 
 statement OK

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -236,9 +236,9 @@ contains:renaming conflict
 
 # ❌ Name used by another item in schema's catalog
 ! ALTER VIEW t1 RENAME TO a
-contains:a is already taken by item in schema
+contains:catalog item 'a' already exists
 ! ALTER VIEW t1 RENAME TO dependent_view;
-contains:dependent_view is already taken by item in schema
+contains:catalog item 'dependent_view' already exists
 
 # 🔬 Aliases
 


### PR DESCRIPTION
Fixes #11448.

I thought about removing the duplicate string by factoring the check-and-bail out into a separate function, to ensure there cannot be an inconsistency. But the result was less readable than what we have now. Plus we have another instance of "catalog item '{}' already exists" in the `coord` crate already anyway.

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  -