### PR TITLE
pipe through allow-cluster-replica-size to compute controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
 name = "cast"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,6 +3368,7 @@ dependencies = [
  "aws-smithy-http",
  "aws-types",
  "bytes",
+ "bytesize",
  "chrono",
  "crossbeam-channel",
  "derivative",
@@ -3670,7 +3677,9 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytesize",
  "derivative",
+ "serde",
 ]
 
 [[package]]

--- a/doc/developer/design/20220413_cluster_replica.md
+++ b/doc/developer/design/20220413_cluster_replica.md
@@ -43,7 +43,7 @@ zone is available, Materialize should automatically assign the availability
 zone with the least existing replicas.
 
 The `SIZE` option will be changed from the existing `SIZE` option to validate
-the set of allowable sizes against a new `--allow-cluster-replica-size`
+the set of allowable sizes against a new `--cluster-replica-sizes`
 command line option.
 
 The `DROP CLUSTER REPLICA` statement will be added:
@@ -89,7 +89,7 @@ properties of [`ServiceConfig`](https://dev.materialize.com/api/rust/mz_orchestr
   * Processes
 
 The mapping between replica size and the above property values will be
-determined by the new `--allow-cluster-replica-size` comand line option, which
+determined by the new `--cluster-replica-sizes` comand line option, which
 accepts a JSON object that can be deserialized into `ClusterReplicaSizeMap`:
 
 ```rust

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -14,6 +14,7 @@ aws-config = { version = "0.10.1", default-features = false, features = ["native
 aws-smithy-http = "0.40.2"
 aws-types = { version = "0.10.1", features = ["hardcoded-credentials"] }
 bytes = "1.1.0"
+bytesize = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = "0.5.4"
 derivative = "2.2.0"

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -138,7 +138,7 @@ where
                 } = &self.orchestrator;
 
                 let default_listen_host = orchestrator.listen_host();
-                
+
                 let size_config = self.replica_sizes.0.get(&size).ok_or_else(|| {
                     anyhow::anyhow!("Size {size} not specified in allowed cluster sizes map")
                 })?;

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -687,7 +687,7 @@ max log level: {max_log_level}",
 
     let replica_sizes = match args.allow_cluster_replica_size {
         None => Default::default(),
-        Some(json) => serde_json::from_str(&json)?,
+        Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
     };
 
     let server = runtime.block_on(materialized::serve(materialized::Config {

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -690,8 +690,6 @@ max log level: {max_log_level}",
         Some(json) => serde_json::from_str(&json)?,
     };
 
-    println!("[btv] replica sizes: {:#?}", replica_sizes);
-
     let server = runtime.block_on(materialized::serve(materialized::Config {
         logical_compaction_window: args.logical_compaction_window,
         timestamp_frequency: args.timestamp_frequency,

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -376,8 +376,8 @@ pub struct Args {
     )]
     opentelemetry_headers: Option<String>,
 
-    #[clap(long, env = "CLUSTER_REPLICA_SIZES")]
-    cluster_replica_size: Option<String>,
+    #[clap(long, env = "MZ_CLUSTER_REPLICA_SIZES")]
+    cluster_replica_sizes: Option<String>,
 
     #[cfg(feature = "tokio-console")]
     /// Turn on the console-subscriber to use materialize with `tokio-console`
@@ -685,12 +685,10 @@ max log level: {max_log_level}",
 
     sys::adjust_rlimits();
 
-    let replica_sizes = match args.cluster_replica_size {
+    let replica_sizes = match args.cluster_replica_sizes {
         None => Default::default(),
         Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
     };
-
-    println!("[btv] {replica_sizes:#?}");
 
     let server = runtime.block_on(materialized::serve(materialized::Config {
         logical_compaction_window: args.logical_compaction_window,

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -376,8 +376,8 @@ pub struct Args {
     )]
     opentelemetry_headers: Option<String>,
 
-    #[clap(long, env = "MZ_ALLOW_CLUSTER_REPLICA_SIZE")]
-    allow_cluster_replica_size: Option<String>,
+    #[clap(long, env = "CLUSTER_REPLICA_SIZES")]
+    cluster_replica_size: Option<String>,
 
     #[cfg(feature = "tokio-console")]
     /// Turn on the console-subscriber to use materialize with `tokio-console`
@@ -685,10 +685,12 @@ max log level: {max_log_level}",
 
     sys::adjust_rlimits();
 
-    let replica_sizes = match args.allow_cluster_replica_size {
+    let replica_sizes = match args.cluster_replica_size {
         None => Default::default(),
         Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
     };
+
+    println!("[btv] {replica_sizes:#?}");
 
     let server = runtime.block_on(materialized::serve(materialized::Config {
         logical_compaction_window: args.logical_compaction_window,

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -376,6 +376,9 @@ pub struct Args {
     )]
     opentelemetry_headers: Option<String>,
 
+    #[clap(long, env = "MZ_ALLOW_CLUSTER_REPLICA_SIZE")]
+    allow_cluster_replica_size: Option<String>,
+
     #[cfg(feature = "tokio-console")]
     /// Turn on the console-subscriber to use materialize with `tokio-console`
     #[clap(long, hide = true)]
@@ -682,6 +685,13 @@ max log level: {max_log_level}",
 
     sys::adjust_rlimits();
 
+    let replica_sizes = match args.allow_cluster_replica_size {
+        None => Default::default(),
+        Some(json) => serde_json::from_str(&json)?,
+    };
+
+    println!("[btv] replica sizes: {:#?}", replica_sizes);
+
     let server = runtime.block_on(materialized::serve(materialized::Config {
         logical_compaction_window: args.logical_compaction_window,
         timestamp_frequency: args.timestamp_frequency,
@@ -703,6 +713,7 @@ max log level: {max_log_level}",
             .unwrap_or(AwsExternalId::NotProvided),
         metrics_registry,
         now: SYSTEM_TIME.clone(),
+        replica_sizes,
     }))?;
 
     eprintln!(

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 use std::fs::Permissions;
 use std::net::SocketAddr;
+use std::num::NonZeroUsize;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -297,7 +298,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 // TODO: limits?
                 cpu_limit: None,
                 memory_limit: None,
-                processes: 1,
+                processes: NonZeroUsize::new(1).unwrap(),
                 labels: HashMap::new(),
             },
         )

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -178,6 +178,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         metrics_listen_addr: None,
         now: config.now,
         cors_allowed_origin: Origin::list([]).into(),
+        replica_sizes: Default::default(),
     }))?;
     let server = Server {
         inner,

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -160,10 +160,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         }
         let mut limits = BTreeMap::new();
         if let Some(memory_limit) = memory_limit {
-            limits.insert(
-                "memory".into(),
-                Quantity(memory_limit.as_bytes().to_string()),
-            );
+            limits.insert("memory".into(), Quantity(memory_limit.as_u64().to_string()));
         }
         if let Some(cpu_limit) = cpu_limit {
             limits.insert(

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -160,7 +160,10 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         }
         let mut limits = BTreeMap::new();
         if let Some(memory_limit) = memory_limit {
-            limits.insert("memory".into(), Quantity(memory_limit.as_u64().to_string()));
+            limits.insert(
+                "memory".into(),
+                Quantity(memory_limit.0.as_u64().to_string()),
+            );
         }
         if let Some(cpu_limit) = cpu_limit {
             limits.insert(
@@ -254,7 +257,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     ..Default::default()
                 },
                 service_name: name.clone(),
-                replicas: Some(processes.try_into()?),
+                replicas: Some(processes.get().try_into()?),
                 template: pod_template_spec,
                 ..Default::default()
             }),
@@ -278,7 +281,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         // template. In theory, Kubernetes would do this automatically, but
         // in practice we have observed that it does not.
         // See: https://github.com/kubernetes/kubernetes/issues/67250
-        for pod_id in 0..processes {
+        for pod_id in 0..processes.get() {
             let pod_name = format!("{}-{}", &name, pod_id);
             let pod = match self.pod_api.get(&pod_name).await {
                 Ok(pod) => pod,
@@ -299,7 +302,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 }
             }
         }
-        let hosts = (0..processes)
+        let hosts = (0..processes.get())
             .map(|i| {
                 format!(
                     "{name}-{i}.{name}.{}.svc.cluster.local",

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -125,7 +125,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
         let path = self.image_dir.join(image);
         let mut processes = vec![];
         let mut handles = vec![];
-        for _ in 0..processes_in {
+        for _ in 0..(processes_in.get()) {
             let mut ports = HashMap::new();
             for port in &ports_in {
                 let p = self

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -9,4 +9,6 @@ publish = false
 [dependencies]
 anyhow = "1.0.56"
 async-trait = "0.1.53"
+bytesize = "1.1.0"
 derivative = "2.2.0"
+serde = "1.0"

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -585,6 +585,7 @@ impl Runner {
             metrics_registry: MetricsRegistry::new(),
             metrics_listen_addr: None,
             now: SYSTEM_TIME.clone(),
+            replica_sizes: Default::default(),
         };
         let server = materialized::serve(mz_config).await?;
         let client = connect(&server).await;


### PR DESCRIPTION
Fixes #11810

Example invocation:

```
cargo run -- --experimental --allow-cluster-replica-size '{"xs": {"processes": 1, "memory_limit": "1GiB", "cpu_limit": 0.25 }, "xl": {"processes": 32, "memory_limit": "128GiB", "cpu_limit": 16}}'
```

### Tips for reviewer

The reason we need a custom deserializer for `Option<ByteSize>` is because the `byte_size` crate, inexplicably, just derives `Deserialize` rather than doing something sensible.

### Testing

Tests coming tomorrow before I land this

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add --allow-cluster-replica-size for cloud orchestration purposes
