### PR TITLE
Document `render_source` and its components

### DIFF
--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -20,7 +20,6 @@ pub struct AvroDecoderState {
 }
 
 impl AvroDecoderState {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         value_schema: &str,
         schema_registry_config: Option<mz_ccsr::ClientConfig>,

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 //! This module provides functions that
-//! build decoding pipelines from _base_ source streams.
+//! build decoding pipelines from raw source streams.
 //!
 //! The primary exports are [`render_decode`], [`render_decode_delimited`], and
 //! [`render_decode_cdcv2`]. See their docs for more details about their differences.

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -13,9 +13,9 @@
 
 pub mod boundary;
 #[cfg(feature = "server")]
-pub(crate) mod decode;
+pub mod decode;
 #[cfg(feature = "server")]
-pub(crate) mod render;
+pub mod render;
 #[cfg(feature = "server")]
 pub(crate) mod server;
 #[cfg(feature = "server")]

--- a/src/storage/src/render/debezium.rs
+++ b/src/storage/src/render/debezium.rs
@@ -903,7 +903,6 @@ struct SkipInfo {
     old_offset: i64,
 }
 
-#[allow(clippy::too_many_arguments)]
 fn log_duplication_info(
     position: RowCoordinates,
     connector_offset: i64,


### PR DESCRIPTION
This pr does the following:

- Change `create_source` and `create_source_simple` into `create_raw_source` and `create_raw_source_simple`. This distinguishes them from `render_source` better, as they are only the first step of source rendering. The use of the word "raw" is based on conversations: https://github.com/MaterializeInc/materialize/pull/12109 and https://github.com/MaterializeInc/materialize/issues/11957
- Add more thorough docs describing the various stages of source rendering, throughout the `mz-storage` crate, and in the function itself
- Changes some `pub(crate)` to `pub` to be able to improve some module docs

### Motivation

better docs

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
