### PR TITLE
zippy: change the default testdrive timeout to 120s

### DIFF
--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -28,7 +28,7 @@ SERVICES = [
     SchemaRegistry(),
     # --persistent-kafka-sources can not be enabled due to gh#11711 , gh#11506
     Materialized(options="--persistent-user-tables"),
-    Testdrive(validate_data_dir=False, no_reset=True, seed=1),
+    Testdrive(validate_data_dir=False, no_reset=True, seed=1, default_timeout="300s"),
 ]
 
 all_action_classes = [


### PR DESCRIPTION
Increase the default timeout for testdrive invocations to account
for the following adverse circumstances:
- due to known bugs, the --persistent-kafka-sources option is not used,
  so all Kafka sources need to be re-ingested from scratch every time
  Mz is restarted.
- the AWS EC2 instances are substantially slower than Hetzner's AMDs

### Motivation

  * This PR fixes a previously unreported bug.

Failurs in the nightly Zippy in CI