### PR TITLE
ci: improve queue selection logic

### DIFF
--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -12,6 +12,8 @@
 steps:
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.cleanup.aws
     timeout_in_minutes: 10
+    agents:
+      queue: linux-x86_64
     env:
       AWS_DEFAULT_REGION: us-east-2
     plugins:

--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -12,7 +12,7 @@ steps:
     branches: main
     timeout_in_minutes: 30
     agents:
-      queue: builder
+      queue: builder-linux-x86_64
     concurrency: 1
     concurrency_group: deploy/devsite
     retry:
@@ -23,7 +23,7 @@ steps:
     branches: main
     timeout_in_minutes: 30
     agents:
-      queue: builder
+      queue: builder-linux-x86_64
     concurrency: 1
     concurrency_group: deploy/website
     retry:
@@ -32,6 +32,8 @@ steps:
 
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.deploy.linux
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     concurrency: 1
     concurrency_group: deploy/linux
     retry:
@@ -62,6 +64,8 @@ steps:
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy/pypi
+    agents:
+      queue: linux-x86_64
     retry:
       manual:
         permit_on_passed: true
@@ -70,6 +74,8 @@ steps:
     trigger: sql-logic-tests
     async: true
     branches: "v*.*rc*"
+    agents:
+      queue: linux-x86_64
     build:
       commit: "$BUILDKITE_COMMIT"
       branch: "$BUILDKITE_BRANCH"
@@ -80,6 +86,8 @@ steps:
     trigger: nightlies
     async: true
     branches: "v*.*rc*"
+    agents:
+      queue: linux-x86_64
     build:
       commit: "$BUILDKITE_COMMIT"
       branch: "$BUILDKITE_BRANCH"

--- a/ci/load/pipeline.yml
+++ b/ci/load/pipeline.yml
@@ -12,6 +12,8 @@
 steps:
   - command: bin/ci-builder run stable env MZ_SCRATCH_NO_DEFAULT_ENV=1 bin/pyactivate --dev -m materialize.cli.cloudbench start --profile confluent --trials 3 --revs HEAD  --append_metadata --s3_root mz-periodic-cloudbench/avro_ingest_periodic materialize.benches.avro_ingest -r 1000000 -n 10 -d big-records
     timeout_in_minutes: 20
+    agents:
+      queue: linux-x86_64
     env:
       AWS_DEFAULT_REGION: us-east-2
     plugins:

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -44,7 +44,7 @@ steps:
     command: bin/ci-builder run stable bin/pyactivate --dev -m ci.test.build x86_64
     timeout_in_minutes: 60
     agents:
-      queue: builder
+      queue: builder-linux-x86_64
 
   - command: bin/ci-builder run stable bin/pyactivate --dev -m ci.nightly.trim_pipeline
     if: build.source == "ui"
@@ -58,6 +58,8 @@ steps:
     label: "Feature benchmark against latest release"
     timeout_in_minutes: 180
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
@@ -69,11 +71,15 @@ steps:
     label: Code coverage
     timeout_in_minutes: 240
     command: bin/ci-builder run nightly bin/pyactivate --dev -m ci.nightly.coverage
+    agents:
+      queue: linux-x86_64
     skip: Disabled due to persistent OOMs when linking
 
   - id: kafka-matrix
     label: Kafka smoke test against previous Kafka versions
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: kafka-matrix
@@ -81,6 +87,8 @@ steps:
   - id: kafka-multi-broker
     label: Kafka multi-broker test
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: kafka-multi-broker
@@ -88,6 +96,8 @@ steps:
   - id: redpanda-testdrive
     label: ":panda_face: :racing_car: testdrive"
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
@@ -96,7 +106,7 @@ steps:
   - id: redpanda-testdrive-aarch64
     label: ":panda_face: :racing_car: testdrive aarch64"
     agents:
-      queue: aarch64
+      queue: linux-aarch64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: testdrive
@@ -105,6 +115,8 @@ steps:
   - id: upgrade
     label: "Upgrade testing"
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: upgrade
@@ -113,6 +125,8 @@ steps:
   - id: limits
     label: "Product limits"
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: limits
@@ -121,6 +135,8 @@ steps:
   - id: cluster-limits
     label: "Cluster Product limits"
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: limits
@@ -130,6 +146,8 @@ steps:
   - id: cluster-testdrive
     label: "Full testdrive against Cluster"
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
@@ -139,6 +157,8 @@ steps:
   - id: proxy
     label: ":squid: proxy"
     depends_on: build-x86_64
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
@@ -149,6 +169,8 @@ steps:
     label: ":racing_car: testdrive with --workers 1"
     depends_on: build-x86_64
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
@@ -167,12 +189,14 @@ steps:
   #         composition: testdrive
   #         args: [--aws-region=us-east-2, --workers=32]
   #   agents:
-  #     queue: x86_64-large
+  #     queue: linux-x86_64-large
 
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"
     depends_on: build-x86_64
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
@@ -183,6 +207,8 @@ steps:
     label: ":racing_car: testdrive with --persistent-user-tables"
     depends_on: build-x86_64
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
@@ -194,6 +220,8 @@ steps:
     label: "AWS credentials and role assumption"
     depends_on: build-x86_64
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
@@ -202,6 +230,8 @@ steps:
   - id: zippy
     label: "Zippy"
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
@@ -209,6 +239,8 @@ steps:
   - id: secrets
     label: "Secrets"
     timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: secrets
@@ -218,6 +250,8 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_mzcompose_*.xml
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persistence
@@ -229,6 +263,8 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_mzcompose_*.xml
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: catalog-compat

--- a/ci/security/pipeline.yml
+++ b/ci/security/pipeline.yml
@@ -12,3 +12,5 @@
 steps:
   - command: bin/ci-builder run stable cargo deny check advisories
     timeout_in_minutes: 5
+    agents:
+      queue: linux

--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -12,6 +12,8 @@ steps:
     label: ":bulb: SQL logic tests"
     timeout_in_minutes: 300
     artifact_paths: target/slt-summary.json
+    agents:
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest

--- a/ci/test/mkpipeline.sh
+++ b/ci/test/mkpipeline.sh
@@ -45,4 +45,6 @@ steps:
   - label: mkpipeline
     command: bin/ci-builder run stable bin/pyactivate --dev -m ci.test.mkpipeline
     priority: 2
+    agents:
+      queue: linux
 EOF


### PR DESCRIPTION
Adjust the other pipelines like the test pipeline was adjusted in #11916
for the new buildkite queue names. Because Buildkite will only autoscale
based on each stack's primary queue, it's best to use the primary queue
name where possible, rather than the old legacy names (e.g., "default"
or "builder").

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported in Slack: Buildkite jobs are getting stuck due to a mismatch between the targeted queues and the queues on which Buildkite is autoscaling.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
