### PR TITLE
persist: change WriteHandle::append to return current upper on mismatch

### DIFF
--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -451,7 +451,8 @@ mod raw_persist_benchmark {
                 batch.iter().map(|((k, v), t, d)| ((&*k, &*v), &*t, &*d)),
                 new_upper,
             )
-            .await??;
+            .await??
+            .expect("invalid current upper");
 
             Ok(())
         }


### PR DESCRIPTION
With timeouts, it can happen that a write succeeds but the write handle
doesn't learn about the updated upper. Previously, in those cases, we
would yield an "invalid usage" error. Now, we instead return the current
upper, similar to `compare_and_append()` and allow the user to update
the write handle to the correct upper.

### Tips for reviewer

I left `NOTE`s and `TODO`s that we should resolve before merging. Also, it seems `append` and `compare_and_append()` almost don't need to return `InvalidUsage` anymore. At least the former never does after this change.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.