### PR TITLE
Move cluster size resolution to the coordinator

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -292,8 +292,18 @@ impl ConcreteComputeInstanceConfig {
                 introspection,
             } => {
                 let size_config = replica_sizes.0.get(&size).ok_or_else(|| {
-                    let mut expected = replica_sizes.0.keys().cloned().collect::<Vec<_>>();
-                    expected.sort();
+                    let mut entries = replica_sizes.0.iter().collect::<Vec<_>>();
+                    entries.sort_by_key(
+                        |(
+                            _name,
+                            ClusterReplicaSizeConfig {
+                                processes,
+                                cpu_limit,
+                                ..
+                            },
+                        )| (*processes, *cpu_limit),
+                    );
+                    let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
                     CoordError::InvalidReplicaSize { size, expected }
                 })?;
                 ConcreteComputeInstanceConfig::Managed {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -79,6 +79,7 @@ use differential_dataflow::lattice::Lattice;
 use futures::future::TryFutureExt;
 use itertools::Itertools;
 use rand::Rng;
+use serde::{Deserialize, Serialize};
 use timely::order::PartialOrder;
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp as _};
@@ -89,7 +90,9 @@ use tracing::warn;
 use uuid::Uuid;
 
 use mz_build_info::BuildInfo;
-use mz_dataflow_types::client::controller::ReadPolicy;
+use mz_dataflow_types::client::controller::{
+    ClusterReplicaSizeConfig, ClusterReplicaSizeMap, ReadPolicy,
+};
 use mz_dataflow_types::client::{
     ComputeInstanceId, ControllerResponse, InstanceConfig, LinearizedTimestampBindingFeedback,
     DEFAULT_COMPUTE_INSTANCE_ID,
@@ -130,14 +133,15 @@ use mz_sql::names::{
 };
 use mz_sql::plan::{
     AlterComputeInstancePlan, AlterIndexEnablePlan, AlterIndexResetOptionsPlan,
-    AlterIndexSetOptionsPlan, AlterItemRenamePlan, AlterSecretPlan, CreateComputeInstancePlan,
-    CreateConnectorPlan, CreateDatabasePlan, CreateIndexPlan, CreateRolePlan, CreateSchemaPlan,
-    CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan,
-    CreateViewPlan, CreateViewsPlan, DropComputeInstancesPlan, DropDatabasePlan, DropItemsPlan,
-    DropRolesPlan, DropSchemaPlan, ExecutePlan, ExplainPlan, FetchPlan, HirRelationExpr,
-    IndexOption, IndexOptionName, InsertPlan, MutationKind, OptimizerConfig, Params, PeekPlan,
-    Plan, QueryWhen, RaisePlan, ReadThenWritePlan, SendDiffsPlan, SetVariablePlan,
-    ShowVariablePlan, StatementDesc, TailFrom, TailPlan, View,
+    AlterIndexSetOptionsPlan, AlterItemRenamePlan, AlterSecretPlan, ComputeInstanceConfig,
+    ComputeInstanceIntrospectionConfig, CreateComputeInstancePlan, CreateConnectorPlan,
+    CreateDatabasePlan, CreateIndexPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan,
+    CreateSinkPlan, CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan,
+    CreateViewsPlan, DropComputeInstancesPlan, DropDatabasePlan, DropItemsPlan, DropRolesPlan,
+    DropSchemaPlan, ExecutePlan, ExplainPlan, FetchPlan, HirRelationExpr, IndexOption,
+    IndexOptionName, InsertPlan, MutationKind, OptimizerConfig, Params, PeekPlan, Plan, QueryWhen,
+    RaisePlan, ReadThenWritePlan, SendDiffsPlan, SetVariablePlan, ShowVariablePlan, StatementDesc,
+    TailFrom, TailPlan, View,
 };
 use mz_sql_parser::ast::RawObjectName;
 use mz_transform::Optimizer;
@@ -243,6 +247,7 @@ pub struct Config {
     pub now: NowFn,
     pub secrets_controller: Box<dyn SecretsController>,
     pub availability_zones: Vec<String>,
+    pub replica_sizes: ClusterReplicaSizeMap,
 }
 
 struct PendingPeek {
@@ -254,6 +259,57 @@ struct PendingPeek {
 pub struct CatalogTxn<'a, T> {
     dataflow_client: &'a mz_dataflow_types::client::Controller<T>,
     catalog: &'a CatalogState,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ConcreteComputeInstanceConfig {
+    Remote {
+        /// A map from replica name to hostnames.
+        replicas: BTreeMap<String, BTreeSet<String>>,
+        introspection: Option<ComputeInstanceIntrospectionConfig>,
+    },
+    Managed {
+        size_config: ClusterReplicaSizeConfig,
+        introspection: Option<ComputeInstanceIntrospectionConfig>,
+    },
+}
+
+impl ConcreteComputeInstanceConfig {
+    pub fn from_plan(
+        plan: ComputeInstanceConfig,
+        replica_sizes: &ClusterReplicaSizeMap,
+    ) -> Result<Self, CoordError> {
+        let config = match plan {
+            mz_sql::plan::ComputeInstanceConfig::Remote {
+                replicas,
+                introspection,
+            } => ConcreteComputeInstanceConfig::Remote {
+                replicas,
+                introspection,
+            },
+            mz_sql::plan::ComputeInstanceConfig::Managed {
+                size,
+                introspection,
+            } => {
+                let size_config = replica_sizes
+                    .0
+                    .get(&size)
+                    .ok_or(CoordError::InvalidReplicaSize { size })?;
+                ConcreteComputeInstanceConfig::Managed {
+                    size_config: *size_config,
+                    introspection,
+                }
+            }
+        };
+        Ok(config)
+    }
+
+    pub fn introspection(&self) -> &Option<ComputeInstanceIntrospectionConfig> {
+        match self {
+            Self::Remote { introspection, .. } => introspection,
+            Self::Managed { introspection, .. } => introspection,
+        }
+    }
 }
 
 /// Glues the external world to the Timely workers.
@@ -311,6 +367,8 @@ pub struct Coordinator {
     /// Handle to secret manager that can create and delete secrets from
     /// an arbitrary secret storage engine.
     secrets_controller: Box<dyn SecretsController>,
+    /// Map of strings to corresponding compute replica sizes.
+    replica_sizes: ClusterReplicaSizeMap,
 }
 
 /// Metadata about an active connection.
@@ -1867,9 +1925,11 @@ impl Coordinator {
         } else {
             Vec::new()
         };
+        let config =
+            ConcreteComputeInstanceConfig::from_plan(plan.config.clone(), &self.replica_sizes)?;
         let op = catalog::Op::CreateComputeInstance {
             name: plan.name.clone(),
-            config: plan.config.clone(),
+            config,
             introspection_sources,
         };
         let r = self.catalog_transact(vec![op], |_| Ok(())).await;
@@ -1900,9 +1960,11 @@ impl Coordinator {
         let instance = self.catalog.state().get_compute_instance(plan.id);
         let old_config = instance.config.clone();
 
+        let config =
+            ConcreteComputeInstanceConfig::from_plan(plan.config.clone(), &self.replica_sizes)?;
         let ops = vec![catalog::Op::UpdateComputeInstanceConfig {
             id: plan.id,
-            config: plan.config.clone(),
+            config,
         }];
         let mut replicas_to_remove = vec![];
         let mut replicas_to_add = vec![];
@@ -1935,8 +1997,12 @@ impl Coordinator {
                     Ok(())
                 }
                 (
-                    InstanceConfig::Managed { size: old_size },
-                    InstanceConfig::Managed { size: new_size },
+                    InstanceConfig::Managed {
+                        size_config: old_size,
+                    },
+                    InstanceConfig::Managed {
+                        size_config: new_size,
+                    },
                 ) => {
                     if old_size != *new_size {
                         coord_bail!("cannot yet change size of cluster");
@@ -4664,6 +4730,7 @@ pub async fn serve(
         metrics_registry,
         now,
         secrets_controller,
+        replica_sizes,
         availability_zones: _,
     }: Config,
 ) -> Result<(Handle, Client), CoordError> {
@@ -4715,6 +4782,7 @@ pub async fn serve(
                 write_lock: Arc::new(tokio::sync::Mutex::new(())),
                 write_lock_wait_group: VecDeque::new(),
                 secrets_controller,
+                replica_sizes,
             };
             let bootstrap = handle.block_on(coord.bootstrap(builtin_table_updates));
             let ok = bootstrap.is_ok();

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -291,10 +291,11 @@ impl ConcreteComputeInstanceConfig {
                 size,
                 introspection,
             } => {
-                let size_config = replica_sizes
-                    .0
-                    .get(&size)
-                    .ok_or(CoordError::InvalidReplicaSize { size })?;
+                let size_config = replica_sizes.0.get(&size).ok_or_else(|| {
+                    let mut expected = replica_sizes.0.keys().cloned().collect::<Vec<_>>();
+                    expected.sort();
+                    CoordError::InvalidReplicaSize { size, expected }
+                })?;
                 ConcreteComputeInstanceConfig::Managed {
                     size_config: *size_config,
                     introspection,

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -73,6 +73,7 @@ pub enum CoordError {
     /// No such cluster replica size has been configured.
     InvalidReplicaSize {
         size: String,
+        expected: Vec<String>,
     },
     /// The selection value for a table mutation operation refers to an invalid object.
     InvalidTableMutationSelection,
@@ -328,8 +329,12 @@ impl fmt::Display for CoordError {
                 value.quoted(),
                 reason,
             ),
-            CoordError::InvalidReplicaSize { size } => {
-                write!(f, "unknown cluster size {size}")
+            CoordError::InvalidReplicaSize { size, expected } => {
+                write!(
+                    f,
+                    "unknown cluster size {size}. Expected one of: {}.",
+                    expected.join(", ")
+                )
             }
             CoordError::InvalidTableMutationSelection => {
                 f.write_str("invalid selection: operation may only refer to user-defined tables")

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -329,7 +329,7 @@ impl fmt::Display for CoordError {
                 reason,
             ),
             CoordError::InvalidReplicaSize { size } => {
-                write!(f, "Size {size} not specified in allowed cluster sizes map")
+                write!(f, "unknown cluster size {size}")
             }
             CoordError::InvalidTableMutationSelection => {
                 f.write_str("invalid selection: operation may only refer to user-defined tables")

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -269,6 +269,9 @@ impl CoordError {
                     doc_page
                 ))
             }
+            CoordError::InvalidReplicaSize { expected, size: _ } => {
+                Some(format!("Valid cluster sizes are: {}", expected.join(", ")))
+            }
             _ => None,
         }
     }
@@ -329,12 +332,8 @@ impl fmt::Display for CoordError {
                 value.quoted(),
                 reason,
             ),
-            CoordError::InvalidReplicaSize { size, expected } => {
-                write!(
-                    f,
-                    "unknown cluster size {size}. Expected one of: {}.",
-                    expected.join(", ")
-                )
+            CoordError::InvalidReplicaSize { size, expected: _ } => {
+                write!(f, "unknown cluster size {size}",)
             }
             CoordError::InvalidTableMutationSelection => {
                 f.write_str("invalid selection: operation may only refer to user-defined tables")

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -70,6 +70,10 @@ pub enum CoordError {
         value: String,
         reason: String,
     },
+    /// No such cluster replica size has been configured.
+    InvalidReplicaSize {
+        size: String,
+    },
     /// The selection value for a table mutation operation refers to an invalid object.
     InvalidTableMutationSelection,
     /// Expression violated a column's constraint
@@ -324,6 +328,9 @@ impl fmt::Display for CoordError {
                 value.quoted(),
                 reason,
             ),
+            CoordError::InvalidReplicaSize { size } => {
+                write!(f, "Size {size} not specified in allowed cluster sizes map")
+            }
             CoordError::InvalidTableMutationSelection => {
                 f.write_str("invalid selection: operation may only refer to user-defined tables")
             }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -37,6 +37,8 @@ use mz_repr::{GlobalId, Row};
 pub mod controller;
 pub use controller::Controller;
 
+use self::controller::ClusterReplicaSizeConfig;
+
 pub mod partitioned;
 pub mod replicated;
 
@@ -60,7 +62,7 @@ pub enum InstanceConfig {
     /// A remote but managed instance.
     Managed {
         /// The size of the cluster.
-        size: String,
+        size_config: ClusterReplicaSizeConfig,
     },
 }
 

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -28,7 +28,7 @@ use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use futures::StreamExt;
 use maplit::hashmap;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use timely::progress::frontier::{Antichain, AntichainRef};
 use timely::progress::Timestamp;
 use tokio_stream::StreamMap;
@@ -60,7 +60,7 @@ pub struct OrchestratorConfig {
     pub linger: bool,
 }
 
-#[derive(Copy, Clone, Debug, Deserialize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ClusterReplicaSizeConfig {
     memory_limit: Option<MemoryLimit>,
     cpu_limit: Option<CpuLimit>,
@@ -103,7 +103,6 @@ pub struct Controller<T = mz_repr::Timestamp> {
     orchestrator: OrchestratorConfig,
     storage_controller: Box<dyn StorageController<Timestamp = T>>,
     compute: BTreeMap<ComputeInstanceId, compute::ComputeControllerState<T>>,
-    replica_sizes: ClusterReplicaSizeMap,
 }
 
 impl<T> Controller<T>
@@ -132,7 +131,7 @@ where
                     compute_instance.add_replica(name, client).await;
                 }
             }
-            InstanceConfig::Managed { size } => {
+            InstanceConfig::Managed { size_config } => {
                 let OrchestratorConfig {
                     orchestrator,
                     computed_image,
@@ -141,10 +140,6 @@ where
                 } = &self.orchestrator;
 
                 let default_listen_host = orchestrator.listen_host();
-
-                let size_config = self.replica_sizes.0.get(&size).ok_or_else(|| {
-                    anyhow::anyhow!("Size {size} not specified in allowed cluster sizes map")
-                })?;
 
                 let service = orchestrator
                     .namespace("compute")
@@ -333,13 +328,11 @@ impl<T> Controller<T> {
     pub fn new<S: StorageController<Timestamp = T> + 'static>(
         orchestrator: OrchestratorConfig,
         storage_controller: S,
-        replica_sizes: ClusterReplicaSizeMap,
     ) -> Self {
         Self {
             orchestrator,
             storage_controller: Box::new(storage_controller),
             compute: BTreeMap::default(),
-            replica_sizes,
         }
     }
 }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -62,9 +62,9 @@ pub struct OrchestratorConfig {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ClusterReplicaSizeConfig {
-    memory_limit: Option<MemoryLimit>,
-    cpu_limit: Option<CpuLimit>,
-    processes: NonZeroUsize,
+    pub memory_limit: Option<MemoryLimit>,
+    pub cpu_limit: Option<CpuLimit>,
+    pub processes: NonZeroUsize,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -349,11 +349,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         storage_client,
         config.data_directory,
     );
-    let dataflow_controller = mz_dataflow_types::client::Controller::new(
-        orchestrator,
-        storage_controller,
-        config.replica_sizes,
-    );
+    let dataflow_controller =
+        mz_dataflow_types::client::Controller::new(orchestrator, storage_controller);
 
     // Initialize coordinator.
     let (coord_handle, coord_client) = mz_coord::serve(mz_coord::Config {
@@ -369,6 +366,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         metrics_registry: config.metrics_registry.clone(),
         now: config.now,
         secrets_controller,
+        replica_sizes: config.replica_sizes.clone(),
         availability_zones: config.availability_zones.clone(),
     })
     .await?;

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use bytesize::ByteSize;
 use derivative::Derivative;
 use serde::de::Unexpected;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// An orchestrator manages services.
 ///
@@ -112,7 +112,7 @@ pub struct ServicePort {
     pub port_hint: i32,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct MemoryLimit(pub ByteSize);
 
 impl<'de> Deserialize<'de> for MemoryLimit {
@@ -128,6 +128,15 @@ impl<'de> Deserialize<'de> for MemoryLimit {
                 })
             })
             .map(MemoryLimit)
+    }
+}
+
+impl Serialize for MemoryLimit {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        <String as Serialize>::serialize(&self.0.to_string(), serializer)
     }
 }
 
@@ -168,5 +177,14 @@ impl<'de> Deserialize<'de> for CpuLimit {
                 millicpus: millicpus as usize,
             })
         }
+    }
+}
+
+impl Serialize for CpuLimit {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        <f64 as Serialize>::serialize(&(self.millicpus as f64 / 1000.0), serializer)
     }
 }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -141,7 +141,7 @@ impl Serialize for MemoryLimit {
 }
 
 /// Describes a limit on CPU resources.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]
 pub struct CpuLimit {
     millicpus: usize,
 }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -385,6 +385,7 @@ impl ErrorResponse {
             CoordError::InvalidRematerialization { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,
+            CoordError::InvalidReplicaSize { .. } => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidTableMutationSelection => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::ConstraintViolation(NotNullViolation(_)) => SqlState::NOT_NULL_VIOLATION,
             CoordError::OperationProhibitsTransaction(_) => SqlState::ACTIVE_SQL_TRANSACTION,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -175,7 +175,7 @@ impl ComputeInstanceConfig {
 }
 
 /// Configuration of introspection for a compute instance.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct ComputeInstanceIntrospectionConfig {
     /// Whether to introspect the introspection.
     pub debugging: bool,

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -195,3 +195,11 @@ DROP CLUSTER foo
 
 statement ok
 CREATE CLUSTER foo REMOTE r1 ('localhost:1234'), INTROSPECTION GRANULARITY '1s'
+
+# Test that bad cluster sizes don't cause a crash
+
+statement ok
+DROP CLUSTER foo
+
+statement error unknown cluster size
+CREATE CLUSTER foo SIZE 'lol'


### PR DESCRIPTION
The mapping from strings to replica size config now lives in the coordinator, so that we can validate them before committing the add cluster command.

As part of this, I needed to split `ComputeInstanceConfig` into two types, to be used in different situations: one has a string name (as before) and is used during planning; the other, now called `ConcreteComputeInstanceConfig` has a resolved size and is used in the catalog and downstream of the coordinator. 

### Motivation

Fixes #11968 .

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

  - Fix the crash reported in #11968 .
