### PR TITLE
expr: deprecate `_nolimit` visitor methods

### DIFF
--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -335,7 +335,8 @@ pub fn prep_scalar_expr(
             session,
         } => {
             let mut res = Ok(());
-            expr.visit_mut_post(&mut |e| {
+            #[allow(deprecated)]
+            expr.visit_mut_post_nolimit(&mut |e| {
                 if let MirScalarExpr::CallUnmaterializable(f) = e {
                     match eval_unmaterializable_func(state, f, logical_time, session) {
                         Ok(evaled) => *e = evaled,
@@ -349,7 +350,8 @@ pub fn prep_scalar_expr(
         // Reject the query if it contains any unmaterializable function calls.
         ExprPrepStyle::Index => {
             let mut last_observed_unmaterializable_func = None;
-            expr.visit_mut_post(&mut |e| {
+            #[allow(deprecated)]
+            expr.visit_mut_post_nolimit(&mut |e| {
                 if let MirScalarExpr::CallUnmaterializable(f) = e {
                     last_observed_unmaterializable_func = Some(f.clone());
                 }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -980,7 +980,8 @@ impl MapFilterProject {
         // Inline expressions per `should_inline`.
         for index in 0..self.expressions.len() {
             let (prior, expr) = self.expressions.split_at_mut(index);
-            expr[0].visit_mut_post(&mut |e| {
+            #[allow(deprecated)]
+            expr[0].visit_mut_post_nolimit(&mut |e| {
                 if let MirScalarExpr::Column(i) = e {
                     if should_inline[*i] {
                         *e = prior[*i - input_arity].clone();
@@ -990,7 +991,8 @@ impl MapFilterProject {
         }
         for (_index, pred) in self.predicates.iter_mut() {
             let expressions = &self.expressions;
-            pred.visit_mut_post(&mut |e| {
+            #[allow(deprecated)]
+            pred.visit_mut_post_nolimit(&mut |e| {
                 if let MirScalarExpr::Column(i) = e {
                     if should_inline[*i] {
                         *e = expressions[*i - input_arity].clone();
@@ -1112,7 +1114,8 @@ pub fn memoize_expr(
     memoized_parts: &mut Vec<MirScalarExpr>,
     input_arity: usize,
 ) {
-    expr.visit_mut_pre_post(
+    #[allow(deprecated)]
+    expr.visit_mut_pre_post_nolimit(
         &mut |e| {
             // We should not eagerly memoize `if` branches that might not be taken.
             // TODO: Memoize expressions in the intersection of `then` and `els`.

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -75,7 +75,8 @@ pub fn canonicalize_equivalences(
             // which will then replace `to_reduce[i]`.
             let mut new_equivalence = Vec::with_capacity(to_reduce[i].len());
             while let Some((_, mut popped_expr)) = to_reduce[i].pop() {
-                popped_expr.visit_mut_post(&mut |e: &mut MirScalarExpr| {
+                #[allow(deprecated)]
+                popped_expr.visit_mut_post_nolimit(&mut |e: &mut MirScalarExpr| {
                     // If a simpler expression can be found that is equivalent
                     // to e,
                     if let Some(simpler_e) = to_reduce.iter().find_map(|cls| {
@@ -179,7 +180,8 @@ fn rank_complexity(expr: &MirScalarExpr) -> usize {
         return 0;
     }
     let mut non_literal_count = 1;
-    expr.visit_post(&mut |e| {
+    #[allow(deprecated)]
+    expr.visit_post_nolimit(&mut |e| {
         if !e.is_literal() {
             non_literal_count += 1
         }
@@ -376,7 +378,8 @@ fn replace_subexpr_and_reduce(
     input_type: &RelationType,
 ) -> bool {
     let mut changed = false;
-    predicate.visit_mut_pre_post(
+    #[allow(deprecated)]
+    predicate.visit_mut_pre_post_nolimit(
         &mut |e| {
             // The `cond` of an if statement is not visited to prevent `then`
             // or `els` from being evaluated before `cond`, resulting in a

--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -175,7 +175,8 @@ impl JoinInputMapper {
     /// where column references have been remapped to the local context.
     /// Assumes that all columns in `expr` are from the same input.
     pub fn map_expr_to_local(&self, mut expr: MirScalarExpr) -> MirScalarExpr {
-        expr.visit_mut_post(&mut |e| {
+        #[allow(deprecated)]
+        expr.visit_mut_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(c) = e {
                 *c -= self.prior_arities[self.input_relation[*c]];
             }
@@ -187,7 +188,8 @@ impl JoinInputMapper {
     /// creates a new version where column references have been remapped to the
     /// global context.
     pub fn map_expr_to_global(&self, mut expr: MirScalarExpr, index: usize) -> MirScalarExpr {
-        expr.visit_mut_post(&mut |e| {
+        #[allow(deprecated)]
+        expr.visit_mut_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(c) = e {
                 *c += self.prior_arities[index];
             }
@@ -312,7 +314,8 @@ impl JoinInputMapper {
         // `e` anyway, so we end up visiting nodes in `e` multiple times
         // here. Alternatively, consider having the future `PredicateKnowledge`
         // take over the responsibilities of this code?
-        expr.visit_mut_pre_post(
+        #[allow(deprecated)]
+        expr.visit_mut_pre_post_nolimit(
             &mut |e| {
                 let mut inputs = self.lookup_inputs(e);
                 if let Some(first_input) = inputs.next() {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -253,7 +253,8 @@ impl MirRelationExpr {
     /// visited in `type_stack`.
     pub fn typ(&self) -> RelationType {
         let mut type_stack = Vec::new();
-        self.visit_pre_post(
+        #[allow(deprecated)]
+        self.visit_pre_post_nolimit(
             &mut |e: &MirRelationExpr| -> Option<Vec<&MirRelationExpr>> {
                 if let MirRelationExpr::Let { body, .. } = &e {
                     // Do not traverse the value sub-graph, since it's not relevant for

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -127,7 +127,8 @@ impl MirScalarExpr {
     /// strict permutation, and it only needs to have entries for
     /// each column referenced in `self`.
     pub fn permute(&mut self, permutation: &[usize]) {
-        self.visit_mut_post(&mut |e| {
+        #[allow(deprecated)]
+        self.visit_mut_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(old_i) = e {
                 *old_i = permutation[*old_i];
             }
@@ -140,7 +141,8 @@ impl MirScalarExpr {
     /// strict permutation, and it only needs to have entries for
     /// each column referenced in `self`.
     pub fn permute_map(&mut self, permutation: &std::collections::HashMap<usize, usize>) {
-        self.visit_mut_post(&mut |e| {
+        #[allow(deprecated)]
+        self.visit_mut_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(old_i) = e {
                 *old_i = permutation[old_i];
             }
@@ -149,7 +151,8 @@ impl MirScalarExpr {
 
     pub fn support(&self) -> HashSet<usize> {
         let mut support = HashSet::new();
-        self.visit_post(&mut |e| {
+        #[allow(deprecated)]
+        self.visit_post_nolimit(&mut |e| {
             if let MirScalarExpr::Column(i) = e {
                 support.insert(*i);
             }
@@ -246,7 +249,8 @@ impl MirScalarExpr {
         let mut old_self = MirScalarExpr::column(0);
         while old_self != *self {
             old_self = self.clone();
-            self.visit_mut_pre_post(
+            #[allow(deprecated)]
+            self.visit_mut_pre_post_nolimit(
                 &mut |e| {
                     match e {
                         // 1a) Decompose IsNull expressions into a disjunction
@@ -677,7 +681,8 @@ impl MirScalarExpr {
             );
         }
 
-        self.visit_mut_pre_post(
+        #[allow(deprecated)]
+        self.visit_mut_pre_post_nolimit(
             &mut |e| {
                 match e {
                     // 2) Push down not expressions
@@ -995,7 +1000,8 @@ impl MirScalarExpr {
     /// `UnmaterializableFunc::MzLogicalTimestamp`.
     pub fn contains_temporal(&self) -> bool {
         let mut contains = false;
-        self.visit_post(&mut |e| {
+        #[allow(deprecated)]
+        self.visit_post_nolimit(&mut |e| {
             if let MirScalarExpr::CallUnmaterializable(UnmaterializableFunc::MzLogicalTimestamp) = e
             {
                 contains = true;
@@ -1007,7 +1013,8 @@ impl MirScalarExpr {
     /// True iff the expression contains an `UnmaterializableFunc`.
     pub fn contains_unmaterializable(&self) -> bool {
         let mut contains = false;
-        self.visit_post(&mut |e| {
+        #[allow(deprecated)]
+        self.visit_post_nolimit(&mut |e| {
             if let MirScalarExpr::CallUnmaterializable(_) = e {
                 contains = true;
             }

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -73,18 +73,34 @@ pub trait VisitChildren {
 ///
 /// All methods provided by this trait ensure that the stack is grown
 /// as needed, to avoid stack overflows when traversing deeply
-/// recursive objects. The `try_*` methods also enforce a recursion
-/// limit of [`RECURSION_LIMIT`] by returning an error when that limit
-/// is exceeded. The infallible visitor methods don't enforce a limit,
-/// as they have no way of reporting errors.
+/// recursive objects. They also enforce a recursion limit of
+/// [`RECURSION_LIMIT`] by returning an error when that limit
+/// is exceeded.
+///
+/// There are also `*_nolimit` methods that don't enforce a recursion
+/// limit. Those methods are deprecated and should not be used.
 pub trait Visit {
     /// Post-order immutable infallible visitor for `self`.
-    fn visit_post<F>(&self, f: &mut F)
+    fn visit_post<F>(&self, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&Self);
+
+    /// Post-order immutable infallible visitor for `self`.
+    /// Does not enforce a recursion limit.
+    #[deprecated = "Use `visit_post` instead."]
+    fn visit_post_nolimit<F>(&self, f: &mut F)
     where
         F: FnMut(&Self);
 
     /// Post-order mutable infallible visitor for `self`.
-    fn visit_mut_post<F>(&mut self, f: &mut F)
+    fn visit_mut_post<F>(&mut self, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&mut Self);
+
+    /// Post-order mutable infallible visitor for `self`.
+    /// Does not enforce a recursion limit.
+    #[deprecated = "Use `visit_mut_post` instead."]
+    fn visit_mut_post_nolimit<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self);
 
@@ -101,12 +117,26 @@ pub trait Visit {
         E: From<RecursionLimitError>;
 
     /// Pre-order immutable infallible visitor for `self`.
-    fn visit_pre<F>(&self, f: &mut F)
+    fn visit_pre<F>(&self, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&Self);
+
+    /// Pre-order immutable infallible visitor for `self`.
+    /// Does not enforce a recursion limit.
+    #[deprecated = "Use `visit_pre` instead."]
+    fn visit_pre_nolimit<F>(&self, f: &mut F)
     where
         F: FnMut(&Self);
 
     /// Pre-order mutable infallible visitor for `self`.
-    fn visit_mut_pre<F>(&mut self, f: &mut F)
+    fn visit_mut_pre<F>(&mut self, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&mut Self);
+
+    /// Pre-order mutable infallible visitor for `self`.
+    /// Does not enforce a recursion limit.
+    #[deprecated = "Use `visit_mut_pre` instead."]
+    fn visit_mut_pre_nolimit<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self);
 
@@ -129,7 +159,25 @@ pub trait Visit {
     ///
     /// Optionally, `pre` can return which children, if any, should be visited
     /// (default is to visit all children).
-    fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2)
+    fn visit_pre_post<F1, F2>(
+        &self,
+        pre: &mut F1,
+        post: &mut F2,
+    ) -> Result<(), RecursionLimitError>
+    where
+        F1: FnMut(&Self) -> Option<Vec<&Self>>,
+        F2: FnMut(&Self);
+
+    /// A generalization of [`Visit::visit_pre`] and [`Visit::visit_post`].
+    /// Does not enforce a recursion limit.
+    ///
+    /// The function `pre` runs on `self` before it runs on any of the children.
+    /// The function `post` runs on children first before the parent.
+    ///
+    /// Optionally, `pre` can return which children, if any, should be visited
+    /// (default is to visit all children).
+    #[deprecated = "Use `visit_pre_post` instead."]
+    fn visit_pre_post_nolimit<F1, F2>(&self, pre: &mut F1, post: &mut F2)
     where
         F1: FnMut(&Self) -> Option<Vec<&Self>>,
         F2: FnMut(&Self);
@@ -141,25 +189,57 @@ pub trait Visit {
     ///
     /// Optionally, `pre` can return which children, if any, should be visited
     /// (default is to visit all children).
-    fn visit_mut_pre_post<F1, F2>(&mut self, pre: &mut F1, post: &mut F2)
+    fn visit_mut_pre_post<F1, F2>(
+        &mut self,
+        pre: &mut F1,
+        post: &mut F2,
+    ) -> Result<(), RecursionLimitError>
+    where
+        F1: FnMut(&mut Self) -> Option<Vec<&mut Self>>,
+        F2: FnMut(&mut Self);
+
+    /// A generalization of [`Visit::visit_mut_pre`] and [`Visit::visit_mut_post`].
+    /// Does not enforce a recursion limit.
+    ///
+    /// The function `pre` runs on `self` before it runs on any of the children.
+    /// The function `post` runs on children first before the parent.
+    ///
+    /// Optionally, `pre` can return which children, if any, should be visited
+    /// (default is to visit all children).
+    #[deprecated = "Use `visit_mut_pre_post` instead."]
+    fn visit_mut_pre_post_nolimit<F1, F2>(&mut self, pre: &mut F1, post: &mut F2)
     where
         F1: FnMut(&mut Self) -> Option<Vec<&mut Self>>,
         F2: FnMut(&mut Self);
 }
 
 impl<T: VisitChildren> Visit for T {
-    fn visit_post<F>(&self, f: &mut F)
+    fn visit_post<F>(&self, f: &mut F) -> Result<(), RecursionLimitError>
     where
         F: FnMut(&Self),
     {
         Visitor::new().visit_post(self, f)
     }
 
-    fn visit_mut_post<F>(&mut self, f: &mut F)
+    fn visit_post_nolimit<F>(&self, f: &mut F)
+    where
+        F: FnMut(&Self),
+    {
+        Visitor::new().visit_post_nolimit(self, f)
+    }
+
+    fn visit_mut_post<F>(&mut self, f: &mut F) -> Result<(), RecursionLimitError>
     where
         F: FnMut(&mut Self),
     {
         Visitor::new().visit_mut_post(self, f)
+    }
+
+    fn visit_mut_post_nolimit<F>(&mut self, f: &mut F)
+    where
+        F: FnMut(&mut Self),
+    {
+        Visitor::new().visit_mut_post_nolimit(self, f)
     }
 
     fn try_visit_post<F, E>(&self, f: &mut F) -> Result<(), E>
@@ -178,18 +258,32 @@ impl<T: VisitChildren> Visit for T {
         Visitor::new().try_visit_mut_post(self, f)
     }
 
-    fn visit_pre<F>(&self, f: &mut F)
+    fn visit_pre<F>(&self, f: &mut F) -> Result<(), RecursionLimitError>
     where
         F: FnMut(&Self),
     {
         Visitor::new().visit_pre(self, f)
     }
 
-    fn visit_mut_pre<F>(&mut self, f: &mut F)
+    fn visit_pre_nolimit<F>(&self, f: &mut F)
+    where
+        F: FnMut(&Self),
+    {
+        Visitor::new().visit_pre_nolimit(self, f)
+    }
+
+    fn visit_mut_pre<F>(&mut self, f: &mut F) -> Result<(), RecursionLimitError>
     where
         F: FnMut(&mut Self),
     {
         Visitor::new().visit_mut_pre(self, f)
+    }
+
+    fn visit_mut_pre_nolimit<F>(&mut self, f: &mut F)
+    where
+        F: FnMut(&mut Self),
+    {
+        Visitor::new().visit_mut_pre_nolimit(self, f)
     }
 
     fn try_visit_pre<F, E>(&self, f: &mut F) -> Result<(), E>
@@ -208,7 +302,7 @@ impl<T: VisitChildren> Visit for T {
         Visitor::new().try_visit_mut_pre(self, f)
     }
 
-    fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2)
+    fn visit_pre_post<F1, F2>(&self, pre: &mut F1, post: &mut F2) -> Result<(), RecursionLimitError>
     where
         F1: FnMut(&Self) -> Option<Vec<&Self>>,
         F2: FnMut(&Self),
@@ -216,12 +310,32 @@ impl<T: VisitChildren> Visit for T {
         Visitor::new().visit_pre_post(self, pre, post)
     }
 
-    fn visit_mut_pre_post<F1, F2>(&mut self, pre: &mut F1, post: &mut F2)
+    fn visit_pre_post_nolimit<F1, F2>(&self, pre: &mut F1, post: &mut F2)
+    where
+        F1: FnMut(&Self) -> Option<Vec<&Self>>,
+        F2: FnMut(&Self),
+    {
+        Visitor::new().visit_pre_post_nolimit(self, pre, post)
+    }
+
+    fn visit_mut_pre_post<F1, F2>(
+        &mut self,
+        pre: &mut F1,
+        post: &mut F2,
+    ) -> Result<(), RecursionLimitError>
     where
         F1: FnMut(&mut Self) -> Option<Vec<&mut Self>>,
         F2: FnMut(&mut Self),
     {
         Visitor::new().visit_mut_pre_post(self, pre, post)
+    }
+
+    fn visit_mut_pre_post_nolimit<F1, F2>(&mut self, pre: &mut F1, post: &mut F2)
+    where
+        F1: FnMut(&mut Self) -> Option<Vec<&mut Self>>,
+        F2: FnMut(&mut Self),
+    {
+        Visitor::new().visit_mut_pre_post_nolimit(self, pre, post)
     }
 }
 
@@ -244,22 +358,44 @@ impl<T: VisitChildren> Visitor<T> {
         }
     }
 
-    fn visit_post<F>(&self, value: &T, f: &mut F)
+    fn visit_post<F>(&self, value: &T, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&T),
+    {
+        self.checked_recur(move |_| {
+            value.try_visit_children(|child| self.visit_post(child, f))?;
+            f(value);
+            Ok(())
+        })
+    }
+
+    fn visit_post_nolimit<F>(&self, value: &T, f: &mut F)
     where
         F: FnMut(&T),
     {
         maybe_grow(|| {
-            value.visit_children(|child| self.visit_post(child, f));
+            value.visit_children(|child| self.visit_post_nolimit(child, f));
             f(value)
         })
     }
 
-    fn visit_mut_post<F>(&self, value: &mut T, f: &mut F)
+    fn visit_mut_post<F>(&self, value: &mut T, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&mut T),
+    {
+        self.checked_recur(move |_| {
+            value.try_visit_mut_children(|child| self.visit_mut_post(child, f))?;
+            f(value);
+            Ok(())
+        })
+    }
+
+    fn visit_mut_post_nolimit<F>(&self, value: &mut T, f: &mut F)
     where
         F: FnMut(&mut T),
     {
         maybe_grow(|| {
-            value.visit_mut_children(|child| self.visit_mut_post(child, f));
+            value.visit_mut_children(|child| self.visit_mut_post_nolimit(child, f));
             f(value)
         })
     }
@@ -286,23 +422,43 @@ impl<T: VisitChildren> Visitor<T> {
         })
     }
 
-    fn visit_pre<F>(&self, value: &T, f: &mut F)
+    fn visit_pre<F>(&self, value: &T, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&T),
+    {
+        self.checked_recur(move |_| {
+            f(value);
+            value.try_visit_children(|child| self.visit_pre(child, f))
+        })
+    }
+
+    fn visit_pre_nolimit<F>(&self, value: &T, f: &mut F)
     where
         F: FnMut(&T),
     {
         maybe_grow(|| {
             f(value);
-            value.visit_children(|child| self.visit_pre(child, f))
+            value.visit_children(|child| self.visit_pre_nolimit(child, f))
         })
     }
 
-    fn visit_mut_pre<F>(&self, value: &mut T, f: &mut F)
+    fn visit_mut_pre<F>(&self, value: &mut T, f: &mut F) -> Result<(), RecursionLimitError>
+    where
+        F: FnMut(&mut T),
+    {
+        self.checked_recur(move |_| {
+            f(value);
+            value.try_visit_mut_children(|child| self.visit_mut_pre(child, f))
+        })
+    }
+
+    fn visit_mut_pre_nolimit<F>(&self, value: &mut T, f: &mut F)
     where
         F: FnMut(&mut T),
     {
         maybe_grow(|| {
             f(value);
-            value.visit_mut_children(|child| self.visit_mut_pre(child, f))
+            value.visit_mut_children(|child| self.visit_mut_pre_nolimit(child, f))
         })
     }
 
@@ -328,7 +484,30 @@ impl<T: VisitChildren> Visitor<T> {
         })
     }
 
-    fn visit_pre_post<F1, F2>(&self, value: &T, pre: &mut F1, post: &mut F2)
+    fn visit_pre_post<F1, F2>(
+        &self,
+        value: &T,
+        pre: &mut F1,
+        post: &mut F2,
+    ) -> Result<(), RecursionLimitError>
+    where
+        F1: FnMut(&T) -> Option<Vec<&T>>,
+        F2: FnMut(&T),
+    {
+        self.checked_recur(move |_| {
+            if let Some(to_visit) = pre(value) {
+                for child in to_visit {
+                    self.visit_pre_post(child, pre, post)?;
+                }
+            } else {
+                value.try_visit_children(|child| self.visit_pre_post(child, pre, post))?;
+            }
+            post(value);
+            Ok(())
+        })
+    }
+
+    fn visit_pre_post_nolimit<F1, F2>(&self, value: &T, pre: &mut F1, post: &mut F2)
     where
         F1: FnMut(&T) -> Option<Vec<&T>>,
         F2: FnMut(&T),
@@ -336,16 +515,39 @@ impl<T: VisitChildren> Visitor<T> {
         maybe_grow(|| {
             if let Some(to_visit) = pre(value) {
                 for child in to_visit {
-                    self.visit_pre_post(child, pre, post);
+                    self.visit_pre_post_nolimit(child, pre, post);
                 }
             } else {
-                value.visit_children(|child| self.visit_pre_post(child, pre, post));
+                value.visit_children(|child| self.visit_pre_post_nolimit(child, pre, post));
             }
             post(value);
         })
     }
 
-    fn visit_mut_pre_post<F1, F2>(&self, value: &mut T, pre: &mut F1, post: &mut F2)
+    fn visit_mut_pre_post<F1, F2>(
+        &self,
+        value: &mut T,
+        pre: &mut F1,
+        post: &mut F2,
+    ) -> Result<(), RecursionLimitError>
+    where
+        F1: FnMut(&mut T) -> Option<Vec<&mut T>>,
+        F2: FnMut(&mut T),
+    {
+        self.checked_recur(move |_| {
+            if let Some(to_visit) = pre(value) {
+                for child in to_visit {
+                    self.visit_mut_pre_post(child, pre, post)?;
+                }
+            } else {
+                value.try_visit_mut_children(|child| self.visit_mut_pre_post(child, pre, post))?;
+            }
+            post(value);
+            Ok(())
+        })
+    }
+
+    fn visit_mut_pre_post_nolimit<F1, F2>(&self, value: &mut T, pre: &mut F1, post: &mut F2)
     where
         F1: FnMut(&mut T) -> Option<Vec<&mut T>>,
         F2: FnMut(&mut T),
@@ -353,10 +555,10 @@ impl<T: VisitChildren> Visitor<T> {
         maybe_grow(|| {
             if let Some(to_visit) = pre(value) {
                 for child in to_visit {
-                    self.visit_mut_pre_post(child, pre, post);
+                    self.visit_mut_pre_post_nolimit(child, pre, post);
                 }
             } else {
-                value.visit_mut_children(|child| self.visit_mut_pre_post(child, pre, post));
+                value.visit_mut_children(|child| self.visit_mut_pre_post_nolimit(child, pre, post));
             }
             post(value);
         })

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -393,7 +393,8 @@ pub fn optimize(
     // `DatumKnowledge` in the stack are the `DatumKnowledge` corresponding to
     // the children.
 
-    expr.visit_mut_pre_post(
+    #[allow(deprecated)]
+    expr.visit_mut_pre_post_nolimit(
         &mut |e| {
             // We should not eagerly memoize `if` branches that might not be taken.
             // TODO: Memoize expressions in the intersection of `then` and `els`.

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -125,10 +125,11 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
                 &mut id_gen,
             )?;
             // Install the `new_local` name wherever `global_id` was used.
+            #[allow(deprecated)]
             dataflow.objects_to_build[other]
                 .plan
                 .as_inner_mut()
-                .visit_mut_post(&mut |expr| {
+                .visit_mut_post_nolimit(&mut |expr| {
                     if let MirRelationExpr::Get { id, .. } = expr {
                         if id == &Id::Global(global_id) {
                             *id = Id::Local(new_local);

--- a/src/transform/src/fusion/join.rs
+++ b/src/transform/src/fusion/join.rs
@@ -143,7 +143,8 @@ impl JoinBuilder {
         // Update and push all of the variables.
         for mut equivalence in equivalences.drain(..) {
             for expr in equivalence.iter_mut() {
-                expr.visit_mut_post(&mut |e| {
+                #[allow(deprecated)]
+                expr.visit_mut_post_nolimit(&mut |e| {
                     if let MirScalarExpr::Column(c) = e {
                         *c += self.num_columns;
                     }
@@ -154,7 +155,8 @@ impl JoinBuilder {
 
         if let Some(mut predicates) = predicates {
             for mut expr in predicates.drain(..) {
-                expr.visit_mut_post(&mut |e| {
+                #[allow(deprecated)]
+                expr.visit_mut_post_nolimit(&mut |e| {
                     if let MirScalarExpr::Column(c) = e {
                         *c += self.num_columns;
                     }

--- a/src/transform/src/fusion/reduce.rs
+++ b/src/transform/src/fusion/reduce.rs
@@ -48,7 +48,8 @@ impl Reduce {
                 // Collect all columns referenced by outer
                 let mut outer_cols = vec![];
                 for expr in group_key.iter() {
-                    expr.visit_post(&mut |e| {
+                    #[allow(deprecated)]
+                    expr.visit_post_nolimit(&mut |e| {
                         if let MirScalarExpr::Column(i) = e {
                             outer_cols.push(*i);
                         }

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -508,7 +508,8 @@ fn install_lifted_mfp(new_join: &mut MirRelationExpr, mfp: MapFilterProject) {
                     expr.permute(&project);
                     // if column references refer to mapped expressions that have been
                     // lifted, replace the column reference with the mapped expression.
-                    expr.visit_mut_pre_post(
+                    #[allow(deprecated)]
+                    expr.visit_mut_pre_post_nolimit(
                         &mut |e| {
                             if let MirScalarExpr::Column(c) = e {
                                 if *c >= mfp.input_arity {

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -337,7 +337,8 @@ impl LiteralLifting {
                                 } else {
                                     let mut cloned_scalar = scalar.clone();
                                     // Propagate literals through expressions and remap columns.
-                                    cloned_scalar.visit_mut_post(&mut |e| {
+                                    #[allow(deprecated)]
+                                    cloned_scalar.visit_mut_post_nolimit(&mut |e| {
                                         if let MirScalarExpr::Column(old_id) = e {
                                             let new_id = projection[*old_id];
                                             if new_id >= first_literal_id {
@@ -364,7 +365,8 @@ impl LiteralLifting {
                     if !literals.is_empty() {
                         let input_arity = input.arity();
                         for expr in exprs.iter_mut() {
-                            expr.visit_mut_post(&mut |e| {
+                            #[allow(deprecated)]
+                            expr.visit_mut_post_nolimit(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -390,7 +392,8 @@ impl LiteralLifting {
                         // in predicates and then lift the `map` around the filter.
                         let input_arity = input.arity();
                         for expr in predicates.iter_mut() {
-                            expr.visit_mut_post(&mut |e| {
+                            #[allow(deprecated)]
+                            expr.visit_mut_post_nolimit(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -443,7 +446,8 @@ impl LiteralLifting {
                         let new_input_mapper = JoinInputMapper::new(inputs);
                         for equivalence in equivalences.iter_mut() {
                             for expr in equivalence.iter_mut() {
-                                expr.visit_mut_post(&mut |e| {
+                                #[allow(deprecated)]
+                                expr.visit_mut_post_nolimit(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         let (col, input) = old_input_mapper.map_column_to_local(*c);
                                         if col >= new_input_mapper.input_arity(input) {
@@ -501,7 +505,8 @@ impl LiteralLifting {
                         let input_arity = input.arity();
                         // Inline literals into group key expressions.
                         for expr in group_key.iter_mut() {
-                            expr.visit_mut_post(&mut |e| {
+                            #[allow(deprecated)]
+                            expr.visit_mut_post_nolimit(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -511,7 +516,8 @@ impl LiteralLifting {
                         }
                         // Inline literals into aggregate value selector expressions.
                         for aggr in aggregates.iter_mut() {
-                            aggr.expr.visit_mut_post(&mut |e| {
+                            #[allow(deprecated)]
+                            aggr.expr.visit_mut_post_nolimit(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
@@ -672,7 +678,8 @@ impl LiteralLifting {
                         let input_arity = input.arity();
                         for key in keys.iter_mut() {
                             for expr in key.iter_mut() {
-                                expr.visit_mut_post(&mut |e| {
+                                #[allow(deprecated)]
+                                expr.visit_mut_post_nolimit(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         if *c >= input_arity {
                                             *e = literals[*c - input_arity].clone();

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -81,7 +81,8 @@ impl NonNullable {
 /// True if the expression contains a "is null" test.
 fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
     let mut result = false;
-    expr.visit_post(&mut |e| {
+    #[allow(deprecated)]
+    expr.visit_post_nolimit(&mut |e| {
         if let MirScalarExpr::CallUnary {
             func: UnaryFunc::IsNull(func::IsNull),
             ..
@@ -96,7 +97,8 @@ fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
 /// Transformations to scalar functions, based on nonnullability of columns.
 fn scalar_nonnullable(expr: &mut MirScalarExpr, metadata: &RelationType) {
     // Tests for null can be replaced by "false" for non-nullable columns.
-    expr.visit_mut_post(&mut |e| {
+    #[allow(deprecated)]
+    expr.visit_mut_post_nolimit(&mut |e| {
         if let MirScalarExpr::CallUnary {
             func: UnaryFunc::IsNull(func::IsNull),
             expr,

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -318,7 +318,8 @@ impl PredicatePushdown {
                                 if !predicate.is_literal_err() || all_errors {
                                     let mut supported = true;
                                     let mut new_predicate = predicate.clone();
-                                    new_predicate.visit_mut_post(&mut |e| {
+                                    #[allow(deprecated)]
+                                    new_predicate.visit_mut_post_nolimit(&mut |e| {
                                         if let MirScalarExpr::Column(c) = e {
                                             if *c >= group_key.len() {
                                                 supported = false;
@@ -326,7 +327,8 @@ impl PredicatePushdown {
                                         }
                                     });
                                     if supported {
-                                        new_predicate.visit_mut_post(&mut |e| {
+                                        #[allow(deprecated)]
+                                        new_predicate.visit_mut_post_nolimit(&mut |e| {
                                             if let MirScalarExpr::Column(i) = e {
                                                 *e = group_key[*i].clone();
                                             }
@@ -763,7 +765,8 @@ impl PredicatePushdown {
                         || PredicatePushdown::can_inline(&scalars[*c - input_arity], input_arity)
                 })
             {
-                predicate.visit_mut_post(&mut |e| {
+                #[allow(deprecated)]
+                predicate.visit_mut_post_nolimit(&mut |e| {
                     if let MirScalarExpr::Column(c) = e {
                         // NB: this inlining would be invalid if can_inline did not
                         // verify that scalars[*c - input_arity] referenced only

--- a/src/transform/src/projection_pushdown.rs
+++ b/src/transform/src/projection_pushdown.rs
@@ -340,7 +340,8 @@ impl ProjectionPushdown {
         relation: &mut MirRelationExpr,
         applied_projections: &HashMap<Id, Vec<usize>>,
     ) {
-        relation.visit_mut_pre(&mut |e| {
+        #[allow(deprecated)]
+        relation.visit_mut_pre_nolimit(&mut |e| {
             if let MirRelationExpr::Project { input, outputs } = e {
                 if let MirRelationExpr::Get { id: inner_id, .. } = &**input {
                     if let Some(new_projection) = applied_projections.get(inner_id) {

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -98,7 +98,8 @@ impl ReductionPushdown {
                 let mut scalars = scalars.clone();
                 for index in 0..scalars.len() {
                     let (lower, upper) = scalars.split_at_mut(index);
-                    upper[0].visit_mut_post(&mut |e| {
+                    #[allow(deprecated)]
+                    upper[0].visit_mut_post_nolimit(&mut |e| {
                         if let mz_expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = lower[*c - arity].clone();
@@ -107,7 +108,8 @@ impl ReductionPushdown {
                     });
                 }
                 for key in group_key.iter_mut() {
-                    key.visit_mut_post(&mut |e| {
+                    #[allow(deprecated)]
+                    key.visit_mut_post_nolimit(&mut |e| {
                         if let mz_expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = scalars[*c - arity].clone();
@@ -116,7 +118,8 @@ impl ReductionPushdown {
                     });
                 }
                 for agg in aggregates.iter_mut() {
-                    agg.expr.visit_mut_post(&mut |e| {
+                    #[allow(deprecated)]
+                    agg.expr.visit_mut_post_nolimit(&mut |e| {
                         if let mz_expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = scalars[*c - arity].clone();

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -148,7 +148,8 @@ impl RedundantJoin {
                         // Update the column offsets in the binding expressions to catch
                         // up with the removal of `remove_input_idx`.
                         for expr in bindings.iter_mut() {
-                            expr.visit_mut_post(&mut |e| {
+                            #[allow(deprecated)]
+                            expr.visit_mut_post_nolimit(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     let (_local_col, input_relation) =
                                         old_input_mapper.map_column_to_local(*c);
@@ -164,7 +165,8 @@ impl RedundantJoin {
                         // from inputs after `remove_input_idx`.
                         for equivalence in equivalences.iter_mut() {
                             for expr in equivalence.iter_mut() {
-                                expr.visit_mut_post(&mut |e| {
+                                #[allow(deprecated)]
+                                expr.visit_mut_post_nolimit(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         let (local_col, input_relation) =
                                             old_input_mapper.map_column_to_local(*c);


### PR DESCRIPTION
This PR renames the existing infallible visitor methods with a `_nolimit` suffix and deprecates them. This frees up the old names for replacement methods that take an infallible callback, but still return a `Result` to report `RecursionLimitError`s. Going forward, new code should use the safe methods instead of the old `_nolimit` ones.

This PR does not make attempts to port the existing client code to the new safe methods and instead adds `#[cfg(allow(deprecation)]` annotations. The intent is to allow us to migrate the client code over time, instead of having to spend a lot of effort now.

### Motivation

   * This PR refactors existing code. See the discussion in #9334.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).