### PR TITLE
materialized: accept X-Materialize-Version header in CORS requests

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use futures::future::TryFutureExt;
 use headers::authorization::{Authorization, Basic, Bearer};
-use headers::HeaderMapExt;
+use headers::{HeaderMapExt, HeaderName};
 use http::header::{HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use hyper::{Body, Method, Request, Response, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
@@ -279,7 +279,11 @@ impl Server {
             .layer(
                 CorsLayer::new()
                     .allow_credentials(false)
-                    .allow_headers([AUTHORIZATION, CONTENT_TYPE])
+                    .allow_headers([
+                        AUTHORIZATION,
+                        CONTENT_TYPE,
+                        HeaderName::from_static("x-materialize-version"),
+                    ])
                     .allow_methods(cors::Any)
                     .allow_origin(self.allowed_origin.clone())
                     .expose_headers(cors::Any)


### PR DESCRIPTION
Our cloud web UI passes along this header so that the server knows what
version of the frontend issued the request. It's perfectly safe to allow
via CORS.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug: the cloud web UI could not communicate with `materialized` in production.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
