### PR TITLE
orchestrator: improve port naming and service labeling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,6 +3344,7 @@ dependencies = [
  "globset",
  "http",
  "http-serde",
+ "maplit",
  "mz-aws-util",
  "mz-ccsr",
  "mz-expr",
@@ -3662,7 +3663,6 @@ dependencies = [
  "dyn-clonable",
  "k8s-openapi",
  "kube",
- "maplit",
  "mz-orchestrator",
 ]
 

--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -74,6 +74,8 @@ spec:
             - --data-directory=/data
             - --dev
             - --orchestrator=kubernetes
+            - --orchestrator-service-label=materialize.cloud/example1=label1
+            - --orchestrator-service-label=materialize.cloud/example2=label2
             - --experimental
         ports:
         - containerPort: 6875

--- a/doc/developer/platform/architecture-cloud.md
+++ b/doc/developer/platform/architecture-cloud.md
@@ -32,9 +32,50 @@ The STORAGE and COMPUTE layers each turn on instances by creating services in
 an [`Orchestrator`]. An `Orchestrator` is backed by Kubernetes in the cloud,
 and a service corresponds directly to a `StatefulSet`. This may evolve soon.
 
+All ports created by the orchestrator have names.
+
+The Kubernetes orchestrator installs the following labels on all services and
+pods that it creates:
+
+  * `materialized.materialize.cloud/namespace`: the orchestrator "subnamespace"
+    in which the service is created. Either `storage` or `compute` at present.
+
+  * `materialized.materialize.cloud/service-id`: the namespace-provided
+    identifier for the service, like "cluster-0" or "runtime".
+
+  * `materialized.materialize.cloud/port-PORT=true`: A label for each named port
+    exposed by the service.
+
+  * `NAMESPACE.materialized.materialize.cloud/KEY`: arbitrary labels assigned
+    at service creation time, prefixed with the `NamespacedOrchestrator`
+    that created the label.
+
+Additionally, the service that invokes `materialized` can pass
+`--orchestrator-service-label` to specify additional labels that should be
+attached to *all* pods and services created by the Kubernetes orchestrator.
+
 ### Secrets
 
 See the [secret design doc](../design/20220303_secrets.md).
+
+## Binaries
+
+There are presently two binaries involved in Materialize Platform:
+
+  * `materialized`, which hosts the controller
+  * `dataflowd`, which hosts either a storage runtime or a compute runtime
+    depending on the `--runtime` option
+
+There are three separate network protocols:
+
+  * The **controller** protocol, which is how `materialized` communicates with
+    `dataflowd`. This protocol is conventionally hosted on port 2100.
+
+  * The **storage** protocol, which is how the compute runtime communicates with
+    the storage runtime. This protocol is conventionally hosted on port 2101.
+
+  * The **compute** protocol, which is how compute nodes communicate with one
+    another. This protocol is conventionally hosted on port 2102.
 
 ## Terraform provider
 

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.21"
 globset = { version = "0.4.8", features = ["serde1"] }
 http = "0.2.6"
 http-serde = "1.1.0"
+maplit = "1.0.2"
 mz-aws-util = { path = "../aws-util" }
 mz-ccsr = { path = "../ccsr" }
 mz-expr = { path = "../expr" }

--- a/src/dataflowd/ci/Dockerfile
+++ b/src/dataflowd/ci/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update && apt-get -qy install ca-certificates curl tini
 
 COPY kdestroy kinit dataflowd /usr/local/bin/
 
-ENTRYPOINT ["tini", "--", "dataflowd", "--listen-addr=0.0.0.0:6876"]
+ENTRYPOINT ["tini", "--", "dataflowd", "--listen-addr=0.0.0.0:2100"]

--- a/src/dataflowd/src/bin/dataflowd.rs
+++ b/src/dataflowd/src/bin/dataflowd.rs
@@ -40,12 +40,12 @@ enum RuntimeType {
 /// Independent dataflow server for Materialize.
 #[derive(clap::Parser)]
 struct Args {
-    /// The address on which to listen for a connection from the coordinator.
+    /// The address on which to listen for a connection from the controller.
     #[clap(
         long,
         env = "DATAFLOWD_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "127.0.0.1:6876"
+        default_value = "127.0.0.1:2100"
     )]
     listen_addr: String,
     /// Number of dataflow worker threads.
@@ -92,7 +92,7 @@ struct Args {
         long,
         env = "DATAFLOWD_STORAGE_ADDR",
         value_name = "HOST:PORT",
-        default_value = "127.0.0.1:6877"
+        default_value = "127.0.0.1:2101"
     )]
     storage_addr: String,
     #[clap(long)]
