### PR TITLE
doc/developer: note that PubNub sources are reclockable

### DIFF
--- a/doc/developer/design/20220411_reclocking_implementation.md
+++ b/doc/developer/design/20220411_reclocking_implementation.md
@@ -23,16 +23,13 @@ reclocked mappings to end users.
 
 We define a **reclockable** source type as one where the upstream system
 provides a useful [gauge of progress](20210714_reclocking.md#description).
-The following source types are reclockable:
+At the time of writing, all source types are reclockable:
 
 * Kafka
 * Kinesis
 * PostgreSQL
-* S3
-
-The following sources types are nonreclockable:
-
 * PubNub
+* S3
 
 ### Storage layer implementation
 
@@ -52,6 +49,7 @@ The type of the `remap` collection depends on the source type:
 | Kafka       | `partition: i32`     | `offset_increment: i64`       |
 | Kinesis     | `shard: i64`         | `sequence_increment: numeric` |
 | PostgreSQL  | `ignored: ()`        | `lsn_increment: i64`          |
+| PubNub      | `region: u32`        | `timetoken_ns_increment: i64` |
 | S3          | `object_key: text`   | `byte_offset_increment: i64`  |
 
 The `remap` collection exists in the Materialize time domain, where a `u64`
@@ -194,6 +192,12 @@ type of the source:
   | mz_timestamp | lsn |
   |--------------|-----|
   | ...          | ... |
+
+* PubNub sources
+
+  | mz_timestamp | region | timetoken |
+  |--------------|--------|-----------|
+  | ...          | ...    | ...       |
 
 * S3 sources
 


### PR DESCRIPTION
After all this time believing that PubNub sources do not have an
upstream gauge of progress... it actually seems that they do. Each
PubNub message has a ["time token"](https://docs.rs/pubnub-hyper/latest/pubnub_hyper/core/data/timetoken/struct.Timetoken.html), which seems to have exactly the
right properties.

It's not possible to use this time token to seek through a PubNub stream
unless the stream has history enabled, but it should always be possible
to use this token to deduplicate messages. You might still miss
messages, but at least you won't duplicate them.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
