### PR TITLE
bin/sqllogictest: add runner script for sqllogictest too

### DIFF
--- a/bin/sqllogictest
+++ b/bin/sqllogictest
@@ -1,0 +1,1 @@
+materialized


### PR DESCRIPTION
I wired up the bin/materialized script to be able to handle sqllogictest
too, but failed to actually commit the addition of bin/sqllogictest.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported in Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
