### PR TITLE
expr: add `ProtoDomainLimit` to `scalar.proto`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3989,6 +3989,7 @@ dependencies = [
  "num_enum",
  "ordered-float",
  "proptest",
+ "proptest-derive",
  "prost",
  "prost-build",
  "rand",

--- a/src/expr/src/proto/id.rs
+++ b/src/expr/src/proto/id.rs
@@ -125,16 +125,15 @@ impl mz_persist_types::Codec for PartitionId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mz_repr::proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {
         #[test]
-        fn id_serialization_roundtrip(original in any::<Id>()) {
-            let proto = ProtoId::from(&original);
-            let serialized = proto.encode_to_vec();
-            let proto = ProtoId::decode(&*serialized).unwrap();
-            let id = Id::try_from(proto).unwrap();
-            assert_eq!(id, original);
+        fn id_protobuf_roundtrip(expect in any::<Id>()) {
+            let actual = protobuf_roundtrip::<_, ProtoId>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
         }
     }
 }

--- a/src/expr/src/proto/mod.rs
+++ b/src/expr/src/proto/mod.rs
@@ -8,3 +8,4 @@
 // by the Apache License, Version 2.0.
 
 pub mod id;
+pub mod scalar;

--- a/src/expr/src/proto/scalar.proto
+++ b/src/expr/src/proto/scalar.proto
@@ -7,13 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-fn main() {
-    prost_build::Config::new()
-        .extern_path(".adt.array", "::mz_repr::proto::adt::array")
-        .extern_path(".strconv", "::mz_repr::proto::strconv")
-        .compile_protos(
-            &["id.proto", "scalar.proto"],
-            &["src/proto", "../repr/src/proto"],
-        )
-        .unwrap();
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package scalar;
+
+message ProtoDomainLimit {
+    oneof kind {
+        google.protobuf.Empty none = 1;
+        int64 inclusive = 2;
+        int64 exclusive = 3;
+    }
 }

--- a/src/expr/src/proto/scalar/mod.rs
+++ b/src/expr/src/proto/scalar/mod.rs
@@ -1,0 +1,58 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+include!(concat!(env!("OUT_DIR"), "/scalar.rs"));
+
+use crate::scalar::DomainLimit;
+use mz_repr::proto::TryFromProtoError;
+
+impl From<&DomainLimit> for ProtoDomainLimit {
+    fn from(limit: &DomainLimit) -> Self {
+        use proto_domain_limit::Kind::*;
+        let kind = match limit {
+            DomainLimit::None => None(()),
+            DomainLimit::Inclusive(v) => Inclusive(*v),
+            DomainLimit::Exclusive(v) => Exclusive(*v),
+        };
+        ProtoDomainLimit { kind: Some(kind) }
+    }
+}
+
+impl TryFrom<ProtoDomainLimit> for DomainLimit {
+    type Error = TryFromProtoError;
+
+    fn try_from(limit: ProtoDomainLimit) -> Result<Self, Self::Error> {
+        use proto_domain_limit::Kind::*;
+        if let Some(kind) = limit.kind {
+            match kind {
+                None(()) => Ok(DomainLimit::None),
+                Inclusive(v) => Ok(DomainLimit::Inclusive(v)),
+                Exclusive(v) => Ok(DomainLimit::Exclusive(v)),
+            }
+        } else {
+            Err(TryFromProtoError::missing_field("`ProtoDomainLimit::kind`"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mz_repr::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn domain_limit_protobuf_roundtrip(expect in any::<DomainLimit>()) {
+            let actual = protobuf_roundtrip::<_, ProtoDomainLimit>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -32,6 +32,13 @@ use crate::RECURSION_LIMIT;
 pub mod func;
 pub mod like_pattern;
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(test)`, so `proptest` can remain a dev-dependency.
+// See https://altsysrq.github.io/proptest-book/proptest-derive/getting-started.html
+// for guidance on using `derive(Arbitrary)` outside of test code.
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub enum MirScalarExpr {
     /// A column of the input row
@@ -1215,6 +1222,7 @@ impl CheckedRecursion for MirScalarExprVisitor {
 }
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum DomainLimit {
     None,
     Inclusive(i64),

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -44,6 +44,7 @@ uuid = "0.8.2"
 [dev-dependencies]
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git" }
 rand = "0.8.5"
+proptest-derive = { git = "https://github.com/materializeInc/proptest.git" }
 
 [dev-dependencies.proptest]
 git = "https://github.com/materializeInc/proptest.git"

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -20,6 +20,13 @@ use std::cmp::Ordering;
 
 use mz_lowertest::MzReflect;
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(test)`, so `proptest` can remain a dev-dependency.
+// See https://altsysrq.github.io/proptest-book/proptest-derive/getting-started.html
+// for guidance on using `derive(Arbitrary)` outside of test code.
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 /// The maximum number of dimensions permitted in an array.
 pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
 
@@ -134,6 +141,7 @@ pub struct ArrayDimension {
 #[derive(
     Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, MzReflect,
 )]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum InvalidArrayError {
     /// The number of dimensions in the array exceedes [`MAX_ARRAY_DIMENSIONS]`.
     TooManyDimensions(usize),

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -17,6 +17,13 @@ use mz_ore::cast::CastFrom;
 
 use std::fmt;
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(test)`, so `proptest` can remain a dev-dependency.
+// See https://altsysrq.github.io/proptest-book/proptest-derive/getting-started.html
+// for guidance on using `derive(Arbitrary)` outside of test code.
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 // https://github.com/postgres/postgres/blob/REL_14_0/src/include/access/htup_details.h#L577-L584
 const MAX_LENGTH: u32 = 10_485_760;
 
@@ -35,6 +42,7 @@ pub struct Char<S: AsRef<str>>(pub S);
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, MzReflect,
 )]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct CharLength(pub(crate) u32);
 
 impl CharLength {

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -23,6 +23,13 @@ use serde::{Deserialize, Serialize};
 use mz_lowertest::MzReflect;
 use mz_ore::cast;
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(test)`, so `proptest` can remain a dev-dependency.
+// See https://altsysrq.github.io/proptest-book/proptest-derive/getting-started.html
+// for guidance on using `derive(Arbitrary)` outside of test code.
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 /// The number of internal decimal units in a [`Numeric`] value.
 pub const NUMERIC_DATUM_WIDTH: u8 = 13;
 
@@ -80,6 +87,7 @@ lazy_static! {
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, MzReflect,
 )]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct NumericMaxScale(pub(crate) u8);
 
 impl NumericMaxScale {

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -17,6 +17,13 @@ use mz_ore::cast::CastFrom;
 
 use std::fmt;
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(test)`, so `proptest` can remain a dev-dependency.
+// See https://altsysrq.github.io/proptest-book/proptest-derive/getting-started.html
+// for guidance on using `derive(Arbitrary)` outside of test code.
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 // https://github.com/postgres/postgres/blob/REL_14_0/src/include/access/htup_details.h#L577-L584
 pub const MAX_MAX_LENGTH: u32 = 10_485_760;
 
@@ -35,6 +42,7 @@ pub struct VarChar<S: AsRef<str>>(pub S);
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, MzReflect,
 )]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct VarCharMaxLength(pub(crate) u32);
 
 impl VarCharMaxLength {

--- a/src/repr/src/proto/adt/array.rs
+++ b/src/repr/src/proto/adt/array.rs
@@ -52,3 +52,19 @@ impl TryFrom<ProtoInvalidArrayError> for InvalidArrayError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn invalid_array_error_protobuf_roundtrip(expect in any::<InvalidArrayError>()) {
+            let actual = protobuf_roundtrip::<_, ProtoInvalidArrayError>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/repr/src/proto/adt/char.rs
+++ b/src/repr/src/proto/adt/char.rs
@@ -27,3 +27,19 @@ impl TryFrom<ProtoCharLength> for CharLength {
         Ok(CharLength(repr.value))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn char_length_protobuf_roundtrip(expect in any::<CharLength>()) {
+            let actual = protobuf_roundtrip::<_, ProtoCharLength>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/repr/src/proto/adt/numeric.rs
+++ b/src/repr/src/proto/adt/numeric.rs
@@ -29,3 +29,19 @@ impl TryFrom<ProtoNumericMaxScale> for NumericMaxScale {
         Ok(NumericMaxScale(u8::from_proto(repr.value)?))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn numeric_max_scale_protobuf_roundtrip(expect in any::<NumericMaxScale>()) {
+            let actual = protobuf_roundtrip::<_, ProtoNumericMaxScale>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/repr/src/proto/adt/varchar.rs
+++ b/src/repr/src/proto/adt/varchar.rs
@@ -27,3 +27,19 @@ impl TryFrom<ProtoVarCharMaxLength> for VarCharMaxLength {
         Ok(VarCharMaxLength(repr.value))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn var_char_max_length_protobuf_roundtrip(expect in any::<VarCharMaxLength>()) {
+            let actual = protobuf_roundtrip::<_, ProtoVarCharMaxLength>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/repr/src/proto/mod.rs
+++ b/src/repr/src/proto/mod.rs
@@ -162,3 +162,13 @@ where
             .try_into()
     }
 }
+
+pub fn protobuf_roundtrip<'t, T, U>(val: &'t T) -> anyhow::Result<T>
+where
+    T: TryFrom<U, Error = TryFromProtoError>,
+    U: From<&'t T> + ::prost::Message + Default,
+{
+    let vec = U::from(&val).encode_to_vec();
+    let val = U::decode(&*vec)?.try_into()?;
+    Ok(val)
+}

--- a/src/repr/src/proto/strconv.rs
+++ b/src/repr/src/proto/strconv.rs
@@ -80,3 +80,28 @@ impl TryFrom<ProtoParseHexError> for ParseHexError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn parse_error_protobuf_roundtrip(expect in any::<ParseError>()) {
+            let actual = protobuf_roundtrip::<_, ProtoParseError>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn parse_hex_error_protobuf_roundtrip(expect in any::<ParseHexError>()) {
+            let actual = protobuf_roundtrip::<_, ProtoParseHexError>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -53,6 +53,13 @@ use crate::adt::interval::Interval;
 use crate::adt::jsonb::{Jsonb, JsonbRef};
 use crate::adt::numeric::{self, Numeric, NUMERIC_DATUM_MAX_PRECISION};
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(test)`, so `proptest` can remain a dev-dependency.
+// See https://altsysrq.github.io/proptest-book/proptest-derive/getting-started.html
+// for guidance on using `derive(Arbitrary)` outside of test code.
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 macro_rules! bail {
     ($($arg:tt)*) => { return Err(format!($($arg)*)) };
 }
@@ -1407,6 +1414,7 @@ where
 
 /// An error while parsing an input as a type.
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct ParseError {
     pub(crate) kind: ParseErrorKind,
     pub(crate) type_name: String,
@@ -1417,6 +1425,7 @@ pub struct ParseError {
 #[derive(
     Ord, PartialOrd, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
 )]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum ParseErrorKind {
     OutOfRange,
     InvalidInputSyntax,
@@ -1490,6 +1499,7 @@ impl fmt::Display for ParseError {
 impl Error for ParseError {}
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub enum ParseHexError {
     InvalidHexDigit(char),
     OddLength,


### PR DESCRIPTION
This is a first of several PRs to come that will conclude with the addition of `ProtoEvalError` to `scalar.proto`.

### Motivation

  * This PR adds a known-desirable feature.

    Will fill this in when we have the EPIC.

### Tips for reviewer

As part of this PR I am also installing a `protobuf_roundtrip` function and adding tests for the following types:

- `ParseError` and `ParseHexError`
- `VarCharMaxLength`
- `NumericMaxScale`
- `CharLength`
- `InvalidArrayError`

Test definitions are unified as follows:
- Each test now follows the same naming pattern (e.g. `domain_limit_protobuf_roundtrip` and `id_protobuf_roundtrip`).
- Up to some types the definitions of these tests are parametric.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A
