### PR TITLE
ci/license: add configuration to bump license file

### DIFF
--- a/ci/license/bump-change-date.sh
+++ b/ci/license/bump-change-date.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# bump-change-date — updates the change date in the LICENSE file.
+
+set -euo pipefail
+
+git_date=$(date "+%B %d, %Y 00:00:00 UTC")
+change_date=$(date -d "+4 years" "+%B %d, %Y")
+version_date=$(date "+%Y%m%d")
+
+export GIT_AUTHOR_DATE=$git_date
+export GIT_COMMITTER_DATE=$git_date
+export GIT_AUTHOR_NAME=Materialize Bot
+export GIT_AUTHOR_EMAIL=infra+github-materializer@materialize.com
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+
+git checkout main
+git pull
+sed -i "s/Licensed Work:.*/Licensed Work:             Materialize Version $version_date/g" LICENSE
+sed -i "s/Change Date:.*/Change Date:               $change_date/g" LICENSE
+git add LICENSE
+git commit -m "LICENSE: update change date"
+git push "https://materializebot:$GITHUB_TOKEN@github.com/MaterializeInc/materialize.git" main

--- a/ci/license/pipeline.yml
+++ b/ci/license/pipeline.yml
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+steps:
+  - label: Bump change date
+    timeout_in_minutes: 10
+    command: ci/license/bump-change-date.sh
+    agents:
+      queue: linux


### PR DESCRIPTION
In the switch to Materialize Platform, we are no longer making regular
releases. Add a script to be run in CI that will automatically update
the change date in the LICENSE file which we can configure to run every
night.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
