### PR TITLE
clear durability frontier on source drop

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -233,7 +233,10 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                         self.storage_state.source_descriptions.remove(&id);
                         self.storage_state.source_uppers.remove(&id);
                         self.storage_state.reported_frontiers.remove(&id);
-                        self.storage_state.ts_histories.remove(&id);
+                        if let Some(history) = self.storage_state.ts_histories.remove(&id) {
+                            history.set_durability_frontier(Antichain::new().borrow());
+                        }
+
                         self.storage_state.ts_source_mapping.remove(&id);
                     } else {
                         if let Some(ts_history) = self.storage_state.ts_histories.get_mut(&id) {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The `SourceToken`'s created by `import_source/create_source` are ultimately held in the `capture` timely operator: https://github.com/MaterializeInc/materialize/blob/98addedefc98dc91acf63fb61291456a71dc9072/src/storage/src/boundary/tcp_boundary.rs#L301-L311

Apparently, for those to be dropped, the `durability_capability` of the `source` operator needs to be exhausted (`advanced` to `&[]`. This capability, as far as I can tell, is derived from the `data` capability of the source, and can lag behind. 

Curiously, `SimpleSource` sources always advance this cap, and are correctly dropped when `DROP SOURCE` is used. `SourceReader` sources (the majority, including kafka), continue to advance the durability cap to the LAST `durability_frontier` of the timestamp binding box" https://github.com/MaterializeInc/materialize/blob/ff45f28e645b1aab8bba936f8887e38b2398d671/src/storage/src/source/mod.rs#L969-L970. This pr causes us to exhaust that frontier when we remove a source.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

I could be misunderstanding some subtle ordering issue here, and its unclear to me if advancing the durability frontier causes the system to make some sort of misguided claim that "the source is finished, forever". If that is the case, then we will likely need to change the `durability_frontier` api to return an `Option<Antichain<Timestamp>>` instead, to indicate that the current state of the source is "dead". However, this may not matter, as dropped sources have id's who are never reused, so in some sense, the entirety of the source _as we know it_  is durably persisted. One subtlety here is that sources can live and produce more data for a short time after they are dropped, as the system realizes they are dead (well, i may be wrong about this).

Separately, @petrosagg `ts_source_mapping` looks like it is NEVER read, and should probably be removed?

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

