### PR TITLE
sql: s/SqlOption/WithOption

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 use enum_kinds::EnumKind;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
-use crate::ast::{AstInfo, Expr, Ident, SqlOption, UnresolvedObjectName, WithOption};
+use crate::ast::{AstInfo, Expr, Ident, UnresolvedObjectName, WithOption};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Schema {
@@ -124,7 +124,7 @@ impl_display_t!(ProtobufSchema);
 pub struct CsrConnectorAvro<T: AstInfo> {
     pub url: String,
     pub seed: Option<CsrSeed>,
-    pub with_options: Vec<SqlOption<T>>,
+    pub with_options: Vec<WithOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CsrConnectorAvro<T> {
@@ -149,7 +149,7 @@ impl_display_t!(CsrConnectorAvro);
 pub struct CsrConnectorProto<T: AstInfo> {
     pub url: String,
     pub seed: Option<CsrSeedCompiledOrLegacy>,
-    pub with_options: Vec<SqlOption<T>>,
+    pub with_options: Vec<WithOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CsrConnectorProto<T> {
@@ -461,7 +461,7 @@ impl_display!(DbzMode);
 pub enum CreateConnector<T: AstInfo> {
     Kafka {
         broker: String,
-        with_options: Vec<SqlOption<T>>,
+        with_options: Vec<WithOption<T>>,
     },
 }
 

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -62,7 +62,7 @@ pub enum AvroSchema<T: AstInfo> {
     },
     InlineSchema {
         schema: Schema,
-        with_options: Vec<WithOption>,
+        with_options: Vec<WithOption<T>>,
     },
 }
 

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -24,8 +24,8 @@ use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    Expr, FunctionArgs, Ident, SqlOption, UnresolvedDataType, UnresolvedDatabaseName,
-    UnresolvedObjectName, UnresolvedSchemaName,
+    Expr, FunctionArgs, Ident, UnresolvedDataType, UnresolvedDatabaseName, UnresolvedObjectName,
+    UnresolvedSchemaName, WithOption,
 };
 
 /// This represents the metadata that lives next to an AST, as we take it through
@@ -299,7 +299,7 @@ pub struct Select<T: AstInfo> {
     /// HAVING
     pub having: Option<Expr<T>>,
     /// OPTION
-    pub options: Vec<SqlOption<T>>,
+    pub options: Vec<WithOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for Select<T> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -382,7 +382,7 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
     pub connector: CreateSourceConnector,
-    pub with_options: Vec<SqlOption<T>>,
+    pub with_options: Vec<WithOption<T>>,
     pub include_metadata: Vec<SourceIncludeMetadata>,
     pub format: CreateSourceFormat<T>,
     pub envelope: Envelope,
@@ -447,7 +447,7 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub in_cluster: Option<T::ClusterName>,
     pub from: T::ObjectName,
     pub connector: CreateSinkConnector<T>,
-    pub with_options: Vec<SqlOption<T>>,
+    pub with_options: Vec<WithOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope>,
     pub with_snapshot: bool,
@@ -502,7 +502,7 @@ pub struct ViewDefinition<T: AstInfo> {
     /// View name
     pub name: UnresolvedObjectName,
     pub columns: Vec<Ident>,
-    pub with_options: Vec<SqlOption<T>>,
+    pub with_options: Vec<WithOption<T>>,
     pub query: Query<T>,
 }
 
@@ -656,7 +656,7 @@ pub struct CreateTableStatement<T: AstInfo> {
     /// Optional schema
     pub columns: Vec<ColumnDef<T>>,
     pub constraints: Vec<TableConstraint<T>>,
-    pub with_options: Vec<SqlOption<T>>,
+    pub with_options: Vec<WithOption<T>>,
     pub if_not_exists: bool,
     pub temporary: bool,
 }
@@ -921,8 +921,8 @@ impl<T: AstInfo> AstDisplay for ClusterOption<T> {
 /// `CREATE TYPE .. AS <TYPE>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateTypeAs<T: AstInfo> {
-    List { with_options: Vec<SqlOption<T>> },
-    Map { with_options: Vec<SqlOption<T>> },
+    List { with_options: Vec<WithOption<T>> },
+    Map { with_options: Vec<WithOption<T>> },
     Record { column_defs: Vec<ColumnDef<T>> },
 }
 
@@ -1686,55 +1686,6 @@ impl<T: AstInfo> AstDisplay for ShowStatementFilter<T> {
     }
 }
 impl_display_t!(ShowStatementFilter);
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum SqlOption<T: AstInfo> {
-    Value {
-        name: Ident,
-        value: Value,
-    },
-    ObjectName {
-        name: Ident,
-        object_name: UnresolvedObjectName,
-    },
-    DataType {
-        name: Ident,
-        data_type: T::DataType,
-    },
-}
-
-impl<T: AstInfo> SqlOption<T> {
-    pub fn name(&self) -> &Ident {
-        match self {
-            SqlOption::Value { name, .. } => name,
-            SqlOption::ObjectName { name, .. } => name,
-            SqlOption::DataType { name, .. } => name,
-        }
-    }
-}
-
-impl<T: AstInfo> AstDisplay for SqlOption<T> {
-    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
-        match self {
-            SqlOption::Value { name, value } => {
-                f.write_node(name);
-                f.write_str(" = ");
-                f.write_node(value);
-            }
-            SqlOption::ObjectName { name, object_name } => {
-                f.write_node(name);
-                f.write_str(" = ");
-                f.write_node(object_name);
-            }
-            SqlOption::DataType { name, data_type } => {
-                f.write_node(name);
-                f.write_str(" = ");
-                f.write_node(data_type);
-            }
-        }
-    }
-}
-impl_display_t!(SqlOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WithOption<T: AstInfo> {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -46,12 +46,12 @@ pub enum Statement<T: AstInfo> {
     CreateIndex(CreateIndexStatement<T>),
     CreateType(CreateTypeStatement<T>),
     CreateRole(CreateRoleStatement),
-    CreateCluster(CreateClusterStatement),
+    CreateCluster(CreateClusterStatement<T>),
     CreateSecret(CreateSecretStatement<T>),
     AlterObjectRename(AlterObjectRenameStatement<T>),
     AlterIndex(AlterIndexStatement<T>),
     AlterSecret(AlterSecretStatement<T>),
-    AlterCluster(AlterClusterStatement),
+    AlterCluster(AlterClusterStatement<T>),
     Discard(DiscardStatement),
     DropDatabase(DropDatabaseStatement<T>),
     DropSchema(DropSchemaStatement<T>),
@@ -77,7 +77,7 @@ pub enum Statement<T: AstInfo> {
     Tail(TailStatement<T>),
     Explain(ExplainStatement<T>),
     Declare(DeclareStatement<T>),
-    Fetch(FetchStatement),
+    Fetch(FetchStatement<T>),
     Close(CloseStatement),
     Prepare(PrepareStatement<T>),
     Execute(ExecuteStatement<T>),
@@ -241,7 +241,7 @@ pub struct CopyStatement<T: AstInfo> {
     // TARGET
     pub target: CopyTarget,
     // OPTIONS
-    pub options: Vec<WithOption>,
+    pub options: Vec<WithOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CopyStatement<T> {
@@ -700,7 +700,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     /// Expressions that form part of the index key. If not included, the
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
-    pub with_options: Vec<WithOption>,
+    pub with_options: Vec<WithOption<T>>,
     pub if_not_exists: bool,
 }
 
@@ -850,16 +850,16 @@ impl_display_t!(CreateTypeStatement);
 
 /// `CREATE CLUSTER ..`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CreateClusterStatement {
+pub struct CreateClusterStatement<T: AstInfo> {
     /// Name of the created cluster.
     pub name: Ident,
     /// Whether the `IF NOT EXISTS` clause was specified.
     pub if_not_exists: bool,
     /// The comma-separated options.
-    pub options: Vec<ClusterOption>,
+    pub options: Vec<ClusterOption<T>>,
 }
 
-impl AstDisplay for CreateClusterStatement {
+impl<T: AstInfo> AstDisplay for CreateClusterStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE CLUSTER ");
         if self.if_not_exists {
@@ -872,27 +872,27 @@ impl AstDisplay for CreateClusterStatement {
         }
     }
 }
-impl_display!(CreateClusterStatement);
+impl_display_t!(CreateClusterStatement);
 
 /// An option in a `CREATE CLUSTER` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ClusterOption {
+pub enum ClusterOption<T: AstInfo> {
     /// The `REMOTE <cluster> (<host> [, <host> ...])` option.
     Remote {
         /// The name.
         name: Ident,
         /// The hosts.
-        hosts: Vec<WithOptionValue>,
+        hosts: Vec<WithOptionValue<T>>,
     },
     /// The `SIZE [[=] <size>]` option.
-    Size(WithOptionValue),
+    Size(WithOptionValue<T>),
     /// The `INTROSPECTION GRANULARITY [[=] <interval>] option.
-    IntrospectionGranularity(WithOptionValue),
+    IntrospectionGranularity(WithOptionValue<T>),
     /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
-    IntrospectionDebugging(WithOptionValue),
+    IntrospectionDebugging(WithOptionValue<T>),
 }
 
-impl AstDisplay for ClusterOption {
+impl<T: AstInfo> AstDisplay for ClusterOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             ClusterOption::Remote { name, hosts } => {
@@ -962,8 +962,8 @@ impl<T: AstInfo> AstDisplay for AlterObjectRenameStatement<T> {
 impl_display_t!(AlterObjectRenameStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum AlterIndexAction {
-    SetOptions(Vec<WithOption>),
+pub enum AlterIndexAction<T: AstInfo> {
+    SetOptions(Vec<WithOption<T>>),
     ResetOptions(Vec<Ident>),
     Enable,
 }
@@ -973,7 +973,7 @@ pub enum AlterIndexAction {
 pub struct AlterIndexStatement<T: AstInfo> {
     pub index_name: T::ObjectName,
     pub if_exists: bool,
-    pub action: AlterIndexAction,
+    pub action: AlterIndexAction<T>,
 }
 
 impl<T: AstInfo> AstDisplay for AlterIndexStatement<T> {
@@ -1027,16 +1027,16 @@ impl_display_t!(AlterSecretStatement);
 
 /// `ALTER CLUSTER ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AlterClusterStatement {
+pub struct AlterClusterStatement<T: AstInfo> {
     /// Name of the cluster to alter.
     pub name: Ident,
     /// Whether the `IF EXISTS` clause was specified.
     pub if_exists: bool,
     /// The comma-separated options.
-    pub options: Vec<ClusterOption>,
+    pub options: Vec<ClusterOption<T>>,
 }
 
-impl AstDisplay for AlterClusterStatement {
+impl<T: AstInfo> AstDisplay for AlterClusterStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER CLUSTER ");
         if self.if_exists {
@@ -1050,7 +1050,7 @@ impl AstDisplay for AlterClusterStatement {
     }
 }
 
-impl_display!(AlterClusterStatement);
+impl_display_t!(AlterClusterStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DiscardStatement {
@@ -1548,7 +1548,7 @@ impl_display!(RollbackStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TailStatement<T: AstInfo> {
     pub relation: TailRelation<T>,
-    pub options: Vec<WithOption>,
+    pub options: Vec<WithOption<T>>,
     pub as_of: Option<Expr<T>>,
 }
 
@@ -1737,12 +1737,12 @@ impl<T: AstInfo> AstDisplay for SqlOption<T> {
 impl_display_t!(SqlOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct WithOption {
+pub struct WithOption<T: AstInfo> {
     pub key: Ident,
-    pub value: Option<WithOptionValue>,
+    pub value: Option<WithOptionValue<T>>,
 }
 
-impl AstDisplay for WithOption {
+impl<T: AstInfo> AstDisplay for WithOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.key);
         if let Some(opt) = &self.value {
@@ -1751,23 +1751,25 @@ impl AstDisplay for WithOption {
         }
     }
 }
-impl_display!(WithOption);
+impl_display_t!(WithOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum WithOptionValue {
+pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
     ObjectName(UnresolvedObjectName),
+    DataType(T::DataType),
 }
 
-impl AstDisplay for WithOptionValue {
+impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             WithOptionValue::Value(value) => f.write_node(value),
             WithOptionValue::ObjectName(name) => f.write_node(name),
+            WithOptionValue::DataType(typ) => f.write_node(typ),
         }
     }
 }
-impl_display!(WithOptionValue);
+impl_display_t!(WithOptionValue);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TransactionMode {
@@ -1959,13 +1961,13 @@ impl_display!(CloseStatement);
 
 /// `FETCH ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct FetchStatement {
+pub struct FetchStatement<T: AstInfo> {
     pub name: Ident,
     pub count: Option<FetchDirection>,
-    pub options: Vec<WithOption>,
+    pub options: Vec<WithOption<T>>,
 }
 
-impl AstDisplay for FetchStatement {
+impl<T: AstInfo> AstDisplay for FetchStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("FETCH ");
         if let Some(ref count) = self.count {
@@ -1979,7 +1981,7 @@ impl AstDisplay for FetchStatement {
         }
     }
 }
-impl_display!(FetchStatement);
+impl_display_t!(FetchStatement);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FetchDirection {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1867,7 +1867,7 @@ impl<'a> Parser<'a> {
         let (col_names, key_constraint) = self.parse_source_columns()?;
         self.expect_keyword(FROM)?;
         let connector = self.parse_create_source_connector()?;
-        let with_options = self.parse_opt_with_sql_options()?;
+        let with_options = dbg!(self.parse_opt_with_sql_options()?);
         // legacy upsert format syntax allows setting the key format after the keyword UPSERT, so we
         // may mutate this variable in the next block
         let mut format = match self.parse_one_of_keywords(&[KEY, FORMAT]) {
@@ -2479,7 +2479,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_cluster_option(&mut self) -> Result<ClusterOption, ParserError> {
+    fn parse_cluster_option(&mut self) -> Result<ClusterOption<Raw>, ParserError> {
         match self.expect_one_of_keywords(&[REMOTE, SIZE, INTROSPECTION])? {
             REMOTE => {
                 let name = self.parse_identifier()?;
@@ -2862,7 +2862,7 @@ impl<'a> Parser<'a> {
         Ok(option)
     }
 
-    fn parse_opt_with_options(&mut self) -> Result<Vec<WithOption>, ParserError> {
+    fn parse_opt_with_options(&mut self) -> Result<Vec<WithOption<Raw>>, ParserError> {
         if self.parse_keyword(WITH) {
             self.parse_with_options(true)
         } else {
@@ -2870,7 +2870,10 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_with_options(&mut self, require_equals: bool) -> Result<Vec<WithOption>, ParserError> {
+    fn parse_with_options(
+        &mut self,
+        require_equals: bool,
+    ) -> Result<Vec<WithOption<Raw>>, ParserError> {
         self.expect_token(&Token::LParen)?;
         let options =
             self.parse_comma_separated(|parser| parser.parse_with_option(require_equals))?;
@@ -2880,7 +2883,7 @@ impl<'a> Parser<'a> {
 
     /// If require_equals is true, parse options of the form `KEY = VALUE` or just
     /// `KEY`. If require_equals is false, additionally support `KEY VALUE` (but still the others).
-    fn parse_with_option(&mut self, require_equals: bool) -> Result<WithOption, ParserError> {
+    fn parse_with_option(&mut self, require_equals: bool) -> Result<WithOption<Raw>, ParserError> {
         let key = self.parse_identifier()?;
         let has_eq = self.consume_token(&Token::Eq);
         // No = was encountered and require_equals is false, so the next token might be
@@ -2899,7 +2902,7 @@ impl<'a> Parser<'a> {
         Ok(WithOption { key, value })
     }
 
-    fn parse_with_option_value(&mut self) -> Result<WithOptionValue, ParserError> {
+    fn parse_with_option_value(&mut self) -> Result<WithOptionValue<Raw>, ParserError> {
         if let Some(value) = self.maybe_parse(Parser::parse_value) {
             Ok(WithOptionValue::Value(value))
         } else if let Some(object_name) = self.maybe_parse(Parser::parse_object_name) {
@@ -4770,7 +4773,7 @@ impl<'a> Parser<'a> {
         };
         let _ = self.parse_keyword(FROM);
         let name = self.parse_identifier()?;
-        let options = self.parse_opt_with_options()?;
+        let options = dbg!(self.parse_opt_with_options()?);
         Ok(Statement::Fetch(FetchStatement {
             name,
             count,

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -18,84 +18,84 @@ CREATE TYPE custom AS MAP (key_type=text, value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (KEY_TYPE=text, VaLuE_tYpE=custom_type)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = custom_type )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("custom_type")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text)
 ----
 CREATE TYPE custom AS MAP ( key_type = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (value_type=bool)
 ----
 CREATE TYPE custom AS MAP ( value_type = bool )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, value_type=bool, random_type=int)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, value_type = bool, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("value_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("value_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS MAP (key_type=text, random_type=int)
 ----
 CREATE TYPE custom AS MAP ( key_type = text, random_type = int4 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [DataType { name: Ident("key_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }, DataType { name: Ident("random_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: Map { with_options: [WithOption { key: Ident("key_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }, WithOption { key: Ident("random_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=text)
 ----
 CREATE TYPE custom AS LIST ( element_type = text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=x)
 ----
 CREATE TYPE custom AS LIST ( element_type = x )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("x")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE custom AS LIST (element_type=_text)
 ----
 CREATE TYPE custom AS LIST ( element_type = _text )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("custom")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("_text")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE schema.t2 AS LIST (element_type=schema.t1)
 ----
 CREATE TYPE schema.t2 AS LIST ( element_type = schema.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("schema"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("schema"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE db2.schema2.t2 AS LIST (element_type=db1.schema1.t1)
 ----
 CREATE TYPE db2.schema2.t2 AS LIST ( element_type = db1.schema1.t1 )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("db2"), Ident("schema2"), Ident("t2")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("db1"), Ident("schema1"), Ident("t1")])), typ_mod: [] })) }] } })
 
 parse-statement
 CREATE TYPE numeric_list AS LIST (element_type=numeric(100,100,100))
 ----
 CREATE TYPE numeric_list AS LIST ( element_type = numeric(100, 100, 100) )
 =>
-CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { with_options: [DataType { name: Ident("element_type"), data_type: Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] } }] } })
+CreateType(CreateTypeStatement { name: UnresolvedObjectName([Ident("numeric_list")]), as_type: List { with_options: [WithOption { key: Ident("element_type"), value: Some(DataType(Other { name: Name(UnresolvedObjectName([Ident("numeric")])), typ_mod: [100, 100, 100] })) }] } })
 
 parse-statement
 CREATE TYPE named_composite AS (a int, b text, c float8);

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -43,7 +43,7 @@ CREATE TABLE t (c int) WITH (foo = 'bar', a = 123)
 ----
 CREATE TABLE t (c int4) WITH (foo = 'bar', a = 123)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [Value { name: Ident("foo"), value: String("bar") }, Value { name: Ident("a"), value: Number("123") }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("t")]), columns: [ColumnDef { name: Ident("c"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [] }], constraints: [], with_options: [WithOption { key: Ident("foo"), value: Some(Value(String("bar"))) }, WithOption { key: Ident("a"), value: Some(Value(Number("123"))) }], if_not_exists: false, temporary: false })
 
 parse-statement
 CREATE TABLE types_table (char_col char, bpchar_col bpchar, text_col text, bool_col boolean, date_col date, time_col time, timestamp_col timestamp, uuid_col uuid, double_col double precision);
@@ -323,7 +323,7 @@ CREATE VIEW v WITH (foo = 'bar', a = 123) AS SELECT 1
 ----
 CREATE VIEW v WITH (foo = 'bar', a = 123) AS SELECT 1
 =>
-CreateView(CreateViewStatement { if_exists: Error, temporary: false, materialized: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("v")]), columns: [], with_options: [Value { name: Ident("foo"), value: String("bar") }, Value { name: Ident("a"), value: Number("123") }], query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
+CreateView(CreateViewStatement { if_exists: Error, temporary: false, materialized: false, definition: ViewDefinition { name: UnresolvedObjectName([Ident("v")]), columns: [], with_options: [WithOption { key: Ident("foo"), value: Some(Value(String("bar"))) }, WithOption { key: Ident("a"), value: Some(Value(Number("123"))) }], query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } } })
 
 parse-statement
 CREATE VIEW v (has, cols) AS SELECT 1, 2
@@ -395,7 +395,7 @@ FORMAT BYTES
 ----
 CREATE SOURCE foo FROM KAFKA BROKER 'bar' TOPIC 'baz' WITH (consistency = 'lug', ssl_certificate_file = '/Path/to/file') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "bar" }, topic: "baz", key: None }), with_options: [Value { name: Ident("consistency"), value: String("lug") }, Value { name: Ident("ssl_certificate_file"), value: String("/Path/to/file") }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "bar" }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }, WithOption { key: Ident("ssl_certificate_file"), value: Some(Value(String("/Path/to/file"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE MATERIALIZED SOURCE foo FROM FILE 'bar' FORMAT PROTOBUF MESSAGE
@@ -410,35 +410,35 @@ CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' WITH (tail = true) FORMAT REGEX 
 ----
 CREATE SOURCE IF NOT EXISTS foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], include_metadata: [], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [WithOption { key: Ident("tail"), value: Some(Value(Boolean(true))) }], include_metadata: [], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 ----
 CREATE SOURCE IF NOT EXISTS foo (one, two) FROM FILE 'bar' COMPRESSION NONE WITH (tail = true) FORMAT REGEX '(asdf)|(jkl)'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], include_metadata: [], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [Ident("one"), Ident("two")], connector: File { path: "bar", compression: None }, with_options: [WithOption { key: Ident("tail"), value: Some(Value(Boolean(true))) }], include_metadata: [], format: Bare(Regex("(asdf)|(jkl)")), envelope: None, if_not_exists: true, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER
 ----
 CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = false) FORMAT CSV WITH HEADER
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], include_metadata: [], format: Bare(Csv { columns: Header { names: [] }, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [WithOption { key: Ident("tail"), value: Some(Value(Boolean(false))) }], include_metadata: [], format: Bare(Csv { columns: Header { names: [] }, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH HEADER (a, b, c)
 ----
 CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = false) FORMAT CSV WITH HEADER (a, b, c)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], include_metadata: [], format: Bare(Csv { columns: Header { names: [Ident("a"), Ident("b"), Ident("c")] }, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [WithOption { key: Ident("tail"), value: Some(Value(Boolean(false))) }], include_metadata: [], format: Bare(Csv { columns: Header { names: [Ident("a"), Ident("b"), Ident("c")] }, delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 ----
 CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = false) FORMAT CSV WITH 3 COLUMNS
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(false) }], include_metadata: [], format: Bare(Csv { columns: Count(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [WithOption { key: Ident("tail"), value: Some(Value(Boolean(false))) }], include_metadata: [], format: Bare(Csv { columns: Count(3), delimiter: ',' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo (one, two) FROM FILE 'bar' FORMAT CSV WITH HEADER
@@ -452,7 +452,7 @@ CREATE SOURCE foo FROM FILE 'bar' WITH (tail = true) FORMAT CSV WITH 3 COLUMNS D
 ----
 CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE WITH (tail = true) FORMAT CSV WITH 3 COLUMNS DELIMITED BY '|'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [Value { name: Ident("tail"), value: Boolean(true) }], include_metadata: [], format: Bare(Csv { columns: Count(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [WithOption { key: Ident("tail"), value: Some(Value(Boolean(true))) }], include_metadata: [], format: Bare(Csv { columns: Count(3), delimiter: '|' }), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE MATERIALIZED OR VIEW foo as SELECT * from bar
@@ -501,7 +501,7 @@ CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'h
 ----
 CREATE SOURCE foo FROM FILE 'bar' COMPRESSION NONE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { url: "http://localhost:8081", seed: None, with_options: [Value { name: Ident("a"), value: String("b") }] } })), envelope: Debezium(Plain), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("foo")]), col_names: [], connector: File { path: "bar", compression: None }, with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { url: "http://localhost:8081", seed: None, with_options: [WithOption { key: Ident("a"), value: Some(Value(String("b"))) }] } })), envelope: Debezium(Plain), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE foo FROM FILE 'bar' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
@@ -592,28 +592,28 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = 2) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [Value { name: Ident("start_offset"), value: Number("2") }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Number("2"))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = []) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [Value { name: Ident("start_offset"), value: Array([]) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [Value { name: Ident("start_offset"), value: Array([Number("2")]) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2, 40000000]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [Value { name: Ident("start_offset"), value: Array([Number("2"), Number("40000000")]) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2"), Number("40000000")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Upsert, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
@@ -718,7 +718,7 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [Value { name: Ident("replication_factor"), value: Number("7") }, Value { name: Ident("retention_ms"), value: Number("10000") }, Value { name: Ident("retention_bytes"), value: Number("10000000000") }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [WithOption { key: Ident("replication_factor"), value: Some(Value(Number("7"))) }, WithOption { key: Ident("retention_ms"), value: Some(Value(Number("10000"))) }, WithOption { key: Ident("retention_bytes"), value: Some(Value(Number("10000000000"))) }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES
@@ -767,7 +767,7 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSIS
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = user)) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { url: "http://localhost:8081", seed: None, with_options: [ObjectName { name: Ident("username"), object_name: UnresolvedObjectName([Ident("user")]) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { url: "http://localhost:8081", seed: None, with_options: [WithOption { key: Ident("username"), value: Some(ObjectName(UnresolvedObjectName([Ident("user")]))) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
@@ -1129,7 +1129,7 @@ CREATE TABLE public.customer (
 ----
 CREATE TABLE public.customer (customer_id int4 DEFAULT nextval(public.customer_customer_id_seq), store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) NOT NULL, email varchar(50), address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamptz, active int4 NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 =>
-CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("nextval")]), args: Args { args: [Identifier([Ident("public"), Ident("customer_customer_id_seq")])], order_by: [] }, filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: Some(UnresolvedObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [Value { name: Ident("fillfactor"), value: Number("20") }, Value { name: Ident("user_catalog_table"), value: Boolean(true) }, Value { name: Ident("autovacuum_vacuum_threshold"), value: Number("100") }], if_not_exists: false, temporary: false })
+CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("nextval")]), args: Args { args: [Identifier([Ident("public"), Ident("customer_customer_id_seq")])], order_by: [] }, filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: Some(UnresolvedObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [WithOption { key: Ident("fillfactor"), value: Some(Value(Number("20"))) }, WithOption { key: Ident("user_catalog_table"), value: Some(Value(Boolean(true))) }, WithOption { key: Ident("autovacuum_vacuum_threshold"), value: Some(Value(Number("100"))) }], if_not_exists: false, temporary: false })
 
 parse-statement roundtrip
 CREATE TABLE public.customer (

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1124,35 +1124,35 @@ SELECT * FROM foo OPTION (bar = 7)
 ----
 SELECT * FROM foo OPTION (bar = 7)
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [Value { name: Ident("bar"), value: Number("7") }] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 7)
 ----
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 7)
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [Value { name: Ident("bar"), value: Number("7") }] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 'baz')
 ----
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar = 'baz')
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [Value { name: Ident("bar"), value: String("baz") }] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(String("baz"))) }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar)
 ----
-error: Expected equals sign, found right parenthesis
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTION (bar)
-                                                      ^
+=>
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: None }] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 parse-statement
 SELECT a, b, min(c) FROM ( SELECT a, b, min(d) as c GROUP BY a, b OPTION (bar = 7)) as agg GROUP BY a, b
 ----
 SELECT a, b, min(c) FROM (SELECT a, b, min(d) AS c GROUP BY a, b OPTION (bar = 7)) AS agg GROUP BY a, b
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: Some(Ident("c")) }], from: [], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [Value { name: Ident("bar"), value: Number("7") }] }), order_by: [], limit: None, offset: None }, alias: Some(TableAlias { name: Ident("agg"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("c")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: None }], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Identifier([Ident("a")]), alias: None }, Expr { expr: Identifier([Ident("b")]), alias: None }, Expr { expr: Function(Function { name: UnresolvedObjectName([Ident("min")]), args: Args { args: [Identifier([Ident("d")])], order_by: [] }, filter: None, over: None, distinct: false }), alias: Some(Ident("c")) }], from: [], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [WithOption { key: Ident("bar"), value: Some(Value(Number("7"))) }] }), order_by: [], limit: None, offset: None }, alias: Some(TableAlias { name: Ident("agg"), columns: [], strict: false }) }, joins: [] }], selection: None, group_by: [Identifier([Ident("a")]), Identifier([Ident("b")])], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
 
 # List subqueries
 parse-statement

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -26,9 +26,9 @@ use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
     AstInfo, CreateIndexStatement, CreateSecretStatement, CreateSinkStatement,
     CreateSourceStatement, CreateTableStatement, CreateTypeAs, CreateTypeStatement,
-    CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op, Query, SqlOption,
-    Statement, TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName, Value,
-    ViewDefinition,
+    CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op, Query, Raw,
+    SqlOption, Statement, TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName,
+    Value, ViewDefinition,
 };
 
 use crate::names::{
@@ -539,16 +539,16 @@ macro_rules! with_options {
             pub $($field_name: Option<$field_type>,)*
         }
 
-        impl ::std::convert::TryFrom<Vec<crate::ast::WithOption>> for $name {
+        impl ::std::convert::TryFrom<Vec<crate::ast::WithOption<Aug>>> for $name {
             type Error = anyhow::Error;
 
-            fn try_from(mut options: Vec<crate::ast::WithOption>) -> Result<Self, Self::Error> {
+            fn try_from(mut options: Vec<crate::ast::WithOption<Aug>>) -> Result<Self, Self::Error> {
                 let v = Self {
                     $($field_name: {
                         match options.iter().position(|opt| opt.key.as_str() == stringify!($field_name)) {
                             None => None,
                             Some(pos) => {
-                                let value: Option<crate::ast::WithOptionValue> = options.swap_remove(pos).value;
+                                let value: Option<crate::ast::WithOptionValue<Aug>> = options.swap_remove(pos).value;
                                 let value: $field_type = with_option_type!(value, $field_type);
                                 Some(value)
                             },

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -26,9 +26,9 @@ use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
     AstInfo, CreateIndexStatement, CreateSecretStatement, CreateSinkStatement,
     CreateSourceStatement, CreateTableStatement, CreateTypeAs, CreateTypeStatement,
-    CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op, Query, Raw,
-    SqlOption, Statement, TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName,
-    Value, ViewDefinition,
+    CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op, Query, Statement,
+    TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition,
+    WithOption, WithOptionValue,
 };
 
 use crate::names::{
@@ -108,29 +108,57 @@ pub fn op(op: &Op) -> Result<&str, PlanError> {
 }
 
 /// Normalizes a list of `WITH` options.
-pub fn options<T: AstInfo>(options: &[SqlOption<T>]) -> BTreeMap<String, Value> {
+///
+/// # Panics
+/// - If any `WithOption`'s `value` is `None`. You can prevent generating these
+///   values during parsing.
+pub fn options<T: AstInfo>(options: &[WithOption<T>]) -> BTreeMap<String, Value> {
     options
         .iter()
-        .map(|o| match o {
-            SqlOption::Value { name, value } => (ident(name.clone()), value.clone()),
-            SqlOption::ObjectName { name, object_name } => (
-                ident(name.clone()),
-                Value::String(object_name.to_ast_string()),
-            ),
-            SqlOption::DataType { name, data_type } => (
-                ident(name.clone()),
-                Value::String(data_type.to_ast_string()),
-            ),
+        .map(|o| {
+            (
+                o.key.to_string(),
+                match o
+                    .value
+                    .as_ref()
+                    // The only places that generate options that do not require
+                    // keys and values do not currently use this code path.
+                    .expect("check that all entries have values before calling `options`")
+                {
+                    WithOptionValue::Value(value) => value.clone(),
+                    WithOptionValue::ObjectName(object_name) => {
+                        Value::String(object_name.to_ast_string())
+                    }
+                    WithOptionValue::DataType(data_type) => {
+                        Value::String(data_type.to_ast_string())
+                    }
+                },
+            )
         })
         .collect()
 }
 
 /// Normalizes `WITH` option keys without normalizing their corresponding
 /// values.
-pub fn option_objects(options: &[SqlOption<Aug>]) -> BTreeMap<String, SqlOption<Aug>> {
+///
+/// # Panics
+/// - If any `WithOption`'s `value` is `None`. You can prevent generating these
+///   values during parsing.
+pub fn option_objects(options: &[WithOption<Aug>]) -> BTreeMap<String, WithOptionValue<Aug>> {
     options
         .iter()
-        .map(|o| (ident(o.name().clone()), o.clone()))
+        .map(|o| {
+            (
+                ident(o.key.clone()),
+                o.value
+                    .as_ref()
+                    .clone()
+                    // The only places that generate options that do not require
+                    // keys and values do not currently use this code path.
+                    .expect("check that all entries have values before calling `option_objects`")
+                    .clone(),
+            )
+        })
         .collect()
 }
 
@@ -308,8 +336,8 @@ pub fn create_statement(
             *materialized = false;
 
             for opt in with_options.iter_mut() {
-                if let SqlOption::ObjectName { name, object_name } = opt {
-                    if ident_ref(name) == "tx_metadata" {
+                if let Some(WithOptionValue::ObjectName(object_name)) = &mut opt.value {
+                    if ident_ref(&opt.key) == "tx_metadata" {
                         // Use the catalog to resolve to a fully qualified name
                         *object_name = unresolve(
                             scx.catalog.resolve_full_name(
@@ -415,8 +443,8 @@ pub fn create_statement(
                 *name = allocate_name(name)?;
                 let mut normalizer = QueryNormalizer::new(scx);
                 for option in with_options {
-                    match option {
-                        SqlOption::DataType { data_type, .. } => {
+                    match &mut option.value {
+                        Some(WithOptionValue::DataType(ref mut data_type)) => {
                             normalizer.visit_data_type_mut(data_type);
                         }
                         _ => unreachable!(),
@@ -539,16 +567,16 @@ macro_rules! with_options {
             pub $($field_name: Option<$field_type>,)*
         }
 
-        impl ::std::convert::TryFrom<Vec<crate::ast::WithOption<Aug>>> for $name {
+        impl ::std::convert::TryFrom<Vec<mz_sql_parser::ast::WithOption<Aug>>> for $name {
             type Error = anyhow::Error;
 
-            fn try_from(mut options: Vec<crate::ast::WithOption<Aug>>) -> Result<Self, Self::Error> {
+            fn try_from(mut options: Vec<mz_sql_parser::ast::WithOption<Aug>>) -> Result<Self, Self::Error> {
                 let v = Self {
                     $($field_name: {
                         match options.iter().position(|opt| opt.key.as_str() == stringify!($field_name)) {
                             None => None,
                             Some(pos) => {
-                                let value: Option<crate::ast::WithOptionValue<Aug>> = options.swap_remove(pos).value;
+                                let value: Option<mz_sql_parser::ast::WithOptionValue<Aug>> = options.swap_remove(pos).value;
                                 let value: $field_type = with_option_type!(value, $field_type);
                                 Some(value)
                             },

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2675,7 +2675,7 @@ pub fn plan_create_role(
 
 pub fn describe_create_cluster(
     _: &StatementContext,
-    _: &CreateClusterStatement,
+    _: &CreateClusterStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2686,7 +2686,7 @@ pub fn plan_create_cluster(
         name,
         if_not_exists,
         options,
-    }: CreateClusterStatement,
+    }: CreateClusterStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     scx.require_experimental_mode("CREATE CLUSTER")?;
     Ok(Plan::CreateComputeInstance(CreateComputeInstancePlan {
@@ -2703,7 +2703,7 @@ const DEFAULT_INTROSPECTION_GRANULARITY: Interval = Interval {
 };
 
 fn plan_cluster_options(
-    options: Vec<ClusterOption>,
+    options: Vec<ClusterOption<Aug>>,
 ) -> Result<ComputeInstanceConfig, anyhow::Error> {
     let mut remote_replicas = BTreeMap::new();
     let mut size = None;
@@ -3124,7 +3124,7 @@ pub fn describe_alter_index_options(
     Ok(StatementDesc::new(None))
 }
 
-fn plan_index_options(with_opts: Vec<WithOption>) -> Result<Vec<IndexOption>, anyhow::Error> {
+fn plan_index_options(with_opts: Vec<WithOption<Aug>>) -> Result<Vec<IndexOption>, anyhow::Error> {
     let with_opts = IndexWithOptions::try_from(with_opts)?;
     let mut out = vec![];
 
@@ -3290,7 +3290,7 @@ pub fn plan_alter_secret(
 
 pub fn describe_alter_cluster(
     _: &StatementContext,
-    _: &AlterClusterStatement,
+    _: &AlterClusterStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3301,7 +3301,7 @@ pub fn plan_alter_cluster(
         name,
         if_exists,
         options,
-    }: AlterClusterStatement,
+    }: AlterClusterStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     scx.require_experimental_mode("ALTER CLUSTER")?;
     let id = match scx.resolve_compute_instance(Some(&name)) {

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -128,7 +128,7 @@ with_options! {
 
 pub fn describe_fetch(
     _: &StatementContext,
-    _: &FetchStatement,
+    _: &FetchStatement<Raw>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -139,7 +139,7 @@ pub fn plan_fetch(
         name,
         count,
         options,
-    }: FetchStatement,
+    }: FetchStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     let options = FetchOptions::try_from(options)?;
     let timeout = match options.timeout {

--- a/src/sql/tests/querymodel/hirroundtrip
+++ b/src/sql/tests/querymodel/hirroundtrip
@@ -260,7 +260,6 @@ select distinct a from x
 round_trip
 select (select true from x), true
 ----
-----
 %0 =
 | Constant ()
 | Map select(%1), true
@@ -270,8 +269,6 @@ select (select true from x), true
 | | | Map true
 | | | Project (#3)
 | |
-----
-----
 
 round_trip
 select y.b, y.c + 1 from y where (select a from x) = y.a


### PR DESCRIPTION
`SqlOption` and `WithOption` were not substantially different enough to warrant both of their presences in the code. This PR merges `SqlOption` into `WithOption`.

This PR's sole purpose is to merge the two structs and does nothing to merge their functionality––i.e. makes no meaningful progress on #5390. I believe that this is still a net improvement to the codebase, though, because engineers regularly (and rightly) get confused as about which struct they should use. This at least defers the confusion a step until they ask how they should actually use the data in the struct :P 

### Motivation

This PR refactors existing code.

### Tips for reviewer

This is largely code movement, but I had to include a few new `expects` which I spent a while convincing myself were OK. When we tackle #5390 (which we should do soon), we should ensure this becomes more robust. 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
