### PR TITLE
Correctly shutdown sources on `Drop`

### DIFF
--- a/src/storage/src/boundary/boundary.rs
+++ b/src/storage/src/boundary/boundary.rs
@@ -6,7 +6,9 @@
 //! Traits and types for capturing and replaying collections of data.
 use std::any::Any;
 use std::cell::RefCell;
+use std::marker::{Send, Sync};
 use std::rc::Rc;
+use std::sync::Arc;
 
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
@@ -22,7 +24,7 @@ pub trait StorageCapture {
         id: GlobalId,
         ok: Collection<G, Row, Diff>,
         err: Collection<G, DataflowError, Diff>,
-        token: Rc<dyn Any>,
+        token: Arc<dyn Any + Send + Sync>,
         name: &str,
         dataflow_id: uuid::Uuid,
     );
@@ -53,7 +55,7 @@ impl<SC: StorageCapture> StorageCapture for Rc<RefCell<SC>> {
         id: GlobalId,
         ok: Collection<G, Row, Diff>,
         err: Collection<G, DataflowError, Diff>,
-        token: Rc<dyn Any>,
+        token: Arc<dyn Any + Send + Sync>,
         name: &str,
         dataflow_id: uuid::Uuid,
     ) {
@@ -101,7 +103,7 @@ impl StorageCapture for DummyBoundary {
         _id: GlobalId,
         _ok: Collection<G, Row, Diff>,
         _err: Collection<G, DataflowError, Diff>,
-        _token: Rc<dyn Any>,
+        _token: Arc<dyn Any + Send + Sync>,
         _name: &str,
         _dataflow_id: uuid::Uuid,
     ) {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -9,15 +9,18 @@
 
 //! Logic related to the creation of dataflow sources.
 
+use std::any::Any;
 use std::cell::RefCell;
+use std::marker::{Send, Sync};
 use std::rc::Rc;
+use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{collection, AsCollection, Collection, Hashable};
 use serde::{Deserialize, Serialize};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::operators::unordered_input::UnorderedHandle;
-use timely::dataflow::operators::ActivateCapability;
-use timely::dataflow::operators::{Map, OkErr, UnorderedInput};
+use timely::dataflow::operators::{ActivateCapability, Map, OkErr, Operator, UnorderedInput};
 use timely::dataflow::Scope;
 
 use mz_dataflow_types::sources::{encoding::*, *};
@@ -31,6 +34,7 @@ use crate::decode::render_decode_delimited;
 use crate::source::{
     self, DecodeResult, DelimitedValueSource, FileSourceReader, KafkaSourceReader,
     KinesisSourceReader, PostgresSourceReader, PubNubSourceReader, S3SourceReader, SourceConfig,
+    SourceToken,
 };
 use crate::storage_state::LocalInput;
 use mz_timely_util::operator::{CollectionExt, StreamExt};
@@ -58,7 +62,10 @@ where
     /// A handle for inserting records into the table.
     handle: UnorderedHandle<Timestamp, (Row, Timestamp, Diff)>,
     /// The initial capability associated with the insert handle.
-    capability: ActivateCapability<Timestamp>,
+    capability: Rc<RefCell<ActivateCapability<Timestamp>>>,
+    /// A type-erased `SourceToken` that, upon drop,
+    /// shuts down the table psesudo-source.
+    token: Arc<dyn Any + Send + Sync>,
 }
 
 /// Imports a table (non-durable, local source of input).
@@ -70,10 +77,42 @@ where
     G: Scope<Timestamp = Timestamp>,
 {
     let ((handle, capability), ok_stream) = scope.new_unordered_input::<(Row, Timestamp, Diff)>();
+    // Convert to reference counted, so that users can downgrade it and allow the
+    // following code to destroy it later on.
+    let capability = Rc::new(RefCell::new(capability));
     let err_collection = Collection::empty(scope);
 
     let as_of_frontier = as_of_frontier.clone();
+    let mut vector = Vec::new();
+    let mut token = None;
+
+    // Note: this `unary` operator is adapted from `Operator::map_in_place`.
+    // It forwards the data along, but adds a way to drop the operator's input capability,
+    // if the returned, thread-safe `SourceToken` is dropped.
     let ok_collection = ok_stream
+        .unary(Pipeline, "MapInPlaceWithSyncToken", |_, operator_info| {
+            let drop_activator = Arc::new(scope.sync_activator_for(&operator_info.address[..]));
+            let drop_activator_weak = Arc::downgrade(&drop_activator);
+
+            let mut local_cap = Some(Rc::clone(&capability));
+
+            token = Some(SourceToken {
+                activator: drop_activator,
+            });
+
+            move |input, output| {
+                // Drop cap and early exit if the source-token is dropped
+                if drop_activator_weak.upgrade().is_none() {
+                    local_cap.take();
+                    return;
+                }
+
+                input.for_each(|time, data| {
+                    data.swap(&mut vector);
+                    output.session(&time).give_vec(&mut vector);
+                })
+            }
+        })
         .map_in_place(move |(_, time, _)| {
             time.advance_by(as_of_frontier.borrow());
         })
@@ -84,6 +123,7 @@ where
         err_collection,
         handle,
         capability,
+        token: Arc::new(token.unwrap()),
     }
 }
 
