### PR TITLE
doc/user: temporarily rename SQL Spellbook section

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -116,7 +116,7 @@ weight = 100
 name = "SQL Commands"
 
 [[menu.main]]
-name = "SQL Patterns 🪄"
+name = "SQL Patterns"
 parent = 'reference'
 identifier = 'sql-patterns'
 weight = 85

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -116,9 +116,9 @@ weight = 100
 name = "SQL Commands"
 
 [[menu.main]]
-name = "SQL Spellbook 🪄"
+name = "SQL Patterns 🪄"
 parent = 'reference'
-identifier = 'sql-spellbook'
+identifier = 'sql-patterns'
 weight = 85
 
 [[menu.main]]

--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -31,7 +31,7 @@ accepts input data from a variety of streaming sources (like Kafka), data stores
 - [Materialize &amp; Postgres CDC](/integrations/cdc-postgres/)
 - [dbt &amp; Materialize](/integrations/dbt/)
 - [Materialize &amp; Node.js](/integrations/node-js/)
-- [Time-windowed computation](/sql/spellbook/temporal-filters/)
+- [Time-windowed computation](/sql/patterns/temporal-filters/)
 {{</ linkbox >}}
 {{< linkbox icon="book" title="Reference" >}}
 - [`CREATE SOURCE`](/sql/create-source/)

