### PR TITLE
lowertest: Resolve `Option<T>` as option first.

### DIFF
--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -259,13 +259,13 @@ construct the enum variant or the struct using the default syntax.
 
 Generally, combinations of the above are supported. The exception are
 types with values that `serde_json` cannot distinguish from `None` because
-`serde_json` serializes them all to the same string "null". 
+`serde_json` serializes them all to the same string "null".
 * Multiple `Option<>`s nested within each other, e.g. `Option<Option<u32>>`, or
   `Option<SingleUnnamedOptionStruct>`, where the struct is defined as
   `SingleUnnamedOptionStruct(Option<u32>)`. `serde_json` cannot distinguish
   `Some(None)` from `None`.
 * `Option<NoArgumentStruct>`. `serde_json` cannot distinguish
-  `Some(NoArgumentStruct)` from `None`. 
+  `Some(NoArgumentStruct)` from `None`.
 
 ## Roundtrip
 

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -41,7 +41,7 @@ Write:
 * a struct with arguments as `(field1 field2 .. fieldn)`
 * a struct with no arguments as the empty string.
 * a `Vec` as `[elem1 elem2 .. elemn]`
-* a tuple as `{elem1 elem2 .. elemn}`
+* a tuple as `[elem1 elem2 .. elemn]`
 * `None` or `null` as `null`
 * `true` (resp. `false`) as `true` (resp. `false`)
 * a string as `"something with quotations"`.
@@ -58,9 +58,23 @@ details.
 As a convenience, a unit enum (resp. a struct with only one argument) can
 alternatively be written as `variant_in_snake_case` (resp. `field1`).
 
-The convenience cannot be used if you have a struct whose only argument is a
-non-unit enum (resp. a struct with multiple arguments). In this case, you
-should use two sets of parentheses, e.g.
+In the case where there are nested single-argument structs, the type resolution
+system always tries to resolve your specification as an instance of the current
+type before trying to resolve the specification as the type of the single
+argument.
+
+Suppose you had two structs:
+```
+struct InnerStruct {only_arg: Option<u32>}
+struct OuterStruct {only_arg: Option<InnerStruct>}
+```
+and you were trying to create an instance of `OuterStruct`. Specifiying:
+* `null` or `(null)` result in an `OuterStruct{only_arg: None}`.
+* `((null))` results in an `OuterStruct{only_arg: Some(InnerStruct{only_arg: None})}`.
+* `1`, `(1)`, or `((1))` result in `OuterStruct{only_arg: Some(InnerStruct{only_arg:Some(1)})}`.
+
+If you have a struct whose only argument is a non-unit enum (resp. a struct
+with multiple arguments), you should use two sets of parentheses, e.g.
 `((variant_in_snake_case field1 .. fieldn))` (resp. `((field1 .. fieldn))`) to
 make it clear that the multiple arguments belong to the inner enum (resp.
 struct) and not the outer struct.
@@ -242,7 +256,16 @@ construct the enum variant or the struct using the default syntax.
 * `Box<>`
 * `Option<>`
 * `Vec<>`
