### PR TITLE
expr, sql: add first_value as a new window function

### DIFF
--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1473,7 +1473,8 @@ pub mod monoids {
             | AggregateFunc::StringAgg { .. }
             | AggregateFunc::RowNumber { .. }
             | AggregateFunc::DenseRank { .. }
-            | AggregateFunc::LagLead { .. } => None,
+            | AggregateFunc::LagLead { .. }
+            | AggregateFunc::FirstValue { .. } => None,
         }
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -910,7 +910,8 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::StringAgg { .. }
         | AggregateFunc::RowNumber { .. }
         | AggregateFunc::DenseRank { .. }
-        | AggregateFunc::LagLead { .. } => ReductionType::Basic,
+        | AggregateFunc::LagLead { .. }
+        | AggregateFunc::FirstValue { .. } => ReductionType::Basic,
     }
 }
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -46,7 +46,8 @@ pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::ProtoColumnOrder;
 pub use relation::{
     compare_columns, AggregateExpr, CollectionPlan, ColumnOrder, JoinImplementation,
-    MirRelationExpr, RowSetFinishing, RECURSION_LIMIT,
+    MirRelationExpr, RowSetFinishing, WindowFrame, WindowFrameBound, WindowFrameUnits,
+    RECURSION_LIMIT,
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -11,9 +11,35 @@
 
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+
 package mz_expr.relation;
 
 message ProtoColumnOrder {
     uint64 column = 1;
     bool desc = 2;
+}
+
+message ProtoWindowFrame {
+    message ProtoWindowFrameBound {
+        oneof kind {
+            google.protobuf.Empty unbounded_preceding = 1;
+            uint64 offset_preceding = 2;
+            google.protobuf.Empty current_row = 3;
+            uint64 offset_following = 4;
+            google.protobuf.Empty unbounded_following = 5;
+        }
+    }
+
+    message ProtoWindowFrameUnits {
+        oneof kind {
+            google.protobuf.Empty rows = 1;
+            google.protobuf.Empty range = 2;
+            google.protobuf.Empty groups = 3;
+        }
+    }
+
+    ProtoWindowFrameUnits units = 1;
+    ProtoWindowFrameBound start_bound = 2;
+    ProtoWindowFrameBound end_bound = 3;
 }

--- a/src/expr/src/relation/func.proto
+++ b/src/expr/src/relation/func.proto
@@ -32,6 +32,11 @@ message ProtoAggregateFunc {
         }
     };
 
+    message ProtoFirstValue {
+        ProtoColumnOrders order_by = 1;
+        mz_expr.relation.ProtoWindowFrame window_frame = 2;
+    }
+
     oneof kind {
         google.protobuf.Empty max_numeric = 1;
         google.protobuf.Empty max_int16 = 2;
@@ -73,6 +78,7 @@ message ProtoAggregateFunc {
         ProtoColumnOrders dense_rank  = 38;
         ProtoLagLead lag_lead  = 39;
         google.protobuf.Empty dummy = 40;
+        ProtoFirstValue first_value = 41;
     }
 }
 

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -25,13 +25,14 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
+use mz_ore::cast::CastFrom;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::numeric::{self, NumericMaxScale};
 use mz_repr::adt::regex::Regex as ReprRegex;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, RelationType, Row, RowArena, ScalarType};
 
-use crate::relation::{compare_columns, ColumnOrder};
+use crate::relation::{compare_columns, ColumnOrder, WindowFrame, WindowFrameBound};
 use crate::scalar::func::{add_timestamp_months, jsonb_stringify};
 use crate::EvalError;
 
@@ -715,6 +716,101 @@ where
     })
 }
 
