### PR TITLE
dbt-materialize: stop using Avro OCF sources/sinks

### DIFF
--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -11,11 +11,21 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services import Materialized, Service, TestCerts
+from materialize.mzcompose.services import (
+    Kafka,
+    Materialized,
+    SchemaRegistry,
+    Service,
+    TestCerts,
+    Zookeeper,
+)
 
 SERVICES = [
     TestCerts(),
     Materialized(),
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
     Service(
         "dbt-test",
         {
@@ -45,16 +55,12 @@ test_cases = [
     TestCase(
         name="no-tls-head",
         materialized_options=[],
-        dbt_env={
-            "DBT_HOST": "materialized",
-        },
+        dbt_env={},
     ),
     TestCase(
         name="no-tls-min-supported-version",
         materialized_options=[],
-        dbt_env={
-            "DBT_HOST": "materialized",
-        },
+        dbt_env={},
         materialized_image="materialize/materialized:v0.20.0",
     ),
     TestCase(
@@ -66,7 +72,6 @@ test_cases = [
             "--tls-ca=/secrets/ca.crt",
         ],
         dbt_env={
-            "DBT_HOST": "materialized",
             "DBT_SSLCERT": "/secrets/materialized.crt",
             "DBT_SSLKEY": "/secrets/materialized.key",
             "DBT_SSLROOTCERT": "/secrets/ca.crt",
@@ -95,11 +100,19 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             with c.test_case(test_case.name):
                 with c.override(materialized):
                     c.down()
+                    c.start_and_wait_for_tcp(
+                        services=["zookeeper", "kafka", "schema-registry"]
+                    )
                     c.up("materialized")
                     c.wait_for_tcp(host="materialized", port=6875)
                     c.run(
                         "dbt-test",
                         "pytest",
                         "dbt-materialize/test",
-                        env_extra=test_case.dbt_env,
+                        env_extra={
+                            "DBT_HOST": "materialized",
+                            "KAFKA_ADDR": "kafka:9092",
+                            "SCHEMA_REGISTRY_URL": "http://schema-registry:8081",
+                            **test_case.dbt_env,
+                        },
                     )

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -77,14 +77,15 @@ sequences:
       - type: dbt
         cmd: run
       - type: relations_equal
-        relations: [test_materialized_view, test_view_index, test_source_index]
+        relations: [test_materialized_view, test_view_index]
       - type: relations_equal
         relations: [actual_indexes, expected_indexes]
-      # TODO(benesch): figure out how to test that the sink emits the correct
-      # data. Ideally we'd just ingest the sink back into Materialize with a
-      # source and then use a `relations_equal` step, but that's hard to do
-      # presently because Avro OCF sinks do not have a stable output filename
-      # and Avro OCF sources do not support glob patterns.
+      # TODO(benesch): figure out how to test that the source/sink emit the
+      # correct data. Ideally we'd just ingest the sink back into Materialize
+      # with the source and then use `relations_equal` with
+      # `test_materialized_view`, but that doesn't work right now because you
+      # can't use `reuse_topic = true` with a sink built on a materialized view.
+      # That will get fixed soon in platform.
   # dbt-materialize does not support incremental models or snapshots
   # test_dbt_incremental: incremental
   # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
@@ -106,11 +107,6 @@ projects:
         swappable: view
   - name: custom_materializations
     paths:
-        testdata/test_csv.csv: |
-            a,b
-            chicken,pig
-            cow,horse
-
         models/test_materialized_view.sql: |
             {{ config(materialized='materializedview') }}
 
@@ -136,9 +132,8 @@ projects:
             {{ config(materialized='source') }}
 
             CREATE SOURCE {{ mz_generate_name('test_source') }}
-            -- TODO(benesch): is there a better way to get the CWD in a test?
-            FROM FILE '{{ flags.os.getcwd() }}/testdata/test_csv.csv'
-            FORMAT CSV WITH HEADER
+            FROM KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-source'
+            FORMAT BYTES
 
         models/test_index.sql: |
             {{ config(materialized='index') }}
@@ -149,19 +144,20 @@ projects:
         models/test_source_index.sql: |
             {{ config(
                 materialized='source',
-                indexes=[{'columns': ['a']}]
+                indexes=[{'columns': ['data']}]
             ) }}
 
             CREATE SOURCE {{ mz_generate_name('test_source_index') }}
-            FROM FILE '{{ flags.os.getcwd() }}/testdata/test_csv.csv'
-            FORMAT CSV WITH HEADER
+            FROM KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-source-index'
+            FORMAT BYTES
 
         models/test_sink.sql: |
             {{ config(materialized='sink') }}
 
             CREATE SINK {{ mz_generate_name('test_sink') }}
-            FROM {{ ref('test_source') }}
-            INTO AVRO OCF 'test_sink.ocf'
+            FROM {{ ref('test_materialized_view') }}
+            INTO KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-sink'
+            FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '{{ env_var('SCHEMA_REGISTRY_URL', 'http://localhost:8081') }}'
 
         models/actual_indexes.sql: |
             SELECT
@@ -182,7 +178,6 @@ projects:
             test_materialized_view_index,1,1,
             test_source,1,1,
             test_source,2,2,
-            test_source,3,3,
             test_source_index,1,1,
             test_view_index,1,1,
             test_view_index,2,,pg_catalog.length(a)


### PR DESCRIPTION
Avro OCF sources and sinks are being removed since they aren't usable in
Materialize Cloud (#11875). This commit changes the dbt test suite to
use Kafka sources and sinks instead.

We lose a little test coverage here because we can no longer verify that
the source actually *works*, but that's okay; we've got plenty of other
tests in Materialize for that. We'll get the test coverage back when
Platform fully supports EOS sinks, and then we can test that a sink that
emits static data can be reingested with the same data, all in dbt.

Touches #11875.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
