### PR TITLE
Decouple storage and compute introspection

### DIFF
--- a/src/dataflow/src/storage/mod.rs
+++ b/src/dataflow/src/storage/mod.rs
@@ -11,3 +11,38 @@ pub mod decode;
 pub mod render;
 pub mod source;
 pub mod storage_state;
+
+use timely::logging::WorkerIdentifier;
+
+use mz_expr::SourceInstanceId;
+use mz_repr::adt::jsonb::Jsonb;
+
+/// Type alias for logging of materialized events.
+pub type Logger = timely::logging_core::Logger<StorageEvent, WorkerIdentifier>;
+
+/// Introspection events produced by the storage layer.
+#[derive(Debug, Clone, PartialOrd, PartialEq)]
+pub enum StorageEvent {
+    /// Underling librdkafka statistics for a Kafka source.
+    KafkaSourceStatistics {
+        /// Materialize source identifier.
+        source_id: SourceInstanceId,
+        /// The old JSONB statistics blob to retract, if any.
+        old: Option<Jsonb>,
+        /// The new JSONB statistics blob to produce, if any.
+        new: Option<Jsonb>,
+    },
+    /// Tracks the source name, id, partition id, and received/ingested offsets
+    SourceInfo {
+        /// Name of the source
+        source_name: String,
+        /// Source identifier
+        source_id: SourceInstanceId,
+        /// Partition identifier
+        partition_id: Option<String>,
+        /// Difference between the previous offset and current highest offset we've seen
+        offset: i64,
+        /// Difference between the previous timestamp and current highest timestamp we've seen
+        timestamp: i64,
+    },
+}

--- a/src/dataflow/src/storage/render/mod.rs
+++ b/src/dataflow/src/storage/render/mod.rs
@@ -136,7 +136,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Source dataflow: {debug_name}");
-    let materialized_logging = timely_worker.log_register().get("materialized");
+    let storage_logging = timely_worker.log_register().get("materialized/storage");
 
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
         // The scope.clone() occurs to allow import in the region.
@@ -161,7 +161,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
                         source.clone(),
                         storage_state,
                         region,
-                        materialized_logging.clone(),
+                        storage_logging.clone(),
                         src_id.clone(),
                     );
 

--- a/src/dataflow/src/storage/render/sources.rs
+++ b/src/dataflow/src/storage/render/sources.rs
@@ -35,7 +35,6 @@ use mz_persist::operators::upsert::PersistentUpsertConfig;
 use mz_persist_types::Codec;
 use mz_repr::{Diff, Row, RowPacker, Timestamp};
 
-use crate::logging::materialized::Logger;
 use crate::operator::{CollectionExt, StreamExt};
 use crate::storage::decode::decode_cdcv2;
 use crate::storage::decode::render_decode;
@@ -50,6 +49,7 @@ use crate::storage::source::{
 };
 use crate::storage::storage_state::LocalInput;
 use crate::storage::storage_state::StorageState;
+use crate::storage::Logger;
 
 /// A type-level enum that holds one of two types of sources depending on their message type
 ///

--- a/src/dataflow/src/storage/source/file.rs
+++ b/src/dataflow/src/storage/source/file.rs
@@ -31,8 +31,8 @@ use mz_dataflow_types::sources::{
 };
 use mz_expr::{PartitionId, SourceInstanceId};
 
-use crate::logging::materialized::Logger;
 use crate::storage::source::{NextMessage, SourceMessage, SourceReader};
+use crate::storage::Logger;
 
 use super::metrics::SourceBaseMetrics;
 

--- a/src/dataflow/src/storage/source/kafka.rs
+++ b/src/dataflow/src/storage/source/kafka.rs
@@ -32,8 +32,8 @@ use mz_kafka_util::{client::MzClientContext, KafkaAddrs};
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
 use mz_repr::adt::jsonb::Jsonb;
 
-use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::storage::source::{NextMessage, SourceMessage, SourceReader};
+use crate::storage::{Logger, StorageEvent};
 
 use self::metrics::KafkaPartitionMetrics;
 use super::metrics::SourceBaseMetrics;