+// The expected input is in the format of [((OriginalRow, InputValue), OrderByExprs...)]
+fn first_value<'a, I>(
+    datums: I,
+    temp_storage: &'a RowArena,
+    order_by: &[ColumnOrder],
+    window_frame: &WindowFrame,
+) -> Datum<'a>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
+    // Sort the datums according to the ORDER BY expressions and return the (OriginalRow, InputValue) record
+    let datums = order_aggregate_datums(datums, order_by);
+
+    // Decode the input (OriginalRow, InputValue) into separate datums
+    let datums = datums
+        .into_iter()
+        .map(|d| {
+            let mut iter = d.unwrap_list().iter();
+            let original_row = iter.next().unwrap();
+            let input_value = iter.next().unwrap();
+
+            (input_value, original_row)
+        })
+        .collect_vec();
+
+    let length = datums.len();
+    let mut result: Vec<(Datum, Datum)> = Vec::with_capacity(length);
+    for (idx, (current_datum, original_row)) in datums.iter().enumerate() {
+        let first_value = match &window_frame.start_bound {
+            // Always return the current value
+            WindowFrameBound::CurrentRow => *current_datum,
+            WindowFrameBound::UnboundedPreceding => {
+                if let WindowFrameBound::OffsetPreceding(end_offset) = &window_frame.end_bound {
+                    let end_offset = usize::cast_from(*end_offset);
+
+                    // If the frame ends before the first row, return null
+                    if idx < end_offset {
+                        Datum::Null
+                    } else {
+                        datums[0].0
+                    }
+                } else {
+                    datums[0].0
+                }
+            }
+            WindowFrameBound::OffsetPreceding(offset) => {
+                let start_offset = usize::cast_from(*offset);
+                let start_idx = idx.saturating_sub(start_offset);
+                if let WindowFrameBound::OffsetPreceding(end_offset) = &window_frame.end_bound {
+                    let end_offset = usize::try_from(*end_offset)
+                        .expect("Window frame offset does not fit in usize");
+
+                    // If the frame is empty or ends before the first row, return null
+                    if start_offset < end_offset || idx < end_offset {
+                        Datum::Null
+                    } else {
+                        datums[start_idx].0
+                    }
+                } else {
+                    datums[start_idx].0
+                }
+            }
+            WindowFrameBound::OffsetFollowing(offset) => {
+                let start_offset =
+                    usize::try_from(*offset).expect("Window frame offset does not fit in usize");
+                let start_idx = idx.saturating_add(start_offset);
+                if let WindowFrameBound::OffsetFollowing(end_offset) = &window_frame.end_bound {
+                    // If the frame is empty or starts after the last row, return null
+                    if offset > end_offset || start_idx >= length {
+                        Datum::Null
+                    } else {
+                        datums[start_idx].0
+                    }
+                } else {
+                    datums.get(start_idx).map(|d| d.0).unwrap_or(Datum::Null)
+                }
+            }
+            // Forbidden during planning
+            WindowFrameBound::UnboundedFollowing => unreachable!(),
+        };
+
+        result.push((first_value, *original_row));
+    }
+
+    let result = result.into_iter().map(|(lag, original_row)| {
+        temp_storage.make_datum(|packer| {
+            packer.push_list(vec![lag, original_row]);
+        })
+    });
+
+    temp_storage.make_datum(|packer| {
+        packer.push_list(result);
+    })
+}
+
 /// Identify whether the given aggregate function is Lag or Lead, since they share
 /// implementations.
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
@@ -796,6 +892,10 @@ pub enum AggregateFunc {
     LagLead {
         order_by: Vec<ColumnOrder>,
         lag_lead: LagLeadType,
+    },
+    FirstValue {
+        order_by: Vec<ColumnOrder>,
+        window_frame: WindowFrame,
     },
     /// Accumulates any number of `Datum::Dummy`s into `Datum::Dummy`.
     ///
@@ -1017,6 +1117,10 @@ impl AggregateFunc {
                 order_by,
                 lag_lead: lag_lead_type,
             } => lag_lead(datums, temp_storage, order_by, lag_lead_type),
+            AggregateFunc::FirstValue {
+                order_by,
+                window_frame,
+            } => first_value(datums, temp_storage, order_by, window_frame),
             AggregateFunc::Dummy => Datum::Dummy,
         }
     }
