### PR TITLE
doc/user: CI check current sitemap for breaks

### DIFF
--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -15,5 +15,11 @@ set -euo pipefail
 
 git clean -ffdX ci/www/public
 hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destination ../../ci/www/public/docs
+# To avoid breaking URLs that already exist, pull the production sitemap
+# and convert it to HTML. htmltest will scan the current prod paths and
+# complain if any have been broken in this build.
+curl https://materialize.com/docs/sitemap.xml -o ci/www/sitemap.xml
+sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/www/sitemap.xml > ci/www/sitemap.html
 echo "<!doctype html>" > ci/www/public/index.html
+cat ci/www/sitemap.html >> ci/www/public/index.html
 htmltest -s ci/www/public -c doc/user/.htmltest.yml

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -24,5 +24,5 @@ git pull
 hugo --gc --source doc/user --destination ../../ci/tmp/
 echo "<!doctype html>" > ci/www/public/index.html
 sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/tmp/sitemap.xml >> ci/www/public/index.html
-git checkout $(CURRENT_BRANCH)
+git checkout $CURRENT_BRANCH
 htmltest -s ci/www/public -c doc/user/.htmltest.yml

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -12,13 +12,18 @@
 # lint.sh — checks for broken links and other HTML errors.
 
 set -euo pipefail
-
+# Save current branch so we can temp checkout main and switch back
+export CURRENT_BRANCH=(git rev-parse --abbrev-ref HEAD)
 git clean -ffdX ci/www/public
 hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destination ../../ci/www/public/docs
 # To avoid breaking URLs that already exist, pull the production sitemap
 # and convert it to HTML. htmltest will scan the current prod paths and
 # complain if any have been broken in this build.
-curl https://materialize.com/docs/sitemap.xml -o ci/www/sitemap.xml
+git checkout main
+git pull
+hugo --gc --source doc/user --destination tmp
 echo "<!doctype html>" > ci/www/public/index.html
+sed ... tmp/sitemap.xml >> ci/www/public/index.html
 sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/www/sitemap.xml >> ci/www/public/index.html
 htmltest -s ci/www/public -c doc/user/.htmltest.yml
+git checkout $(CURRENT_BRANCH)

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -21,8 +21,8 @@ hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destinat
 # complain if any have been broken in this build.
 git checkout main
 git pull
-hugo --gc --source doc/user --destination tmp
+hugo --gc --source doc/user --destination ../../ci/tmp/
 echo "<!doctype html>" > ci/www/public/index.html
-sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' tmp/sitemap.xml >> ci/www/public/index.html
+sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ../../ci/tmp/sitemap.xml >> ci/www/public/index.html
 git checkout $(CURRENT_BRANCH)
 htmltest -s ci/www/public -c doc/user/.htmltest.yml

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -23,6 +23,6 @@ git checkout main
 git pull
 hugo --gc --source doc/user --destination ../../ci/tmp/
 echo "<!doctype html>" > ci/www/public/index.html
-sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ../../ci/tmp/sitemap.xml >> ci/www/public/index.html
+sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/tmp/sitemap.xml >> ci/www/public/index.html
 git checkout $(CURRENT_BRANCH)
 htmltest -s ci/www/public -c doc/user/.htmltest.yml

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -23,7 +23,6 @@ git checkout main
 git pull
 hugo --gc --source doc/user --destination tmp
 echo "<!doctype html>" > ci/www/public/index.html
-sed ... tmp/sitemap.xml >> ci/www/public/index.html
-sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/www/sitemap.xml >> ci/www/public/index.html
-htmltest -s ci/www/public -c doc/user/.htmltest.yml
+sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' tmp/sitemap.xml >> ci/www/public/index.html
 git checkout $(CURRENT_BRANCH)
+htmltest -s ci/www/public -c doc/user/.htmltest.yml

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -19,7 +19,6 @@ hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destinat
 # and convert it to HTML. htmltest will scan the current prod paths and
 # complain if any have been broken in this build.
 curl https://materialize.com/docs/sitemap.xml -o ci/www/sitemap.xml
-sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/www/sitemap.xml > ci/www/sitemap.html
 echo "<!doctype html>" > ci/www/public/index.html
-cat ci/www/sitemap.html >> ci/www/public/index.html
+sed 's/<loc>\(.*\)<\/loc>/<a href="\1"><\/a>/g' ci/www/sitemap.xml >> ci/www/public/index.html
 htmltest -s ci/www/public -c doc/user/.htmltest.yml


### PR DESCRIPTION
This is really ugly, but it's useful.

### The problem

To maintain cleanliness in docs, we use `htmltest` to scan the static site build for broken links and other obvious HTML errors.

That's great, but it misses one particularly prevalent category of broken link errors: Broken links across builds.

**For Example:**
- if I move it and update all internal links, I won't necessarily remember to create an alias, and once again EXTERNAL links will break.
- If I delete a docs page, and all the INTERNAL links to the docs page, all tests will pass but I will have created a 404 for any EXTERNAL links to the deleted page. It's better to think about "what is the best page to send these users to now" instead of just giving them a 404

### The Solution

1. Download the **production** XML sitemap which contains local paths to all the public URLs for Docs. Save it in the same directory as the rest of the local build the CI script uses to scan for broken links
2. Search/replace the xml to convert `<loc>/path/</loc>` to `<a href="/path/"></a>`

I saw we are already doing a little hack where we have to add an index.html at the top level so I just dump the converted sitemap into that same file.