@@ -403,7 +403,7 @@ impl KafkaSourceReader {
     fn update_stats(&mut self) {
         while let Ok(stats) = self.stats_rx.try_recv() {
             if let Some(logger) = self.logger.as_mut() {
-                logger.log(MaterializedEvent::KafkaSourceStatistics {
+                logger.log(StorageEvent::KafkaSourceStatistics {
                     source_id: self.id,
                     old: self.last_stats.take(),
                     new: Some(stats.clone()),
@@ -525,7 +525,7 @@ impl Drop for KafkaSourceReader {
     fn drop(&mut self) {
         // Retract any metrics logged for this source.
         if let Some(logger) = self.logger.as_mut() {
-            logger.log(MaterializedEvent::KafkaSourceStatistics {
+            logger.log(StorageEvent::KafkaSourceStatistics {
                 source_id: self.id,
                 old: self.last_stats.take(),
                 new: None,

--- a/src/dataflow/src/storage/source/kinesis.rs
+++ b/src/dataflow/src/storage/source/kinesis.rs
@@ -29,9 +29,9 @@ use mz_dataflow_types::sources::{
 use mz_expr::{PartitionId, SourceInstanceId};
 use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 
-use crate::logging::materialized::Logger;
 use crate::storage::source::metrics::{KinesisMetrics, SourceBaseMetrics};
 use crate::storage::source::{NextMessage, SourceMessage, SourceReader};
+use crate::storage::Logger;
 
 /// To read all data from a Kinesis stream, we need to continually update
 /// our knowledge of the stream's shards by calling the ListShards API.

--- a/src/dataflow/src/storage/source/mod.rs
+++ b/src/dataflow/src/storage/source/mod.rs
@@ -58,11 +58,11 @@ use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
 use self::metrics::SourceBaseMetrics;
 
 use super::source::util::source;
-use crate::logging::materialized::{Logger, MaterializedEvent};
 use crate::operator::StreamExt;
 use crate::storage::source::timestamp::TimestampBindingRc;
 use crate::storage::source::timestamp::TimestampBindingUpdater;
 use crate::storage::source::timestamp::{AssignedTimestamp, SourceTimestamp};
+use crate::storage::{Logger, StorageEvent};
 
 mod file;
 mod gen;
@@ -520,7 +520,7 @@ impl Drop for SourceMetrics {
         // retract our partition from logging
         if let Some(logger) = self.logger.as_mut() {
             for (partition, metric) in self.partition_metrics.iter() {
-                logger.log(MaterializedEvent::SourceInfo {
+                logger.log(StorageEvent::SourceInfo {
                     source_name: self.source_name.clone(),
                     source_id: self.source_id,
                     partition_id: partition.into(),
@@ -557,7 +557,7 @@ impl PartitionMetrics {
         offset: i64,
         timestamp: i64,
     ) {
-        logger.log(MaterializedEvent::SourceInfo {
+        logger.log(StorageEvent::SourceInfo {
             source_name: source_name.to_string(),
             source_id,
             partition_id: partition_id.into(),

--- a/src/dataflow/src/storage/source/s3.rs
+++ b/src/dataflow/src/storage/source/s3.rs
@@ -56,8 +56,8 @@ use mz_ore::task;
 use mz_repr::MessagePayload;
 use tracing::{debug, error, trace, warn};
 
-use crate::logging::materialized::Logger;
 use crate::storage::source::{NextMessage, SourceMessage, SourceReader};
+use crate::storage::Logger;
 
 use self::metrics::{BucketMetrics, ScanBucketMetrics};
 use self::notifications::{Event, EventType, TestEvent};


### PR DESCRIPTION
This PR partitions the introspection events of storage and compute, and captures and processes each independently. The goal is to allow the storage crate to define its own event type, but otherwise to know next to nothing about logging (in particular, nothing about how to build the dataflows needed for the results, nor the types of the results, nor how to stash them anywhere).

In the future storage may want to assume more logging agency, and that is totally fine, but at the moment it does not seem lined up to handle this on its own (it relies on compute to configure the logging and provide access to the results).

### Motivation

Storage had a dependence on dataflow logging, which was relatively complicated and otherwise private to the compute facet of `dataflow`.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
