### PR TITLE
Add protobuf support for `mz_expr::relation::func::TableFunc`

### DIFF
--- a/src/expr/src/relation/func.proto
+++ b/src/expr/src/relation/func.proto
@@ -13,6 +13,8 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "expr/src/relation.proto";
+import "repr/src/relation_and_scalar.proto";
+import "repr/src/adt/regex.proto";
 
 package mz_expr.relation.func;
 
@@ -71,5 +73,40 @@ message ProtoAggregateFunc {
         ProtoColumnOrders dense_rank  = 38;
         ProtoLagLead lag_lead  = 39;
         google.protobuf.Empty dummy = 40;
+    }
+}
+
+message ProtoCaptureGroupDesc {
+    uint32 index = 1;
+    optional string name = 2;
+    bool nullable = 3;
+}
+
+message ProtoAnalyzedRegex {
+    mz_repr.adt.regex.ProtoRegex regex = 1;
+    repeated ProtoCaptureGroupDesc groups = 2;
+}
+
+message ProtoTableFunc {
+    message ProtoWrap {
+        repeated mz_repr.relation_and_scalar.ProtoColumnType types = 1;
+        uint64 width = 2;
+    }
+
+    oneof kind {
+        bool jsonb_each = 1;
+        google.protobuf.Empty jsonb_object_keys = 2;
+        bool jsonb_array_elements = 3;
+        ProtoAnalyzedRegex regexp_extract = 4;
+        uint64 csv_extract = 5;
+        google.protobuf.Empty generate_series_int32 = 6;
+        google.protobuf.Empty generate_series_int64 = 7;
+        google.protobuf.Empty generate_series_timestamp = 8;
+        google.protobuf.Empty generate_series_timestamp_tz = 9;
+        google.protobuf.Empty repeat = 10;
+        mz_repr.relation_and_scalar.ProtoScalarType unnest_array = 11;
+        mz_repr.relation_and_scalar.ProtoScalarType unnest_list = 12;
+        ProtoWrap wrap = 13;
+        google.protobuf.Empty generate_subscripts_array = 14;
     }
 }

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -38,7 +38,8 @@ pub mod util;
 pub use datum_vec::{DatumVec, DatumVecBorrow};
 pub use global_id::GlobalId;
 pub use relation::{
-    ColumnName, ColumnType, NotNullViolation, ProtoColumnName, RelationDesc, RelationType,
+    ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, RelationDesc,
+    RelationType,
 };
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, Row, RowArena,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -30,7 +30,9 @@ pub use crate::relation_and_scalar::{ProtoColumnName, ProtoColumnType};
 ///
 /// To construct a column type, either initialize the struct directly, or
 /// use the [`ScalarType::nullable`] method.
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(
+    Arbitrary, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, Hash, MzReflect,
+)]
 pub struct ColumnType {
     /// The underlying scalar type (e.g., Int32 or String) of this column.
     pub scalar_type: ScalarType,


### PR DESCRIPTION
Add protobuf support for `mz_expr::relation::func::TableFunc`

Fixes #11929 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None