### PR TITLE
storage: allow SourceReader implementations to return structured errors from get_next_message

### DIFF
--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -75,6 +75,7 @@ pub enum SourceErrorDetails {
     Initialization(String),
     FileIO(String),
     Persistence(String),
+    Other(String),
 }
 
 impl Display for SourceErrorDetails {
@@ -89,6 +90,7 @@ impl Display for SourceErrorDetails {
             }
             SourceErrorDetails::FileIO(e) => write!(f, "file IO: {}", e),
             SourceErrorDetails::Persistence(e) => write!(f, "persistence: {}", e),
+            SourceErrorDetails::Other(e) => write!(f, "{}", e),
         }
     }
 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -32,7 +32,7 @@ use mz_kafka_util::{client::MzClientContext, KafkaAddrs};
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
 use mz_repr::adt::jsonb::Jsonb;
 
-use crate::source::{NextMessage, SourceMessage, SourceReader};
+use crate::source::{NextMessage, SourceMessage, SourceReader, SourceReaderError};
 
 use self::metrics::KafkaPartitionMetrics;
 use super::metrics::SourceBaseMetrics;
@@ -200,7 +200,9 @@ impl SourceReader for KafkaSourceReader {
     ///
     /// If a message has an offset that is smaller than the next expected offset for this consumer
     /// (and this partition) we skip this message, and seek to the appropriate offset
-    fn get_next_message(&mut self) -> Result<NextMessage<Self::Key, Self::Value>, anyhow::Error> {
+    fn get_next_message(
+        &mut self,
+    ) -> Result<NextMessage<Self::Key, Self::Value>, SourceReaderError> {
         let partition_info = self.partition_info.lock().unwrap().take();
         if let Some(partitions) = partition_info {
             for pid in partitions {

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -47,7 +47,7 @@ impl SimpleSource for PubNubSourceReader {
             .build()
             .map_err(|e| SourceError {
                 source_id: self.source_id,
-                error: SourceErrorDetails::FileIO(e.to_string()),
+                error: SourceErrorDetails::Other(e.to_string()),
             })?;
 
         let mut pubnub = Builder::new()
@@ -59,7 +59,7 @@ impl SimpleSource for PubNubSourceReader {
         let channel: channel::Name = channel.parse().or_else(|_| {
             Err(SourceError {
                 source_id: self.source_id,
-                error: SourceErrorDetails::FileIO(format!("invalid pubnub channel: {}", channel)),
+                error: SourceErrorDetails::Other(format!("invalid pubnub channel: {}", channel)),
             })
         })?;
 
@@ -75,7 +75,7 @@ impl SimpleSource for PubNubSourceReader {
 
                     timestamper.insert(row).await.map_err(|e| SourceError {
                         source_id: self.source_id,
-                        error: SourceErrorDetails::FileIO(e.to_string()),
+                        error: SourceErrorDetails::Other(e.to_string()),
                     })?;
                 }
             }

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -419,7 +419,7 @@ INSERT INTO pk_table VALUES (99999);
 # todo: we're purifying Postgres view names incorrectly, fix that and this error!
 # should be "materialize.public.pk_table"
 ! SELECT COUNT(*) = 0 FROM pk_table;
-regex:Source error: .*: file IO: db error: ERROR: publication "mz_source" does not exist
+regex:Source error: .*: db error: ERROR: publication "mz_source" does not exist
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP SCHEMA conflict_schema CASCADE;


### PR DESCRIPTION
I noticed 2 things:
- `SimpleSource`'s are able to return _structured_ `SourceError`'s, whereas `SourceReader` implementors
- Those `anyhow::Error`'s are blindly converted into `FileIO` type source error, even if they have nothing to do with file io

To deal with these I did the following:
- Add a more general `Other` `SourceErrorDetails`-variant that doesn't editorialize the error message presented to users
- Add a `SourceReaderError` that allows user to continue to `?` `anyhow::Error`'s (or explicit `.into()`) to `Other`-type errors, but also allows them to return structured errors
  - Automatically add the `source_id` field to make it easier to construct
- Adjusted the impl's to compile correctly, and fixed some testdrives (luckily not many)

I did not yet do these, as they are fine to do lat
- Add an `Error` impl for this error, as its seems unnecessary, but it can be added later
- Structure all the errors returned by existing sources
- change the type of `SourceReader::new`, which follows a different early exit error path

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The file source does some grossness where it re-wraps an anyhow::Error 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- Technically, I believe this can change how we persist errors onto disk as we added a `Other` 
