### PR TITLE
simplify SourceReader for kinesis

### DIFF
--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -42,9 +42,9 @@ use crate::render::envelope_none;
 use crate::render::envelope_none::PersistentEnvelopeNoneConfig;
 use crate::source::timestamp::{AssignedTimestamp, SourceTimestamp};
 use crate::source::{
-    self, DecodeResult, FileSourceReader, KafkaSourceReader, KinesisSourceReader,
-    PersistentTimestampBindingsConfig, PostgresSourceReader, PubNubSourceReader, S3SourceReader,
-    SourceConfig,
+    self, DecodeResult, DelimitedValueSource, FileSourceReader, KafkaSourceReader,
+    KinesisSourceReader, PersistentTimestampBindingsConfig, PostgresSourceReader,
+    PubNubSourceReader, S3SourceReader, SourceConfig,
 };
 use crate::storage_state::LocalInput;
 use crate::storage_state::StorageState;
@@ -335,14 +335,15 @@ where
                         ((SourceType::Delimited(ok), ts, err), cap)
                     }
                     ExternalSourceConnector::Kinesis(_) => {
-                        let ((ok, ts, err), cap) = source::create_source::<_, KinesisSourceReader>(
-                            source_config,
-                            &connector,
-                            source_persist_config
-                                .as_ref()
-                                .map(|config| config.bindings_config.clone()),
-                            storage_state.aws_external_id.clone(),
-                        );
+                        let ((ok, ts, err), cap) =
+                            source::create_source::<_, DelimitedValueSource<KinesisSourceReader>>(
+                                source_config,
+                                &connector,
+                                source_persist_config
+                                    .as_ref()
+                                    .map(|config| config.bindings_config.clone()),
+                                storage_state.aws_external_id.clone(),
+                            );
                         ((SourceType::Delimited(ok), ts, err), cap)
                     }
                     ExternalSourceConnector::S3(_) => {

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -55,7 +55,7 @@ pub struct KinesisSourceReader {
     /// TODO(natacha): this should be moved to timestamper
     last_checked_shards: Instant,
     /// Storage for messages that have not yet been timestamped
-    buffered_messages: VecDeque<SourceMessage<Option<Vec<u8>>, Option<Vec<u8>>>>,
+    buffered_messages: VecDeque<SourceMessage<(), Option<Vec<u8>>>>,
     /// Count of processed message
     processed_message_count: i64,
     /// Metrics from which per-shard metrics get created.
@@ -114,7 +114,7 @@ impl KinesisSourceReader {
 }
 
 impl SourceReader for KinesisSourceReader {
-    type Key = Option<Vec<u8>>;
+    type Key = ();
     type Value = Option<Vec<u8>>;
 
     fn new(
@@ -232,7 +232,7 @@ impl SourceReader for KinesisSourceReader {
                                 offset: self.processed_message_count,
                             },
                             upstream_time_millis: None,
-                            key: None,
+                            key: (),
                             value: Some(data),
                             headers: None,
                         };


### PR DESCRIPTION
Pure code movement. I found this to be very confusing, as trait impls should declare truthfully what they can support. I would make the new `From` impl more generic `D: Default`, but it conflicts with the `impl From<T> for T` impl in core

### Motivation

   * This PR refactors existing code.
see above



### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None


