### PR TITLE
Fix ordering issue in ts_binding command handling

### DIFF
--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -455,6 +455,12 @@ where
             }
             durability_updates.push((*id, write_frontier));
         }
+
+        // Note: this seal is not performed in a transaction with the above `update_many`.
+        // This is fine/correct, but subtle. If we crash in between these 2 writes, the
+        // updates will be read in their entirety, and future updates past the old upper will
+        // still be accepted. Later seals will never erroneously seal times for ts bindings
+        // that were recorded, because we always record bindings before seal-ing here.
         self.state.stash.seal_batch(&seals)?;
 
         self.update_durability_frontiers(durability_updates).await?;


### PR DESCRIPTION
The previous ordering can change the internal upper state before timestamp bindings are persisted. While this currently does not cause issues, people could make reasonable changes to `update_write_frontiers` that forward this new information to compute/adapter such that a crash before persisting could cause correctness issues. Re-ordering these statements avoids this issue, and make the WAL-like behavior of ts bindings more clear. I missed this in my review of @petrosagg 's pr.


Additionally, I added an extra explanation of some write orderings in the `persist_timestamp_bindings`, even though @petrosagg will likely delete that code when we switch to `append`-based apis

### Motivation
   * This PR refactors existing code.

### Testing

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None