### PR TITLE
doc/developer: remove mention of split-debuginfo

### DIFF
--- a/doc/developer/fast-compiles.md
+++ b/doc/developer/fast-compiles.md
@@ -100,33 +100,6 @@ here:
 [endler]: https://endler.dev/2020/rust-compile-times/
 [nethercote]: https://nnethercote.github.io/perf-book/compile-times.html
 
-## Split Mac Debug Information
-
-Apparently, a significant part of the time spent compiling a macOS rust binary
-is creating the debug info, which previously required scanning the entire binary
-with the `dsymutil` tool. As of stable rust 1.51.0, the [new `split-debuginfo =
-"unpacked"` option][split-debuginfo-unpacked] allows for skipping this step and
-using the `.o` object files for backtraces, resulting in a link time decrease.
-Most debug tooling then "should work as long as you don't need to move the
-binary to a different location while retaining the debug information." In
-summary, as long as you're not moving the debug binary, this should be a free
-speedup.
-
-This can be enabled by setting the following option in cargo's `.config`:
-
-```yaml
-[profile.dev]
-  split-debuginfo = "unpacked"
-```
-
-On Ruchir's laptop after an initial compile:
-
-- With default options `touch src/materialized/src/bin/materialized/main.rs;
-  cargo run` (basically just relinking) takes ~1m15s
-- With this option, it takes ~30s
-
-[split-debuginfo-unpacked]: https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#splitting-debug-information
-
 ## Experimental Mac Linker
 
 The LLVM clang project has an old Mach-O (macOS) linker that seems to be


### PR DESCRIPTION
[Since Rust 1.53, `split-debuginfo = unpacked` is the default on macOS](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1530-2021-06-17), so there is no need to specifically mention it as a performance optimization anymore.

### Motivation

   * This PR cleans up developer docs.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).