-* Combinations of the above.
+
+Generally, combinations of the above are supported. The exception are
+types with values that `serde_json` cannot distinguish from `None` because
+`serde_json` serializes them all to the same string "null". 
+* Multiple `Option<>`s nested within each other, e.g. `Option<Option<u32>>`, or
+  `Option<SingleUnnamedOptionStruct>`, where the struct is defined as
+  `SingleUnnamedOptionStruct(Option<u32>)`. `serde_json` cannot distinguish
+  `Some(None)` from `None`.
+* `Option<NoArgumentStruct>`. `serde_json` cannot distinguish
+  `Some(NoArgumentStruct)` from `None`. 
 
 ## Roundtrip
 

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -161,9 +161,11 @@ where
     }
 
     if let Some(first_arg) = stream_iter.next() {
+        // If type is `Option<T>`, convert the token to None if it is null,
+        // otherwise, try to convert it to an instance of `T`.
         if option_found {
             if let TokenTree::Ident(ident) = &first_arg {
-                if ident.to_string() == "null" {
+                if *ident == "null" {
                     return Ok(Some("null".to_string()));
                 }
             }
@@ -623,8 +625,11 @@ where
     if let Some(result) = ctx.reverse_syntax_override(json, &type_name, rti) {
         return result;
     }
-    if let Value::Null = json {
-        if option_found {
+    // If type is `Option<T>`, convert the value to "null" if it is null,
+    // otherwise, try to convert it to a spec corresponding to an object of
+    // type `T`.
+    if option_found {
+        if let Value::Null = json {
             return "null".to_string();
         }
     }

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -33,16 +33,26 @@ mod tests {
 
     #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct MultiNamedArg {
-        fizz: Vec<Option<bool>>,
+        fizz: Vec<Option<MultiUnnamedArg>>,
         #[serde(default)]
         bizz: Vec<Vec<(SingleUnnamedArg, bool)>>,
     }
 
     #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct FirstArgEnum {
-        test_enum: Box<TestEnum>,
+        test_enum: Box<Box<TestEnum>>,
         #[serde(default)]
         second_arg: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
+    struct SingleNamedOptionArg {
+        named_field: Option<bool>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
+    struct SecondLayerOfOption {
+        named_field: Option<SingleNamedOptionArg>,
     }
 
     #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
@@ -60,11 +70,12 @@ mod tests {
         SingleUnnamedField2(Vec<i64>),
         SingleUnnamedField3(MultiNamedArg),
         SingleUnnamedZeroArgField(ZeroArg),
-        MultiUnnamedFields(MultiUnnamedArg, MultiNamedArg, Box<TestEnum>),
+        MultiUnnamedFields(MultiUnnamedArg, Option<Box<TestEnum>>, Box<TestEnum>),
         MultiUnnamedFields2(OptionalArg, FirstArgEnum, #[serde(default)] String),
         MultiUnnamedZeroArgFields(ZeroArg, ZeroArg),
-        MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg),
+        MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg, Option<SingleNamedOptionArg>),
         Unit,
+        OptionStructNesting(SecondLayerOfOption),
     }
 
     lazy_static! {

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -40,6 +40,7 @@ mod tests {
 
     #[derive(Debug, Deserialize, PartialEq, Serialize, MzReflect)]
     struct FirstArgEnum {
+        #[allow(clippy::redundant_allocation)]
         test_enum: Box<Box<TestEnum>>,
         #[serde(default)]
         second_arg: String,

--- a/src/lowertest/tests/testdata/build
+++ b/src/lowertest/tests/testdata/build
@@ -96,9 +96,9 @@ Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum:
 #single field is a Vec
 
 build
-(multi_unnamed_fields 
-    ([], "bar") 
-    (single_unnamed_field_3 [([[10 [["bc" 7] ["34" 34]] 20]] "aaa") null ([] "baz")]) 
+(multi_unnamed_fields
+    ([], "bar")
+    (single_unnamed_field_3 [([[10 [["bc" 7] ["34" 34]] 20]] "aaa") null ([] "baz")])
     (single_named_field [0 10 11]))
 ----
 Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(MultiUnnamedArg([(10, [("bc", 7), ("34", 34)], 20)], "aaa")), None, Some(MultiUnnamedArg([], "baz"))], bizz: [] })), SingleNamedField { foo: [0, 10, 11] }))

--- a/src/lowertest/tests/testdata/build
+++ b/src/lowertest/tests/testdata/build
@@ -22,10 +22,10 @@ build
         ]
         "hello"
     )
-    ([true false null] [[[100 true] [200 false]][]])
+    (single_unnamed_field_3 ([([] "a") ([[1 [] 0]] "poof") null] [[[100 true] [200 false]][]]))
     (single_named_field [0 10 42]))
 ----
-Some(MultiUnnamedFields(MultiUnnamedArg([(3, [("world", 5), ("this", 2)], 4), (2, [], 0)], "hello"), MultiNamedArg { fizz: [Some(true), Some(false), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] }, SingleNamedField { foo: [0, 10, 42] }))
+Some(MultiUnnamedFields(MultiUnnamedArg([(3, [("world", 5), ("this", 2)], 4), (2, [], 0)], "hello"), Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(MultiUnnamedArg([], "a")), Some(MultiUnnamedArg([(1, [], 0)], "poof")), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] })), SingleNamedField { foo: [0, 10, 42] }))
 
 build
 (multi_named_fields null false)
@@ -96,14 +96,17 @@ Some(MultiUnnamedFields2(OptionalArg(false, (0.0, 0)), FirstArgEnum { test_enum:
 #single field is a Vec
 
 build
-(multi_unnamed_fields ([], "bar") [false null true] (single_named_field [0 10 11]))
+(multi_unnamed_fields 
+    ([], "bar") 
+    (single_unnamed_field_3 [([[10 [["bc" 7] ["34" 34]] 20]] "aaa") null ([] "baz")]) 
+    (single_named_field [0 10 11]))
 ----
-Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), MultiNamedArg { fizz: [Some(false), None, Some(true)], bizz: [] }, SingleNamedField { foo: [0, 10, 11] }))
+Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(MultiUnnamedArg([(10, [("bc", 7), ("34", 34)], 20)], "aaa")), None, Some(MultiUnnamedArg([], "baz"))], bizz: [] })), SingleNamedField { foo: [0, 10, 11] }))
 
 build
