### PR TITLE
expr: add protobuf support for `VariadicFunc` (complete)

### DIFF
--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -12,6 +12,7 @@ fn main() {
         .extern_path(".mz_repr.adt.array", "::mz_repr::adt::array")
         .extern_path(".mz_repr.adt.numeric", "::mz_repr::adt::numeric")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
+        .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.strconv", "::mz_repr::strconv")
         .compile_protos(
             &[

--- a/src/expr/src/scalar/func.proto
+++ b/src/expr/src/scalar/func.proto
@@ -10,6 +10,7 @@
 syntax = "proto3";
 
 import "repr/src/adt/numeric.proto";
+import "repr/src/relation_and_scalar.proto";
 import "google/protobuf/empty.proto";
 
 package mz_expr.scalar.func;
@@ -522,6 +523,9 @@ message ProtoBinaryFunc {
 }
 
 message ProtoVariadicFunc {
+    message ProtoRecordCreate {
+        repeated mz_repr.relation_and_scalar.ProtoColumnName field_names = 1;
+    }
     oneof kind {
         google.protobuf.Empty coalesce = 1;
         google.protobuf.Empty greatest = 2;
@@ -533,16 +537,11 @@ message ProtoVariadicFunc {
         google.protobuf.Empty replace = 8;
         google.protobuf.Empty jsonb_build_array = 9;
         google.protobuf.Empty jsonb_build_object = 10;
-        // unsupported: ArrayCreate { elem_type: ScalarType }
-        google.protobuf.Empty array_create = 11;
-        // unsupported: ArrayToString { elem_type: ScalarType }
-        google.protobuf.Empty array_to_string = 12;
-        // unsupported: ArrayIndex { offset: usize }
-        google.protobuf.Empty array_index = 13;
-        // unsupported: ListCreate { elem_type: ScalarType }
-        google.protobuf.Empty list_create = 14;
-        // unsupported: RecordCreate { field_names: Vec<ColumnName> }
-        google.protobuf.Empty record_create = 15;
+        mz_repr.relation_and_scalar.ProtoScalarType array_create = 11;
+        mz_repr.relation_and_scalar.ProtoScalarType array_to_string = 12;
+        uint64 array_index = 13;
+        mz_repr.relation_and_scalar.ProtoScalarType list_create = 14;
+        ProtoRecordCreate record_create = 15;
         google.protobuf.Empty list_index = 16;
         google.protobuf.Empty list_slice_linear = 17;
         google.protobuf.Empty split_part = 18;

--- a/src/expr/src/scalar/func.proto
+++ b/src/expr/src/scalar/func.proto
@@ -532,7 +532,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty least = 3;
         google.protobuf.Empty concat = 4;
         google.protobuf.Empty make_timestamp = 5;
-        google.protobuf.Empty pad_leading = 6;
+        google.protobuf.Empty pad_leading = 16;
         google.protobuf.Empty substr = 7;
         google.protobuf.Empty replace = 8;
         google.protobuf.Empty jsonb_build_array = 9;
@@ -542,7 +542,7 @@ message ProtoVariadicFunc {
         uint64 array_index = 13;
         mz_repr.relation_and_scalar.ProtoScalarType list_create = 14;
         ProtoRecordCreate record_create = 15;
-        google.protobuf.Empty list_index = 16;
+        google.protobuf.Empty list_index = 6;
         google.protobuf.Empty list_slice_linear = 17;
         google.protobuf.Empty split_part = 18;
         google.protobuf.Empty regexp_match = 19;

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2882,6 +2882,12 @@ impl fmt::Display for BinaryFunc {
     }
 }
 
+/// An explicit [`Arbitrary`] implementation needed here because of a known
+/// `proptest` issue.
+///
+/// Revert to the derive-macro impementation once the issue[^1] is fixed.
+///
+/// [^1]: <https://github.com/AltSysrq/proptest/issues/152>
 impl Arbitrary for BinaryFunc {
     type Parameters = ();
 
@@ -3663,6 +3669,12 @@ pub enum UnaryFunc {
 
 use proptest::{prelude::*, strategy::*};
 
+/// An explicit [`Arbitrary`] implementation needed here because of a known
+/// `proptest` issue.
+///
+/// Revert to the derive-macro impementation once the issue[^1] is fixed.
+///
+/// [^1]: <https://github.com/AltSysrq/proptest/issues/152>
 impl Arbitrary for UnaryFunc {
     type Parameters = ();
 
@@ -6941,6 +6953,12 @@ impl fmt::Display for VariadicFunc {
     }
 }
 
+/// An explicit [`Arbitrary`] implementation needed here because of a known
+/// `proptest` issue.
+///
+/// Revert to the derive-macro impementation once the issue[^1] is fixed.
+///
+/// [^1]: <https://github.com/AltSysrq/proptest/issues/152>
 impl Arbitrary for VariadicFunc {
     type Parameters = ();
 

--- a/src/repr/src/chrono.rs
+++ b/src/repr/src/chrono.rs
@@ -149,7 +149,7 @@ pub fn any_datetime() -> impl Strategy<Value = DateTime<Utc>> {
 }
 
 pub fn any_fixed_offset() -> impl Strategy<Value = FixedOffset> {
-    (-86_401..86_400).prop_map(FixedOffset::east)
+    (-86_399..86_400).prop_map(FixedOffset::east)
 }
 
 pub fn any_timezone() -> impl Strategy<Value = Tz> {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -37,12 +37,14 @@ pub mod util;
 
 pub use datum_vec::{DatumVec, DatumVecBorrow};
 pub use global_id::GlobalId;
-pub use relation::{ColumnName, ColumnType, NotNullViolation, RelationDesc, RelationType};
+pub use relation::{
+    ColumnName, ColumnType, NotNullViolation, ProtoColumnName, RelationDesc, RelationType,
+};
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena,
     RowPacker, RowRef,
 };
-pub use scalar::{AsColumnType, Datum, DatumType, ScalarBaseType, ScalarType};
+pub use scalar::{AsColumnType, Datum, DatumType, ProtoScalarType, ScalarBaseType, ScalarType};
 
 // Concrete types used throughout Materialize for the generic parameters in Timely/Differential Dataflow.
 /// System-wide timestamp type.


### PR DESCRIPTION
Leftovers from #11823.

### Motivation

  * This PR adds a known-desirable feature.

    Closes [#11749](11749).

### Tips for reviewer

I only need one from @wangandi  or @lluki to take a look. The commits (in append order) do the following:

1. Add a note that states why we need explicit `Arbitrary` implementations for most `~Func` enums.
2. Complete the implementation of the missing `VariadicFunc` variants from the various traits and the `*.proto` file.
3. Swap some field tags from the `ProtoVariadicFunc` definition so the most common cases receive a 1-byte tag.
4. Fix a bad range in `any_fixed_offset`.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Tested with

```rust
cargo test -p mz-expr variadic_func_protobuf_roundtrip -- --nocapture
```

### Release notes

N/A
