### PR TITLE
coord: rely on sqlite to handle cleanup on cluster drop

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -110,7 +110,7 @@ const MIGRATIONS: &[&dyn Migration] = &[
      );
 
      CREATE TABLE compute_introspection_source_indexes (
-        compute_id integer NOT NULL REFERENCES compute_instances,
+        compute_id integer NOT NULL REFERENCES compute_instances (id) ON DELETE CASCADE,
         name text NOT NULL,
         index_id integer NOT NULL UNIQUE,
         PRIMARY KEY (compute_id, name)
@@ -718,14 +718,6 @@ impl Transaction<'_> {
     }
 
     pub fn remove_compute_instance(&self, name: &str) -> Result<(), Error> {
-        let _ = self
-            .inner
-            .prepare_cached(
-                "DELETE FROM compute_introspection_source_indexes WHERE compute_id =
-                    (SELECT id FROM compute_instances WHERE name = ?)",
-            )?
-            .execute(params![name])?;
-
         let n = self
             .inner
             .prepare_cached("DELETE FROM compute_instances WHERE name = ?")?


### PR DESCRIPTION
This is a more fool-proof and easy-to-follow pattern to solve the issue closed in #11804

### Motivation

This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
