### PR TITLE
sql: Remove IF NOT EXISTS from CREATE CLUSTER statement

### DIFF
--- a/doc/developer/design/20220214_create_cluster.md
+++ b/doc/developer/design/20220214_create_cluster.md
@@ -14,7 +14,7 @@ create, alter, drop, and list clusters, respectively:
 
 ```
 create_cluster_stmt ::=
-  CREATE CLUSTER [IF NOT EXISTS] <name> [[WITH] <option> [, <option>...]]
+  CREATE CLUSTER <name> [[WITH] <option> [, <option>...]]
 
 alter_cluster_stmt ::=
   ALTER CLUSTER <name> [[SET] <option> [, <option>...]]
@@ -38,8 +38,7 @@ a catalog, and so do not belong in the usual namespace of databases and schemas.
 For a similarly scoped object in PostgreSQL, see [publications].
 
 The `CREATE CLUSTER` statement creates a new cluster. It returns an error if
-a cluster with the specified name already exists unless the `IF NOT EXISTS`
-clause is present.
+a cluster with the specified name already exists.
 
 The `ALTER CLUSTER` statement changes properties of an existing cluster.
 

--- a/doc/developer/design/20220413_cluster_replica.md
+++ b/doc/developer/design/20220413_cluster_replica.md
@@ -16,11 +16,11 @@ follows:
 
 ```sql
 create_cluster_stmt ::=
-  CREATE CLUSTER [IF NOT EXISTS] <name>
+  CREATE CLUSTER <name>
     [<inline_replica> [, <inline_replica> ...]]
 
 create_cluster_replica_stmt ::=
-  CREATE CLUSTER REPLICA [IF NOT EXISTS] <name> FOR <cluster>
+  CREATE CLUSTER REPLICA <name> FOR <cluster>
     [<replica_option> [, <replica_option> ...]]
 
 inline_replica ::= REPLICA <name> [<replica_option> [, <replica_option> ...]]

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1889,12 +1889,6 @@ impl Coordinator {
                     .unwrap();
                 Ok(ExecuteResponse::CreatedComputeInstance { existed: false })
             }
-            Err(CoordError::Catalog(catalog::Error {
-                kind: catalog::ErrorKind::ClusterAlreadyExists(_),
-                ..
-            })) if plan.if_not_exists => {
-                Ok(ExecuteResponse::CreatedComputeInstance { existed: true })
-            }
             Err(err) => Err(err),
         }
     }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -879,8 +879,6 @@ impl_display_t!(CreateTypeStatement);
 pub struct CreateClusterStatement<T: AstInfo> {
     /// Name of the created cluster.
     pub name: Ident,
-    /// Whether the `IF NOT EXISTS` clause was specified.
-    pub if_not_exists: bool,
     /// The comma-separated options.
     pub options: Vec<ClusterOption<T>>,
 }
@@ -888,9 +886,6 @@ pub struct CreateClusterStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for CreateClusterStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("CREATE CLUSTER ");
-        if self.if_not_exists {
-            f.write_str("IF NOT EXISTS ");
-        }
         f.write_node(&self.name);
         if !self.options.is_empty() {
             f.write_str(" ");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2491,7 +2491,6 @@ impl<'a> Parser<'a> {
 
     fn parse_create_cluster(&mut self) -> Result<Statement<Raw>, ParserError> {
         self.next_token();
-        let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_identifier()?;
         let _ = self.parse_keyword(WITH);
         let options = if matches!(self.peek_token(), Some(Token::Semicolon) | None) {
@@ -2501,7 +2500,6 @@ impl<'a> Parser<'a> {
         };
         Ok(Statement::CreateCluster(CreateClusterStatement {
             name,
-            if_not_exists,
             options,
         }))
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1280,7 +1280,7 @@ CREATE CLUSTER cluster
 ----
 CREATE CLUSTER cluster
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [] })
 
 parse-statement
 CREATE CLUSTER cluster VIRTUAL
@@ -1294,28 +1294,28 @@ CREATE CLUSTER cluster SIZE 'small'
 ----
 CREATE CLUSTER cluster SIZE 'small'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Size(Value(String("small")))] })
 
 parse-statement
 CREATE CLUSTER cluster SIZE = 'small'
 ----
 CREATE CLUSTER cluster SIZE 'small'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Size(Value(String("small")))] })
 
 parse-statement
 CREATE CLUSTER cluster SIZE 'small', REMOTE replica1 ('host1'), SIZE 'medium', REMOTE replica2 ('host2')
 ----
 CREATE CLUSTER cluster SIZE 'small', REMOTE replica1 ('host1'), SIZE 'medium', REMOTE replica2 ('host2')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Size(Value(String("small"))), Remote { name: Ident("replica1"), hosts: [Value(String("host1"))] }, Size(Value(String("medium"))), Remote { name: Ident("replica2"), hosts: [Value(String("host2"))] }] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Size(Value(String("small"))), Remote { name: Ident("replica1"), hosts: [Value(String("host1"))] }, Size(Value(String("medium"))), Remote { name: Ident("replica2"), hosts: [Value(String("host2"))] }] })
 
 parse-statement
 CREATE CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
 ----
 CREATE CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), if_not_exists: false, options: [Remote { name: Ident("replica1"), hosts: [Value(String("host1")), Value(String("host2"))] }, Remote { name: Ident("replica2"), hosts: [Value(String("host3")), Value(String("host4"))] }] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Remote { name: Ident("replica1"), hosts: [Value(String("host1")), Value(String("host2"))] }, Remote { name: Ident("replica2"), hosts: [Value(String("host3")), Value(String("host4"))] }] })
 
 parse-statement
 ALTER CLUSTER cluster REMOTE replica1 ('host1', 'host2'), REMOTE replica2 ('host3', 'host4')

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -149,7 +149,6 @@ pub struct CreateRolePlan {
 #[derive(Debug)]
 pub struct CreateComputeInstancePlan {
     pub name: String,
-    pub if_not_exists: bool,
     pub config: ComputeInstanceConfig,
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2681,15 +2681,10 @@ pub fn describe_create_cluster(
 
 pub fn plan_create_cluster(
     _: &StatementContext,
-    CreateClusterStatement {
-        name,
-        if_not_exists,
-        options,
-    }: CreateClusterStatement<Aug>,
+    CreateClusterStatement { name, options }: CreateClusterStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     Ok(Plan::CreateComputeInstance(CreateComputeInstancePlan {
         name: normalize::ident(name),
-        if_not_exists,
         config: plan_cluster_options(options)?,
     }))
 }


### PR DESCRIPTION
CREATE IF NOT EXISTS (CINE) features tend to be a debated feature in
SQL. Searching "CINE" on the postgres hackers mailing lists reveals
some past discussions about this feature. In general after executing
a CINE statement, the state of the system can be ambigious if the
details of the create statement don't match the details of the existing
object.

This commit removes the IF NOT EXISTS feature from CREATE CLUSTER since
we don't currently have a use case for it.

### Motivation
This PR refactors existing code.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Removes `IF NOT EXISTS` syntax from `CREATE CLUSTER` statements
