### PR TITLE
ci/license: correct bump of copyright year

### DIFF
--- a/ci/license/bump-change-date.sh
+++ b/ci/license/bump-change-date.sh
@@ -30,7 +30,7 @@ git pull
 sed -Ei \
     -e "s/Licensed Work:.*/Licensed Work:             Materialize Version $version_date/g" \
     -e "s/Change Date:.*/Change Date:               $change_date/g" \
-    -e "s/The Licensed Work is ¬© [0-9]{4}/The Licensed Work is ¬© $year/g" \
+    -e "s/The Licensed Work is © [0-9]{4}/The Licensed Work is © $year/g" \
     LICENSE
 git add LICENSE
 git commit -m "LICENSE: update change date"


### PR DESCRIPTION
The script had a misplaced character that prevented correct updating of
the copyright year.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
