### PR TITLE
test/testdrive: migrate tests off of Avro OCF sources/sinks

### DIFF
--- a/test/testdrive/avro-nonnull-record.td
+++ b/test/testdrive/avro-nonnull-record.td
@@ -28,12 +28,14 @@ $ set writer-schema={
     ]
   }
 
-$ avro-ocf-write path=data.ocf schema=${writer-schema}
+$ kafka-create-topic topic=data
+$ kafka-ingest topic=data format=avro schema=${writer-schema}
 {"a": {"b": 1, "c": 1}}
 {"a": {"b": 2, "c": 1}}
 
 > CREATE MATERIALIZED SOURCE basic
-  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > SELECT (b1.a).b, (b2.a).b FROM basic b1 LEFT JOIN basic b2 ON (b1.a).b = (b2.a).c
 1 1

--- a/test/testdrive/avro-unions.td
+++ b/test/testdrive/avro-unions.td
@@ -21,13 +21,15 @@ $ set writer-schema={
     ]
   }
 
-$ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
+$ kafka-create-topic topic=data
+$ kafka-ingest topic=data format=avro schema=${writer-schema}
 {"a": {"long": 1}, "b": null, "c": null, "d": {"string": "d"}}
 {"a": {"long": 2}, "b": {"long": 2}, "c": {"string": "foo"}, "d": {"long": 4}}
 {"a": {"long": 2}, "b": {"long": 2}, "c": {"long": 3}, "d": {"string": "d"}}
 
 > CREATE MATERIALIZED SOURCE unions
-  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > SHOW COLUMNS FROM unions
 name       nullable  type
@@ -38,11 +40,10 @@ c1         true      bigint
 c2         true      text
 d1         true      bigint
 d2         true      text
-mz_obj_no  false     bigint
 
 > SELECT * FROM unions
-a   b       c1      c2     d1      d2      mz_obj_no
-----------------------------------------------------
-1   <null>  <null>  <null>  <null>  d      1
-2   2       <null>  foo     4       <null> 2
-2   2       3       <null>  <null>  d      3
+a   b       c1      c2     d1      d2
+------------------------------------------
+1   <null>  <null>  <null>  <null>  d
+2   2       <null>  foo     4       <null>
+2   2       3       <null>  <null>  d

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -18,37 +18,37 @@ $ set writer-schema={
     ]
   }
 
-$ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
+$ kafka-create-topic topic=data
+$ kafka-ingest topic=data format=avro schema=${writer-schema}
 {"a": 1, "b": 1}
 
 # Materialized sources are synonymous with having an index automatically created
 > CREATE MATERIALIZED SOURCE mz_data
-  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > SELECT index_position FROM mz_index_columns WHERE index_id LIKE '%u%'
 index_position
 --------------
 1
 2
-3
 
 > SELECT position, name FROM mz_columns where id LIKE '%u%';
 position         name
 ----------------------
 1                a
 2                b
-3                mz_obj_no
 
 > SHOW INDEXES FROM mz_data
 cluster on_name  key_name             seq_in_index  column_name  expression  nullable enabled
 --------------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> mz_data  mz_data_primary_idx  1             a            <null>      false    true
 <VARIABLE_OUTPUT> mz_data  mz_data_primary_idx  2             b            <null>      false    true
-<VARIABLE_OUTPUT> mz_data  mz_data_primary_idx  3             mz_obj_no    <null>      false    true
 
 # Non-materialized views do not have indexes automatically created
 > CREATE SOURCE data
-  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > SHOW INDEXES FROM data
 cluster on_name  key_name  seq_in_index  column_name  expression  nullable  enabled
@@ -62,7 +62,6 @@ cluster on_name  key_name          seq_in_index column_name  expression  nullabl
 ----------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> data     data_primary_idx  1            a            <null>      false    true
 <VARIABLE_OUTPUT> data     data_primary_idx  2            b            <null>      false    true
-<VARIABLE_OUTPUT> data     data_primary_idx  3            mz_obj_no    <null>      false    true
 
 > CREATE DEFAULT INDEX ON mz_data
 
