### PR TITLE
stash: don't wrap sqlite conn in Arc Mutex

### DIFF
--- a/src/stash/benches/sqlite.rs
+++ b/src/stash/benches/sqlite.rs
@@ -32,7 +32,7 @@ fn bench_update(c: &mut Criterion) {
 
 fn bench_update_many(c: &mut Criterion) {
     let file = NamedTempFile::new().unwrap();
-    let stash = Sqlite::open(file.path()).unwrap();
+    let mut stash = Sqlite::open(file.path()).unwrap();
 
     let orders = stash.collection::<String, String>("orders").unwrap();
     let mut ts = 1;
@@ -69,7 +69,7 @@ fn bench_consolidation(c: &mut Criterion) {
 
 fn bench_consolidation_large(c: &mut Criterion) {
     let file = NamedTempFile::new().unwrap();
-    let stash = Sqlite::open(file.path()).unwrap();
+    let mut stash = Sqlite::open(file.path()).unwrap();
 
     let orders = stash.collection::<String, String>("orders").unwrap();
     let mut ts = 0;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -52,7 +52,7 @@ pub trait Stash {
     ///
     /// It is valid to construct multiple handles to the same named collection
     /// and use them simultaneously.
-    fn collection<K, V>(&self, name: &str) -> Result<StashCollection<K, V>, StashError>
+    fn collection<K, V>(&mut self, name: &str) -> Result<StashCollection<K, V>, StashError>
     where
         K: Codec + Ord,
         V: Codec + Ord;
@@ -66,7 +66,7 @@ pub trait Stash {
     /// frontier. The time may also be greater than the upper frontier,
     /// indicating data that has not yet been made definite.
     fn iter<K, V>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
     ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
     where
@@ -82,7 +82,7 @@ pub trait Stash {
     /// frontier. The time may also be greater than the upper frontier,
     /// indicating data that has not yet been made definite.
     fn iter_key<K, V>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
         key: &K,
     ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
@@ -111,7 +111,7 @@ pub trait Stash {
     ///
     /// If this method returns `Ok`, the entries have been made durable.
     fn update_many<K: Codec, V: Codec, I>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
         entries: I,
     ) -> Result<(), StashError>
@@ -126,7 +126,7 @@ pub trait Stash {
     /// Intuitively, this method declares that all times less than `upper` are
     /// definite.
     fn seal<K, V>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
         upper: AntichainRef<Timestamp>,
     ) -> Result<(), StashError>;
@@ -136,7 +136,7 @@ pub trait Stash {
     ///
     /// See [Stash::seal]
     fn seal_batch<K, V>(
-        &self,
+        &mut self,
         seals: &[(StashCollection<K, V>, Antichain<Timestamp>)],
     ) -> Result<(), StashError> {
         for (id, new_upper) in seals {
@@ -153,7 +153,7 @@ pub trait Stash {
     /// Intuitively, this method performs logical compaction. Existing entries
     /// whose time is less than `since` are fast-forwarded to `since`.
     fn compact<K, V>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
         since: AntichainRef<Timestamp>,
     ) -> Result<(), StashError>;
@@ -163,7 +163,7 @@ pub trait Stash {
     ///
     /// See [Stash::compact]
     fn compact_batch<K, V>(
-        &self,
+        &mut self,
         compactions: &[(StashCollection<K, V>, Antichain<Timestamp>)],
     ) -> Result<(), StashError> {
         for (id, since) in compactions {
@@ -177,14 +177,14 @@ pub trait Stash {
     /// Intuitively, this method performs physical compaction. Existing
     /// key–value pairs whose time is less than the since frontier are
     /// consolidated together when possible.
-    fn consolidate<K, V>(&self, collection: StashCollection<K, V>) -> Result<(), StashError>;
+    fn consolidate<K, V>(&mut self, collection: StashCollection<K, V>) -> Result<(), StashError>;
 
     /// Performs multiple consolidations at once, potentially in a more performant way than
     /// performing the individual consolidations one by one.
     ///
     /// See [Stash::consolidate]
     fn consolidate_batch<K, V>(
-        &self,
+        &mut self,
         collections: &[StashCollection<K, V>],
     ) -> Result<(), StashError> {
         for collection in collections {
@@ -195,13 +195,13 @@ pub trait Stash {
 
     /// Reports the current since frontier.
     fn since<K, V>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
     ) -> Result<Antichain<Timestamp>, StashError>;
 
     /// Reports the current upper frontier.
     fn upper<K, V>(
-        &self,
+        &mut self,
         collection: StashCollection<K, V>,
     ) -> Result<Antichain<Timestamp>, StashError>;
 }

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -77,7 +77,7 @@ impl Action for VerifyTimestampCompactionAction {
                             })?
                             .id();
 
-                        let stash = mz_stash::Sqlite::open(&path.join("storage"))?;
+                        let mut stash = mz_stash::Sqlite::open(&path.join("storage"))?;
                         let collection = stash
                             .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}"))?;
                         let bindings: Vec<(PartitionId, u64, MzOffset)> = stash.iter(collection)?


### PR DESCRIPTION
This allowed the sqlite impl to be Clone'd, but that's not a thing that
we even do. We've internally discussed multiple times that users of stash
are responsible for ensuring only one thing is happening on a stash at
once, so disallowing cloning seems perfectly fine. Also, the upcoming
postgres with an in memory fence counter means we even more don't want
to need cloning, so this seems like a good direction to go.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
