### PR TITLE
dbt-materialize: release `v1.0.5`

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,9 +1,14 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.0.5 - 2022-04-26
 
-* Discontinue support for custom index materialization.
-* Enable defining indexes when creating a materializedview, view, or source.
+* Deprecate support for custom index materialization.
+* Enable defining indexes when creating a `materializedview`, `view`, or `source` using the `indexes` config.
+
+  ```sql
+  {{ config(materialized='view',
+          indexes=[{'columns': ['symbol']}]) }}
+  ```
 
 ## 1.0.4 - 2022-03-27
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.0.4"
+version = "1.0.5"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.0.4",
+    version="1.0.5",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a new release of `dbt-materialize` with the first leg of work from #10600. 

See the changelog for details.

### Motivation

* Some users are keen to switch index definition to the new config-based approach, which sounds like enough motivation to cut a release.

### Tips for reviewer

* There are pending documentation tasks (#11538) that need to be pushed into the dbt repo soon, but that shouldn't block the release.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any user-facing behavior changes