@@ -71,10 +70,8 @@ cluster on_name  key_name              seq_in_index  column_name  expression  nu
 ----------------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> mz_data  mz_data_primary_idx   1             a            <null>      false     true
 <VARIABLE_OUTPUT> mz_data  mz_data_primary_idx   2             b            <null>      false     true
-<VARIABLE_OUTPUT> mz_data  mz_data_primary_idx   3             mz_obj_no    <null>      false     true
 <VARIABLE_OUTPUT> mz_data  mz_data_primary_idx1  1             a            <null>      false     true
 <VARIABLE_OUTPUT> mz_data  mz_data_primary_idx1  2             b            <null>      false     true
-<VARIABLE_OUTPUT> mz_data  mz_data_primary_idx1  3             mz_obj_no    <null>      false     true
 
 # Materialized views are synonymous with having an index automatically created
 > CREATE MATERIALIZED VIEW matv AS
@@ -100,7 +97,6 @@ cluster on_name    key_name               seq_in_index  column_name  expression 
 ----------------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> data_view  data_view_primary_idx  1             a            <null>      false    true
 <VARIABLE_OUTPUT> data_view  data_view_primary_idx  2             b            <null>      false    true
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # Default indexes are equivalent in structure to indexes added automatically with the "MATERIALIZED" keyword
 > CREATE MATERIALIZED VIEW mz_data_view as SELECT * from data
@@ -110,7 +106,6 @@ cluster on_name       key_name                  seq_in_index  column_name  expre
 ------------------------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> mz_data_view  mz_data_view_primary_idx  1             a            <null>      false    true
 <VARIABLE_OUTPUT> mz_data_view  mz_data_view_primary_idx  2             b            <null>      false    true
-<VARIABLE_OUTPUT> mz_data_view  mz_data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
@@ -120,7 +115,6 @@ cluster on_name    key_name               seq_in_index  column_name  expression 
 ------------------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> data_view  data_view_primary_idx  1             a            <null>      false    true
 <VARIABLE_OUTPUT> data_view  data_view_primary_idx  2             b            <null>      false    true
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 # IF NOT EXISTS works for both automatically and explicitly created default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON matv
@@ -147,10 +141,8 @@ cluster on_name    key_name               seq_in_index  column_name  expression 
 ----------------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> data_view  data_view_primary_idx  1             a            <null>      false    true
 <VARIABLE_OUTPUT> data_view  data_view_primary_idx  2             b            <null>      false    true
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  3             mz_obj_no    <null>      false    true
 <VARIABLE_OUTPUT> data_view  named_idx              1             a            <null>      false    true
 <VARIABLE_OUTPUT> data_view  named_idx              2             b            <null>      false    true
-<VARIABLE_OUTPUT> data_view  named_idx              3             mz_obj_no    <null>      false    true
 
 > DROP INDEX data_view_primary_idx
 > DROP INDEX named_idx

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -18,12 +18,14 @@ $ set writer-schema={
     ]
   }
 
-$ avro-ocf-write path=data.ocf schema=${writer-schema} codec=null
+$ kafka-create-topic topic=data
+$ kafka-ingest topic=data format=avro schema=${writer-schema}
 {"a": 1, "b": "dog"}
 
 # Create library of objects and verify names
 > CREATE MATERIALIZED SOURCE mz_data
-  FROM AVRO OCF '${testdrive.temp-dir}/data.ocf'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > CREATE SINK sink1 FROM mz_data
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
@@ -37,7 +39,6 @@ cluster on_name  key_name             seq_in_index  column_name  expression  nul
 ---------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> mz_view  mz_view_primary_idx  1             a            <null>      false    true
 <VARIABLE_OUTPUT> mz_view  mz_view_primary_idx  2             b            <null>      false    true
-<VARIABLE_OUTPUT> mz_view  mz_view_primary_idx  3             mz_obj_no    <null>      false    true
 
 > CREATE VIEW dependent_view AS
     SELECT * FROM mz_view;
