### PR TITLE
expr: Add protobuf for chrono types

### DIFF
--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -11,11 +11,13 @@ fn main() {
     prost_build::Config::new()
         .compile_protos(
             &[
+                "chrono.proto",
                 "row.proto",
                 "strconv.proto",
                 "relation_and_scalar.proto",
                 "adt/array.proto",
                 "adt/char.proto",
+                "adt/datetime.proto",
                 "adt/numeric.proto",
                 "adt/varchar.proto",
             ],

--- a/src/repr/src/chrono.rs
+++ b/src/repr/src/chrono.rs
@@ -1,0 +1,39 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![cfg(feature = "test-utils")]
+
+//! Custom [`proptest::strategy::Strategy`] implementations for the
+//! [`chrono`] fields used inthe codebase.
+//!
+//! See the [`proptest`] docs[^1] for an example.
+//!
+//! [^1]: <https://altsysrq.github.io/proptest-book/proptest-derive/modifiers.html#strategy>
+
+use chrono::{DateTime, Duration, FixedOffset, NaiveDateTime, Timelike, Utc};
+use chrono_tz::{Tz, TZ_VARIANTS};
+use proptest::prelude::Strategy;
+
+pub fn any_naive_datetime() -> impl Strategy<Value = NaiveDateTime> {
+    use ::chrono::naive::{MAX_DATETIME, MIN_DATETIME};
+    (0..(MAX_DATETIME.nanosecond() - MIN_DATETIME.nanosecond()))
+        .prop_map(|x| MIN_DATETIME + Duration::nanoseconds(x as i64))
+}
+
+pub fn any_datetime() -> impl Strategy<Value = DateTime<Utc>> {
+    any_naive_datetime().prop_map(|x| DateTime::from_utc(x, Utc))
+}
+
+pub fn any_fixed_offset() -> impl Strategy<Value = FixedOffset> {
+    (-86_401..86_400).prop_map(FixedOffset::east)
+}
+
+pub fn any_timezone() -> impl Strategy<Value = Tz> {
+    (0..TZ_VARIANTS.len()).prop_map(|idx| *TZ_VARIANTS.get(idx).unwrap())
+}

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -28,11 +28,12 @@ mod row;
 mod scalar;
 
 pub mod adt;
+pub mod chrono;
+pub mod proto;
 pub mod strconv;
 pub mod util;
 
 pub use datum_vec::{DatumVec, DatumVecBorrow};
-pub mod proto;
 pub use relation::{ColumnName, ColumnType, NotNullViolation, RelationDesc, RelationType};
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena,

--- a/src/repr/src/proto/adt/datetime.proto
+++ b/src/repr/src/proto/adt/datetime.proto
@@ -1,0 +1,48 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package adt.datetime;
+
+import "chrono.proto";
+import "google/protobuf/empty.proto";
+
+message ProtoTimezone {
+    oneof kind {
+        chrono.ProtoFixedOffset fixed_offset = 1;
+        chrono.ProtoTz tz = 2;
+    }
+}
+
+message ProtoDateTimeUnits {
+    oneof kind {
+        google.protobuf.Empty epoch = 1;
+        google.protobuf.Empty millennium = 2;
+        google.protobuf.Empty century = 3;
+        google.protobuf.Empty decade = 4;
+        google.protobuf.Empty year = 5;
+        google.protobuf.Empty quarter = 6;
+        google.protobuf.Empty week = 7;
+        google.protobuf.Empty month = 8;
+        google.protobuf.Empty hour = 9;
+        google.protobuf.Empty day = 10;
+        google.protobuf.Empty day_of_week = 11;
+        google.protobuf.Empty day_of_year = 12;
+        google.protobuf.Empty iso_day_of_week = 13;
+        google.protobuf.Empty iso_day_of_year = 14;
+        google.protobuf.Empty minute = 15;
+        google.protobuf.Empty second = 16;
+        google.protobuf.Empty milliseconds = 17;
+        google.protobuf.Empty microseconds = 18;
+        google.protobuf.Empty timezone = 19;
+        google.protobuf.Empty timezone_hour = 20;
+        google.protobuf.Empty timezone_minute = 21;
+    }
+}

--- a/src/repr/src/proto/adt/datetime.rs
+++ b/src/repr/src/proto/adt/datetime.rs
@@ -1,0 +1,126 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf structs mirroring [`crate::adt::datetime`].
+
+include!(concat!(env!("OUT_DIR"), "/adt.datetime.rs"));
+
+use super::super::{ProtoRepr, TryFromProtoError};
+use crate::adt::datetime::Timezone::*;
+use crate::adt::datetime::{DateTimeUnits, Timezone};
+use chrono::FixedOffset;
+use chrono_tz::Tz;
+
+impl From<&Timezone> for ProtoTimezone {
+    fn from(value: &Timezone) -> Self {
+        use proto_timezone::Kind;
+        ProtoTimezone {
+            kind: Some(match value {
+                FixedOffset(fo) => Kind::FixedOffset(fo.into_proto()),
+                Tz(tz) => Kind::Tz(tz.into_proto()),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ProtoTimezone> for Timezone {
+    type Error = TryFromProtoError;
+
+    fn try_from(value: ProtoTimezone) -> Result<Self, Self::Error> {
+        use proto_timezone::Kind;
+        let kind = value
+            .kind
+            .ok_or_else(|| TryFromProtoError::MissingField("ProtoTimezone::kind".into()))?;
+        Ok(match kind {
+            Kind::FixedOffset(pof) => Timezone::FixedOffset(FixedOffset::from_proto(pof)?),
+            Kind::Tz(ptz) => Timezone::Tz(Tz::from_proto(ptz)?),
+        })
+    }
+}
+
+impl From<&DateTimeUnits> for ProtoDateTimeUnits {
+    fn from(value: &DateTimeUnits) -> Self {
+        use proto_date_time_units::Kind;
+        ProtoDateTimeUnits {
+            kind: Some(match value {
+                DateTimeUnits::Epoch => Kind::Epoch(()),
+                DateTimeUnits::Millennium => Kind::Millennium(()),
+                DateTimeUnits::Century => Kind::Century(()),
+                DateTimeUnits::Decade => Kind::Decade(()),
+                DateTimeUnits::Year => Kind::Year(()),
+                DateTimeUnits::Quarter => Kind::Quarter(()),
+                DateTimeUnits::Week => Kind::Week(()),
+                DateTimeUnits::Month => Kind::Month(()),
+                DateTimeUnits::Hour => Kind::Hour(()),
+                DateTimeUnits::Day => Kind::Day(()),
+                DateTimeUnits::DayOfWeek => Kind::DayOfWeek(()),
+                DateTimeUnits::DayOfYear => Kind::DayOfYear(()),
+                DateTimeUnits::IsoDayOfWeek => Kind::IsoDayOfWeek(()),
+                DateTimeUnits::IsoDayOfYear => Kind::IsoDayOfYear(()),
+                DateTimeUnits::Minute => Kind::Minute(()),
+                DateTimeUnits::Second => Kind::Second(()),
+                DateTimeUnits::Milliseconds => Kind::Milliseconds(()),
+                DateTimeUnits::Microseconds => Kind::Microseconds(()),
+                DateTimeUnits::Timezone => Kind::Timezone(()),
+                DateTimeUnits::TimezoneHour => Kind::TimezoneHour(()),
+                DateTimeUnits::TimezoneMinute => Kind::TimezoneMinute(()),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ProtoDateTimeUnits> for DateTimeUnits {
+    type Error = TryFromProtoError;
+
+    fn try_from(value: ProtoDateTimeUnits) -> Result<Self, Self::Error> {
+        use proto_date_time_units::Kind;
+        let kind = value
+            .kind
+            .ok_or_else(|| TryFromProtoError::MissingField("ProtoDateTimeUnits.kind".into()))?;
+        Ok(match kind {
+            Kind::Epoch(_) => DateTimeUnits::Epoch,
+            Kind::Millennium(_) => DateTimeUnits::Millennium,
+            Kind::Century(_) => DateTimeUnits::Century,
+            Kind::Decade(_) => DateTimeUnits::Decade,
+            Kind::Year(_) => DateTimeUnits::Year,
+            Kind::Quarter(_) => DateTimeUnits::Quarter,
+            Kind::Week(_) => DateTimeUnits::Week,
+            Kind::Month(_) => DateTimeUnits::Month,
+            Kind::Hour(_) => DateTimeUnits::Hour,
+            Kind::Day(_) => DateTimeUnits::Day,
+            Kind::DayOfWeek(_) => DateTimeUnits::DayOfWeek,
+            Kind::DayOfYear(_) => DateTimeUnits::DayOfYear,
+            Kind::IsoDayOfWeek(_) => DateTimeUnits::IsoDayOfWeek,
+            Kind::IsoDayOfYear(_) => DateTimeUnits::IsoDayOfYear,
+            Kind::Minute(_) => DateTimeUnits::Minute,
+            Kind::Second(_) => DateTimeUnits::Second,
+            Kind::Milliseconds(_) => DateTimeUnits::Milliseconds,
+            Kind::Microseconds(_) => DateTimeUnits::Microseconds,
+            Kind::Timezone(_) => DateTimeUnits::Timezone,
+            Kind::TimezoneHour(_) => DateTimeUnits::TimezoneHour,
+            Kind::TimezoneMinute(_) => DateTimeUnits::TimezoneMinute,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
+
+    proptest! {
+       #[test]
+        fn datetimeunits_serialization_roundtrip(expect in any::<DateTimeUnits>() ) {
+            let actual = protobuf_roundtrip::<_, ProtoDateTimeUnits>(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}

--- a/src/repr/src/proto/adt/mod.rs
+++ b/src/repr/src/proto/adt/mod.rs
@@ -11,5 +11,6 @@
 
 pub mod array;
 pub mod char;
+pub mod datetime;
 pub mod numeric;
 pub mod varchar;

--- a/src/repr/src/proto/chrono.proto
+++ b/src/repr/src/proto/chrono.proto
@@ -1,0 +1,35 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package chrono;
+
+message ProtoTz {
+    string name = 1;
+}
+
+message ProtoNaiveDate {
+   int32 year = 1;
+   uint32 ordinal = 2;
+}
+
+message ProtoNaiveTime {
+    uint32 secs = 1;
+    uint32 frac = 2;
+}
+
+message ProtoNaiveDateTime {
+    ProtoNaiveDate date = 1;
+    ProtoNaiveTime time = 2;
+}
+
+message ProtoFixedOffset {
+    int32 local_minus_utc = 1;
+}

--- a/src/repr/src/proto/chrono.rs
+++ b/src/repr/src/proto/chrono.rs
@@ -1,0 +1,161 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Protobuf encoding for types from the [`chrono`] crate.
+
+include!(concat!(env!("OUT_DIR"), "/chrono.rs"));
+
+use crate::proto::{ProtoRepr, TryFromProtoError};
+use chrono::{DateTime, Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
+use chrono_tz::Tz;
+use std::str::FromStr;
+
+impl ProtoRepr for NaiveDate {
+    type Repr = ProtoNaiveDate;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        ProtoNaiveDate {
+            year: self.year(),
+            ordinal: self.ordinal(),
+        }
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        NaiveDate::from_yo_opt(repr.year, repr.ordinal).ok_or_else(|| {
+            TryFromProtoError::DateConversionError(format!(
+                "NaiveDate::from_yo_opt({},{}) failed",
+                repr.year, repr.ordinal
+            ))
+        })
+    }
+}
+
+impl ProtoRepr for NaiveTime {
+    type Repr = ProtoNaiveTime;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        ProtoNaiveTime {
+            secs: self.num_seconds_from_midnight(),
+            frac: self.nanosecond(),
+        }
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        NaiveTime::from_num_seconds_from_midnight_opt(repr.secs, repr.frac).ok_or_else(|| {
+            TryFromProtoError::DateConversionError(format!(
+                "NaiveTime::from_num_seconds_from_midnight_opt({},{}) failed",
+                repr.secs, repr.frac
+            ))
+        })
+    }
+}
+
+impl ProtoRepr for NaiveDateTime {
+    type Repr = ProtoNaiveDateTime;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        ProtoNaiveDateTime {
+            date: Some(self.date().into_proto()),
+            time: Some(self.time().into_proto()),
+        }
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        let date =
+            NaiveDate::from_proto(repr.date.ok_or_else(|| {
+                TryFromProtoError::MissingField("ProtoNaiveDateTime::date".into())
+            })?)?;
+
+        let time =
+            NaiveTime::from_proto(repr.time.ok_or_else(|| {
+                TryFromProtoError::MissingField("ProtoNaiveDateTime::time".into())
+            })?)?;
+
+        Ok(NaiveDateTime::new(date, time))
+    }
+}
+
+impl ProtoRepr for DateTime<Utc> {
+    type Repr = ProtoNaiveDateTime;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        self.naive_utc().into_proto()
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        Ok(DateTime::from_utc(NaiveDateTime::from_proto(repr)?, Utc))
+    }
+}
+
+impl ProtoRepr for FixedOffset {
+    type Repr = ProtoFixedOffset;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        ProtoFixedOffset {
+            local_minus_utc: self.local_minus_utc(),
+        }
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        FixedOffset::east_opt(repr.local_minus_utc).ok_or_else(|| {
+            TryFromProtoError::DateConversionError(format!(
+                "FixedOffset::east_opt({}) failed.",
+                repr.local_minus_utc
+            ))
+        })
+    }
+}
+
+/// Encode a Tz as string representation. This is not the most space efficient solution, but
+/// it is immune to changes in the chrono_tz (and is fully compatible with its public API).
+impl ProtoRepr for chrono_tz::Tz {
+    type Repr = ProtoTz;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        ProtoTz {
+            name: self.name().into(),
+        }
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        Tz::from_str(&repr.name).map_err(TryFromProtoError::DateConversionError)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::protobuf_repr_roundtrip;
+    use crate::chrono::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(4096))]
+
+        #[test]
+        fn naive_date_time_protobuf_roundtrip(expect in any_naive_datetime() ) {
+            let actual =  protobuf_repr_roundtrip(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+
+        #[test]
+        fn date_time_protobuf_roundtrip(expect in any_datetime() ) {
+            let actual =  protobuf_repr_roundtrip(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+
+        #[test]
+        fn fixed_offset_protobuf_roundtrip(expect in any_fixed_offset() ) {
+            let actual =  protobuf_repr_roundtrip(&expect);
+            assert!(actual.is_ok());
+            assert_eq!(actual.unwrap(), expect);
+        }
+    }
+}


### PR DESCRIPTION
Add Protobuf support for chrono::types: `NaiveDate`, `NaiveTime`, `NaiveDatetime`, `DateTime<Utc>`, `FixedOffset` and, `DateTimeUnits`.

Fixes #11756

Tracked in #11735
