### PR TITLE
*: use prost's built-in support for generating FileDescriptorSets

### DIFF
--- a/demo/billing/build.rs
+++ b/demo/billing/build.rs
@@ -10,36 +10,15 @@
 use std::env;
 use std::fs::File;
 use std::path::PathBuf;
-use std::process::Command;
-
-const PROTOS: &[&str] = &["billing.proto"];
-const INCLUDE_DIRS: &[&str] = &["resources"];
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
-    // Compile protobufs to Rust.
     prost_build::Config::new()
         .include_file("mod.rs")
-        .compile_protos(PROTOS, INCLUDE_DIRS)
+        .file_descriptor_set_path(out_dir.join("file_descriptor_set.pb"))
+        .compile_protos(&["billing.proto"], &["resources"])
         .unwrap();
-
-    // Compile protobufs to a file descriptor set.
-    let mut cmd = Command::new(prost_build::protoc());
-    cmd.arg("--include_imports")
-        .arg("-o")
-        .arg(out_dir.join("file_descriptor_set.pb"));
-    for dir in INCLUDE_DIRS {
-        cmd.arg("-I");
-        cmd.arg(dir);
-    }
-    for proto in PROTOS {
-        cmd.arg(proto);
-    }
-    let status = cmd.status().expect("building file descriptor set failed");
-    if !status.success() {
-        panic!("building file descriptor set failed with status {}", status);
-    }
 
     // Work around a prost bug in which the module index expects to include a
     // file for the well-known types.

--- a/src/interchange/build.rs
+++ b/src/interchange/build.rs
@@ -8,40 +8,13 @@
 // by the Apache License, Version 2.0.
 
 use std::env;
-use std::fs::File;
 use std::path::PathBuf;
-use std::process::Command;
-
-const PROTOS: &[&str] = &["benchmark.proto"];
-const INCLUDE_DIRS: &[&str] = &["testdata"];
 
 fn main() {
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    // Compile protobufs to Rust.
     prost_build::Config::new()
         .include_file("mod.rs")
-        .compile_protos(PROTOS, INCLUDE_DIRS)
+        .file_descriptor_set_path(out_dir.join("file_descriptor_set.pb"))
+        .compile_protos(&["benchmark.proto"], &["testdata"])
         .unwrap();
-
-    // Compile protobufs to a file descriptor set.
-    let mut cmd = Command::new(prost_build::protoc());
-    cmd.arg("--include_imports")
-        .arg("-o")
-        .arg(out_dir.join("file_descriptor_set.pb"));
-    for dir in INCLUDE_DIRS {
-        cmd.arg("-I");
-        cmd.arg(dir);
-    }
-    for proto in PROTOS {
-        cmd.arg(proto);
-    }
-    let status = cmd.status().expect("building file descriptor set failed");
-    if !status.success() {
-        panic!("building file descriptor set failed with status {}", status);
-    }
-
-    // Work around a prost bug in which the module index expects to include a
-    // file for the well-known types.
-    File::create(out_dir.join("google.protobuf.rs")).unwrap();
 }


### PR DESCRIPTION
Not sure how I missed this, but prost has built-in support for
generating the FileDescriptorSet. Use it, rather than reinventing it.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