-(multi_unnamed_fields ([], "bar") ([false null true]) (single_named_field [0 10 11]))
+(multi_unnamed_fields ([], "bar") (multi_unnamed_zero_arg_fields) (single_named_field [0 10 11]))
 ----
-Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), MultiNamedArg { fizz: [Some(false), None, Some(true)], bizz: [] }, SingleNamedField { foo: [0, 10, 11] }))
+Some(MultiUnnamedFields(MultiUnnamedArg([], "bar"), Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg)), SingleNamedField { foo: [0, 10, 11] }))
 
 build
 (single_unnamed_field2 [-1 4 -2 0])
@@ -113,9 +116,9 @@ Some(SingleUnnamedField2([-1, 4, -2, 0]))
 #single field is a struct with named fields
 
 build
-(single_unnamed_field3 ([true false false null] [[[-1.25 true] [1.24 false]]]))
+(single_unnamed_field3 ([([] "boop") null] [[[-1.25 true] [1.24 false]]]))
 ----
-Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(true), Some(false), Some(false), None], bizz: [[(SingleUnnamedArg(-1.25), true), (SingleUnnamedArg(1.24), false)]] }))
+Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(MultiUnnamedArg([], "boop")), None], bizz: [[(SingleUnnamedArg(-1.25), true), (SingleUnnamedArg(1.24), false)]] }))
 
 # Arguments are assumed to be part of an outer struct/enum
 # unless enclosed in parentheses.
@@ -134,6 +137,18 @@ build
 (multi_unnamed_fields_2 true (unit "baz"))
 ----
 Some(MultiUnnamedFields2(OptionalArg(true, (0.0, 0)), FirstArgEnum { test_enum: Unit, second_arg: "baz" }, ""))
+
+build
+(multi_unnamed_fields_2 (false [12.2 2]) (multi_named_fields "baz"))
+----
+Some(MultiUnnamedFields2(OptionalArg(false, (12.2, 2)), FirstArgEnum { test_enum: MultiNamedFields { bar: None, baz: false }, second_arg: "baz" }, ""))
+
+build
+(multi_unnamed_fields_2 (false [12.2 2]) ((multi_named_fields "baz")))
+----
+Some(MultiUnnamedFields2(OptionalArg(false, (12.2, 2)), FirstArgEnum { test_enum: MultiNamedFields { bar: Some("baz"), baz: false }, second_arg: "" }, ""))
+
+# Zero arg structs are specified as the empty string
 
 build
 (single_unnamed_zero_arg_field)
@@ -156,11 +171,44 @@ multi_unnamed_zero_arg_fields
 Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg))
 
 build
-(multi_unnamed_fields_first_zero_arg true)
+(multi_unnamed_fields_first_zero_arg true null)
 ----
-Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (0.0, 0))))
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (0.0, 0)), None))
 
 build
-(multi_unnamed_fields_first_zero_arg (true [3.14 2]))
+(multi_unnamed_fields_first_zero_arg (true [3.14 2]) (null))
 ----
-Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (3.14, 2))))
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (3.14, 2)), Some(SingleNamedOptionArg { named_field: None })))
+
+# Ambiguity resolution test when there are multiple single
+# argument Option<Struct> around each other.
+
+build
+(option_struct_nesting null)
+----
+Some(OptionStructNesting(SecondLayerOfOption { named_field: None }))
+
+build
+(option_struct_nesting (null))
+----
+Some(OptionStructNesting(SecondLayerOfOption { named_field: None }))
+
+build
+(option_struct_nesting ((null)))
+----
+Some(OptionStructNesting(SecondLayerOfOption { named_field: Some(SingleNamedOptionArg { named_field: None }) }))
+
+build
+(option_struct_nesting true)
+----
+Some(OptionStructNesting(SecondLayerOfOption { named_field: Some(SingleNamedOptionArg { named_field: Some(true) }) }))
+
+build
+(option_struct_nesting (true))
+----
+Some(OptionStructNesting(SecondLayerOfOption { named_field: Some(SingleNamedOptionArg { named_field: Some(true) }) }))
+
+build
+(option_struct_nesting ((true)))
+----
+Some(OptionStructNesting(SecondLayerOfOption { named_field: Some(SingleNamedOptionArg { named_field: Some(true) }) }))

--- a/src/lowertest/tests/testdata/build-override
+++ b/src/lowertest/tests/testdata/build-override
@@ -66,9 +66,9 @@ Some(SingleUnnamedField2([-1, 4, -2, 0]))
 #single field is a struct with named fields
 
 build override=true
