### PR TITLE
jemalloc: declare alloc in bin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3459,6 +3459,7 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "serde",
+ "tikv-jemallocator",
  "timely",
  "tokio",
  "tokio-serde",

--- a/src/dataflowd/Cargo.toml
+++ b/src/dataflowd/Cargo.toml
@@ -22,3 +22,11 @@ tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 tracing = "0.1.33"
 tracing-subscriber = "0.3.11"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+# According to jemalloc developers, `background_threads` should always be
+# enabled, except in "esoteric" situations that don't apply to Materialize
+# (Namely: if the application relies on new threads not being created for whatever reason)
+#
+# See: https://github.com/jemalloc/jemalloc/issues/956#issuecomment-316224733
+tikv-jemallocator = { version = "0.4.3", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }

--- a/src/dataflowd/src/bin/dataflowd.rs
+++ b/src/dataflowd/src/bin/dataflowd.rs
@@ -29,6 +29,18 @@ use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 
+// Disable jemalloc on macOS, as it is not well supported [0][1][2].
+// The issues present as runaway latency on load test workloads that are
+// comfortably handled by the macOS system allocator. Consider re-evaluating if
+// jemalloc's macOS support improves.
+//
+// [0]: https://github.com/jemalloc/jemalloc/issues/26
+// [1]: https://github.com/jemalloc/jemalloc/issues/843
+// [2]: https://github.com/jemalloc/jemalloc/issues/1467
+#[cfg(not(target_os = "macos"))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[derive(clap::ArgEnum, Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 enum RuntimeType {
     /// Host only the compute portion of the dataflow.

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -56,6 +56,18 @@ use mz_ore::now::SYSTEM_TIME;
 mod sys;
 mod tracing;
 
+// Disable jemalloc on macOS, as it is not well supported [0][1][2].
+// The issues present as runaway latency on load test workloads that are
+// comfortably handled by the macOS system allocator. Consider re-evaluating if
+// jemalloc's macOS support improves.
+//
+// [0]: https://github.com/jemalloc/jemalloc/issues/26
+// [1]: https://github.com/jemalloc/jemalloc/issues/843
+// [2]: https://github.com/jemalloc/jemalloc/issues/1467
+#[cfg(not(target_os = "macos"))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 type OptionalDuration = Option<Duration>;
 
 fn parse_optional_duration(s: &str) -> Result<OptionalDuration, anyhow::Error> {

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -53,18 +53,6 @@ pub mod mux;
 pub mod server_metrics;
 pub mod telemetry;
 
-// Disable jemalloc on macOS, as it is not well supported [0][1][2].
-// The issues present as runaway latency on load test workloads that are
-// comfortably handled by the macOS system allocator. Consider re-evaluating if
-// jemalloc's macOS support improves.
-//
-// [0]: https://github.com/jemalloc/jemalloc/issues/26
-// [1]: https://github.com/jemalloc/jemalloc/issues/843
-// [2]: https://github.com/jemalloc/jemalloc/issues/1467
-#[cfg(not(target_os = "macos"))]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
 pub const BUILD_INFO: BuildInfo = BuildInfo {
     version: env!("CARGO_PKG_VERSION"),
     sha: run_command_str!(


### PR DESCRIPTION
Currently, materialized declares the allocator in its lib module. This
can cause conflicts if the module is shared with another declaration of an
allocator. For this reason, move the allocator definition to the binary
itself.

Use jemalloc for dataflowd, similarly to materialized.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A