### PR TITLE
materialized: add basic WebSocket API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,6 +630,7 @@ checksum = "ab2504b827a8bef941ba3dd64bdffe9cf56ca182908a147edd6189c95fbcae7d"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64",
  "bitflags",
  "bytes",
  "futures-util",
@@ -646,8 +647,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sha-1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-http",
  "tower-layer",
@@ -3134,6 +3137,9 @@ name = "mz-coord"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-stream",
+ "bincode",
+ "byteorder",
  "bytes",
  "chrono",
  "const_format",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.57"
+async-stream = "0.3.3"
+bincode = { version = "1.3.3", optional = true }
+byteorder = "1.4.3"
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 const_format = "0.2.23"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -30,7 +30,9 @@ name = "materialized-unstable"
 anyhow = "1.0.57"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 async-trait = "0.1.53"
-axum = { version = "0.5.6", features = ["headers"] }
+atty = "0.2.14"
+axum = { version = "0.5.6", features = ["headers", "ws"] }
+backtrace = "0.3.64"
 base64 = "0.13.0"
 bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -114,6 +114,7 @@ impl Server {
                 "/api/internal/catalog",
                 routing::get(catalog::handle_internal_catalog),
             )
+            .route("/api/sql", routing::get(sql::handle_sql_ws))
             .route("/api/sql", routing::post(sql::handle_sql))
             .route("/memory", routing::get(memory::handle_memory))
             .route(
@@ -184,7 +185,10 @@ impl Server {
         let router = self.router.lock().expect("lock poisoned").clone();
         let svc = router.layer(Extension(conn_protocol));
         let http = hyper::server::conn::Http::new();
-        http.serve_connection(conn, svc).err_into().await
+        http.serve_connection(conn, svc)
+            .with_upgrades()
+            .err_into()
+            .await
     }
 
     // Handler functions are attached by various submodules. They all have a

--- a/src/materialized/src/http/sql.rs
+++ b/src/materialized/src/http/sql.rs
@@ -7,10 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::WebSocketUpgrade;
 use axum::response::IntoResponse;
 use axum::Json;
+use futures::TryStreamExt;
 use http::StatusCode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+use mz_coord::SessionClient;
+use tokio::pin;
 
 use crate::http::AuthedClient;
 
@@ -27,4 +33,47 @@ pub async fn handle_sql(
         Ok(res) => Ok(Json(res)),
         Err(e) => Err((StatusCode::BAD_REQUEST, e.to_string())),
     }
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+pub async fn handle_sql_ws(
+    AuthedClient(mut client): AuthedClient,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    ws.on_upgrade(|mut ws| async move {
+        if let Err(e) = run_ws(&mut ws, &mut client).await {
+            let _ = send_ws_response(
+                &mut ws,
+                ErrorResponse {
+                    error: e.to_string(),
+                },
+            );
+        }
+    })
+}
+
+async fn run_ws(ws: &mut WebSocket, client: &mut SessionClient) -> Result<(), anyhow::Error> {
+    let request = match ws.recv().await.transpose()? {
+        None => return Ok(()),
+        Some(request) => request.into_text()?,
+    };
+    let SqlRequest { sql } = serde_json::from_str(&request)?;
+    let rx = client.simple_tail(&sql).await?;
+    pin!(rx);
+    while let Some(row) = rx.try_next().await? {
+        send_ws_response(ws, row).await?;
+    }
+    Ok(())
+}
+
+async fn send_ws_response<T>(ws: &mut WebSocket, response: T) -> Result<(), axum::Error>
+where
+    T: Serialize,
+{
+    ws.send(Message::Text(serde_json::to_string(&response).unwrap()))
+        .await
 }


### PR DESCRIPTION
Stolen from @benesch's #11821, per this comment:

> I'm not planning on doing more work on this, so please feel free to run with this.

----

Add a WebSocket API to `materialized` via the /api/sql endpoint The
protocol uses JSON to stream back the results of TAIL queries, and looks
like this:

```
  client: {"sql": "TAIL t"}
  server: [time, diff, data]
  server: [time, diff, data]
  server: ...
```

### TODOs left before this is ready

- [ ] > @mjibson: We are returning an error because we don't know how to serialize the response, but the query actually ran, so we're lying to the users about if it happened or not. We're lucky today that we disallow ddls in txns because that has the side effect of preventing them here, but that's not a good foundation. We need to not error here and instead serialize all of these correctly, or otherwise prevent them before execution.

- [ ] Improve protocol to more interactive one, like `pgwire`, rather than one-response-and-tail


### Motivation

  * This PR adds a feature that has not yet been specified.

  The cloud web UI wants to be able to stream `materialized`'s status updates. This is the magic that will make that happen.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - [ ] Document WebSocket API