@@ -59,9 +60,9 @@ materialize.public.mz_data_primary_idx
 
 # Test that data can be selected from the source before renaming.
 > SELECT * FROM mz_data
-a  b    mz_obj_no
------------------
-1  dog  1
+a  b
+------
+1  dog
 
 > ALTER SOURCE mz_data RENAME TO renamed_mz_data;
 
@@ -77,9 +78,9 @@ materialize.public.renamed_mz_data
 
 # Test that data can be selected from the source after renaming.
 > SELECT * FROM renamed_mz_data
-a  b    mz_obj_no
------------------
-1  dog  1
+a  b
+------
+1  dog
 
 # Test that data can be selected from the source if it is rematerialized with
 # the new name. This previously tripped an assertion that asserted that a source
@@ -88,9 +89,9 @@ a  b    mz_obj_no
 > DROP INDEX mz_data_primary_idx
 > CREATE DEFAULT INDEX ON renamed_mz_data
 > SELECT * FROM renamed_mz_data
-a  b    mz_obj_no
------------------
-1  dog  1
+a  b
+------
+1  dog
 
 > SELECT name FROM mz_catalog_names WHERE name LIKE '%materialize.public.mz_view%';
 name
@@ -175,12 +176,11 @@ cluster on_name          key_name       seq_in_index  column_name expression nul
 ---------------------------------------------------------------------------------------------
 <VARIABLE_OUTPUT> renamed_mz_view  renamed_index  1             a           <null>     false    true
 <VARIABLE_OUTPUT> renamed_mz_view  renamed_index  2             b           <null>     false    true
-<VARIABLE_OUTPUT> renamed_mz_view  renamed_index  3             mz_obj_no   <null>     false    true
 
 > SHOW CREATE INDEX renamed_index
 Index               "Create Index"
 ---------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_index "CREATE INDEX \"renamed_index\" IN CLUSTER [1] ON \"materialize\".\"public\".\"renamed_mz_view\" (\"a\", \"b\", \"mz_obj_no\")"
+materialize.public.renamed_index "CREATE INDEX \"renamed_index\" IN CLUSTER [1] ON \"materialize\".\"public\".\"renamed_mz_view\" (\"a\", \"b\")"
 
 # Simple dependencies are renamed
 > SHOW CREATE VIEW dependent_view
@@ -210,7 +210,7 @@ materialize.public.oppositional_view "CREATE VIEW \"materialize\".\"public\".\"o
 > ALTER VIEW renamed_mz_view RENAME TO t1
 > CREATE VIEW a AS SELECT 1 AS a
 > CREATE VIEW v0 AS SELECT 2 AS b
-> CREATE VIEW t2 (a, b, t1_a, t1_b, mz_obj_no) AS
+> CREATE VIEW t2 (a, b, t1_a, t1_b) AS
   SELECT * FROM a
   JOIN v0
   ON a.a = v0.b

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -69,8 +69,9 @@ u      false     uuid
 "85907cb9-ac9b-4e35-84b8-60dc69368aca"
 
 > CREATE SINK uuid_sink_${testdrive.seed} FROM data_view
-  INTO AVRO OCF '${testdrive.temp-dir}/uuid-sink.ocf'
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-$ avro-ocf-verify sink=materialize.public.uuid_sink_${testdrive.seed}
+$ kafka-verify format=avro sort-messages=true sink=materialize.public.uuid_sink_${testdrive.seed}
 {"before": null, "after": {"row":{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}
 {"before": null, "after": {"row":{"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}}


### PR DESCRIPTION
Avro OCF sources and sinks are slated for removal, since they don't work
in Materialize Cloud. See #11875.

This commit migrates tests that incidentally use Avro OCF sources and
sinks to use Avro-formatted Kafka sources and sinks instead. That is,
these tests were not meant to test Avro OCF sources/sinks specifically,
but rather other facets of the Avro encoding/decoding logic, and
therefore should continue to exist even when Avro OCF sources/sinks are
removed.

Extracted from #11936.

Co-authored-by: Gus Wynn <gus@materialize.com>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
