### PR TITLE
turn on MZ_SOFT_ASSERTIONS=1 in the testdrive binary

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -499,6 +499,7 @@ class Testdrive(Service):
         if environment is None:
             environment = [
                 "TMPDIR=/share/tmp",
+                "MZ_SOFT_ASSERTIONS=1",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
                 # then accidentally dependent on the state of the host machine.


### PR DESCRIPTION
### Motivation

No good reason not to

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
None