### PR TITLE
sql: deexperimentalize SHOW ... IN CLUSTER

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -476,7 +476,6 @@ fn show_sinks<'a>(
     };
 
     if let Some(cluster) = in_cluster {
-        scx.require_experimental_mode("SHOW SINKS...IN CLUSTER")?;
         query_filters.push(format!("clusters.id = {}", cluster.0));
     }
 
@@ -594,7 +593,6 @@ pub fn show_indexes<'a>(
     }
 
     if let Some(cluster) = in_cluster {
-        scx.require_experimental_mode("SHOW INDEXES...IN CLUSTER")?;
         query_filter.push(format!("clusters.id = {}", cluster.0))
     };
 
@@ -669,8 +667,6 @@ pub fn show_clusters<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, anyhow::Error> {
-    scx.require_experimental_mode("SHOW CLUSTERS")?;
-
     let query = "SELECT mz_clusters.name FROM mz_catalog.mz_clusters".to_string();
 
     ShowSelect::new(scx, query, filter, None, None)


### PR DESCRIPTION
The other cluster-related commands are no longer experimental, so no
need for `SHOW ... IN CLUSTER` to be experimental.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
