### PR TITLE
mzcompose: Update Redpanda to v21.11.12

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -231,7 +231,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v21.11.8",
+        version: str = "v21.11.12",
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         ports: Optional[List[int]] = None,


### PR DESCRIPTION
Update Redpanda to [v21.11.12](https://github.com/redpanda-data/redpanda/releases/tag/v21.11.12)

### Motivation

Keep up to date with Redpanda improvements.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

  - mzcompose: Update Redpanda to v21.11.12
