### PR TITLE
doc/user: publish to https://materialize.com/docs/unstable

### DIFF
--- a/ci/deploy/website.sh
+++ b/ci/deploy/website.sh
@@ -33,7 +33,7 @@ declare -A shortlinks=(
 )
 
 cd doc/user
-hugo --gc --baseURL /docs --destination public/docs
+hugo --gc --baseURL /docs --destination public/docs/unstable
 cp -R ../../ci/deploy/website/. public/
 hugo deploy
 

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -22,6 +22,8 @@
 <meta name="twitter:title" content="{{ $title }}">
 <meta name="twitter:image" content="https://user-images.githubusercontent.com/11527560/159138593-09223308-ce91-4582-a47a-a03166fef26b.gif">
 <meta name="twitter:description" content="{{ $description }}">
+{{/* TODO(benesch): allow indexing when platform docs become the live docs. */}}
+<meta name="robots" content="noindex">
 <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">
 <link rel=apple-touch-icon sizes=180x180 href="{{ .Site.BaseURL }}/images/materialize_logo_180.png">
 <link rel=icon type="image/png" sizes=32x32 href="{{ .Site.BaseURL }}/images/materialize_favicon_32.png">


### PR DESCRIPTION
While Materialize Platform is under heavy development, change the main
branch to deploy its docs to the temporary staging ground of
https://materialize.com/docs/unstable. This will give us space to
document the new features in Materialize Platform without confusing
users of v0.26 LTS.

The v0.26 LTS docs are now built from the `lts-docs` branch and pushed
to https://materialize.com/docs.

Once we launch Materialize Platform, we'll delete the `lts-docs` branch,
and move the Platform docs to https://materialize.com/docs.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Platform prep.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
