### PR TITLE
Replica availability zone plumbing

### DIFF
--- a/doc/developer/design/20220413_cluster_replica.md
+++ b/doc/developer/design/20220413_cluster_replica.md
@@ -37,7 +37,7 @@ be the moment at which compute resources are provisioned.
 The `SIZE` and `REMOTE` options must not be specified together.
 
 The `AVAILABILITY ZONE` option is new. The set of allowable availability zones
-will be determined by a new `--allow-availability-zone=AZ` command line option.
+will be determined by a new `--availability-zone=AZ` command line option.
 If no availability zone is specified explicitly, and at least one availability
 zone is available, Materialize should automatically assign the availability
 zone with the least existing replicas.
@@ -163,7 +163,7 @@ physical AZs in different accounts.
 The Pulumi infrastructure will need to provide nodes groups in several
 availability zones in production. The environment controller will plumb
 the list of... available... availability zones to `materialized` via the
-new `--allow-availability-zone` argument.
+new `--availability-zone` argument.
 
 ## Future work
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -242,6 +242,7 @@ pub struct Config {
     pub metrics_registry: MetricsRegistry,
     pub now: NowFn,
     pub secrets_controller: Box<dyn SecretsController>,
+    pub availability_zones: Vec<String>,
 }
 
 struct PendingPeek {
@@ -4661,6 +4662,7 @@ pub async fn serve(
         metrics_registry,
         now,
         secrets_controller,
+        availability_zones: _,
     }: Config,
 ) -> Result<(Handle, Client), CoordError> {
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -183,6 +183,7 @@ where
                                 "cluster-id".into() => instance.to_string(),
                                 "type".into() => "cluster".into(),
                             },
+                            availability_zone: None,
                         },
                     )
                     .await?;

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -309,6 +309,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 memory_limit: None,
                 processes: NonZeroUsize::new(1).unwrap(),
                 labels: HashMap::new(),
+                availability_zone: None,
             },
         )
         .await?;

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -120,6 +120,8 @@ pub struct Config {
     pub now: NowFn,
     /// Map of strings to corresponding compute replica sizes.
     pub replica_sizes: ClusterReplicaSizeMap,
+    /// Availability zones compute resources may be deployed in.
+    pub availability_zones: Vec<String>,
 }
 
 /// Configures TLS encryption for connections.
@@ -366,6 +368,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         metrics_registry: config.metrics_registry.clone(),
         now: config.now,
         secrets_controller,
+        availability_zones: config.availability_zones.clone(),
     })
     .await?;
 

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -180,6 +180,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         now: config.now,
         cors_allowed_origin: Origin::list([]).into(),
         replica_sizes: Default::default(),
+        availability_zones: Default::default(),
     }))?;
     let server = Server {
         inner,

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -156,6 +156,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             cpu_limit,
             processes,
             labels: labels_in,
+            availability_zone,
         }: ServiceConfig<'_>,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let name = format!("{}-{id}", self.namespace);
@@ -223,6 +224,8 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             .iter()
             .map(|p| (p.name.clone(), p.port_hint))
             .collect();
+        let node_selector = availability_zone
+            .map(|az| BTreeMap::from([("materialize.cloud/availability-zone".to_string(), az)]));
         let mut pod_template_spec = PodTemplateSpec {
             metadata: Some(ObjectMeta {
                 labels: Some(labels.clone()),
@@ -251,6 +254,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     }),
                     ..Default::default()
                 }],
+                node_selector,
                 ..Default::default()
             }),
         };

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -115,6 +115,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             cpu_limit: _,
             processes: processes_in,
             labels: _,
+            availability_zone: _,
         }: ServiceConfig<'_>,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let full_id = format!("{}-{}", self.namespace, id);

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -94,6 +94,9 @@ pub struct ServiceConfig<'a> {
     ///
     /// The orchestrator backend may apply a prefix to the key if appropriate.
     pub labels: HashMap<String, String>,
+    /// The availability zone the service should be run in. If no availability
+    /// zone is specified, the orchestrator is free to choose one.
+    pub availability_zone: Option<String>,
 }
 
 /// A named port associated with a service.

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -587,6 +587,7 @@ impl Runner {
             metrics_listen_addr: None,
             now: SYSTEM_TIME.clone(),
             replica_sizes: Default::default(),
+            availability_zones: Default::default(),
         };
         let server = materialized::serve(mz_config).await?;
         let client = connect(&server).await;


### PR DESCRIPTION
This PR introduces the initial plumbing for constraining compute replicas to availability zones:

- It adds a flag `--availability-zone` to materialized, for specifying the available AZs.
- It adds the field `ServiceConfig::availability_zone`, for constraining a service to a given AZ.

Checking `CREATE REPLICA` commands against the list of allowed AZs is not included, as #11808 must be finished first.

### Motivation

  * This PR adds a known-desirable feature: #11809.

### Tips for reviewer

There are still a couple open discussion points. I'm adding them to the relevant code parts.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

I've tested the `node_selector` config locally with minikube, where it works as expected. No attempts to test with EKS were made.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add `--availability-zone` option to materialized, for orchestration purposes
