### PR TITLE
doc: Fix typo in Postgres CDC guide

### DIFF
--- a/doc/user/content/guides/cdc-postgres.md
+++ b/doc/user/content/guides/cdc-postgres.md
@@ -199,7 +199,7 @@ If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://doc
 1. Check that the connector is running:
 
     ```bash
-    curl http://$CURRENT_HOST:8083/connectors/inventory-connector/status
+    curl http://$CURRENT_HOST:8083/connectors/your-connector/status
     ```
 
     The first time it connects to a Postgres server, Debezium takes a [consistent snapshot](https://debezium.io/documentation/reference/1.6/connectors/postgresql.html#postgresql-snapshots) of the tables selected for replication, so you should see that the pre-existing records in the replicated table are initially pushed into your Kafka topic:


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

In step 1, we create a new connector called `your-connector` but in step 3 we instruct the users to query a connector called `inventory-connector` (`curl http://$CURRENT_HOST:8083/connectors/your-connector/status`).

This was pointed out in this discussion [here](https://materializeinc.slack.com/archives/C03648YB34N/p1649719771052989?thread_ts=1649700514.829269&cid=C03648YB34N).