### PR TITLE
Allow wildcard cors origin

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -29,7 +29,7 @@ use openssl::ssl::{Ssl, SslContext};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio_openssl::SslStream;
 use tower::ServiceBuilder;
-use tower_http::cors::{self, CorsLayer, Origin, AnyOr};
+use tower_http::cors::{self, AnyOr, CorsLayer, Origin};
 use tracing::error;
 
 use mz_coord::session::Session;
@@ -95,7 +95,11 @@ pub struct Server {
 
 impl Server {
     pub fn new(config: Config) -> Server {
-        let allowed_origin = if config.allowed_origins.iter().any(|val| val.as_bytes() == b"*") {
+        let allowed_origin = if config
+            .allowed_origins
+            .iter()
+            .any(|val| val.as_bytes() == b"*")
+        {
             tower_http::cors::Any.into()
         } else {
             Origin::list(config.allowed_origins).into()

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -29,7 +29,7 @@ use openssl::ssl::{Ssl, SslContext};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio_openssl::SslStream;
 use tower::ServiceBuilder;
-use tower_http::cors::{self, CorsLayer, Origin};
+use tower_http::cors::{self, CorsLayer, Origin, AnyOr};
 use tracing::error;
 
 use mz_coord::session::Session;
@@ -90,11 +90,16 @@ pub struct Server {
     metrics_registry: MetricsRegistry,
     global_metrics: Metrics,
     pgwire_metrics: mz_pgwire::Metrics,
-    allowed_origin: Origin,
+    allowed_origin: AnyOr<Origin>,
 }
 
 impl Server {
     pub fn new(config: Config) -> Server {
+        let allowed_origin = if config.allowed_origins.iter().any(|val| val.as_bytes() == b"*") {
+            tower_http::cors::Any.into()
+        } else {
+            Origin::list(config.allowed_origins).into()
+        };
         Server {
             tls: config.tls,
             frontegg: config.frontegg,
@@ -102,7 +107,7 @@ impl Server {
             metrics_registry: config.metrics_registry,
             global_metrics: config.global_metrics,
             pgwire_metrics: config.pgwire_metrics,
-            allowed_origin: Origin::list(config.allowed_origins),
+            allowed_origin,
         }
     }
 


### PR DESCRIPTION
This should allow the `*` wildcard for CORS origin.

### Testing

Untested, will test before landing

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Allow `--cors-allowed-origin='*'`
