### PR TITLE
doc/user: bring `lts-docs` to v0.26.0-LTS

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -7,6 +7,7 @@ pygmentsUseClasses = true
 # Keep the releases in reverse order of their release date. The first release
 # in the list is assumed to be the most recent.
 versions = [
+  { name = "v0.26.0", date = "13 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
   { name = "v0.25.0", date = "31 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.24.0", date = "24 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.23.0", date = "18 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -19,6 +19,35 @@ the PR description instead. They will be migrated here during the release
 process by the release notes team.
 {{< /comment >}}
 
+{{% version-header v0.26.0 %}}
+
+v0.26.0 is a **long-term support (LTS)** release of Materialize. We will support
+the v0.26 series through at least August 31, 2022, issuing patch releases as
+necessary to address severe bugs and security vulnerabilities.
+
+- **Breaking change.** Change the return type of the
+  [`list_length`](/sql/functions/#list-func) function from [`bigint`] to
+  [`integer`].
+
+- Optionally emit the message headers in [Kafka
+  sources](/sql/create-source/kafka/) via the new
+  [`INCLUDE HEADERS`](/sql/create-source/kafka/#headers) option.
+
+- Allow `ROW` literals to be used as arguments to the
+  [`coalesce`](/sql/functions/#generic) function and in `VALUES` clauses
+  {{% gh 8597 10422 %}}.
+
+- Change most functions that accept [polymorphic
+  parameters](/sql/types/#polymorphism) to promote arguments to a "best common
+  type." For example, when concatenating a `smallint list` to a `bigint list`,
+  Materialize will now cast the `smallint list` to a `bigint list`, resulting in
+  a concanated list of type `bigint list`.
+
+- Add the [`map_length`](/sql/types/map/#count-entries-in-map-map_length) function, which computes the
+  number of entries in a [`map`] value.
+
+- Fix a memory leak in [`TAIL`](/sql/tail) {{% gh 11540 %}}.
+
 {{% version-header v0.25.0 %}}
 
 - Fix `base64` decoding to support numerals in encoded strings. Previously, if the encoded string contained a numeral, decoding would fail.
@@ -1729,7 +1758,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 - Add the `--experimental` command-line option to enable a new [experimental
   mode], which grants access to experimental features
   at the risk of compromising stability and backwards compatibility. Forthcoming
-  features that require experimental mode will be marked as such in their
+  features that require [experimental mode] will be marked as such in their
   documentation.
 
 - Support [SASL PLAIN authentication for Kafka sources](/sql/create-source/kafka/#sasl).
@@ -2120,6 +2149,7 @@ a problem with PostgreSQL JDBC 42.3.0.
 [`date`]: /sql/types/date
 [`double precision`]: /sql/types/float8
 [experimental mode]: /cli/#experimental-mode
+[`integer`]: /sql/types/integer/
 [`interval`]: /sql/types/interval
 [`list`]: /sql/types/list/
 [`map`]: /sql/types/map/

--- a/doc/user/content/sql/types/map.md
+++ b/doc/user/content/sql/types/map.md
@@ -28,9 +28,15 @@ Field | Use
 _map&lowbar;string_ | A well-formed map object.
 _value&lowbar;type_ | The [type](../../types) of the map's values.
 
-## Operators
+## Map functions + operators
+
+### Operators
 
 {{% map-operators %}}
+
+### Functions
+
+{{< fnlist "Map" >}}
 
 ## Details
 

--- a/doc/user/layouts/shortcodes/version-header.html
+++ b/doc/user/layouts/shortcodes/version-header.html
@@ -1,7 +1,7 @@
 {{$version := (.Get 0)}}
-{{$versionMeta := index (where $.Site.Params.versions "name" (.Get 0)) 0}}
+{{$versionMeta := index (where $.Site.Params.versions "name" $version) 0}}
 
-## {{$version}} {{if not $versionMeta}}(Unreleased){{end}} {id="{{$version}}"}
+## {{$version}} {{if $versionMeta.lts}}LTS{{end}} {{if not $versionMeta}}(Unreleased){{end}} {id="{{$version}}"}
 
 {{with $versionMeta}}
 <p class="release-date">Released on {{.date}}.</p>

--- a/doc/user/layouts/shortcodes/version-list.html
+++ b/doc/user/layouts/shortcodes/version-list.html
@@ -11,7 +11,12 @@
       {{range $i, $version := .Site.Params.Versions}}
         <tr>
           <td>
-            <strong><a href="../release-notes/#{{$version.name}}">{{$version.name}}</a></strong>
+            <strong>
+              <a href="../release-notes/#{{$version.name}}">
+                {{$version.name}}
+                {{if $version.lts}}LTS{{end}}
+              </a>
+            </strong>
           </td>
           <td>{{$version.date}}</td>
           <td>
@@ -25,7 +30,7 @@
               </a>
             {{end}}
           </td>
-          <td><span class="symbol">{{if lt $i 2}}✓{{end}}</span></td>
+          <td><span class="symbol">{{if lt $i 1}}✓{{end}}</span></td>
       {{end}}
     </tbody>
   </table>


### PR DESCRIPTION
### Motivation

The `lts-docs` branch is still on `v0.25.0`, so bumping it to `v0.26.0`.