### PR TITLE
coord: Implement KubernetesSecretsController

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,6 +4018,7 @@ name = "mz-secrets"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "mz-repr",
 ]
 
@@ -4026,6 +4027,7 @@ name = "mz-secrets-filesystem"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "mz-secrets",
 ]
 
@@ -4034,9 +4036,11 @@ name = "mz-secrets-kubernetes"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "k8s-openapi",
  "kube",
  "mz-secrets",
+ "tracing",
 ]
 
 [[package]]

--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -76,6 +76,7 @@ spec:
             - --computed-image=$(bin/mzimage spec --dev computed)
             - --data-directory=/data
             - --orchestrator=kubernetes
+            - --secrets-controller=kubernetes
             - --orchestrator-service-label=materialize.cloud/example1=label1
             - --orchestrator-service-label=materialize.cloud/example2=label2
             - --kubernetes-image-pull-policy=never

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1987,10 +1987,12 @@ impl Coordinator {
             create_sql: format!("CREATE SECRET {} AS '********'", full_name),
         };
 
-        self.secrets_controller.apply(vec![SecretOp::Ensure {
-            id,
-            contents: payload,
-        }])?;
+        self.secrets_controller
+            .apply(vec![SecretOp::Ensure {
+                id,
+                contents: payload,
+            }])
+            .await?;
 
         let ops = vec![catalog::Op::CreateItem {
             id,
@@ -2006,7 +2008,11 @@ impl Coordinator {
                 ..
             })) if if_not_exists => Ok(ExecuteResponse::CreatedSecret { existed: true }),
             Err(err) => {
-                match self.secrets_controller.apply(vec![SecretOp::Delete { id }]) {
+                match self
+                    .secrets_controller
+                    .apply(vec![SecretOp::Delete { id }])
+                    .await
+                {
                     Ok(_) => {}
                     Err(e) => {
                         warn!(
@@ -4129,10 +4135,12 @@ impl Coordinator {
 
         let payload = self.extract_secret(session, &mut secret_as)?;
 
-        self.secrets_controller.apply(vec![SecretOp::Ensure {
-            id,
-            contents: payload,
-        }])?;
+        self.secrets_controller
+            .apply(vec![SecretOp::Ensure {
+                id,
+                contents: payload,
+            }])
+            .await?;
 
         Ok(ExecuteResponse::AlteredObject(ObjectType::Secret))
     }
@@ -4429,7 +4437,7 @@ impl Coordinator {
             .map(|id| SecretOp::Delete { id })
             .collect_vec();
 
-        match self.secrets_controller.apply(ops) {
+        match self.secrets_controller.apply(ops).await {
             Ok(_) => {}
             Err(e) => {
                 warn!("Dropping secrets has encountered an error: {}", e);

--- a/src/secrets-filesystem/Cargo.toml
+++ b/src/secrets-filesystem/Cargo.toml
@@ -8,4 +8,5 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.56"
+async-trait = "0.1.53"
 mz-secrets = { path = "../secrets" }

--- a/src/secrets-filesystem/src/lib.rs
+++ b/src/secrets-filesystem/src/lib.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 use anyhow::Error;
+use async_trait::async_trait;
 use mz_secrets::{SecretOp, SecretsController};
 use std::fs;
 use std::fs::OpenOptions;
@@ -26,8 +27,9 @@ impl FilesystemSecretsController {
     }
 }
 
+#[async_trait]
 impl SecretsController for FilesystemSecretsController {
-    fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), Error> {
+    async fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), Error> {
         assert_eq!(ops.len(), 1);
         for op in ops.iter() {
             match op {

--- a/src/secrets-kubernetes/Cargo.toml
+++ b/src/secrets-kubernetes/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.56"
+async-trait = "0.1.53"
 mz-secrets = { path = "../secrets" }
 k8s-openapi = { version = "0.14.0", features = ["v1_22"] }
 kube = { version = "0.71.0", features = ["ws"] }
+tracing = "0.1.34"

--- a/src/secrets-kubernetes/src/lib.rs
+++ b/src/secrets-kubernetes/src/lib.rs
@@ -63,14 +63,13 @@ impl KubernetesSecretsController {
         let secret = KubernetesSecretsController::make_secret_with_name(name.clone());
         match secret_api.create(&PostParams::default(), &secret).await {
             Ok(_) => Ok(()),
+            Err(kube::Error::Api(e)) if e.code == 409 => {
+                info!("Secret {} already exists", name);
+                Ok(())
+            }
             Err(e) => {
-                if e.to_string().contains("AlreadyExists") {
-                    info!("Secret {} already exists", name);
-                    Ok(())
-                } else {
-                    error!("creating secret failed: {}", e);
-                    Err(e)
-                }
+                error!("creating secret failed: {}", e);
+                Err(e)
             }
         }?;
 

--- a/src/secrets-kubernetes/src/lib.rs
+++ b/src/secrets-kubernetes/src/lib.rs
@@ -8,15 +8,38 @@
 // by the Apache License, Version 2.0.
 
 use anyhow::{bail, Error};
+use async_trait::async_trait;
+use k8s_openapi::api::core::v1::Secret;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::ByteString;
+use kube::api::{Patch, PatchParams, PostParams};
 use kube::config::KubeConfigOptions;
-use kube::{Client, Config};
+use kube::{Api, Client, Config};
 use mz_secrets::{SecretOp, SecretsController};
+use std::collections::BTreeMap;
+use tracing::{error, info};
+
+const FIELD_MANAGER: &str = "materialized";
+const HARDCODED_NAME: &str = "dataflowd-secret";
 
 pub struct KubernetesSecretsController {
-    _kube_client: Client,
+    secret_api: Api<Secret>,
 }
 
 impl KubernetesSecretsController {
+    fn make_secret_with_name(name: String) -> Secret {
+        Secret {
+            data: None,
+            immutable: None,
+            metadata: ObjectMeta {
+                name: Some(name),
+                ..Default::default()
+            },
+            string_data: None,
+            type_: None,
+        }
+    }
+
     pub async fn new(context: String) -> Result<KubernetesSecretsController, anyhow::Error> {
         let kubeconfig_options = KubeConfigOptions {
             context: Some(context),
@@ -33,15 +56,64 @@ impl KubernetesSecretsController {
             },
         };
         let client = Client::try_from(kubeconfig)?;
+        let secret_api: Api<Secret> = Api::default_namespaced(client);
 
-        Ok(KubernetesSecretsController {
-            _kube_client: client,
-        })
+        let name: String = format!("{}", HARDCODED_NAME);
+
+        let secret = KubernetesSecretsController::make_secret_with_name(name.clone());
+        match secret_api.create(&PostParams::default(), &secret).await {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                if e.to_string().contains("AlreadyExists") {
+                    info!("Secret {} already exists", name);
+                    Ok(())
+                } else {
+                    error!("creating secret failed: {}", e);
+                    Err(e)
+                }
+            }
+        }?;
+
+        Ok(KubernetesSecretsController { secret_api })
     }
 }
 
+#[async_trait]
 impl SecretsController for KubernetesSecretsController {
-    fn apply(&mut self, _ops: Vec<SecretOp>) -> Result<(), Error> {
+    async fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), Error> {
+        let name: String = format!("{}", HARDCODED_NAME);
+
+        let mut secret: Secret = self.secret_api.get(&*name).await?;
+
+        let mut data = secret.data.map_or_else(BTreeMap::new, |m| m);
+
+        for op in ops.iter() {
+            match op {
+                SecretOp::Ensure { id, contents } => {
+                    info!("inserting/updating secret with ID: {}", id);
+                    data.insert(id.to_string(), ByteString(contents.clone()));
+                }
+                SecretOp::Delete { id } => {
+                    info!("deleting secret with ID: {}", id);
+                    data.remove(&*id.to_string());
+                }
+            }
+        }
+
+        secret.data = Some(data);
+
+        // Managed_fields can not be present in the object that is being patched.
+        // if present, they lead to an 'metadata.managedFields must be nil' error
+        secret.metadata.managed_fields = None;
+
+        self.secret_api
+            .patch(
+                &name,
+                &PatchParams::apply(FIELD_MANAGER).force(),
+                &Patch::Apply(secret),
+            )
+            .await?;
+
         return Ok(());
     }
 }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 [dependencies]
 anyhow = "1.0.56"
 mz-repr = { path = "../repr" }
+async-trait = "0.1.53"

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -6,10 +6,12 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
+use async_trait::async_trait;
 use mz_repr::GlobalId;
 
 /// Securely stores secrets.
-pub trait SecretsController: Send {
+#[async_trait]
+pub trait SecretsController: Send + Sync {
     /// Applies the specified secret operations in bulk.
     ///
     /// Implementations must apply the operations atomically. If the method
@@ -19,7 +21,7 @@ pub trait SecretsController: Send {
     ///
     /// Implementations are permitted to reject combinations of operations which
     /// they cannot apply atomically.
-    fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), anyhow::Error>;
+    async fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), anyhow::Error>;
 }
 
 /// An operation on a [`SecretsController`].


### PR DESCRIPTION
Continued work on Secrets. This PR adds the Kubernetes SecretsController which creates/updates secrets in Kubernetes. The secret is currently not mounted on any pods.

The name of the secret is hard-coded and well-known.

### Motivation

This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

