### PR TITLE
Expr/dataflow-types: Protobuf support for ColumnOrder and TopKPlan

### DIFF
--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -9,6 +9,7 @@
 
 fn main() {
     prost_build::Config::new()
+        .extern_path(".mz_expr.relation", "::mz_expr")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.proto", "::mz_repr::proto")
         .type_attribute(
@@ -19,6 +20,7 @@ fn main() {
             &[
                 "dataflow-types/src/logging.proto",
                 "dataflow-types/src/postgres_source.proto",
+                "dataflow-types/src/plan/top_k.proto",
             ],
             &[".."],
         )

--- a/src/dataflow-types/src/plan/top_k.proto
+++ b/src/dataflow-types/src/plan/top_k.proto
@@ -1,0 +1,44 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+import "expr/src/relation.proto";
+
+package mz_dataflow_types.plan.top_k;
+
+message ProtoTopKPlan {
+    oneof kind {
+        ProtoBasicTopKPlan basic = 1;
+        ProtoMonotonicTopKPlan monotonic_top_k = 2;
+        ProtoMonotonicTop1Plan monotonic_top_1 = 3;
+    }
+}
+
+message ProtoBasicTopKPlan {
+    repeated uint64 group_key = 1;
+    repeated mz_expr.relation.ProtoColumnOrder order_key = 2;
+    optional uint64 limit = 3;
+    uint64 offset = 4;
+    uint64 arity = 5;
+}
+
+message ProtoMonotonicTop1Plan {
+    repeated uint64 group_key = 1;
+    repeated mz_expr.relation.ProtoColumnOrder order_key = 2;
+}
+
+message ProtoMonotonicTopKPlan {
+    repeated uint64 group_key = 1;
+    repeated mz_expr.relation.ProtoColumnOrder order_key = 2;
+    optional uint64 limit = 3;
+    uint64 arity = 4;
+}

--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -15,9 +15,11 @@ fn main() {
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.strconv", "::mz_repr::strconv")
+        .type_attribute(".", "#[allow(missing_docs)]")
         .compile_protos(
             &[
                 "expr/src/id.proto",
+                "expr/src/relation.proto",
                 "expr/src/scalar.proto",
                 "expr/src/scalar/func.proto",
             ],

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -39,6 +39,7 @@ pub use linear::{
 pub use relation::func::{AggregateFunc, LagLeadType, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
+pub use relation::ProtoColumnOrder;
 pub use relation::{
     compare_columns, AggregateExpr, CollectionPlan, ColumnOrder, JoinImplementation,
     MirRelationExpr, RowSetFinishing, RECURSION_LIMIT,

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -1,0 +1,19 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+package mz_expr.relation;
+
+message ProtoColumnOrder {
+    uint64 column = 1;
+    bool desc = 2;
+}


### PR DESCRIPTION
Closes #11973.

First commit is protobuf support for `ColumnOrder`. Second commit is protobuf support for `TopKPlan`.

### Tips for reviewer

Pretty much straightforward, except that `ColumnOrder` and `TopKPlan` live in modules with the attribute `#![deny(missing_docs)]`, and then `bin/pre-push` complains that `Proto*` are missing documentation. 
I added `.type_attribute(".", "#[allow(missing_docs)]")` to `src/expr/src/build.rs`, and it works fine. But TopKPlan is an enum,  so I had to add `#![allow(missing_docs)]` to the top of the top_k.rs file. See Slack conversation [here](https://materializeinc.slack.com/archives/CM7ATT65S/p1650570101407349).

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user facing behavior changes