@@ -1045,6 +1149,7 @@ impl AggregateFunc {
             AggregateFunc::RowNumber { .. } => Datum::empty_list(),
             AggregateFunc::DenseRank { .. } => Datum::empty_list(),
             AggregateFunc::LagLead { .. } => Datum::empty_list(),
+            AggregateFunc::FirstValue { .. } => Datum::empty_list(),
             _ => Datum::Null,
         }
     }
@@ -1139,6 +1244,28 @@ impl AggregateFunc {
                     element_type: Box::new(ScalarType::Record {
                         fields: vec![
                             (ColumnName::from(column_name), value_type),
+                            (ColumnName::from("?record?"), original_row_type),
+                        ],
+                        custom_id: None,
+                        custom_name: None,
+                    }),
+                    custom_id: None,
+                }
+            }
+            AggregateFunc::FirstValue { .. } => {
+                // The input type for FirstValue is ((OriginalRow, EncodedArgs), OrderByExprs...)
+                let fields = input_type.scalar_type.unwrap_record_element_type();
+                let original_row_type = fields[0].unwrap_record_element_type()[0]
+                    .clone()
+                    .nullable(false);
+                let value_type = fields[0].unwrap_record_element_type()[1]
+                    .clone()
+                    .nullable(true);
+
+                ScalarType::List {
+                    element_type: Box::new(ScalarType::Record {
+                        fields: vec![
+                            (ColumnName::from("?first_value?"), value_type),
                             (ColumnName::from("?record?"), original_row_type),
                         ],
                         custom_id: None,
@@ -1443,6 +1570,7 @@ impl fmt::Display for AggregateFunc {
                 lag_lead: LagLeadType::Lead,
                 ..
             } => f.write_str("lead"),
+            AggregateFunc::FirstValue { .. } => f.write_str("first_value"),
             AggregateFunc::Dummy => f.write_str("dummy"),
         }
     }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -979,6 +979,13 @@ impl From<&AggregateFunc> for ProtoAggregateFunc {
                         }),
                     })
                 }
+                AggregateFunc::FirstValue {
+                    order_by,
+                    window_frame,
+                } => Kind::FirstValue(proto_aggregate_func::ProtoFirstValue {
+                    order_by: Some(order_by.into()),
+                    window_frame: Some(window_frame.into()),
+                }),
                 AggregateFunc::Dummy => Kind::Dummy(()),
             }),
         }
@@ -1061,6 +1068,12 @@ impl TryFrom<ProtoAggregateFunc> for AggregateFunc {
                         ))
                     }
                 },
+            },
+            Kind::FirstValue(pfv) => AggregateFunc::FirstValue {
+                order_by: pfv.order_by.try_into_if_some("ProtoFirstValue::order_by")?,
+                window_frame: pfv
+                    .window_frame
+                    .try_into_if_some("ProtoFirstValue::window_frame")?,
             },
             Kind::Dummy(()) => AggregateFunc::Dummy,
         })

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1997,6 +1997,111 @@ where
     tiebreaker()
 }
 
