### PR TITLE
devsite: Upload all, not only index

### DIFF
--- a/ci/deploy/devsite.sh
+++ b/ci/deploy/devsite.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-aws s3 cp misc/www/index.html s3://materialize-dev-website/index.html
+aws s3 cp --recursive misc/www/ s3://materialize-dev-website/
 
 bin/doc
 aws s3 sync --size-only target-xcompile/doc/ s3://materialize-dev-website/api/rust


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug: Upload the whole `misc/www` directory instead of only `index.html`.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
