### PR TITLE
ci: Move the unused-dependencies job to Nightly

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -35,6 +35,7 @@ steps:
           - { value: zippy }
           - { value: secrets }
           - { value: catalog-compat }
+          - { value: unused-deps }
         multiple: true
         required: false
     if: build.source == "ui"
@@ -233,3 +234,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: catalog-compat
           run: catalog-compat
+
+  - id: unused-deps
+    label: Unused dependencies
+    command: bin/ci-builder run nightly bin/unused-deps
+    # inputs:
+    #  - Cargo.lock
+    #  - "**/Cargo.toml"
+    #  - "**/*.rs"
+    timeout_in_minutes: 30
+    # https://github.com/est31/cargo-udeps/issues/103
+    soft_fail: true
+    agents:
+      queue: linux-x86_64

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -72,19 +72,6 @@ steps:
     agents:
       queue: mac
 
-  - id: unused-deps
-    label: Unused dependencies
-    command: bin/ci-builder run nightly bin/unused-deps
-    inputs:
-      - Cargo.lock
-      - "**/Cargo.toml"
-      - "**/*.rs"
-    timeout_in_minutes: 30
-    # https://github.com/est31/cargo-udeps/issues/103
-    soft_fail: true
-    agents:
-      queue: linux-x86_64
-
   - id: lint-allocator
     label: Lint memory allocator
     command: bin/ci-builder run stable ci/test/lint-allocator.sh


### PR DESCRIPTION
That job has been failing for a while due to a bug outside of Mz
and at the same time takes a non-trivial number of minutes to run.

### Motivation

  * This PR adds a feature that has not yet been specified.

CI needs to be sped up by any means possible