### PR TITLE
antithesis: use container tags

### DIFF
--- a/misc/python/materialize/cli/deploy_antithesis.py
+++ b/misc/python/materialize/cli/deploy_antithesis.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import os
+import sys
 from pathlib import Path
 
 from materialize import mzbuild, spawn
@@ -27,9 +28,14 @@ def main() -> None:
     repo = mzbuild.Repository(root)
     deps = repo.resolve_dependencies([repo.images[name] for name in IMAGES])
     deps.acquire()
+
+    tag = sys.argv[1] if sys.argv[1] is not None else "latest"
+
     for mzimage in IMAGES:
-        spawn.runv(["docker", "tag", deps[mzimage].spec(), f"{REGISTRY}/{mzimage}"])
-        spawn.runv(["docker", "push", f"{REGISTRY}/{mzimage}"])
+        spawn.runv(
+            ["docker", "tag", deps[mzimage].spec(), f"{REGISTRY}/{mzimage}:{tag}"]
+        )
+        spawn.runv(["docker", "push", f"{REGISTRY}/{mzimage}:{tag}"])
 
 
 if __name__ == "__main__":

--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     networks:
       antithesis-net:
         ipv4_address: 10.0.0.11
-    image: antithesis-cp-combined
+    image: antithesis-cp-combined:${ANT_IMAGE_TAG}
   materialized:
     hostname: materialized
     container_name: materialized
@@ -33,7 +33,7 @@ services:
       --disable-telemetry
       --retain-prometheus-metrics 1s
       --no-sigbus-sigsegv-backtraces
-    image: antithesis-materialized
+    image: antithesis-materialized:${ANT_IMAGE_TAG}
     volumes:
       - mzdata:/share/mzdata:rw
       - tmp:/share/tmp:rw
@@ -63,7 +63,7 @@ services:
       - bash
     environment:
       TMPDIR: /share/tmp
-    image: antithesis-testdrive
+    image: antithesis-testdrive:${ANT_IMAGE_TAG}
     init: true
     volumes:
       - mzdata:/share/mzdata:rw


### PR DESCRIPTION
In order for a "latest" and a "dev" set of containers to be
testable separately:

- have the deploy_antithesis.py script tag all containers produced
  with a tag provided on the command line (defaults to "latest")

- Use an environment variable in the 'image' sections of docker-compose.yml.
  The Antithesis environment will replace this variable with the name
  of the tag being tested.

### Motivation

  * This PR adds a known-desirable feature.

This is needed so that we can test a "latest" and a "dev" versions of Mz in the Antithesis environment.