### PR TITLE
add launch.json for attaching DAP-compatible editors to GDB

### DIFF
--- a/misc/editor/dap/launch-gdb.json
+++ b/misc/editor/dap/launch-gdb.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "mzd attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/target/debug/materialized",
+            "cwd": "${workspaceFolder}",
+            "processId": "${command:pickProcess}",
+            "environment": [],
+            "MIMode": "gdb",
+            "miDebuggerPath": "rust-gdb"
+        },
+        {
+            "name": "computed attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/target/debug/computed",
+            "cwd": "${workspaceFolder}",
+            "processId": "${command:pickProcess}",
+            "environment": [],
+            "MIMode": "gdb",
+            "miDebuggerPath": "rust-gdb"
+        },
+        {
+            "name": "storaged attach",
+            "type": "cppdbg",
+            "request": "attach",
+            "program": "${workspaceFolder}/target/debug/storaged",
+            "cwd": "${workspaceFolder}",
+            "processId": "${command:pickProcess}",
+            "environment": [],
+            "MIMode": "gdb",
+            "miDebuggerPath": "rust-gdb"
+        }
+    ]
+}


### PR DESCRIPTION
This is working for me (dap-mode in emacs) but I'd appreciate if someone who uses vscode could also try it out and see that attaching to the various running processes works.