### PR TITLE
interchange: avoid double-wrapping record types in JSON sinks

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -343,7 +343,7 @@ $ kafka-verify format=avro sink=materialize.public.double_avro_2 sort-messages=t
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.json_avro sort-messages=true key=false
-{"before": null, "after": {"row": {"a": 1, "b": 2, "c": 3}}, "transaction": {"id": "0"}}
+{"before": null, "after": {"a": 1, "b": 2, "c": 3}, "transaction": {"id": "0"}}
 
 > CREATE SINK json_avro_2 FROM simple_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-avro'
@@ -351,7 +351,7 @@ $ kafka-verify format=json sink=materialize.public.json_avro sort-messages=true 
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.json_avro_2 sort-messages=true key=false
-{"before": null, "after": {"row": {"a": 1, "b": 2, "c": 3}}, "transaction": {"id": "0"}}
+{"before": null, "after": {"a": 1, "b": 2, "c": 3}, "transaction": {"id": "0"}}
 
 ! CREATE SINK json_reuse_topic_no_parens FROM simple_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'json-reuse-topic'
@@ -368,7 +368,7 @@ contains:For FORMAT JSON, you need to manually specify an Avro consistency topic
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.json_reuse_topic_no_parens sort-messages=true key=false
-{"before": null, "after": {"row": {"a": 1, "b": 2, "c": 3}}, "transaction": {"id": "0"}}
+{"before": null, "after": {"a": 1, "b": 2, "c": 3}, "transaction": {"id": "0"}}
 
 # This updated syntax will also succeed, creating a reusable topic.
 > CREATE SINK json_reuse_topic_with_parens FROM rt_binding_consistency_test_source

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -14,7 +14,7 @@
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.simple_view_sink key=false
-{"before": null, "after": {"row": {"a": 1, "b": 2, "c": 3}}}
+{"before": null, "after": {"a": 1, "b": 2, "c": 3}}
 
 > CREATE SINK simple_view_upsert FROM simple_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unnamed-upsert'
@@ -49,7 +49,7 @@ $ kafka-verify format=json sink=materialize.public.simple_view_upsert key=true
 
 # Due to limitations in $ kafka-verify, the entire expected JSON output needs to be provided on a single line
 $ kafka-verify format=json sink=materialize.public.types_sink key=false
-{"before":null,"after":{"row":{"c1":true,"c2":false,"c3":null,"c4":123456789,"c5":1234.5678,"c6":"1234.5678","c7":"1321009871123","c8":"1320966671123","c9":"2011-11-11","c10":"11:11:11.123456","c11":"1 year","c12":"324373a5-7718-46b1-a7ea-4a7c9981fc4e","c13":[209,130,208,181,208,186,209,129,209,130],"c14":{"a":2}}}}
+{"before":null,"after":{"c1":true,"c2":false,"c3":null,"c4":123456789,"c5":1234.5678,"c6":"1234.5678","c7":"1321009871123","c8":"1320966671123","c9":"2011-11-11","c10":"11:11:11.123456","c11":"1 year","c12":"324373a5-7718-46b1-a7ea-4a7c9981fc4e","c13":[209,130,208,181,208,186,209,129,209,130],"c14":{"a":2}}}
 
 # Special characters
 
@@ -61,7 +61,7 @@ $ kafka-verify format=json sink=materialize.public.types_sink key=false
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.special_characters_sink key=false
-{"before":null,"after":{"row":{"c1":"текст","c2":"\"","c3":"'","c4":"\\","c5":"a\n\tb"}}}
+{"before":null,"after":{"c1":"текст","c2":"\"","c3":"'","c4":"\\","c5":"a\n\tb"}}
 
 # Record
 
@@ -72,7 +72,7 @@ $ kafka-verify format=json sink=materialize.public.special_characters_sink key=f
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.record_sink key=false
-{"before":null,"after":{"row":{"simple_view":{"record0":{"a":1,"b":2,"c":3}}}}}
+{"before":null,"after":{"simple_view":{"a":1,"b":2,"c":3}}}
 
 # Duplicate column names
 ! CREATE VIEW duplicate_cols AS SELECT 'a1' AS a, 'a1' AS a;
@@ -95,7 +95,7 @@ contains:column "a" specified more than once
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.complex_type_sink key=false
-{"before": null, "after": {"row": {"c1": [[1,2],[3,4]], "c2": {"a":{"b":1, "c":2}, "d": {"e":3, "f":4}}}}}
+{"before": null, "after": {"c1": [[1,2],[3,4]], "c2": {"a":{"b":1, "c":2}, "d": {"e":3, "f":4}}}}
 
 # testdrive will not automatically clean up types, so we need to do that ourselves
 


### PR DESCRIPTION
JSON sinks were previously double-wrapping record types in an object
with a field named after the record, as in:

    {"before": null, "after": {"row": {"a": 1, "b": 2, "c": 3}}}

This is at odds with Debezium, which outputs:

    {"before": null, "after": {"a": 1, "b": 2, "c": 3}}

This commit changes our JSON sink format to the latter to match
Debezium.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
