### PR TITLE
soft_fail kafka resumption tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -343,6 +343,8 @@ steps:
     label: Kafka resumption tests
     depends_on: build-x86_64
     timeout_in_minutes: 30
+    # https://github.com/MaterializeInc/materialize/issues/11992
+    soft_fail: true
     artifact_paths: junit_mzcompose_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
### Motivation

Mark Kakfa resumption tests `soft_fail`, they're flaky. See #11992.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A