### PR TITLE
ci: Move certain tests to Nightly in order to lighten the CI load

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -34,6 +34,8 @@ steps:
           - { value: feature-benchmark-persistence }
           - { value: aws-config }
           - { value: zippy }
+          - { value: persistence-failpoints }
+          - { value: catalog-compat }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -206,3 +208,23 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
+
+  - id: persistence-failpoints
+    label: Persistence failpoints
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    artifact_paths: junit_mzcompose_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persistence
+          run: failpoints
+
+  - id: catalog-compat
+    label: Catalog compatibility test
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    artifact_paths: junit_mzcompose_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: catalog-compat
+          run: catalog-compat

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -131,16 +131,6 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persistence
 
-  - id: persistence-failpoints
-    label: Persistence failpoints
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_mzcompose_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persistence
-          run: failpoints
-
   - id: cluster-smoke
     label: Cluster smoke test
     depends_on: build-x86_64
@@ -228,16 +218,6 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: kafka-ingest-open-loop
           run: smoke-test
-
-  - id: catalog-compat
-    label: Catalog compatibility test
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_mzcompose_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: catalog-compat
-          run: catalog-compat
 
   - id: restarts
     label: Restart test


### PR DESCRIPTION
- the "catalog-compat" tests, as the bulk of the
  upgrade testing effort is in the "upgrade" job.

- the "persistence-failpoints" tests, as persistence
  and recovery is being tested by the main "persistence" job

### Motivation

  * This PR fixes a previously unreported bug.

CI is slow and agents are permanently occupied.