### PR TITLE
More explicitly plan `Get` stages

### DIFF
--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -157,15 +157,8 @@ pub enum Plan<T = mz_repr::Timestamp> {
         // seems generally advantageous to do that instead (to avoid cloning
         // rows, by using `mfp` first on borrowed data).
         keys: AvailableCollections,
-        /// Any linear operator work to apply as part of producing the data.
-        ///
-        /// This logic allows us to efficiently extract collections from data
-        /// that have been pre-arranged, avoiding copying rows that are not
-        /// used and columns that are projected away.
-        mfp: MapFilterProject,
-        /// Whether the input is from an arrangement, and if so,
-        /// whether we can seek to a specific value therein
-        key_val: Option<(Vec<MirScalarExpr>, Option<Row>)>,
+        /// The actions to take when introducing the collection.
+        plan: GetPlan,
     },
     /// Binds `value` to `id`, and then results in `body` with that binding.
     ///
@@ -312,6 +305,17 @@ pub enum Plan<T = mz_repr::Timestamp> {
         /// The MFP that must be applied to the input.
         input_mfp: MapFilterProject,
     },
+}
+
+/// How a `Get` stage will be rendered.
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub enum GetPlan {
+    /// Simply pass input arrangements on to the next stage.
+    PassArrangements,
+    /// Using the supplied key, optionally seek the row, and apply the MFP.
+    Arrangement(Vec<MirScalarExpr>, Option<Row>, MapFilterProject),
+    /// Scan the input collection (unarranged) and apply the MFP.
+    Collection(MapFilterProject),
 }
 
 /// Various bits of state to print along with error messages during LIR planning,
@@ -466,36 +470,43 @@ impl<T: timely::progress::Timestamp> Plan<T> {
                     .iter()
                     .filter_map(|key| {
                         mfp.literal_constraints(&key.0)
-                            .map(|val| (key.clone(), Some(val)))
+                            .map(|val| (key.clone(), val))
                     })
-                    .max_by_key(|(key, _val)| key.0.len())
-                    .or_else(|| {
-                        in_keys
-                            .arbitrary_arrangement()
-                            .map(|key| (key.clone(), None))
-                    });
+                    .max_by_key(|(key, _val)| key.0.len());
 
-                if let Some(((key, permutation, thinning), _)) = &key_val {
+                // Determine the plan of action for the `Get` stage.
+                let plan = if let Some(((key, permutation, thinning), val)) = &key_val {
                     mfp.permute(permutation.clone(), thinning.len() + key.len());
-                }
+                    in_keys.arranged = vec![(key.clone(), permutation.clone(), thinning.clone())];
+                    GetPlan::Arrangement(key.clone(), Some(val.clone()), mfp)
+                } else if !mfp.is_identity() {
+                    // We need to ensure a collection exists, which means we must form it.
+                    if let Some((key, permutation, thinning)) =
+                        in_keys.arbitrary_arrangement().cloned()
+                    {
+                        mfp.permute(permutation.clone(), thinning.len() + key.len());
+                        in_keys.arranged = vec![(key.clone(), permutation, thinning)];
+                        GetPlan::Arrangement(key, None, mfp)
+                    } else {
+                        GetPlan::Collection(mfp)
+                    }
+                } else {
+                    // By default, just pass input arrangements through.
+                    GetPlan::PassArrangements
+                };
 
-                let out_keys = if mfp.is_identity() {
+                let out_keys = if let GetPlan::PassArrangements = plan {
                     in_keys.clone()
                 } else {
                     AvailableCollections::new_raw()
                 };
 
-                // If we discover a literal constraint, we can discard other arrangements.
-                if let Some((key, Some(_))) = &key_val {
-                    in_keys.arranged = vec![key.clone()];
-                }
                 // Return the plan, and any keys if an identity `mfp`.
                 (
                     Plan::Get {
                         id: id.clone(),
                         keys: in_keys,
-                        mfp,
-                        key_val: key_val.map(|((key, _, _), val)| (key, val)),
+                        plan,
                     },
                     out_keys,
                 )
@@ -1016,20 +1027,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
 
                 // For all other variants, just replace inputs with appropriately sharded versions.
                 // This is surprisingly verbose, but that is all it is doing.
-                Plan::Get {
-                    id,
-                    keys,
-                    mfp,
-                    key_val,
-                } => vec![
-                    Plan::Get {
-                        id,
-                        keys,
-                        mfp,
-                        key_val,
-                    };
-                    parts
-                ],
+                Plan::Get { id, keys, plan } => vec![Plan::Get { id, keys, plan }; parts],
                 Plan::Let { value, body, id } => {
                     let value_parts = value.partition_among(parts);
                     let body_parts = body.partition_among(parts);
@@ -1172,8 +1170,7 @@ impl<T> CollectionPlan for Plan<T> {
             Plan::Get {
                 id,
                 keys: _,
-                mfp: _,
-                key_val: _,
+                plan: _,
             } => match id {
                 Id::Global(id) => {
                     out.insert(*id);

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -340,16 +340,7 @@ Query:
       "raw": true,
       "arranged": []
     },
-    "mfp": {
-      "expressions": [],
-      "predicates": [],
-      "projection": [
-        0,
-        1
-      ],
-      "input_arity": 2
-    },
-    "key_val": null
+    "plan": "PassArrangements"
   }
 }
 
@@ -379,16 +370,7 @@ Query:
       "raw": true,
       "arranged": []
     },
-    "mfp": {
-      "expressions": [],
-      "predicates": [],
-      "projection": [
-        0,
-        1
-      ],
-      "input_arity": 2
-    },
-    "key_val": null
+    "plan": "PassArrangements"
   }
 }
 
