### PR TITLE
orchestrator: rename ServiceConfig::{processes => scale}

### DIFF
--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -129,7 +129,7 @@ const MIGRATIONS: &[&dyn Migration] = &[
          (4, NULL, 'mz_internal'),
          (5, NULL, 'information_schema');
      INSERT INTO roles VALUES (1, 'materialize');
-     INSERT INTO compute_instances (id, name, config) VALUES (1, 'default', '{\"Managed\":{\"size_config\":{\"memory_limit\": null, \"cpu_limit\": null, \"processes\": 1},\"introspection\":{\"debugging\":false,\"granularity\":{\"secs\":1,\"nanos\":0}}}}');",
+     INSERT INTO compute_instances (id, name, config) VALUES (1, 'default', '{\"Managed\":{\"size_config\":{\"memory_limit\": null, \"cpu_limit\": null, \"scale\": 1},\"introspection\":{\"debugging\":false,\"granularity\":{\"secs\":1,\"nanos\":0}}}}');",
     // Add new migrations here.
     //
     // Migrations should be preceded with a comment of the following form:

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -296,11 +296,9 @@ impl ConcreteComputeInstanceConfig {
                         |(
                             _name,
                             ClusterReplicaSizeConfig {
-                                processes,
-                                cpu_limit,
-                                ..
+                                scale, cpu_limit, ..
                             },
-                        )| (*processes, *cpu_limit),
+                        )| (*scale, *cpu_limit),
                     );
                     let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
                     CoordError::InvalidReplicaSize { size, expected }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -64,7 +64,7 @@ pub struct OrchestratorConfig {
 pub struct ClusterReplicaSizeConfig {
     pub memory_limit: Option<MemoryLimit>,
     pub cpu_limit: Option<CpuLimit>,
-    pub processes: NonZeroUsize,
+    pub scale: NonZeroUsize,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -73,10 +73,10 @@ pub struct ClusterReplicaSizeMap(pub HashMap<String, ClusterReplicaSizeConfig>);
 impl Default for ClusterReplicaSizeMap {
     fn default() -> Self {
         // {
-        //     "1": {"processes": 1},
-        //     "2": {"processes": 2},
+        //     "1": {"scale": 1},
+        //     "2": {"scale": 2},
         //     /// ...
-        //     "16": {"processes": 16}
+        //     "16": {"scale": 16}
         // }
         let inner = (1..=16)
             .map(|i| {
@@ -85,7 +85,7 @@ impl Default for ClusterReplicaSizeMap {
                     ClusterReplicaSizeConfig {
                         memory_limit: None,
                         cpu_limit: None,
-                        processes: NonZeroUsize::new(i).unwrap(),
+                        scale: NonZeroUsize::new(i).unwrap(),
                     },
                 )
             })
@@ -173,7 +173,7 @@ where
                             ],
                             cpu_limit: size_config.cpu_limit,
                             memory_limit: size_config.memory_limit,
-                            processes: size_config.processes,
+                            scale: size_config.scale,
                             labels: hashmap! {
                                 "cluster-id".into() => instance.to_string(),
                                 "type".into() => "cluster".into(),

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -307,7 +307,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                 // TODO: limits?
                 cpu_limit: None,
                 memory_limit: None,
-                processes: NonZeroUsize::new(1).unwrap(),
+                scale: NonZeroUsize::new(1).unwrap(),
                 labels: HashMap::new(),
                 availability_zone: None,
             },

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -155,7 +155,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             ports: ports_in,
             memory_limit,
             cpu_limit,
-            processes,
+            scale,
             labels: labels_in,
             availability_zone,
         }: ServiceConfig<'_>,
@@ -304,7 +304,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     ..Default::default()
                 },
                 service_name: name.clone(),
-                replicas: Some(processes.get().try_into()?),
+                replicas: Some(scale.get().try_into()?),
                 template: pod_template_spec,
                 ..Default::default()
             }),
@@ -328,7 +328,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         // template. In theory, Kubernetes would do this automatically, but
         // in practice we have observed that it does not.
         // See: https://github.com/kubernetes/kubernetes/issues/67250
-        for pod_id in 0..processes.get() {
+        for pod_id in 0..scale.get() {
             let pod_name = format!("{}-{}", &name, pod_id);
             let pod = match self.pod_api.get(&pod_name).await {
                 Ok(pod) => pod,
@@ -349,7 +349,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 }
             }
         }
-        let hosts = (0..processes.get())
+        let hosts = (0..scale.get())
             .map(|i| {
                 format!(
                     "{name}-{i}.{name}.{}.svc.cluster.local",

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -113,7 +113,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             ports: ports_in,
             memory_limit: _,
             cpu_limit: _,
-            processes: processes_in,
+            scale: scale_in,
             labels: _,
             availability_zone: _,
         }: ServiceConfig<'_>,
@@ -126,7 +126,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
         let path = self.image_dir.join(image);
         let mut processes = vec![];
         let mut handles = vec![];
-        for _ in 0..(processes_in.get()) {
+        for _ in 0..(scale_in.get()) {
             let mut ports = HashMap::new();
             for port in &ports_in {
                 let p = self

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -87,8 +87,8 @@ pub struct ServiceConfig<'a> {
     pub memory_limit: Option<MemoryLimit>,
     /// An optional limit on the CPU that the service can use.
     pub cpu_limit: Option<CpuLimit>,
-    /// The number of processes to run.
-    pub processes: NonZeroUsize,
+    /// The number of copies of this service to run.
+    pub scale: NonZeroUsize,
     /// Arbitrary key–value pairs to attach to the service in the orchestrator
     /// backend.
     ///


### PR DESCRIPTION
The term "scale" was deemed to be less confusing than "processes" when
in the context of Kubernetes.

See: https://github.com/MaterializeInc/cloud/pull/2865#discussion_r857843441

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
