### PR TITLE
doc/user: dev/stage/prod segment tag

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -65,35 +65,32 @@ addEventListener("DOMContentLoaded", () => {
   gtag('config', 'UA-138552650-1');
 </script>
 
-{{/* 6Sense */}}
-<script>
-  window._6si = window._6si || [];
-  window._6si.push(['enableEventTracking', true]);
-  window._6si.push(['setToken', 'c80e8f20a805b2c7e4a37b9d7d0b261d']);
-  window._6si.push(['setEndpoint', 'b.6sc.co']);
-
-  (function() {
-    var gd = document.createElement('script');
-    gd.type = 'text/javascript';
-    gd.async = true;
-    gd.src = '//j.6sc.co/6si.min.js';
-
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gd, s);
-  })();
-</script>
-
 {{/* Leadfeeder */}}
 <script> (function(){ window.ldfdr = window.ldfdr || {}; (function(d, s, ss, fs){ fs = d.getElementsByTagName(s)[0]; function ce(src){ var cs = d.createElement(s); cs.src = src; setTimeout(function(){fs.parentNode.insertBefore(cs,fs)}, 1); } ce(ss); })(document, 'script', 'https://sc.lfeeder.com/lftracker_v1_bElvO73R0rE8ZMqj.js'); })(); </script>
+{{end}}
 
 {{/* Segment */}}
 <script>
-  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m";analytics.SNIPPET_VERSION="4.13.2";
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};
+  {{ if in (printf "%s" .Site.BaseURL) "preview" }}
+  {{/* Stage */}}
+  analytics._writeKey="fuo8pqI0wvoojiShBQXSZopWLZggS8ny";;
+  analytics.SNIPPET_VERSION="4.15.3";
+  analytics.load("fuo8pqI0wvoojiShBQXSZopWLZggS8ny");
+  {{ else if hugo.IsProduction }}
+  {{/* Prod */}}
+  analytics._writeKey="NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m";;
+  analytics.SNIPPET_VERSION="4.15.3";
   analytics.load("NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m");
+  {{ else }}
+  {{/* Dev */}}
+  analytics._writeKey="dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk";;
+  analytics.SNIPPET_VERSION="4.15.3";
+  analytics.load("dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk");
+  {{ end }}
   analytics.page();
   }}();
 </script>
-{{end}}
 
 {{/* Tabs */}}
 <script>

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -72,15 +72,15 @@ addEventListener("DOMContentLoaded", () => {
 {{/* Segment */}}
 <script>
   !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.materialize.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.15.3";
-  {{ if in (printf "%s" .Site.BaseURL) "preview" }}
-    {{/* Stage */}}
-    analytics._writeKey="fuo8pqI0wvoojiShBQXSZopWLZggS8ny";
-    analytics.load("fuo8pqI0wvoojiShBQXSZopWLZggS8ny");
-  {{ else if hugo.IsProduction }}
-    {{/* Prod */}}
-    analytics._writeKey="NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m";
+  {{ if hugo.IsProduction }}
+    {{/* Prod/Stage */}}
+    var SEGMENT_ID = 'NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m';
+    if(window.location.hostname.includes('preview')) {
+      SEGMENT_ID = 'fuo8pqI0wvoojiShBQXSZopWLZggS8ny';
+    }
+    analytics._writeKey=SEGMENT_ID;
     analytics._cdn="https://cdn.segment.materialize.com";
-    analytics.load("NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m");
+    analytics.load(SEGMENT_ID);
   {{ else }}
     {{/* Dev */}}
     analytics._writeKey="dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk";

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -71,22 +71,20 @@ addEventListener("DOMContentLoaded", () => {
 
 {{/* Segment */}}
 <script>
-  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};
+  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.materialize.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.15.3";
   {{ if in (printf "%s" .Site.BaseURL) "preview" }}
-  {{/* Stage */}}
-  analytics._writeKey="fuo8pqI0wvoojiShBQXSZopWLZggS8ny";;
-  analytics.SNIPPET_VERSION="4.15.3";
-  analytics.load("fuo8pqI0wvoojiShBQXSZopWLZggS8ny");
+    {{/* Stage */}}
+    analytics._writeKey="fuo8pqI0wvoojiShBQXSZopWLZggS8ny";
+    analytics.load("fuo8pqI0wvoojiShBQXSZopWLZggS8ny");
   {{ else if hugo.IsProduction }}
-  {{/* Prod */}}
-  analytics._writeKey="NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m";;
-  analytics.SNIPPET_VERSION="4.15.3";
-  analytics.load("NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m");
+    {{/* Prod */}}
+    analytics._writeKey="NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m";
+    analytics._cdn="https://cdn.segment.materialize.com";
+    analytics.load("NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m");
   {{ else }}
-  {{/* Dev */}}
-  analytics._writeKey="dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk";;
-  analytics.SNIPPET_VERSION="4.15.3";
-  analytics.load("dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk");
+    {{/* Dev */}}
+    analytics._writeKey="dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk";
+    analytics.load("dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk");
   {{ end }}
   analytics.page();
   }}();


### PR DESCRIPTION
Eventually we should separate these out into environment variables, but I think this works fine for now.

This uses separate Segment write IDs for dev/stage/prod.

By default Hugo only has "production" and not production, so I use Javascript to look at teh hostname to separate staging and prod. (These keys are not secret, we treat the data with that in mind.)

Not sure if this will work but we will see with this preview link. 

### Review

- Running the branch locally fires events to `dGeQYRjmGVsqDI0KIARrAhTvk1BdJJhk`
- Staging fires events to `fuo8pqI0wvoojiShBQXSZopWLZggS8ny`
- Prod is `NCe6YQCHM9g04X9yEBUFtoWOuqZU8J1m` _Can't really test until in production._