--- a/doc/user/content/cloud/get-started-with-cloud.md
+++ b/doc/user/content/cloud/get-started-with-cloud.md
@@ -180,7 +180,7 @@ Materialize efficiently supports [all types of SQL joins](/sql/join/#examples) u
 
 ### Temporal filters
 
-In Materialize, [temporal filters](/sql/spellbook/temporal-filters/) allow you to define time-windows over otherwise unbounded streams of data. This can be useful for things like modeling business processes or limiting resource usage.
+In Materialize, [temporal filters](/sql/patterns/temporal-filters/) allow you to define time-windows over otherwise unbounded streams of data. This can be useful for things like modeling business processes or limiting resource usage.
 
 1. If, instead of computing and maintaining the _overall_ count of market orders, we want to get the _moving_ count from the past minute, we'd use a temporal filter defined by the `mz_logical_timestamp()` function:
 

--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -237,7 +237,7 @@ Materialize efficiently supports [all types of SQL joins](/sql/join/#examples) u
 
 ### Temporal filters
 
-In Materialize, [temporal filters](/sql/spellbook/temporal-filters/) allow you to define time-windows over otherwise unbounded streams of data. This is useful to model business processes or simply to limit resource usage, for example.
+In Materialize, [temporal filters](/sql/patterns/temporal-filters/) allow you to define time-windows over otherwise unbounded streams of data. This is useful to model business processes or simply to limit resource usage, for example.
 
 1. If, instead of computing and maintaining the _overall_ count, we want to get the _moving_ count over the past minute:
 

--- a/doc/user/content/known-limitations.md
+++ b/doc/user/content/known-limitations.md
@@ -21,7 +21,7 @@ us know on the linked-to GitHub issue.
 
 ### Functions
 
-- Materialize does not support [window functions](https://www.postgresql.org/docs/current/tutorial-window.html). In some cases, you may be able to achieve the desired results with [temporal filters](/sql/spellbook/temporal-filters/) or the [TOP K by group](/sql/spellbook/top-k/) idiom instead. {{% gh 213 %}}
+- Materialize does not support [window functions](https://www.postgresql.org/docs/current/tutorial-window.html). In some cases, you may be able to achieve the desired results with [temporal filters](/sql/patterns/temporal-filters/) or the [TOP K by group](/sql/patterns/top-k/) idiom instead. {{% gh 213 %}}
 - Table functions in scalar positions are only partially supported. We currently
   support no more than one table function in scalar position, which can only be
   situated in the query's outermost projection. {{% gh 1546 %}}

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -243,7 +243,7 @@ It's also possible to set a start offset based on Kafka timestamps, using the `k
 
 It's important to note that `kafka_time_offset` is a property of the source: it will be calculated _once_ at the time the `CREATE SOURCE` statement is issued. This means that the computed start offsets will be the **same** for all views depending on the source and **stable** across restarts.
 
-If you need to limit the amount of data maintained as state after source creation, consider using [temporal filters](/sql/spellbook/temporal-filters/) instead.
+If you need to limit the amount of data maintained as state after source creation, consider using [temporal filters](/sql/patterns/temporal-filters/) instead.
 
 #### `WITH` options
 

--- a/doc/user/content/sql/functions/now_and_mz_logical_timestamp.md
+++ b/doc/user/content/sql/functions/now_and_mz_logical_timestamp.md
@@ -11,7 +11,7 @@ In Materialize, `now()` doesn't represent the system time, as it does in most sy
 `mz_logical_timestamp()` comes closer to what `now()` typically indicates. It represents the logical time at which a query executes. Its typical uses are:
 
 * Internal debugging
-* Defining [temporal filters](/sql/spellbook/temporal-filters/)
+* Defining [temporal filters](/sql/patterns/temporal-filters/)
 
 ## Internal debugging
 
@@ -21,7 +21,7 @@ In Materialize, `now()` doesn't represent the system time, as it does in most sy
 
 You can use `mz_logical_timestamp()` to define temporal filters for materialized view, which implement various windowing idioms.
 
-For more information, see [Temporal Filters](/sql/spellbook/temporal-filters/).
+For more information, see [Temporal Filters](/sql/patterns/temporal-filters/).
 
 ## Restrictions
 

--- a/doc/user/content/sql/join.md
+++ b/doc/user/content/sql/join.md
@@ -103,7 +103,7 @@ SELECT * FROM
 ```
 
 For a real-world example of a `LATERAL` subquery, see the [Top-K by group
-idiom](/sql/spellbook/top-k/).
+idiom](/sql/patterns/top-k/).
 
 
 ## Examples

--- a/doc/user/content/sql/patterns/manual-materialization.md
+++ b/doc/user/content/sql/patterns/manual-materialization.md
@@ -4,5 +4,5 @@ description: "Use Materialize more efficiently by creating non-materialized view
 draft: true
 menu:
   main:
-    parent: 'sql-spellbook'
+    parent: 'sql-patterns'
 ---

--- a/doc/user/content/sql/patterns/temporal-filters.md
+++ b/doc/user/content/sql/patterns/temporal-filters.md
@@ -5,7 +5,7 @@ aliases:
   - /guides/temporal-filters/
 menu:
   main:
-    parent: 'sql-spellbook'
+    parent: 'sql-patterns'
 ---
 
 Temporal filters allow you to implement several windowing idioms (tumbling, hopping, and sliding), in addition to more nuanced temporal queries.

--- a/doc/user/content/sql/patterns/top-k.md
+++ b/doc/user/content/sql/patterns/top-k.md
@@ -7,7 +7,7 @@ aliases:
   - /guides/top-k
 menu:
   main:
-    parent: 'sql-spellbook'
+    parent: 'sql-patterns'
 disable_toc: true
 ---
 

--- a/doc/user/content/sql/patterns/window-functions.md
+++ b/doc/user/content/sql/patterns/window-functions.md
@@ -4,5 +4,5 @@ description: "Use lateral joins as a streaming-efficient stand-in for many windo
 draft: true
 menu:
   main:
-    parent: 'sql-spellbook'
+    parent: 'sql-patterns'
 ---

--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -458,7 +458,7 @@
       The logical time at which a query executes. Used for temporal filters and internal debugging.
       <br><br>
       **Note**: This function generally behaves like a [non-pure] function, but
-      can be used in limited contexts in materialized views as a [temporal filter](/sql/spellbook/temporal-filters/).
+      can be used in limited contexts in materialized views as a [temporal filter](/sql/patterns/temporal-filters/).
     url: now_and_mz_logical_timestamp
     unmaterializable: true
 


### PR DESCRIPTION
As discussed, rename `SQL Spellbook` to `SQL Patterns` until we have something more meaty and "launchable".