### PR TITLE
materialized: allow enabling CORS by origin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,8 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tonic",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -6388,9 +6390,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -6400,8 +6402,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6435,9 +6436,9 @@ checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -123,7 +123,7 @@ impl Client {
 /// it is created, and frees that ID for potential reuse when it is dropped.
 ///
 /// See also [`Client`].
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ConnClient {
     conn_id: u32,
     inner: Client,

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -87,6 +87,8 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 tokio = { version = "1.17.0", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-stream = { version = "0.1.8", features = ["net"] }
+tower = "0.4.12"
+tower-http = { version = "0.2.5", features = ["cors"] }
 tracing = "0.1.32"
 tracing-subscriber = "0.3.10"
 

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -38,6 +38,7 @@ use backtrace::Backtrace;
 use chrono::Utc;
 use clap::{AppSettings, ArgEnum, Parser};
 use fail::FailScenario;
+use http::header::HeaderValue;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use sysinfo::{ProcessorExt, SystemExt};
@@ -378,6 +379,10 @@ pub struct Args {
         hide = true
     )]
     frontegg_api_token_url: Option<String>,
+    /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
+    /// specified origin.
+    #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN", hide = true)]
+    cors_allowed_origin: Vec<HeaderValue>,
 
     // === Storage options. ===
     /// Where to store data.
@@ -851,6 +856,7 @@ max log level: {max_log_level}",
         third_party_metrics_listen_addr: args.third_party_metrics_listen_addr,
         tls,
         frontegg,
+        cors_allowed_origins: args.cors_allowed_origin,
         data_directory,
         orchestrator,
         storage,

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -21,6 +21,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use ::http::header::HeaderValue;
 use anyhow::{anyhow, Context};
 use compile_time_run::run_command_str;
 use futures::StreamExt;
@@ -125,6 +126,9 @@ pub struct Config {
     pub tls: Option<TlsConfig>,
     /// Materialize Cloud configuration to enable Frontegg JWT user authentication.
     pub frontegg: Option<FronteggAuthentication>,
+    /// Origins for which cross-origin resource sharing (CORS) for HTTP requests
+    /// is permitted.
+    pub cors_allowed_origins: Vec<HeaderValue>,
 
     // === Storage options. ===
     /// The directory in which `materialized` should store its own metadata.
@@ -490,6 +494,7 @@ pub async fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
             metrics_registry,
             global_metrics: metrics,
             pgwire_metrics: pgwire_server.metrics(),
+            allowed_origins: config.cors_allowed_origins,
         });
         let mut mux = Mux::new();
         mux.add_handler(pgwire_server);

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -167,6 +167,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         persist: PersistConfig::disabled(),
         third_party_metrics_listen_addr: None,
         now: config.now,
+        cors_allowed_origins: vec![],
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -563,6 +563,7 @@ impl Runner {
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             tls: None,
             frontegg: None,
+            cors_allowed_origins: vec![],
             experimental_mode: true,
             disable_user_indexes: false,
             safe_mode: false,


### PR DESCRIPTION
In Materialize Platform, the web UI will make requests of `materialized`
directly. It does so from a different origin, so we need to enable
cross-origin resource sharing (CORS) or those requests are blocked by
the browser.

This commit adds a new command line option to `materialized` named
`--cors-allowed-origin` that allows the operator of `materialized` to
specify from what origins CORS requests are allowed.

Touches https://github.com/MaterializeInc/materialize/issues/11533. This doesn't actually entirely resolve https://github.com/MaterializeInc/materialize/issues/11533, because
this commit doesn't switch us to using axum; I figured out how to get
the CORS support in with our existing framework.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A (internal-only CLI flag)