@@ -120,7 +120,7 @@ fn create_communication_config(args: &Args) -> Result<timely::CommunicationConfi
         let mut addresses = Vec::new();
         if args.hosts.is_empty() {
             for index in 0..processes {
-                addresses.push(format!("localhost:{}", 2101 + index));
+                addresses.push(format!("localhost:{}", 2102 + index));
             }
         } else {
             if let Ok(file) = ::std::fs::File::open(args.hosts[0].clone()) {

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 anyhow = "1.0.56"
 async-trait = "0.1.53"
 dyn-clonable = "0.9.0"
-maplit = "1.0.2"
 mz-orchestrator = { path = "../orchestrator" }
 k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
 kube = { version = "0.70.0", features = ["ws"] }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
 use std::fmt;
 
 use async_trait::async_trait;
@@ -69,13 +70,29 @@ pub struct ServiceConfig {
     /// Arguments for the process.
     pub args: Vec<String>,
     /// Ports to expose.
-    pub ports: Vec<i32>,
+    pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.
     pub memory_limit: Option<MemoryLimit>,
     /// An optional limit on the CPU that the service can use.
     pub cpu_limit: Option<CpuLimit>,
     /// The number of processes to run.
     pub processes: usize,
+    /// Arbitrary key–value pairs to attach to the service in the orchestrator
+    /// backend.
+    ///
+    /// The orchestrator backend may apply a prefix to the key if appropriate.
+    pub labels: HashMap<String, String>,
+}
+
+/// A named port associated with a service.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServicePort {
+    /// A descriptive name for the port.
+    ///
+    /// Note that not all orchestrator backends make use of port names.
+    pub name: String,
+    /// The port number.
+    pub port: i32,
 }
 
 /// Describes a limit on memory resources.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -26,31 +26,31 @@ SERVICES = [
     SchemaRegistry(),
     Dataflowd(
         name="dataflowd_compute_1",
-        options="--workers 2 --processes 2 --process 0 dataflowd_compute_1:2101 dataflowd_compute_2:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
-        ports=[6876, 2101],
+        options="--workers 2 --processes 2 --process 0 dataflowd_compute_1:2102 dataflowd_compute_2:2102 --storage-addr dataflowd_storage:2101 --runtime compute",
+        ports=[2100, 2102],
     ),
     Dataflowd(
         name="dataflowd_compute_2",
-        options="--workers 2 --processes 2 --process 1 dataflowd_compute_1:2101 dataflowd_compute_2:2101 --storage-addr dataflowd_storage:2102 --runtime compute",
-        ports=[6876, 2101],
+        options="--workers 2 --processes 2 --process 1 dataflowd_compute_1:2102 dataflowd_compute_2:2102 --storage-addr dataflowd_storage:2101 --runtime compute",
+        ports=[2100, 2102],
     ),
     Dataflowd(
         name="dataflowd_compute_3",
-        options="--workers 2 --processes 2 --process 0 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute --linger --reconcile",
-        ports=[6876, 2101],
+        options="--workers 2 --processes 2 --process 0 dataflowd_compute_3:2102 dataflowd_compute_4:2102 --storage-addr dataflowd_storage:2101 --runtime compute --linger --reconcile",
+        ports=[2100, 2102],
     ),
     Dataflowd(
         name="dataflowd_compute_4",
-        options="--workers 2 --processes 2 --process 1 dataflowd_compute_3:2101 dataflowd_compute_4:2101 --storage-addr dataflowd_storage:2102 --runtime compute --linger --reconcile",
-        ports=[6876, 2101],
+        options="--workers 2 --processes 2 --process 1 dataflowd_compute_3:2102 dataflowd_compute_4:2102 --storage-addr dataflowd_storage:2101 --runtime compute --linger --reconcile",
+        ports=[2100, 2102],
     ),
     Dataflowd(
         name="dataflowd_storage",
-        options="--workers 2 --storage-addr dataflowd_storage:2102 --runtime storage",
-        ports=[6876, 2102],
+        options="--workers 2 --storage-addr dataflowd_storage:2101 --runtime storage",
+        ports=[2100, 2101],
     ),
     Materialized(
-        options="--storage-compute-addr=dataflowd_storage:2102 --storage-controller-addr=dataflowd_storage:6876",
+        options="--storage-compute-addr=dataflowd_storage:2101 --storage-controller-addr=dataflowd_storage:2100",
     ),
     Testdrive(
         volumes=[
@@ -92,7 +92,7 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.up("dataflowd_compute_1")
     c.up("dataflowd_compute_2")
     c.sql(
-        "CREATE CLUSTER c REMOTE replica1 ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876');"
+        "CREATE CLUSTER c REMOTE replica1 ('dataflowd_compute_1:2100', 'dataflowd_compute_2:2100');"
     )
     c.run("testdrive", *glob)
 
@@ -102,8 +102,8 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.sql(
         """
         ALTER CLUSTER c
-            REMOTE replica1 ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876'),
-            REMOTE replica2 ('dataflowd_compute_3:6876', 'dataflowd_compute_4:6876')
+            REMOTE replica1 ('dataflowd_compute_1:2100', 'dataflowd_compute_2:2100'),
+            REMOTE replica2 ('dataflowd_compute_3:2100', 'dataflowd_compute_4:2100')
         """
     )
     c.run("testdrive", *glob)
@@ -118,13 +118,13 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.sql(
         """
         ALTER CLUSTER c
-            REMOTE replica1 ('dataflowd_compute_1:6876', 'dataflowd_compute_2:6876')
+            REMOTE replica1 ('dataflowd_compute_1:2100', 'dataflowd_compute_2:2100')
         """
     )
     c.sql(
         """
         ALTER CLUSTER c
-            REMOTE replica2 ('dataflowd_compute_3:6876', 'dataflowd_compute_4:6876')
+            REMOTE replica2 ('dataflowd_compute_3:2100', 'dataflowd_compute_4:2100')
         """
     )
     c.run("testdrive", "smoke/insert-select.td")


### PR DESCRIPTION
Add names to ports in orchestrator services. Also add a consistent
labeling scheme, including the ability for the `materialized` operator
to specify labels that will be attached to all pods.

The known ports and labels are described in architecture-cloud.md.

This is the materialized half of MaterializeInc/cloud#2608.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
