### PR TITLE
materialized: swap HTTP server for axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.1",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,6 +2837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "materialized"
 version = "0.26.1-dev"
 dependencies = [
@@ -2800,6 +2852,7 @@ dependencies = [
  "assert_cmd",
  "async-trait",
  "atty",
+ "axum",
  "backtrace",
  "base64",
  "bytes",
@@ -2820,6 +2873,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "http",
+ "http-body",
  "hyper",
  "hyper-openssl",
  "hyper-proxy",
@@ -2830,6 +2884,7 @@ dependencies = [
  "krb5-src",
  "lazy_static",
  "libc",
+ "mime",
  "mz-build-info",
  "mz-coord",
  "mz-dataflow",
@@ -2879,6 +2934,7 @@ dependencies = [
  "sysinfo",
  "tar",
  "tempfile",
+ "thiserror",
  "tikv-jemallocator",
  "timely",
  "tokio",
@@ -2887,7 +2943,6 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tonic",
- "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -4151,6 +4206,7 @@ dependencies = [
  "timely",
  "tokio",
  "tokio-postgres",
+ "tower-http",
  "uuid",
  "walkdir",
 ]
@@ -6067,6 +6123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "synstructure"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6585,6 +6647,7 @@ dependencies = [
  "http-body",
  "http-range-header",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3522,6 +3522,7 @@ dependencies = [
  "mz-ore",
  "reqwest",
  "serde",
+ "thiserror",
  "tokio",
  "uuid",
 ]

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -14,5 +14,6 @@ jsonwebtoken = "8.0.1"
 mz-ore = { path = "../ore" }
 reqwest = "0.11.10"
 serde = { version = "1.0.135", features = ["derive"] }
+thiserror = "1.0.30"
 tokio = "1.16.1"
 uuid = "0.8.2"

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -261,6 +261,6 @@ pub enum FronteggError {
     TokenExpired,
     #[error("unauthorized organization")]
     UnauthorizedTenant,
-    #[error("wrong email")]
+    #[error("email in access token did not match the expected email")]
     WrongEmail,
 }

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -50,6 +50,7 @@ hyper = { version = "0.14.18", features = ["http1", "server"] }
 hyper-openssl = "0.9.2"
 include_dir = "0.7.2"
 itertools = "0.10.3"
+jsonwebtoken = "8.0.1"
 krb5-src = { version = "0.3.2", features = ["binaries"] }
 lazy_static = "1.4.0"
 libc = "0.2.122"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -32,8 +32,10 @@ anyhow = "1.0.56"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 async-trait = "0.1.53"
 atty = "0.2.14"
+axum = { version = "0.5.1", features = ["headers"] }
 backtrace = "0.3.64"
 base64 = "0.13.0"
+bytes = "1.1.0"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 clap = { version = "3.1.8", features = ["wrap_help", "env", "derive"] }
@@ -46,6 +48,7 @@ futures = "0.3.21"
 headers = "0.3.7"
 hex = "0.4.3"
 http = "0.2.6"
+http-body = "0.4.4"
 hyper = { version = "0.14.18", features = ["http1", "server"] }
 hyper-openssl = "0.9.2"
 include_dir = "0.7.2"
@@ -54,6 +57,7 @@ jsonwebtoken = "8.0.1"
 krb5-src = { version = "0.3.2", features = ["binaries"] }
 lazy_static = "1.4.0"
 libc = "0.2.122"
+mime = "0.3.16"
 mz-build-info = { path = "../build-info" }
 mz-coord = { path = "../coord" }
 mz-dataflow = { path = "../dataflow" }
@@ -88,11 +92,11 @@ shell-words = "1.1.0"
 sysctl = "0.4.4"
 sysinfo = "0.23.9"
 tempfile = "3.2.0"
+thiserror = "1.0.30"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.17.0", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-stream = { version = "0.1.8", features = ["net"] }
-tower = "0.4.12"
 tower-http = { version = "0.2.5", features = ["cors"] }
 tracing = "0.1.33"
 tracing-subscriber = "0.3.11"

--- a/src/materialized/src/http/memory.rs
+++ b/src/materialized/src/http/memory.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use askama::Template;
-use hyper::{Body, Request, Response};
+use axum::response::IntoResponse;
 
 use crate::http::util;
 use crate::BUILD_INFO;
@@ -19,13 +19,10 @@ struct MemoryTemplate<'a> {
     version: &'a str,
 }
 
-pub fn handle_memory(
-    _: Request<Body>,
-    _: &mut mz_coord::SessionClient,
-) -> Result<Response<Body>, anyhow::Error> {
-    Ok(util::template_response(MemoryTemplate {
+pub async fn handle_memory() -> impl IntoResponse {
+    util::template_response(MemoryTemplate {
         version: BUILD_INFO.version,
-    }))
+    })
 }
 
 #[derive(Template)]
@@ -34,11 +31,8 @@ struct HierarchicalMemoryTemplate<'a> {
     version: &'a str,
 }
 
-pub fn handle_hierarchical_memory(
-    _: Request<Body>,
-    _: &mut mz_coord::SessionClient,
-) -> Result<Response<Body>, anyhow::Error> {
-    Ok(util::template_response(HierarchicalMemoryTemplate {
+pub async fn handle_hierarchical_memory() -> impl IntoResponse {
+    util::template_response(HierarchicalMemoryTemplate {
         version: BUILD_INFO.version,
-    }))
+    })
 }

--- a/src/materialized/src/http/templates/flamegraph.html
+++ b/src/materialized/src/http/templates/flamegraph.html
@@ -3,12 +3,12 @@
 {% block title %}{{ title }}{% endblock %}
 
 {% block head %}
-<link href="/css/vendor/d3-flame-graph.css" rel="stylesheet">
-<link href="/css/flamegraph.css" rel="stylesheet">
+<link href="/static/css/vendor/d3-flame-graph.css" rel="stylesheet">
+<link href="/static/css/flamegraph.css" rel="stylesheet">
 
-<script src="/js/vendor/d3.js"></script>
-<script src="/js/vendor/d3-flame-graph.js"></script>
-<script src="/js/flamegraph.js"></script>
+<script src="/static/js/vendor/d3.js"></script>
+<script src="/static/js/vendor/d3-flame-graph.js"></script>
+<script src="/static/js/flamegraph.js"></script>
 {% endblock %}
 
 {% block content %}

--- a/src/materialized/src/http/templates/hierarchical-memory.html
+++ b/src/materialized/src/http/templates/hierarchical-memory.html
@@ -45,12 +45,12 @@ svg {
   background-color: #f1f1f1;
 }
 </style>
-<script src="/js/vendor/react.js"></script>
-<script src="/js/vendor/react-dom.js"></script>
-<script src="/js/vendor/babel-standalone.js"></script> {# JSX compilation #}
-<script src="/js/vendor/@hpcc-js/wasm.js"></script> {# GraphViz in WASM #}
-<script src="/js/vendor/pako.js"></script> {# Zlib compression #}
-<script src="/js/hierarchical-memory.jsx" type="text/babel"></script>
+<script src="/static/js/vendor/react.js"></script>
+<script src="/static/js/vendor/react-dom.js"></script>
+<script src="/static/js/vendor/babel-standalone.js"></script> {# JSX compilation #}
+<script src="/static/js/vendor/@hpcc-js/wasm.js"></script> {# GraphViz in WASM #}
+<script src="/static/js/vendor/pako.js"></script> {# Zlib compression #}
+<script src="/static/js/hierarchical-memory.jsx" type="text/babel"></script>
 {% endblock %}
 
 {% block content %}

--- a/src/materialized/src/http/templates/memory.html
+++ b/src/materialized/src/http/templates/memory.html
@@ -3,14 +3,14 @@
 {% block title %}Memory{% endblock %}
 
 {% block head %}
-<link href="/css/memory.css" rel="stylesheet">
+<link href="/static/css/memory.css" rel="stylesheet">
 
-<script src="/js/vendor/react.js"></script>
-<script src="/js/vendor/react-dom.js"></script>
-<script src="/js/vendor/babel-standalone.js"></script> {# JSX compilation #}
-<script src="/js/vendor/@hpcc-js/wasm.js"></script> {# GraphViz in WASM #}
-<script src="/js/vendor/pako.js"></script> {# Zlib compression #}
-<script src="/js/memory.jsx" type="text/babel"></script>
+<script src="/static/js/vendor/react.js"></script>
+<script src="/static/js/vendor/react-dom.js"></script>
+<script src="/static/js/vendor/babel-standalone.js"></script> {# JSX compilation #}
+<script src="/static/js/vendor/@hpcc-js/wasm.js"></script> {# GraphViz in WASM #}
+<script src="/static/js/vendor/pako.js"></script> {# Zlib compression #}
+<script src="/static/js/memory.jsx" type="text/babel"></script>
 {% endblock %}
 
 {% block content %}

--- a/src/materialized/src/http/templates/prof.html
+++ b/src/materialized/src/http/templates/prof.html
@@ -26,7 +26,7 @@
         <button type="submit" name="action" value="activate">Activate</button>
       </form>
   {% endmatch %}
-  <a href="prof?dump_stats">Download stats</a>
+  <a href="prof?action=dump_stats">Download stats</a>
 {% when crate::http::prof::MemProfilingStatus::Disabled %}
     <p>Jemalloc profiling is not available.</p>
     {% if std::env::consts::OS == "macos" %}

--- a/src/materialized/src/http/util.rs
+++ b/src/materialized/src/http/util.rs
@@ -10,24 +10,12 @@
 //! HTTP utilities.
 
 use askama::Template;
-use hyper::{Body, Response, StatusCode};
+use axum::response::Html;
 
 /// Renders a template into an HTTP response.
-pub fn template_response<T>(template: T) -> Response<Body>
+pub fn template_response<T>(template: T) -> Html<String>
 where
     T: Template,
 {
-    let contents = template.render().expect("template rendering cannot fail");
-    Response::new(Body::from(contents))
-}
-
-/// Renders a status code and error message into an HTTP response.
-pub fn error_response<S>(code: StatusCode, message: S) -> Response<Body>
-where
-    S: Into<String>,
-{
-    Response::builder()
-        .status(code)
-        .body(Body::from(message.into()))
-        .unwrap()
+    Html(template.render().expect("template rendering cannot fail"))
 }

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -23,7 +23,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use ::http::header::HeaderValue;
 use anyhow::{anyhow, Context};
 use compile_time_run::run_command_str;
 use futures::StreamExt;
@@ -38,6 +37,7 @@ use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod, SslVerifyMode};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
+use tower_http::cors::{AnyOr, Origin};
 
 use mz_build_info::BuildInfo;
 use mz_coord::LoggingConfig;
@@ -122,7 +122,7 @@ pub struct Config {
     pub frontegg: Option<FronteggAuthentication>,
     /// Origins for which cross-origin resource sharing (CORS) for HTTP requests
     /// is permitted.
-    pub cors_allowed_origins: Vec<HeaderValue>,
+    pub cors_allowed_origin: AnyOr<Origin>,
 
     // === Storage options. ===
     /// The directory in which `materialized` should store its own metadata.
@@ -537,7 +537,7 @@ pub async fn serve(mut config: Config) -> Result<Server, anyhow::Error> {
             metrics_registry,
             global_metrics: metrics,
             pgwire_metrics: pgwire_server.metrics(),
-            allowed_origins: config.cors_allowed_origins,
+            allowed_origin: config.cors_allowed_origin,
         });
         let mut mux = Mux::new();
         mux.add_handler(pgwire_server);

--- a/src/materialized/tests/auth.rs
+++ b/src/materialized/tests/auth.rs
@@ -29,7 +29,7 @@ use hyper::http::uri::Scheme;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{body, Body, Request, Response, Server, StatusCode, Uri};
 use hyper_openssl::HttpsConnector;
-use jsonwebtoken::{self, EncodingKey, DecodingKey};
+use jsonwebtoken::{self, DecodingKey, EncodingKey};
 use mz_ore::now::SYSTEM_TIME;
 use openssl::asn1::Asn1Time;
 use openssl::error::ErrorStack;
@@ -292,6 +292,10 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                             for (k, v) in headers.iter() {
                                 req.headers_mut().unwrap().insert(k, v.clone());
                             }
+                            req.headers_mut().unwrap().insert(
+                                "Content-Type",
+                                HeaderValue::from_static("application/x-www-form-urlencoded"),
+                            );
                             req.body(Body::from("sql=SELECT pg_catalog.current_user()"))
                                 .unwrap()
                         }),

--- a/src/materialized/tests/auth.rs
+++ b/src/materialized/tests/auth.rs
@@ -29,7 +29,7 @@ use hyper::http::uri::Scheme;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{body, Body, Request, Response, Server, StatusCode, Uri};
 use hyper_openssl::HttpsConnector;
-use jsonwebtoken::{self, EncodingKey};
+use jsonwebtoken::{self, EncodingKey, DecodingKey};
 use mz_ore::now::SYSTEM_TIME;
 use openssl::asn1::Asn1Time;
 use openssl::error::ErrorStack;
@@ -494,11 +494,11 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
     )?;
     let frontegg_auth = FronteggAuthentication::new(FronteggConfig {
         admin_api_token_url: frontegg_server.url.clone(),
-        jwk_rsa_pem: &ca.pkey.public_key_to_pem()?,
+        decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem()?)?,
         tenant_id,
         now: SYSTEM_TIME.clone(),
         refresh_before_secs: REFRESH_BEFORE_SECS as i64,
-    })?;
+    });
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("{client_id}{secret}");
 
@@ -633,11 +633,11 @@ fn test_auth() -> Result<(), Box<dyn Error>> {
     let frontegg_server = start_mzcloud(encoding_key, tenant_id, users, now.clone(), 1_000)?;
     let frontegg_auth = FronteggAuthentication::new(FronteggConfig {
         admin_api_token_url: frontegg_server.url,
-        jwk_rsa_pem: &ca.pkey.public_key_to_pem()?,
+        decoding_key: DecodingKey::from_rsa_pem(&ca.pkey.public_key_to_pem()?)?,
         tenant_id,
         now,
         refresh_before_secs: 0,
-    })?;
+    });
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("{client_id}{secret}");
     let frontegg_basic = Authorization::basic(frontegg_user, frontegg_password);

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -27,6 +27,7 @@ use postgres::types::{FromSql, Type};
 use postgres::Socket;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
+use tower_http::cors::Origin;
 
 use materialized::{StorageConfig, TlsMode};
 
@@ -168,7 +169,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         persist: PersistConfig::disabled(),
         third_party_metrics_listen_addr: None,
         now: config.now,
-        cors_allowed_origins: vec![],
+        cors_allowed_origin: Origin::list([]).into(),
     }))?;
     let server = Server {
         inner,

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -32,5 +32,6 @@ time = "0.3.9"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.17.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2", features = ["with-chrono-0_4", "with-uuid-0_8", "with-serde_json-1"] }
+tower-http = { version = "0.2.5", features = ["cors"] }
 uuid = "0.8.2"
 walkdir = "2.3.2"

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -54,6 +54,7 @@ use tokio_postgres::types::FromSql;
 use tokio_postgres::types::Kind as PgKind;
 use tokio_postgres::types::Type as PgType;
 use tokio_postgres::{NoTls, Row, SimpleQueryMessage};
+use tower_http::cors::Origin;
 use uuid::Uuid;
 
 use mz_pgrepr::{Interval, Jsonb, Numeric, Value};
@@ -564,7 +565,7 @@ impl Runner {
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             tls: None,
             frontegg: None,
-            cors_allowed_origins: vec![],
+            cors_allowed_origin: Origin::list([]).into(),
             experimental_mode: true,
             disable_user_indexes: false,
             safe_mode: false,


### PR DESCRIPTION
axum is the Rust HTTP server framework that we've been looking for.
We're using it quite successfully in MaterializeInc/cloud. Use it in
materialized, too. It handles quite a bit of routing and form parsing
that we previously had to do manually.

Forthcoming commits will be able to build on this foundation to provide
a WebSocket API. We'll also be able to use nested routing to split the
HTTP server up into separate crates, so that other binaries besides
`materialized` can provide an HTTP server. For example, `dataflowd`
needs to expose metrics and profiling endpoints.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
