### PR TITLE
persist: fix typos

### DIFF
--- a/src/persist/README.md
+++ b/src/persist/README.md
@@ -4,7 +4,7 @@ The primary abstraction of the persist library is a set of named collections,
 made and kept definite through durable storage. Each of these collections is
 closely analogous to (and internally modeled after) differential dataflow's
 [arrangement], or more generally its [Collection]. In the language of the
-[correctness doc], these are each are described by a `[since, upper)`.
+[correctness doc], these are each described by a `[since, upper)`.
 
 [correctness doc]: https://github.com/MaterializeInc/materialize/blob/v0.13.0/doc/developer/design/20210831_correctness.md#description
 [Collection]: differential_dataflow::collection::Collection
@@ -50,7 +50,7 @@ you view it as [rustdoc for the persist crate].
   - _write_: Durably adding a set of records to a persisted collection.
   - _seal_: Durably advancing the frontier of a persisted collection. NB: A
     common initial misconception when encountering persist is that _write_ is
-    like a filesystem write with minimal durability guarantees and _seal_ like
+    like a filesystem write with minimal durability guarantees and _seal_
     is like fsync, but this incorrect. A write whose future has resolved as
     successful is durable, regardless of when or if it's sealed.
   - _storage_: An external source of data durability. All of persist's
@@ -341,7 +341,7 @@ operate a bit more like persisted sources.
 # Integration with Sources
 - TODO copy in [aljoscha's doc]
 
-[aljoscha's doc]: [https://github.com/MaterializeInc/materialize/pull/8414
+[aljoscha's doc]: https://github.com/MaterializeInc/materialize/pull/8414
 
 # Integration with Platform
 

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -2056,7 +2056,7 @@ mod tests {
         // Normal case: registration uses same key and value codec.
         let _ = block_on(|res| i.register("stream", "key", "val", res))?;
 
-        // i64erent key codec
+        // Different key codec
         assert_eq!(
             block_on(|res| i.register("stream", "nope", "val", res)),
             Err(Error::from(
@@ -2064,7 +2064,7 @@ mod tests {
             ))
         );
 
-        // i64erent val codec
+        // Different val codec
         assert_eq!(
             block_on(|res| i.register("stream", "key", "nope", res)),
             Err(Error::from(

--- a/src/persist/src/operators/mod.rs
+++ b/src/persist/src/operators/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Timely and i64erential Dataflow operators for persisting and replaying
+//! Timely and Differential Dataflow operators for persisting and replaying
 //! data.
 
 pub mod replay;

--- a/src/persist/src/runtime.rs
+++ b/src/persist/src/runtime.rs
@@ -797,7 +797,7 @@ mod tests {
         // Normal case: registration uses same key and value codec.
         let _ = client.create_or_load::<(), String>("stream");
 
-        // i64erent key codec
+        // Different key codec
         assert_eq!(
             client
                 .create_or_load::<Vec<u8>, String>("stream")
@@ -808,7 +808,7 @@ mod tests {
             ))
         );
 
-        // i64erent val codec
+        // Different val codec
         assert_eq!(
             client.create_or_load::<(), Vec<u8>>("stream").0.stream_id(),
             Err(Error::from(


### PR DESCRIPTION
Fixes misc typos in the `persist` docs.

### Motivation

   * This PR improves documentation.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).