### PR TITLE
Harmonize error message while waiting for storage connection.

### DIFF
--- a/src/storage/src/boundary/tcp_boundary.rs
+++ b/src/storage/src/boundary/tcp_boundary.rs
@@ -112,8 +112,8 @@ pub mod server {
         info!("About to bind to {addr}");
         let listener = TcpListener::bind(addr).await?;
         info!(
-            "listening for storage connection on  {:?}...",
-            listener.local_addr()
+            "listening for storage connection on {}...",
+            listener.local_addr()?
         );
 
         let thread = mz_ore::task::spawn(


### PR DESCRIPTION
This makes the form of the error message match the one for the
coordinator connection. E.g.

```
listening for coordinator connection on 0.0.0.0:2100...
```

vs.

```
listening for storage connection on 0.0.0.0:2101...
```

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

none
