### PR TITLE
pass storaged/computed log filters in mz mzcompose

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -49,6 +49,8 @@ class Materialized(Service):
                 # To dynamically change the environment during a workflow run,
                 # use Composition.override.
                 "MZ_LOG_FILTER",
+                "STORAGED_LOG_FILTER",
+                "COMPUTED_LOG_FILTER",
             ]
 
         if forward_aws_credentials:


### PR DESCRIPTION
These aren't passed through, I want to be able to set the storaged log filter when i am using an mzcompose

### Motivation

internal infra


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
