### PR TITLE
Warn on frontegg authentication failures in pgwire & http

### DIFF
--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -30,7 +30,7 @@ use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio_openssl::SslStream;
 use tower::ServiceBuilder;
 use tower_http::cors::{self, CorsLayer, Origin};
-use tracing::error;
+use tracing::{error, warn};
 
 use mz_coord::session::Session;
 use mz_frontegg_auth::FronteggAuthentication;
@@ -198,7 +198,10 @@ impl Server {
                             }
                             Ok(email)
                         })
-                        .map_err(|_e| "unauthorized")
+                        .map_err(|e| {
+                            warn!("HTTP request failed authentication: {}", e);
+                            "unauthorized"
+                        })
                 } else {
                     // If there was no mzcloud auth, we can use the cert's username if present,
                     // otherwise the system user.


### PR DESCRIPTION
This keeps the connection endpoint in the dark about why authentication failed, but does alert admins that a connection attempt has been thwarted.

### Motivation

  * This PR adds a known-desirable feature.

Administrators (and runners of e2e tests (-:) will wish to know why their users can't authenticate to their materialize deployments.

### Tips for reviewer

This is a  pretty straightforward port over from the axum change in https://github.com/MaterializeInc/materialize/commit/cc9864f36ea7ea766386a1f5eed62a17a7b55679#diff-68196d3d09d6214bdd1d08a3c96fff19763953c41e5ce1e8d4d4d87407290d26R279. I added the pgwire warning because we'll need that too (and will file a separate PR against main for that).

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - The server now logs a warning when invalid frontegg credentials are passed in an HTTP or pgwire connection attempt.