-(single_unnamed_field3 ([true false false null] [[[-1.25 true] [1.24 false]]]))
+(single_unnamed_field3 ([([] "boop") null] [[[-1.25 true] [1.24 false]]]))
 ----
-Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(true), Some(false), Some(false), None], bizz: [[(SingleUnnamedArg(-1.25), true), (SingleUnnamedArg(1.24), false)]] }))
+Some(SingleUnnamedField3(MultiNamedArg { fizz: [Some(MultiUnnamedArg([], "boop")), None], bizz: [[(SingleUnnamedArg(-1.25), true), (SingleUnnamedArg(1.24), false)]] }))
 
 build override=true
 (multi_unnamed_fields_2 false unit)
@@ -116,14 +116,14 @@ multi_unnamed_zero_arg_fields
 Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg))
 
 build override=true
-(multi_unnamed_fields_first_zero_arg true)
+(multi_unnamed_fields_first_zero_arg true null)
 ----
-Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (0.0, 0))))
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (0.0, 0)), None))
 
 build override=true
-(multi_unnamed_fields_first_zero_arg (true [3.14 2]))
+(multi_unnamed_fields_first_zero_arg (true [3.14 2]) (null))
 ----
-Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (3.14, 2))))
+Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(true, (3.14, 2)), Some(SingleNamedOptionArg { named_field: None })))
 
 # Override tests.
 
@@ -139,10 +139,10 @@ build override=true
         ]
         "hello"
     )
-    ([true false null] [[[100 true] [200 false]][]])
+    (multi_unnamed_zero_arg_fields)
     (single_named_field [0 10 42]))
 ----
-Some(MultiUnnamedFields(MultiUnnamedArg([(4, [("world", 6), ("this", 3)], 5), (3, [], 1)], "hello"), MultiNamedArg { fizz: [Some(true), Some(false), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] }, SingleNamedField { foo: [1, 11, 43] }))
+Some(MultiUnnamedFields(MultiUnnamedArg([(4, [("world", 6), ("this", 3)], 5), (3, [], 1)], "hello"), Some(MultiUnnamedZeroArgFields(ZeroArg, ZeroArg)), SingleNamedField { foo: [1, 11, 43] }))
 
 build override=true
 (single_unnamed_field +1.1)
@@ -154,9 +154,9 @@ Some(SingleUnnamedField(SingleUnnamedArg(1.1)))
 build override=true
 (multi_unnamed_fields
     (2 "goodbye")
-    ([true false null] [[[100 true] [200 false]][]])
-    (multi_unnamed_fields 3 ([] [[[-1 true]]])
-         (multi_unnamed_fields "again" ([false false false] []) unit)
+    null
+    (multi_unnamed_fields 3 null
+         (multi_unnamed_fields "again" (multi_unnamed_fields_first_zero_arg false false) unit)
         ))
 ----
-Some(MultiUnnamedFields(MultiUnnamedArg([(2, [("\"goodbye\"", 2)], 2)], "\"goodbye\""), MultiNamedArg { fizz: [Some(true), Some(false), None], bizz: [[(SingleUnnamedArg(100.0), true), (SingleUnnamedArg(200.0), false)], []] }, MultiUnnamedFields(MultiUnnamedArg([(3, [("", 3)], 3)], ""), MultiNamedArg { fizz: [], bizz: [[(SingleUnnamedArg(-1.0), true)]] }, MultiUnnamedFields(MultiUnnamedArg([], "again"), MultiNamedArg { fizz: [Some(false), Some(false), Some(false)], bizz: [] }, Unit))))
+Some(MultiUnnamedFields(MultiUnnamedArg([(2, [("\"goodbye\"", 2)], 2)], "\"goodbye\""), None, MultiUnnamedFields(MultiUnnamedArg([(3, [("", 3)], 3)], ""), None, MultiUnnamedFields(MultiUnnamedArg([], "again"), Some(MultiUnnamedFieldsFirstZeroArg(ZeroArg, OptionalArg(false, (0.0, 0)), Some(SingleNamedOptionArg { named_field: Some(false) }))), Unit))))


### PR DESCRIPTION
Fixes several previously unreported issues:
1) If lowertest sees that "null" represents an instance of `Option<T>`, it should resolve "null" to None as opposed to an instance of `T`.
2) lowertest only stripped the first `Box` or `Option` it saw instead of stripping until it saw a non `Box` or `Option`.
3) Some unsupported edge cases were not properly documented.

### Tips for reviewer

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing changes.
