### PR TITLE
repr: remove `custom_name` from `ScalarType::Record`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ dependencies = [
  "futures",
  "itertools",
  "lazy_static",
+ "maplit",
  "mz-avro",
  "mz-avro-derive",
  "mz-ccsr",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -3075,10 +3075,6 @@ impl ExprHumanizer for ConnCatalog<'_> {
                 let item = self.get_item(id);
                 self.minimal_qualification(item.name()).to_string()
             }
-            Record {
-                custom_name: Some(name),
-                ..
-            } => name.clone(),
             Record { fields, .. } => format!(
                 "record({})",
                 fields

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1031,7 +1031,6 @@ pub mod sources {
                                                 .map(|(name, ty)| (name.clone(), ty.clone()))
                                                 .collect(),
                                             custom_id: None,
-                                            custom_name: None,
                                         },
                                     }]);
 
@@ -1350,7 +1349,6 @@ pub mod sources {
                                         ),
                                     ],
                                     custom_id: None,
-                                    custom_name: None,
                                 }),
                                 custom_id: None,
                             },

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -1448,7 +1448,6 @@ impl AggregateFunc {
                             }),
                         ],
                         custom_id: None,
-                        custom_name: None,
                     }),
                     custom_id: None,
                 },
@@ -1471,7 +1470,6 @@ impl AggregateFunc {
                             }),
                         ],
                         custom_id: None,
-                        custom_name: None,
                     }),
                     custom_id: None,
                 },
@@ -1499,7 +1497,6 @@ impl AggregateFunc {
                             (ColumnName::from("?record?"), original_row_type),
                         ],
                         custom_id: None,
-                        custom_name: None,
                     }),
                     custom_id: None,
                 }
@@ -1521,7 +1518,6 @@ impl AggregateFunc {
                             (ColumnName::from("?record?"), original_row_type),
                         ],
                         custom_id: None,
-                        custom_name: None,
                     }),
                     custom_id: None,
                 }
@@ -1543,7 +1539,6 @@ impl AggregateFunc {
                             (ColumnName::from("?record?"), original_row_type),
                         ],
                         custom_id: None,
-                        custom_name: None,
                     }),
                     custom_id: None,
                 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -5611,7 +5611,6 @@ impl VariadicFunc {
                     .zip(input_types.into_iter())
                     .collect(),
                 custom_id: None,
-                custom_name: None,
             }
             .nullable(false),
             SplitPart => ScalarType::String.nullable(in_nullable),

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -19,6 +19,7 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 futures = "0.3.21"
 itertools = "0.10.3"
 lazy_static = "1.4.0"
+maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-avro-derive = { path = "../avro-derive" }
 mz-ccsr = { path = "../ccsr" }