@@ -420,16 +402,7 @@ Query:
           "raw": true,
           "arranged": []
         },
-        "mfp": {
-          "expressions": [],
-          "predicates": [],
-          "projection": [
-            0,
-            1
-          ],
-          "input_arity": 2
-        },
-        "key_val": null
+        "plan": "PassArrangements"
       }
     },
     "top_k_plan": {
@@ -481,16 +454,7 @@ Query:
           "raw": true,
           "arranged": []
         },
-        "mfp": {
-          "expressions": [],
-          "predicates": [],
-          "projection": [
-            0,
-            1
-          ],
-          "input_arity": 2
-        },
-        "key_val": null
+        "plan": "PassArrangements"
       }
     },
     "top_k_plan": {
@@ -540,16 +504,7 @@ Query:
       "raw": true,
       "arranged": []
     },
-    "mfp": {
-      "expressions": [],
-      "predicates": [],
-      "projection": [
-        0,
-        1
-      ],
-      "input_arity": 2
-    },
-    "key_val": null
+    "plan": "PassArrangements"
   }
 }
 
@@ -581,16 +536,7 @@ Query:
       "raw": true,
       "arranged": []
     },
-    "mfp": {
-      "expressions": [],
-      "predicates": [],
-      "projection": [
-        0,
-        1
-      ],
-      "input_arity": 2
-    },
-    "key_val": null
+    "plan": "PassArrangements"
   }
 }
 

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -98,15 +98,16 @@ Query:
                     "raw": true,
                     "arranged": []
                   },
-                  "mfp": {
-                    "expressions": [],
-                    "predicates": [],
-                    "projection": [
-                      0
-                    ],
-                    "input_arity": 16
-                  },
-                  "key_val": null
+                  "plan": {
+                    "Collection": {
+                      "expressions": [],
+                      "predicates": [],
+                      "projection": [
+                        0
+                      ],
+                      "input_arity": 16
+                    }
+                  }
                 }
               },
               "forms": {
@@ -145,13 +146,14 @@ Query:
                 "raw": true,
                 "arranged": []
               },
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [],
-                "input_arity": 9
-              },
-              "key_val": null
+              "plan": {
+                "Collection": {
+                  "expressions": [],
+                  "predicates": [],
+                  "projection": [],
+                  "input_arity": 9
+                }
+              }
             }
           }
         ],
