### PR TITLE
Make listen host for spawned processes vary based on orchestrator

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -99,6 +99,7 @@ where
                     computed_image,
                     storage_addr,
                 } = &self.orchestrator;
+                let default_listen_host = orchestrator.default_listen_host();
                 let service = orchestrator
                     .namespace("compute")
                     .ensure_service(
@@ -108,8 +109,11 @@ where
                             args: &|ports| {
                                 vec![
                                     format!("--storage-addr={storage_addr}"),
-                                    format!("--listen-addr=0.0.0.0:{}", ports["controller"]),
-                                    format!("0.0.0.0:{}", ports["compute"]),
+                                    format!(
+                                        "--listen-addr={}:{}",
+                                        default_listen_host, ports["controller"]
+                                    ),
+                                    format!("{}:{}", default_listen_host, ports["compute"]),
                                 ]
                             },
                             ports: vec![

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -257,6 +257,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         ),
         OrchestratorBackend::Process(config) => Box::new(ProcessOrchestrator::new(config).await?),
     };
+    let default_listen_host = orchestrator.default_listen_host();
     let storage_service = orchestrator
         .namespace("storage")
         .ensure_service(
@@ -266,8 +267,14 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 args: &|ports| {
                     vec![
                         format!("--workers=1"),
-                        format!("--storage-addr=0.0.0.0:{}", ports["compute"]),
-                        format!("--listen-addr=0.0.0.0:{}", ports["controller"]),
+                        format!(
+                            "--storage-addr={}:{}",
+                            default_listen_host, ports["compute"]
+                        ),
+                        format!(
+                            "--listen-addr={}:{}",
+                            default_listen_host, ports["controller"]
+                        ),
                         format!("--persist-blob-url={}", config.persist_location.blob_uri),
                         format!(
                             "--persist-consensus-url={}",

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -83,6 +83,9 @@ impl KubernetesOrchestrator {
 }
 
 impl Orchestrator for KubernetesOrchestrator {
+    fn default_listen_host(&self) -> &'static str {
+        "0.0.0.0"
+    }
     fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator> {
         Arc::new(NamespacedKubernetesOrchestrator {
             service_api: Api::default_namespaced(self.client.clone()),

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -69,6 +69,9 @@ impl ProcessOrchestrator {
 }
 
 impl Orchestrator for ProcessOrchestrator {
+    fn default_listen_host(&self) -> &'static str {
+        "127.0.0.1"
+    }
     fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator> {
         let mut namespaces = self.namespaces.lock().expect("lock poisoned");
         Arc::clone(namespaces.entry(namespace.into()).or_insert_with(|| {

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -28,6 +28,8 @@ use derivative::Derivative;
 /// The intent is that you can implement `Orchestrator` with pods in Kubernetes,
 /// containers in Docker, or processes on your local machine.
 pub trait Orchestrator: fmt::Debug + Send + Sync {
+    // Default host used to bind to.
+    fn default_listen_host(&self) -> &'static str;
     /// Enter a namespace in the orchestrator.
     fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator>;
 }


### PR DESCRIPTION
The KubernetesOrchestrator still defaults to 0.0.0.0, but the ProcessOrchestrator now defaults to 127.0.0.1. Similar in spirit to #11233.

### Motivation

  * This PR fixes a bug reported in Slack.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Processes started by `bin/materialized` now default to listening only on localhost. The behavior for the main `materialized` process remains unchanged.
