### PR TITLE
orchestrator-kubernetes: set image pull policy to always

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -206,6 +206,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     name: "default".into(),
                     image: Some(image),
                     args: Some(args(&ports)),
+                    image_pull_policy: Some("Always".into()),
                     ports: Some(
                         ports_in
                             .iter()


### PR DESCRIPTION
When using image tags like "unstable" and "latest", tell Kubernetes to
check for new versions. This makes the cloud prototype environment work
a bit better.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug: environments are crash-looping in cloud due to skew between materialized and dataflowd.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
