### PR TITLE
repr: add `strconv.proto`

### DIFF
--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -9,6 +9,9 @@
 
 fn main() {
     prost_build::Config::new()
-        .compile_protos(&["row.proto", "adt/array.proto"], &["src/proto"])
+        .compile_protos(
+            &["adt/array.proto", "row.proto", "strconv.proto"],
+            &["src/proto"],
+        )
         .unwrap();
 }

--- a/src/repr/src/proto/adt/array.rs
+++ b/src/repr/src/proto/adt/array.rs
@@ -14,8 +14,8 @@ include!(concat!(env!("OUT_DIR"), "/adt.array.rs"));
 use super::super::{ProtoRepr, TryFromProtoError};
 use crate::adt::array::InvalidArrayError;
 
-impl From<InvalidArrayError> for ProtoInvalidArrayError {
-    fn from(error: InvalidArrayError) -> Self {
+impl From<&InvalidArrayError> for ProtoInvalidArrayError {
+    fn from(error: &InvalidArrayError) -> Self {
         use proto_invalid_array_error::*;
         use Kind::*;
         let kind = match error {

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -13,13 +13,14 @@ pub mod adt;
 pub mod row;
 
 use mz_ore::cast::CastFrom;
-use std::num::TryFromIntError;
+use std::{char::CharTryFromError, num::TryFromIntError};
 
 /// An error thrown when trying to convert from a `*.proto`-generated type
 /// `Proto$T` to `$T`.
 #[derive(Debug)]
 pub enum TryFromProtoError {
     TryFromIntError(TryFromIntError),
+    CharTryFromError(CharTryFromError),
     MissingField(String),
     InvalidChar(String),
 }
@@ -36,11 +37,18 @@ impl From<TryFromIntError> for TryFromProtoError {
     }
 }
 
+impl From<CharTryFromError> for TryFromProtoError {
+    fn from(error: CharTryFromError) -> Self {
+        TryFromProtoError::CharTryFromError(error)
+    }
+}
+
 impl std::fmt::Display for TryFromProtoError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use TryFromProtoError::*;
         match self {
             TryFromIntError(error) => error.fmt(f),
+            CharTryFromError(error) => error.fmt(f),
             MissingField(field) => write!(f, "Missing value for `{}`", field),
             InvalidChar(str) => write!(f, "String '{}' does not encode a single UTF8 char", str),
         }
@@ -52,6 +60,7 @@ impl std::error::Error for TryFromProtoError {
         use TryFromProtoError::*;
         match self {
             TryFromIntError(error) => Some(error),
+            CharTryFromError(error) => Some(error),
             MissingField(_) | InvalidChar(_) => None,
         }
     }
@@ -95,17 +104,14 @@ impl ProtoRepr for usize {
 }
 
 impl ProtoRepr for char {
-    type Repr = String;
+    type Repr = u32;
 
     fn into_proto(self: Self) -> Self::Repr {
-        self.to_string()
+        self.into()
     }
 
     fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
-        match repr.len() {
-            1 => Ok(repr.chars().next().unwrap()),
-            _ => Err(TryFromProtoError::InvalidChar(repr)),
-        }
+        char::try_from(repr).map_err(|err| err.into())
     }
 }
 

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod adt;
 pub mod row;
+pub mod strconv;
 
 use mz_ore::cast::CastFrom;
 use std::{char::CharTryFromError, num::TryFromIntError};

--- a/src/repr/src/proto/row.proto
+++ b/src/repr/src/proto/row.proto
@@ -65,15 +65,15 @@ enum ProtoDatumOther {
     // This enum is initially used only in a oneof, which means we can
     // distinguish unset without this sentinel. But stick one in here anyway,
     // in case this enum gets used somewhere else in the future.
-    Unknown = 0;
-    Null = 1;
-    False = 2;
-    True = 3;
-    JsonNull = 4;
-    Dummy = 5;
-    NumericPosInf = 6;
-    NumericNegInf = 7;
-    NumericNaN = 8;
+    UNKNOWN = 0;
+    NULL = 1;
+    FALSE = 2;
+    TRUE = 3;
+    JSON_NULL = 4;
+    DUMMY = 5;
+    NUMERIC_POS_INF = 6;
+    NUMERIC_NEG_INF = 7;
+    NUMERIC_NA_N = 8;
 }
 
 message ProtoDate {

--- a/src/repr/src/proto/strconv.proto
+++ b/src/repr/src/proto/strconv.proto
@@ -1,0 +1,31 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package strconv;
+
+message ProtoParseError {
+    oneof kind {
+        google.protobuf.Empty out_of_range = 1;
+        google.protobuf.Empty invalid_input_syntax = 2;
+    }
+    string type_name = 1001;
+    string input = 1002;
+    optional string details = 1003;
+}
+
+message ProtoParseHexError {
+    oneof kind {
+        uint32 invalid_hex_digit = 1;
+        google.protobuf.Empty odd_length = 2;
+    }
+}

--- a/src/repr/src/proto/strconv.rs
+++ b/src/repr/src/proto/strconv.rs
@@ -1,0 +1,82 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::adt::array`].
+include!(concat!(env!("OUT_DIR"), "/strconv.rs"));
+
+use super::{ProtoRepr, TryFromProtoError};
+use crate::strconv::{ParseError, ParseErrorKind, ParseHexError};
+
+impl From<&ParseError> for ProtoParseError {
+    fn from(error: &ParseError) -> Self {
+        use proto_parse_error::*;
+        use Kind::*;
+        let kind = match error.kind {
+            ParseErrorKind::OutOfRange => OutOfRange(()),
+            ParseErrorKind::InvalidInputSyntax => InvalidInputSyntax(()),
+        };
+        ProtoParseError {
+            kind: Some(kind),
+            type_name: error.type_name.clone(),
+            input: error.input.clone(),
+            details: error.details.clone(),
+        }
+    }
+}
+
+impl TryFrom<ProtoParseError> for ParseError {
+    type Error = TryFromProtoError;
+
+    fn try_from(error: ProtoParseError) -> Result<Self, Self::Error> {
+        use proto_parse_error::Kind::*;
+
+        if let Some(kind) = error.kind {
+            Ok(ParseError {
+                kind: match kind {
+                    OutOfRange(()) => ParseErrorKind::OutOfRange,
+                    InvalidInputSyntax(()) => ParseErrorKind::InvalidInputSyntax,
+                },
+                type_name: error.type_name,
+                input: error.input,
+                details: error.details,
+            })
+        } else {
+            Err(TryFromProtoError::missing_field("`ProtoParseError::kind`"))
+        }
+    }
+}
+
+impl From<&ParseHexError> for ProtoParseHexError {
+    fn from(error: &ParseHexError) -> Self {
+        use proto_parse_hex_error::*;
+        use Kind::*;
+        let kind = match error {
+            ParseHexError::InvalidHexDigit(v) => InvalidHexDigit(v.into_proto()),
+            ParseHexError::OddLength => OddLength(()),
+        };
+        ProtoParseHexError { kind: Some(kind) }
+    }
+}
+
+impl TryFrom<ProtoParseHexError> for ParseHexError {
+    type Error = TryFromProtoError;
+
+    fn try_from(error: ProtoParseHexError) -> Result<Self, Self::Error> {
+        use proto_parse_hex_error::Kind::*;
+        match error.kind {
+            Some(kind) => match kind {
+                InvalidHexDigit(v) => Ok(ParseHexError::InvalidHexDigit(char::from_proto(v)?)),
+                OddLength(()) => Ok(ParseHexError::OddLength),
+            },
+            None => Err(TryFromProtoError::missing_field(
+                "`ProtoParseHexError::kind`",
+            )),
+        }
+    }
+}

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -1408,10 +1408,10 @@ where
 /// An error while parsing an input as a type.
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct ParseError {
-    kind: ParseErrorKind,
-    type_name: String,
-    input: String,
-    details: Option<String>,
+    pub(crate) kind: ParseErrorKind,
+    pub(crate) type_name: String,
+    pub(crate) input: String,
+    pub(crate) details: Option<String>,
 }
 
 #[derive(


### PR DESCRIPTION
Adds `Proto$T` types and `From` and `TryFrom` conversions for error types defined in `strconv.rs`

### Motivation

* This PR adds a feature that has not yet been specified.

This is needed in preparation for the upcoming Protobuf support for LIR expressions.

### Tips for reviewer

As part of this PR I am also fixing some issues discussed offline (changes can be found in the individual commits).

1. repr: use `char::Repr` = u32` in `ProtoRepr`
1. repr: use reference in `From<&InvalidArrayError>`
1. repr: fix warnings due to wrong case in `row.proto` enum.

@danhhz please check the last item.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A
