### PR TITLE
docs/user: fix copy commands

### DIFF
--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -220,6 +220,9 @@ Materialize efficiently supports [all types of SQL joins](/sql/join/#examples) u
 
     ```sql
     SELECT * FROM cnt_ticker;
+    ```
+
+    ```
      ticker | cnt
     --------+-----
      AAPL   |  42
@@ -252,7 +255,9 @@ In Materialize, [temporal filters](/guides/temporal-filters/) allow you to defin
 
     ```sql
     SELECT * FROM cnt_sliding;
+    ```
 
+    ```
        symbol    | cnt
     -------------+-----
      Apple       |  31


### PR DESCRIPTION
### Motivation

Some of the COPY commands contain both the SQL and mz output where we should only be copying the commands we actually want users to execute. 

### Tips for reviewer

### Testing

N/A