+/// Describe a window frame, e.g. `RANGE UNBOUNDED PRECEDING` or
+/// `ROWS BETWEEN 5 PRECEDING AND CURRENT ROW`.
+///
+/// Window frames define a subset of the partition , and only a subset of
+/// window functions make use of the window frame.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect)]
+pub struct WindowFrame {
+    /// ROWS, RANGE or GROUPS
+    pub units: WindowFrameUnits,
+    /// Where the frame starts
+    pub start_bound: WindowFrameBound,
+    /// Where the frame ends
+    pub end_bound: WindowFrameBound,
+}
+
+impl WindowFrame {
+    /// Return the default window frame used when one is not explicitly defined
+    pub fn default() -> Self {
+        WindowFrame {
+            units: WindowFrameUnits::Range,
+            start_bound: WindowFrameBound::UnboundedPreceding,
+            end_bound: WindowFrameBound::CurrentRow,
+        }
+    }
+
+    fn includes_current_row(&self) -> bool {
+        use WindowFrameBound::*;
+        match self.start_bound {
+            UnboundedPreceding => match self.end_bound {
+                UnboundedPreceding => false,
+                OffsetPreceding(0) => true,
+                OffsetPreceding(_) => false,
+                CurrentRow => true,
+                OffsetFollowing(_) => true,
+                UnboundedFollowing => true,
+            },
+            OffsetPreceding(0) => match self.end_bound {
+                UnboundedPreceding => unreachable!(),
+                OffsetPreceding(0) => true,
+                // Any nonzero offsets here will create an empty window
+                OffsetPreceding(_) => false,
+                CurrentRow => true,
+                OffsetFollowing(_) => true,
+                UnboundedFollowing => true,
+            },
+            OffsetPreceding(_) => match self.end_bound {
+                UnboundedPreceding => unreachable!(),
+                // Window ends at the current row
+                OffsetPreceding(0) => true,
+                OffsetPreceding(_) => false,
+                CurrentRow => true,
+                OffsetFollowing(_) => true,
+                UnboundedFollowing => true,
+            },
+            CurrentRow => true,
+            OffsetFollowing(0) => match self.end_bound {
+                UnboundedPreceding => unreachable!(),
+                OffsetPreceding(_) => unreachable!(),
+                CurrentRow => unreachable!(),
+                OffsetFollowing(_) => true,
+                UnboundedFollowing => true,
+            },
+            OffsetFollowing(_) => match self.end_bound {
+                UnboundedPreceding => unreachable!(),
+                OffsetPreceding(_) => unreachable!(),
+                CurrentRow => unreachable!(),
+                OffsetFollowing(_) => false,
+                UnboundedFollowing => false,
+            },
+            UnboundedFollowing => false,
+        }
+    }
+}
+
+/// Describe how frame bounds are interpreted
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect)]
+pub enum WindowFrameUnits {
+    /// Each row is treated as the unit of work for bounds
+    Rows,
+    /// Each peer group is treated as the unit of work for bounds,
+    /// and offset-based bounds use the value of the ORDER BY expression
+    Range,
+    /// Each peer group is treated as the unit of work for bounds.
+    /// Groups is currently not supported, and it is rejected during planning.
+    Groups,
+}
+
+/// Specifies [WindowFrame]'s `start_bound` and `end_bound`
+///
+/// The order between frame bounds is significant, as Postgres enforces
+/// some restrictions there.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, MzReflect, PartialOrd, Ord)]
+pub enum WindowFrameBound {
+    /// `UNBOUNDED PRECEDING`
+    UnboundedPreceding,
+    /// `<N> PRECEDING`
+    OffsetPreceding(u64),
+    /// `CURRENT ROW`
+    CurrentRow,
+    /// `<N> FOLLOWING`
+    OffsetFollowing(u64),
+    /// `UNBOUNDED FOLLOWING`.
+    UnboundedFollowing,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1773,6 +1773,52 @@ impl AggregateExpr {
                 }
             }
 
+            // The input type for LagLead is a ((OriginalRow, InputValue), OrderByExprs...)
+            AggregateFunc::FirstValue { window_frame, .. } => {
+                let tuple = self
+                    .expr
+                    .clone()
+                    .call_unary(UnaryFunc::RecordGet(scalar_func::RecordGet(0)));
+
+                // Get the overall return type
+                let return_type = self
+                    .typ(input_type)
+                    .scalar_type
+                    .unwrap_list_element_type()
+                    .clone();
+                let first_value_return_type = return_type.unwrap_record_element_type()[0].clone();
+
+                // Extract the original row
+                let original_row = tuple
+                    .clone()
+                    .call_unary(UnaryFunc::RecordGet(scalar_func::RecordGet(0)));
+
+                // Extract the input value
+                let expr = tuple.call_unary(UnaryFunc::RecordGet(scalar_func::RecordGet(1)));
+
+                // If the window frame includes the current (single) row, return its value, null otherwise
+                let value = if window_frame.includes_current_row() {
+                    expr
+                } else {
+                    MirScalarExpr::literal_null(first_value_return_type)
+                };
+
+                MirScalarExpr::CallVariadic {
+                    func: VariadicFunc::ListCreate {
+                        elem_type: return_type,
+                    },
+                    exprs: vec![MirScalarExpr::CallVariadic {
+                        func: VariadicFunc::RecordCreate {
+                            field_names: vec![
+                                ColumnName::from("?first_value?"),
+                                ColumnName::from("?record?"),
+                            ],
+                        },
+                        exprs: vec![value, original_row],
+                    }],
+                }
+            }
+
             // All other variants should return the argument to the aggregation.
             AggregateFunc::MaxNumeric
             | AggregateFunc::MaxInt16

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -520,6 +520,12 @@ impl From<ScalarWindowFunc> for Operation<ScalarWindowFunc> {
     }
 }
 
