### PR TITLE
feature-benchmark: Tone down the ParallelDataflows scenario

### DIFF
--- a/test/feature-benchmark/scenarios_concurrency.py
+++ b/test/feature-benchmark/scenarios_concurrency.py
@@ -99,7 +99,7 @@ $ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-sc
 class ParallelDataflows(Concurrency):
     """Measure the time it takes to compute multiple parallel dataflows."""
 
-    SCALE = 5
+    SCALE = 4
     VIEWS = 100
 
     def benchmark(self) -> MeasurementSource:


### PR DESCRIPTION
The scenario is OOMing because of #11921 so it needs to be toned down.

  * This PR fixes a previously unreported bug.

Failures in Nightly.