### PR TITLE
coord: add IntervalStyle as a new parameter

### DIFF
--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -18,6 +18,7 @@ database                    materialize                                "Sets the
 extra_float_digits          3                                          "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                  ""                                         "Allows failpoints to be dynamically activated."
 integer_datetimes           on                                         "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
+IntervalStyle               postgres                                   "Sets the display format for interval values (PostgreSQL)."
 DateStyle                   "ISO, MDY"                                 "Sets the display format for date and time values (PostgreSQL)."
 search_path                 "mz_catalog, pg_catalog, public, mz_temp"  "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
 server_version              9.5.0                                      "Shows the server version (PostgreSQL)."
@@ -135,3 +136,11 @@ info
 
 ! SET client_min_messages to invalid
 contains:invalid value for parameter "client_min_messages": "invalid"
+
+> SHOW intervalstyle
+postgres
+
+! SET intervalstyle = 'postgres-legacy'
+contains:parameter "IntervalStyle" can only be set to "postgres"
+
+> SET intervalstyle = 'postgres';


### PR DESCRIPTION
This parameter is currently read-only, and it is required for `postgres_fdw` compat. More context in https://github.com/MaterializeInc/product/issues/152.

### Motivation
  * This PR adds a known-desirable feature: required for https://github.com/MaterializeInc/product/issues/152

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Allow setting the `IntervalStyle` session parameter to its default value of `postgres`. Setting it to other values remains unsupported.
