### PR TITLE
expr,sql: add `lag` as a new window function

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -632,6 +632,13 @@
   functions:
   - signature: 'dense_rank() -> int'
     description: Returns the rank of the current row within its partition without gaps, counting from 1.
+  - signature: 'lag(value anycompatible [, offset integer [, default anycompatible ]]) -> int'
+    description: >-
+      Returns `value` evaluated at the row that is `offset` rows before the current row within the partition;
+      if there is no such row, instead returns `default` (which must be of a type compatible with `value`).
+      If `offset` is `NULL`, `NULL` is returned instead.
+      Both `offset` and `default` are evaluated with respect to the current row.
+      If omitted, `offset` defaults to 1 and `default` to `NULL`.
   - signature: 'row_number() -> int'
     description: Returns the number of the current row within its partition, counting from 1.
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1472,7 +1472,8 @@ pub mod monoids {
             | AggregateFunc::ListConcat { .. }
             | AggregateFunc::StringAgg { .. }
             | AggregateFunc::RowNumber { .. }
-            | AggregateFunc::DenseRank { .. } => None,
+            | AggregateFunc::DenseRank { .. }
+            | AggregateFunc::Lag { .. } => None,
         }
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -572,6 +572,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::ListConcat { .. }
         | AggregateFunc::StringAgg { .. }
         | AggregateFunc::RowNumber { .. }
