### PR TITLE
persist: make API structs Send + Sync

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -30,7 +30,7 @@ use crate::Id;
 
 #[derive(Debug)]
 pub struct Machine<K, V, T, D> {
-    consensus: Arc<dyn Consensus>,
+    consensus: Arc<dyn Consensus + Send + Sync>,
 
     seqno: Option<SeqNo>,
     state: State<K, V, T, D>,
@@ -54,7 +54,7 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64,
 {
-    pub fn new(id: Id, consensus: Arc<dyn Consensus>) -> Self {
+    pub fn new(id: Id, consensus: Arc<dyn Consensus + Send + Sync>) -> Self {
         Machine {
             consensus,
             seqno: None,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -70,7 +70,7 @@ pub struct SnapshotSplit {
 pub struct SnapshotIter<K, V, T, D> {
     as_of: Antichain<T>,
     batches: Vec<String>,
-    blob: Arc<dyn BlobMulti>,
+    blob: Arc<dyn BlobMulti + Send + Sync>,
     _phantom: PhantomData<(K, V, T, D)>,
 }
 
@@ -207,7 +207,7 @@ pub struct Listen<K, V, T, D> {
     as_of: Antichain<T>,
     frontier: Antichain<T>,
     machine: Machine<K, V, T, D>,
-    blob: Arc<dyn BlobMulti>,
+    blob: Arc<dyn BlobMulti + Send + Sync>,
 }
 
 impl<K, V, T, D> Listen<K, V, T, D>
@@ -326,7 +326,7 @@ where
 {
     pub(crate) reader_id: ReaderId,
     pub(crate) machine: Machine<K, V, T, D>,
-    pub(crate) blob: Arc<dyn BlobMulti>,
+    pub(crate) blob: Arc<dyn BlobMulti + Send + Sync>,
 
     pub(crate) since: Antichain<T>,
 }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -65,7 +65,7 @@ where
 {
     pub(crate) writer_id: WriterId,
     pub(crate) machine: Machine<K, V, T, D>,
-    pub(crate) blob: Arc<dyn BlobMulti>,
+    pub(crate) blob: Arc<dyn BlobMulti + Send + Sync>,
 
     pub(crate) upper: Antichain<T>,
 }


### PR DESCRIPTION
This makes them usable in async tasks, where Futures need to be Send +
Sync.

We add the constraints to where traits are used as opposed to adding
them on the traits directly because the constraints come from the API
and are not needed on the BlobMulti and Consensus traits in general.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.