### PR TITLE
Protobuf: use single include! per crate

### DIFF
--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -13,6 +13,7 @@ fn main() {
             &[
                 "row.proto",
                 "strconv.proto",
+                "scalar.proto",
                 "adt/array.proto",
                 "adt/char.proto",
                 "adt/numeric.proto",

--- a/src/repr/src/proto/adt/array.rs
+++ b/src/repr/src/proto/adt/array.rs
@@ -9,10 +9,9 @@
 
 //! Protobuf structs mirroring [`crate::adt::array`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.array.rs"));
-
 use super::super::{ProtoRepr, TryFromProtoError};
 use crate::adt::array::InvalidArrayError;
+use crate::proto::gen::adt::array::*;
 
 impl From<&InvalidArrayError> for ProtoInvalidArrayError {
     fn from(error: &InvalidArrayError) -> Self {

--- a/src/repr/src/proto/adt/char.rs
+++ b/src/repr/src/proto/adt/char.rs
@@ -9,9 +9,8 @@
 
 //! Protobuf structs mirroring [`crate::adt::char`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.char.rs"));
-
 use crate::adt::char::CharLength;
+use crate::proto::gen::adt::char::*;
 use crate::proto::TryFromProtoError;
 
 impl From<&CharLength> for ProtoCharLength {

--- a/src/repr/src/proto/adt/numeric.rs
+++ b/src/repr/src/proto/adt/numeric.rs
@@ -9,9 +9,8 @@
 
 //! Protobuf structs mirroring [`crate::adt::numeric`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.numeric.rs"));
-
 use crate::adt::numeric::NumericMaxScale;
+use crate::proto::gen::adt::numeric::*;
 use crate::proto::{ProtoRepr, TryFromProtoError};
 
 impl From<&NumericMaxScale> for ProtoNumericMaxScale {

--- a/src/repr/src/proto/adt/varchar.rs
+++ b/src/repr/src/proto/adt/varchar.rs
@@ -9,9 +9,8 @@
 
 //! Protobuf structs mirroring [`crate::adt::varchar`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.varchar.rs"));
-
 use crate::adt::varchar::VarCharMaxLength;
+use crate::proto::gen::adt::varchar::*;
 use crate::proto::TryFromProtoError;
 
 impl From<&VarCharMaxLength> for ProtoVarCharMaxLength {

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod adt;
 pub mod row;
+mod scalar;
 pub mod strconv;
 
 use mz_ore::cast::CastFrom;

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -17,6 +17,10 @@ pub mod strconv;
 use mz_ore::cast::CastFrom;
 use std::{char::CharTryFromError, num::TryFromIntError};
 
+pub(crate) mod gen {
+    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+}
+
 /// An error thrown when trying to convert from a `*.proto`-generated type
 /// `Proto$T` to `$T`.
 #[derive(Debug)]

--- a/src/repr/src/proto/relation.proto
+++ b/src/repr/src/proto/relation.proto
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// Since protobuf does not support cyclic includes, the types for
+// ColumnName and ColumnType are defined in proto/scalar.rs.

--- a/src/repr/src/proto/relation.rs
+++ b/src/repr/src/proto/relation.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::relation`] are defined
+//! in [`crate::scalar`].

--- a/src/repr/src/proto/scalar.proto
+++ b/src/repr/src/proto/scalar.proto
@@ -16,6 +16,18 @@ import "adt/char.proto";
 import "adt/numeric.proto";
 import "adt/varchar.proto";
 
+
+// protobuf does not support cycling imports. ProtoColumnName and ProtoScalarType
+// belong would belong to proto/relation.proto
+message ProtoColumnName {
+    optional string value = 1;
+}
+
+message ProtoColumnType {
+    ProtoScalarType scalar_type = 1;
+    bool nullable = 2;
+}
+
 message ProtoScalarType {
     // ScalarType::Numeric contains an Option<NumericMaxScale>
     // None is encoded as this field not present.
@@ -36,8 +48,8 @@ message ProtoScalarType {
     }
 
     message ProtoRecordField {
-        string ColumnName = 1; // TODO: Create and use ProtoColumnName
-        string ColumnType = 2; // TODO: Create and use ProtoColumnType
+        ProtoColumnName ColumnName = 1; // TODO: Create and use ProtoColumnName
+        ProtoColumnType ColumnType = 2; // TODO: Create and use ProtoColumnType
     }
 
     message ProtoRecord {

--- a/src/repr/src/proto/scalar.proto
+++ b/src/repr/src/proto/scalar.proto
@@ -1,0 +1,84 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package scalar;
+
+import "google/protobuf/empty.proto";
+import "adt/char.proto";
+import "adt/numeric.proto";
+import "adt/varchar.proto";
+
+message ProtoScalarType {
+    // ScalarType::Numeric contains an Option<NumericMaxScale>
+    // None is encoded as this field not present.
+    message ProtoNumeric {
+        adt.numeric.ProtoNumericMaxScale max_scale = 1;
+    }
+    message ProtoChar {
+        adt.char.ProtoCharLength length = 1;
+    }
+
+    message ProtoVarChar {
+        adt.varchar.ProtoVarCharMaxLength max_length = 1;
+    }
+
+    message ProtoList {
+        ProtoScalarType element_type = 1;
+        optional uint32 custom_oid = 2;
+    }
+
+    message ProtoRecordField {
+        string ColumnName = 1; // TODO: Create and use ProtoColumnName
+        string ColumnType = 2; // TODO: Create and use ProtoColumnType
+    }
+
+    message ProtoRecord {
+        repeated ProtoRecordField fields = 1;
+        optional uint32 custom_oid = 2;
+        optional string custom_name = 3;
+    }
+
+    message ProtoMap {
+        ProtoScalarType value_type = 1;
+        optional uint32 custom_oid = 2;
+    }
+
+    oneof kind  {
+        google.protobuf.Empty Bool = 1;
+        google.protobuf.Empty Int16 = 2;
+        google.protobuf.Empty Int32 = 3;
+        google.protobuf.Empty Int64 = 4;
+        google.protobuf.Empty Float32 = 5;
+        google.protobuf.Empty Float64 = 6;
+        ProtoNumeric Numeric = 7;
+        google.protobuf.Empty Date = 8;
+        google.protobuf.Empty Time = 9;
+        google.protobuf.Empty Timestamp = 10;
+        google.protobuf.Empty TimestampTz = 11;
+        google.protobuf.Empty Interval = 12;
+        google.protobuf.Empty PgLegacyChar = 13;
+        google.protobuf.Empty Bytes = 14;
+        google.protobuf.Empty String = 15;
+        ProtoChar Char = 16;
+        ProtoVarChar VarChar = 17;
+        google.protobuf.Empty Jsonb = 18;
+        google.protobuf.Empty Uuid = 19;
+        ProtoScalarType Array = 20;
+        ProtoList List = 21;
+        ProtoRecord Record = 22;
+        google.protobuf.Empty Oid = 23;
+        ProtoMap Map = 24;
+        google.protobuf.Empty RegProc = 25;
+        google.protobuf.Empty RegType = 26;
+        google.protobuf.Empty RegClass = 27;
+        google.protobuf.Empty Int2Vector = 28;
+    }
+}

--- a/src/repr/src/proto/scalar.proto
+++ b/src/repr/src/proto/scalar.proto
@@ -17,8 +17,8 @@ import "adt/numeric.proto";
 import "adt/varchar.proto";
 
 
-// protobuf does not support cycling imports. ProtoColumnName and ProtoScalarType
-// belong would belong to proto/relation.proto
+// Note: protobuf does not support cyclic imports. ProtoColumnName and ProtoScalarType
+// belong to proto/relation.proto if it was supported.
 message ProtoColumnName {
     optional string value = 1;
 }
@@ -29,8 +29,6 @@ message ProtoColumnType {
 }
 
 message ProtoScalarType {
-    // ScalarType::Numeric contains an Option<NumericMaxScale>
-    // None is encoded as this field not present.
     message ProtoNumeric {
         adt.numeric.ProtoNumericMaxScale max_scale = 1;
     }

--- a/src/repr/src/proto/scalar.rs
+++ b/src/repr/src/proto/scalar.rs
@@ -1,0 +1,172 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::scalar`].
+
+include!(concat!(env!("OUT_DIR"), "/scalar.rs"));
+use crate::proto::TryFromProtoError;
+use crate::scalar::ScalarType;
+
+impl From<&ScalarType> for ProtoScalarType {
+    fn from(value: &ScalarType) -> Self {
+        use proto_scalar_type::Kind::*;
+        use proto_scalar_type::*;
+
+        ProtoScalarType {
+            kind: Some(match value {
+                ScalarType::Bool => Bool(()),
+                ScalarType::Int16 => Int16(()),
+                ScalarType::Int32 => Int32(()),
+                ScalarType::Int64 => Int64(()),
+                ScalarType::Float32 => Float32(()),
+                ScalarType::Float64 => Float64(()),
+                ScalarType::Date => Date(()),
+                ScalarType::Time => Time(()),
+                ScalarType::Timestamp => Timestamp(()),
+                ScalarType::TimestampTz => TimestampTz(()),
+                ScalarType::Interval => Interval(()),
+                ScalarType::PgLegacyChar => PgLegacyChar(()),
+                ScalarType::Bytes => Bytes(()),
+                ScalarType::String => String(()),
+                ScalarType::Jsonb => Jsonb(()),
+                ScalarType::Uuid => Uuid(()),
+                ScalarType::Oid => Oid(()),
+                ScalarType::RegProc => RegProc(()),
+                ScalarType::RegType => RegType(()),
+                ScalarType::RegClass => RegClass(()),
+                ScalarType::Int2Vector => Int2Vector(()),
+
+                ScalarType::Numeric { max_scale } => Numeric(ProtoNumeric {
+                    max_scale: max_scale.map(|x| (&x).into()),
+                }),
+                ScalarType::Char { length } => Char(ProtoChar {
+                    length: length.map(|x| (&x).into()),
+                }),
+                ScalarType::VarChar { max_length } => VarChar(ProtoVarChar {
+                    max_length: max_length.map(|x| (&x).into()),
+                }),
+                ScalarType::List {
+                    element_type,
+                    custom_oid,
+                } => List(Box::new(ProtoList {
+                    element_type: Some(Box::new((&(**element_type)).into())),
+                    custom_oid: *custom_oid,
+                })),
+                ScalarType::Record {
+                    custom_oid,
+                    fields: _,
+                    custom_name,
+                } => Record(ProtoRecord {
+                    custom_oid: *custom_oid,
+                    fields: vec![], // TODO: Replace me with ProtoRecordField
+                    custom_name: custom_name.clone(),
+                }),
+                ScalarType::Array(typ) => Array(Box::new((&**typ).into())),
+                ScalarType::Map {
+                    value_type,
+                    custom_oid,
+                } => Map(Box::new(ProtoMap {
+                    value_type: Some(Box::new((&(**value_type)).into())),
+                    custom_oid: *custom_oid,
+                })),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ProtoScalarType> for ScalarType {
+    type Error = TryFromProtoError;
+
+    fn try_from(value: ProtoScalarType) -> Result<Self, Self::Error> {
+        use proto_scalar_type::Kind::*;
+
+        let kind = value
+            .kind
+            .ok_or_else(|| TryFromProtoError::MissingField("ProtoScalarType::Kind".into()))?;
+
+        match kind {
+            Bool(()) => Ok(ScalarType::Bool),
+            Int16(()) => Ok(ScalarType::Int16),
+            Int32(()) => Ok(ScalarType::Int32),
+            Int64(()) => Ok(ScalarType::Int64),
+            Float32(()) => Ok(ScalarType::Float32),
+            Float64(()) => Ok(ScalarType::Float64),
+            Date(()) => Ok(ScalarType::Date),
+            Time(()) => Ok(ScalarType::Time),
+            Timestamp(()) => Ok(ScalarType::Timestamp),
+            TimestampTz(()) => Ok(ScalarType::TimestampTz),
+            Interval(()) => Ok(ScalarType::Interval),
+            PgLegacyChar(()) => Ok(ScalarType::PgLegacyChar),
+            Bytes(()) => Ok(ScalarType::Bytes),
+            String(()) => Ok(ScalarType::String),
+            Jsonb(()) => Ok(ScalarType::Jsonb),
+            Uuid(()) => Ok(ScalarType::Uuid),
+            Oid(()) => Ok(ScalarType::Oid),
+            RegProc(()) => Ok(ScalarType::RegProc),
+            RegType(()) => Ok(ScalarType::RegType),
+            RegClass(()) => Ok(ScalarType::RegClass),
+            Int2Vector(()) => Ok(ScalarType::Int2Vector),
+
+            Numeric(pn) => Ok(ScalarType::Numeric {
+                max_scale: match pn.max_scale {
+                    Some(x) => Some(x.try_into()?),
+                    None => None,
+                },
+            }),
+            Char(x) => Ok(ScalarType::Char {
+                length: match x.length {
+                    Some(x) => Some(x.try_into()?),
+                    None => None,
+                },
+            }),
+
+            VarChar(x) => Ok(ScalarType::VarChar {
+                max_length: match x.max_length {
+                    Some(x) => Some(x.try_into()?),
+                    None => Err(TryFromProtoError::MissingField(
+                        "ProtoVarChar::max_length".into(),
+                    ))?,
+                },
+            }),
+            Array(x) => {
+                // Can't inline this without type hints
+                let st: ScalarType = (*x).try_into()?;
+                Ok(ScalarType::Array(st.into()))
+            }
+            List(x) => Ok(ScalarType::List {
+                element_type: match x.element_type {
+                    Some(x) => {
+                        let st: ScalarType = (*x).try_into()?;
+                        st.into()
+                    }
+                    None => Err(TryFromProtoError::MissingField("xx".into()))?,
+                },
+                custom_oid: x.custom_oid,
+            }),
+            Record(x) => {
+                let fields = vec![]; //TODO: Replace me with ColumnType proto
+                Ok(ScalarType::Record {
+                    custom_oid: x.custom_oid,
+                    fields,
+                    custom_name: x.custom_name,
+                })
+            }
+            Map(x) => Ok(ScalarType::Map {
+                value_type: match x.value_type {
+                    Some(x) => {
+                        let st: ScalarType = (*x).try_into()?;
+                        st.into()
+                    }
+                    None => Err(TryFromProtoError::MissingField("xx".into()))?,
+                },
+                custom_oid: x.custom_oid,
+            }),
+        }
+    }
+}

--- a/src/repr/src/proto/scalar.rs
+++ b/src/repr/src/proto/scalar.rs
@@ -9,8 +9,10 @@
 
 //! Protobuf structs mirroring [`crate::scalar`] and [`crate::relation`]
 
-include!(concat!(env!("OUT_DIR"), "/scalar.rs"));
-use crate::proto::scalar::proto_scalar_type::ProtoRecordField;
+//include!(concat!(env!("OUT_DIR"), "/scalar.rs"));
+use crate::proto::gen::scalar::proto_scalar_type::ProtoRecordField;
+use crate::proto::gen::scalar::*;
+
 use crate::proto::TryFromProtoError;
 use crate::proto::TryIntoIfSome;
 use crate::scalar::ScalarType;
@@ -86,8 +88,8 @@ impl From<&ScalarType> for Box<ProtoScalarType> {
 
 impl From<&ScalarType> for ProtoScalarType {
     fn from(value: &ScalarType) -> Self {
-        use proto_scalar_type::Kind::*;
-        use proto_scalar_type::*;
+        use super::gen::scalar::proto_scalar_type::Kind::*;
+        use super::gen::scalar::proto_scalar_type::*;
 
         ProtoScalarType {
             kind: Some(match value {
@@ -156,7 +158,7 @@ impl TryFrom<ProtoScalarType> for ScalarType {
     type Error = TryFromProtoError;
 
     fn try_from(value: ProtoScalarType) -> Result<Self, TryFromProtoError> {
-        use proto_scalar_type::Kind::*;
+        use crate::proto::gen::scalar::proto_scalar_type::Kind::*;
 
         let kind = value
             .kind

--- a/src/repr/src/proto/scalar.rs
+++ b/src/repr/src/proto/scalar.rs
@@ -145,7 +145,9 @@ impl TryFrom<ProtoScalarType> for ScalarType {
                         let st: ScalarType = (*x).try_into()?;
                         st.into()
                     }
-                    None => Err(TryFromProtoError::MissingField("xx".into()))?,
+                    None => Err(TryFromProtoError::MissingField(
+                        "ProtoList::element_type".into(),
+                    ))?,
                 },
                 custom_oid: x.custom_oid,
             }),
@@ -163,7 +165,9 @@ impl TryFrom<ProtoScalarType> for ScalarType {
                         let st: ScalarType = (*x).try_into()?;
                         st.into()
                     }
-                    None => Err(TryFromProtoError::MissingField("xx".into()))?,
+                    None => Err(TryFromProtoError::MissingField(
+                        "ProtoMap::value_type".into(),
+                    ))?,
                 },
                 custom_oid: x.custom_oid,
             }),

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -185,7 +185,7 @@ impl RelationType {
 
 /// The name of a column in a [`RelationDesc`].
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
-pub struct ColumnName(String);
+pub struct ColumnName(pub(crate) String);
 
 impl ColumnName {
     /// Returns this column name as a `str`.


### PR DESCRIPTION
Currently each protobuf conversion module does an `include!` on the corresponding generated protobuf file. This is problematic if we try to move some conversion functions away from their intended location. For example the From and TryFrom implementations of `ColumnName` and `ColumnType` should live in `expr/proto/relation.rs`. In the current structure we would have to `include!` again the generated file. However this defines all the generated Protobuf enums *twice*, which creates all sorts of problems. 

It would be cleaner to include only once, and then use normal rust `use` to refer to it. For example, the attached PR creates a structure that only uses one `include!` per crate.

### Motivation

   * This PR refactors existing code.



### Tips for reviewer

 * Only have a look at the last commit: 2ca12552d767caba8950c2d33e6f5deacd2bae4a

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
