### PR TITLE
repr: add protobuf for (Var)CharLength, NumericMaxScale

### DIFF
--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -10,7 +10,14 @@
 fn main() {
     prost_build::Config::new()
         .compile_protos(
-            &["adt/array.proto", "row.proto", "strconv.proto"],
+            &[
+                "row.proto",
+                "strconv.proto",
+                "adt/array.proto",
+                "adt/char.proto",
+                "adt/numeric.proto",
+                "adt/varchar.proto",
+            ],
             &["src/proto"],
         )
         .unwrap();

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -35,7 +35,7 @@ pub struct Char<S: AsRef<str>>(pub S);
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, MzReflect,
 )]
-pub struct CharLength(u32);
+pub struct CharLength(pub(crate) u32);
 
 impl CharLength {
     /// A length of one.

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -80,7 +80,7 @@ lazy_static! {
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, MzReflect,
 )]
-pub struct NumericMaxScale(u8);
+pub struct NumericMaxScale(pub(crate) u8);
 
 impl NumericMaxScale {
     /// A max scale of zero.

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -35,7 +35,7 @@ pub struct VarChar<S: AsRef<str>>(pub S);
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, MzReflect,
 )]
-pub struct VarCharMaxLength(u32);
+pub struct VarCharMaxLength(pub(crate) u32);
 
 impl VarCharMaxLength {
     /// Consumes the newtype wrapper, returning the inner `u32`.

--- a/src/repr/src/proto/adt/char.proto
+++ b/src/repr/src/proto/adt/char.proto
@@ -7,9 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Protobuf structs mirroring [`crate::adt`].
+syntax = "proto3";
 
-pub mod array;
-pub mod char;
-pub mod numeric;
-pub mod varchar;
+package adt.char;
+
+message ProtoCharLength {
+    uint32 value = 1;
+}

--- a/src/repr/src/proto/adt/char.rs
+++ b/src/repr/src/proto/adt/char.rs
@@ -1,0 +1,29 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::adt::char`].
+
+include!(concat!(env!("OUT_DIR"), "/adt.char.rs"));
+
+use crate::adt::char::CharLength;
+use crate::proto::TryFromProtoError;
+
+impl TryFrom<ProtoCharLength> for CharLength {
+    type Error = TryFromProtoError;
+
+    fn try_from(repr: ProtoCharLength) -> Result<Self, Self::Error> {
+        Ok(CharLength(repr.value))
+    }
+}
+
+impl From<&CharLength> for ProtoCharLength {
+    fn from(x: &CharLength) -> Self {
+        ProtoCharLength { value: x.0 }
+    }
+}

--- a/src/repr/src/proto/adt/char.rs
+++ b/src/repr/src/proto/adt/char.rs
@@ -14,16 +14,16 @@ include!(concat!(env!("OUT_DIR"), "/adt.char.rs"));
 use crate::adt::char::CharLength;
 use crate::proto::TryFromProtoError;
 
+impl From<&CharLength> for ProtoCharLength {
+    fn from(x: &CharLength) -> Self {
+        ProtoCharLength { value: x.0 }
+    }
+}
+
 impl TryFrom<ProtoCharLength> for CharLength {
     type Error = TryFromProtoError;
 
     fn try_from(repr: ProtoCharLength) -> Result<Self, Self::Error> {
         Ok(CharLength(repr.value))
-    }
-}
-
-impl From<&CharLength> for ProtoCharLength {
-    fn from(x: &CharLength) -> Self {
-        ProtoCharLength { value: x.0 }
     }
 }

--- a/src/repr/src/proto/adt/numeric.proto
+++ b/src/repr/src/proto/adt/numeric.proto
@@ -7,9 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Protobuf structs mirroring [`crate::adt`].
+syntax = "proto3";
 
-pub mod array;
-pub mod char;
-pub mod numeric;
-pub mod varchar;
+package adt.numeric;
+
+message ProtoNumericMaxScale {
+    uint32 value = 1;
+}

--- a/src/repr/src/proto/adt/numeric.rs
+++ b/src/repr/src/proto/adt/numeric.rs
@@ -1,0 +1,31 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::adt::numeric`].
+
+include!(concat!(env!("OUT_DIR"), "/adt.numeric.rs"));
+
+use crate::adt::numeric::NumericMaxScale;
+use crate::proto::{ProtoRepr, TryFromProtoError};
+
+impl TryFrom<ProtoNumericMaxScale> for NumericMaxScale {
+    type Error = TryFromProtoError;
+
+    fn try_from(repr: ProtoNumericMaxScale) -> Result<Self, Self::Error> {
+        Ok(NumericMaxScale(u8::from_proto(repr.value)?))
+    }
+}
+
+impl From<&NumericMaxScale> for ProtoNumericMaxScale {
+    fn from(value: &NumericMaxScale) -> Self {
+        ProtoNumericMaxScale {
+            value: value.0.into_proto(),
+        }
+    }
+}

