### PR TITLE
materialized: add basic WebSocket API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,7 @@ checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64",
  "bitflags",
  "bytes",
  "futures-util",
@@ -665,8 +666,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha-1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tower-layer",
@@ -3296,6 +3299,7 @@ name = "mz-coord"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "bincode",
  "byteorder",
  "chrono",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.56"
+async-stream = "0.3.3"
 bincode = { version = "1.3.3", optional = true }
 byteorder = "1.4.3"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -11,6 +11,10 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
+use anyhow::anyhow;
+use async_stream::stream;
+use futures::Stream;
+use serde_json::Value;
 use tokio::sync::{mpsc, oneshot, watch};
 use uuid::Uuid;
 
@@ -388,51 +392,6 @@ impl SessionClient {
         &mut self,
         stmts: &str,
     ) -> Result<SimpleExecuteResponse, CoordError> {
-        // Convert most floats to a JSON Number. JSON Numbers don't support NaN or
-        // Infinity, so those will still be rendered as strings.
-        fn float_to_json(f: f64) -> serde_json::Value {
-            match serde_json::Number::from_f64(f) {
-                Some(n) => serde_json::Value::Number(n),
-                None => serde_json::Value::String(f.to_string()),
-            }
-        }
-
-        fn datum_to_json(datum: &Datum) -> serde_json::Value {
-            match datum {
-                // Convert some common things to a native JSON value. This doesn't need to be
-                // too exhaustive because the SQL-over-HTTP interface is currently not hooked
-                // up to arbitrary external user queries.
-                Datum::Null | Datum::JsonNull => serde_json::Value::Null,
-                Datum::False => serde_json::Value::Bool(false),
-                Datum::True => serde_json::Value::Bool(true),
-                Datum::Int16(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
-                Datum::Int32(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
-                Datum::Int64(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
-                Datum::Float32(n) => float_to_json(n.into_inner() as f64),
-                Datum::Float64(n) => float_to_json(n.into_inner()),
-                Datum::Numeric(d) => {
-                    // serde_json requires floats to be finite
-                    if d.0.is_infinite() {
-                        serde_json::Value::String(d.0.to_string())
-                    } else {
-                        serde_json::Value::Number(
-                            serde_json::Number::from_f64(f64::try_from(d.0).unwrap()).unwrap(),
-                        )
-                    }
-                }
-                Datum::String(s) => serde_json::Value::String(s.to_string()),
-                Datum::List(list) => serde_json::Value::Array(
-                    list.iter().map(|entry| datum_to_json(&entry)).collect(),
-                ),
-                Datum::Map(map) => serde_json::Value::Object(
-                    map.iter()
-                        .map(|(k, v)| (k.to_owned(), datum_to_json(&v)))
-                        .collect(),
-                ),
-                _ => serde_json::Value::String(datum.to_string()),
-            }
-        }
-
         let stmts = mz_sql::parse::parse(&stmts).map_err(|e| CoordError::Unstructured(e.into()))?;
         self.start_transaction(None).await?;
         const EMPTY_PORTAL: &str = "";
@@ -481,6 +440,47 @@ impl SessionClient {
         Ok(SimpleExecuteResponse { results })
     }
 
+    /// Like [`SessionClient::simple_execute`], but for `TAIL` queries.
+    pub async fn simple_tail(
+        &mut self,
+        stmt: &str,
+    ) -> Result<impl Stream<Item = Result<Vec<Value>, CoordError>>, CoordError> {
+        let stmts = mz_sql::parse::parse(&stmt).map_err(|e| CoordError::Unstructured(e.into()))?;
+        if stmts.len() != 1 {
+            coord_bail!("only one statement is supported");
+        }
+        self.start_transaction(None).await?;
+        const EMPTY_PORTAL: &str = "";
+        self.declare(EMPTY_PORTAL.into(), stmts.into_element(), vec![])
+            .await?;
+        let desc = self
+            .session()
+            .get_portal_unverified(EMPTY_PORTAL)
+            .map(|portal| portal.desc.clone())
+            .expect("unnamed portal should be present");
+        if !desc.param_types.is_empty() {
+            return Err(CoordError::Unsupported("parameters"));
+        }
+        match self.execute(EMPTY_PORTAL.into()).await? {
+            ExecuteResponse::Tailing { mut rx } => Ok(stream! {
+                while let Some(res) = rx.recv().await {
+                    match res {
+                        PeekResponseUnary::Rows(rows) => {
+                            let mut datum_vec = mz_repr::DatumVec::new();
+                            for row in rows {
+                                let datums = datum_vec.borrow_with(&row);
+                                yield Ok(datums.iter().map(datum_to_json).collect());
+                            }
+                        }
+                        PeekResponseUnary::Error(e) => yield Err(CoordError::Unstructured(anyhow!(e))),
+                        PeekResponseUnary::Canceled => yield Err(CoordError::Unstructured(anyhow!("execution canceled"))),
+                    }
+                }
+            }),
+            _ => coord_bail!("statements of the executed type"),
+        }
+    }
+
     /// Returns a mutable reference to the session bound to this client.
     pub fn session(&mut self) -> &mut Session {
         self.session.as_mut().unwrap()
@@ -509,5 +509,50 @@ impl Drop for SessionClient {
                 .send(Command::Terminate { session })
                 .expect("coordinator unexpectedly gone");
         }
+    }
+}
+
+// Convert most floats to a JSON Number. JSON Numbers don't support NaN or
+// Infinity, so those will still be rendered as strings.
+fn float_to_json(f: f64) -> serde_json::Value {
+    match serde_json::Number::from_f64(f) {
+        Some(n) => serde_json::Value::Number(n),
+        None => serde_json::Value::String(f.to_string()),
+    }
+}
+
+fn datum_to_json(datum: &Datum) -> serde_json::Value {
+    match datum {
+        // Convert some common things to a native JSON value. This doesn't need to be
+        // too exhaustive because the SQL-over-HTTP interface is currently not hooked
+        // up to arbitrary external user queries.
+        Datum::Null | Datum::JsonNull => serde_json::Value::Null,
+        Datum::False => serde_json::Value::Bool(false),
+        Datum::True => serde_json::Value::Bool(true),
+        Datum::Int16(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
+        Datum::Int32(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
+        Datum::Int64(n) => serde_json::Value::Number(serde_json::Number::from(*n)),
+        Datum::Float32(n) => float_to_json(n.into_inner() as f64),
+        Datum::Float64(n) => float_to_json(n.into_inner()),
+        Datum::Numeric(d) => {
+            // serde_json requires floats to be finite
+            if d.0.is_infinite() {
+                serde_json::Value::String(d.0.to_string())
+            } else {
+                serde_json::Value::Number(
+                    serde_json::Number::from_f64(f64::try_from(d.0).unwrap()).unwrap(),
+                )
+            }
+        }
+        Datum::String(s) => serde_json::Value::String(s.to_string()),
+        Datum::List(list) => {
+            serde_json::Value::Array(list.iter().map(|entry| datum_to_json(&entry)).collect())
+        }
+        Datum::Map(map) => serde_json::Value::Object(
+            map.iter()
+                .map(|(k, v)| (k.to_owned(), datum_to_json(&v)))
+                .collect(),
+        ),
+        _ => serde_json::Value::String(datum.to_string()),
     }
 }

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0.56"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 async-trait = "0.1.53"
 atty = "0.2.14"
-axum = { version = "0.5.1", features = ["headers"] }
+axum = { version = "0.5.1", features = ["headers", "ws"] }
 backtrace = "0.3.64"
 base64 = "0.13.0"
 bytes = "1.1.0"

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -119,6 +119,11 @@ impl Server {
         let frontegg = Arc::new(frontegg);
         let router = Router::new()
             .route("/", routing::get(root::handle_home))
+            .route(
+                "/api/internal/catalog",
+                routing::get(catalog::handle_internal_catalog),
+            )
+            .route("/api/sql", routing::post(sql::handle_sql))
             .route("/memory", routing::get(memory::handle_memory))
             .route(
                 "/metrics",
@@ -130,13 +135,8 @@ impl Server {
                 "/hierarchical-memory",
                 routing::get(memory::handle_hierarchical_memory),
             )
-            .route(
-                "/internal/catalog",
-                routing::get(catalog::handle_internal_catalog),
-            )
             .route("/prof", routing::get(prof::handle_get))
             .route("/prof", routing::post(prof::handle_post))
-            .route("/sql", routing::post(sql::handle_sql))
             .route("/static/*path", routing::get(root::handle_static))
             .route(
                 "/status",

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -123,6 +123,7 @@ impl Server {
                 "/api/internal/catalog",
                 routing::get(catalog::handle_internal_catalog),
             )
+            .route("/api/sql", routing::get(sql::handle_sql_ws))
             .route("/api/sql", routing::post(sql::handle_sql))
             .route("/memory", routing::get(memory::handle_memory))
             .route(
@@ -206,7 +207,10 @@ impl Server {
         let router = self.router.lock().expect("lock poisoned").clone();
         let svc = router.layer(Extension(conn_protocol));
         let http = hyper::server::conn::Http::new();
-        http.serve_connection(conn, svc).err_into().await
+        http.serve_connection(conn, svc)
+            .with_upgrades()
+            .err_into()
+            .await
     }
 
     // Handler functions are attached by various submodules. They all have a

--- a/src/materialized/src/http/sql.rs
+++ b/src/materialized/src/http/sql.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use axum::extract::Form;
 use axum::response::IntoResponse;
 use axum::Json;
 use http::StatusCode;
@@ -16,13 +15,13 @@ use serde::Deserialize;
 use crate::http::AuthedClient;
 
 #[derive(Deserialize)]
-pub struct SqlForm {
+pub struct SqlRequest {
     sql: String,
 }
 
 pub async fn handle_sql(
     AuthedClient(mut client): AuthedClient,
-    Form(SqlForm { sql }): Form<SqlForm>,
+    Json(SqlRequest { sql }): Json<SqlRequest>,
 ) -> impl IntoResponse {
     match client.simple_execute(&sql).await {
         Ok(res) => Ok(Json(res)),

--- a/src/materialized/src/http/sql.rs
+++ b/src/materialized/src/http/sql.rs
@@ -7,10 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::WebSocketUpgrade;
 use axum::response::IntoResponse;
 use axum::Json;
+use futures::TryStreamExt;
 use http::StatusCode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+use mz_coord::SessionClient;
+use tokio::pin;
 
 use crate::http::AuthedClient;
 
@@ -27,4 +33,47 @@ pub async fn handle_sql(
         Ok(res) => Ok(Json(res)),
         Err(e) => Err((StatusCode::BAD_REQUEST, e.to_string())),
     }
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+pub async fn handle_sql_ws(
+    AuthedClient(mut client): AuthedClient,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    ws.on_upgrade(|mut ws| async move {
+        if let Err(e) = run_ws(&mut ws, &mut client).await {
+            let _ = send_ws_response(
+                &mut ws,
+                ErrorResponse {
+                    error: e.to_string(),
+                },
+            );
+        }
+    })
+}
+
+async fn run_ws(ws: &mut WebSocket, client: &mut SessionClient) -> Result<(), anyhow::Error> {
+    let request = match ws.recv().await.transpose()? {
+        None => return Ok(()),
+        Some(request) => request.into_text()?,
+    };
+    let SqlRequest { sql } = serde_json::from_str(&request)?;
+    let rx = client.simple_tail(&sql).await?;
+    pin!(rx);
+    while let Some(row) = rx.try_next().await? {
+        send_ws_response(ws, row).await?;
+    }
+    Ok(())
+}
+
+async fn send_ws_response<T>(ws: &mut WebSocket, response: T) -> Result<(), axum::Error>
+where
+    T: Serialize,
+{
+    ws.send(Message::Text(serde_json::to_string(&response).unwrap()))
+        .await
 }

--- a/src/materialized/src/http/static/js/hierarchical-memory.jsx
+++ b/src/materialized/src/http/static/js/hierarchical-memory.jsx
@@ -12,12 +12,10 @@
 const hpccWasm = window['@hpcc-js/wasm'];
 
 async function query(sql) {
-  const body = new URLSearchParams();
-  body.append('sql', sql);
-  const response = await fetch('/sql', {
+  const response = await fetch('/api/sql', {
     method: 'POST',
-    body: body,
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: JSON.stringify({sql: sql}),
+    headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {
     const text = await response.text();

--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -12,12 +12,10 @@
 const hpccWasm = window['@hpcc-js/wasm'];
 
 async function query(sql) {
-  const body = new URLSearchParams();
-  body.append('sql', sql);
-  const response = await fetch('/sql', {
+  const response = await fetch('/api/sql', {
     method: 'POST',
-    body: body,
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: JSON.stringify({sql: sql}),
+    headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {
     const text = await response.text();


### PR DESCRIPTION
@necaris, as promised! Still a bit rough, but all the pieces are there. I'm not planning on doing more work on this, so please feel free to run with this.

----

Add a WebSocket API to `materialized` via the /api/sql endpoint The
protocol uses JSON to stream back the results of TAIL queries, and looks
like this:

```
  client: {"sql": "TAIL t"}
  server: [time, diff, data]
  server: [time, diff, data]
  server: ...
```


### Motivation

  * This PR adds a feature that has not yet been specified.

  The cloud web UI wants to be able to stream `materialized`'s status updates. This is the magic that will make that happen.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
