### PR TITLE
materialized: improve HTTP API

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -119,6 +119,11 @@ impl Server {
         let frontegg = Arc::new(frontegg);
         let router = Router::new()
             .route("/", routing::get(root::handle_home))
+            .route(
+                "/api/internal/catalog",
+                routing::get(catalog::handle_internal_catalog),
+            )
+            .route("/api/sql", routing::post(sql::handle_sql))
             .route("/memory", routing::get(memory::handle_memory))
             .route(
                 "/metrics",
@@ -130,13 +135,8 @@ impl Server {
                 "/hierarchical-memory",
                 routing::get(memory::handle_hierarchical_memory),
             )
-            .route(
-                "/internal/catalog",
-                routing::get(catalog::handle_internal_catalog),
-            )
             .route("/prof", routing::get(prof::handle_get))
             .route("/prof", routing::post(prof::handle_post))
-            .route("/sql", routing::post(sql::handle_sql))
             .route("/static/*path", routing::get(root::handle_static))
             .route(
                 "/status",

--- a/src/materialized/src/http/sql.rs
+++ b/src/materialized/src/http/sql.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use axum::extract::Form;
 use axum::response::IntoResponse;
 use axum::Json;
 use http::StatusCode;
@@ -16,13 +15,13 @@ use serde::Deserialize;
 use crate::http::AuthedClient;
 
 #[derive(Deserialize)]
-pub struct SqlForm {
+pub struct SqlRequest {
     sql: String,
 }
 
 pub async fn handle_sql(
     AuthedClient(mut client): AuthedClient,
-    Form(SqlForm { sql }): Form<SqlForm>,
+    Json(SqlRequest { sql }): Json<SqlRequest>,
 ) -> impl IntoResponse {
     match client.simple_execute(&sql).await {
         Ok(res) => Ok(Json(res)),

--- a/src/materialized/src/http/static/js/hierarchical-memory.jsx
+++ b/src/materialized/src/http/static/js/hierarchical-memory.jsx
@@ -12,12 +12,10 @@
 const hpccWasm = window['@hpcc-js/wasm'];
 
 async function query(sql) {
-  const body = new URLSearchParams();
-  body.append('sql', sql);
-  const response = await fetch('/sql', {
+  const response = await fetch('/api/sql', {
     method: 'POST',
-    body: body,
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: JSON.stringify({sql: sql}),
+    headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {
     const text = await response.text();

--- a/src/materialized/src/http/static/js/memory.jsx
+++ b/src/materialized/src/http/static/js/memory.jsx
@@ -12,12 +12,10 @@
 const hpccWasm = window['@hpcc-js/wasm'];
 
 async function query(sql) {
-  const body = new URLSearchParams();
-  body.append('sql', sql);
-  const response = await fetch('/sql', {
+  const response = await fetch('/api/sql', {
     method: 'POST',
-    body: body,
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: JSON.stringify({sql: sql}),
+    headers: { 'Content-Type': 'application/json' },
   });
   if (!response.ok) {
     const text = await response.text();

--- a/src/materialized/tests/auth.rs
+++ b/src/materialized/tests/auth.rs
@@ -46,6 +46,7 @@ use postgres::config::SslMode;
 use postgres::error::SqlState;
 use postgres_openssl::MakeTlsConnector;
 use serde::Deserialize;
+use serde_json::json;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
@@ -281,7 +282,7 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                         Ipv4Addr::LOCALHOST,
                         server.inner.local_addr().port()
                     ))
-                    .path_and_query("/sql")
+                    .path_and_query("/api/sql")
                     .build()
                     .unwrap();
                 let res = runtime.block_on(
@@ -294,10 +295,12 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                             }
                             req.headers_mut().unwrap().insert(
                                 "Content-Type",
-                                HeaderValue::from_static("application/x-www-form-urlencoded"),
+                                HeaderValue::from_static("application/json"),
                             );
-                            req.body(Body::from("sql=SELECT pg_catalog.current_user()"))
-                                .unwrap()
+                            req.body(Body::from(
+                                json!({"sql": "SELECT pg_catalog.current_user()"}).to_string(),
+                            ))
+                            .unwrap()
                         }),
                 );
                 match assert {

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -195,7 +195,7 @@ impl Action for SqlAction {
                     let path = temp_mzdata.path();
                     let disk_state = Catalog::open_debug(&path, NOW_ZERO.clone()).await?.dump();
                     let mem_state = reqwest::get(&format!(
-                        "http://{}/internal/catalog",
+                        "http://{}/api/internal/catalog",
                         state.materialized_addr,
                     ))
                     .await?


### PR DESCRIPTION
Split out from #11821 because this is mergeable as is.

----

Move the API endpoints under /api so it is clear which routes are meant
for programmatic access and which are not. Also change /api/sql to
accept request data as JSON rather than form data, for consistency with
its JSON output format.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
