### PR TITLE
Set default introspection granularity to 1s for new clusters

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2491,22 +2491,12 @@ impl Catalog {
                             replicas,
                             introspection,
                         } => {
-                            if introspection.is_some() {
-                                coord_bail!(
-                                    "cannot change introspection options on existing cluster"
-                                );
-                            }
                             InstanceConfig::Remote { replicas }
                         }
                         ComputeInstanceConfig::Managed {
                             size,
                             introspection,
                         } => {
-                            if introspection.is_some() {
-                                coord_bail!(
-                                    "cannot change introspection options on existing cluster"
-                                );
-                            }
                             InstanceConfig::Managed { size }
                         }
                     };

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2489,16 +2489,12 @@ impl Catalog {
                         ComputeInstanceConfig::Local => InstanceConfig::Local,
                         ComputeInstanceConfig::Remote {
                             replicas,
-                            introspection,
-                        } => {
-                            InstanceConfig::Remote { replicas }
-                        }
+                            introspection: _,
+                        } => InstanceConfig::Remote { replicas },
                         ComputeInstanceConfig::Managed {
                             size,
-                            introspection,
-                        } => {
-                            InstanceConfig::Managed { size }
-                        }
+                            introspection: _,
+                        } => InstanceConfig::Managed { size },
                     };
                     vec![Action::UpdateComputeInstanceConfig { id, config }]
                 }

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -480,6 +480,21 @@ macro_rules! with_option_type {
             _ => ::anyhow::bail!("expected Interval"),
         }
     };
+    ($name:expr, OptionalInterval) => {
+        match $name {
+            Some(crate::ast::WithOptionValue::Value(Value::String(value))) => {
+                if value.as_str() == "off" {
+                    None
+                } else {
+                    Some(mz_repr::strconv::parse_interval(&value)?)
+                }
+            }
+            Some(crate::ast::WithOptionValue::Value(Value::Interval(interval))) => {
+                Some(mz_repr::strconv::parse_interval(&interval.value)?)
+            }
+            _ => ::anyhow::bail!("expected Interval or 'off'"),
+        }
+    };
 }
 
 /// Ensures that the given set of options are empty, useful for validating that


### PR DESCRIPTION
### Motivation

match the previous behavior of the default cluster

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Enable logging dataflows by default in non-default clusters.