### PR TITLE
coord,materialized: allow executing DDL via SQL HTTP API

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -303,10 +303,29 @@ pub struct SimpleExecuteResponse {
     pub results: Vec<SimpleResult>,
 }
 
+/// The result of a single query executed with `simple_execute`.
 #[derive(Debug, Serialize)]
-pub struct SimpleResult {
-    pub rows: Vec<Vec<serde_json::Value>>,
-    pub col_names: Vec<String>,
+#[serde(untagged)]
+pub enum SimpleResult {
+    /// The query returned rows.
+    Rows {
+        /// The result rows.
+        rows: Vec<Vec<serde_json::Value>>,
+        /// The name of the columns in the row.
+        col_names: Vec<String>,
+    },
+    /// The query executed successfully but did not return rows.
+    Ok,
+    /// The query returned an error.
+    Err { error: String },
+}
+
+impl SimpleResult {
+    pub(crate) fn err(msg: impl fmt::Display) -> SimpleResult {
+        SimpleResult::Err {
+            error: msg.to_string(),
+        }
+    }
 }
 
 /// The state of a cancellation request.


### PR DESCRIPTION
The SQL HTTP API previously silently discarded non-`SELECT` statement
types. (Even worse, it often silently executed those statements and then
produced an error.)

This commit jams in support for all DDL statements to unblock our cloud
web UI. Someone should take a more principled look at this API soon, but
this should be good enough for the short term.

Fix #11938.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
