### PR TITLE
Give `metrics::Metrics` a real name

### DIFF
--- a/src/dataflow/src/decode/metrics/mod.rs
+++ b/src/dataflow/src/decode/metrics/mod.rs
@@ -14,11 +14,11 @@ use crate::decode::{DataDecoderInner, PreDelimitedFormat};
 
 /// Metrics specific to a single worker.
 #[derive(Clone, Debug)]
-pub struct Metrics {
+pub struct DecodeMetrics {
     events_read: IntCounterVec,
 }
 
-impl Metrics {
+impl DecodeMetrics {
     pub fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
             events_read: registry.register(metric!(

--- a/src/dataflow/src/decode/mod.rs
+++ b/src/dataflow/src/decode/mod.rs
@@ -38,11 +38,12 @@ use tracing::error;
 use self::avro::AvroDecoderState;
 use self::csv::CsvDecoderState;
 use self::protobuf::ProtobufDecoderState;
-use crate::metrics::Metrics;
 use crate::source::{DecodeResult, SourceOutput};
+use metrics::DecodeMetrics as Metrics;
 
 mod avro;
 mod csv;
+pub mod metrics;
 mod protobuf;
 
 pub fn decode_cdcv2<G: Scope<Timestamp = Timestamp>>(

--- a/src/dataflow/src/lib.rs
+++ b/src/dataflow/src/lib.rs
@@ -15,7 +15,6 @@ mod activator;
 mod arrangement;
 mod decode;
 mod event;
-mod metrics;
 mod operator;
 mod render;
 mod replay;

--- a/src/dataflow/src/render/sources.rs
+++ b/src/dataflow/src/render/sources.rs
@@ -420,7 +420,7 @@ where
                                 &envelope,
                                 metadata_columns,
                                 &mut linear_operators,
-                                storage_state.unspecified_metrics.clone(),
+                                storage_state.decode_metrics.clone(),
                             ),
                             SourceType::ByteStream(source) => render_decode(
                                 &source,
@@ -428,7 +428,7 @@ where
                                 dataflow_debug_name,
                                 metadata_columns,
                                 &mut linear_operators,
-                                storage_state.unspecified_metrics.clone(),
+                                storage_state.decode_metrics.clone(),
                             ),
                         };
                         if let Some(tok) = extra_token {

--- a/src/dataflow/src/server/storage_state.rs
+++ b/src/dataflow/src/server/storage_state.rs
@@ -28,7 +28,7 @@ use mz_ore::now::NowFn;
 use mz_persist::client::RuntimeClient;
 use mz_repr::{Diff, Row, Timestamp};
 
-use crate::metrics::Metrics;
+use crate::decode::metrics::DecodeMetrics;
 use crate::render::sources::PersistedSourceManager;
 use crate::server::boundary::StorageCapture;
 use crate::server::LocalInput;
@@ -66,8 +66,8 @@ pub struct StorageState {
     /// ever be one running (rendered) source of a persisted source, and if there is one, this map
     /// will contain a handle to it.
     pub persisted_sources: PersistedSourceManager,
-    /// Metrics reported by all dataflows.
-    pub unspecified_metrics: Metrics,
+    /// Decoding metrics reported by all dataflows.
+    pub decode_metrics: DecodeMetrics,
     /// Handle to the persistence runtime. None if disabled.
     pub persist: Option<RuntimeClient>,
     /// Tracks the conditional write frontiers we have reported.


### PR DESCRIPTION
Our source decoding metrics were just dropped into the root of `mz-dataflow` under the name `metrics::Metrics`, with a comment announcing only that they were `/// Metrics specific to a single worker.` It seems that they are related to decoding of source events, so I named them this and moved them under `decode`.

### Motivation

   * This PR refactors existing code.

The previous code made no effort to explain to others the role or requirements of this code, impairing reorganization.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
