### PR TITLE
WIP: Rework parts of create_source

### DIFF
--- a/src/storage/src/source/util.rs
+++ b/src/storage/src/source/util.rs
@@ -13,7 +13,7 @@ use std::rc::Rc;
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{OperatorInfo, OutputHandle};
-use timely::dataflow::operators::{Capability, CapabilitySet};
+use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
 use timely::Data;
 
@@ -56,7 +56,6 @@ where
     B: FnOnce(OperatorInfo) -> L,
     L: FnMut(
             &mut Capability<Timestamp>,
-            &mut CapabilitySet<Timestamp>,
             &mut OutputHandle<G::Timestamp, D, Tee<G::Timestamp, D>>,
         ) -> SourceStatus
         + 'static,
@@ -71,9 +70,7 @@ where
 
     builder.build(|mut capabilities| {
         let data_capability = capabilities.pop().unwrap();
-        let durability_capability = CapabilitySet::from_elem(data_capability.clone());
-
-        let capabilities_rc = Rc::new(RefCell::new(Some((data_capability, durability_capability))));
+        let capabilities_rc = Rc::new(RefCell::new(Some(data_capability)));
 
         // Export a token to the outside word that will keep this source alive.
         token = Some(SourceToken {
@@ -85,11 +82,11 @@ where
 
         move |_frontier| {
             let mut caps = capabilities_rc.borrow_mut();
-            if let Some((data_cap, durability_capability)) = &mut *caps {
+            if let Some(data_cap) = &mut *caps {
                 // We still have our capability, so the source is still alive.
                 // Delegate to the inner source.
                 if let SourceStatus::Done =
-                    tick(data_cap, durability_capability, &mut data_output.activate())
+                    tick(data_cap, &mut data_output.activate())
                 {
                     // The inner source is finished. Drop our capability.
                     *caps = None;


### PR DESCRIPTION
This *draft* PR explores what it would look like to start to move away from `TimestampBinding` stuff, and towards timestamping through a `persist` collection. It makes some changes around `fn create_source` meant to:
1. extract the presumed-interactive binding determination from the innermost loop,
2. only transmit durable data, and stash non-durable data for the future (for reasons of HA, we don't want to ship bad data),
3. stop relying on a `durability_capability`.

Ideally, we would replace certain key moments with attempts to commit timestamp bindings to a `persist` collection, and win or lose read bindings out of the collection to drive timestamp bindings for data that have been received.

I trashed some metrics that were in the way of making things legible (and which seemed not long for this world once we get reclocking in place). No strong opinions that they must leave, only that they make it harder to read and understand the code.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
