### PR TITLE
dataflow-types: maybe deflake Kafka resumption tests

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -254,7 +254,6 @@ where
     T: Timestamp + Lattice,
 {
     pub async fn recv(&mut self) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
-        let mut storage_alive = true;
         loop {
             let mut compute_stream: StreamMap<_, _> = self
                 .compute
@@ -301,7 +300,7 @@ where
                         }
                     }
                 }
-                response = self.storage_controller.recv(), if storage_alive => {
+                response = self.storage_controller.recv() => {
                     match response? {
                         Some(StorageResponse::TimestampBindings(feedback)) => {
                             // Order is important here. We must durably record
@@ -318,7 +317,7 @@ where
                         Some(StorageResponse::LinearizedTimestamps(res)) => {
                             return Ok(Some(ControllerResponse::LinearizedTimestamps(res)));
                         }
-                        None => storage_alive = false,
+                        None => (),
                     }
                 }
                 else => return Ok(None),


### PR DESCRIPTION
PR #11846 was the first PR to fail the Kafka resumption tests. On a
close look, it was accidentally behavior changing, in that a `None`
response from the storage instance caused further messages from the
storage instance to be ignored.

This commit restores the previous behavior in which a `None` response
from the storage layer is entirely ignored, and further `Some` responses
that may occur are processed. This seems in violation of the
documentation on how `recv` works (`None` indicates permanent shutdown),
but worth a shot.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR maybe fixes a recognized bug: #11920.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
