### PR TITLE
[ci] Remove agents.queue tag from mkpipeline step

### DIFF
--- a/ci/test/mkpipeline.sh
+++ b/ci/test/mkpipeline.sh
@@ -45,6 +45,4 @@ steps:
   - label: mkpipeline
     command: bin/ci-builder run stable bin/pyactivate --dev -m ci.test.mkpipeline
     priority: 2
-    agents:
-      queue: linux
 EOF


### PR DESCRIPTION
as title

### Motivation

Deploy seems to be broken since #11985 with "`agents` is not a valid property on the `trigger` step."