### PR TITLE
persist: add unreliable wrappers for BlobMulti and Consensus

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -47,6 +47,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["metrics", "ta
 mz-persist-types = { path = "../persist-types" }
 parquet2 = { version = "0.10.3", default-features = false }
 prost = "0.9.0"
+rand = { version = "0.8.5", features = ["small_rng"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 semver = "1.0.7"
 serde = { version = "1.0.136", features = ["derive"] }
@@ -59,7 +60,6 @@ uuid = { version = "0.8.2", features = ["v4"] }
 [dev-dependencies]
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["html_reports"] }
 mz-ore = { path = "../ore", default-features = false, features = ["test"] }
-rand = { version = "0.8.5", features = ["small_rng"] }
 serde_json = "1.0.79"
 tempfile = "3.2.0"
 


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