@@ -106,7 +146,7 @@ pub(crate) fn import_source<G>(
     src_id: GlobalId,
 ) -> (
     (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>),
-    Rc<dyn std::any::Any>,
+    Arc<dyn std::any::Any + Send + Sync>,
 )
 where
     G: Scope<Timestamp = Timestamp>,
@@ -119,7 +159,7 @@ where
     }
 
     // Tokens that we should return from the method.
-    let mut needed_tokens: Vec<Rc<dyn std::any::Any>> = Vec::new();
+    let mut needed_tokens: Vec<Arc<dyn std::any::Any + Send + Sync>> = Vec::new();
 
     // This uid must be unique across all different instantiations of a source
     let uid = SourceInstanceId {
@@ -152,24 +192,24 @@ where
             // Make the new local input reflect the latest table state, then add the
             // local input to the table state.
             {
-                let mut session = table.handle.session(table.capability.clone());
+                let mut session = table.handle.session(table.capability.borrow().clone());
                 for (row, time, diff) in &table_state.data {
                     let mut time = *time;
                     time.advance_by(table_state.since.borrow());
-                    assert!(time >= *table.capability.time());
+                    assert!(time >= *table.capability.borrow().time());
                     session.give((row.clone(), time, *diff));
                 }
             }
-            table.capability.downgrade(&table_state.upper);
+            table.capability.borrow_mut().downgrade(&table_state.upper);
 
-            // Convert to reference counted, so that users can drop it.
-            let capability = Rc::new(RefCell::new(table.capability));
             table_state.inputs.push(LocalInput {
                 handle: table.handle,
-                capability: Rc::downgrade(&capability),
+                // Hand off our a `Weak` to the core capability, so that
+                // it is correctly dropped if the token is dropped.
+                capability: Rc::downgrade(&table.capability),
             });
 
-            ((table.ok_collection, table.err_collection), capability)
+            ((table.ok_collection, table.err_collection), table.token)
         }
 
         SourceConnector::External {
@@ -332,7 +372,7 @@ where
                                 schema_registry_config,
                                 confluent_wire_format,
                             );
-                            needed_tokens.push(Rc::new(token));
+                            needed_tokens.push(Arc::new(token));
                             (oks, None)
                         } else {
                             let (results, extra_token) = match ok_source {
@@ -355,7 +395,7 @@ where
                                 ),
                             };
                             if let Some(tok) = extra_token {
-                                needed_tokens.push(Rc::new(tok));
+                                needed_tokens.push(Arc::new(tok));
                             }
 
                             // render envelopes
@@ -531,7 +571,7 @@ where
             use differential_dataflow::operators::consolidate::ConsolidateStream;
             collection = collection.consolidate_stream();
 
-            let source_token = Rc::new(capability);
+            let source_token = Arc::new(capability);
 
             // We also need to keep track of this mapping globally to activate sources
             // on timestamp advancement queries
@@ -539,12 +579,12 @@ where
                 .ts_source_mapping
                 .entry(src_id)
                 .or_insert_with(Vec::new)
-                .push(Rc::downgrade(&source_token));
+                .push(Arc::downgrade(&source_token));
 
             needed_tokens.push(source_token);
 
             // Return the collections and any needed tokens.
-            ((collection, err_collection), Rc::new(needed_tokens))
+            ((collection, err_collection), Arc::new(needed_tokens))
         }
     }
 }

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -12,13 +12,11 @@
 // https://github.com/tokio-rs/prost/issues/237
 #![allow(missing_docs)]
 
-use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::{self, Debug};
 use std::pin::Pin;
