### PR TITLE
zippy: remove the use of tables

### DIFF
--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -23,7 +23,7 @@ WatermarkedObjects = List[Union[TableExists, SourceExists]]
 class CreateView(Action):
     @classmethod
     def requires(self) -> Set[Type[Capability]]:
-        return {MzIsRunning, SourceExists, TableExists}
+        return {MzIsRunning, SourceExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         view_name = "view" + str(random.randint(1, 10))

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -27,7 +27,7 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     # --persistent-kafka-sources can not be enabled due to gh#11711 , gh#11506
-    Materialized(options="--persistent-user-tables"),
+    Materialized(),
     Testdrive(validate_data_dir=False, no_reset=True, seed=1, default_timeout="300s"),
 ]
 
@@ -39,15 +39,16 @@ all_action_classes = [
     CreateTopic,
     CreateSource,
     CreateSource,
-    CreateTable,
     CreateView,
     ValidateView,
     ValidateView,
-    Insert,
-    ShiftForward,
-    ShiftBackward,
-    DeleteFromTail,
-    DeleteFromHead,
+    # Not currently viable with persistence disabled
+    #    CreateTable,
+    #    Insert,
+    #    ShiftForward,
+    #    ShiftBackward,
+    #    DeleteFromTail,
+    #    DeleteFromHead,
     KafkaInsert,
     KafkaDeleteFromHead,
     KafkaDeleteFromTail,


### PR DESCRIPTION
Until persistence is re-enabled, remove the use of
tables from the framework.

### Motivation

  * This PR fixes a previously unreported bug.

Nightly Zippy started failing because the --persistent-user-tables option is no longer supported.