### PR TITLE
coord: Add support for ALTER SECRET {} AS <EXPR>

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -2111,7 +2111,7 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, CoordError> {
         let CreateSecretPlan {
             name,
-            secret,
+            mut secret,
             full_name,
             if_not_exists,
         } = plan;
@@ -2119,7 +2119,7 @@ impl Coordinator {
         let temp_storage = RowArena::new();
         prep_scalar_expr(
             self.catalog.state(),
-            &mut secret.secret_as.clone(),
+            &mut secret.secret_as,
             ExprPrepStyle::OneShot {
                 logical_time: None,
                 session,
@@ -4373,18 +4373,18 @@ impl Coordinator {
         session: &Session,
         plan: AlterSecretPlan,
     ) -> Result<ExecuteResponse, CoordError> {
-        let AlterSecretPlan { id, secret } = plan;
+        let AlterSecretPlan { id, mut secret_as } = plan;
 
         let temp_storage = RowArena::new();
         prep_scalar_expr(
             self.catalog.state(),
-            &mut secret.secret_as.clone(),
+            &mut secret_as,
             ExprPrepStyle::OneShot {
                 logical_time: None,
                 session,
             },
         )?;
-        let evaled = secret.secret_as.eval(&[], &temp_storage)?;
+        let evaled = secret_as.eval(&[], &temp_storage)?;
 
         if evaled == Datum::Null {
             coord_bail!("secret value can not be null");

--- a/src/secrets-filesystem/src/lib.rs
+++ b/src/secrets-filesystem/src/lib.rs
@@ -35,8 +35,9 @@ impl SecretsController for FilesystemSecretsController {
                     let file_path = self.secrets_storage_path.join(format!("{}", id));
                     let mut file = OpenOptions::new()
                         .mode(0o600)
-                        .create_new(true)
+                        .create(true)
                         .write(true)
+                        .truncate(true)
                         .open(file_path)?;
                     file.write_all(contents)?;
                     file.sync_all()?;

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1006,7 +1006,7 @@ impl_display_t!(AlterIndexStatement);
 /// `ALTER SECRET ... AS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterSecretStatement<T: AstInfo> {
-    pub secret_name: T::ObjectName,
+    pub name: T::ObjectName,
     pub if_exists: bool,
     pub value: Expr<T>,
 }
@@ -1017,7 +1017,7 @@ impl<T: AstInfo> AstDisplay for AlterSecretStatement<T> {
         if self.if_exists {
             f.write_str("IF EXISTS ");
         }
-        f.write_node(&self.secret_name);
+        f.write_node(&self.name);
         f.write_str(" AS ");
         f.write_node(&self.value);
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2992,7 +2992,7 @@ impl<'a> Parser<'a> {
             AS => {
                 let value = self.parse_expr()?;
                 Statement::AlterSecret(AlterSecretStatement {
-                    secret_name: name,
+                    name: name,
                     if_exists,
                     value,
                 })

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2992,7 +2992,7 @@ impl<'a> Parser<'a> {
             AS => {
                 let value = self.parse_expr()?;
                 Statement::AlterSecret(AlterSecretStatement {
-                    name: name,
+                    name,
                     if_exists,
                     value,
                 })

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1413,4 +1413,4 @@ ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 ----
 ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 =>
-AlterSecret(AlterSecretStatement { secret_name: Name(UnresolvedObjectName([Ident("secret")])), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+AlterSecret(AlterSecretStatement { name: Name(UnresolvedObjectName([Ident("secret")])), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -395,7 +395,7 @@ pub struct AlterItemRenamePlan {
 #[derive(Debug)]
 pub struct AlterSecretPlan {
     pub id: GlobalId,
-    pub secret: Secret,
+    pub secret_as: MirScalarExpr,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -111,6 +111,7 @@ pub enum Plan {
     AlterIndexResetOptions(AlterIndexResetOptionsPlan),
     AlterIndexEnable(AlterIndexEnablePlan),
     AlterItemRename(AlterItemRenamePlan),
+    AlterSecret(AlterSecretPlan),
     Declare(DeclarePlan),
     Fetch(FetchPlan),
     Close(ClosePlan),
@@ -389,6 +390,12 @@ pub struct AlterItemRenamePlan {
     pub current_full_name: FullObjectName,
     pub to_name: String,
     pub object_type: ObjectType,
+}
+
+#[derive(Debug)]
+pub struct AlterSecretPlan {
+    pub id: GlobalId,
+    pub secret: Secret,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3096,7 +3096,7 @@ pub fn plan_alter_secret(
     scx: &StatementContext,
     stmt: AlterSecretStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
-    scx.require_experimental_mode("CREATE SECRET")?;
+    scx.require_experimental_mode("ALTER SECRET")?;
 
     let AlterSecretStatement {
         name,
@@ -3117,7 +3117,7 @@ pub fn plan_alter_secret(
     };
     if entry.item_type() != CatalogItemType::Secret {
         bail!(
-            "{} is a {} not a secret",
+            "{} is a {} not a SECRET",
             name.full_name_str(),
             entry.item_type()
         )

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3123,16 +3123,9 @@ pub fn plan_alter_secret(
         )
     }
     let id = entry.id();
-
-    let create_sql = normalize::create_statement(&scx, Statement::AlterSecret(stmt.clone()))?;
     let secret_as = query::plan_secret_as(scx, value.clone())?;
 
-    let secret = Secret {
-        create_sql,
-        secret_as,
-    };
-
-    Ok(Plan::AlterSecret(AlterSecretPlan { id, secret }))
+    Ok(Plan::AlterSecret(AlterSecretPlan { id, secret_as }))
 }
 
 pub fn describe_alter_cluster(

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -53,6 +53,12 @@ insert into t1 values (1);
 statement error catalog item 't1' already exists
 CREATE SECRET t1 AS decode('c2VjcmV0Cg==', 'base64');
 
+statement error t1 is a table not a SECRET
+ALTER SECRET t1 rename to t2
+
+statement error t1 is a table not a SECRET
+ALTER SECRET t1 as 'textsecret';
+
 statement OK
 DROP SECRET secret
 
@@ -98,8 +104,11 @@ DROP SECRET existing
 statement error Expected end of statement, found dot
 ALTER SECRET public.certificate RENAME TO public2.certificate2;
 
-statement error ALTER SECRET not yet supported
-alter secret certificate as decode('c2VjcmV0Cg==', 'base64');
+statement OK
+ALTER SECRET certificate as decode('c2VjcmV0Cg==', 'base64');
+
+statement error unknown catalog item 'nonexistant'
+ALTER SECRET nonexistant as decode('c2VjcmV0Cg==', 'base64');
 
 statement OK
 create schema testschema

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -54,7 +54,7 @@ statement error catalog item 't1' already exists
 CREATE SECRET t1 AS decode('c2VjcmV0Cg==', 'base64');
 
 statement error t1 is a table not a SECRET
-ALTER SECRET t1 rename to t2
+ALTER SECRET t1 rename to t2;
 
 statement error t1 is a table not a SECRET
 ALTER SECRET t1 as 'textsecret';


### PR DESCRIPTION
Continued work on SECRETS.

This PR adds the ability to alter existing secrets with new content via the ALTER SECRET {} AS <EXPR> statement. ALTER SECRET {} RENAME TO {} has already been supported.

### Motivation

This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

