### PR TITLE
mzcompose: fix entrypoint use in exec()

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -601,18 +601,16 @@ class Composition:
             stdin: read STDIN from a string.
         """
 
-        entrypoint = (
-            self.compose["services"][service]["entrypoint"]
-            if "entrypoint" in self.compose["services"][service]
-            else None
-        )
-
         return self.invoke(
             "exec",
             *(["--detach"] if detach else []),
             "-T",
             service,
-            *([entrypoint] if entrypoint else []),
+            *(
+                self.compose["services"][service]["entrypoint"]
+                if "entrypoint" in self.compose["services"][service]
+                else []
+            ),
             *args,
             stdin=stdin,
         )


### PR DESCRIPTION
Make sure that the exec() call works for services with and
without an entrypoint.

### Motivation

  * This PR fixes a previously unreported bug.

Zippy started failing in Nightly after mzcompose changes meant to allow testing of disk-stored secrets