### PR TITLE
mzcompose: Update Redpanda to v21.11.13

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -221,7 +221,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v21.11.12",
+        version: str = "v21.11.13",
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         ports: Optional[List[int]] = None,

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -103,9 +103,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 def workflow_testdrive_redpanda_ci(c: Composition) -> None:
     """Run testdrive against files known to be supported by Redpanda."""
 
-    # https://github.com/vectorizedio/redpanda/issues/2397
-    KNOWN_FAILURES = {"kafka-time-offset.td"}
-
     files = set(
         # NOTE(benesch): invoking the shell like this to filter testdrive files is
         # pretty gross. Let's not get into the habit of using this construction.
@@ -113,5 +110,4 @@ def workflow_testdrive_redpanda_ci(c: Composition) -> None:
             ["sh", "-c", "grep -lr '\$.*kafka-ingest' *.td"], cwd=Path(__file__).parent
         ).split()
     )
-    files -= KNOWN_FAILURES
     c.workflow("default", "--redpanda", *files)


### PR DESCRIPTION
### Motivation

* Redpanda now [correctly supports kafka-time-offset](https://github.com/vectorizedio/redpanda/issues/2397)

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

  - Redpanda now [correctly supports kafka-time-offset](https://github.com/vectorizedio/redpanda/issues/2397)
