### PR TITLE
ci: Fix shellcheck issue

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -165,15 +165,15 @@ case "$cmd" in
                 --volume "/var/run/docker.sock:/var/run/docker.sock"
                 --user "$(id -u):$(stat -c %g /var/run/docker.sock)"
                 --network host
-                --env DOCKER_TLS_VERIFY="${DOCKER_TLS_VERIFY-}"
-                --env DOCKER_HOST="${DOCKER_HOST-}"
+                --env "DOCKER_TLS_VERIFY=${DOCKER_TLS_VERIFY-}"
+                --env "DOCKER_HOST=${DOCKER_HOST-}"
             )
 
             # Forward Docker daemon certificates, if requested.
             if [[ "${DOCKER_CERT_PATH:-}" ]]; then
                 args+=(
                     --volume "$DOCKER_CERT_PATH:/docker-certs"
-                    --env DOCKER_CERT_PATH=/docker-certs
+                    --env "DOCKER_CERT_PATH=/docker-certs"
                 )
             fi
 


### PR DESCRIPTION
Running `bin/pre-push` would generate the following error: 
```
$ xargs shellcheck -P SCRIPTDIR

In bin/ci-builder line 168:
                --env DOCKER_TLS_VERIFY="${DOCKER_TLS_VERIFY-}"
                      ^----------------^ SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.

Did you mean: 
                --env "DOCKER_TLS_VERIFY=""${DOCKER_TLS_VERIFY-}"


In bin/ci-builder line 169:
                --env DOCKER_HOST="${DOCKER_HOST-}"
                      ^----------^ SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.

Did you mean: 
                --env "DOCKER_HOST=""${DOCKER_HOST-}"


In bin/ci-builder line 176:
                    --env DOCKER_CERT_PATH=/docker-certs
                          ^----------------------------^ SC2191: The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.

Did you mean: 
                    --env "DOCKER_CERT_PATH=/docker-certs"

For more information:
  https://www.shellcheck.net/wiki/SC2191 -- The = here is literal. To assign ...
```
This PR fixes that error

### Motivation
This PR fixes a previously unreported bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes.
