### PR TITLE
Fix soundness hole in QGM implementation

### DIFF
--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -75,11 +75,11 @@ pub struct Model {
     /// The ID of the box representing the entry-point of the query.
     pub(crate) top_box: BoxId,
     /// All boxes in the query graph model.
-    boxes: HashMap<BoxId, Box<RefCell<QueryBox>>>,
+    boxes: HashMap<BoxId, RefCell<QueryBox>>,
     /// Used for assigning unique IDs to query boxes.
     box_id_gen: Gen<BoxId>,
     /// All quantifiers in the query graph model.
-    quantifiers: HashMap<QuantifierId, Box<RefCell<Quantifier>>>,
+    quantifiers: HashMap<QuantifierId, RefCell<Quantifier>>,
     /// Used for assigning unique IDs to quantifiers.
     quantifier_id_gen: Gen<QuantifierId>,
 }
@@ -334,7 +334,7 @@ impl From<Values> for BoxType {
 impl Model {
     pub(crate) fn make_box(&mut self, box_type: BoxType) -> BoxId {
         let id = self.box_id_gen.allocate_id();
-        let b = Box::new(RefCell::new(QueryBox {
+        let b = RefCell::new(QueryBox {
             id,
             box_type,
             columns: Vec::new(),
@@ -342,7 +342,7 @@ impl Model {
             ranging_quantifiers: QuantifierSet::new(),
             distinct: DistinctOperation::Preserve,
             attributes: Attributes::new(),
-        }));
+        });
         self.boxes.insert(id, b);
         id
     }
@@ -397,13 +397,13 @@ impl Model {
         parent_box: BoxId,
     ) -> QuantifierId {
         let id = self.quantifier_id_gen.allocate_id();
-        let q = Box::new(RefCell::new(Quantifier {
+        let q = RefCell::new(Quantifier {
             id,
             quantifier_type,
             input_box,
             parent_box,
             alias: None,
-        }));
+        });
         self.quantifiers.insert(id, q);
         self.get_mut_box(parent_box).quantifiers.insert(id);
         self.get_mut_box(input_box).ranging_quantifiers.insert(id);
@@ -991,7 +991,7 @@ pub(crate) mod model_test_util {
 
     impl Model {
         /// Return an iterator over all quantifiers in the model
-        pub(crate) fn quantifiers(&self) -> impl Iterator<Item = &Box<RefCell<Quantifier>>> {
+        pub(crate) fn quantifiers(&self) -> impl Iterator<Item = &RefCell<Quantifier>> {
             self.quantifiers.values()
         }
     }

--- a/src/sql/src/query_model/model/graph.rs
+++ b/src/sql/src/query_model/model/graph.rs
@@ -104,7 +104,7 @@ impl<T> Deref for BoundRef<'_, T> {
 /// bound to a specific [`Model`].
 #[derive(Debug)]
 pub(crate) struct BoundRefMut<'a, T> {
-    model: &'a mut Model,
+    model: &'a Model,
     r#ref: RefMut<'a, T>,
 }
 
@@ -376,19 +376,16 @@ impl Model {
     }
 
     /// Get a mutable reference to the box identified by `box_id` bound to this [`Model`].
-    pub(crate) fn get_mut_box(&mut self, box_id: BoxId) -> BoundRefMut<'_, QueryBox> {
-        let model_ptr = self as *mut Self;
-        unsafe {
-            let reference = (*model_ptr)
-                .boxes
-                .get(&box_id)
-                .expect("a valid box identifier")
-                .borrow_mut();
+    pub(crate) fn get_mut_box(&self, box_id: BoxId) -> BoundRefMut<'_, QueryBox> {
+        let reference = self
+            .boxes
+            .get(&box_id)
+            .expect("a valid box identifier")
+            .borrow_mut();
 
-            BoundRefMut {
-                model: &mut *model_ptr,
-                r#ref: reference,
-            }
+        BoundRefMut {
+            model: self,
+            r#ref: reference,
         }
     }
 
@@ -433,18 +430,15 @@ impl Model {
         &'a mut self,
         quantifier_id: QuantifierId,
     ) -> BoundRefMut<'a, Quantifier> {
-        let model_ptr = self as *mut Self;
-        unsafe {
-            let reference = (*model_ptr)
-                .quantifiers
-                .get(&quantifier_id)
-                .expect("a valid quantifier identifier")
-                .borrow_mut();
+        let reference = self
+            .quantifiers
+            .get(&quantifier_id)
+            .expect("a valid quantifier identifier")
+            .borrow_mut();
 
-            BoundRefMut {
-                model: &mut *model_ptr,
-                r#ref: reference,
-            }
+        BoundRefMut {
+            model: self,
+            r#ref: reference,
         }
     }
 


### PR DESCRIPTION
### Motivation

The API exposed was previously unsound as it was possible through safe
use to obtain two aliasing &mut references to the Model

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

