### PR TITLE
doc/user: switch existing user-facing walkthroughs to link to the new `/demos` repo

### DIFF
--- a/doc/user/content/integrations/docker.md
+++ b/doc/user/content/integrations/docker.md
@@ -44,23 +44,6 @@ On macOS:
 
 Note that on Linux, Docker automatically shares memory with the host machines; as long as your host machine has more than 8 GB of memory, you shouldn't run into issues.
 
-### Use the `mzcompose` wrapper script
-
-Materialize's Docker Compose configurations do not work directly with the
-`docker-compose` command, but require a thin wrapper called `mzcompose`.
-
-You will need [**Python 3.5+**][python] to run
-`mzcompose`. This is installed by default on recent versions of macOS and most
-Linux distributions.
-
-The `mzcompose` wrapper accepts all the same arguments and options as
-`docker-compose`. Use it just as you would `docker-compose`:
-
-```shell
-$ cd demo/http_logs
-$ ./mzcompose up -d  # replaces `docker-compose up -d`
-```
-
 [Docker]: https://docs.docker.com/get-started/overview/
 [Docker Compose]: https://docs.docker.com/compose/
 [python]: https://www.python.org/downloads/

--- a/doc/user/content/quickstarts/live-analytics.md
+++ b/doc/user/content/quickstarts/live-analytics.md
@@ -115,11 +115,11 @@ Putting this all together, our deployment looks like this:
 
 ### Preparing the environment
 
