### PR TITLE
test: port a few more file source-using tests to Kafka sources

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -132,14 +132,16 @@ $ kafka-create-topic topic=input_cdcv2
 
 > CREATE MATERIALIZED VIEW input_kafka_dbz_derived_table AS SELECT * FROM ( SELECT * FROM input_kafka_dbz ) AS a1;
 
-$ file-append path=static.csv
+$ kafka-create-topic topic=static
+$ kafka-ingest topic=static format=bytes
 city,state,zip
 Rochester,NY,14618
 New York,NY,10004
 "bad,place""",CA,92679
 
 > CREATE SOURCE input_csv
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-static-${testdrive.seed}'
   FORMAT CSV WITH 3 COLUMNS
 
 > CREATE SINK output1 FROM input_kafka_cdcv2

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -7,13 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=request.log
+$ kafka-create-topic topic=request-log
+$ kafka-ingest topic=request-log format=bytes
 123.17.127.5 - - [22/Jan/2020 18:59:52] "GET / HTTP/1.1" 200 -
 8.15.119.56 - - [22/Jan/2020 18:59:52] "GET /detail/nNZpqxzR HTTP/1.1" 200 -
 96.12.83.72 - - [22/Jan/2020 18:59:52] "GET /search/?kw=helper+ins+hennaed HTTP/1.1" 200 -
 
 # Regex explained here: https://www.debuggex.com/r/k48kBEt-lTMUZbaw
-> CREATE MATERIALIZED SOURCE regex_source FROM FILE '${testdrive.temp-dir}/request.log'
+> CREATE MATERIALIZED SOURCE regex_source
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-request-log-${testdrive.seed}'
   FORMAT REGEX '(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -'
 
 > SHOW COLUMNS FROM regex_source
@@ -25,11 +27,11 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-mz_line_no         false     bigint
+mz_offset          false     bigint
 
-> SELECT * FROM regex_source ORDER BY mz_line_no
-ip            ts                      path                                           search_kw           product_detail_id  code  mz_line_no
---------------------------------------------------------------------------------------------------------------------------------------------
+> SELECT * FROM regex_source
+ip            ts                      path                                           search_kw           product_detail_id  code  mz_offset
+-------------------------------------------------------------------------------------------------------------------------------------------
 123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
 8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
 96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
@@ -40,7 +42,7 @@ search_kw
 helper+ins+hennaed
 
 > CREATE MATERIALIZED SOURCE regex_source_named_cols (ip, ts, path, search_kw, product_detail_id, code)
-  FROM FILE '${testdrive.temp-dir}/request.log'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-request-log-${testdrive.seed}'
   FORMAT REGEX '(?P<foo1>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<foo2>[^]]+)\] "(?P<foo3>(?:GET /search/\?kw=(?P<foo4>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<foo5>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<foo6>\d{3}) -'
 
 > SHOW COLUMNS FROM regex_source_named_cols
@@ -52,11 +54,11 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-mz_line_no         false     bigint
+mz_offset          false     bigint
 
 # verify metadata column renaming
 > CREATE MATERIALIZED SOURCE regex_source_renamed_cols (ip, ts, path, search_kw, product_detail_id, code, lineno)
-  FROM FILE '${testdrive.temp-dir}/request.log'
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-request-log-${testdrive.seed}'
   FORMAT REGEX '(?P<foo1>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<foo2>[^]]+)\] "(?P<foo3>(?:GET /search/\?kw=(?P<foo4>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<foo5>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<foo6>\d{3}) -'
 
 > SHOW COLUMNS FROM regex_source_renamed_cols
@@ -70,21 +72,23 @@ product_detail_id  true      text
 code               true      text
 lineno             false     bigint
 
-> SELECT * FROM regex_source_named_cols ORDER BY mz_line_no
-ip            ts                      path                                           search_kw           product_detail_id  code  mz_line_no
---------------------------------------------------------------------------------------------------------------------------------------------
+> SELECT * FROM regex_source_named_cols
+ip            ts                      path                                           search_kw           product_detail_id  code  mz_offset
+-------------------------------------------------------------------------------------------------------------------------------------------
 123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
 8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
 96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
 
 # Malformed regex with non-utf-8 characters
-$ file-append path=malformed-request.log
+$ kafka-create-topic topic=malformed-request-log
+$ kafka-ingest topic=malformed-request-log format=bytes
 123.17.127.5 - - [22/Jan/2020 18:59:52] "GET / HTTP/1.1" 200 -
 8.15.119.56 - - [22/Jan/2020 18:59:52] "GET /detail/nNZpqxzR HTTP/1.1" 200 -
 this line has invalid UTF-8 and will be cause dataflow errors --> \x80 <--
 96.12.83.72 - - [22/Jan/2020 18:59:52] "GET /search/?kw=helper+ins+hennaed HTTP/1.1" 200 -
 
