### PR TITLE
orchestrator: fix dropping of clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1489,33 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dyn-clonable"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e9232f0e607a262ceb9bd5141a3dfb3e4db6994b31989bbfd845878cba59fd4"
-dependencies = [
- "dyn-clonable-impl",
- "dyn-clone",
-]
-
-[[package]]
-name = "dyn-clonable-impl"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558e40ea573c374cf53507fd240b7ee2f5477df7cfebdb97323ec61c719399c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
-
-[[package]]
 name = "educe"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3733,7 +3706,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "derivative",
- "dyn-clonable",
 ]
 
 [[package]]
@@ -3742,7 +3714,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "dyn-clonable",
  "k8s-openapi",
  "kube",
  "mz-orchestrator",

--- a/bin/materialized
+++ b/bin/materialized
@@ -11,6 +11,8 @@
 #
 # materialized — build and run materialized and its constituent services.
 
+set -euo pipefail
+
 . misc/shlib/shlib.bash
 
 release=false

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -175,7 +175,7 @@ where
             if let Some(OrchestratorConfig { orchestrator, .. }) = &mut self.orchestrator {
                 orchestrator
                     .namespace("compute")
-                    .drop_service(&format!("instance-{instance}"))
+                    .drop_service(&format!("cluster-{instance}"))
                     .await?;
             }
             compute.client.send(ComputeCommand::DropInstance).await?;

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.56"
 async-trait = "0.1.53"
-dyn-clonable = "0.9.0"
 mz-orchestrator = { path = "../orchestrator" }
 k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
 kube = { version = "0.70.0", features = ["ws"] }

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -10,4 +10,3 @@ publish = false
 anyhow = "1.0.56"
 async-trait = "0.1.53"
 derivative = "2.2.0"
-dyn-clonable = "0.9.0"


### PR DESCRIPTION
Fix the orchestrator trait to support correct dropping of clusters in
the process orchestrator. (We were inadvertently constructing a new
namespaced orchestrator on every CREATE CLUSTER/DROP CLUSTER call, which
worked fine for the Kubernetes orchestrator, but not for the process
orchestrator.)

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