-1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
+1. [Set up Docker and Docker compose](/integrations/docker), if you haven't
    already.
 
    **Note for macOS users:** Be sure to [increase Docker
-   resources](/third-party/docker/#increase-docker-resources) to at least 2 CPUs
+   resources](/integrations/docker/#increase-docker-resources) to at least 2 CPUs
    and 8GB memory. Running Docker for Mac with less resources may cause the demo
    to fail.
 
@@ -384,6 +384,6 @@ etc. but this is a reasonable workflow.
 
 ## Related pages
 
--   [Microservice demo](../microservice)
--   [Log parsing demo](../log-parsing)
+-   [Replace a microservice with a SQL query](/quickstarts/microservice/)
+-   [Run SQL on streaming logs](/quickstarts/log-parsing/)
 -   [`CREATE SOURCE`](/sql/create-source)

--- a/doc/user/content/quickstarts/live-analytics.md
+++ b/doc/user/content/quickstarts/live-analytics.md
@@ -115,28 +115,28 @@ Putting this all together, our deployment looks like this:
 
 ### Preparing the environment
 
-1. [Set up Docker and Docker compose](/integrations/docker), if you haven't
+1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
    already.
 
    **Note for macOS users:** Be sure to [increase Docker
-   resources](/integrations/docker/#increase-docker-resources) to at least 2 CPUs
+   resources](/third-party/docker/#increase-docker-resources) to at least 2 CPUs
    and 8GB memory. Running Docker for Mac with less resources may cause the demo
    to fail.
 
-1. Clone the Materialize repository at the latest release:
+1. Clone the Materialize demos repository:
 
     ```shell
-    git clone --depth=1 --branch {{< version >}} https://github.com/MaterializeInc/materialize.git
+    git clone https://github.com/MaterializeInc/demos.git
     ```
 
    You can also view the demo's code on
-   [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/chbench).
+   [GitHub](https://github.com/MaterializeInc/demos/tree/main/chbench).
 
 1. Download and start all of the components we've listed above by running:
 
    ```shell
-   cd materialize/demo/chbench
-   ./mzcompose run default
+   cd demos/chbench
+   docker-compose up -d
    ```
 
    Note that downloading the Docker images necessary for the demo can take quite
@@ -152,10 +152,10 @@ Now that our deployment is running (and looks like the diagram shown above), we
 can get Materialize to read data from Kafka and define the views we want
 Materialize to maintain for us.
 
-1. Launch the `psql` SQL shell against Materialize by running:
+1. Launch the `mzcli` SQL shell against Materialize by running:
 
     ```shell
-    ./mzcompose sql materialized
+    docker-compose run cli
     ```
 
 1. Within the CLI, ensure you have all of the necessary sources, which represent
@@ -352,9 +352,6 @@ Materialize to maintain for us.
     alt="Materialize real-time business intelligence dashboard in metabase"
 >}}
 
-If you want to see more chBench queries, you can repeat these steps for the view
-`query07` or any of the queries listed in our [chBench query index](https://github.com/MaterializeInc/materialize/blob/{{< version >}}/demo/chbench/chbench/mz-default-mysql.cfg).
-
 ## Recap
 
 In this demo, we saw:
@@ -387,6 +384,6 @@ etc. but this is a reasonable workflow.
 
 ## Related pages
 
--   [Replace a microservice with a SQL query](/quickstarts/microservice/)
--   [Run SQL on streaming logs](/quickstarts/log-parsing/)
+-   [Microservice demo](../microservice)
+-   [Log parsing demo](../log-parsing)
 -   [`CREATE SOURCE`](/sql/create-source)

--- a/doc/user/content/quickstarts/log-parsing.md
+++ b/doc/user/content/quickstarts/log-parsing.md
@@ -240,7 +240,7 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. [Set up Docker and Docker compose](/integrations/docker), if you haven't
+1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
    already.
 
 1. Verify that you have Python 3 or greater installed.
@@ -250,25 +250,25 @@ In a future iteration, we'll make this demo more interactive.
     Python 3.7.5
     ```
 
-1. Clone the Materialize repo at the latest release:
+1. Clone the Materialize demos repository:
 
     ```shell
-    git clone --depth=1 --branch {{< version >}} https://github.com/MaterializeInc/materialize.git
+    git clone https://github.com/MaterializeInc/demos.git
     ```
 
-1. Move to the `demo/http_logs` dir:
+1. Move to the `demos/http-logs` directory:
 
     ```shell
-    cd materialize/demo/http_logs
+    cd demos/http-logs
     ```
 
     You can also find the demo's code on
-    [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/http_logs).
+    [GitHub](https://github.com/MaterializeInc/demos/tree/main/http-logs).
 
 1. Download and start all of the components we've listed above by running:
 
    ```shell
-   ./mzcompose up
+   docker-compose up -d
    ```
 
    Note that downloading the Docker images necessary for the demo can take quite
@@ -280,12 +280,12 @@ Now that our deployment is running (and looks like the diagram shown above), we
 can see that Materialize is ingesting the logs and structuring them. We'll also
 get a chance to see how Materialize can handle queries on our data.
 
-1. Launch a new terminal window and `cd materialize/demo/http_logs`.
+1. Launch a new terminal window and `cd demos/http_logs`.
 
 1. Launch the Materialize CLI (`mzcli`) by running:
 
     ```shell
-    ./mzcompose run cli
+    docker-compose run cli
     ```
 
 1. Within `mzcli`, ensure you have all of the necessary sources, which represent
@@ -388,7 +388,7 @@ In this demo, we saw:
 
 ## Related pages
 
-- [Microservice demo](/quickstarts/microservice/)
-- [Build a Real-time analytics dashboard](/quickstarts/live-analytics/)
+- [Microservice demo](../microservice)
+- [Business intelligence demo](../business-intelligence)
 - [`CREATE SOURCE`](/sql/create-source)
 - [Functions + Operators](/sql/functions)

--- a/doc/user/content/quickstarts/log-parsing.md
+++ b/doc/user/content/quickstarts/log-parsing.md
@@ -240,7 +240,7 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
+1. [Set up Docker and Docker compose](/integrations/docker), if you haven't
    already.
 
 1. Verify that you have Python 3 or greater installed.
@@ -388,7 +388,7 @@ In this demo, we saw:
 
 ## Related pages
 
-- [Microservice demo](../microservice)
-- [Business intelligence demo](../business-intelligence)
+- [Microservice demo](/quickstarts/microservice/)
+- [Build a Real-time analytics dashboard](/quickstarts/live-analytics/)
 - [`CREATE SOURCE`](/sql/create-source)
 - [Functions + Operators](/sql/functions)

--- a/doc/user/content/quickstarts/microservice.md
+++ b/doc/user/content/quickstarts/microservice.md
@@ -402,7 +402,7 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
+1. [Set up Docker and Docker compose](/integrations/docker), if you haven't
    already.
 
 1. Clone the Materialize demos repository:
@@ -535,6 +535,7 @@ In this demo, we saw:
 
 ## Related pages
 
-- [Business intelligence demo](../business-intelligence)
-- [Log parsing demo](../log-parsing)
-- [`CREATE SOURCE`](/sql/create-source)
+- [Microservice demo](/quickstarts/microservice/)
+- [Build a real-time analytics dashboard](/quickstarts/live-analytics/)
+- [Log parsing demo](/quickstarts/log-parsing/)
+- [`CREATE SOURCE`](/sql/create-source/)

--- a/doc/user/content/quickstarts/microservice.md
+++ b/doc/user/content/quickstarts/microservice.md
@@ -281,13 +281,13 @@ We'll then create a materialized view for this data, as well as convert its unit
 
 ```sql
 CREATE MATERIALIZED VIEW billing_prices AS
-	SELECT
-		CAST(column1 AS INT8) AS client_id,
-		((CAST(column2 AS FLOAT8)) / 1000.0)
-			AS price_per_cpu_ms,
-		((CAST(column3 AS FLOAT8)) / 1000.0)
-			AS price_per_gb_ms
-	FROM price_source;
+    SELECT
+        CAST(column1 AS INT8) AS client_id,
+        ((CAST(column2 AS FLOAT8)) / 1000.0)
+            AS price_per_cpu_ms,
+        ((CAST(column3 AS FLOAT8)) / 1000.0)
+            AS price_per_gb_ms
+    FROM price_source;
 ```
 
 For more details on how CSV sources work, see [`CREATE SOURCES`](/sql/create-source/csv-file).
@@ -402,23 +402,23 @@ In a future iteration, we'll make this demo more interactive.
 
 ### Preparing the environment
 
-1. [Set up Docker and Docker compose](/integrations/docker), if you haven't
+1. [Set up Docker and Docker compose](/third-party/docker), if you haven't
    already.
 
-1. Clone the Materialize repository:
+1. Clone the Materialize demos repository:
 
     ```shell
-    git clone --depth=1 --branch {{< version >}} https://github.com/MaterializeInc/materialize.git
+    git clone https://github.com/MaterializeInc/demos.git
     ```
 
     You can also view the demo's code on
-    [GitHub](https://github.com/MaterializeInc/materialize/tree/{{< version >}}/demo/billing).
+    [GitHub](https://github.com/MaterializeInc/demos/tree/main/billing).
 
 1. Download and start all of the components we've listed above by running:
 
     ```shell
-    cd materialize/demo/billing
-    ./mzcompose run default
+    cd demos/billing
+    docker-compose up -d
     ```
 
    Note that downloading the Docker images necessary for the demo can take quite
@@ -432,10 +432,10 @@ In a future iteration, we'll make this demo more interactive.
 Now that our deployment is running (and looks like the diagram shown above), we
 can see that Materialize is ingesting the `protobuf` data and normalizing it.
 
-1. Launch a `psql` shell connected to `materialized`:
+1. Launch the `mzcli` SQL shell connected to `materialized`:
 
     ```shell
-    ./mzcompose sql materialized
+    docker-compose run cli
     ```
 
 1. Show the source we've created:
@@ -535,7 +535,6 @@ In this demo, we saw:
 
 ## Related pages
 
-- [Microservice demo](/quickstarts/microservice/)
-- [Build a real-time analytics dashboard](/quickstarts/live-analytics/)
-- [Log parsing demo](/quickstarts/log-parsing/)
-- [`CREATE SOURCE`](/sql/create-source/)
+- [Business intelligence demo](../business-intelligence)
+- [Log parsing demo](../log-parsing)
+- [`CREATE SOURCE`](/sql/create-source)


### PR DESCRIPTION
Now that the new `demos` repo is up, switch the instructions in the user-facing documentation. 

This will only be applied to the `lts-docs` branch, since we eventually need to replace the existing demos with different ones and can just start from scratch in `main` (ref. #12012). I'll open a follow-up PR to remove the Docker bit from `main`, though, since that's easy to overlook later on.

(**CC:** @ruf-io)