### PR TITLE
Move `PostgresSourceReader` to `SourceReader` over `SimpleSource`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3229,6 +3229,7 @@ dependencies = [
  "serde_json",
  "timely",
  "tokio",
+ "tokio-postgres",
  "tokio-serde",
  "tokio-stream",
  "tokio-util 0.7.2",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -44,6 +44,7 @@ tokio = "1.18.2"
 tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-stream = " 0.1.8"
 tokio-util = { version = "0.7.2", features = ["codec"] }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 url = { version = "2.2.2", features = ["serde"] }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1784,12 +1784,12 @@ pub mod sources {
     #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
     pub enum SourceEnvelope {
         /// The most trivial version is `None`, which typically produces triples where the diff
-        /// is ALWAYS `1`
+        /// is `1`. However, some sources are able to produce values with more exotic diff's,
+        /// such as the posgres source. Currently, this is the only variant usable with
+        /// those sources.
         ///
         /// If the `KeyEnvelope` is present,
         /// include the key columns as an output column of the source with the given properties.
-        // TODO(guswynn): update `None` docs to describe `-1` diff case, when support for it is
-        // added for postgres sources.
         None(KeyEnvelope),
         /// `Debezium` avoids holding onto previously seen values by trusting the required
         /// `before` and `after` value fields coming from the upstream source.

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1612,6 +1612,16 @@ pub mod sources {
         }
     }
 
+    /// Convert from `PgLsn` to MzOffset
+    impl From<tokio_postgres::types::PgLsn> for MzOffset {
+        fn from(lsn: tokio_postgres::types::PgLsn) -> Self {
+            let lsn_as_u64: u64 = lsn.into();
+            MzOffset {
+                offset: lsn_as_u64.try_into().unwrap(),
+            }
+        }
+    }
+
     /// Which piece of metadata a column corresponds to
     #[derive(Arbitrary, Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
     pub enum IncludedColumnSource {

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -317,7 +317,15 @@ fn process_new_data(
             .entry(key);
 
         let new_entry = UpsertSourceData {
-            value: new_value.map(ResultExt::err_into),
+            value: new_value.map(ResultExt::err_into).map(|res| {
+                res.map(|(v, diff)| match diff {
+                    1 => v,
+                    _ => unreachable!(
+                        "Upsert should only be used with sources \
+                                        with no explicit diff"
+                    ),
+                })
+            }),
             position: new_position,
             // upsert sources don't have a column for this, so setting it to
             // `None` is fine.

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -33,7 +33,9 @@ use mz_kafka_util::{client::create_new_client_config, client::MzClientContext, K
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
 use mz_repr::{adt::jsonb::Jsonb, GlobalId};
 
-use crate::source::{NextMessage, SourceMessage, SourceReader, SourceReaderError};
+use crate::source::{
+    NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
+};
 
 use self::metrics::KafkaPartitionMetrics;
 
@@ -490,7 +492,7 @@ impl KafkaSourceReader {
             NextMessage::TransientDelay
         } else {
             *last_offset_ref = offset;
-            NextMessage::Ready(message)
+            NextMessage::Ready(SourceMessageType::Finalized(message))
         }
     }
 }

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -56,7 +56,7 @@ pub struct KinesisSourceReader {
     /// TODO(natacha): this should be moved to timestamper
     last_checked_shards: Instant,
     /// Storage for messages that have not yet been timestamped
-    buffered_messages: VecDeque<SourceMessage<(), Option<Vec<u8>>>>,
+    buffered_messages: VecDeque<SourceMessage<(), Option<Vec<u8>>, ()>>,
     /// Count of processed message
     processed_message_count: i64,
     /// Metrics from which per-shard metrics get created.
@@ -121,6 +121,7 @@ impl KinesisSourceReader {
 impl SourceReader for KinesisSourceReader {
     type Key = ();
     type Value = Option<Vec<u8>>;
+    type Diff = ();
 
     fn new(
         _source_name: String,
@@ -161,7 +162,7 @@ impl SourceReader for KinesisSourceReader {
     }
     fn get_next_message(
         &mut self,
-    ) -> Result<NextMessage<Self::Key, Self::Value>, SourceReaderError> {
+    ) -> Result<NextMessage<Self::Key, Self::Value, Self::Diff>, SourceReaderError> {
         assert_eq!(self.shard_queue.len(), self.shard_set.len());
 
         //TODO move to timestamper
@@ -250,6 +251,7 @@ impl SourceReader for KinesisSourceReader {
                             key: (),
                             value: Some(data),
                             headers: None,
+                            specific_diff: (),
                         };
                         self.buffered_messages.push_back(source_message);
                     }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -13,43 +13,41 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, bail};
-use async_trait::async_trait;
-use futures::{pin_mut, StreamExt, TryStreamExt};
+use futures::{pin_mut, FutureExt, StreamExt, TryStreamExt};
 use mz_postgres_util::TableInfo;
 use once_cell::sync::Lazy;
 use postgres_protocol::message::backend::{
     LogicalReplicationMessage, ReplicationMessage, TupleData,
 };
+use timely::scheduling::SyncActivator;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::runtime::Handle;
+use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_postgres::error::{DbError, Severity, SqlState};
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
 use tokio_postgres::SimpleQueryMessage;
 use tracing::{error, info, warn};
 
-use crate::source::{SimpleSource, SourceError, SourceTransaction, Timestamper};
 use mz_dataflow_types::postgres_source::PostgresTable;
-use mz_dataflow_types::{sources::PostgresSourceConnector, SourceErrorDetails};
-use mz_repr::{Datum, GlobalId, Row};
+use mz_dataflow_types::sources::{
+    encoding::SourceDataEncoding, ExternalSourceConnector, MzOffset, PostgresSourceConnector,
+};
+use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::SourceErrorDetails;
+use mz_expr::PartitionId;
+use mz_ore::task;
+use mz_repr::{Datum, Diff, GlobalId, Row};
 
 use self::metrics::PgSourceMetrics;
 use super::metrics::SourceBaseMetrics;
+use crate::source::{
+    NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
+};
 
 mod metrics;
 
 /// Postgres epoch is 2000-01-01T00:00:00Z
 static PG_EPOCH: Lazy<SystemTime> = Lazy::new(|| UNIX_EPOCH + Duration::from_secs(946_684_800));
-
-/// Information required to sync data from Postgres
-pub struct PostgresSourceReader {
-    source_id: GlobalId,
-    connector: PostgresSourceConnector,
-    /// Our cursor into the WAL
-    lsn: PgLsn,
-    metrics: PgSourceMetrics,
-    source_tables: HashMap<u32, PostgresTable>,
-}
 
 trait ErrorExt {
     fn is_recoverable(&self) -> bool;
@@ -128,15 +126,67 @@ macro_rules! try_recoverable {
     };
 }
 
-impl PostgresSourceReader {
-    /// Constructs a new instance
-    pub fn new(
+// Message used to communicate between `get_next_message` and the tokio task
+enum InternalMessage {
+    Err(SourceReaderError),
+    Value {
+        value: Row,
+        lsn: PgLsn,
+        diff: Diff,
+        end: bool,
+    },
+}
+
+/// Information required to sync data from Postgres
+pub struct PostgresSourceReader {
+    receiver_stream: Receiver<InternalMessage>,
+}
+
+/// An internal struct held by the spawned tokio task
+struct PostgresTaskInfo {
+    source_id: GlobalId,
+    connector: PostgresSourceConnector,
+    /// Our cursor into the WAL
+    lsn: PgLsn,
+    metrics: PgSourceMetrics,
+    source_tables: HashMap<u32, PostgresTable>,
+    sender: Sender<InternalMessage>,
+    activator: SyncActivator,
+}
+
+impl SourceReader for PostgresSourceReader {
+    type Key = ();
+    type Value = Row;
+    // Postgres can produce deletes that cause retractions
+    type Diff = Diff;
+
+    fn new(
+        _source_name: String,
         source_id: GlobalId,
-        connector: PostgresSourceConnector,
-        metrics: &SourceBaseMetrics,
-    ) -> Self {
-        Self {
-            source_id,
+        _worker_id: usize,
+        _worker_count: usize,
+        consumer_activator: SyncActivator,
+        connector: ExternalSourceConnector,
+        _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
+        _encoding: SourceDataEncoding,
+        metrics: SourceBaseMetrics,
+        _connector_context: ConnectorContext,
+    ) -> Result<Self, anyhow::Error> {
+        let connector = match connector {
+            ExternalSourceConnector::Postgres(pg) => pg,
+            _ => {
+                panic!("Postgres is the only legitimate ExternalSourceConnector for PostgresSourceReader")
+            }
+        };
+
+        let (dataflow_tx, dataflow_rx) = tokio::sync::mpsc::channel(10_000);
+
+        let task_info = PostgresTaskInfo {
+            source_id: source_id.clone(),
+            connector: connector.clone(),
+            /// Our cursor into the WAL
+            lsn: 0.into(),
+            metrics: PgSourceMetrics::new(&metrics, source_id),
             source_tables: HashMap::from_iter(
                 connector
                     .details
@@ -144,12 +194,226 @@ impl PostgresSourceReader {
                     .iter()
                     .map(|t| (t.relation_id, t.clone())),
             ),
-            connector,
-            lsn: 0.into(),
-            metrics: PgSourceMetrics::new(metrics, source_id),
-        }
+            sender: dataflow_tx,
+            activator: consumer_activator,
+        };
+
+        task::spawn(
+            || format!("postgres_source:{}", source_id),
+            postgres_replication_loop(task_info),
+        );
+        Ok(Self {
+            receiver_stream: dataflow_rx,
+        })
     }
 
+    // TODO(guswynn): use `next` instead of using a channel
+    fn get_next_message(
+        &mut self,
+    ) -> Result<NextMessage<Self::Key, Self::Value, Self::Diff>, SourceReaderError> {
+        // TODO(guswynn): consider if `try_recv` is better or the same as `now_or_never`
+        let ret = match self.receiver_stream.recv().now_or_never() {
+            Some(Some(InternalMessage::Value {
+                value,
+                diff,
+                lsn,
+                end,
+            })) => {
+                let offset: u64 = lsn.into();
+                if end {
+                    Ok(NextMessage::Ready(SourceMessageType::Finalized(
+                        SourceMessage {
+                            partition: PartitionId::None,
+                            offset: MzOffset {
+                                offset: offset.try_into().unwrap(),
+                            },
+                            upstream_time_millis: None,
+                            key: (),
+                            value,
+                            headers: None,
+                            specific_diff: diff,
+                        },
+                    )))
+                } else {
+                    Ok(NextMessage::Ready(SourceMessageType::InProgress(
+                        SourceMessage {
+                            partition: PartitionId::None,
+                            offset: MzOffset {
+                                offset: offset.try_into().unwrap(),
+                            },
+                            upstream_time_millis: None,
+                            key: (),
+                            value,
+                            headers: None,
+                            specific_diff: diff,
+                        },
+                    )))
+                }
+            }
+            Some(Some(InternalMessage::Err(e))) => Err(e),
+            None => Ok(NextMessage::Pending),
+            Some(None) => Ok(NextMessage::Finished),
+        };
+
+        ret
+    }
+}
+
+/// Defers to `postgres_replication_loop_inner` and sends errors through the channel if they occur
+async fn postgres_replication_loop(mut task_info: PostgresTaskInfo) {
+    match postgres_replication_loop_inner(&mut task_info).await {
+        Ok(()) => {}
+        Err(e) => {
+            // Drop the send error, as we have no way of communicating back to the
+            // source operator if the channel is gone.
+            let _ = task_info.sender.send(InternalMessage::Err(e)).await;
+            task_info
+                .activator
+                .activate()
+                .expect("postgres reader activation failed");
+        }
+    }
+}
+
+/// Core logic
+async fn postgres_replication_loop_inner(
+    task_info: &mut PostgresTaskInfo,
+) -> Result<(), SourceReaderError> {
+    let source_id = task_info.source_id.clone();
+    // Buffer rows from snapshot to retract and retry, if initial snapshot fails.
+    // Postgres sources cannot proceed without a successful snapshot.
+    let mut snapshot_tx = Transaction::new();
+    loop {
+        let file =
+            tokio::fs::File::from_std(tempfile::tempfile().map_err(|e| SourceReaderError {
+                inner: SourceErrorDetails::FileIO(e.to_string()),
+            })?);
+        let mut writer = tokio::io::BufWriter::new(file);
+        match task_info
+            .produce_snapshot(&mut snapshot_tx, &mut writer)
+            .await
+        {
+            Ok(_) => {
+                info!(
+                    "replication snapshot for source {} succeeded",
+                    &task_info.source_id
+                );
+                snapshot_tx
+                    .close(task_info.lsn, &task_info.sender, &task_info.activator)
+                    .await;
+                break;
+            }
+            Err(ReplicationError::Recoverable(e)) => {
+                writer.flush().await.map_err(|e| SourceReaderError {
+                    inner: SourceErrorDetails::Initialization(e.to_string()),
+                })?;
+                warn!(
+                    "replication snapshot for source {} failed, retrying: {}",
+                    &task_info.source_id, e
+                );
+                let reader = BufReader::new(writer.into_inner().into_std().await);
+                let res = PostgresTaskInfo::revert_snapshot(&mut snapshot_tx, reader)
+                    .await
+                    .map_err(|e| SourceReaderError {
+                        inner: SourceErrorDetails::FileIO(e.to_string()),
+                    });
+                snapshot_tx
+                    .close(task_info.lsn, &task_info.sender, &task_info.activator)
+                    .await;
+
+                res?;
+            }
+            Err(ReplicationError::Fatal(e)) => {
+                return Err(SourceReaderError {
+                    inner: SourceErrorDetails::Initialization(e.to_string()),
+                })
+            }
+        }
+
+        // TODO(petrosagg): implement exponential back-off
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+
+    loop {
+        match task_info.produce_replication().await {
+            Err(ReplicationError::Recoverable(e)) => {
+                warn!(
+                    "replication for source {} interrupted, retrying: {}",
+                    source_id, e
+                )
+            }
+            Err(ReplicationError::Fatal(e)) => {
+                return Err(SourceReaderError {
+                    inner: SourceErrorDetails::FileIO(e.to_string()),
+                })
+            }
+            Ok(_) => {
+                // shutdown iniated elsewhere
+                return Ok(());
+            }
+        }
+
+        // TODO(petrosagg): implement exponential back-off
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        info!("resuming replication for source {}", source_id);
+    }
+}
+
+/// A helper struct build and produce transactions
+struct Transaction {
+    rows: Vec<(Row, Diff)>,
+}
+
+impl Transaction {
+    pub fn new() -> Self {
+        Transaction { rows: vec![] }
+    }
+
+    /// Record an insertion of a row in the current transaction
+    pub fn insert(&mut self, row: Row) {
+        self.rows.push((row, 1));
+    }
+
+    /// Record a deletion of a row in the current transaction
+    pub fn delete(&mut self, row: Row) {
+        self.rows.push((row, -1));
+    }
+
+    /// Finalize a transaction and send it off through the channel
+    ///
+    /// Care must be taken to ALWAYS call this if inserts/deletes have occurred,
+    /// unless you are on an early-exit error path, and the `PostgresSourceReader`
+    /// is shutting down.
+    pub async fn close(
+        &mut self,
+        lsn: PgLsn,
+        sender: &Sender<InternalMessage>,
+        activator: &SyncActivator,
+    ) {
+        let num = self.rows.len();
+        for (i, (row, diff)) in self.rows.drain(..).enumerate() {
+            // a closed receiver means the source has been shutdown
+            // (dropped or the process is dying), so just continue on
+            // without activation
+            if let Ok(_) = sender
+                .send(InternalMessage::Value {
+                    value: row,
+                    lsn,
+                    diff,
+                    end: i == (num - 1),
+                })
+                .await
+            {
+                activator
+                    .activate()
+                    .expect("postgres reader activation failed");
+            }
+        }
+    }
+}
+
+// implement the core pg logic in this impl block
+impl PostgresTaskInfo {
     /// Validates that all expected tables exist in the publication tables and they have the same schema
     fn validate_tables(&self, tables: Vec<TableInfo>) -> Result<(), anyhow::Error> {
         let pub_tables: HashMap<u32, PostgresTable> = tables
@@ -186,7 +450,7 @@ impl PostgresSourceReader {
     /// the LSN at which we should start the replication stream at.
     async fn produce_snapshot<W: AsyncWrite + Unpin>(
         &mut self,
-        snapshot_tx: &mut SourceTransaction<'_>,
+        snapshot_tx: &mut Transaction,
         buffer: &mut W,
     ) -> Result<(), ReplicationError> {
         let client =
@@ -278,7 +542,7 @@ impl PostgresSourceReader {
                     }
                     Ok(())
                 }));
-                try_recoverable!(snapshot_tx.insert(mz_row.clone()).await);
+                snapshot_tx.insert(mz_row.clone());
                 try_fatal!(
                     buffer
                         .write_all(&try_fatal!(bincode::serialize(&mz_row)))
@@ -295,18 +559,16 @@ impl PostgresSourceReader {
 
     /// Reverts a failed snapshot by deleting any processed rows from the dataflow.
     async fn revert_snapshot<R: Read + Seek>(
-        &self,
-        snapshot_tx: &mut SourceTransaction<'_>,
+        snapshot_tx: &mut Transaction,
         mut reader: R,
     ) -> Result<(), anyhow::Error> {
         tokio::task::block_in_place(|| -> Result<(), anyhow::Error> {
             let len = reader.seek(SeekFrom::Current(0))?;
             reader.seek(SeekFrom::Start(0))?;
             let mut reader = reader.take(len);
-            let handle = Handle::current();
             while reader.limit() > 0 {
                 let row = bincode::deserialize_from(&mut reader)?;
-                handle.block_on(snapshot_tx.delete(row))?;
+                snapshot_tx.delete(row);
             }
             Ok(())
         })
@@ -318,7 +580,7 @@ impl PostgresSourceReader {
     ///
     /// The `old_tuple` argument can be used as a source of data to use when encountering unchanged
     /// TOAST values.
-    fn row_from_tuple<'a, T>(&mut self, rel_id: u32, tuple_data: T) -> Result<Row, anyhow::Error>
+    fn row_from_tuple<'a, T>(rel_id: u32, tuple_data: T) -> Result<Row, anyhow::Error>
     where
         T: IntoIterator<Item = &'a TupleData>,
     {
@@ -346,10 +608,7 @@ impl PostgresSourceReader {
         Ok(row)
     }
 
-    async fn produce_replication(
-        &mut self,
-        timestamper: &Timestamper,
-    ) -> Result<(), ReplicationError> {
+    async fn produce_replication(&mut self) -> Result<(), ReplicationError> {
         use ReplicationError::*;
 
         let client =
@@ -370,272 +629,218 @@ impl PostgresSourceReader {
         let mut last_keepalive = Instant::now();
         let mut inserts = vec![];
         let mut deletes = vec![];
-        while let Some(item) = stream.try_next().await? {
-            use ReplicationMessage::*;
-            // The upstream will periodically request keepalive responses by setting the reply field
-            // to 1. However, we cannot rely on these messages arriving on time. For example, when
-            // the upstream is sending a big transaction its keepalive messages are queued and can
-            // be delayed arbitrarily.  Therefore, we also make sure to send a proactive keepalive
-            // every 30 seconds.
-            //
-            // See: https://www.postgresql.org/message-id/CAMsr+YE2dSfHVr7iEv1GSPZihitWX-PMkD9QALEGcTYa+sdsgg@mail.gmail.com
-            if matches!(item, PrimaryKeepAlive(ref k) if k.reply() == 1)
-                || last_keepalive.elapsed() > Duration::from_secs(30)
-            {
-                let ts: i64 = PG_EPOCH
-                    .elapsed()
-                    .expect("system clock set earlier than year 2000!")
-                    .as_micros()
-                    .try_into()
-                    .expect("software more than 200k years old, consider updating");
-
-                try_recoverable!(
-                    stream
-                        .as_mut()
-                        .standby_status_update(self.lsn, self.lsn, self.lsn, ts, 0)
-                        .await
-                );
-                last_keepalive = Instant::now();
-            }
-            match item {
-                XLogData(xlog_data) => {
-                    self.metrics.total.inc();
-                    use LogicalReplicationMessage::*;
-
-                    match xlog_data.data() {
-                        Begin(_) => {
-                            if !inserts.is_empty() || !deletes.is_empty() {
-                                return Err(Fatal(anyhow!(
-                                    "got BEGIN statement after uncommitted data"
-                                )));
-                            }
-                        }
-                        Insert(insert) => {
-                            self.metrics.inserts.inc();
-                            let rel_id = insert.rel_id();
-                            if !self.source_tables.contains_key(&rel_id) {
-                                continue;
-                            }
-                            let new_tuple = insert.tuple().tuple_data();
-                            let row = try_fatal!(self.row_from_tuple(rel_id, new_tuple));
-                            inserts.push(row);
-                        }
-                        Update(update) => {
-                            self.metrics.updates.inc();
-                            let rel_id = update.rel_id();
-                            if !self.source_tables.contains_key(&rel_id) {
-                                continue;
-                            }
-                            let old_tuple = try_fatal!(update
-                                .old_tuple()
-                                .ok_or_else(|| anyhow!("Old row missing from replication stream for table with OID = {}. \
-                                        Did you forget to set REPLICA IDENTITY to FULL for your table?", rel_id)))
-                            .tuple_data();
-                            let old_row = try_fatal!(self.row_from_tuple(rel_id, old_tuple));
-                            deletes.push(old_row);
-
-                            // If the new tuple contains unchanged toast values, reuse the ones
-                            // from the old tuple
-                            let new_tuple = update
-                                .new_tuple()
-                                .tuple_data()
-                                .iter()
-                                .zip(old_tuple.iter())
-                                .map(|(new, old)| match new {
-                                    TupleData::UnchangedToast => old,
-                                    _ => new,
-                                });
-                            let new_row = try_fatal!(self.row_from_tuple(rel_id, new_tuple));
-                            inserts.push(new_row);
-                        }
-                        Delete(delete) => {
-                            self.metrics.deletes.inc();
-                            let rel_id = delete.rel_id();
-                            if !self.source_tables.contains_key(&rel_id) {
-                                continue;
-                            }
-                            let old_tuple = try_fatal!(delete
-                                .old_tuple()
-                                .ok_or_else(|| anyhow!("Old row missing from replication stream for table with OID = {}. \
-                                        Did you forget to set REPLICA IDENTITY to FULL for your table?", rel_id)))
-                            .tuple_data();
-                            let row = try_fatal!(self.row_from_tuple(rel_id, old_tuple));
-                            deletes.push(row);
-                        }
-                        Commit(commit) => {
-                            self.metrics.transactions.inc();
-                            self.lsn = commit.end_lsn().into();
-
-                            let tx = timestamper.start_tx().await;
-
-                            for row in deletes.drain(..) {
-                                try_fatal!(tx.delete(row).await);
-                            }
-                            for row in inserts.drain(..) {
-                                try_fatal!(tx.insert(row).await);
-                            }
-                            self.metrics.lsn.set(self.lsn.into());
-                        }
-                        Relation(relation) => {
-                            let rel_id = relation.rel_id();
-                            match self.source_tables.get(&rel_id) {
-                                Some(source_table) => {
-                                    // Start with the cheapest check first, this will catch the majority of alters
-                                    if source_table.columns.len() != relation.columns().len() {
-                                        error!(
-                                            "alter table detected on {} with id {}",
-                                            source_table.name, source_table.relation_id
-                                        );
-                                        return Err(Fatal(anyhow!(
-                                            "source table {} with oid {} has been altered",
-                                            source_table.name,
-                                            source_table.relation_id
-                                        )));
-                                    }
-                                    if source_table.name.ne(relation.name().unwrap())
-                                        || source_table.namespace.ne(relation.namespace().unwrap())
-                                    {
-                                        error!(
-                                            "table name changed on {}.{} with id {} to {}.{}",
-                                            source_table.namespace,
-                                            source_table.name,
-                                            source_table.relation_id,
-                                            relation.namespace().unwrap(),
-                                            relation.name().unwrap()
-                                        );
-                                        return Err(Fatal(anyhow!(
-                                            "source table {} with oid {} has been altered",
-                                            source_table.name,
-                                            source_table.relation_id
-                                        )));
-                                    }
-                                    // Relation messages do not include nullability/primary_key data
-                                    // so we check the name, type_oid, and type_mod explicitly and error if any of them differ
-                                    if !source_table.columns.iter().zip(relation.columns()).all(
-                                        |(src, rel)| {
-                                            src.name == rel.name().unwrap()
-                                                && src.type_oid == rel.type_id()
-                                                && src.type_mod == rel.type_modifier()
-                                        },
-                                    ) {
-                                        error!("alter table error: name {}, oid {}, old_schema {:?}, new_schema {:?}", source_table.name, source_table.relation_id, source_table.columns, relation.columns());
-                                        return Err(Fatal(anyhow!(
-                                            "source table {} with oid {} has been altered",
-                                            source_table.name,
-                                            source_table.relation_id
-                                        )));
-                                    }
-                                }
-                                // Ignore messages for tables we do not know about
-                                None => continue,
-                            }
-                        }
-                        Origin(_) | Type(_) => {
-                            self.metrics.ignored.inc();
-                        }
-                        Truncate(truncate) => {
-                            let tables = truncate
-                                .rel_ids()
-                                .iter()
-                                // Filter here makes option handling in map "safe"
-                                .filter_map(|id| self.source_tables.get(&id))
-                                .map(|table| {
-                                    format!("name: {} id: {}", table.name, table.relation_id)
-                                })
-                                .collect::<Vec<String>>();
-                            return Err(Fatal(anyhow!(
-                                "source table(s) {} got truncated",
-                                tables.join(", ")
-                            )));
-                        }
-                        // The enum is marked as non_exhaustive. Better to be conservative here in
-                        // case a new message is relevant to the semantics of our source
-                        _ => return Err(Fatal(anyhow!("unexpected logical replication message"))),
-                    }
-                }
-                // Handled above
-                PrimaryKeepAlive(_) => {}
-                // The enum is marked non_exhaustive, better be conservative
-                _ => return Err(Fatal(anyhow!("Unexpected replication message"))),
-            }
-        }
-        Err(Recoverable(anyhow!("replication stream ended")))
-    }
-}
-
-#[async_trait]
-impl SimpleSource for PostgresSourceReader {
-    /// The top-level control of the state machine and retry logic
-    async fn start(mut self, timestamper: &Timestamper) -> Result<(), SourceError> {
-        // Buffer rows from snapshot to retract and retry, if initial snapshot fails.
-        // Postgres sources cannot proceed without a successful snapshot.
-        {
-            let mut snapshot_tx = timestamper.start_tx().await;
-            loop {
-                let file =
-                    tokio::fs::File::from_std(tempfile::tempfile().map_err(|e| SourceError {
-                        source_id: self.source_id,
-                        error: SourceErrorDetails::FileIO(e.to_string()),
-                    })?);
-                let mut writer = tokio::io::BufWriter::new(file);
-                match self.produce_snapshot(&mut snapshot_tx, &mut writer).await {
-                    Ok(_) => {
-                        info!(
-                            "replication snapshot for source {} succeeded",
-                            &self.source_id
-                        );
-                        break;
-                    }
-                    Err(ReplicationError::Recoverable(e)) => {
-                        writer.flush().await.map_err(|e| SourceError {
-                            source_id: self.source_id,
-                            error: SourceErrorDetails::Initialization(e.to_string()),
-                        })?;
-                        warn!(
-                            "replication snapshot for source {} failed, retrying: {}",
-                            &self.source_id, e
-                        );
-                        let reader = BufReader::new(writer.into_inner().into_std().await);
-                        self.revert_snapshot(&mut snapshot_tx, reader)
-                            .await
-                            .map_err(|e| SourceError {
-                                source_id: self.source_id,
-                                error: SourceErrorDetails::FileIO(e.to_string()),
-                            })?;
-                    }
-                    Err(ReplicationError::Fatal(e)) => {
-                        return Err(SourceError {
-                            source_id: self.source_id,
-                            error: SourceErrorDetails::Initialization(e.to_string()),
-                        })
-                    }
-                }
-
-                // TODO(petrosagg): implement exponential back-off
-                tokio::time::sleep(Duration::from_secs(3)).await;
-            }
-        }
-
+        let closer = self.sender.clone();
         loop {
-            match self.produce_replication(timestamper).await {
-                Err(ReplicationError::Recoverable(e)) => {
-                    warn!(
-                        "replication for source {} interrupted, retrying: {}",
-                        self.source_id, e
-                    )
-                }
-                Err(ReplicationError::Fatal(e)) => {
-                    return Err(SourceError {
-                        source_id: self.source_id,
-                        error: SourceErrorDetails::FileIO(e.to_string()),
-                    })
-                }
-                Ok(_) => unreachable!("replication stream cannot exit without an error"),
-            }
+            // This select is safe because `Sender::closed` is cancel-safe
+            // and when `closed` finishes, dropping the `try_next` future is fine,
+            // as we are shutting down and don't have any control over whether we
+            // would have seen the next item or not. Additionally, `try_next`
+            // just holds a reference to the stream, so it is cancel-safe.
+            //
+            // TODO(guswynn): avoid this select! complexity by just moving to `SourceReader::next`
+            tokio::select! {
+                biased;
+                _ = closer.closed() => {
+                    return Ok(())
+                },
+                item = stream.try_next() => {
+                    if let Some(item) = item? {
+                        use ReplicationMessage::*;
+                        // The upstream will periodically request keepalive responses by setting the reply field
+                        // to 1. However, we cannot rely on these messages arriving on time. For example, when
+                        // the upstream is sending a big transaction its keepalive messages are queued and can
+                        // be delayed arbitrarily.  Therefore, we also make sure to send a proactive keepalive
+                        // every 30 seconds.
+                        //
+                        // See: https://www.postgresql.org/message-id/CAMsr+YE2dSfHVr7iEv1GSPZihitWX-PMkD9QALEGcTYa+sdsgg@mail.gmail.com
+                        if matches!(item, PrimaryKeepAlive(ref k) if k.reply() == 1)
+                            || last_keepalive.elapsed() > Duration::from_secs(30)
+                        {
+                            let ts: i64 = PG_EPOCH
+                                .elapsed()
+                                .expect("system clock set earlier than year 2000!")
+                                .as_micros()
+                                .try_into()
+                                .expect("software more than 200k years old, consider updating");
 
-            // TODO(petrosagg): implement exponential back-off
-            tokio::time::sleep(Duration::from_secs(3)).await;
-            info!("resuming replication for source {}", self.source_id);
+                            try_recoverable!(
+                                stream
+                                    .as_mut()
+                                    .standby_status_update(self.lsn, self.lsn, self.lsn, ts, 0)
+                                    .await
+                            );
+                            last_keepalive = Instant::now();
+                        }
+                        match item {
+                            XLogData(xlog_data) => {
+                                self.metrics.total.inc();
+                                use LogicalReplicationMessage::*;
+
+                                match xlog_data.data() {
+                                    Begin(_) => {
+                                        if !inserts.is_empty() || !deletes.is_empty() {
+                                            return Err(Fatal(anyhow!(
+                                                "got BEGIN statement after uncommitted data"
+                                            )));
+                                        }
+                                    }
+                                    Insert(insert) => {
+                                        self.metrics.inserts.inc();
+                                        let rel_id = insert.rel_id();
+                                        if !self.source_tables.contains_key(&rel_id) {
+                                            continue;
+                                        }
+                                        let new_tuple = insert.tuple().tuple_data();
+                                        let row = try_fatal!(PostgresTaskInfo::row_from_tuple(rel_id, new_tuple));
+                                        inserts.push(row);
+                                    }
+                                    Update(update) => {
+                                        self.metrics.updates.inc();
+                                        let rel_id = update.rel_id();
+                                        if !self.source_tables.contains_key(&rel_id) {
+                                            continue;
+                                        }
+                                        let old_tuple = try_fatal!(update
+                                            .old_tuple()
+                                            .ok_or_else(|| anyhow!("Old row missing from replication stream for table with OID = {}. \
+                                                    Did you forget to set REPLICA IDENTITY to FULL for your table?", rel_id)))
+                                        .tuple_data();
+                                        let old_row =
+                                            try_fatal!(PostgresTaskInfo::row_from_tuple(rel_id, old_tuple));
+                                        deletes.push(old_row);
+
+                                        // If the new tuple contains unchanged toast values, reuse the ones
+                                        // from the old tuple
+                                        let new_tuple = update
+                                            .new_tuple()
+                                            .tuple_data()
+                                            .iter()
+                                            .zip(old_tuple.iter())
+                                            .map(|(new, old)| match new {
+                                                TupleData::UnchangedToast => old,
+                                                _ => new,
+                                            });
+                                        let new_row =
+                                            try_fatal!(PostgresTaskInfo::row_from_tuple(rel_id, new_tuple));
+                                        inserts.push(new_row);
+                                    }
+                                    Delete(delete) => {
+                                        self.metrics.deletes.inc();
+                                        let rel_id = delete.rel_id();
+                                        if !self.source_tables.contains_key(&rel_id) {
+                                            continue;
+                                        }
+                                        let old_tuple = try_fatal!(delete
+                                            .old_tuple()
+                                            .ok_or_else(|| anyhow!("Old row missing from replication stream for table with OID = {}. \
+                                                    Did you forget to set REPLICA IDENTITY to FULL for your table?", rel_id)))
+                                        .tuple_data();
+                                        let row = try_fatal!(PostgresTaskInfo::row_from_tuple(rel_id, old_tuple));
+                                        deletes.push(row);
+                                    }
+                                    Commit(commit) => {
+                                        self.metrics.transactions.inc();
+                                        self.lsn = commit.end_lsn().into();
+
+                                        let mut tx = Transaction::new();
+
+                                        for row in deletes.drain(..) {
+                                            tx.delete(row);
+                                        }
+                                        for row in inserts.drain(..) {
+                                            tx.insert(row);
+                                        }
+
+                                        tx.close(self.lsn, &self.sender, &self.activator).await;
+                                        self.metrics.lsn.set(self.lsn.into());
+                                    }
+                                    Relation(relation) => {
+                                        let rel_id = relation.rel_id();
+                                        match self.source_tables.get(&rel_id) {
+                                            Some(source_table) => {
+                                                // Start with the cheapest check first, this will catch the majority of alters
+                                                if source_table.columns.len() != relation.columns().len() {
+                                                    error!(
+                                                        "alter table detected on {} with id {}",
+                                                        source_table.name, source_table.relation_id
+                                                    );
+                                                    return Err(Fatal(anyhow!(
+                                                        "source table {} with oid {} has been altered",
+                                                        source_table.name,
+                                                        source_table.relation_id
+                                                    )));
+                                                }
+                                                if source_table.name.ne(relation.name().unwrap())
+                                                    || source_table.namespace.ne(relation.namespace().unwrap())
+                                                {
+                                                    error!(
+                                                        "table name changed on {}.{} with id {} to {}.{}",
+                                                        source_table.namespace,
+                                                        source_table.name,
+                                                        source_table.relation_id,
+                                                        relation.namespace().unwrap(),
+                                                        relation.name().unwrap()
+                                                    );
+                                                    return Err(Fatal(anyhow!(
+                                                        "source table {} with oid {} has been altered",
+                                                        source_table.name,
+                                                        source_table.relation_id
+                                                    )));
+                                                }
+                                                // Relation messages do not include nullability/primary_key data
+                                                // so we check the name, type_oid, and type_mod explicitly and error if any of them differ
+                                                if !source_table.columns.iter().zip(relation.columns()).all(
+                                                    |(src, rel)| {
+                                                        src.name == rel.name().unwrap()
+                                                            && src.type_oid == rel.type_id()
+                                                            && src.type_mod == rel.type_modifier()
+                                                    },
+                                                ) {
+                                                    error!("alter table error: name {}, oid {}, old_schema {:?}, new_schema {:?}", source_table.name, source_table.relation_id, source_table.columns, relation.columns());
+                                                    return Err(Fatal(anyhow!(
+                                                        "source table {} with oid {} has been altered",
+                                                        source_table.name,
+                                                        source_table.relation_id
+                                                    )));
+                                                }
+                                            }
+                                            // Ignore messages for tables we do not know about
+                                            None => continue,
+                                        }
+                                    }
+                                    Origin(_) | Type(_) => {
+                                        self.metrics.ignored.inc();
+                                    }
+                                    Truncate(truncate) => {
+                                        let tables = truncate
+                                            .rel_ids()
+                                            .iter()
+                                            // Filter here makes option handling in map "safe"
+                                            .filter_map(|id| self.source_tables.get(&id))
+                                            .map(|table| {
+                                                format!("name: {} id: {}", table.name, table.relation_id)
+                                            })
+                                            .collect::<Vec<String>>();
+                                        return Err(Fatal(anyhow!(
+                                            "source table(s) {} got truncated",
+                                            tables.join(", ")
+                                        )));
+                                    }
+                                    // The enum is marked as non_exhaustive. Better to be conservative here in
+                                    // case a new message is relevant to the semantics of our source
+                                    _ => return Err(Fatal(anyhow!("unexpected logical replication message"))),
+                                }
+                            }
+                            // Handled above
+                            PrimaryKeepAlive(_) => {}
+                            // The enum is marked non_exhaustive, better be conservative
+                            _ => return Err(Fatal(anyhow!("Unexpected replication message"))),
+                        }
+                    } else {
+                        return Err(Recoverable(anyhow!("replication stream ended")))
+                    }
+                }
+            }
         }
     }
 }

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -219,14 +219,11 @@ impl SourceReader for PostgresSourceReader {
                 lsn,
                 end,
             })) => {
-                let offset: u64 = lsn.into();
                 if end {
                     Ok(NextMessage::Ready(SourceMessageType::Finalized(
                         SourceMessage {
                             partition: PartitionId::None,
-                            offset: MzOffset {
-                                offset: offset.try_into().unwrap(),
-                            },
+                            offset: lsn.into(),
                             upstream_time_millis: None,
                             key: (),
                             value,
@@ -238,9 +235,7 @@ impl SourceReader for PostgresSourceReader {
                     Ok(NextMessage::Ready(SourceMessageType::InProgress(
                         SourceMessage {
                             partition: PartitionId::None,
-                            offset: MzOffset {
-                                offset: offset.try_into().unwrap(),
-                            },
+                            offset: lsn.into(),
                             upstream_time_millis: None,
                             key: (),
                             value,

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -22,7 +22,7 @@ use mz_dataflow_types::ConnectorContext;
 use mz_expr::PartitionId;
 use mz_repr::{Datum, GlobalId, Row};
 
-use crate::source::{SourceMessage, SourceReader, SourceReaderError};
+use crate::source::{SourceMessage, SourceMessageType, SourceReader, SourceReaderError};
 
 /// Information required to sync data from PubNub
 pub struct PubNubSourceReader {
@@ -84,7 +84,7 @@ impl SourceReader for PubNubSourceReader {
     async fn next(
         &mut self,
         timestamp_frequency: Duration,
-    ) -> Option<Result<SourceMessage<Self::Key, Self::Value>, SourceReaderError>> {
+    ) -> Option<Result<SourceMessageType<Self::Key, Self::Value>, SourceReaderError>> {
         loop {
             let stream = match &mut self.stream {
                 None => {
@@ -101,7 +101,7 @@ impl SourceReader for PubNubSourceReader {
 
                         let row = Row::pack_slice(&[Datum::String(&s)]);
 
-                        return Some(Ok(SourceMessage {
+                        return Some(Ok(SourceMessageType::Finalized(SourceMessage {
                             partition: PartitionId::None,
                             offset: MzOffset {
                                 // NOTE(guswynn):
@@ -122,7 +122,7 @@ impl SourceReader for PubNubSourceReader {
                             key: (),
                             value: row,
                             headers: None,
-                        }));
+                        })));
                     }
                 }
                 None => {

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -35,6 +35,7 @@ pub struct PubNubSourceReader {
 impl SourceReader for PubNubSourceReader {
     type Key = ();
     type Value = Row;
+    type Diff = ();
 
     fn new(
         _source_name: String,
@@ -84,7 +85,8 @@ impl SourceReader for PubNubSourceReader {
     async fn next(
         &mut self,
         timestamp_frequency: Duration,
-    ) -> Option<Result<SourceMessageType<Self::Key, Self::Value>, SourceReaderError>> {
+    ) -> Option<Result<SourceMessageType<Self::Key, Self::Value, Self::Diff>, SourceReaderError>>
+    {
         loop {
             let stream = match &mut self.stream {
                 None => {
@@ -122,6 +124,7 @@ impl SourceReader for PubNubSourceReader {
                             key: (),
                             value: row,
                             headers: None,
+                            specific_diff: (),
                         })));
                     }
                 }

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -784,6 +784,7 @@ where
 impl SourceReader for S3SourceReader {
     type Key = ();
     type Value = Option<Vec<u8>>;
+    type Diff = ();
 
     fn new(
         source_name: String,
@@ -882,7 +883,7 @@ impl SourceReader for S3SourceReader {
 
     fn get_next_message(
         &mut self,
-    ) -> Result<NextMessage<Self::Key, Self::Value>, SourceReaderError> {
+    ) -> Result<NextMessage<Self::Key, Self::Value, Self::Diff>, SourceReaderError> {
         match self.receiver_stream.recv().now_or_never() {
             Some(Some(Ok(InternalMessage { record }))) => {
                 self.offset += 1;
@@ -894,6 +895,7 @@ impl SourceReader for S3SourceReader {
                         key: (),
                         value: record,
                         headers: None,
+                        specific_diff: (),
                     },
                 )))
             }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -351,11 +351,7 @@ where
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
     for (source_id, source) in dataflow.source_imports.iter_mut() {
-        if let mz_dataflow_types::sources::SourceConnector::External {
-            envelope: mz_dataflow_types::sources::SourceEnvelope::None(_),
-            ..
-        } = source.description.connector
-        {
+        if source.description.connector.append_only() {
             monotonic.insert(source_id.clone());
         }
     }


### PR DESCRIPTION
Ultimately, I think we should not have multiple `Source` traits. This is the first such change for this: switching `Postgres` off of a `SimpleSource` to a full `SourceReader`. Note that this gives us timestamp bindings for pg for free!

This pr has several subtle parts:
- The first commit resolves an outstanding bug: `SourceReader` assumes that a message at some offset the last such message. Pg has transactions that happen at the same timestamp, so we need to support holding back a cursor to support this. This is quite subtle, and @petrosagg may be interested in looking closely
- The second commit adds support for sources that _retract_ (that is, dd diffs that ARENT `1`) values. This is to support both replication failure (causing a revert), and pg deletes. 
	- This pr uses new associated types to avoid unwraps as much as possible, but to keep `render_source` readable, forces a `diff` in the value in `DecodeResult`.
	-  We add `unreachable!` for not-possible `diff` values in envelopes that don't support esoteric diffs (namely, things other than `None`. Its not 100% clear to me if `KeyEnvelope::None` is the only supported `SourceEnvelope::None`, but the coden as-written does not deal with 
- The third commit actually moves pg to a `SourceReader`. As much code as possible is preserved, and I opted for the `get_next_message` route over `next`, as we can transform all sources at the same time
- The final commit ensures that pg sources are not considered monotonic. This appears to have already been an outstanding bug

### Motivation

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/materialize/issues/11899

### Tips for reviewer

I recommend reviewing the commits in this pr separately. 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
