### PR TITLE
stash: offer batched API to amortize operation cost

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -175,10 +175,9 @@ const MIGRATIONS: &[&dyn Migration] = &[
             .query_and_then([], |row| Ok(row.get::<_, SqlVal<GlobalId>>(0)?.0))?
             .collect::<Result<Vec<_>, Error>>()?;
 
-        let stash = Stash::new(
-            mz_stash::Sqlite::open(&data_dir_path.join("storage"))
-                .expect("unable to open STORAGE stash"),
-        );
+        let stash = mz_stash::Sqlite::open(&data_dir_path.join("storage"))
+            .expect("unable to open STORAGE stash");
+
         let mut statement = tx.prepare(
             "SELECT pid, timestamp, offset FROM timestamps WHERE sid = ? ORDER BY pid, timestamp",
         )?;
@@ -199,7 +198,7 @@ const MIGRATIONS: &[&dyn Migration] = &[
                 })?
                 .collect::<Result<Vec<_>, Error>>()?;
 
-            let mut ts_binding_stash = stash
+            let ts_binding_stash = stash
                 .collection::<PartitionId, ()>(&format!("timestamp-bindings-{source_id}"))
                 .expect("failed to read timestamp bindings");
 
@@ -208,17 +207,20 @@ const MIGRATIONS: &[&dyn Migration] = &[
             // for an explanation of the logic
             let mut last_reported_ts_bindings: HashMap<_, MzOffset> = HashMap::new();
             let seal_ts = bindings.iter().map(|(_, ts, _)| *ts).max();
-            ts_binding_stash
-                .update_many(bindings.into_iter().map(|(pid, ts, offset)| {
-                    let prev_offset = last_reported_ts_bindings.entry(pid.clone()).or_default();
-                    let update = ((pid, ()), ts, offset.offset - prev_offset.offset);
-                    prev_offset.offset = offset.offset;
-                    update
-                }))
+            stash
+                .update_many(
+                    ts_binding_stash,
+                    bindings.into_iter().map(|(pid, ts, offset)| {
+                        let prev_offset = last_reported_ts_bindings.entry(pid.clone()).or_default();
+                        let update = ((pid, ()), ts, offset.offset - prev_offset.offset);
+                        prev_offset.offset = offset.offset;
+                        update
+                    }),
+                )
                 .expect("failed to write timestamp bindings");
 
-            ts_binding_stash
-                .seal(Antichain::from_iter(seal_ts).borrow())
+            stash
+                .seal(ts_binding_stash, Antichain::from_iter(seal_ts).borrow())
                 .expect("failed to write timestamp bindings");
         }
 

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -137,10 +137,10 @@ pub trait Stash {
     /// See [Stash::seal]
     fn seal_batch<K, V>(
         &self,
-        seals: &[(StashCollection<K, V>, AntichainRef<Timestamp>)],
+        seals: &[(StashCollection<K, V>, Antichain<Timestamp>)],
     ) -> Result<(), StashError> {
         for (id, new_upper) in seals {
-            self.seal(*id, *new_upper)?;
+            self.seal(*id, new_upper.borrow())?;
         }
         Ok(())
     }
@@ -164,10 +164,10 @@ pub trait Stash {
     /// See [Stash::compact]
     fn compact_batch<K, V>(
         &self,
-        compactions: &[(StashCollection<K, V>, AntichainRef<Timestamp>)],
+        compactions: &[(StashCollection<K, V>, Antichain<Timestamp>)],
     ) -> Result<(), StashError> {
         for (id, since) in compactions {
-            self.compact(*id, *since)?;
+            self.compact(*id, since.borrow())?;
         }
         Ok(())
     }

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -27,44 +27,6 @@ pub type Diff = i64;
 pub type Timestamp = i64;
 pub type Id = i64;
 
-pub trait StashConn: std::fmt::Debug + Send {
-    fn collection<K, V>(&self, name: &str) -> Result<StashCollection<Self, K, V>, StashError>
-    where
-        Self: Sized,
-        K: Codec + Ord,
-        V: Codec + Ord;
-
-    fn iter(
-        &self,
-        collection_id: Id,
-    ) -> Result<Vec<((Vec<u8>, Vec<u8>), Timestamp, Diff)>, StashError>;
-
-    fn iter_key(
-        &self,
-        collection_id: Id,
-        key: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Timestamp, Diff)>, StashError>;
-
-    fn update_many<I>(&self, collection_id: Id, entries: I) -> Result<(), StashError>
-    where
-        I: IntoIterator<Item = ((Vec<u8>, Vec<u8>), Timestamp, Diff)>;
-
-    fn seal(&self, collection_id: Id, new_upper: AntichainRef<Timestamp>)
-        -> Result<(), StashError>;
-
-    fn compact(
-        &self,
-        collection_id: Id,
-        new_since: AntichainRef<Timestamp>,
-    ) -> Result<(), StashError>;
-
-    fn consolidate(&self, collection_id: Id) -> Result<(), StashError>;
-
-    fn since(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError>;
-
-    fn upper(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError>;
-}
-
 /// A durable metadata store.
 ///
 /// A stash manages any number of named [`StashCollection`]s.
@@ -78,19 +40,7 @@ pub trait StashConn: std::fmt::Debug + Send {
 /// truth, the intent is to swap all stashes for STORAGE collections.
 ///
 /// [STORAGE]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/platform/architecture-db.md#STORAGE
-#[derive(Debug)]
-pub struct Stash<C> {
-    conn: C,
-}
-
-impl<C> Stash<C>
-where
-    C: StashConn,
-{
-    pub fn new(conn: C) -> Stash<C> {
-        Stash { conn }
-    }
-
+pub trait Stash {
     /// Loads or creates the named collection.
     ///
     /// If the collection with the specified name does not yet exist, it is
@@ -102,13 +52,158 @@ where
     ///
     /// It is valid to construct multiple handles to the same named collection
     /// and use them simultaneously.
-    pub fn collection<K, V>(&self, name: &str) -> Result<StashCollection<C, K, V>, StashError>
+    fn collection<K, V>(&self, name: &str) -> Result<StashCollection<K, V>, StashError>
     where
         K: Codec + Ord,
-        V: Codec + Ord,
-    {
-        self.conn.collection(name)
+        V: Codec + Ord;
+
+    /// Iterates over all entries in the stash.
+    ///
+    /// Entries are iterated in `(key, value, time)` order and are guaranteed
+    /// to be consolidated.
+    ///
+    /// Each entry's time is guaranteed to be greater than or equal to the since
+    /// frontier. The time may also be greater than the upper frontier,
+    /// indicating data that has not yet been made definite.
+    fn iter<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
+    where
+        K: Codec + Ord,
+        V: Codec + Ord;
+
+    /// Iterates over entries in the stash for the given key.
+    ///
+    /// Entries are iterated in `(value, timestamp)` order and are guaranteed
+    /// to be consolidated.
+    ///
+    /// Each entry's time is guaranteed to be greater than or equal to the since
+    /// frontier. The time may also be greater than the upper frontier,
+    /// indicating data that has not yet been made definite.
+    fn iter_key<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+        key: &K,
+    ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
+    where
+        K: Codec + Ord,
+        V: Codec + Ord;
+
+    /// Adds a single entry to the arrangement.
+    ///
+    /// The entry's time must be greater than or equal to the upper frontier.
+    ///
+    /// If this method returns `Ok`, the entry has been made durable.
+    fn update<K: Codec, V: Codec>(
+        &mut self,
+        collection: StashCollection<K, V>,
+        data: (K, V),
+        time: Timestamp,
+        diff: Diff,
+    ) -> Result<(), StashError> {
+        self.update_many(collection, iter::once((data, time, diff)))
     }
+
+    /// Atomically adds multiple entries to the arrangement.
+    ///
+    /// Each entry's time must be greater than or equal to the upper frontier.
+    ///
+    /// If this method returns `Ok`, the entries have been made durable.
+    fn update_many<K: Codec, V: Codec, I>(
+        &self,
+        collection: StashCollection<K, V>,
+        entries: I,
+    ) -> Result<(), StashError>
+    where
+        I: IntoIterator<Item = ((K, V), Timestamp, Diff)>;
+
+    /// Advances the upper frontier to the specified value.
+    ///
+    /// The provided `upper` must be greater than or equal to the current upper
+    /// frontier.
+    ///
+    /// Intuitively, this method declares that all times less than `upper` are
+    /// definite.
+    fn seal<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+        upper: AntichainRef<Timestamp>,
+    ) -> Result<(), StashError>;
+
+    /// Performs multiple seals at once, potentially in a more performant way than
+    /// performing the individual seals one by one.
+    ///
+    /// See [Stash::seal]
+    fn seal_batch<K, V>(
+        &self,
+        seals: &[(StashCollection<K, V>, AntichainRef<Timestamp>)],
+    ) -> Result<(), StashError> {
+        for (id, new_upper) in seals {
+            self.seal(*id, *new_upper)?;
+        }
+        Ok(())
+    }
+
+    /// Advances the since frontier to the specified value.
+    ///
+    /// The provided `since` must be greater than or equal to the current since
+    /// frontier but less than or equal to the current upper frontier.
+    ///
+    /// Intuitively, this method performs logical compaction. Existing entries
+    /// whose time is less than `since` are fast-forwarded to `since`.
+    fn compact<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+        since: AntichainRef<Timestamp>,
+    ) -> Result<(), StashError>;
+
+    /// Performs multiple compactions at once, potentially in a more performant way than
+    /// performing the individual compactions one by one.
+    ///
+    /// See [Stash::compact]
+    fn compact_batch<K, V>(
+        &self,
+        compactions: &[(StashCollection<K, V>, AntichainRef<Timestamp>)],
+    ) -> Result<(), StashError> {
+        for (id, since) in compactions {
+            self.compact(*id, *since)?;
+        }
+        Ok(())
+    }
+
+    /// Consolidates entries less than the since frontier.
+    ///
+    /// Intuitively, this method performs physical compaction. Existing
+    /// key–value pairs whose time is less than the since frontier are
+    /// consolidated together when possible.
+    fn consolidate<K, V>(&self, collection: StashCollection<K, V>) -> Result<(), StashError>;
+
+    /// Performs multiple consolidations at once, potentially in a more performant way than
+    /// performing the individual consolidations one by one.
+    ///
+    /// See [Stash::consolidate]
+    fn consolidate_batch<K, V>(
+        &self,
+        collections: &[StashCollection<K, V>],
+    ) -> Result<(), StashError> {
+        for collection in collections {
+            self.consolidate(*collection)?;
+        }
+        Ok(())
+    }
+
+    /// Reports the current since frontier.
+    fn since<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Antichain<Timestamp>, StashError>;
+
+    /// Reports the current upper frontier.
+    fn upper<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Antichain<Timestamp>, StashError>;
 }
 
 /// `StashCollection` is like a differential dataflow [`Collection`], but the
@@ -124,154 +219,26 @@ where
 /// frontier, call [`compact`]. To advance the upper frontier, call [`seal`]. To
 /// physically compact data beneath the since frontier, call [`consolidate`].
 ///
-/// [`compact`]: StashCollection::compact
-/// [`consolidate`]: StashCollection::consolidate
-/// [`seal`]: StashCollection::seal
+/// [`compact`]: Stash::compact
+/// [`consolidate`]: Stash::consolidate
+/// [`seal`]: Stash::seal
 /// [correctness vocabulary document]: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20210831_correctness.md
 /// [`Collection`]: differential_dataflow::collection::Collection
-pub struct StashCollection<C, K, V>
-where
-    K: Codec + Ord,
-    V: Codec + Ord,
-{
-    conn: C,
-    collection_id: Id,
+pub struct StashCollection<K, V> {
+    id: Id,
     _kv: PhantomData<(K, V)>,
 }
 
-impl<C, K, V> StashCollection<C, K, V>
-where
-    C: StashConn,
-    K: Codec + Ord,
-    V: Codec + Ord,
-{
-    /// Iterates over all entries in the stash.
-    ///
-    /// Entries are iterated in `(key, value, time)` order and are guaranteed
-    /// to be consolidated.
-    ///
-    /// Each entry's time is guaranteed to be greater than or equal to the since
-    /// frontier. The time may also be greater than the upper frontier,
-    /// indicating data that has not yet been made definite.
-    ///
-    /// [`consolidate`]: StashCollection::consolidate
-    /// [`update`]: StashCollection::update
-    /// [`update_many`]: StashCollection::update_many
-    pub fn iter(&self) -> Result<impl Iterator<Item = ((K, V), Timestamp, Diff)>, StashError> {
-        let mut rows = self
-            .conn
-            .iter(self.collection_id)?
-            .into_iter()
-            .map(|((k, v), ts, diff)| {
-                let k = K::decode(&k)?;
-                let v = V::decode(&v)?;
-                Ok(((k, v), ts, diff))
-            })
-            .collect::<Result<Vec<_>, String>>()?;
-        differential_dataflow::consolidation::consolidate_updates(&mut rows);
-        Ok(rows.into_iter())
-    }
-
-    /// Iterates over entries in the stash for the given key.
-    ///
-    /// Entries are iterated in `(value, timestamp)` order and are guaranteed
-    /// to be consolidated.
-    ///
-    /// Each entry's time is guaranteed to be greater than or equal to the since
-    /// frontier. The time may also be greater than the upper frontier,
-    /// indicating data that has not yet been made definite.
-    ///
-    /// [`consolidate`]: StashCollection::consolidate
-    /// [`update`]: StashCollection::update
-    /// [`update_many`]: StashCollection::update_many
-    pub fn iter_key(
-        &self,
-        key: K,
-    ) -> Result<impl Iterator<Item = (V, Timestamp, Diff)>, StashError> {
-        let mut key_buf = vec![];
-        key.encode(&mut key_buf);
-        let mut rows = self
-            .conn
-            .iter_key(self.collection_id, &key_buf)?
-            .into_iter()
-            .map(|(v, ts, diff)| {
-                let v = V::decode(&v)?;
-                Ok((v, ts, diff))
-            })
-            .collect::<Result<Vec<_>, String>>()?;
-        differential_dataflow::consolidation::consolidate_updates(&mut rows);
-        Ok(rows.into_iter())
-    }
-
-    /// Adds a single entry to the arrangement.
-    ///
-    /// The entry's time must be greater than or equal to the upper frontier.
-    ///
-    /// If this method returns `Ok`, the entry has been made durable.
-    pub fn update(&mut self, data: (K, V), time: Timestamp, diff: Diff) -> Result<(), StashError> {
-        self.update_many(iter::once((data, time, diff)))
-    }
-
-    /// Atomically adds multiple entries to the arrangement.
-    ///
-    /// Each entry's time must be greater than or equal to the upper frontier.
-    ///
-    /// If this method returns `Ok`, the entries have been made durable.
-    pub fn update_many<I>(&mut self, entries: I) -> Result<(), StashError>
-    where
-        I: IntoIterator<Item = ((K, V), Timestamp, Diff)>,
-    {
-        let entries = entries.into_iter().map(|((key, value), ts, diff)| {
-            let mut key_buf = vec![];
-            let mut value_buf = vec![];
-            key.encode(&mut key_buf);
-            value.encode(&mut value_buf);
-            ((key_buf, value_buf), ts, diff)
-        });
-        self.conn.update_many(self.collection_id, entries)
-    }
-
-    /// Advances the upper frontier to the specified value.
-    ///
-    /// The provided `upper` must be greater than or equal to the current upper
-    /// frontier.
-    ///
-    /// Intuitively, this method declares that all times less than `upper` are
-    /// definite.
-    pub fn seal(&self, new_upper: AntichainRef<Timestamp>) -> Result<(), StashError> {
-        self.conn.seal(self.collection_id, new_upper)
-    }
-
-    /// Advances the since frontier to the specified value.
-    ///
-    /// The provided `since` must be greater than or equal to the current since
-    /// frontier but less than or equal to the current upper frontier.
-    ///
-    /// Intuitively, this method performs logical compaction. Existing entries
-    /// whose time is less than `since` are fast-forwarded to `since`.
-    pub fn compact(&self, new_since: AntichainRef<Timestamp>) -> Result<(), StashError> {
-        self.conn.compact(self.collection_id, new_since)
-    }
-
-    /// Consolidates entries less than the since frontier.
-    ///
-    /// Intuitively, this method performs physical compaction. Existing
-    /// key–value pairs whose time is less than the since frontier are
-    /// consolidated together when possible.
-    pub fn consolidate(&mut self) -> Result<(), StashError> {
-        self.conn.consolidate(self.collection_id)
-    }
-
-    /// Reports the current since frontier.
-    pub fn since(&self) -> Result<Antichain<Timestamp>, StashError> {
-        self.conn.since(self.collection_id)
-    }
-
-    /// Reports the current upper frontier.
-    pub fn upper(&self) -> Result<Antichain<Timestamp>, StashError> {
-        self.conn.upper(self.collection_id)
+impl<K, V> Clone for StashCollection<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            _kv: PhantomData,
+        }
     }
 }
+
+impl<K, V> Copy for StashCollection<K, V> {}
 
 struct AntichainFormatter<'a, T>(&'a [T]);
 

--- a/src/stash/src/sqlite.rs
+++ b/src/stash/src/sqlite.rs
@@ -22,8 +22,7 @@ use mz_persist_types::Codec;
 use timely::progress::frontier::AntichainRef;
 
 use crate::{
-    AntichainFormatter, Diff, Id, InternalStashError, StashCollection, StashConn, StashError,
-    Timestamp,
+    AntichainFormatter, Diff, Id, InternalStashError, Stash, StashCollection, StashError, Timestamp,
 };
 
 const APPLICATION_ID: i32 = 0x0872_e898; // chosen randomly
@@ -116,8 +115,8 @@ impl Sqlite {
     }
 }
 
-impl StashConn for Sqlite {
-    fn collection<K, V>(&self, name: &str) -> Result<StashCollection<Self, K, V>, StashError>
+impl Stash for Sqlite {
+    fn collection<K, V>(&self, name: &str) -> Result<StashCollection<K, V>, StashError>
     where
         K: Codec + Ord,
         V: Codec + Ord,
@@ -155,21 +154,22 @@ impl StashConn for Sqlite {
 
         tx.commit()?;
         Ok(StashCollection {
-            conn: Self {
-                conn: Arc::clone(&self.conn),
-            },
-            collection_id,
+            id: collection_id,
             _kv: PhantomData,
         })
     }
 
-    fn iter(
+    fn iter<K, V>(
         &self,
-        collection_id: Id,
-    ) -> Result<Vec<((Vec<u8>, Vec<u8>), Timestamp, Diff)>, StashError> {
+        collection: StashCollection<K, V>,
+    ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
+    where
+        K: Codec + Ord,
+        V: Codec + Ord,
+    {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let since = match self.since_tx(&tx, collection_id)?.into_option() {
+        let since = match self.since_tx(&tx, collection.id)?.into_option() {
             Some(since) => since,
             None => {
                 return Err(StashError::from(
@@ -177,30 +177,39 @@ impl StashConn for Sqlite {
                 ));
             }
         };
-        let rows = tx
+        let mut rows = tx
             .prepare(
                 "SELECT key, value, time, diff FROM data
                  WHERE collection_id = $collection_id",
             )?
-            .query_and_then(named_params! {"$collection_id": collection_id}, |row| {
-                let key = row.get("key")?;
-                let value = row.get("value")?;
+            .query_and_then(named_params! {"$collection_id": collection.id}, |row| {
+                let key_buf: Vec<_> = row.get("key")?;
+                let value_buf: Vec<_> = row.get("value")?;
+                let key = K::decode(&key_buf)?;
+                let value = V::decode(&value_buf)?;
                 let time = row.get("time")?;
                 let diff = row.get("diff")?;
                 Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
             })?
             .collect::<Result<Vec<_>, _>>()?;
+        differential_dataflow::consolidation::consolidate_updates(&mut rows);
         Ok(rows)
     }
 
-    fn iter_key(
+    fn iter_key<K, V>(
         &self,
-        collection_id: Id,
-        key: &[u8],
-    ) -> Result<Vec<(Vec<u8>, Timestamp, Diff)>, StashError> {
+        collection: StashCollection<K, V>,
+        key: &K,
+    ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
+    where
+        K: Codec + Ord,
+        V: Codec + Ord,
+    {
+        let mut key_buf = vec![];
+        key.encode(&mut key_buf);
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let since = match self.since_tx(&tx, collection_id)?.into_option() {
+        let since = match self.since_tx(&tx, collection.id)?.into_option() {
             Some(since) => since,
             None => {
                 return Err(StashError::from(
@@ -208,34 +217,40 @@ impl StashConn for Sqlite {
                 ));
             }
         };
-        let rows = tx
+        let mut rows = tx
             .prepare(
                 "SELECT value, time, diff FROM data
                  WHERE collection_id = $collection_id AND key = $key",
             )?
             .query_and_then(
                 named_params! {
-                    "$collection_id": collection_id,
-                    "$key": key,
+                    "$collection_id": collection.id,
+                    "$key": key_buf,
                 },
                 |row| {
-                    let value = row.get("value")?;
+                    let value_buf: Vec<_> = row.get("value")?;
+                    let value = V::decode(&value_buf)?;
                     let time = row.get("time")?;
                     let diff = row.get("diff")?;
                     Ok::<_, StashError>((value, cmp::max(time, since), diff))
                 },
             )?
             .collect::<Result<Vec<_>, _>>()?;
+        differential_dataflow::consolidation::consolidate_updates(&mut rows);
         Ok(rows)
     }
 
-    fn update_many<I>(&self, collection_id: Id, entries: I) -> Result<(), StashError>
+    fn update_many<K: Codec, V: Codec, I>(
+        &self,
+        collection: StashCollection<K, V>,
+        entries: I,
+    ) -> Result<(), StashError>
     where
-        I: IntoIterator<Item = ((Vec<u8>, Vec<u8>), Timestamp, Diff)>,
+        I: IntoIterator<Item = ((K, V), Timestamp, Diff)>,
     {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let upper = self.upper_tx(&tx, collection_id)?;
+        let upper = self.upper_tx(&tx, collection.id)?;
         let mut insert_stmt = tx.prepare(
             "INSERT INTO data (collection_id, key, value, time, diff)
              VALUES ($collection_id, $key, $value, $time, $diff)
@@ -245,6 +260,8 @@ impl StashConn for Sqlite {
             "DELETE FROM data
              WHERE collection_id = $collection_id AND key = $key AND value = $value AND time = $time AND diff = 0",
         )?;
+        let mut key_buf = vec![];
+        let mut value_buf = vec![];
         for ((key, value), time, diff) in entries {
             if !upper.less_equal(&time) {
                 return Err(StashError::from(format!(
@@ -253,17 +270,21 @@ impl StashConn for Sqlite {
                     AntichainFormatter(&upper)
                 )));
             }
+            key_buf.clear();
+            value_buf.clear();
+            key.encode(&mut key_buf);
+            value.encode(&mut value_buf);
             insert_stmt.execute(named_params! {
-                "$collection_id": collection_id,
-                "$key": key,
-                "$value": value,
+                "$collection_id": collection.id,
+                "$key": key_buf,
+                "$value": value_buf,
                 "$time": time,
                 "$diff": diff,
             })?;
             delete_stmt.execute(named_params! {
-                "$collection_id": collection_id,
-                "$key": key,
-                "$value": value,
+                "$collection_id": collection.id,
+                "$key": key_buf,
+                "$value": value_buf,
                 "$time": time,
             })?;
         }
@@ -273,14 +294,14 @@ impl StashConn for Sqlite {
         Ok(())
     }
 
-    fn seal(
+    fn seal<K, V>(
         &self,
-        collection_id: Id,
+        collection: StashCollection<K, V>,
         new_upper: AntichainRef<Timestamp>,
     ) -> Result<(), StashError> {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let upper = self.upper_tx(&tx, collection_id)?;
+        let upper = self.upper_tx(&tx, collection.id)?;
         if PartialOrder::less_than(&new_upper, &upper.borrow()) {
             return Err(StashError::from(format!(
                 "seal request {} is less than the current upper frontier {}",
@@ -290,21 +311,21 @@ impl StashConn for Sqlite {
         }
         tx.execute(
             "UPDATE uppers SET upper = $upper WHERE collection_id = $collection_id",
-            named_params! {"$upper": new_upper.as_option(), "$collection_id": collection_id},
+            named_params! {"$upper": new_upper.as_option(), "$collection_id": collection.id},
         )?;
         tx.commit()?;
         Ok(())
     }
 
-    fn compact(
+    fn compact<K, V>(
         &self,
-        collection_id: Id,
+        collection: StashCollection<K, V>,
         new_since: AntichainRef<Timestamp>,
     ) -> Result<(), StashError> {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let since = self.since_tx(&tx, collection_id)?;
-        let upper = self.upper_tx(&tx, collection_id)?;
+        let since = self.since_tx(&tx, collection.id)?;
+        let upper = self.upper_tx(&tx, collection.id)?;
         if PartialOrder::less_than(&upper.borrow(), &new_since) {
             return Err(StashError::from(format!(
                 "compact request {} is greater than the current upper frontier {}",
@@ -321,16 +342,16 @@ impl StashConn for Sqlite {
         }
         tx.execute(
             "UPDATE sinces SET since = $since WHERE collection_id = $collection_id",
-            named_params! {"$since": new_since.as_option(), "$collection_id": collection_id},
+            named_params! {"$since": new_since.as_option(), "$collection_id": collection.id},
         )?;
         tx.commit()?;
         Ok(())
     }
 
-    fn consolidate(&self, collection_id: Id) -> Result<(), StashError> {
+    fn consolidate<K, V>(&self, collection: StashCollection<K, V>) -> Result<(), StashError> {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let since = self.since_tx(&tx, collection_id)?.into_option();
+        let since = self.since_tx(&tx, collection.id)?.into_option();
         match since {
             Some(since) => {
                 tx.execute(
@@ -340,14 +361,14 @@ impl StashConn for Sqlite {
                      GROUP BY key, value
                      ON CONFLICT (collection_id, key, value, time) DO UPDATE SET diff = diff + excluded.diff",
                     named_params! {
-                        "$collection_id": collection_id,
+                        "$collection_id": collection.id,
                         "$since": since,
                     },
                 )?;
                 tx.execute(
                     "DELETE FROM data WHERE collection_id = $collection_id AND time < $since",
                     named_params! {
-                        "$collection_id": collection_id,
+                        "$collection_id": collection.id,
                         "$since": since,
                     },
                 )?;
@@ -356,7 +377,7 @@ impl StashConn for Sqlite {
                 tx.execute(
                     "DELETE FROM data WHERE collection_id = $collection_id",
                     named_params! {
-                        "$collection_id": collection_id,
+                        "$collection_id": collection.id,
                     },
                 )?;
             }
@@ -366,19 +387,25 @@ impl StashConn for Sqlite {
     }
 
     /// Reports the current since frontier.
-    fn since(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
+    fn since<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Antichain<Timestamp>, StashError> {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let since = self.since_tx(&tx, collection_id)?;
+        let since = self.since_tx(&tx, collection.id)?;
         tx.commit()?;
         Ok(since)
     }
 
     /// Reports the current upper frontier.
-    fn upper(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
+    fn upper<K, V>(
+        &self,
+        collection: StashCollection<K, V>,
+    ) -> Result<Antichain<Timestamp>, StashError> {
         let mut conn = self.conn.lock().expect("lock poisoned");
         let tx = conn.transaction()?;
-        let upper = self.upper_tx(&tx, collection_id)?;
+        let upper = self.upper_tx(&tx, collection.id)?;
         tx.commit()?;
         Ok(upper)
     }

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -77,11 +77,11 @@ impl Action for VerifyTimestampCompactionAction {
                             })?
                             .id();
 
-                        let stash = Stash::new(mz_stash::Sqlite::open(&path.join("storage"))?);
+                        let stash = mz_stash::Sqlite::open(&path.join("storage"))?;
                         let collection = stash
                             .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}"))?;
-                        let bindings: Vec<(PartitionId, u64, MzOffset)> = collection
-                            .iter()?
+                        let bindings: Vec<(PartitionId, u64, MzOffset)> = stash.iter(collection)?
+                            .into_iter()
                             .map(|((pid, _), ts, offset)| {
                                 (
                                     pid,


### PR DESCRIPTION
### Motivation

After the switch to using `Stash` as the durable storage for timestamp bindings performance took a bit hit because the number of durable operations scaled with the number of objects that we needed to operate on.

This PR rewords the Stash API to allow batched operations which should bring back the lost performance. 
### Tips for reviewer

Commit by commit recommended

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Once normal CI passes we should fire a nightly run to verify that we're back at the previous performance levels.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
