### PR TITLE
bin/cluster-dev: set image pull policy to never

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,6 +3679,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "clap",
  "k8s-openapi",
  "kube",
  "mz-orchestrator",

--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -59,6 +59,7 @@ metadata:
 spec:
   serviceName: materialized
   replicas: 1
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: materialized
@@ -77,6 +78,7 @@ spec:
             - --orchestrator=kubernetes
             - --orchestrator-service-label=materialize.cloud/example1=label1
             - --orchestrator-service-label=materialize.cloud/example2=label2
+            - --kubernetes-image-pull-policy=never
             - --experimental
         ports:
         - containerPort: 6875

--- a/src/materialized/ci/.gitignore
+++ b/src/materialized/ci/.gitignore
@@ -1,1 +1,3 @@
+/computed
+/storaged
 /materialized

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.56"
 async-trait = "0.1.53"
+clap = { version = "3.1.9", features = ["derive"] }
 mz-orchestrator = { path = "../orchestrator" }
 k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
 kube = { version = "0.71.0", features = ["ws"] }


### PR DESCRIPTION
When developing using bin/cluster-dev, the
materialized/storaged/computed images will not be available on Docker
Hub; they'll have been pushed to the local Docker daemon directly. This
is incompatible with the default image pull policy of "always" that we
want to use in prodution. So, expose the image pull policy as a
command-line flag, and set it to "never" when running via
bin/cluster-dev.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
