### PR TITLE
materialized: allow content-type CORS header

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use futures::future::TryFutureExt;
 use headers::authorization::{Authorization, Basic, Bearer};
 use headers::HeaderMapExt;
-use http::header::{HeaderValue, AUTHORIZATION};
+use http::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use hyper::{Body, Method, Request, Response, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
 use mz_ore::metrics::MetricsRegistry;
@@ -279,7 +279,7 @@ impl Server {
             .layer(
                 CorsLayer::new()
                     .allow_credentials(false)
-                    .allow_headers([AUTHORIZATION])
+                    .allow_headers([AUTHORIZATION, CONTENT_TYPE])
                     .allow_methods(cors::Any)
                     .allow_origin(self.allowed_origin.clone())
                     .expose_headers(cors::Any)


### PR DESCRIPTION
Allowing `Content-Type` explicitly is required for content types besides
URL-encoded formdata and plain text. Notably important for
application/json.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A