--- a/src/repr/src/proto/adt/numeric.rs
+++ b/src/repr/src/proto/adt/numeric.rs
@@ -14,18 +14,18 @@ include!(concat!(env!("OUT_DIR"), "/adt.numeric.rs"));
 use crate::adt::numeric::NumericMaxScale;
 use crate::proto::{ProtoRepr, TryFromProtoError};
 
-impl TryFrom<ProtoNumericMaxScale> for NumericMaxScale {
-    type Error = TryFromProtoError;
-
-    fn try_from(repr: ProtoNumericMaxScale) -> Result<Self, Self::Error> {
-        Ok(NumericMaxScale(u8::from_proto(repr.value)?))
-    }
-}
-
 impl From<&NumericMaxScale> for ProtoNumericMaxScale {
     fn from(value: &NumericMaxScale) -> Self {
         ProtoNumericMaxScale {
             value: value.0.into_proto(),
         }
+    }
+}
+
+impl TryFrom<ProtoNumericMaxScale> for NumericMaxScale {
+    type Error = TryFromProtoError;
+
+    fn try_from(repr: ProtoNumericMaxScale) -> Result<Self, Self::Error> {
+        Ok(NumericMaxScale(u8::from_proto(repr.value)?))
     }
 }

--- a/src/repr/src/proto/adt/varchar.proto
+++ b/src/repr/src/proto/adt/varchar.proto
@@ -7,9 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Protobuf structs mirroring [`crate::adt`].
+syntax = "proto3";
 
-pub mod array;
-pub mod char;
-pub mod numeric;
-pub mod varchar;
+package adt.varchar;
+
+message ProtoVarCharMaxLength {
+    uint32 value = 1;
+}

--- a/src/repr/src/proto/adt/varchar.rs
+++ b/src/repr/src/proto/adt/varchar.rs
@@ -14,16 +14,16 @@ include!(concat!(env!("OUT_DIR"), "/adt.varchar.rs"));
 use crate::adt::varchar::VarCharMaxLength;
 use crate::proto::TryFromProtoError;
 
+impl From<&VarCharMaxLength> for ProtoVarCharMaxLength {
+    fn from(value: &VarCharMaxLength) -> Self {
+        ProtoVarCharMaxLength { value: value.0 }
+    }
+}
+
 impl TryFrom<ProtoVarCharMaxLength> for VarCharMaxLength {
     type Error = TryFromProtoError;
 
     fn try_from(repr: ProtoVarCharMaxLength) -> Result<Self, Self::Error> {
         Ok(VarCharMaxLength(repr.value))
-    }
-}
-
-impl From<&VarCharMaxLength> for ProtoVarCharMaxLength {
-    fn from(value: &VarCharMaxLength) -> Self {
-        ProtoVarCharMaxLength { value: value.0 }
     }
 }

--- a/src/repr/src/proto/adt/varchar.rs
+++ b/src/repr/src/proto/adt/varchar.rs
@@ -1,0 +1,29 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::adt::varchar`].
+
+include!(concat!(env!("OUT_DIR"), "/adt.varchar.rs"));
+
+use crate::adt::varchar::VarCharMaxLength;
+use crate::proto::TryFromProtoError;
+
+impl TryFrom<ProtoVarCharMaxLength> for VarCharMaxLength {
+    type Error = TryFromProtoError;
+
+    fn try_from(repr: ProtoVarCharMaxLength) -> Result<Self, Self::Error> {
+        Ok(VarCharMaxLength(repr.value))
+    }
+}
+
+impl From<&VarCharMaxLength> for ProtoVarCharMaxLength {
+    fn from(value: &VarCharMaxLength) -> Self {
+        ProtoVarCharMaxLength { value: value.0 }
+    }
+}

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -116,6 +116,18 @@ impl ProtoRepr for char {
     }
 }
 
+impl ProtoRepr for u8 {
+    type Repr = u32;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        self as u32
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        u8::try_from(repr).map_err(TryFromProtoError::TryFromIntError)
+    }
+}
+
 impl<T: ProtoRepr> ProtoRepr for Option<T> {
     type Repr = Option<T::Repr>;
 


### PR DESCRIPTION
### Motivation

This is a follow up for PR #11489 and adds Protobuf (de-) serialization for `VarCharLength`, `NumericMaxScale`, `CharLength` .

### Tips for reviewer

 * The only interesting thing is that i had to implement `ProtoRepr` for `u8` .

### Testing

We will add protobuf tests in a later PR.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
