### PR TITLE
dataflow-types: make `metadata_columns` and `metadata_column_types` agree

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1341,7 +1341,7 @@ pub mod sources {
                     // TODO: should key be included in the sorted list? Breaking change, and it's
                     // already special (it commonly multiple columns embedded in it).
                     let mut items = BTreeMap::new();
-                    if include_defaults {
+                    if include_defaults && offset.is_none() {
                         items.insert(4, IncludedColumnSource::DefaultPosition);
                     }
                     for (include, ty) in [

--- a/test/testdrive/github-12005.td
+++ b/test/testdrive/github-12005.td
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=test
+
+$ kafka-ingest topic=test format=bytes
+jack,jill
+goofus,gallant
+
+> CREATE SOURCE src
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-test-${testdrive.seed}'
+  FORMAT CSV WITH 2 COLUMNS
+  INCLUDE OFFSET
+
+> CREATE MATERIALIZED VIEW v AS
+  SELECT column1 || column2 AS c FROM src
+
+> SELECT * FROM v
+jackjill
+goofusgallant


### PR DESCRIPTION
These two functions are tightly coupled and need to make the same
decision about which metadata columns exist given the same input.  Prior
to this commit, `metadata_columns` would elide Kafka's default metadata
if an offset was explicitly specified, but `metadata_column_types` would
not. This disparity caused #12005.

`metadata_columns` was making the right decision here (i.e., the ones
that our tests expect), so change `metadata_column_types` to match.

On a meta level, the way this code is structured is a recipe for bugs of
this form. I'm sure there are more lurking. We need to get on #11957
ASAP.

Fix #12005.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Don't think too hard about the surrounding code structure issues.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
