### PR TITLE
expr: add protobuf support for `UnmaterializableFunc`

### DIFF
--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -12,7 +12,7 @@ fn main() {
         .extern_path(".adt.array", "::mz_repr::proto::adt::array")
         .extern_path(".strconv", "::mz_repr::proto::strconv")
         .compile_protos(
-            &["id.proto", "scalar.proto"],
+            &["id.proto", "scalar.proto", "scalar/func.proto"],
             &["src/proto", "../repr/src/proto"],
         )
         .unwrap();

--- a/src/expr/src/proto/id.rs
+++ b/src/expr/src/proto/id.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+//! Protobuf structs mirroring `crate::id`.
+
 use bytes::BufMut;
 use prost::Message;
 

--- a/src/expr/src/proto/scalar/func.proto
+++ b/src/expr/src/proto/scalar/func.proto
@@ -1,0 +1,32 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package scalar.func;
+
+message ProtoUnmaterializableFunc {
+    oneof kind {
+        google.protobuf.Empty current_database = 1;
+        google.protobuf.Empty current_schemas_with_system = 2;
+        google.protobuf.Empty current_schemas_without_system = 3;
+        google.protobuf.Empty current_timestamp = 4;
+        google.protobuf.Empty current_user = 5;
+        google.protobuf.Empty mz_cluster_id = 6;
+        google.protobuf.Empty mz_logical_timestamp = 7;
+        google.protobuf.Empty mz_session_id = 8;
+        google.protobuf.Empty mz_uptime = 9;
+        google.protobuf.Empty mz_version = 10;
+        google.protobuf.Empty pg_backend_pid = 11;
+        google.protobuf.Empty pg_postmaster_start_time = 12;
+        google.protobuf.Empty version = 13;
+    }
+}

--- a/src/expr/src/proto/scalar/func.rs
+++ b/src/expr/src/proto/scalar/func.rs
@@ -1,0 +1,84 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::scalar::func`].
+
+use crate::scalar::func::UnmaterializableFunc;
+use mz_repr::proto::TryFromProtoError;
+
+include!(concat!(env!("OUT_DIR"), "/scalar.func.rs"));
+
+impl From<&UnmaterializableFunc> for ProtoUnmaterializableFunc {
+    fn from(func: &UnmaterializableFunc) -> Self {
+        use proto_unmaterializable_func::Kind::*;
+        let kind = match func {
+            UnmaterializableFunc::CurrentDatabase => CurrentDatabase(()),
+            UnmaterializableFunc::CurrentSchemasWithSystem => CurrentSchemasWithSystem(()),
+            UnmaterializableFunc::CurrentSchemasWithoutSystem => CurrentSchemasWithoutSystem(()),
+            UnmaterializableFunc::CurrentTimestamp => CurrentTimestamp(()),
+            UnmaterializableFunc::CurrentUser => CurrentUser(()),
+            UnmaterializableFunc::MzClusterId => MzClusterId(()),
+            UnmaterializableFunc::MzLogicalTimestamp => MzLogicalTimestamp(()),
+            UnmaterializableFunc::MzSessionId => MzSessionId(()),
+            UnmaterializableFunc::MzUptime => MzUptime(()),
+            UnmaterializableFunc::MzVersion => MzVersion(()),
+            UnmaterializableFunc::PgBackendPid => PgBackendPid(()),
+            UnmaterializableFunc::PgPostmasterStartTime => PgPostmasterStartTime(()),
+            UnmaterializableFunc::Version => Version(()),
+        };
+        ProtoUnmaterializableFunc { kind: Some(kind) }
+    }
+}
+
+impl TryFrom<ProtoUnmaterializableFunc> for UnmaterializableFunc {
+    type Error = TryFromProtoError;
+
+    fn try_from(func: ProtoUnmaterializableFunc) -> Result<Self, Self::Error> {
+        use proto_unmaterializable_func::Kind::*;
+        if let Some(kind) = func.kind {
+            match kind {
+                CurrentDatabase(()) => Ok(UnmaterializableFunc::CurrentDatabase),
+                CurrentSchemasWithSystem(()) => Ok(UnmaterializableFunc::CurrentSchemasWithSystem),
+                CurrentSchemasWithoutSystem(()) => {
+                    Ok(UnmaterializableFunc::CurrentSchemasWithoutSystem)
+                }
+                CurrentTimestamp(()) => Ok(UnmaterializableFunc::CurrentTimestamp),
+                CurrentUser(()) => Ok(UnmaterializableFunc::CurrentUser),
+                MzClusterId(()) => Ok(UnmaterializableFunc::MzClusterId),
+                MzLogicalTimestamp(()) => Ok(UnmaterializableFunc::MzLogicalTimestamp),
+                MzSessionId(()) => Ok(UnmaterializableFunc::MzSessionId),
+                MzUptime(()) => Ok(UnmaterializableFunc::MzUptime),
+                MzVersion(()) => Ok(UnmaterializableFunc::MzVersion),
+                PgBackendPid(()) => Ok(UnmaterializableFunc::PgBackendPid),
+                PgPostmasterStartTime(()) => Ok(UnmaterializableFunc::PgPostmasterStartTime),
+                Version(()) => Ok(UnmaterializableFunc::Version),
+            }
+        } else {
+            Err(TryFromProtoError::missing_field(
+                "`ProtoUnmaterializableFunc::kind`",
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mz_repr::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn unmaterializable_func_protobuf_roundtrip(expect in any::<UnmaterializableFunc>()) {
+            let actual = protobuf_roundtrip::<_, ProtoUnmaterializableFunc>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/expr/src/proto/scalar/mod.rs
+++ b/src/expr/src/proto/scalar/mod.rs
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-include!(concat!(env!("OUT_DIR"), "/scalar.rs"));
+pub mod func;
 
 use crate::scalar::{DomainLimit, EvalError};
 use mz_repr::proto::{ProtoRepr, TryFromProtoError, TryIntoIfSome};
+
+include!(concat!(env!("OUT_DIR"), "/scalar.rs"));
 
 impl From<&DomainLimit> for ProtoDomainLimit {
     fn from(limit: &DomainLimit) -> Self {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -50,6 +50,12 @@ use mz_repr::{
 use crate::scalar::func::format::DateTimeFormat;
 use crate::{like_pattern, EvalError, MirScalarExpr};
 
+// The `Arbitrary` impls are only used during testing and we gate them
+// behind `cfg(feature = "test-utils")`, so `proptest` can remain a dev-dependency.
+// See https://github.com/MaterializeInc/materialize/pull/11717.
+#[cfg(feature = "test-utils")]
+use proptest_derive::Arbitrary;
+
 #[macro_use]
 mod macros;
 mod encoding;
@@ -59,6 +65,7 @@ mod impls;
 pub use impls::*;
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[cfg_attr(feature = "test-utils", derive(Arbitrary))]
 pub enum UnmaterializableFunc {
     CurrentDatabase,
     CurrentSchemasWithSystem,

--- a/src/repr/src/proto/adt/array.rs
+++ b/src/repr/src/proto/adt/array.rs
@@ -9,10 +9,10 @@
 
 //! Protobuf structs mirroring [`crate::adt::array`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.array.rs"));
-
 use super::super::{ProtoRepr, TryFromProtoError};
 use crate::adt::array::InvalidArrayError;
+
+include!(concat!(env!("OUT_DIR"), "/adt.array.rs"));
 
 impl From<&InvalidArrayError> for ProtoInvalidArrayError {
     fn from(error: &InvalidArrayError) -> Self {

--- a/src/repr/src/proto/adt/char.rs
+++ b/src/repr/src/proto/adt/char.rs
@@ -9,10 +9,10 @@
 
 //! Protobuf structs mirroring [`crate::adt::char`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.char.rs"));
-
 use crate::adt::char::CharLength;
 use crate::proto::TryFromProtoError;
+
+include!(concat!(env!("OUT_DIR"), "/adt.char.rs"));
 
 impl From<&CharLength> for ProtoCharLength {
     fn from(x: &CharLength) -> Self {

--- a/src/repr/src/proto/adt/numeric.rs
+++ b/src/repr/src/proto/adt/numeric.rs
@@ -9,10 +9,10 @@
 
 //! Protobuf structs mirroring [`crate::adt::numeric`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.numeric.rs"));
-
 use crate::adt::numeric::NumericMaxScale;
 use crate::proto::{ProtoRepr, TryFromProtoError};
+
+include!(concat!(env!("OUT_DIR"), "/adt.numeric.rs"));
 
 impl From<&NumericMaxScale> for ProtoNumericMaxScale {
     fn from(value: &NumericMaxScale) -> Self {

--- a/src/repr/src/proto/adt/varchar.rs
+++ b/src/repr/src/proto/adt/varchar.rs
@@ -9,10 +9,10 @@
 
 //! Protobuf structs mirroring [`crate::adt::varchar`].
 
-include!(concat!(env!("OUT_DIR"), "/adt.varchar.rs"));
-
 use crate::adt::varchar::VarCharMaxLength;
 use crate::proto::TryFromProtoError;
+
+include!(concat!(env!("OUT_DIR"), "/adt.varchar.rs"));
 
 impl From<&VarCharMaxLength> for ProtoVarCharMaxLength {
     fn from(value: &VarCharMaxLength) -> Self {


### PR DESCRIPTION
Adds protobuf support for `UnmaterializableFunc`.

### Motivation

  * This PR adds a known-desirable feature.

Closes #11746.


### Tips for reviewer

- The first commit moves `import!` statements after all `use` and `mod` declarations in `mz-repr`.
- The second commit closes #11746. At the moment this `enum` consists only of nullary variants, so the conversion trait implementations are trivial.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A