### PR TITLE
materialized: set default CORS allowed origins

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -679,8 +679,19 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
         .any(|val| val.as_bytes() == b"*")
     {
         cors::Any.into()
-    } else {
+    } else if !args.cors_allowed_origin.is_empty() {
         Origin::list(args.cors_allowed_origin).into()
+    } else {
+        let port = args.listen_addr.port();
+        Origin::list([
+            HeaderValue::from_str(&format!("http://localhost:{}", port)).unwrap(),
+            HeaderValue::from_str(&format!("http://127.0.0.1:{}", port)).unwrap(),
+            HeaderValue::from_str(&format!("http://[::1]:{}", port)).unwrap(),
+            HeaderValue::from_str(&format!("https://localhost:{}", port)).unwrap(),
+            HeaderValue::from_str(&format!("https://127.0.0.1:{}", port)).unwrap(),
+            HeaderValue::from_str(&format!("https://[::1]:{}", port)).unwrap(),
+        ])
+        .into()
     };
 
     // Configure orchestrator.


### PR DESCRIPTION
By default, allow cross-origin requests from localhost:6875 (or
whichever port Materialize is listening on). This makes the admin
interface work out of the box when developing locally.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported in Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
