### PR TITLE
antithesis: remove the use of --workers

### DIFF
--- a/misc/python/materialize/cli/deploy_antithesis.py
+++ b/misc/python/materialize/cli/deploy_antithesis.py
@@ -29,7 +29,7 @@ def main() -> None:
     deps = repo.resolve_dependencies([repo.images[name] for name in IMAGES])
     deps.acquire()
 
-    tag = sys.argv[1] if sys.argv[1] is not None else "latest"
+    tag = sys.argv[1] if len(sys.argv) > 1 else "latest"
 
     for mzimage in IMAGES:
         spawn.runv(

--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     command:
       --listen-addr 0.0.0.0:6875
       --data-directory=/share/mzdata
-      --workers 2
       --experimental
       --timestamp-frequency 100ms
       --no-sigbus-sigsegv-backtraces


### PR DESCRIPTION
The --workers option is no longer valid, so should not be passed
to materialized

### Motivation

  * This PR fixes a previously unreported bug.

The Antithesis builds were failing