### PR TITLE
feature-benchmark: Disable the KafkaRaw scenario

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -102,3 +102,8 @@ class Scenario(RootScenario):
 # Used for scenarios that need to be explicitly run from the command line using --root-scenario ScenarioBig
 class ScenarioBig(RootScenario):
     pass
+
+
+# Used for disabled scenarios
+class ScenarioDisabled(RootScenario):
+    pass

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -23,6 +23,7 @@ from materialize.feature_benchmark.scenario import (
     BenchmarkingSequence,
     Scenario,
     ScenarioBig,
+    ScenarioDisabled,
 )
 
 
@@ -595,7 +596,7 @@ class Kafka(Scenario):
     pass
 
 
-class KafkaRaw(Kafka):
+class KafkaRaw(ScenarioDisabled):
     def shared(self) -> Action:
         return TdAction(
             self.schema()


### PR DESCRIPTION
The KafkaRaw scenario relies on the presence of mz_kafka_source_statistics
which is being retired. There are other Kafka ingestion scenarios that
remain running.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI failures in the KafkaRaw scenario due to functionality being removed from the product.