-use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
@@ -35,7 +33,7 @@ use timely::dataflow::operators::generic::OutputHandle;
 use timely::dataflow::operators::{Capability, CapabilitySet, Event};
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
-use timely::scheduling::activate::{Activator, SyncActivator};
+use timely::scheduling::activate::SyncActivator;
 use timely::Data;
 use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
 use tracing::error;
@@ -276,18 +274,21 @@ where
     }
 }
 
-/// A `SourceToken` manages interest in a source.
+// TODO(guswynn): consider moving back to non-thread-safe `RC`'s if
+// we end up with a boundary-per-worker
+// TODO(guswynn): consider just using `SyncActivateOnDrop` if merged into timely
+/// A `SourceToken` manages interest in a source, and is thread-safe.
 ///
 /// When the `SourceToken` is dropped the associated source will be stopped.
 pub struct SourceToken {
-    capabilities: Rc<RefCell<Option<(Capability<Timestamp>, CapabilitySet<Timestamp>)>>>,
-    activator: Activator,
+    pub activator: Arc<SyncActivator>,
 }
 
 impl Drop for SourceToken {
     fn drop(&mut self) {
-        *self.capabilities.borrow_mut() = None;
-        self.activator.activate();
+        // Best effort: sync activation
+        // failures are ignored
+        let _ = self.activator.activate();
     }
 }
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -7,7 +7,8 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::{Rc, Weak};
+use std::rc::Rc;
+use std::sync::Weak;
 use std::time::{Duration, Instant};
 
 use differential_dataflow::lattice::Lattice;
@@ -60,6 +61,7 @@ pub struct StorageState {
     /// and we should aim for that but are not there yet.
     pub source_uppers: HashMap<GlobalId, Rc<RefCell<Antichain<mz_repr::Timestamp>>>>,
     /// Handles to external sources, keyed by ID.
+    // TODO(guswynn): determine if this field is needed
     pub ts_source_mapping: HashMap<GlobalId, Vec<Weak<Option<SourceToken>>>>,
     /// Timestamp data updates for each source.
     pub ts_histories: HashMap<GlobalId, TimestampBindingRc>,


### PR DESCRIPTION
Before this pr, sources are timely-worker-local objects, and they return what amounts `Rc`'s or `Rc<RefCell>`'s of thread-local capabilities. The intent is that if these capabilities are dropped, then the source operators are correctly shutdown. However, now that all sources end with `EventPusher`'s that consolidate all messages into a single tcp boundary. This boundary holds onto a thread-safe token, which the `EventPusher`'s notice is dropped and drop their worker-local tokens. However, there is not guarantee that new data or progress, in either the `ok` or `err` streams of a source will happen, which means the trigger for dropping those tokens may never run.

Instead, @frankmcsherry and I decided that we should just upgrade the original source-tokens to be thread-safe. The way we do this is very consistent across multiple locations:

- Make the core capabilities local variables.
- Make the returned token a `SourceToken`, which is a share-able `SyncActivator` that activates on Drop.
- Keep an `Arc`'s `Weak` around in the operator. When `upgrading` is impossible, that means the token is dropped, and respond by dropping the local capabilities.
  - This code is guaranteed to run because the token drop will activate the operator.

The places we do this are:
- the core `source` operator used by sources in `mz_storage::source::util`
- `import_table` in `mz_storage::render::sources`
  - This one is complex because we had to switch `map_in_place` to its implementation with some complexity added
  - I tested this by testing that the drop was correctly called when I selected from a table.
- The "non-source" replay thing in `mz_storage::render`. I have no idea how to test this one (cc @antiguru @frankmcsherry )

### Perf implications
This pr means each source timely step will have at least 2 added atomic `CAS`'s. If this becomes a problem, then we can switch to an atomic flag as opposed to a full `Weak::upgrade`, which may save us some perf.

Additionally: we may be able to switch back to `Rc`'s someday, if we move off of `tcp_boundary` and `persist`-per-worker instead.

### Motivation

  * This PR fixes a previously unreported bug.

Sources are not correctly dropped

### Tips for reviewer

https://github.com/TimelyDataflow/differential-dataflow/pull/364 is a smaller, more readable change that gives an example of the exact same kind of change we are doing in multiple places here (and in fact, that change is required for the `decode_cdcv2` token to work in this pr.

Also, this pr has some code that is very similar copied to many places. While we may avoid bugs by consolidating it into a function, its unclear if there is a clean way to do so, and it may make the code more unreadable.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
