### PR TITLE
dataflow-types: reconfigure Response

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -387,13 +387,17 @@ pub struct TimestampBindingFeedback<T = mz_repr::Timestamp> {
     pub bindings: Vec<(GlobalId, Vec<(PartitionId, T, MzOffset)>)>,
 }
 
-/// Responses that the worker/dataflow can provide back to the coordinator.
+/// Responses that the controller can provide back to the coordinator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Response<T = mz_repr::Timestamp> {
-    /// A compute response.
-    Compute(ComputeResponse<T>),
-    /// A storage response.
-    Storage(StorageResponse<T>),
+pub enum ControllerResponse<T = mz_repr::Timestamp> {
+    /// The worker's response to a specified (by connection id) peek.
+    PeekResponse(Uuid, PeekResponse),
+    /// The worker's next response to a specified tail.
+    TailResponse(GlobalId, TailResponse<T>),
+    /// Data about timestamp bindings, sent to the coordinator, in service
+    /// of a specific "linearized" read request.
+    // TODO(benesch,gus): update language to avoid the term "linearizability".
+    LinearizedTimestamps(LinearizedTimestampBindingFeedback<T>),
 }
 
 /// Responses that the compute nature of a worker/dataflow can provide back to the coordinator.


### PR DESCRIPTION
The `Response` type is currently an enum that contained all storage
responses and all compute responses. But some of these responses are
meant to be handled entirely by the controller; i.e., not all of them
are meant to be forwarded on to the coordinator for additional
processing.

This commit makes the protocol explicit in the type system. The
controller now returns responses of type `ControllerResponse`, which
contains a subset of the possible storage and compute responses. In the
future, `ControllerResponse` can diverge even further from
`StorageResponse` and `ComputeResponse`, e.g., when a response is
generated entirely in the controller and does not require communication
with a storage or compute instance.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code to further tease apart storage and compute.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