+impl From<ValueWindowFunc> for Operation<(HirScalarExpr, ValueWindowFunc)> {
+    fn from(a: ValueWindowFunc) -> Operation<(HirScalarExpr, ValueWindowFunc)> {
+        Operation::unary(move |_ecx, e| Ok((e, a.clone())))
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 /// Describes possible types of function parameters.
 ///
@@ -2562,6 +2568,9 @@ lazy_static! {
                     };
                     Ok((e, ValueWindowFunc::Lead))
                 }) => AnyCompatible, 3111;
+            },
+            "first_value" => ValueWindow {
+                params!(Any) => ValueWindowFunc::FirstValue => Any, 3112;
             },
 
             // Table functions.

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -368,6 +368,10 @@ impl ValueWindowExpr {
                 order_by: self.order_by,
                 lag_lead: mz_expr::LagLeadType::Lead,
             },
+            ValueWindowFunc::FirstValue => mz_expr::AggregateFunc::FirstValue {
+                order_by: self.order_by,
+                window_frame: self.window_frame,
+            },
         }
     }
 }
@@ -377,6 +381,7 @@ impl ValueWindowExpr {
 pub enum ValueWindowFunc {
     Lag,
     Lead,
+    FirstValue,
 }
 
 impl ValueWindowFunc {
@@ -388,6 +393,7 @@ impl ValueWindowFunc {
                     .clone()
                     .nullable(true)
             }
+            ValueWindowFunc::FirstValue => input_type.scalar_type.nullable(true),
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -35,7 +35,8 @@ use crate::plan::Params;
 
 // these happen to be unchanged at the moment, but there might be additions later
 pub use mz_expr::{
-    BinaryFunc, ColumnOrder, TableFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc,
+    BinaryFunc, ColumnOrder, TableFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc, WindowFrame,
+    WindowFrameBound, WindowFrameUnits,
 };
 
 use super::Explanation;
@@ -329,6 +330,7 @@ pub struct ValueWindowExpr {
     pub func: ValueWindowFunc,
     pub expr: Box<HirScalarExpr>,
     pub order_by: Vec<ColumnOrder>,
+    pub window_frame: WindowFrame,
 }
 
 impl ValueWindowExpr {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -60,7 +60,7 @@ use mz_sql_parser::ast::{
     Ident, InsertSource, IsExprConstruct, Join, JoinConstraint, JoinOperator, Limit, OrderByExpr,
     Query, Select, SelectItem, SetExpr, SetOperator, SubscriptPosition, TableAlias, TableFactor,
     TableFunction, TableWithJoins, UnresolvedObjectName, UpdateStatement, Value, Values,
-    WindowSpec,
+    WindowFrame, WindowFrameBound, WindowFrameUnits, WindowSpec,
 };
 
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
@@ -3982,7 +3982,7 @@ fn plan_function<'a>(
         }
         Func::Scalar(impls) => impls,
         Func::ScalarWindow(impls) => {
-            let (window_spec, scalar_args, partition) = validate_window_function_plan(ecx, f)?;
+            let (window_spec, _, scalar_args, partition) = validate_window_function_plan(ecx, f)?;
 
             let func = func::select_impl(
                 ecx,
@@ -4004,7 +4004,8 @@ fn plan_function<'a>(
             }));
         }
         Func::ValueWindow(impls) => {
-            let (window_spec, scalar_args, partition) = validate_window_function_plan(ecx, f)?;
+            let (window_spec, window_frame, scalar_args, partition) =
+                validate_window_function_plan(ecx, f)?;
 
             let (expr, func) = func::select_impl(
                 ecx,
@@ -4021,6 +4022,7 @@ fn plan_function<'a>(
                     func,
                     expr: Box::new(expr),
                     order_by: col_orders,
+                    window_frame,
                 }),
                 partition,
                 order_by,
