### PR TITLE
Correct values going into metric labels

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -172,7 +172,7 @@ impl SourceReader for KafkaSourceReader {
         let partition_ids = start_offsets.keys().copied().collect();
         Ok(KafkaSourceReader {
             topic_name: topic.clone(),
-            source_name: source_name.clone(),
+            source_name,
             id: source_id,
             partition_consumers: VecDeque::new(),
             consumer,

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -188,8 +188,8 @@ impl SourceReader for KafkaSourceReader {
                 base_metrics,
                 partition_ids,
                 topic,
-                source_name,
-                source_id,
+                source_id.source_id.to_string(),
+                source_id.dataflow_id.to_string(),
             ),
         })
     }

--- a/src/storage/src/source/kafka/metrics.rs
+++ b/src/storage/src/source/kafka/metrics.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use prometheus::core::AtomicI64;
 use tracing::debug;
 
-use mz_expr::SourceInstanceId;
 use mz_ore::iter::IteratorExt;
 use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 
@@ -28,16 +27,16 @@ impl KafkaPartitionMetrics {
         base_metrics: SourceBaseMetrics,
         ids: Vec<i32>,
         topic: String,
-        source_name: String,
-        source_id: SourceInstanceId,
+        source_id: String,
+        source_instance: String,
     ) -> Self {
         let metrics = &base_metrics.partition_specific;
         Self {
             partition_offset_map: HashMap::from_iter(ids.iter().map(|id| {
                 let labels = &[
                     topic.clone(),
-                    source_name.clone(),
-                    source_id.to_string(),
+                    source_id.clone(),
+                    source_instance.clone(),
                     format!("{}", id),
                 ];
                 (
@@ -47,7 +46,11 @@ impl KafkaPartitionMetrics {
                         .get_delete_on_drop_gauge(labels.to_vec()),
                 )
             })),
-            labels: vec![topic.clone(), source_name.clone(), source_id.to_string()],
+            labels: vec![
+                topic.clone(),
+                source_id.clone(),
+                source_instance.to_string(),
+            ],
             base_metrics,
         }
     }


### PR DESCRIPTION
When I originally added this metric I didn't quite get the labels correct, this PR fixes them so that `mz_kafka_partition_offset_max` and `mz_partition_offset_ingested` have the same values for the same labels on the same source as they are expected to. 

### Motivation


  * This PR fixes a recognized bug.

    https://github.com/MaterializeInc/cloud/issues/2878

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - This change corrects the values being placed in `mz_kafka_partition_offset_max` labels to match other metrics for the same source.
