### PR TITLE
persist: add a tiny bit of structure to timeout errors

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -220,7 +220,7 @@ where
             }
             let sleep = Duration::from_secs(1);
             if Instant::now() + sleep > deadline {
-                return Err(ExternalError::from(anyhow!("timeout at {:?}", deadline)));
+                return Err(ExternalError::new_timeout(deadline));
             }
             // Wait a bit and try again.
             //
@@ -280,7 +280,7 @@ where
                     // TODO: Some sort of exponential backoff here?
                     let sleep = Duration::from_secs(0);
                     if Instant::now() + sleep > deadline {
-                        return Err(ExternalError::from(anyhow!("timeout at {:?}", deadline)));
+                        return Err(ExternalError::new_timeout(deadline));
                     }
                     continue;
                 }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -121,7 +121,7 @@ where
                     None => {
                         let sleep = Duration::from_secs(1);
                         if Instant::now() + sleep > deadline {
-                            return Err(ExternalError::from(anyhow!("timeout at {:?}", deadline)));
+                            return Err(ExternalError::new_timeout(deadline));
                         }
                         info!(
                             "unexpected missing blob, trying again in {:?}: {}",
@@ -283,7 +283,7 @@ where
                     None => {
                         let sleep = Duration::from_secs(1);
                         if Instant::now() + sleep > deadline {
-                            return Err(ExternalError::from(anyhow!("timeout at {:?}", deadline)));
+                            return Err(ExternalError::new_timeout(deadline));
                         }
                         info!(
                             "unexpected missing blob, trying again in {:?}: {}",

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -13,7 +13,6 @@ use std::ops::Range;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use anyhow::anyhow;
 use async_trait::async_trait;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -259,7 +258,7 @@ impl<B: BlobMulti + Send + Sync> BlobMulti for UnreliableBlobMulti<B> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 
     async fn list_keys(&self, deadline: Instant) -> Result<Vec<String>, ExternalError> {
@@ -269,7 +268,7 @@ impl<B: BlobMulti + Send + Sync> BlobMulti for UnreliableBlobMulti<B> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 
     async fn set(
@@ -285,7 +284,7 @@ impl<B: BlobMulti + Send + Sync> BlobMulti for UnreliableBlobMulti<B> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 
     async fn delete(&self, deadline: Instant, key: &str) -> Result<(), ExternalError> {
@@ -295,7 +294,7 @@ impl<B: BlobMulti + Send + Sync> BlobMulti for UnreliableBlobMulti<B> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 }
 
@@ -345,7 +344,7 @@ impl<C: Consensus + Send + Sync> Consensus for UnreliableConsensus<C> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 
     async fn compare_and_set(
@@ -364,7 +363,7 @@ impl<C: Consensus + Send + Sync> Consensus for UnreliableConsensus<C> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 
     async fn scan(
@@ -379,7 +378,7 @@ impl<C: Consensus + Send + Sync> Consensus for UnreliableConsensus<C> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 
     async fn truncate(
@@ -394,7 +393,7 @@ impl<C: Consensus + Send + Sync> Consensus for UnreliableConsensus<C> {
                 return res;
             }
         }
-        Err(ExternalError::from(anyhow!("unreliable: timeout")))
+        Err(ExternalError::new_timeout(deadline))
     }
 }
 


### PR DESCRIPTION
It turns out that we do already have instances where a caller has some
response to a timeout error other than "uh oh, panic".

### Motivation

  * This PR adds a feature that has not yet been specified.

Make Chae's life easier.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