@@ -4248,6 +4250,7 @@ fn validate_window_function_plan<'a>(
 ) -> Result<
     (
         &'a WindowSpec<Aug>,
+        mz_expr::WindowFrame,
         Vec<CoercibleScalarExpr>,
         Vec<HirScalarExpr>,
     ),
@@ -4274,9 +4277,10 @@ fn validate_window_function_plan<'a>(
         Some(over) => over,
         None => sql_bail!("window function {} requires an OVER clause", name),
     };
-    if window_spec.window_frame.is_some() {
-        bail_unsupported!("window frames");
-    }
+    let window_frame = match window_spec.window_frame.as_ref() {
+        Some(frame) => plan_window_frame(frame)?,
+        None => mz_expr::WindowFrame::default(),
+    };
     let mut partition = Vec::new();
     for expr in &window_spec.partition_by {
         partition.push(plan_expr(ecx, expr)?.type_as_any(ecx)?);
@@ -4297,7 +4301,82 @@ fn validate_window_function_plan<'a>(
         }
     };
 
-    Ok((window_spec, scalar_args, partition))
+    Ok((window_spec, window_frame, scalar_args, partition))
+}
+
+fn plan_window_frame(
+    WindowFrame {
+        units,
+        start_bound,
+        end_bound,
+    }: &WindowFrame,
+) -> Result<mz_expr::WindowFrame, PlanError> {
+    use mz_expr::WindowFrameBound::*;
+    let units = window_frame_unit_ast_to_expr(units)?;
+    let start_bound = window_frame_bound_ast_to_expr(start_bound);
+    let end_bound = end_bound
+        .as_ref()
+        .map(window_frame_bound_ast_to_expr)
+        .unwrap_or(CurrentRow);
+
+    // Validate bounds according to Postgres rules
+    match (&start_bound, &end_bound) {
+        // Start bound can't be UNBOUNDED FOLLOWING
+        (UnboundedFollowing, _) => {
+            sql_bail!("frame start cannot be UNBOUNDED FOLLOWING")
+        }
+        // End bound can't be UNBOUNDED PRECEDING
+        (_, UnboundedPreceding) => {
+            sql_bail!("frame end cannot be UNBOUNDED PRECEDING")
+        }
+        // Start bound should come before end bound in the list of bound definitions
+        (CurrentRow, OffsetPreceding(_)) => {
+            sql_bail!("frame starting from current row cannot have preceding rows")
+        }
+        (OffsetFollowing(_), OffsetPreceding(_) | CurrentRow) => {
+            sql_bail!("frame starting from following row cannot have preceding rows")
+        }
+        // Other bounds are valid
+        (_, _) => (),
+    }
+
+    // RANGE is only supported in the default frame
+    if units == mz_expr::WindowFrameUnits::Range
+        && (start_bound != UnboundedPreceding || end_bound != CurrentRow)
+    {
+        bail_unsupported!("RANGE in non-default window frames")
+    }
+
+    let frame = mz_expr::WindowFrame {
+        units,
+        start_bound,
+        end_bound,
+    };
+    Ok(frame)
+}
+
+fn window_frame_unit_ast_to_expr(
+    unit: &WindowFrameUnits,
+) -> Result<mz_expr::WindowFrameUnits, PlanError> {
+    match unit {
+        WindowFrameUnits::Rows => Ok(mz_expr::WindowFrameUnits::Rows),
+        WindowFrameUnits::Range => Ok(mz_expr::WindowFrameUnits::Range),
+        WindowFrameUnits::Groups => bail_unsupported!("GROUPS in window frames"),
+    }
+}
+
+fn window_frame_bound_ast_to_expr(bound: &WindowFrameBound) -> mz_expr::WindowFrameBound {
+    match bound {
+        WindowFrameBound::CurrentRow => mz_expr::WindowFrameBound::CurrentRow,
+        WindowFrameBound::Preceding(None) => mz_expr::WindowFrameBound::UnboundedPreceding,
+        WindowFrameBound::Preceding(Some(offset)) => {
+            mz_expr::WindowFrameBound::OffsetPreceding(*offset)
+        }
+        WindowFrameBound::Following(None) => mz_expr::WindowFrameBound::UnboundedFollowing,
+        WindowFrameBound::Following(Some(offset)) => {
+            mz_expr::WindowFrameBound::OffsetFollowing(*offset)
+        }
+    }
 }
 
 // Implement these as two identical enums without From/Into impls so that they

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -2084,3 +2084,1496 @@ query II
 SELECT f1, lead(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t4 GROUP BY f1 ORDER BY 1
 ----
 NULL NULL
+
+## window frames
+
+# Invalid frame start
+query error frame start cannot be UNBOUNDED FOLLOWING
+SELECT row_number() OVER (ROWS UNBOUNDED FOLLOWING)
+
+# Invalid frame end
+query error frame end cannot be UNBOUNDED PRECEDING
+SELECT row_number() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING)
+
+# End frame can't be of a type that comes before the start bound
+query error frame starting from current row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)
+
+query error frame starting from following row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING)
+
+query error frame starting from following row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW)
+
+# But end offsets can come before start offsets
+query I
+SELECT row_number() OVER (ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+----
+1
+
+query I
+SELECT row_number() OVER (ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+----
+1
+
+# Negative offsets are not allowed
+# Our error message is different from Postgres, so it's not checked here
+query error
+SELECT row_number() OVER (ROWS -1 PRECEDING)
+
+query error
+SELECT row_number() OVER (ROWS -1 FOLLOWING)
+
+# Current implementation restrictions
+# RANGE is not supported outside of the default frame
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND 1 PRECEDING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+
+# Default window frame works fine
+query I
+SELECT row_number() OVER ()
+----
+1
+
+query I
+SELECT row_number() OVER (RANGE UNBOUNDED PRECEDING)
+----
+1
+
+query I
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+----
+1
+
+# GROUPS is not supported at all
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+
+## first_value
+
+# Default frame (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN 0 PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND 0 PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  2
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND CURRENT ROW
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
+# Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND x FOLLOWING
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
+# TODO(andrioni): this one is wrong, should be all nulls
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# TODO(andrioni): this one is wrong, should be all nulls
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x > y
+# TODO(andrioni): this one is wrong, should be all nulls
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# TODO(andrioni): this one is wrong, should be all nulls
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# u64::MAX PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551615 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551614 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+#reduce_elision code path
+statement ok
+CREATE TABLE t5 (f1 INTEGER)
+----
+
+statement ok
+INSERT INTO t5 VALUES (1)
+----
+
+# Default frame, includes current row
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at UNBOUNDED PRECEDING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 1 PRECEDING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 0 PRECEDING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at CURRENT ROW
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 0 FOLLOWING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 1 FOLLOWING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL


### PR DESCRIPTION
`first_value` is our first function that actually depends on window frames, so this also includes the implementation of window frames.

On window frames, some features were left intentionally not implemented, and will be implemented in the future based on prioritization:
- Support for `GROUPS` in the frame clause
- Support for `RANGE` outside of the default frame (`RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`
- Frame exclusion rules
- Named windows

### Motivation

  * This PR adds a known-desirable feature: it is part of MaterializeInc/product#139

### Tips for reviewer

- Tests are 80% of this PR, and isolated in their own commit.
- Each semantic set of changes is in a separate commit, and you should read them in order, as later commits do depend on earlier ones.
- The first two commits involve only the definition/implementation of window frames.
- The next two commits involve the implementation of `first_value`.
- The last commit is a bunch of SLT tests ensuring both window frames and first_value behave appropriately. All outputs were validated against Postgres 14.2.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - add `first_value` as a new window function.
