### PR TITLE
mzcompose: shave ~4s from workflow startup time

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -737,19 +737,14 @@ class Composition:
         if isinstance(port, str):
             port = int(port.split(":")[0])
         ui.progress(f"waiting for {host}:{port}", "C")
-        for remaining in ui.timeout_loop(timeout_secs):
-            cmd = f"docker run --rm -t --network {self.name}_default ubuntu:focal-20210723".split()
-
-            try:
-                _check_tcp(cmd[:], host, port, timeout_secs)
-            except subprocess.CalledProcessError:
-                ui.progress(" {}".format(int(remaining)))
-            else:
-                ui.progress(" success!", finish=True)
-                return
-
-        ui.progress(" error!", finish=True)
-        raise UIError(f"unable to connect to {host}:{port}")
+        cmd = f"docker run --rm -t --network {self.name}_default ubuntu:focal-20210723".split()
+        try:
+            _check_tcp(cmd[:], host, port, timeout_secs)
+        except subprocess.CalledProcessError:
+            ui.progress(" error!", finish=True)
+            raise UIError(f"unable to connect to {host}:{port}")
+        else:
+            ui.progress(" success!", finish=True)
 
     # TODO(benesch): replace with Docker health checks.
     def wait_for_postgres(
@@ -955,7 +950,7 @@ def _check_tcp(
             str(timeout_secs),
             "bash",
             "-c",
-            f"cat < /dev/null > /dev/tcp/{host}/{port}",
+            f"until [ cat < /dev/null > /dev/tcp/{host}/{port} ] ; do sleep 0.1 ; done",
         ]
     )
     try:
@@ -986,7 +981,7 @@ def _wait_for_pg(
     args = f"dbname={dbname} host={host} port={port} user={user} password={password}"
     ui.progress(f"waiting for {args} to handle {query!r}", "C")
     error = None
-    for remaining in ui.timeout_loop(timeout_secs):
+    for remaining in ui.timeout_loop(timeout_secs, tick=0.1):
         try:
             conn = pg8000.connect(
                 database=dbname,

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -203,6 +203,7 @@ class Kafka(Service):
             "KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1",
             "KAFKA_MESSAGE_MAX_BYTES=15728640",
             "KAFKA_REPLICA_FETCH_MAX_BYTES=15728640",
+            "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=100",
         ],
         depends_on: List[str] = ["zookeeper"],
         volumes: List[str] = [],

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -82,7 +82,7 @@ def progress(
     print(msg, file=sys.stderr, flush=True, end=end)
 
 
-def timeout_loop(timeout: int, tick: int = 1) -> Generator[float, None, None]:
+def timeout_loop(timeout: int, tick: float = 1.0) -> Generator[float, None, None]:
     """Loop until timeout, optionally sleeping until tick
 
     Always iterates at least once
@@ -106,7 +106,7 @@ def timeout_loop(timeout: int, tick: int = 1) -> Generator[float, None, None]:
 
 
 async def async_timeout_loop(
-    timeout: int, tick: int = 1
+    timeout: int, tick: float = 1.0
 ) -> AsyncGenerator[float, None]:
     """Loop until timeout, asynchronously sleeping until tick
 


### PR DESCRIPTION
The following measures save ~4s from the startup time of a workflow
that requires a complete Kafka environment:

- _check_tcp() will now retry every 100ms rather than every 1s

- the check has been moved to run entirely in a single 'docker run'
  command, thereby removing the overhead of calling 'docker run'
  repeatedly.

- the group.initial.rebalance.delay.ms option is used to allow
  the schema registry to connect to Kafka faster, speeding up
  its startup sequence.

### Motivation

  * This PR fixes a previously unreported bug.

Slow schema registry startup time was slowly eating at my soul.