### PR TITLE
feature-benchmark: Remove performance testing of persistence from Nig…

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -31,7 +31,6 @@ steps:
           - { value: testdrive-partitions-5 }
           - { value: persistence-testdrive }
           - { value: feature-benchmark }
-          - { value: feature-benchmark-persistence }
           - { value: aws-config }
           - { value: zippy }
           - { value: secrets }
@@ -66,21 +65,6 @@ steps:
           args:
             - --other-tag
             - latest
-
-  - id: feature-benchmark-persistence
-    label: "Feature benchmark against latest release with persistence"
-    timeout_in_minutes: 180
-    depends_on: build-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args:
-            - --other-tag
-            - latest
-            - --this-options
-            - "--persistent-user-tables --persistent-kafka-sources"
-            - --other-options
-            - "--persistent-user-tables --persistent-kafka-sources"
 
   - id: coverage
     label: Code coverage


### PR DESCRIPTION
…htly

gh#11779 causes the CI to hang, so we will stop benchmarking on-disk
persistence for the time being. Benchmarking will be revived to measure
the performance of platform-based persistence in due course.


### Motivation

  * This PR fixes a previously unreported bug.
Nightly hangs due to https://github.com/MaterializeInc/materialize/issues/11779