### PR TITLE
Pass hosts/ports to computed processes from orchestrators, enabling multi-process instances.

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -167,7 +167,7 @@ pub struct Args {
     orchestrator_linger: Option<bool>,
     /// Base port for spawning various services
     #[structopt(long, default_value = "2100")]
-    base_service_port: i32,
+    base_service_port: u16,
 
     // === Secrets controller options. ===
     /// The secrets controller implementation to use

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -272,16 +272,16 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             "runtime",
             ServiceConfig {
                 image: config.orchestrator.storaged_image.clone(),
-                args: &|ports| {
+                args: &|_hosts_ports, my_ports, _my_index| {
                     let mut storage_opts = vec![
                         format!("--workers=1"),
                         format!(
                             "--storage-addr={}:{}",
-                            default_listen_host, ports["compute"]
+                            default_listen_host, my_ports["compute"]
                         ),
                         format!(
                             "--listen-addr={}:{}",
-                            default_listen_host, ports["controller"]
+                            default_listen_host, my_ports["controller"]
                         ),
                         format!("--persist-blob-url={}", config.persist_location.blob_uri),
                         format!(

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -37,7 +37,7 @@ lazy_static! {
         Ok(addr) => addr.parse().expect("unable to parse KAFKA_ADDRS"),
         _ => "localhost:9092".parse().unwrap(),
     };
-    static ref PORT_ALLOCATOR: Arc<IdAllocator<i32>> = Arc::new(IdAllocator::new(2100, 2200));
+    static ref PORT_ALLOCATOR: Arc<IdAllocator<u16>> = Arc::new(IdAllocator::new(2100, 2200));
 }
 
 #[derive(Clone)]

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -195,7 +195,6 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
         }
 
         // Now create all the processes that weren't detected as being still alive
-        // let hosts_ports = std::iter::from_fn(|| ("localhost".to_string(), ))
         let hosts_ports = processes
             .iter()
             .map(|ports| ("localhost".to_string(), ports.clone()))

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -214,7 +214,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                         path.clone(),
                         args.clone(),
                         Arc::clone(&self.port_allocator),
-                        std::mem::take(&mut processes[i]),
+                        processes[i].clone(),
                         self.suppress_output,
                         std::mem::take(port_metadata_file_locations[i].as_mut().unwrap()),
                     ),

--- a/src/orchestrator-process/src/port_metadata_file.rs
+++ b/src/orchestrator-process/src/port_metadata_file.rs
@@ -33,7 +33,7 @@ impl<P: AsRef<Path>> PortMetadataFile<P> {
     /// Attempts to open and write the specified port metadata file.
     pub fn open(
         path: P,
-        port_metadata: &HashMap<String, i32>,
+        port_metadata: &HashMap<String, u16>,
     ) -> Result<PortMetadataFile<P>, Error> {
         let port_metadata = serde_json::to_string(&port_metadata)
             .unwrap_or_else(|_| panic!("failed to serialize {:?}", port_metadata));
@@ -57,7 +57,7 @@ impl<P: AsRef<Path>> PortMetadataFile<P> {
     }
 
     /// Reads the contents of a `PortMetadataFile`
-    pub fn read(path: P) -> Result<HashMap<String, i32>, Error> {
+    pub fn read(path: P) -> Result<HashMap<String, u16>, Error> {
         let file = OpenOptions::new().read(true).open(path)?;
         let reader = BufReader::new(file);
         let port_metadata = reader.lines().next().expect("empty port metadata file")?;

--- a/src/orchestrator-process/tests/port_metadata_file.rs
+++ b/src/orchestrator-process/tests/port_metadata_file.rs
@@ -23,7 +23,7 @@ fn test_port_metadata_file_basic() -> Result<(), Box<dyn Error>> {
     let dir = tempfile::tempdir()?;
     let path = dir.path().join("portfile");
 
-    let port_metadata: HashMap<String, i32> =
+    let port_metadata: HashMap<String, u16> =
         vec![("joe".to_string(), 42), ("shmoe".to_string(), 666)]
             .into_iter()
             .collect();

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -77,10 +77,23 @@ pub struct ServiceConfig<'a> {
     ///
     /// Often names a container on Docker Hub or a path on the local machine.
     pub image: String,
-    /// A function that generates the arguments for each process the service
-    /// given the mapping from port names to assignments.
+    /// A function that generates the arguments for each process of the service
+    /// given various information about the process to be configured.
+    ///
+    /// The first argument is the port mappings for each host; the second mapping is the
+    /// port mappings for the host or set of hosts presently being configured.
+    ///
+    /// The third argument is the index of this process in the service, _if available_.
+    /// It is not available from all orchestrators; for example, the Kubernetes orchestrator
+    /// configures the arguments for all processes at once.
     #[derivative(Debug = "ignore")]
-    pub args: &'a (dyn Fn(&HashMap<String, i32>) -> Vec<String> + Send + Sync),
+    pub args: &'a (dyn Fn(
+        &[(String, HashMap<String, u16>)],
+        &HashMap<String, u16>,
+        Option<usize>,
+    ) -> Vec<String>
+             + Send
+             + Sync),
     /// Ports to expose.
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.
@@ -109,7 +122,7 @@ pub struct ServicePort {
     /// The desired port number.
     ///
     /// Not all orchestrator backends will make use of the hint.
-    pub port_hint: i32,
+    pub port_hint: u16,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION

### Motivation

Fixes #12053

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Pass correct command-line arguments for multi-process compute clusters. (4xlarge and above)