### PR TITLE
testdrive: port file delimiter test to s3

### DIFF
--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -7,26 +7,42 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=posix.txt
+$ s3-create-bucket bucket=test
+
+$ s3-put-object bucket=test key=posix
 foo
 bar
 
 > CREATE MATERIALIZED SOURCE posix
-  FROM FILE '${testdrive.temp-dir}/posix.txt'
+  FROM S3 DISCOVER OBJECTS MATCHING 'posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT BYTES;
 
-> SELECT data FROM posix ORDER BY mz_line_no;
+> SELECT data FROM posix ORDER BY mz_record;
 foo
 bar
 
-$ file-append path=non_posix.txt trailing-newline=false
+$ s3-put-object bucket=test key=non-posix trailing-newline=false
 foo
 bar
 
 > CREATE MATERIALIZED SOURCE non_posix
-  FROM FILE '${testdrive.temp-dir}/non_posix.txt'
+  FROM S3 DISCOVER OBJECTS MATCHING 'non-posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT BYTES;
 
-> SELECT data FROM non_posix ORDER BY mz_line_no;
+> SELECT data FROM non_posix ORDER BY mz_record;
 foo
 bar


### PR DESCRIPTION
File sources are slated for removal (see #11875). Port a test that uses
file sources to test how the source ingestion pipeline handles trailing
newlines to use S3 sources instead, as we still want to test this part
of the source ingestion pipeline.

This requires changes to testdrive to make the behavior of
`s3-put-object` match the behavior of `file-append`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
