### PR TITLE
persist: hook up transmissible Location to Client construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "timely",
  "tokio",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -53,6 +53,7 @@ serde = { version = "1.0.136", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread"] }
 tracing = "0.1.32"
+url = "2.2.2"
 uuid = { version = "0.8.2", features = ["v4"] }
 
 [dev-dependencies]

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -1,0 +1,145 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Configuration for [crate::location] implementations.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::anyhow;
+use url::Url;
+
+use crate::file::{FileBlobConfig, FileBlobMulti};
+use crate::location::{BlobMulti, Consensus, ExternalError};
+use crate::s3::{S3BlobConfig, S3BlobMulti};
+use crate::sqlite::SqliteConsensus;
+
+/// Config for an implementation of [BlobMulti].
+#[derive(Debug)]
+pub enum BlobMultiConfig {
+    /// Config for [FileBlobMulti].
+    File(FileBlobConfig),
+    /// Config for [S3BlobMulti].
+    S3(S3BlobConfig),
+}
+
+impl BlobMultiConfig {
+    /// Opens the associated implementation of [BlobMulti].
+    pub async fn open(self, deadline: Instant) -> Result<Arc<dyn BlobMulti>, ExternalError> {
+        match self {
+            BlobMultiConfig::File(config) => FileBlobMulti::open(deadline, config)
+                .await
+                .map(|x| Arc::new(x) as Arc<dyn BlobMulti>),
+            BlobMultiConfig::S3(config) => S3BlobMulti::open(deadline, config)
+                .await
+                .map(|x| Arc::new(x) as Arc<dyn BlobMulti>),
+        }
+    }
+
+    /// Parses a [BlobMulti] config from a uri string.
+    pub async fn try_from(value: &str) -> Result<Self, ExternalError> {
+        let url = Url::parse(value)
+            .map_err(|err| anyhow!("failed to parse blob location {} as a url: {}", &value, err))?;
+        let mut query_params = url.query_pairs().collect::<HashMap<_, _>>();
+
+        let config = match url.scheme() {
+            "file" => {
+                let config = FileBlobConfig::from(url.path());
+                Ok(BlobMultiConfig::File(config))
+            }
+            "s3" => {
+                let bucket = url
+                    .host()
+                    .ok_or_else(|| anyhow!("missing bucket: {}", &url.as_str()))?
+                    .to_string();
+                let prefix = url
+                    .path()
+                    .strip_prefix('/')
+                    .unwrap_or_else(|| url.path())
+                    .to_string();
+                let role_arn = query_params.remove("aws_role_arn").map(|x| x.into_owned());
+                let config = S3BlobConfig::new(bucket, prefix, role_arn).await?;
+                Ok(BlobMultiConfig::S3(config))
+            }
+            p => Err(anyhow!(
+                "unknown persist blob scheme {}: {}",
+                p,
+                url.as_str()
+            )),
+        }?;
+
+        if !query_params.is_empty() {
+            return Err(ExternalError::from(anyhow!(
+                "unknown blob location params {}: {}",
+                query_params
+                    .keys()
+                    .map(|x| x.to_owned())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                url.as_str(),
+            )));
+        }
+
+        Ok(config)
+    }
+}
+
+/// Config for an implementation of [Consensus].
+#[derive(Debug)]
+pub enum ConsensusConfig {
+    /// Config for [SqliteConsensus].
+    Sqlite(String),
+}
+
+impl ConsensusConfig {
+    /// Opens the associated implementation of [Consensus].
+    pub async fn open(self, _deadline: Instant) -> Result<Arc<dyn Consensus>, ExternalError> {
+        match self {
+            ConsensusConfig::Sqlite(config) => {
+                SqliteConsensus::open(config).map(|x| Arc::new(x) as Arc<dyn Consensus>)
+            }
+        }
+    }
+
+    /// Parses a [Consensus] config from a uri string.
+    pub async fn try_from(value: &str) -> Result<Self, ExternalError> {
+        let url = Url::parse(value).map_err(|err| {
+            anyhow!(
+                "failed to parse consensus location {} as a url: {}",
+                &value,
+                err
+            )
+        })?;
+        let query_params = url.query_pairs().collect::<HashMap<_, _>>();
+
+        let config = match url.scheme() {
+            "sqlite" => Ok(ConsensusConfig::Sqlite(url.path().to_owned())),
+            p => Err(anyhow!(
+                "unknown persist consensus scheme {}: {}",
+                p,
+                url.as_str()
+            )),
+        }?;
+
+        if !query_params.is_empty() {
+            return Err(ExternalError::from(anyhow!(
+                "unknown consensus location params {}: {}",
+                query_params
+                    .keys()
+                    .map(|x| x.to_owned())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                url.as_str(),
+            )));
+        }
+
+        Ok(config)
+    }
+}

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -532,10 +532,7 @@ pub struct FileBlobMulti {
 
 impl FileBlobMulti {
     /// Opens the given location for non-exclusive read-write access.
-    pub async fn open_multi(
-        _deadline: Instant,
-        config: FileBlobConfig,
-    ) -> Result<Self, ExternalError> {
+    pub async fn open(_deadline: Instant, config: FileBlobConfig) -> Result<Self, ExternalError> {
         let base_dir = config.base_dir;
         fs::create_dir_all(&base_dir).map_err(Error::from)?;
         let core = FileBlobCore {
@@ -638,7 +635,7 @@ mod tests {
         let temp_dir = tempfile::tempdir().map_err(Error::from)?;
         blob_multi_impl_test(move |path| {
             let instance_dir = temp_dir.path().join(path);
-            FileBlobMulti::open_multi(no_timeout, instance_dir.into())
+            FileBlobMulti::open(no_timeout, instance_dir.into())
         })
         .await
     }

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -20,6 +20,7 @@
 
 use std::fmt;
 
+pub mod cfg;
 pub mod client;
 pub mod error;
 pub mod file;

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -134,6 +134,14 @@ impl From<Error> for ExternalError {
     }
 }
 
+impl From<std::io::Error> for ExternalError {
+    fn from(x: std::io::Error) -> Self {
+        ExternalError {
+            inner: anyhow::Error::new(x),
+        }
+    }
+}
+
 impl From<rusqlite::Error> for ExternalError {
     fn from(x: rusqlite::Error) -> Self {
         ExternalError {
@@ -875,9 +883,9 @@ pub mod tests {
         Ok(())
     }
 
-    pub async fn consensus_impl_test<C: Consensus, F: FnMut() -> Result<C, Error>>(
+    pub async fn consensus_impl_test<C: Consensus, F: FnMut() -> Result<C, ExternalError>>(
         mut new_fn: F,
-    ) -> Result<(), Error> {
+    ) -> Result<(), ExternalError> {
         let consensus = new_fn()?;
 
         let key = "heyo!";

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -769,7 +769,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mem_consensus() -> Result<(), Error> {
+    async fn mem_consensus() -> Result<(), ExternalError> {
         consensus_impl_test(|| Ok(MemConsensus::default())).await
     }
 


### PR DESCRIPTION
This is patterned off of mz_coord::persistcfg, which used string urls
(technically uris) so these configs could easily be passed via cli flags
or env vars.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

I'm open to other options if anyone has a better idea.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