--- a/src/interchange/src/avro.rs
+++ b/src/interchange/src/avro.rs
@@ -152,7 +152,7 @@ mod tests {
         ];
         for (typ, datum, expected) in valid_pairings {
             let desc = RelationDesc::empty().with_column("column1", typ.nullable(false));
-            let schema_generator = AvroSchemaGenerator::new(None, None, None, desc, false);
+            let schema_generator = AvroSchemaGenerator::new(None, None, None, desc, false, false);
             let avro_value =
                 encode_datums_as_avro(std::iter::once(datum), schema_generator.value_columns());
             assert_eq!(

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -190,15 +190,16 @@ pub fn build_schema(row_schema: serde_json::Value) -> Schema {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
 
-    use super::*;
-    use crate::avro::encode_datums_as_avro;
-    use crate::encode::column_names_and_types;
     use mz_avro::types::Value;
     use mz_avro::AvroDeserializer;
     use mz_avro::GeneralDeserializer;
     use mz_repr::{ColumnName, ColumnType, RelationDesc, Row, ScalarType};
 
+    use super::*;
+    use crate::avro::encode_datums_as_avro;
+    use crate::encode::column_names_and_types;
     use crate::json::build_row_schema_json;
 
     /// Collected state to encode update batches and progress statements.
@@ -277,8 +278,11 @@ mod tests {
             .with_column("price", ScalarType::Float64.nullable(true));
 
         let encoder = Encoder::new(desc.clone());
-        let row_schema =
-            build_row_schema_json(&crate::encode::column_names_and_types(desc), "data");
+        let row_schema = build_row_schema_json(
+            &crate::encode::column_names_and_types(desc),
+            "data",
+            &HashMap::new(),
+        );
         let schema = build_schema(row_schema);
 
         let values = vec![

--- a/src/interchange/src/avro/schema.rs
+++ b/src/interchange/src/avro/schema.rs
@@ -194,7 +194,6 @@ fn validate_schema_2(
             ScalarType::Record {
                 fields: columns,
                 custom_id: None,
-                custom_name: None,
             }
         }
         SchemaPiece::Array(inner) => {

--- a/src/interchange/src/protobuf.rs
+++ b/src/interchange/src/protobuf.rs
@@ -166,7 +166,6 @@ fn derive_inner_type(
             let ty = ScalarType::Record {
                 fields,
                 custom_id: None,
-                custom_name: None,
             };
             Ok(ty.nullable(true))
         }

--- a/src/pgrepr/src/types.rs
+++ b/src/pgrepr/src/types.rs
@@ -797,7 +797,6 @@ impl TryFrom<&Type> for ScalarType {
             Type::Record(_) => Ok(ScalarType::Record {
                 fields: vec![],
                 custom_id: None,
-                custom_name: None,
             }),
             Type::Text => Ok(ScalarType::String),
             Type::Time { precision: None } => Ok(ScalarType::Time),

--- a/src/repr-test-util/tests/testdata/scalartype
+++ b/src/repr-test-util/tests/testdata/scalartype
@@ -58,7 +58,7 @@ build-scalar-type
      ["col3name" ((list interval (user 34234)) false) ]]
      (user 0) "recordname")
 ----
-Record { fields: [(ColumnName("col1name"), ColumnType { scalar_type: Date, nullable: true }), (ColumnName("col2name"), ColumnType { scalar_type: List { element_type: Map { value_type: Bytes, custom_id: Some(User(98)) }, custom_id: None }, nullable: false }), (ColumnName("col3name"), ColumnType { scalar_type: List { element_type: Interval, custom_id: Some(User(34234)) }, nullable: false })], custom_id: Some(User(0)), custom_name: Some("recordname") }
+Record { fields: [(ColumnName("col1name"), ColumnType { scalar_type: Date, nullable: true }), (ColumnName("col2name"), ColumnType { scalar_type: List { element_type: Map { value_type: Bytes, custom_id: Some(User(98)) }, custom_id: None }, nullable: false }), (ColumnName("col3name"), ColumnType { scalar_type: List { element_type: Interval, custom_id: Some(User(34234)) }, nullable: false })], custom_id: Some(User(0)) }
 
 build-scalar-type
 nonexistent

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -61,18 +61,13 @@ impl ColumnType {
                 })
             }
             (
-                ScalarType::Record {
-                    fields,
-                    custom_id,
-                    custom_name,
-                },
+                ScalarType::Record { fields, custom_id },
                 ScalarType::Record {
                     fields: other_fields,
                     custom_id: other_custom_id,
-                    custom_name: other_custom_name,
                 },
             ) => {
-                if custom_id != other_custom_id || custom_name != other_custom_name {
+                if custom_id != other_custom_id {
                     bail!(
                         "Can't union types: {:?} and {:?}",
                         self.scalar_type,
@@ -98,7 +93,6 @@ impl ColumnType {
                     scalar_type: ScalarType::Record {
                         fields: union_fields,
                         custom_id,
-                        custom_name,
                     },
                     nullable: self.nullable || other.nullable,
                 })

--- a/src/repr/src/relation_and_scalar.proto
+++ b/src/repr/src/relation_and_scalar.proto
@@ -55,7 +55,6 @@ message ProtoScalarType {
         reserved 2;
         reserved "custom_oid";
         repeated ProtoRecordField fields = 1;
-        optional string custom_name = 3;
         optional global_id.ProtoGlobalId custom_id = 4;
     }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -92,12 +92,8 @@ impl TypeCategory {
             | ScalarType::String
             | ScalarType::Char { .. }
             | ScalarType::VarChar { .. } => Self::String,
-            ScalarType::Record {
-                custom_name,
-                custom_id,
-                ..
-            } => {
-                if custom_name.is_some() || custom_id.is_some() {
+            ScalarType::Record { custom_id, .. } => {
+                if custom_id.is_some() {
                     Self::Composite
                 } else {
                     Self::Pseudo

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -506,7 +506,6 @@ impl AbstractExpr for CoercibleScalarExpr {
                     scalar_type: ScalarType::Record {
                         fields,
                         custom_id: None,
-                        custom_name: None,
                     },
                     nullable: false,
                 })

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -938,7 +938,6 @@ impl HirScalarExpr {
                                             let record_type = ScalarType::Record {
                                                 fields,
                                                 custom_id: None,
-                                                custom_name: None,
                                             };
                                             let agg_input = mz_expr::MirScalarExpr::CallVariadic {
                                                 func: mz_expr::VariadicFunc::ListCreate {
@@ -970,7 +969,6 @@ impl HirScalarExpr {
                                                     })
                                                     .collect_vec(),
                                                 custom_id: None,
-                                                custom_name: None,
                                             }
                                             .nullable(false);
                                             let func = func.into_expr();
@@ -1133,7 +1131,6 @@ impl HirScalarExpr {
                                             let original_row_record_type = ScalarType::Record {
                                                 fields,
                                                 custom_id: None,
-                                                custom_name: None,
                                             };
 
                                             // Build a new record with the original row in a record in a list + the encoded args in a record
@@ -1163,7 +1160,6 @@ impl HirScalarExpr {
                                             let fn_input_record_type = ScalarType::Record {
                                                 fields: fn_input_record_fields,
                                                 custom_id: None,
-                                                custom_name: None,
                                             }
                                             .nullable(false);
 
@@ -1186,7 +1182,6 @@ impl HirScalarExpr {
                                                     fn_input_record_type.nullable(false),
                                                 )],
                                                 custom_id: None,
-                                                custom_name: None,
                                             }
                                             .nullable(false);
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -4553,7 +4553,6 @@ fn scalar_type_from_catalog(
                         .collect::<Result<Vec<_>, PlanError>>()?;
                     Ok(ScalarType::Record {
                         fields: scalars,
-                        custom_name: None,
                         custom_id: Some(id),
                     })
                 }


### PR DESCRIPTION
The `custom_name` field is redundant with the `custom_id` field, so
remove it.

This field was used by Avro sinks to name some well-known record types
in the generated Avro schemas. Pivot this schema generation to use the
custom ID field instead. This requires a bit of a hack to give these
types IDs, because these aren't real types in the catalog yet, but it's
still a net improvement.

Fix #11344.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
