### PR TITLE
persist-client: rename poll_next async fn to just next

### DIFF
--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -466,7 +466,7 @@ mod raw_persist_benchmark {
             let mut count = 0;
             // TODO: setting a smaller deadline (of say 1 second), causes failures
             // sometimes.
-            let events = self.poll_next(Duration::from_millis(100_000)).await?;
+            let events = self.next(Duration::from_millis(100_000)).await?;
 
             for event in events {
                 if let ListenEvent::Progress(t) = event {

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -95,11 +95,11 @@ where
     /// Attempt to pull out the next values of this iterator.
     ///
     /// An empty vector is returned if this iterator is exhausted.
-    pub async fn poll_next(
+    pub async fn next(
         &mut self,
         timeout: Duration,
     ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, ExternalError> {
-        trace!("SnapshotIter::poll_next timeout={:?}", timeout);
+        trace!("SnapshotIter::next timeout={:?}", timeout);
         let deadline = Instant::now() + timeout;
         loop {
             let key = match self.batches.last() {
@@ -185,7 +185,7 @@ where
 
         let mut ret = Vec::new();
         loop {
-            let mut next = self.poll_next(NO_TIMEOUT).await?;
+            let mut next = self.next(NO_TIMEOUT).await?;
             if next.is_empty() {
                 ret.sort();
                 return Ok(ret);
@@ -224,11 +224,11 @@ where
     D: Semigroup + Codec64,
 {
     /// Attempt to pull out the next values of this subscription.
-    pub async fn poll_next(
+    pub async fn next(
         &mut self,
         timeout: Duration,
     ) -> Result<Vec<ListenEvent<K, V, T, D>>, ExternalError> {
-        trace!("Listen::poll_next timeout={:?}", timeout);
+        trace!("Listen::next timeout={:?}", timeout);
         let deadline = Instant::now() + timeout;
 
         let (batch_keys, desc) = self
@@ -256,7 +256,7 @@ where
 
         let mut ret = Vec::new();
         while self.frontier.less_than(ts) {
-            let mut next = self.poll_next(NO_TIMEOUT).await?;
+            let mut next = self.next(NO_TIMEOUT).await?;
             ret.append(&mut next);
         }
         return Ok(ret);


### PR DESCRIPTION
### Motivation

`poll_*` functions in async rust are used only for the low level primitives that actually poll (i.e functions that receive a `std::task::Context` and return a `std::task::Poll<T>`. If it's an async method that can be awaited it should have a normal name.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
