### PR TITLE
testdrive: Avoid unnecessary storage copies

### DIFF
--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -35,7 +35,7 @@ use mz_sql_parser::ast::{
 
 use crate::action::{Action, ControlFlow, State};
 use crate::parser::{FailSqlCommand, SqlCommand, SqlErrorMatchType, SqlOutput};
-use crate::util::mz_data::mzdata_copy;
+use crate::util::mz_data::catalog_copy;
 
 pub struct SqlAction {
     cmd: SqlCommand,
@@ -191,7 +191,7 @@ impl Action for SqlAction {
                 | Statement::CreateView { .. }
                 | Statement::DropDatabase { .. }
                 | Statement::DropObjects { .. } => {
-                    let temp_mzdata = mzdata_copy(path)?;
+                    let temp_mzdata = catalog_copy(path)?;
                     let path = temp_mzdata.path();
                     let disk_state = Catalog::open_debug(&path, NOW_ZERO.clone()).await?.dump();
                     let mem_state = reqwest::get(&format!(

--- a/src/testdrive/src/util/mz_data.rs
+++ b/src/testdrive/src/util/mz_data.rs
@@ -30,3 +30,16 @@ pub fn mzdata_copy(catalog_path: &PathBuf) -> Result<TempDir, anyhow::Error> {
     )?;
     Ok(temp_dir)
 }
+
+/// Creates a temporary copy of Materialize's mzdata's catalog databases
+///
+/// This is useful because running validations against the catalog can conflict with the running
+/// Materialize instance. Therefore it's better to run validations on a copy of the catalog.
+pub fn catalog_copy(catalog_path: &PathBuf) -> Result<TempDir, anyhow::Error> {
+    let temp_dir = tempfile::tempdir()?;
+    fs::copy(
+        catalog_path.join(CATALOG_DB_NAME),
+        temp_dir.path().join(CATALOG_DB_NAME),
+    )?;
+    Ok(temp_dir)
+}


### PR DESCRIPTION
Avoids unnecessarily copying the SQLite storage DB during Testdrive

### Motivation
This PR refactors existing code.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes.
