### PR TITLE
Enable creating source using connector

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -872,16 +872,6 @@ impl CatalogItem {
         }
     }
 
-    pub fn catalog_connector(
-        &self,
-        name: &QualifiedObjectName,
-    ) -> Result<&dyn CatalogConnector, SqlCatalogError> {
-        match &self {
-            CatalogItem::Connector(conn) => Ok(conn),
-            _ => Err(SqlCatalogError::UnknownConnector(name.item.clone())),
-        }
-    }
-
     /// Collects the identifiers of the dataflows that this item depends
     /// upon.
     pub fn uses(&self) -> &[GlobalId] {

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, info, trace};
+use tracing::{info, trace};
 
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_dataflow_types::client::{ComputeInstanceId, InstanceConfig};
@@ -1862,19 +1862,6 @@ impl Catalog {
         Ok(&self.state.compute_instances_by_id[id])
     }
 
-    pub fn resolve_connector(
-        &self,
-        connector: &PartialObjectName,
-        conn_id: u32,
-    ) -> Result<&Connector, SqlCatalogError> {
-        debug!(%connector, "resolve connector");
-        let entry = self.resolve(|schema| &schema.items, None, &vec![], connector, conn_id)?;
-        match entry.item() {
-            CatalogItem::Connector(ctr) => Ok(ctr),
-            _ => Err(SqlCatalogError::UnknownConnector(connector.to_string())),
-        }
-    }
-
     /// Resolves [`PartialObjectName`] into a [`CatalogEntry`].
     ///
     /// If `name` does not specify a database, the `current_database` is used.
@@ -3223,17 +3210,6 @@ impl SessionCatalog for ConnCatalog<'_> {
                 compute_instance as &dyn mz_sql::catalog::CatalogComputeInstance
             })
     }
-
-    // fn resolve_connector(
-    //     &self,
-    //     connector: &PartialObjectName,
-    // ) -> Result<&dyn mz_sql::catalog::CatalogConnector, SqlCatalogError> {
-    //     // self.catalog.resolve_item(connector).map(|entry| {entry as &dyn mz_sql::catalog::CatalogConnector})
-    //     self.catalog
-    //         .resolve_connector(connector, self.conn_id)
-    //         .map(|entry| entry as &dyn mz_sql::catalog::CatalogConnector)
-    //     // Err(SqlCatalogError::UnknownConnector(connector.to_string())
-    // }
 
     fn resolve_item(
         &self,

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -1045,6 +1045,13 @@ impl CatalogEntry {
         }
     }
 
