### PR TITLE
add a wrapper to prepend subprocess names to tracing logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,7 @@ dependencies = [
 name = "mz-ore"
 version = "0.0.0"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "async-trait",
  "atty",

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -120,6 +120,10 @@ struct Args {
         default_value = "info"
     )]
     log_filter: String,
+
+    /// Add the process name to the tracing logs
+    #[clap(long, hide = true)]
+    log_process_name: bool,
 }
 
 #[tokio::main]
@@ -216,6 +220,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             log_filter: &args.log_filter,
             opentelemetry_endpoint: None,
             opentelemetry_headers: None,
+            prefix: args.log_process_name.then(|| "computed"),
             #[cfg(feature = "tokio-console")]
             tokio_console: false,
         },

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -221,6 +221,7 @@ where
                                         ),
                                         format!("--processes={}", size_config.scale),
                                         format!("--workers={}", size_config.workers),
+                                        "--log-process-name".to_string(),
                                     ];
                                     compute_opts.extend(hosts_ports.iter().map(|(host, ports)| {
                                         format!("{host}:{}", ports["compute"])

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -493,6 +493,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
             log_filter: &args.log_filter,
             opentelemetry_endpoint: args.opentelemetry_endpoint.as_deref(),
             opentelemetry_headers: args.opentelemetry_headers.as_deref(),
+            prefix: None,
             #[cfg(feature = "tokio-console")]
             tokio_console: args.tokio_console,
         },

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -308,6 +308,7 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
                             "--listen-addr={}:{}",
                             default_listen_host, my_ports["controller"]
                         ),
+                        "--log-process-name".to_string(),
                     ];
                     if config.orchestrator.linger {
                         storage_opts.push(format!("--linger"))

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -42,6 +42,7 @@ tokio-openssl = { version = "0.6.3", optional = true }
 tracing-subscriber = { version = "0.3.11", default-features = false, features = ["env-filter", "fmt", "tracing-log"], optional = true }
 
 # For the `tracing` feature
+ansi_term = { version = "0.12.1", optional = true }
 atty = { version = "0.2.14", optional = true }
 tracing = { version = "0.1.34", optional = true }
 tracing-opentelemetry = { version = "0.17", optional = true }
@@ -64,6 +65,7 @@ default = ["network", "chrono", "cli", "metrics", "stack", "test"]
 network = ["async-trait", "bytes", "futures", "openssl", "smallvec", "tokio-openssl", "tokio", "task"]
 task = ["tokio", "tokio/tracing"]
 tracing_ = [
+  "ansi_term",
   "atty",
   "metrics",
   "tracing",

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -107,6 +107,10 @@ struct Args {
         default_value = "info"
     )]
     log_filter: String,
+
+    /// Add the process name to the tracing logs
+    #[clap(long, hide = true)]
+    log_process_name: bool,
 }
 
 #[tokio::main]
@@ -140,6 +144,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             log_filter: &args.log_filter,
             opentelemetry_endpoint: None,
             opentelemetry_headers: None,
+            prefix: args.log_process_name.then(|| "storaged"),
             #[cfg(feature = "tokio-console")]
             tokio_console: false,
         },


### PR DESCRIPTION
I find it really hard to figure out what process each log line came from, when debugging. 

I asked the tracing folks about this, and they suggested a `span` with the subprocess name opened in the beginning of main, but I was worried that this was hacky, and also might mess with opentelemetry, so I decided on a custom `FormatEvent` impl.

Unfortunately, there is no way to inject this name after the timestamp, unless I pretty recreate the [very complex] `Format` struct of `tracing-subscriber`, so prepending is the next best thing. Let me know what you think!


This is what it looks like:

```
2022-04-25T16:43:15.758195Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 10ms
2022-04-25T16:43:15.771152Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 20ms
2022-04-25T16:43:15.794078Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 40ms
2022-04-25T16:43:15.836257Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 80ms
2022-04-25T16:43:15.919394Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 160ms
2022-04-25T16:43:16.081895Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 320ms
2022-04-25T16:43:16.405037Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2100: Connection refused (os error 61); reconnecting in 640ms
storaged: 2022-04-25T16:43:16.642461Z  INFO storaged: about to bind to "127.0.0.1:2100"
storaged: 2022-04-25T16:43:16.642784Z  INFO storaged: listening for coordinator connection on 127.0.0.1:2100...
storaged: 2022-04-25T16:43:16.642807Z  INFO storaged: starting persist client...
storaged: 2022-04-25T16:43:16.646028Z  INFO mz_storage::boundary::tcp_boundary::server: About to bind to 127.0.0.1:2101
storaged: 2022-04-25T16:43:16.646102Z  INFO mz_storage::boundary::tcp_boundary::server: listening for storage connection on 127.0.0.1:2101...
storaged: 2022-04-25T16:43:17.048324Z  INFO storaged: coordinator connection accepted
=======================================================================
Thank you for trying Materialize!

We are interested in any and all feedback you have, which may be able
to improve both our software and your queries! Please reach out at:

    Web: https://materialize.com
    GitHub issues: https://github.com/MaterializeInc/materialize/issues
    Email: support@materialize.com
    Twitter: @MaterializeInc
=======================================================================

materialized v0.26.1-dev (b91dc94c8) listening on 127.0.0.1:6875...
2022-04-25T16:43:17.362626Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 10ms
2022-04-25T16:43:17.375741Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 20ms
2022-04-25T16:43:17.398803Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 40ms
2022-04-25T16:43:17.441858Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 80ms
2022-04-25T16:43:17.524121Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 160ms
2022-04-25T16:43:17.687149Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 320ms
2022-04-25T16:43:18.010515Z  WARN mz_dataflow_types::client::tcp: Error connecting to localhost:2102: Connection refused (os error 61); reconnecting in 640ms
computed: 2022-04-25T16:43:18.445378Z ERROR computed: error
computed: 2022-04-25T16:43:18.445454Z  WARN computed: warn
computed: 2022-04-25T16:43:18.445464Z  INFO computed: info
computed: 2022-04-25T16:43:18.445597Z  INFO computed: about to bind to "127.0.0.1:2102"
computed: 2022-04-25T16:43:18.445876Z  INFO computed: listening for coordinator connection on 127.0.0.1:2102...
computed: 2022-04-25T16:43:18.446275Z  INFO mz_storage::boundary::tcp_boundary::client: About to connect to "localhost:2101"
computed: 2022-04-25T16:43:18.449956Z  INFO mz_storage::boundary::tcp_boundary::client: Connected to storage server
computed: 2022-04-25T16:43:18.652975Z  INFO computed: coordinator connection accepted
2022-04-25T16:43:18.653004Z  WARN mz_dataflow_types::client::replicated: Rehydrating replica "default"
```

### Motivation

  * This PR adds a feature that has not yet been specified.
see above

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