-        | AggregateFunc::DenseRank { .. } => ReductionType::Basic,
+        | AggregateFunc::DenseRank { .. }
+        | AggregateFunc::Lag { .. } => ReductionType::Basic,
     }
 }

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -509,6 +509,11 @@ impl<'a> Explanation<'a> {
                     WindowExprType::Scalar(scalar) => {
                         write!(f, "{}()", scalar.clone().into_expr())?
                     }
+                    WindowExprType::Value(scalar) => {
+                        write!(f, "{}(", scalar.clone().into_expr())?;
+                        self.fmt_scalar_expr(f, &scalar.expr)?;
+                        write!(f, ")")?
+                    }
                 }
                 write!(f, " over (")?;
                 for (i, e) in expr.partition.iter().enumerate() {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -207,15 +207,21 @@ impl WindowExpr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// A window function with its parameters.
 ///
-/// There are two types of window functions: scalar window functions, that
-/// return a different scalar value for each row within a partition, and
-/// aggregate window functions, that return the same value for all the tuples
-/// within the same partition. Aggregate window functions can be computed
-/// by joining the input relation with a reduction over the same relation
-/// that computes the aggregation using the partition key as its grouping
-/// key.
+/// There are three types of window functions:
+/// - scalar window functions, that return a different scalar value for each
+/// row within a partition that depends exclusively on the position of the row
+/// within the partition;
+/// - value window functions, that return a scalar value for each row within a
+/// partition that might be computed based on a single previous, current or
+/// following row;
+/// - aggregate window functions, that return a computed value for the row that
+/// depends on multiple other rows within the same partition. Aggregate window
+/// functions can be in some cases be computed by joining the input relation
+/// with a reduction over the same relation that computes the aggregation using
+/// the partition key as its grouping key.
 pub enum WindowExprType {
     Scalar(ScalarWindowExpr),
+    Value(ValueWindowExpr),
 }
 
 impl WindowExprType {
@@ -225,6 +231,7 @@ impl WindowExprType {
     {
         match self {
             Self::Scalar(expr) => expr.visit_expressions(f),
+            Self::Value(expr) => expr.visit_expressions(f),
         }
     }
 
@@ -234,6 +241,7 @@ impl WindowExprType {
     {
         match self {
             Self::Scalar(expr) => expr.visit_expressions_mut(f),
+            Self::Value(expr) => expr.visit_expressions_mut(f),
         }
     }
 
@@ -245,6 +253,7 @@ impl WindowExprType {
     ) -> ColumnType {
         match self {
             Self::Scalar(expr) => expr.typ(outers, inner, params),
+            Self::Value(expr) => expr.typ(outers, inner, params),
         }
     }
 }
@@ -311,6 +320,65 @@ impl ScalarWindowFunc {
         match self {
             ScalarWindowFunc::RowNumber => ScalarType::Int64.nullable(false),
             ScalarWindowFunc::DenseRank => ScalarType::Int64.nullable(false),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ValueWindowExpr {
+    pub func: ValueWindowFunc,
+    pub expr: Box<HirScalarExpr>,
+    pub order_by: Vec<ColumnOrder>,
+}
+
+impl ValueWindowExpr {
+    pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
+    {
+        f(&self.expr)
+    }
+
+    pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
+    {
+        f(&mut self.expr)
+    }
+
+    fn typ(
+        &self,
+        outers: &[RelationType],
+        inner: &RelationType,
+        params: &BTreeMap<usize, ScalarType>,
+    ) -> ColumnType {
+        self.func.output_type(self.expr.typ(outers, inner, params))
+    }
+
+    pub fn into_expr(self) -> mz_expr::AggregateFunc {
+        match self.func {
+            ValueWindowFunc::Lag => mz_expr::AggregateFunc::Lag {
+                order_by: self.order_by,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Value Window functions
+pub enum ValueWindowFunc {
+    Lag,
+}
+
+impl ValueWindowFunc {
+    pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        match self {
+            ValueWindowFunc::Lag => {
+                // The input is a (value, offset, default) record, so extract the type of the first arg
+                input_type.scalar_type.unwrap_record_element_type()[0]
+                    .clone()
+                    .nullable(true)
+            }
         }
     }
 }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1040,6 +1040,224 @@ impl HirScalarExpr {
                                     });
                             SS::Column(inner.arity() - 1)
                         }
+                        WindowExprType::Value(func) => {
+                            let hir_scalar_input = func.expr.clone();
+                            *inner =
+                                inner
+                                    .take_dangerous()
+                                    .let_in(id_gen, |id_gen, mut get_inner| {
+                                        let order_by = order_by
+                                            .into_iter()
+                                            .map(|o| {
+                                                o.applied_to(
+                                                    id_gen,
+                                                    col_map,
+                                                    cte_map,
+                                                    &mut get_inner,
+                                                    subquery_map,
+                                                )
+                                            })
+                                            .collect_vec();
+
+                                        // Compute the encoded args for all rows
+                                        let mir_encoded_args = hir_scalar_input.applied_to(
+                                            id_gen,
+                                            col_map,
+                                            cte_map,
+                                            &mut get_inner,
+                                            subquery_map,
+                                        );
+                                        let mir_encoded_args_type =
+                                            mir_encoded_args.typ(&get_inner.typ()).scalar_type;
+
+                                        // Record input arity here so that any group_keys that need to mutate get_inner
+                                        // don't add those columns to the aggregate input.
+                                        let input_arity = get_inner.typ().arity();
+                                        // The reduction that computes the window function must be keyed on the columns
+                                        // from the outer context, plus the expressions in the partition key. The current
+                                        // subquery will be 'executed' for every distinct row from the outer context so
+                                        // by putting the outer columns in the grouping key we isolate each re-execution.
+                                        let mut group_key = col_map
+                                            .inner
+                                            .iter()
+                                            .map(|(_, outer_col)| *outer_col)
+                                            .sorted()
+                                            .collect_vec();
+                                        for p in partition {
+                                            let key = p.applied_to(
+                                                id_gen,
+                                                col_map,
+                                                cte_map,
+                                                &mut get_inner,
+                                                subquery_map,
+                                            );
+                                            if let mz_expr::MirScalarExpr::Column(c) = key {
+                                                group_key.push(c);
+                                            } else {
+                                                get_inner = get_inner.map_one(key);
+                                                group_key.push(get_inner.arity() - 1);
+                                            }
+                                        }
+
+                                        get_inner.let_in(id_gen, |_id_gen, get_inner| {
+                                            let to_reduce = get_inner;
+                                            let input_type = to_reduce.typ();
+
+                                            // Original columns of the relation
+                                            let fields = input_type
+                                                .column_types
+                                                .iter()
+                                                .take(input_arity)
+                                                .map(|t| (ColumnName::from("?column?"), t.clone()))
+                                                .collect_vec();
+
+                                            // Original row made into a record
+                                            let original_row_record =
+                                                mz_expr::MirScalarExpr::CallVariadic {
+                                                    func: mz_expr::VariadicFunc::RecordCreate {
+                                                        field_names: fields
+                                                            .iter()
+                                                            .map(|(name, _)| name.clone())
+                                                            .collect_vec(),
+                                                    },
+                                                    exprs: (0..input_arity)
+                                                        .map(|column| {
+                                                            mz_expr::MirScalarExpr::Column(column)
+                                                        })
+                                                        .collect_vec(),
+                                                };
+                                            let original_row_record_type = ScalarType::Record {
+                                                fields,
+                                                custom_oid: None,
+                                                custom_name: None,
+                                            };
+
+                                            // Build a new record with the original row in a record in a list + the encoded args in a record
+                                            let fn_input_record_fields =
+                                                [original_row_record_type, mir_encoded_args_type]
+                                                    .iter()
+                                                    .map(|t| {
+                                                        (
+                                                            ColumnName::from("?column?"),
+                                                            t.clone().nullable(false),
+                                                        )
+                                                    })
+                                                    .collect_vec();
+                                            let fn_input_record =
+                                                mz_expr::MirScalarExpr::CallVariadic {
+                                                    func: mz_expr::VariadicFunc::RecordCreate {
+                                                        field_names: fn_input_record_fields
+                                                            .iter()
+                                                            .map(|(n, _)| n.clone())
+                                                            .collect_vec(),
+                                                    },
+                                                    exprs: vec![
+                                                        original_row_record,
+                                                        mir_encoded_args,
+                                                    ],
+                                                };
+                                            let fn_input_record_type = ScalarType::Record {
+                                                fields: fn_input_record_fields,
+                                                custom_oid: None,
+                                                custom_name: None,
+                                            }
+                                            .nullable(false);
+
+                                            // Build a new record with the record above + the ORDER BY exprs
+                                            // This follows the standard encoding of ORDER BY exprs used by aggregate functions
+                                            let mut agg_input = vec![fn_input_record];
+                                            agg_input.extend(order_by.clone());
+                                            let agg_input = mz_expr::MirScalarExpr::CallVariadic {
+                                                func: mz_expr::VariadicFunc::RecordCreate {
+                                                    field_names: (0..2)
+                                                        .map(|_| ColumnName::from("?column?"))
+                                                        .collect_vec(),
+                                                },
+                                                exprs: agg_input,
+                                            };
+
+                                            let agg_input_type = ScalarType::Record {
+                                                fields: vec![(
+                                                    ColumnName::from("?column?"),
+                                                    fn_input_record_type.nullable(false),
+                                                )],
+                                                custom_oid: None,
+                                                custom_name: None,
+                                            }
+                                            .nullable(false);
+
+                                            let func = func.into_expr();
+                                            let aggregate = mz_expr::AggregateExpr {
+                                                func,
+                                                expr: agg_input,
+                                                distinct: false,
+                                            };
+
+                                            // Actually call reduce with the window function
+                                            // The input is [((OriginalRow, EncodedArgs), OrderByExprs...)]
+                                            // The output of the aggregation function should be a list of tuples that has
+                                            // the result in the first position, and the original row in the second position
+                                            let mut reduce = to_reduce
+                                                .reduce(
+                                                    group_key.clone(),
+                                                    vec![aggregate.clone()],
+                                                    None,
+                                                )
+                                                .flat_map(
+                                                    mz_expr::TableFunc::UnnestList {
+                                                        el_typ: aggregate
+                                                            .func
+                                                            .output_type(agg_input_type)
+                                                            .scalar_type
+                                                            .unwrap_list_element_type()
+                                                            .clone(),
+                                                    },
+                                                    vec![mz_expr::MirScalarExpr::Column(
+                                                        group_key.len(),
+                                                    )],
+                                                );
+                                            let record_col = reduce.arity() - 1;
+
+                                            // Unpack the record output by the window function
+                                            for c in 0..input_arity {
+                                                reduce =
+                                                    reduce
+                                                        .take_dangerous()
+                                                        .map_one(mz_expr::MirScalarExpr::CallUnary {
+                                                        func: mz_expr::UnaryFunc::RecordGet(c),
+                                                        expr: Box::new(
+                                                            mz_expr::MirScalarExpr::CallUnary {
+                                                                func: mz_expr::UnaryFunc::RecordGet(
+                                                                    1,
+                                                                ),
+                                                                expr: Box::new(
+                                                                    mz_expr::MirScalarExpr::Column(
+                                                                        record_col,
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ),
+                                                    });
+                                            }
+
+                                            // Append the column with the result of the window function.
+                                            reduce = reduce.take_dangerous().map_one(
+                                                mz_expr::MirScalarExpr::CallUnary {
+                                                    func: mz_expr::UnaryFunc::RecordGet(0),
+                                                    expr: Box::new(mz_expr::MirScalarExpr::Column(
+                                                        record_col,
+                                                    )),
+                                                },
+                                            );
+
+                                            let agg_col = record_col + 1 + input_arity;
+                                            reduce.project(
+                                                (record_col + 1..agg_col + 1).collect_vec(),
+                                            )
+                                        })
+                                    });
+                            SS::Column(inner.arity() - 1)
+                        }
                     }
                 }
             }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -629,3 +629,709 @@ ORDER BY y, z DESC, x
 1  1  c  NaN
 1  2  c  NaN
 2  3  c    1
+
+## lag
+
+# Simple cases
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     b
+b     c
+c     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+b     b
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+b     b
+c     b
+c     c
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+NULL  b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+a     a
+NULL  a
+NULL  a
+a     b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+c     a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(x) OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+NULL  a
+c     c
+c     c
+b     c
+b     b
+b     b
+a     b
+a     a
+a     a
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+
+# With default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  -1
+1  c  NaN  -1
+2  c  NaN  1
+3  c  1  2
+4  b  1  -1
+4  b  0  4
+1  a  1  -1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# Complex expressions
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  -9
+3  c  1  -8
+4  b  1  NULL
+4  b  0  5
+1  a  1  NULL
+2  a  1  2
+2  a  1  3
+3  a  1  3
+
+# Nulls in the first argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# Nulls in the first argument with a default value in the third argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+
+# Zero offset
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  7
+1  c  NaN  1
+2  c  NaN  2
+3  c  1  3
+4  b  1  4
+4  b  0  4
+1  a  1  1
+2  a  1  2
+2  a  1  2
+3  a  1  3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  2
+1  c  NaN  NaN
+2  c  NaN  NaN
+3  c  1  4
+4  b  1  5
+4  b  0  4
+1  a  1  2
+2  a  1  3
+2  a  1  3
+3  a  1  4
+
+# Positive offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  1
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  2
+2  a  1  NULL
+3  a  1  3
+
+# Out of range positive offsets
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1  NULL
+4  b  1  4
+4  b  0  NULL
+1  a  1  2
+2  a  1  2
+2  a  1  3
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NaN
+2  c  NaN  4
+3  c  1  NULL
+4  b  1  4
+4  b  0  NULL
+1  a  1  3
+2  a  1  3
+2  a  1  4
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  4
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  3
+2  a  1  4
+2  a  1  NULL
+3  a  1  NULL
+
+# Out of range negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Variable per row offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  1
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  1
+2  c  NaN  1
+3  c  1  1
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+
+# Null offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  1
+
+# Null offset with default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+# Variable per row default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  -5
+1  c  NaN  NaN
+2  c  NaN  1
+3  c  1  2
+4  b  1  1
+4  b  0  4
+1  a  1  1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# reduce_elision code path
+# Default offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+# Zero offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+# Negative offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, -1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+# Default value with offset 1
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  10
+3  10
+
+# Default value with offset 0
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+# Complex expression
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  3
+3  13
+
+# Complex offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+3  NULL
+1  2
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  4
+
+# Complex default value
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -1335,3 +1335,18 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
 1  2
 3  12
+
+# Null value in input relation
+# This was caused by a bug in the reduce elision logic
+statement ok
+CREATE TABLE t3 (f1 INTEGER)
+----
+
+statement ok
+INSERT INTO t3 VALUES (NULL)
+----
+
+query II
+SELECT f1, lag(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t3 GROUP BY f1 ORDER BY 1
+----
+NULL NULL


### PR DESCRIPTION
`lag` has the same core performance characteristics as `row_number` and other window functions.

Due to the differences between the scalar/ranking window functions (`row_number`, `dense_rank`, etc) and the value window functions (`lag`, `lead`, `first_value`, etc), a new code path is introduced for the value window functions, with a custom lowering logic and argument handling strategy that should be common to all of them.

### Motivation

  * This PR adds a known-desirable feature: it is part of MaterializeInc/product#139

### Tips for reviewer
* I tried to keep the gnarliest parts heavily commented, as it took me some time to understand them well enough to even know what to do (e.g. everything in lowering.rs).
* Some code is shared with the old window function implementation, but I've tried to minimize the amount of refactors there because this PR was getting large enough already.
* `lag` should be basically the same thing, but I decided to implement it in a separate PR this PR was getting large enough already.
* Some other notes inline.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add `lag` as a new window function.
