### PR TITLE
fix kafka-headers test for multi-partition

### DIFF
--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -84,7 +84,7 @@ fish2   fishval  1000   <null>   <null>
 
 
 # Works with other includes
-$ kafka-create-topic topic=headers_also
+$ kafka-create-topic topic=headers_also partitions=1
 
 $ kafka-ingest format=avro topic=headers_also key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus":"gusfive"}
 {"key": "fish"} {"f1": "fishval", "f2": 1000}


### PR DESCRIPTION
the earlier tests in this file test multi-partition with headers, this just needs to be fixed so that the `INCLUDE PARTITION` works
locally tested with `--kafka-default-partitions=5`

### Motivation

  * This PR fixes a previously unreported bug.
nightly regression


### Testing

- [ x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
