### PR TITLE
persist: add WriteHandle::fetch_upper(), which retrieves the shard-global upper

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -64,6 +64,14 @@ where
         self.state.shard_id()
     }
 
+    pub async fn upper(&mut self, deadline: Instant) -> Result<Antichain<T>, ExternalError> {
+        // This unconditionally fetches the latest state and uses that to
+        // determine if we can serve `as_of`. TODO: We could instead check first
+        // and only fetch if necessary.
+        self.fetch_and_update_state(deadline).await?;
+        Ok(self.state.upper())
+    }
+
     pub async fn register(
         &mut self,
         deadline: Instant,

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -259,6 +259,10 @@ where
         self.seqno
     }
 
+    pub fn upper(&self) -> Antichain<T> {
+        self.collections.upper()
+    }
+
     pub fn clone_apply<R, E, WorkFn>(&self, work_fn: &mut WorkFn) -> Result<(R, Self), E>
     where
         WorkFn: FnMut(SeqNo, &mut StateCollections<T>) -> Result<R, E>,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -381,6 +381,42 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn fetch_upper() -> Result<(), Box<dyn std::error::Error>> {
+        mz_ore::test::init_logging();
+
+        let data = vec![
+            (("1".to_owned(), "one".to_owned()), 1, 1),
+            (("2".to_owned(), "two".to_owned()), 2, 1),
+        ];
+
+        let client = new_test_client().await?;
+
+        let shard_id = ShardId::new();
+
+        let (mut write1, _read1) = client
+            .open::<String, String, u64, i64>(NO_TIMEOUT, shard_id)
+            .await?;
+
+        let (mut write2, _read2) = client
+            .open::<String, String, u64, i64>(NO_TIMEOUT, shard_id)
+            .await?;
+
+        let res = write1.append_slice(&data[..], 3).await?;
+        assert_eq!(res, Ok(()));
+
+        let write2_upper = write2.upper().clone();
+        let global_upper = write2.fetch_upper(NO_TIMEOUT).await?;
+
+        // The writer upper should not advance if another writer advances.
+        assert_eq!(write2_upper, Antichain::from_elem(0));
+
+        // The shard-global upper does advance.
+        assert_eq!(global_upper, Antichain::from_elem(3));
+
+        Ok(())
+    }
+
     // Make sure that the API structs are Sync + Send, so that they can be used in async tasks.
     // NOTE: This is a compile-time only test. If it compiles, we're good.
     #[allow(unused)]

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -90,6 +90,18 @@ where
         &self.upper
     }
 
+    /// Fetches and returns the shard-global `upper`.
+    ///
+    /// This requires fetching the latest state from consensus and is therefore a potentially
+    /// expensive operation.
+    pub async fn fetch_upper(&mut self, timeout: Duration) -> Result<Antichain<T>, ExternalError> {
+        trace!("WriteHandle::fetch_upper timeout={:?}", timeout,);
+        let deadline = Instant::now() + timeout;
+        let upper = self.machine.upper(deadline).await?;
+
+        Ok(upper)
+    }
+
     /// Applies `updates` to this shard and downgrades this handle's upper to
     /// `new_upper`.
     ///


### PR DESCRIPTION
### Motivation

This is needed in the new persist source (https://github.com/MaterializeInc/materialize/pull/11964) to determine a since that the controller can downgrade to. The controller looks at the write frontier (which is the persist `upper`) and the compaction policy to determine a since to downgrade to.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