-> CREATE MATERIALIZED SOURCE bad_regex_source FROM FILE '${testdrive.temp-dir}/malformed-request.log'
+> CREATE MATERIALIZED SOURCE bad_regex_source
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-malformed-request-log-${testdrive.seed}'
   FORMAT REGEX '(?P<ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<ts>[^]]+)\] "(?P<path>(?:GET /search/\?kw=(?P<search_kw>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<product_detail_id>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<code>\d{3}) -'
 
 ! SELECT * FROM bad_regex_source

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -9,18 +9,22 @@
 
 $ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
 
-$ file-append path=test.csv
-a,b
+$ kafka-create-topic topic=test
+$ kafka-ingest topic=test format=bytes
 jack,jill
 goofus,gallant
 
-> CREATE SOURCE src
-  FROM FILE '${testdrive.temp-dir}/test.csv'
-  FORMAT CSV WITH HEADER
+> CREATE SOURCE src (a, b)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-test-${testdrive.seed}'
+  FORMAT CSV WITH 2 COLUMNS
+  INCLUDE OFFSET
 
-> CREATE MATERIALIZED SOURCE src_materialized
-  FROM FILE '${testdrive.temp-dir}/test.csv'
-  FORMAT CSV WITH HEADER
+> CREATE MATERIALIZED SOURCE src_materialized (a, b)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-test-${testdrive.seed}'
+  FORMAT CSV WITH 2 COLUMNS
+  INCLUDE OFFSET
 
 > CREATE VIEW v1 AS
   SELECT a || b AS c FROM src
@@ -109,12 +113,12 @@ cluster name   type  volatility
 <CLUSTER_NAME> snk5   user  unknown
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_offset": 1}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk2 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_offset": 1}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
@@ -142,36 +146,27 @@ $ kafka-verify format=avro sink=materialize.public.snk6
 {"before": null, "after": {"row":{"c": true}}}
 
 # Test AS OF and WITH/WITHOUT SNAPSHOT.
-> CREATE MATERIALIZED SOURCE dynamic_src
-  FROM FILE '${testdrive.temp-dir}/test.csv' WITH (tail = true)
-  FORMAT CSV WITH HEADER
 
-# Ensure the data is read into the source before creating sinks from it
-# to correctly test WITH/WITHOUT SNAPSHOT.
-> SELECT * FROM dynamic_src
-jack jill 1
-goofus gallant 2
-
-> CREATE SINK snk7 FROM dynamic_src
+> CREATE SINK snk7 FROM src_materialized
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk7'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITHOUT SNAPSHOT
 
-> CREATE SINK snk8 FROM dynamic_src
+> CREATE SINK snk8 FROM src_materialized
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk8'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH SNAPSHOT
 
-$ file-append path=test.csv
+$ kafka-ingest topic=test format=bytes
 extra,row
 
 $ kafka-verify format=avro sink=materialize.public.snk7
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 3}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_offset": 3}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_line_no": 3}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_line_no": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_line_no": 1}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_offset": 3}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_offset": 1}}}
 
 # Test that we are correctly handling WITH/WITHOUT SNAPSHOT on views with
 # empty upper frontier

--- a/test/testdrive/transactions-timedomain-nonmaterialized.td
+++ b/test/testdrive/transactions-timedomain-nonmaterialized.td
@@ -9,18 +9,21 @@
 
 # Test behavior of timedomains with non-materialized sources.
 
-$ file-append path=static.csv
+$ kafka-create-topic topic=static
+$ kafka-ingest topic=static format=bytes
 1
 2
 4
 
 > CREATE MATERIALIZED SOURCE indexed (c)
-  FROM FILE '${testdrive.temp-dir}/static.csv'
-  FORMAT CSV WITH 1 COLUMNS
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-static-${testdrive.seed}'
+  FORMAT TEXT
 
 > CREATE SOURCE unindexed (c)
-  FROM FILE '${testdrive.temp-dir}/static.csv'
-  FORMAT CSV WITH 1 COLUMNS
+  FROM KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-static-${testdrive.seed}'
+  FORMAT TEXT
 
 > CREATE VIEW v_unindexed AS SELECT count(*) FROM unindexed
 


### PR DESCRIPTION
File sources are slated for removal (see #11875). This commit ports a
few more tests that only incidentally use file sources to use Kafka
sources instead.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
