### PR TITLE
bin/cluster-dev: force docker-env output for bash

### DIFF
--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -19,7 +19,7 @@ set -euo pipefail
 export MZ_DEV_CI_BUILDER_DOCKER_HOST=${DOCKER_HOST:-}
 export MZ_DEV_CI_BUILDER_DOCKER_TLS_VERIFY=${DOCKER_TLS_VERIFY:-}
 export MZ_DEV_CI_BUILDER_DOCKER_CERT_PATH=${DOCKER_CERT_PATH:-}
-eval "$(minikube docker-env)"
+eval "$(minikube docker-env --shell bash)"
 
 bin/mzimage acquire --dev storaged
 bin/mzimage acquire --dev computed


### PR DESCRIPTION
It appears that `minikube docker-env` selects its output format based on the $SHELL env variable. $SHELL does not specify the current shell, but the default shell. So on a system that uses a POSIX non-compliant shell, like fish, `minikube docker-env` outputs a format bash does not understand. To mitigate this, set the target shell to bash explicitly.

### Motivation

  * This PR fixes a previously unreported bug.

    As a `fish` user, if I run `bin/cluster-dev` without this change, it fails with this error:

    ```
    bin/cluster-dev: line 22: set: -g: invalid option
    ```

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).