### PR TITLE
coord,sql: add typcategory field to pg_type

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1086,7 +1086,8 @@ lazy_static! {
             .with_column("id", ScalarType::String.nullable(false))
             .with_column("oid", ScalarType::Oid.nullable(false))
             .with_column("schema_id", ScalarType::Int64.nullable(false))
-            .with_column("name", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("category", ScalarType::String.nullable(false)),
         persistent: false,
     };
     pub static ref MZ_ARRAY_TYPES: BuiltinTable = BuiltinTable {
@@ -1576,6 +1577,23 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
     -- 'a' is used internally to denote an array type, but in postgres they show up
     -- as 'b'.
     (CASE mztype WHEN 'a' THEN 'b' ELSE mztype END)::pg_catalog.char AS typtype,
+    (CASE category
+        WHEN 'array' THEN 'A'
+        WHEN 'bit-string' THEN 'V'
+        WHEN 'boolean' THEN 'B'
+        WHEN 'composite' THEN 'C'
+        WHEN 'date-time' THEN 'D'
+        WHEN 'enum' THEN 'E'
+        WHEN 'geometric' THEN 'G'
+        WHEN 'list' THEN 'U' -- List types are user-defined from PostgreSQL's perspective.
+        WHEN 'network-address' THEN 'I'
+        WHEN 'numeric' THEN 'N'
+        WHEN 'pseudo' THEN 'P'
+        WHEN 'string' THEN 'S'
+        WHEN 'timespan' THEN 'T'
+        WHEN 'user-defined' THEN 'U'
+        WHEN 'unknown' THEN 'X'
+    END) AS typcategory,
     0::pg_catalog.oid AS typrelid,
     NULL::pg_catalog.oid AS typelem,
     coalesce(

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -15,7 +15,7 @@ use mz_ore::collections::CollectionExt;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::{Datum, Diff, Row};
 use mz_sql::ast::{CreateIndexStatement, Statement};
-use mz_sql::catalog::{CatalogDatabase, CatalogType};
+use mz_sql::catalog::{CatalogDatabase, CatalogType, TypeCategory};
 use mz_sql::names::{DatabaseId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier};
 use mz_sql_parser::ast::display::AstDisplay;
 
@@ -400,6 +400,7 @@ impl CatalogState {
                 Datum::UInt32(oid),
                 Datum::Int64(schema_id.into()),
                 Datum::String(name),
+                Datum::String(&TypeCategory::from_catalog_type(&typ.details.typ).to_string()),
             ]),
             diff,
         };

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -446,6 +446,72 @@ pub enum CatalogType<T: TypeReference> {
     Int2Vector,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Mirrored from [PostgreSQL's `typcategory`][typcategory].
+///
+/// Note that Materialize also uses a number of pseudotypes when planning, but
+/// we have yet to need to integrate them with `TypeCategory`.
+///
+/// [typcategory]:
+/// https://www.postgresql.org/docs/9.6/catalog-pg-type.html#CATALOG-TYPCATEGORY-TABLE
+pub enum TypeCategory {
+    /// Array type.
+    Array,
+    /// Bit string type.
+    BitString,
+    /// Boolean type.
+    Boolean,
+    /// Composite type.
+    Composite,
+    /// Date/time type.
+    DateTime,
+    /// Enum type.
+    Enum,
+    /// Geometric type.
+    Geometric,
+    /// List type. Materialize specific.
+    List,
+    /// Network address type.
+    NetworkAddress,
+    /// Numeric type.
+    Numeric,
+    /// Pseudo type.
+    Pseudo,
+    /// Range type.
+    Range,
+    /// String type.
+    String,
+    /// Timestamp type.
+    Timespan,
+    /// User-defined type.
+    UserDefined,
+    /// Unknown type.
+    Unknown,
+}
+
+impl fmt::Display for TypeCategory {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(match self {
+            TypeCategory::Array => "array",
+            TypeCategory::BitString => "bit-string",
+            TypeCategory::Boolean => "boolean",
+            TypeCategory::Composite => "composite",
+            TypeCategory::DateTime => "date-time",
+            TypeCategory::Enum => "enum",
+            TypeCategory::Geometric => "geometric",
+            TypeCategory::List => "list",
+            TypeCategory::NetworkAddress => "network-address",
+            TypeCategory::Numeric => "numeric",
+            TypeCategory::Pseudo => "pseudo",
+            TypeCategory::Range => "range",
+            TypeCategory::String => "string",
+            TypeCategory::Timespan => "timespan",
+            TypeCategory::UserDefined => "user-defined",
+            TypeCategory::Unknown => "unknown",
+        })
+    }
+}
+
 /// An error returned by the catalog.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CatalogError {

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -25,7 +25,7 @@ use super::error::PlanError;
 use super::expr::{CoercibleScalarExpr, ColumnRef, HirScalarExpr, UnaryFunc};
 use super::query::{ExprContext, QueryContext};
 use super::scope::Scope;
-use crate::func::TypeCategory;
+use crate::catalog::TypeCategory;
 
 /// Like func::sql_impl_func, but for casts.
 fn sql_impl_cast(expr: &'static str) -> CastTemplate {


### PR DESCRIPTION
The typcategory field unlocks compatibility with the pgtyped NPM
package, which we want to use to get typesafe queries against
Materialize in Materialize Cloud.

Fix #11683.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