+    pub fn catalog_connector(&self) -> Result<&Connector, SqlCatalogError> {
+        match self.item() {
+            CatalogItem::Connector(connector) => Ok(connector),
+            _ => Err(SqlCatalogError::UnknownConnector(self.name().to_string())),
+        }
+    }
+
     /// Returns the [`mz_dataflow_types::sources::SourceConnector`] associated with
     /// this `CatalogEntry`.
     pub fn source_connector(&self) -> Result<&SourceConnector, SqlCatalogError> {
@@ -3352,12 +3359,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
     }
 
     fn catalog_connector(&self) -> Result<&dyn CatalogConnector, SqlCatalogError> {
-        match self.item() {
-            CatalogItem::Connector(conn) => Ok(conn),
-            _ => Err(SqlCatalogError::UnknownConnector(
-                "Item is not a connector".to_string(),
-            )),
-        }
+        Ok(self.catalog_connector()?)
     }
 
     fn create_sql(&self) -> &str {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -76,7 +76,6 @@ use anyhow::{anyhow, Context};
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
-use futures::future::TryFutureExt;
 use itertools::Itertools;
 use rand::Rng;
 use timely::order::PartialOrder;
@@ -1340,13 +1339,15 @@ impl Coordinator {
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
                 let conn_id = session.conn_id();
                 let params = portal.parameters.clone();
+                let catalog = self.catalog.for_session(&session);
                 let purify_fut = mz_sql::pure::purify_create_source(
                     self.now(),
                     self.catalog.config().aws_external_id.clone(),
                     stmt,
+                    &catalog,
                 );
                 task::spawn(|| format!("purify:{conn_id}"), async move {
-                    let result = purify_fut.err_into().await;
+                    let result = purify_fut.await.map_err(|e| e.into());
                     internal_cmd_tx
                         .send(Message::CreateSourceStatementReady(
                             CreateSourceStatementReady {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1129,6 +1129,14 @@ pub mod sources {
         },
     }
 
+    impl ConnectorInner {
+        pub fn uri(&self) -> String {
+            match self {
+                ConnectorInner::Kafka { broker, .. } => broker.to_string(),
+            }
+        }
+    }
+
     #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
     pub enum Compression {
         Gzip,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -559,9 +559,8 @@ impl AstDisplay for CreateSourceConnector {
                         f.write_str("'");
                     }
                     KafkaConnector::Reference { connector } => {
-                        f.write_str("CONNECTOR '");
+                        f.write_str("CONNECTOR ");
                         f.write_node(connector);
-                        f.write_str("'");
                     }
                 }
                 f.write_str(" TOPIC '");

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -474,9 +474,12 @@ impl<T: AstInfo> AstDisplay for CreateConnector<T> {
             } => {
                 f.write_str("KAFKA BROKER '");
                 f.write_node(&display::escape_single_quote_string(broker));
-                f.write_str("' WITH (");
-                f.write_node(&display::comma_separated(&with_options));
-                f.write_str(")");
+                f.write_str("'");
+                if with_options.len() > 0 {
+                    f.write_str(" WITH (");
+                    f.write_node(&display::comma_separated(&with_options));
+                    f.write_str(")");
+                }
             }
         }
     }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1870,8 +1870,7 @@ impl<'a> Parser<'a> {
             Keyword::Kafka => {
                 self.expect_keyword(BROKER)?;
                 let broker = self.parse_literal_string()?;
-                self.expect_keyword(WITH)?;
-                let with_options = self.parse_with_options(true)?;
+                let with_options = self.parse_opt_with_options()?;
                 CreateConnector::Kafka {
                     broker,
                     with_options,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1429,3 +1429,10 @@ DROP CONNECTOR conn1
 DROP CONNECTOR conn1
 =>
 DropObjects(DropObjectsStatement { materialized: false, object_type: Connector, if_exists: false, names: [Name(UnresolvedObjectName([Ident("conn1")]))], cascade: false })
+
+parse-statement
+CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+----
+CREATE SOURCE src1 FROM KAFKA CONNECTOR 'conn1' TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: UnresolvedObjectName([Ident("conn1")]) }, topic: "baz", key: None }), with_options: [Value { name: Ident("consistency"), value: String("lug") }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1433,6 +1433,6 @@ DropObjects(DropObjectsStatement { materialized: false, object_type: Connector, 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTOR 'conn1' TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: UnresolvedObjectName([Ident("conn1")]) }, topic: "baz", key: None }), with_options: [Value { name: Ident("consistency"), value: String("lug") }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: UnresolvedObjectName([Ident("conn1")]) }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -136,12 +136,6 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
         compute_instance_name: Option<&str>,
     ) -> Result<&dyn CatalogComputeInstance, CatalogError>;
 
-    // /// Resolves the named connector
-    // fn resolve_connector(
-    //     &self,
-    //     connector_name: &PartialObjectName,
-    // ) -> Result<&dyn CatalogConnector, CatalogError>;
-
     /// Resolves a partially-specified item name.
     ///
     /// If the partial name has a database component, it searches only the

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -136,6 +136,12 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer {
         compute_instance_name: Option<&str>,
     ) -> Result<&dyn CatalogComputeInstance, CatalogError>;
 
+    // /// Resolves the named connector
+    // fn resolve_connector(
+    //     &self,
+    //     connector_name: &PartialObjectName,
+    // ) -> Result<&dyn CatalogConnector, CatalogError>;
+
     /// Resolves a partially-specified item name.
     ///
     /// If the partial name has a database component, it searches only the
@@ -267,6 +273,15 @@ pub trait CatalogComputeInstance {
     fn indexes(&self) -> &std::collections::HashSet<GlobalId>;
 }
 
+/// A connector in a [`SessionCatalog`]
+pub trait CatalogConnector {
+    /// Returns the connection URI for this connector regardless of type
+    fn uri(&self) -> String;
+
+    /// Returns the options associated with this connector as a Vec, if the type does not support options or none were specified this will be empty
+    fn options(&self) -> std::collections::BTreeMap<String, String>;
+}
+
 /// An item in a [`SessionCatalog`].
 ///
 /// Note that "item" has a very specific meaning in the context of a SQL
@@ -298,6 +313,12 @@ pub trait CatalogItem {
     /// If the catalog item is not of a type that contains a `SourceConnector`
     /// (i.e., anything other than sources), it returns an error.
     fn source_connector(&self) -> Result<&SourceConnector, CatalogError>;
+
+    /// Returns the resolved connector, called a catalog connector to disambiguate
+    ///
+    /// If the catalog item is not of a type that implements `CatalogConnector`
+    /// it returns an error
+    fn catalog_connector(&self) -> Result<&dyn CatalogConnector, CatalogError>;
 
     /// Returns the type of the catalog item.
     fn item_type(&self) -> CatalogItemType;

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -339,13 +339,7 @@ pub fn create_statement(
                 if let Some(WithOptionValue::ObjectName(object_name)) = &mut opt.value {
                     if ident_ref(&opt.key) == "tx_metadata" {
                         // Use the catalog to resolve to a fully qualified name
-                        *object_name = unresolve(
-                            scx.catalog.resolve_full_name(
-                                scx.catalog
-                                    .resolve_item(&unresolved_object_name(object_name.clone())?)?
-                                    .name(),
-                            ),
-                        );
+                        *object_name = allocate_name(object_name)?;
                     }
                 }
             }
@@ -354,13 +348,7 @@ pub fn create_statement(
                 ..
             }) = connector
             {
-                *connector = unresolve(
-                    scx.catalog.resolve_full_name(
-                        &scx.catalog
-                            .resolve_item(&unresolved_object_name(connector.clone())?)?
-                            .name(),
-                    ),
-                );
+                *connector = allocate_name(connector)?;
             };
         }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -347,12 +347,25 @@ pub fn plan_create_source(
 
     let (external_connector, encoding) = match connector {
         CreateSourceConnector::Kafka(kafka) => {
-            let (broker, topic) = match &kafka.connector {
-                mz_sql_parser::ast::KafkaConnector::Inline { broker } => (broker, &kafka.topic),
-                // Temporary until the rest of the connector plumbing is finished
-                mz_sql_parser::ast::KafkaConnector::Reference { .. } => unreachable!(),
+            let (broker, topic, options) = match &kafka.connector {
+                mz_sql_parser::ast::KafkaConnector::Inline { broker } => {
+                    (broker.to_owned(), &kafka.topic, None)
+                }
+                mz_sql_parser::ast::KafkaConnector::Reference { connector } => {
+                    let connector_name = normalize::unresolved_object_name(connector.clone())?;
+                    let item = scx.catalog.resolve_item(&connector_name)?;
+                    let connector = item.catalog_connector()?;
+                    depends_on.push(item.id());
+                    (connector.uri(), &kafka.topic, Some(connector.options()))
+                }
             };
-            let config_options = kafka_util::extract_config(&mut with_options)?;
+
+            // If we got options from a connector then use those, they have already had kafka_util::extract_config run on them
+            let config_options = if let Some(opts) = options {
+                opts
+            } else {
+                kafka_util::extract_config(&mut with_options)?
+            };
 
             let group_id_prefix = match with_options.remove("group_id_prefix") {
                 None => None,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -60,6 +60,10 @@ pub fn purify_create_source(
     mut stmt: CreateSourceStatement<Raw>,
     catalog: &dyn SessionCatalog,
 ) -> impl Future<Output = Result<CreateSourceStatement<Raw>, anyhow::Error>> {
+    // For a kafka source using a connector we need to resolve the connector and pull data from it to perform purification
+    // since we need to connect to a broker and get partition offsets from it
+    // Interacting with the catalog must be done before the async block since otherwise it could remain locked for
+    // indeterminate periods of time while we wait for external systems
     let resolved_connector = if let CreateSourceStatement {
         connector:
             CreateSourceConnector::Kafka(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -166,14 +166,7 @@ pub fn purify_create_source(
                     None => {}
                 }
             }
-            // Report an error if a file cannot be opened, or if it is a directory.
-            CreateSourceConnector::File { path, .. } => {
-                let f = File::open(&path).await?;
-                if f.metadata().await?.is_dir() {
-                    bail!("Expected a regular file, but {} is a directory.", path);
-                }
-                file = Some(f);
-            }
+
             CreateSourceConnector::AvroOcf { path, .. } => {
                 let path = path.clone();
                 task::block_in_place(|| {
@@ -192,6 +185,14 @@ pub fn purify_create_source(
                     }
                     Ok::<_, anyhow::Error>(())
                 })?;
+            }
+            // Report an error if a file cannot be opened, or if it is a directory.
+            CreateSourceConnector::File { path, .. } => {
+                let f = File::open(&path).await?;
+                if f.metadata().await?.is_dir() {
+                    bail!("Expected a regular file, but {} is a directory.", path);
+                }
+                file = Some(f);
             }
             CreateSourceConnector::S3 { .. } => {
                 let aws_config = normalize::aws_config(&mut with_options_map, None)?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -12,6 +12,7 @@
 //! See the [crate-level documentation](crate) for details.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::iter;
 use std::path::Path;
 use std::sync::Arc;
@@ -19,7 +20,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, ensure, Context};
 use aws_arn::ARN;
 use csv::ReaderBuilder;
-use mz_sql_parser::ast::KafkaSourceConnector;
+use mz_sql_parser::ast::{KafkaConnector, KafkaSourceConnector};
 use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
 use protobuf_native::MessageLite;
@@ -31,7 +32,7 @@ use uuid::Uuid;
 
 use mz_ccsr::{Client, GetBySubjectError};
 use mz_dataflow_types::postgres_source::PostgresSourceDetails;
-use mz_dataflow_types::sources::{AwsConfig, AwsExternalId};
+use mz_dataflow_types::sources::{AwsConfig, AwsExternalId, ConnectorInner};
 use mz_repr::strconv;
 
 use crate::ast::{
@@ -40,6 +41,7 @@ use crate::ast::{
     CsvColumns, DbzMode, Envelope, Format, Ident, ProtobufSchema, Raw, Value, WithOption,
     WithOptionValue,
 };
+use crate::catalog::SessionCatalog;
 use crate::kafka_util;
 use crate::normalize;
 
@@ -52,155 +54,192 @@ use crate::normalize;
 /// time to complete. As a result purification does *not* have access to a
 /// [`SessionCatalog`](crate::catalog::SessionCatalog), as that would require
 /// locking access to the catalog for an unbounded amount of time.
-pub async fn purify_create_source(
+pub fn purify_create_source(
     now: u64,
     aws_external_id: AwsExternalId,
     mut stmt: CreateSourceStatement<Raw>,
-) -> Result<CreateSourceStatement<Raw>, anyhow::Error> {
-    let CreateSourceStatement {
-        connector,
-        format,
-        envelope,
-        with_options,
-        include_metadata: _,
+    catalog: &dyn SessionCatalog,
+) -> impl Future<Output = Result<CreateSourceStatement<Raw>, anyhow::Error>> {
+    let resolved_connector = if let CreateSourceStatement {
+        connector:
+            CreateSourceConnector::Kafka(
+                KafkaSourceConnector {
+                    connector:
+                        KafkaConnector::Reference {
+                            connector: connector_name,
+                        },
+                    ..
+                },
+                ..,
+            ),
         ..
-    } = &mut stmt;
-
-    let mut with_options_map = normalize::options(with_options);
-    let mut config_options = BTreeMap::new();
-
-    let mut file = None;
-    match connector {
-        CreateSourceConnector::Kafka(KafkaSourceConnector {
-            connector: broker,
-            topic,
+    } = &stmt
+    {
+        normalize::unresolved_object_name(connector_name.clone())
+            .map_err(anyhow::Error::new)
+            .and_then(|name| catalog.resolve_item(&name).map_err(anyhow::Error::new))
+            .and_then(|conn| {
+                let connector = conn.catalog_connector()?;
+                Ok(ConnectorInner::Kafka {
+                    broker: connector.uri().parse()?,
+                    config_options: connector.options(),
+                })
+            })
+    } else {
+        Err(anyhow!(
+            "SQL statement does not contain a valid connector reference"
+        ))
+    };
+    async move {
+        let CreateSourceStatement {
+            connector,
+            format,
+            envelope,
+            with_options,
+            include_metadata: _,
             ..
-        }) => {
-            match broker {
-                // Temporary until the rest of the connector plumbing is finished
-                mz_sql_parser::ast::KafkaConnector::Reference { .. } => unreachable!(),
-                mz_sql_parser::ast::KafkaConnector::Inline { broker } => {
-                    if !broker.contains(':') {
-                        *broker += ":9092";
-                    }
+        } = &mut stmt;
 
-                    // Verify that the provided security options are valid and then test them.
-                    config_options = kafka_util::extract_config(&mut with_options_map)?;
-                    let consumer = kafka_util::create_consumer(&broker, &topic, &config_options)
-                        .await
-                        .map_err(|e| {
-                            anyhow!("Failed to create and connect Kafka consumer: {}", e)
-                        })?;
+        let mut with_options_map = normalize::options(with_options);
+        let mut config_options = BTreeMap::new();
 
-                    // Translate `kafka_time_offset` to `start_offset`.
-                    match kafka_util::lookup_start_offsets(
-                        Arc::clone(&consumer),
-                        &topic,
-                        &with_options_map,
-                        now,
-                    )
-                    .await?
-                    {
-                        Some(start_offsets) => {
-                            // Drop `kafka_time_offset`
-                            with_options.retain(|val| match val.value {
-                                Some(WithOptionValue::Value(..)) => {
-                                    val.key.as_str() != "kafka_time_offset"
-                                }
-                                _ => true,
-                            });
-
-                            // Add `start_offset`
-                            with_options.push(WithOption {
-                                key: Ident::new("start_offset"),
-                                value: Some(WithOptionValue::Value(Value::Array(
-                                    start_offsets
-                                        .iter()
-                                        .map(|offset| Value::Number(offset.to_string()))
-                                        .collect(),
-                                ))),
-                            });
+        let mut file = None;
+        match connector {
+            CreateSourceConnector::Kafka(KafkaSourceConnector {
+                connector, topic, ..
+            }) => {
+                let (broker, connector_options) = match connector {
+                    mz_sql_parser::ast::KafkaConnector::Reference { .. } => {
+                        match resolved_connector? {
+                            ConnectorInner::Kafka {
+                                broker,
+                                config_options,
+                            } => (broker.to_string(), Some(config_options)),
                         }
-                        _ => {}
                     }
-                }
-            }
-        }
-        CreateSourceConnector::AvroOcf { path, .. } => {
-            let path = path.clone();
-            task::block_in_place(|| {
-                // mz_avro::Reader has no async equivalent, so we're stuck
-                // using blocking calls here.
-                let f = std::fs::File::open(path)?;
-                let r = mz_avro::Reader::new(f)?;
-                if !with_options_map.contains_key("reader_schema") {
-                    let schema = serde_json::to_string(r.writer_schema()).unwrap();
-                    with_options.push(WithOption {
-                        key: Ident::new("reader_schema"),
-                        value: Some(WithOptionValue::Value(Value::String(schema))),
-                    });
-                }
-                Ok::<_, anyhow::Error>(())
-            })?;
-        }
-        // Report an error if a file cannot be opened, or if it is a directory.
-        CreateSourceConnector::File { path, .. } => {
-            let f = File::open(&path).await?;
-            if f.metadata().await?.is_dir() {
-                bail!("Expected a regular file, but {} is a directory.", path);
-            }
-            file = Some(f);
-        }
-        CreateSourceConnector::S3 { .. } => {
-            let aws_config = normalize::aws_config(&mut with_options_map, None)?;
-            validate_aws_credentials(&aws_config, aws_external_id).await?;
-        }
-        CreateSourceConnector::Kinesis { arn } => {
-            let region = arn
-                .parse::<ARN>()
-                .context("Unable to parse provided ARN")?
-                .region
-                .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
+                    mz_sql_parser::ast::KafkaConnector::Inline { broker } => {
+                        (broker.to_string(), None)
+                    }
+                };
+                config_options = if let Some(options) = connector_options {
+                    options
+                } else {
+                    // Verify that the provided security options are valid and then test them.
+                    kafka_util::extract_config(&mut with_options_map)?
+                };
+                let consumer = kafka_util::create_consumer(&broker, &topic, &config_options)
+                    .await
+                    .map_err(|e| anyhow!("Failed to create and connect Kafka consumer: {}", e))?;
 
-            let aws_config = normalize::aws_config(&mut with_options_map, Some(region.into()))?;
-            validate_aws_credentials(&aws_config, aws_external_id).await?;
-        }
-        CreateSourceConnector::Postgres {
-            conn,
-            publication,
-            slot,
-            details,
-        } => {
-            slot.get_or_insert_with(|| {
-                format!(
-                    "materialize_{}",
-                    Uuid::new_v4().to_string().replace('-', "")
+                // Translate `kafka_time_offset` to `start_offset`.
+                match kafka_util::lookup_start_offsets(
+                    Arc::clone(&consumer),
+                    &topic,
+                    &with_options_map,
+                    now,
                 )
-            });
+                .await?
+                {
+                    Some(start_offsets) => {
+                        // Drop `kafka_time_offset`
+                        with_options.retain(|val| match val {
+                            mz_sql_parser::ast::WithOption { key, .. } => {
+                                key.as_str() != "kafka_time_offset"
+                            }
+                        });
 
-            // verify that we can connect upstream and snapshot publication metadata
-            let tables = mz_postgres_util::publication_info(&conn, &publication).await?;
+                        // Add `start_offset`
+                        with_options.push(mz_sql_parser::ast::WithOption {
+                            key: mz_sql_parser::ast::Ident::new("start_offset"),
+                            value: Some(mz_sql_parser::ast::WithOptionValue::Value(Value::Array(
+                                start_offsets
+                                    .iter()
+                                    .map(|offset| Value::Number(offset.to_string()))
+                                    .collect(),
+                            ))),
+                        });
+                    }
+                    None => {}
+                }
+            }
+            // Report an error if a file cannot be opened, or if it is a directory.
+            CreateSourceConnector::File { path, .. } => {
+                let f = File::open(&path).await?;
+                if f.metadata().await?.is_dir() {
+                    bail!("Expected a regular file, but {} is a directory.", path);
+                }
+                file = Some(f);
+            }
+            CreateSourceConnector::AvroOcf { path, .. } => {
+                let path = path.clone();
+                task::block_in_place(|| {
+                    // mz_avro::Reader has no async equivalent, so we're stuck
+                    // using blocking calls here.
+                    let f = std::fs::File::open(path)?;
+                    let r = mz_avro::Reader::new(f)?;
+                    if !with_options_map.contains_key("reader_schema") {
+                        let schema = serde_json::to_string(r.writer_schema()).unwrap();
+                        with_options.push(mz_sql_parser::ast::WithOption {
+                            key: mz_sql_parser::ast::Ident::new("reader_schema"),
+                            value: Some(mz_sql_parser::ast::WithOptionValue::Value(
+                                mz_sql_parser::ast::Value::String(schema),
+                            )),
+                        });
+                    }
+                    Ok::<_, anyhow::Error>(())
+                })?;
+            }
+            CreateSourceConnector::S3 { .. } => {
+                let aws_config = normalize::aws_config(&mut with_options_map, None)?;
+                validate_aws_credentials(&aws_config, aws_external_id).await?;
+            }
+            CreateSourceConnector::Kinesis { arn } => {
+                let region = arn
+                    .parse::<ARN>()
+                    .context("Unable to parse provided ARN")?
+                    .region
+                    .ok_or_else(|| anyhow!("Provided ARN does not include an AWS region"))?;
 
-            let details_proto = PostgresSourceDetails {
-                tables: tables.into_iter().map(|t| t.into()).collect(),
-                slot: slot.clone().expect("slot must exist"),
-            };
-            *details = Some(hex::encode(details_proto.encode_to_vec()));
+                let aws_config = normalize::aws_config(&mut with_options_map, Some(region.into()))?;
+                validate_aws_credentials(&aws_config, aws_external_id).await?;
+            }
+            CreateSourceConnector::Postgres {
+                conn,
+                publication,
+                slot,
+                details,
+            } => {
+                slot.get_or_insert_with(|| {
+                    format!(
+                        "materialize_{}",
+                        Uuid::new_v4().to_string().replace('-', "")
+                    )
+                });
+
+                // verify that we can connect upstream and snapshot publication metadata
+                let tables = mz_postgres_util::publication_info(&conn, &publication).await?;
+
+                let details_proto = PostgresSourceDetails {
+                    tables: tables.into_iter().map(|t| t.into()).collect(),
+                    slot: slot.clone().expect("slot must exist"),
+                };
+                *details = Some(hex::encode(details_proto.encode_to_vec()));
+            }
+            CreateSourceConnector::PubNub { .. } => (),
         }
-        CreateSourceConnector::PubNub { .. } => (),
+
+        purify_source_format(
+            format,
+            connector,
+            &envelope,
+            file,
+            &config_options,
+            with_options,
+        )
+        .await?;
+
+        Ok(stmt)
     }
-
-    purify_source_format(
-        format,
-        connector,
-        &envelope,
-        file,
-        &config_options,
-        with_options,
-    )
-    .await?;
-
-    Ok(stmt)
 }
 
 async fn purify_source_format(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -28,6 +28,7 @@ use reqwest::Url;
 use tokio::fs::File;
 use tokio::io::AsyncBufReadExt;
 use tokio::task;
+use tracing::info;
 use uuid::Uuid;
 
 use mz_ccsr::{Client, GetBySubjectError};
@@ -145,7 +146,7 @@ pub fn purify_create_source(
                         with_options.retain(|val| match val {
                             WithOption { key, .. } => key.as_str() != "kafka_time_offset",
                         });
-
+                        info!("add start_offset {:?}", start_offsets);
                         // Add `start_offset`
                         with_options.push(WithOption {
                             key: Ident::new("start_offset"),

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -9,8 +9,9 @@
 
 use crate::ast::Expr;
 use crate::catalog::{
-    CatalogComputeInstance, CatalogConfig, CatalogDatabase, CatalogError, CatalogItem,
-    CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, IdReference, SessionCatalog,
+    CatalogComputeInstance, CatalogConfig, CatalogConnector, CatalogDatabase, CatalogError,
+    CatalogItem, CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, IdReference,
+    SessionCatalog,
 };
 use crate::func::{Func, MZ_CATALOG_BUILTINS, MZ_INTERNAL_BUILTINS, PG_CATALOG_BUILTINS};
 use crate::names::{
@@ -140,6 +141,10 @@ impl CatalogItem for TestCatalogItem {
     }
 
     fn type_details(&self) -> Option<&CatalogTypeDetails<IdReference>> {
+        unimplemented!()
+    }
+
+    fn catalog_connector(&self) -> Result<&dyn CatalogConnector, CatalogError> {
         unimplemented!()
     }
 }

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -104,53 +104,54 @@ a
 1
 2
 
-# Ensure connectors work with SASL_PLAIN auth
-> CREATE CONNECTOR sasl_connector
-  FOR KAFKA BROKER '${testdrive.kafka-addr}'
-  WITH (
-      security_protocol = 'SASL_SSL',
-      sasl_mechanisms = 'PLAIN',
-      sasl_username = 'materialize',
-      sasl_password = 'sekurity',
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-
-> CREATE MATERIALIZED SOURCE connector_data
-  FROM KAFKA CONNECTOR sasl_connector
-  TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  WITH (
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  ENVELOPE DEBEZIUM
-
-> SELECT * FROM connector_data
-a
----
-1
-2
-
-> CREATE CONNECTOR sasl_env_pw_connector
-  FOR KAFKA BROKER '${testdrive.kafka-addr}'
-  WITH (
-      security_protocol = 'SASL_SSL',
-      sasl_mechanisms = 'PLAIN',
-      sasl_username = 'materialize',
-      sasl_password_env = 'SASL_PASSWORD',
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-
-> CREATE MATERIALIZED SOURCE connector_env_pw_data
-  FROM KAFKA CONNECTOR sasl_env_pw_connector
-  TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  WITH (
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  ENVELOPE DEBEZIUM
-
-> SELECT * from connector_env_pw_data
-a
----
-1
-2
+#TODO(nharring-adjacent): Uncomment once this test runs with experimental enabled
+## Ensure connectors work with SASL_PLAIN auth
+#> CREATE CONNECTOR sasl_connector
+#  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+#  WITH (
+#      security_protocol = 'SASL_SSL',
+#      sasl_mechanisms = 'PLAIN',
+#      sasl_username = 'materialize',
+#      sasl_password = 'sekurity',
+#      ssl_ca_location = '/share/secrets/ca.crt'
+#  )
+#
+#> CREATE MATERIALIZED SOURCE connector_data
+#  FROM KAFKA CONNECTOR sasl_connector
+#  TOPIC 'testdrive-data-${testdrive.seed}'
+#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+#  WITH (
+#      ssl_ca_location = '/share/secrets/ca.crt'
+#  )
+#  ENVELOPE DEBEZIUM
+#
+#> SELECT * FROM connector_data
+#a
+#---
+#1
+#2
+#
+#> CREATE CONNECTOR sasl_env_pw_connector
+#  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+#  WITH (
+#      security_protocol = 'SASL_SSL',
+#      sasl_mechanisms = 'PLAIN',
+#      sasl_username = 'materialize',
+#      sasl_password_env = 'SASL_PASSWORD',
+#      ssl_ca_location = '/share/secrets/ca.crt'
+#  )
+#
+#> CREATE MATERIALIZED SOURCE connector_env_pw_data
+#  FROM KAFKA CONNECTOR sasl_env_pw_connector
+#  TOPIC 'testdrive-data-${testdrive.seed}'
+#  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+#  WITH (
+#      ssl_ca_location = '/share/secrets/ca.crt'
+#  )
+#  ENVELOPE DEBEZIUM
+#
+#> SELECT * from connector_env_pw_data
+#a
+#---
+#1
+#2

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -103,3 +103,54 @@ a
 ---
 1
 2
+
+# Ensure connectors work with SASL_PLAIN auth
+> CREATE CONNECTOR sasl_connector
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+  WITH (
+      security_protocol = 'SASL_SSL',
+      sasl_mechanisms = 'PLAIN',
+      sasl_username = 'materialize',
+      sasl_password = 'sekurity',
+      ssl_ca_location = '/share/secrets/ca.crt'
+  )
+
+> CREATE MATERIALIZED SOURCE connector_data
+  FROM KAFKA CONNECTOR sasl_connector
+  TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      ssl_ca_location = '/share/secrets/ca.crt'
+  )
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM connector_data
+a
+---
+1
+2
+
+> CREATE CONNECTOR sasl_env_pw_connector
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+  WITH (
+      security_protocol = 'SASL_SSL',
+      sasl_mechanisms = 'PLAIN',
+      sasl_username = 'materialize',
+      sasl_password_env = 'SASL_PASSWORD',
+      ssl_ca_location = '/share/secrets/ca.crt'
+  )
+
+> CREATE MATERIALIZED SOURCE connector_env_pw_data
+  FROM KAFKA CONNECTOR sasl_env_pw_connector
+  TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      ssl_ca_location = '/share/secrets/ca.crt'
+  )
+  ENVELOPE DEBEZIUM
+
+> SELECT * from connector_env_pw_data
+a
+---
+1
+2

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -145,3 +145,34 @@ exact:error publishing kafka schemas for sink: unable to publish value schema to
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
 contains:self signed certificate in certificate chain
+
+# Ensure that connectors work with SSL basic_auth
+> CREATE CONNECTOR kafka_ssl
+  FOR KAFKA BROKER 'kafka:9092'
+  WITH (
+      security_protocol = 'SSL',
+      ssl_key_location = '/share/secrets/materialized.key',
+      ssl_certificate_location = '/share/secrets/materialized.crt',
+      ssl_ca_location = '/share/secrets/ca.crt',
+      ssl_key_password = 'mzmzmz'
+  )
+
+> CREATE MATERIALIZED SOURCE connector_source
+  FROM KAFKA CONNECTOR kafka_ssl
+  TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      ssl_key_location = '/share/secrets/materialized.key',
+      ssl_certificate_location = '/share/secrets/materialized.crt',
+      ssl_ca_location = '/share/secrets/ca.crt',
+      username = "materialize",
+      password = "sekurity"
+  )
+  ENVELOPE DEBEZIUM
+
+
+> SELECT * FROM connector_source
+a
+---
+1
+2

--- a/test/testdrive/connector-kafka-broker.td
+++ b/test/testdrive/connector-kafka-broker.td
@@ -12,9 +12,13 @@
 ###
 # Test core functionality by creating, introspecting and dropping a connector
 ###
+$ kafka-create-topic topic=connector_test partitions=1
+$ kafka-ingest format=bytes topic=connector_test
+1,2
+2,3
+
 > CREATE CONNECTOR testconn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
-  WITH (security_protocol = 'PLAINTEXT')
 
 > SELECT name, connector_type from mz_connectors
 name  connector_type
@@ -24,33 +28,27 @@ testconn   kafka
 > SHOW CREATE CONNECTOR testconn
 Connector   "Create Connector"
 ---------------------------------
-materialize.public.testconn   "CREATE CONNECTOR \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER '${testdrive.kafka-addr}' WITH (\"security_protocol\" = 'PLAINTEXT')"
+materialize.public.testconn   "CREATE CONNECTOR \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER '${testdrive.kafka-addr}'"
 
 
 > DROP CONNECTOR testconn
-
-$ kafka-create-topic topic=connector_test partitions=1
-$ kafka-ingest format=bytes topic=connector_test
-1,2
-2,3
 
 ###
 # Test that connectors work in creating a source
 ###
 > CREATE CONNECTOR testconn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
-  WITH (security_protocol = 'PLAINTEXT')
 
 > CREATE MATERIALIZED SOURCE connector_source (first, second)
   FROM KAFKA CONNECTOR testconn
-  TOPIC 'connector_test-${testdrive.seed}'
+  TOPIC 'testdrive-connector_test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
 
-# For some reason this does not work in testdrive, ignoring for now so it can prove drop semantics work correctly
 > SELECT * FROM connector_source
 first second mz_offset
 ----------------------
-2     3      1
+1     2      1
+2     3      2
 
 # Confirm we cannot drop the connector while a source depends upon it
 ! DROP CONNECTOR testconn;

--- a/test/testdrive/connector-kafka-broker.td
+++ b/test/testdrive/connector-kafka-broker.td
@@ -47,10 +47,10 @@ $ kafka-ingest format=bytes topic=connector_test
   FORMAT CSV WITH 2 COLUMNS
 
 # For some reason this does not work in testdrive, ignoring for now so it can prove drop semantics work correctly
-#> SELECT * FROM connector_source
-#first second mz_offset
-#----------------------
-#2     3      1
+> SELECT * FROM connector_source
+first second mz_offset
+----------------------
+2     3      1
 
 # Confirm we cannot drop the connector while a source depends upon it
 ! DROP CONNECTOR testconn;

--- a/test/testdrive/connector-kafka-broker.td
+++ b/test/testdrive/connector-kafka-broker.td
@@ -9,10 +9,12 @@
 #
 # Test basic connector functionality
 
+###
 # Test core functionality by creating, introspecting and dropping a connector
+###
 > CREATE CONNECTOR testconn
-  FOR KAFKA BROKER 'kafka:1234'
-  WITH (security_protocol = 'SASL_SSL', sasl_mechanisms = 'PLAIN')
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+  WITH (security_protocol = 'PLAINTEXT')
 
 > SELECT name, connector_type from mz_connectors
 name  connector_type
@@ -22,7 +24,41 @@ testconn   kafka
 > SHOW CREATE CONNECTOR testconn
 Connector   "Create Connector"
 ---------------------------------
-materialize.public.testconn   "CREATE CONNECTOR \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER 'kafka:1234' WITH (\"security_protocol\" = 'SASL_SSL', \"sasl_mechanisms\" = 'PLAIN')"
+materialize.public.testconn   "CREATE CONNECTOR \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER '${testdrive.kafka-addr}' WITH (\"security_protocol\" = 'PLAINTEXT')"
 
 
 > DROP CONNECTOR testconn
+
+$ kafka-create-topic topic=connector_test partitions=1
+$ kafka-ingest format=bytes topic=connector_test
+1,2
+2,3
+
+###
+# Test that connectors work in creating a source
+###
+> CREATE CONNECTOR testconn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+  WITH (security_protocol = 'PLAINTEXT')
+
+> CREATE MATERIALIZED SOURCE connector_source (first, second)
+  FROM KAFKA CONNECTOR testconn
+  TOPIC 'connector_test-${testdrive.seed}'
+  FORMAT CSV WITH 2 COLUMNS
+
+# For some reason this does not work in testdrive, ignoring for now so it can prove drop semantics work correctly
+#> SELECT * FROM connector_source
+#first second mz_offset
+#----------------------
+#2     3      1
+
+# Confirm we cannot drop the connector while a source depends upon it
+! DROP CONNECTOR testconn;
+contains:depended upon by catalog item 'materialize.public.connector_source'
+
+# Confirm the drop works if we add cascade
+> DROP CONNECTOR testconn CASCADE;
+
+# Validate the cascading drop actually happened
+! SELECT * FROM connector_source
+contains:unknown catalog item 'connector_source'

--- a/test/testdrive/connector-kafka-broker.td
+++ b/test/testdrive/connector-kafka-broker.td
@@ -9,6 +9,7 @@
 #
 # Test basic connector functionality
 
+# Test core functionality by creating, introspecting and dropping a connector
 > CREATE CONNECTOR testconn
   FOR KAFKA BROKER 'kafka:1234'
   WITH (security_protocol = 'SASL_SSL', sasl_mechanisms = 'PLAIN')

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -902,7 +902,7 @@ a b
   FORMAT AVRO USING SCHEMA '${ms-dbz-schema}'
   ENVELOPE DEBEZIUM
 
-> SELECT * FROM ms_dbz
+> SELECT * FROM ms_dbz_uncommitted
 a b
 ---
 1 1


### PR DESCRIPTION
This PR is the third in the series adding `CONNECTOR` as a new catalog type which allows for re-using config properties across sources as described in #11504. This PR expands the `CREATE SOURCE` syntax for `KAFKA` sources to allow use of the `CONNECTOR` keyword in place of `BROKER` as described in [the design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20220404_connectors.md) and adds test cases to the `kafka-sasl-plain` and `kafka-ssl` testdrive workflows.

### Motivation

  * This PR adds a known-desirable feature.

    https://github.com/MaterializeInc/materialize/issues/11504

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - It is now possible to create kafka sources with connectors to re-use broker URI and authentication parameters when running in experimental mode.