@@ -198,15 +200,7 @@ Query:
                 "raw": true,
                 "arranged": []
               },
-              "mfp": {
-                "expressions": [],
-                "predicates": [],
-                "projection": [
-                  0
-                ],
-                "input_arity": 1
-              },
-              "key_val": null
+              "plan": "PassArrangements"
             }
           },
           {
@@ -229,16 +223,17 @@ Query:
                                   "raw": true,
                                   "arranged": []
                                 },
-                                "mfp": {
-                                  "expressions": [],
-                                  "predicates": [],
-                                  "projection": [
-                                    11,
-                                    12
-                                  ],
-                                  "input_arity": 16
-                                },
-                                "key_val": null
+                                "plan": {
+                                  "Collection": {
+                                    "expressions": [],
+                                    "predicates": [],
+                                    "projection": [
+                                      11,
+                                      12
+                                    ],
+                                    "input_arity": 16
+                                  }
+                                }
                               }
                             },
                             "forms": {
@@ -282,15 +277,7 @@ Query:
                                       "raw": true,
                                       "arranged": []
                                     },
-                                    "mfp": {
-                                      "expressions": [],
-                                      "predicates": [],
-                                      "projection": [
-                                        0
-                                      ],
-                                      "input_arity": 1
-                                    },
-                                    "key_val": null
+                                    "plan": "PassArrangements"
                                   }
                                 },
                                 "key_val_plan": {
@@ -361,37 +348,38 @@ Query:
                                   "raw": true,
                                   "arranged": []
                                 },
-                                "mfp": {
-                                  "expressions": [],
-                                  "predicates": [
-                                    [
-                                      1,
-                                      {
-                                        "CallUnary": {
-                                          "func": {
-                                            "Not": null
-                                          },
-                                          "expr": {
-                                            "CallUnary": {
-                                              "func": {
-                                                "IsNull": null
-                                              },
-                                              "expr": {
-                                                "Column": 0
+                                "plan": {
+                                  "Collection": {
+                                    "expressions": [],
+                                    "predicates": [
+                                      [
+                                        1,
+                                        {
+                                          "CallUnary": {
+                                            "func": {
+                                              "Not": null
+                                            },
+                                            "expr": {
+                                              "CallUnary": {
+                                                "func": {
+                                                  "IsNull": null
+                                                },
+                                                "expr": {
+                                                  "Column": 0
+                                                }
                                               }
                                             }
                                           }
                                         }
-                                      }
-                                    ]
-                                  ],
-                                  "projection": [
-                                    0,
-                                    4
-                                  ],
-                                  "input_arity": 9
-                                },
-                                "key_val": null
+                                      ]
+                                    ],
+                                    "projection": [
+                                      0,
+                                      4
+                                    ],
+                                    "input_arity": 9
+                                  }
+                                }
                               }
                             },
                             "forms": {


### PR DESCRIPTION
`Get` stages have historically been "planned" with a few field members that implicitly described what behavior should happen. The complexity has grown in the meantime, with more explicit permutations requiring adjustment of the `mfp` member which no longer acts as a good proxy for "can we pass the information unmodified".

Instead, this PR adds explicit plan options for the things we might do with the input data:
1. `PassArrangements` just passes existing arrangements along. Great if there is not a `mfp`.
2. `Arrangement` is used to indicate that we should consume an arrangement and produce a collection, with an optional key value to look up.
3. `Collection` indicates that there is no arrangement, and we should look for an input collection.

These seem to disambiguate the behavior well enough, and while in principle they are isomorphic to the pre-existing member field options, they are more explicit and less likely to be incorrectly interpreted.

fixes #11793

### Motivation

`Get` stages were being mis-rendered as arrangement-less collections, when they could have presented arrangements.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
