### PR TITLE
transform: partial reduction pushdown tests

### DIFF
--- a/src/transform/tests/testdata/partial-reduction-pushdown
+++ b/src/transform/tests/testdata/partial-reduction-pushdown
@@ -1,0 +1,498 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for partial reduction pushdown to constant inputs.
+#
+# TODO: Implement support for partial reduction pushdown.
+# The general idea was discussed in
+# https://github.com/MaterializeInc/materialize/issues/10119, but we
+# decided that we need to spend more time on formalizing the proposed
+# approach, to ensure it is actually correct. Until we have done so,
+# the tests here only exercise the non-partial reduction pushdown
+# optimizationand are mostly equivalent to the tests in
+# `reduction-pushdown`.
+
+cat
+(defsource w [int16 int32])
+(defsource x [int32 string])
+(defsource y ([int16 string] [[1]]))
+(defsource z [int16 string])
+----
+ok
+
+# Distinct Pushdown tests
+
+build apply=ReductionPushdown
+(reduce (join [(get x) (constant [] [int32 string])] [[#1 #3]]) [#1] [])
+----
+----
+%0 =
+| Get x (u1)
+| Distinct group=(#1)
+
+%1 =
+| Constant
+| Distinct group=(#1)
+
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+----
+----
+
+## distinct(<multiple columns from same input>)
+
+build apply=ReductionPushdown
+(reduce (join [(constant [] [int32 string]) (get y)] [[#1 #3]]) [#0 #1] [])
+----
+----
+%0 =
+| Constant
+| Distinct group=(#0, #1)
+
+%1 =
+| Get y (u2)
+| Distinct group=(#1)
+
+%2 =
+| Join %0 %1 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1)
+----
+----
+
+## distinct(<multiple columns from differing inputs>)
+
+build apply=ReductionPushdown
+(reduce (join [(get x) (constant [] [int32 string])] [[#1 #3]]) [#0 #1 #2] [])
+----
+----
+%0 =
+| Get x (u1)
+| Distinct group=(#0, #1)
+
+%1 =
+| Constant
+| Distinct group=(#1, #0)
+
+%2 =
+| Join %0 %1 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #1, #3)
+----
+----
+
+## Negative test: Perform a full reduction pushdown
+## if all inputs are constant
+
+build apply=ReductionPushdown
+(reduce
+    (join [(constant [] [int32 string]) (constant [] [int32 string])] [[#1 #3]])
+    [#1]
+    [])
+----
+----
+%0 =
+| Constant
+| Distinct group=(#1)
+
+%1 =
+| Constant
+| Distinct group=(#1)
+
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+----
+----
+
+## Expressions in join equivalence classes
+
+build apply=ReductionPushdown
+(reduce
+    (join [(constant [] [int32 string]) (get y)] [[(call_variadic substr [#1 5]) #3]])
+    [#3]
+    [])
+----
+----
+%0 =
+| Constant
+| Distinct group=(substr(#1, 5))
+
+%1 =
+| Get y (u2)
+| Distinct group=(#1)
+
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#1)
+----
+----
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (constant [] [int32 string])]
+        [[(call_variadic substr [#1 5]) #3]])
+    [(call_variadic substr [#1 5])]
+    [])
+----
+----
+%0 =
+| Get x (u1)
+| Distinct group=(substr(#1, 5))
+
+%1 =
+| Constant
+| Distinct group=(#1)
+
+%2 =
+| Join %0 %1 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0)
+----
+----
+
+### Negative test: Do not do reduction pushdown
+### if there are multi-component expressions in the join equivalence
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (constant [] [int32 string])]
+        [[(call_variadic substr [#1 5]) (call_binary text_concat #1 #3)]])
+    [(call_variadic substr [#1 5])]
+    [])
+----
+----
+%0 =
+| Get x (u1)
+
+%1 =
+| Constant
+
+%2 =
+| Join %0 %1 (= substr(#1, 5) (#1 || #3))
+| | implementation = Unimplemented
+| Distinct group=(substr(#1, 5))
+----
+----
+
+build apply=ReductionPushdown
+(reduce
+    (join [(constant [] [int32 string]) (get y)]
+        [[(call_variadic substr [#1 5]) #3]
+         [(call_binary text_concat #1 #3) "hello"]])
+    [(call_variadic substr [#1 5])]
+    [])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Get y (u2)
+
+%2 =
+| Join %0 %1 (= substr(#1, 5) #3) (= (#1 || #3) "hello")
+| | implementation = Unimplemented
+| Distinct group=(substr(#1, 5))
+----
+----
+
+### Negative test: multi-input expression in group by key
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (constant [] [int32 string])]
+        [[(call_binary text_concat #1 #3) "hello"]])
+    [(call_binary text_concat #1 #3)]
+    [])
+----
+----
+%0 =
+| Get x (u1)
+
+%1 =
+| Constant
+
+%2 =
+| Join %0 %1 (= (#1 || #3) "hello")
+| | implementation = Unimplemented
+| Distinct group=((#1 || #3))
+----
+----
+
+## Distinct pushdown across more than two inputs
+## Make sure no cross joins happen.
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (get y) (constant [] [int32 string] y)] [[#1 #3 #5]])
+    [#1]
+    [])
+----
+----
+%0 =
+| Get x (u1)
+| Distinct group=(#1)
+
+%1 =
+| Get y (u2)
+| Distinct group=(#1)
+
+%2 =
+| Constant
+| Distinct group=(#1)
+
+%3 =
+| Join %0 %1 %2 (= #0 #1 #2)
+| | implementation = Unimplemented
+| Project (#0)
+----
+----
+
+build apply=ReductionPushdown
+(reduce
+    (join
+        [(get x) (constant [] [int32 string]) (constant [] [string int32])]
+        [[#1 #3] [#2 #4]])
+    [#1 #5]
+    [])
+----
+----
+%0 =
+| Get x (u1)
+| Distinct group=(#1)
+
+%1 =
+| Constant
+
+%2 =
+| Constant
+
+%3 =
+| Join %1 %2 (= #0 #2)
+| | implementation = Unimplemented
+| Distinct group=(#1, #3)
+
+%4 =
+| Join %0 %3 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#0, #2)
+----
+----
+
+### Negative test: Perform a full pushdown
+### if each sub-join is non-constant
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (constant [] [int32 string]) (get z)] [[#0 #2] [#1 #5]])
+    [#3 #5]
+    [])
+----
+----
+%0 =
+| Get x (u1)
+
+%1 =
+| Constant
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Unimplemented
+| Distinct group=(#3, #1)
+
+%3 =
+| Get z (u3)
+| Distinct group=(#1)
+
+%4 =
+| Join %2 %3 (= #1 #2)
+| | implementation = Unimplemented
+| Project (#0, #2)
+----
+----
+
+## Cross join tests
+
+build apply=ReductionPushdown
+(reduce (join [(constant [] [int32 string]) (get y) (get z)] [[#3 #5]]) [#5] [])
+----
+----
+%0 =
+| Constant
+| Distinct group=()
+
+%1 =
+| Get y (u2)
+| Distinct group=(#1)
+
+%2 =
+| Get z (u3)
+| Distinct group=(#1)
+
+%3 =
+| Join %0 %1 %2 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#1)
+----
+----
+
+build apply=ReductionPushdown
+(reduce (join [(constant [] [int32 string]) (get y) (get z)] [[#3 #5]]) [#0] [])
+----
+----
+%0 =
+| Constant
+| Distinct group=(#0)
+
+%1 =
+| Get y (u2)
+
+%2 =
+| Get z (u3)
+
+%3 =
+| Join %1 %2 (= #1 #3)
+| | implementation = Unimplemented
+| Distinct group=()
+
+%4 =
+| Join %0 %3
+| | implementation = Unimplemented
+| Project (#0)
+----
+----
+
+# Pushdown agg(distinct <single-input-expression>)
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (constant [] [int32 string])] [[#1 #3]])
+    [#1]
+    [(sum_int32 #0 true)])
+----
+----
+%0 =
+| Get x (u1)
+| Reduce group=(#1)
+| | agg sum(distinct #0)
+
+%1 =
+| Constant
+| Distinct group=(#1)
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Unimplemented
+| Project (#0, #1)
+----
+----
+
+build apply=ReductionPushdown
+(reduce
+    (join [(get x) (constant [] [int32 string]) (get z)] [[#1 #3]])
+    [#3]
+    [(sum_int16 #2 true)])
+----
+----
+%0 =
+| Get x (u1)
+| Distinct group=(#1)
+
+%1 =
+| Constant
+| Reduce group=(#1)
+| | agg sum(distinct #0)
+
+%2 =
+| Get z (u3)
+| Distinct group=()
+
+%3 =
+| Join %0 %1 %2 (= #0 #1)
+| | implementation = Unimplemented
+| Project (#1, #2)
+----
+----
+
+build apply=ReductionPushdown
+(reduce
+    (join
+        [(constant [] [int32 string]) (constant [] [int32 string]) (get z)]
+        [[#1 #3 #5]])
+    [#3]
+    [(sum_int32 (call_unary neg_int32 #0) true) (sum_int16 #2 true)])
+----
+----
+%0 =
+| Constant
+| Reduce group=(#1)
+| | agg sum(distinct -(#0))
+
+%1 =
+| Constant
+| Reduce group=(#1)
+| | agg sum(distinct #0)
+
+%2 =
+| Get z (u3)
+| Distinct group=(#1)
+
+%3 =
+| Join %0 %1 %2 (= #0 #2 #4)
+| | implementation = Unimplemented
+| Project (#2, #1, #3)
+----
+----
+
+# Pushdown agg(distinct <single-component multi-input expression>)
+
+build apply=ReductionPushdown
+(reduce
+    (join
+        [(constant [] [int32 string])
+         (constant [] [int32 string])
+         (constant [] [int32 string])
+         (get w)]
+        [[#1 #3 #5] [#4 #6]])
+    [#6]
+    [(sum_int32 (call_binary add_int32 #0 (call_unary cast_int16_to_int32 #2)) true)
+     (sum_int16 (call_binary mul_int16 #2 #4) true)])
+----
+----
+%0 =
+| Constant
+
+%1 =
+| Constant
+
+%2 =
+| Constant
+
+%3 =
+| Join %0 %1 %2 (= #1 #3 #5)
+| | implementation = Unimplemented
+| Reduce group=(#4)
+| | agg sum(distinct (#0 + i16toi32(#2)))
+| | agg sum(distinct (#2 * #4))
+
+%4 =
+| Get w (u0)
+| Distinct group=(#0)
+
+%5 =
+| Join %3 %4 (= #0 #3)
+| | implementation = Unimplemented
+| Project (#3, #1, #2)
+----
+----


### PR DESCRIPTION
We decided in #10119 that we need to formalize the partial reduction pushdown approach properly before implementing it. This PR only adds tests that can be used once we implement the optimization.

### Motivation

  * This PR adds tests for a future desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).