### PR TITLE
Expr/repr: Protobuf support for regex

### DIFF
--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -13,6 +13,7 @@ fn main() {
         .extern_path(".mz_repr.adt.char", "::mz_repr::adt::char")
         .extern_path(".mz_repr.adt.datetime", "::mz_repr::adt::datetime")
         .extern_path(".mz_repr.adt.numeric", "::mz_repr::adt::numeric")
+        .extern_path(".mz_repr.adt.regex", "::mz_repr::adt::regex")
         .extern_path(".mz_repr.adt.varchar", "::mz_repr::adt::varchar")
         .extern_path(".mz_repr.chrono", "::mz_repr::chrono")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
@@ -23,6 +24,7 @@ fn main() {
                 "expr/src/id.proto",
                 "expr/src/scalar.proto",
                 "expr/src/scalar/func.proto",
+                "expr/src/scalar/like_pattern.proto",
             ],
             &[".."],
         )

--- a/src/expr/src/scalar/func.proto
+++ b/src/expr/src/scalar/func.proto
@@ -12,9 +12,11 @@ syntax = "proto3";
 import "repr/src/adt/char.proto";
 import "repr/src/adt/datetime.proto";
 import "repr/src/adt/numeric.proto";
+import "repr/src/adt/regex.proto";
 import "repr/src/adt/varchar.proto";
 import "repr/src/chrono.proto";
 import "repr/src/relation_and_scalar.proto";
+import "expr/src/scalar/like_pattern.proto";
 import "google/protobuf/empty.proto";
 
 package mz_expr.scalar.func;
@@ -211,12 +213,9 @@ message ProtoUnaryFunc {
         google.protobuf.Empty byte_length_string = 150;
         google.protobuf.Empty char_length = 151;
         google.protobuf.Empty chr = 152;
-        // todo: IsLikeMatch: blocked on like_pattern::Matcher
-        google.protobuf.Empty is_like_match = 153;
-        // todo: IsRegexpMatch: blocked on Regex
-        google.protobuf.Empty is_regexp_match = 154;
-        // todo: RegexpMatch: blocked on Regex
-        google.protobuf.Empty regexp_match = 155;
+        mz_expr.scalar.like_pattern.ProtoMatcher is_like_match = 153;
+        mz_repr.adt.regex.ProtoRegex is_regexp_match = 154;
+        mz_repr.adt.regex.ProtoRegex regexp_match = 155;
         mz_repr.adt.datetime.ProtoDateTimeUnits extract_interval = 156;
         mz_repr.adt.datetime.ProtoDateTimeUnits extract_time = 157;
         mz_repr.adt.datetime.ProtoDateTimeUnits extract_timestamp = 158;

--- a/src/expr/src/scalar/like_pattern.proto
+++ b/src/expr/src/scalar/like_pattern.proto
@@ -1,0 +1,35 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package mz_expr.scalar.like_pattern;
+
+message ProtoSubpattern {
+    uint64 consume = 1;
+    bool many = 2;
+    string suffix = 3;
+}
+
+message ProtoMatcherImpl {
+    message ProtoSubpatternVec {
+        repeated ProtoSubpattern vec = 1;
+    }
+
+    oneof kind {
+        ProtoSubpatternVec string = 1;
+        string regex = 2;
+    }
+}
+
+message ProtoMatcher {
+    string pattern = 1;
+    bool case_insensitive = 2;
+    ProtoMatcherImpl matcher_impl = 3;
+}

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -11,12 +11,16 @@ use std::mem;
 use std::str::FromStr;
 
 use derivative::Derivative;
+use proptest::prelude::{Arbitrary, Strategy};
 use regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Serialize};
 
 use crate::scalar::EvalError;
 use mz_lowertest::MzReflect;
 use mz_ore::fmt::FormatBuffer;
+use mz_repr::proto::{ProtoRepr, TryFromProtoError, TryIntoIfSome};
+
+include!(concat!(env!("OUT_DIR"), "/mz_expr.scalar.like_pattern.rs"));
 
 /// The number of subpatterns after which using regexes would be more efficient.
 const MAX_SUBPATTERNS: usize = 5;
@@ -119,10 +123,67 @@ impl Matcher {
     }
 }
 
