### PR TITLE
repr: add `TryIntoIfSome` trait

### DIFF
--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -22,7 +22,7 @@ use std::{char::CharTryFromError, num::TryFromIntError};
 pub enum TryFromProtoError {
     /// A wrapped [`TryFromIntError`] due to failed integer downcast.
     TryFromIntError(TryFromIntError),
-    /// A wrapped [`TryFromIntError`] due to failed [`char`] conversion.
+    /// A wrapped [`CharTryFromError`] due to failed [`char`] conversion.
     CharTryFromError(CharTryFromError),
     /// Indicates an `Option<U>` field in the `Proto$T` that should be set,
     /// but for some reason it is not. In practice this should never occur.
@@ -30,7 +30,7 @@ pub enum TryFromProtoError {
 }
 
 impl TryFromProtoError {
-    // Construct a new [`TryFromProtoError::MissingField`] instance.
+    /// Construct a new [`TryFromProtoError::MissingField`] instance.
     pub fn missing_field<T: ToString>(s: T) -> TryFromProtoError {
         TryFromProtoError::MissingField(s.to_string())
     }
@@ -140,5 +140,24 @@ impl<T: ProtoRepr> ProtoRepr for Option<T> {
 
     fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
         repr.map(T::from_proto).transpose()
+    }
+}
+
+/// Convenience syntax for trying to convert a `Self` value of type
+/// `Option<U>` to `T` if the value is `Some(value)`, or returning
+/// [`TryFromProtoError::MissingField`] if the value is `None`.
+pub trait TryIntoIfSome<T> {
+    fn try_into_if_some<S: ToString>(self, field: S) -> Result<T, TryFromProtoError>;
+}
+
+/// A blanket implementation for `Option<U>` where `U` is the
+/// `Proto$T` type for `T`.
+impl<T, U> TryIntoIfSome<T> for Option<U>
+where
+    T: TryFrom<U, Error = TryFromProtoError>,
+{
+    fn try_into_if_some<S: ToString>(self, field: S) -> Result<T, TryFromProtoError> {
+        self.ok_or_else(|| TryFromProtoError::missing_field(field))?
+            .try_into()
     }
 }

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -20,13 +20,17 @@ use std::{char::CharTryFromError, num::TryFromIntError};
 /// `Proto$T` to `$T`.
 #[derive(Debug)]
 pub enum TryFromProtoError {
+    /// A wrapped [`TryFromIntError`] due to failed integer downcast.
     TryFromIntError(TryFromIntError),
+    /// A wrapped [`TryFromIntError`] due to failed [`char`] conversion.
     CharTryFromError(CharTryFromError),
+    /// Indicates an `Option<U>` field in the `Proto$T` that should be set,
+    /// but for some reason it is not. In practice this should never occur.
     MissingField(String),
-    InvalidChar(String),
 }
 
 impl TryFromProtoError {
+    // Construct a new [`TryFromProtoError::MissingField`] instance.
     pub fn missing_field<T: ToString>(s: T) -> TryFromProtoError {
         TryFromProtoError::MissingField(s.to_string())
     }
@@ -51,7 +55,6 @@ impl std::fmt::Display for TryFromProtoError {
             TryFromIntError(error) => error.fmt(f),
             CharTryFromError(error) => error.fmt(f),
             MissingField(field) => write!(f, "Missing value for `{}`", field),
-            InvalidChar(str) => write!(f, "String '{}' does not encode a single UTF8 char", str),
         }
     }
 }
@@ -62,7 +65,7 @@ impl std::error::Error for TryFromProtoError {
         match self {
             TryFromIntError(error) => Some(error),
             CharTryFromError(error) => Some(error),
-            MissingField(_) | InvalidChar(_) => None,
+            MissingField(_) => None,
         }
     }
 }


### PR DESCRIPTION
Cleans up some leftovers from #11607 and introduces some convenience syntax in the form of the `TryIntoIfSome` trait.

### Motivation

   * This PR refactors existing code.

I forgot to remove the `TryFromProtoError::InvalidChar` as part of `#11607`.

Also, as I am working on Protobuf-ization of `EvalError`, I am running into the issue where I have nested complex field types of type `U` in the original type `T` that are represented as `Option<T>` in `Proto$T` ([see this Discord discussion for details](https://discord.com/channels/500028886025895936/664895722121986061/958707895900463154)). Consequently, I decided to hide the

```rust
field_value.map(U::try_from)
    .transpose()?
    .ok_or_else(|| TryFromProtoError::missing_field(field))
```

pattern behind a single method in a `TryIntoIfSome` trait.

### Tips for reviewer

See the [Motivation](#motivation) section for details.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A