### PR TITLE
Minor warning fixes 

### DIFF
--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -91,7 +91,7 @@ def cargo(
         extra_env = {
             f"CMAKE_SYSTEM_NAME": "Linux",
             f"CARGO_TARGET_{_target_env}_LINKER": f"{_target}-cc",
-            f"CARGO_TARGET_DIR": ROOT / "target-xcompile",
+            f"CARGO_TARGET_DIR": str(ROOT / "target-xcompile"),
             f"TARGET_AR": f"{_target}-ar",
             f"TARGET_CPP": f"{_target}-cpp",
             f"TARGET_CC": f"{_target}-cc",

--- a/src/aws-util/src/lib.rs
+++ b/src/aws-util/src/lib.rs
@@ -12,6 +12,7 @@
 #![warn(missing_docs, missing_debug_implementations)]
 #![cfg_attr(nightly_doc_features, feature(doc_cfg))]
 
+#[cfg(any(feature = "kinesis", feature = "sqs", feature = "s3", feature = "sts"))]
 mod util;
 
 pub mod config;


### PR DESCRIPTION
This PR fixes two warnings that annoyed me recently during development (see commits).

- The mypy-warning occurred when running `bin/pre-push` locally. I wonder why it isn't also visible in CI.
- The dead_code warning appeared sometimes when running `cargo check/test` on individual crates. ~~Instead of silencing the warning, we could also gate the `connector` function on the various features, but I figured silencing is lower-maintenance.~~

### Motivation

 * This PR improves developer experience.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).