+impl From<&Matcher> for ProtoMatcher {
+    fn from(x: &Matcher) -> Self {
+        ProtoMatcher {
+            pattern: x.pattern.clone(),
+            case_insensitive: x.case_insensitive,
+            matcher_impl: Some((&x.matcher_impl).into()),
+        }
+    }
+}
+
+impl TryFrom<ProtoMatcher> for Matcher {
+    type Error = TryFromProtoError;
+
+    fn try_from(x: ProtoMatcher) -> Result<Self, Self::Error> {
+        Ok(Matcher {
+            pattern: x.pattern,
+            case_insensitive: x.case_insensitive,
+            matcher_impl: x
+                .matcher_impl
+                .try_into_if_some("ProtoMatcher::matcher_impl")?,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, MzReflect)]
 enum MatcherImpl {
     String(Vec<Subpattern>),
     Regex(#[serde(with = "serde_regex")] Regex),
+}
+
+impl From<&MatcherImpl> for ProtoMatcherImpl {
+    fn from(x: &MatcherImpl) -> Self {
+        use proto_matcher_impl::Kind::*;
+        use proto_matcher_impl::ProtoSubpatternVec;
+        ProtoMatcherImpl {
+            kind: Some(match x {
+                MatcherImpl::String(subpatterns) => String(ProtoSubpatternVec {
+                    vec: subpatterns.iter().map(Into::into).collect(),
+                }),
+                MatcherImpl::Regex(regex) => Regex(regex.clone().into_proto()),
+            }),
+        }
+    }
+}
+
+impl TryFrom<ProtoMatcherImpl> for MatcherImpl {
+    type Error = TryFromProtoError;
+
+    fn try_from(x: ProtoMatcherImpl) -> Result<Self, Self::Error> {
+        use proto_matcher_impl::Kind::*;
+        use proto_matcher_impl::ProtoSubpatternVec;
+        match x.kind {
+            Some(String(ProtoSubpatternVec { vec })) => Ok(MatcherImpl::String(
+                vec.into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            Some(Regex(regex)) => Ok(MatcherImpl::Regex(regex::Regex::from_proto(regex)?)),
+            None => Err(TryFromProtoError::missing_field("ProtoMatcherImpl::kind")),
+        }
+    }
 }
 
 /// Builds a Matcher that matches a SQL LIKE pattern.
@@ -147,6 +208,14 @@ pub fn compile(pattern: &str, case_insensitive: bool) -> Result<Matcher, EvalErr
         case_insensitive,
         matcher_impl,
     })
+}
+
+pub fn any_matcher() -> impl Strategy<Value = Matcher> {
+    (
+        r"(_|%)?(([[:alpha:]]|(\\_)|(\\%)|(\\\\)|华){1, 10}(_|%)?){0, 6}",
+        bool::arbitrary(),
+    )
+        .prop_map(|(pattern, case_insensitive)| compile(&pattern, case_insensitive).unwrap())
 }
 
 // The algorithm below is based on the observation that any LIKE pattern can be
@@ -209,6 +278,28 @@ impl Subpattern {
             }
         }
         regex_syntax::escape_into(&self.suffix, r);
+    }
+}
+
+impl From<&Subpattern> for ProtoSubpattern {
+    fn from(x: &Subpattern) -> Self {
+        ProtoSubpattern {
+            consume: x.consume.into_proto(),
+            many: x.many,
+            suffix: x.suffix.clone(),
+        }
+    }
+}
+
+impl TryFrom<ProtoSubpattern> for Subpattern {
+    type Error = TryFromProtoError;
+
+    fn try_from(x: ProtoSubpattern) -> Result<Self, Self::Error> {
+        Ok(Subpattern {
+            consume: usize::from_proto(x.consume)?,
+            many: x.many,
+            suffix: x.suffix,
+        })
     }
 }
 

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -21,6 +21,7 @@ fn main() {
                 "repr/src/adt/char.proto",
                 "repr/src/adt/datetime.proto",
                 "repr/src/adt/numeric.proto",
+                "repr/src/adt/regex.proto",
                 "repr/src/adt/varchar.proto",
             ],
             &[".."],

--- a/src/repr/src/adt/regex.proto
+++ b/src/repr/src/adt/regex.proto
@@ -1,0 +1,16 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package mz_repr.adt.regex;
+
+message ProtoRegex {
+    string regex = 1;
+}

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -95,7 +95,7 @@ impl ProtoRepr for regex::Regex {
     }
 
     fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
-        Ok(regex::Regex::new(&repr).map_err(|e| TryFromProtoError::RegexError(e))?)
+        Ok(regex::Regex::new(&repr).map_err(TryFromProtoError::RegexError)?)
     }
 }
 
@@ -115,9 +115,10 @@ impl TryFrom<ProtoRegex> for Regex {
     }
 }
 
-// TODO: generate more sophisticated regexes:
-// * Support groups.
-// * Support a greater range of characters and character classes.
+// TODO: this is not really high priority, but this could modified to generate a
+// greater variety of regexes. Ignoring the beginning-of-file/line and EOF/EOL
+// symbols, the only regexes being generated are `.{#repetitions}` and
+// `x{#repetitions}`.
 const BEGINNING_SYMBOLS: &str = r"((\\A)|\^)?";
 const CHARACTERS: &str = r"[\.x]{1}";
 const REPETITIONS: &str = r"((\*|\+|\?|(\{[1-9],?\}))\??)?";

--- a/src/repr/src/proto.rs
+++ b/src/repr/src/proto.rs
@@ -24,6 +24,8 @@ pub enum TryFromProtoError {
     CharTryFromError(CharTryFromError),
     /// A date conversion failed
     DateConversionError(String),
+    /// A regex compilation failed
+    RegexError(regex::Error),
     /// Indicates an `Option<U>` field in the `Proto$T` that should be set,
     /// but for some reason it is not. In practice this should never occur.
     MissingField(String),
@@ -55,6 +57,7 @@ impl std::fmt::Display for TryFromProtoError {
             TryFromIntError(error) => error.fmt(f),
             CharTryFromError(error) => error.fmt(f),
             DateConversionError(msg) => write!(f, "Date conversion failed: `{}`", msg),
+            RegexError(error) => error.fmt(f),
             MissingField(field) => write!(f, "Missing value for `{}`", field),
         }
     }
@@ -66,6 +69,7 @@ impl std::error::Error for TryFromProtoError {
         match self {
             TryFromIntError(error) => Some(error),
             CharTryFromError(error) => Some(error),
+            RegexError(error) => Some(error),
             DateConversionError(_) => None,
             MissingField(_) => None,
         }


### PR DESCRIPTION
Closes #11972.

`regex::Regex` is just mapped to a String because the original string that the regex was compiled from is the only thing that the [interface](https://docs.rs/regex/latest/regex/struct.Regex.html) exposes. `serde_regex` also just returns the original string that the regex was compiled from.

I think I got fairly decent proptest coverage for like patterns. Postgres reference for LIKE can be found [here](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE).

Proptest coverage for [`regex::Regex`](https://docs.rs/regex/latest/regex/) is quite primitive, but I figured that we shouldn't hold up the rest of the protobuf-ing for it.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing behavior changes.
