### PR TITLE
coord,sql: Support `pg_get_viewdef` SQL functions

### DIFF
--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -604,6 +604,7 @@ Field          | Type        | Meaning
 `schema_id`    | [`bigint`]  | The ID of the schema to which the view belongs.
 `name`         | [`text`]    | The name of the view.
 `volatility`   | [`text`]    | Whether the view is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
+`definition`   | [`text`]    | The view definition (a `SELECT` query).
 
 ### `mz_worker_materialization_frontiers`
 

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -690,11 +690,17 @@
     description: >-
       Returns the constraint definition for the given `oid`. Currently always
       returns NULL since constraints aren't supported.
-  - signature: 'pg_get_indexdef(index: oid[, column integer, pretty: bool]) -> text'
+  - signature: 'pg_get_indexdef(index: oid[, column: integer, pretty: bool]) -> text'
     description: >-
       Reconstructs the creating command for an index. (This is a decompiled
       reconstruction, not the original text of the command.) If column is
       supplied and is not zero, only the definition of that column is reconstructed.
+  - signature: 'pg_get_viewdef(view_name: text[, pretty: bool]) -> text'
+    description: Returns the underlying SELECT command for the given view.
+  - signature: 'pg_get_viewdef(view_oid: oid[, pretty: bool]) -> text'
+    description: Returns the underlying SELECT command for the given view.
+  - signature: 'pg_get_viewdef(view_oid: oid[, wrap_column: integer]) -> text'
+    description: Returns the underlying SELECT command for the given view.
   - signature: 'pg_table_is_visible(relation: oid) -> boolean'
     description: Reports whether the relation with the specified OID is visible in the search path.
   - signature: 'pg_type_is_visible(relation: oid) -> boolean'

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1130,7 +1130,8 @@ lazy_static! {
             .with_column("oid", ScalarType::Oid.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
             .with_column("name", ScalarType::String.nullable(false))
-            .with_column("volatility", ScalarType::String.nullable(false)),
+            .with_column("volatility", ScalarType::String.nullable(false))
+            .with_column("definition", ScalarType::String.nullable(false)),
         persistent: false,
     };
     pub static ref MZ_TYPES: BuiltinTable = BuiltinTable {
@@ -1955,7 +1956,8 @@ pub const PG_VIEWS: BuiltinView = BuiltinView {
     sql: "CREATE VIEW pg_catalog.pg_views AS SELECT
     s.name AS schemaname,
     v.name AS viewname,
-    NULL::pg_catalog.oid AS viewowner
+    NULL::pg_catalog.oid AS viewowner,
+    v.definition AS definition
 FROM mz_catalog.mz_views v
 LEFT JOIN mz_catalog.mz_schemas s ON s.id = v.schema_id
 LEFT JOIN mz_catalog.mz_databases d ON d.id = s.database_id

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2069,6 +2069,25 @@ lazy_static! {
                     END)"
                 ) => String, 2507;
             },
+            // pg_get_viewdef returns the (query part of) the given view's definition.
+            // We currently don't support pretty-printing (the `Bool`/`Int32` parameters).
+            "pg_get_viewdef" => Scalar {
+                params!(String) => sql_impl_func(
+                    "(SELECT definition FROM mz_catalog.mz_views WHERE name = $1)"
+                ) => String, 1640;
+                params!(Oid) => sql_impl_func(
+                    "(SELECT definition FROM mz_catalog.mz_views WHERE oid = $1)"
+                ) => String, 1641;
+                params!(String, Bool) => sql_impl_func(
+                    "(SELECT definition FROM mz_catalog.mz_views WHERE name = $1)"
+                ) => String, 2505;
+                params!(Oid, Bool) => sql_impl_func(
+                    "(SELECT definition FROM mz_catalog.mz_views WHERE oid = $1)"
+                ) => String, 2506;
+                params!(Oid, Int32) => sql_impl_func(
+                    "(SELECT definition FROM mz_catalog.mz_views WHERE oid = $1)"
+                ) => String, 3159;
+            },
             // pg_get_expr is meant to convert the textual version of
             // pg_node_tree data into parseable expressions. However, we don't
             // use the pg_get_expr structure anywhere and the equivalent columns

--- a/test/sqllogictest/pg_catalog_views.slt
+++ b/test/sqllogictest/pg_catalog_views.slt
@@ -15,12 +15,12 @@ CREATE VIEW test_view1 AS SELECT 1
 statement ok
 CREATE VIEW test_view2 AS SELECT 2
 
-query TTT colnames
+query TTTT colnames
 SELECT * FROM pg_catalog.pg_views WHERE viewname LIKE 'test_%'
 ----
-schemaname  viewname    viewowner
-public      test_view1  NULL
-public      test_view2  NULL
+schemaname  viewname    viewowner  definition
+public      test_view1  NULL       SELECT␠1;
+public      test_view2  NULL       SELECT␠2;
 
 mode standard
 
@@ -29,4 +29,4 @@ query TT
 SHOW CREATE VIEW pg_views
 ----
 pg_catalog.pg_views
-CREATE VIEW "pg_catalog"."pg_views" AS SELECT "s"."name" AS "schemaname", "v"."name" AS "viewname", NULL::"pg_catalog"."oid" AS "viewowner" FROM "mz_catalog"."mz_views" AS "v" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "v"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" WHERE "d"."name" = "pg_catalog"."current_database"()
+CREATE VIEW "pg_catalog"."pg_views" AS SELECT "s"."name" AS "schemaname", "v"."name" AS "viewname", NULL::"pg_catalog"."oid" AS "viewowner", "v"."definition" AS "definition" FROM "mz_catalog"."mz_views" AS "v" LEFT JOIN "mz_catalog"."mz_schemas" AS "s" ON "s"."id" = "v"."schema_id" LEFT JOIN "mz_catalog"."mz_databases" AS "d" ON "d"."id" = "s"."database_id" WHERE "d"."name" = "pg_catalog"."current_database"()

--- a/test/sqllogictest/pg_get_viewdef.slt
+++ b/test/sqllogictest/pg_get_viewdef.slt
@@ -1,0 +1,111 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# This file is derived from the logic test suite in CockroachDB. The
+# original file was retrieved on June 10, 2019 from:
+#
+# The original source code is subject to the terms of the Apache
+# 2.0 license, a copy of which can be found in the LICENSE file at the
+# root of this repository.
+
+statement ok
+CREATE TABLE t (a int, b int, c int)
+
+statement ok
+CREATE VIEW t_view AS SELECT t.a, b FROM t
+
+# Test pg_get_viewdef(view_name)
+
+query T
+SELECT pg_get_viewdef('doesnotexist')
+----
+NULL
+
+query T
+SELECT pg_get_viewdef('t_view')
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+# Test pg_get_viewdef(view_oid)
+
+query T
+SELECT pg_get_viewdef(0)
+----
+NULL
+
+query T
+SELECT pg_get_viewdef('t_view'::regclass::oid)
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+# Test pg_get_viewdef(view_name, pretty)
+
+query T
+SELECT pg_get_viewdef('doesnotexist', true)
+----
+NULL
+
+query T
+SELECT pg_get_viewdef('doesnotexist', false)
+----
+NULL
+
+query T
+SELECT pg_get_viewdef('t_view', true)
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+query T
+SELECT pg_get_viewdef('t_view', false)
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+# Test pg_get_viewdef(view_oid, pretty)
+
+query T
+SELECT pg_get_viewdef(0, true)
+----
+NULL
+
+query T
+SELECT pg_get_viewdef(0, false)
+----
+NULL
+
+query T
+SELECT pg_get_viewdef('t_view'::regclass::oid, true)
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+query T
+SELECT pg_get_viewdef('t_view'::regclass::oid, false)
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+# Test pg_get_viewdef(view_oid, wrap_column)
+
+query T
+SELECT pg_get_viewdef(0, 80)
+----
+NULL
+
+query T
+SELECT pg_get_viewdef('t_view'::regclass::oid, 80)
+----
+SELECT "t"."a", "b" FROM [u1 AS "materialize"."public"."t"];
+
+# Test retrieving view definition after table rename
+
+statement ok
+ALTER TABLE t RENAME TO t2
+
+query T
+SELECT pg_get_viewdef('t_view'::regclass::oid)
+----
+SELECT "t2"."a", "b" FROM [u1 AS "materialize"."public"."t2"];

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -182,16 +182,16 @@ contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW values_system_view AS SELECT * FROM input_values_view, source_system;
 > CREATE VIEW values_system_user_view AS SELECT * FROM input_values_view, source_system_user;
 > CREATE VIEW values_cdcv2_view AS SELECT * FROM input_values_view, source_cdcv2;
-> CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM input_values_view, mz_catalog_names, mz_views, mz_source_info;
+> CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM input_values_view, mz_catalog_names, mz_views, mz_source_info;
 
 # System sources, tables, and logs should be joinable with eachother.
-> CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info;
+> CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info;
 
 # System things should be joinable only with system sources.
-! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_cdcv2;
+! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
-> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
-> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
+> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, source_system;
+> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_catalog_names, mz_views, mz_source_info, input_table;
 
 # EXPLAIN should complain too.
 ! EXPLAIN SELECT * FROM source_system, source_cdcv2;


### PR DESCRIPTION
This PR adds a new column, `definition` to both `mz_views` and `pg_views`, and then implements `pg_get_viewdef` in terms of `mz_views.definition`. See also the commit messages.

`pg_views.definition` isn't actually needed by us, but I figured it was a good idea to extend the Postgres compatibility layer while I'm at it anyway.

There are still two issues I'd like to discuss. I'm adding annotations to the relevant code parts.

### Motivation

  * This PR adds a known-desirable feature.

    Closes #11591.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add the `definition` column to [`mz_views`](/sql/system-catalog#mz_views)
  - Add the [`pg_get_viewdef`](/sql/functions/#pg_get_viewdef) functions.
