### PR TITLE
persist: hook up Jepsen's Maelstrom for correctness testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,12 +3661,15 @@ dependencies = [
  "mz-persist",
  "mz-persist-types",
  "num_cpus",
+ "num_enum",
  "rand",
  "serde",
+ "serde_json",
  "tempfile",
  "timely",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.0.0"
 edition = "2021"
 rust-version = "1.60.0"
 publish = false
+autoexamples = false
 # Since we intentionally will only ever have one bench target, auto discovery of
 # benches is unnecessary. Turning it off allows us to have helper code in
 # src/benches.
@@ -21,6 +22,9 @@ bench = false
 [[bench]]
 name = "benches"
 harness = false
+
+[[example]]
+name = "persistcli"
 
 [dependencies]
 anyhow = { version = "1.0.57", features = ["backtrace"] }
@@ -44,4 +48,7 @@ uuid = { version = "0.8.2", features = ["v4"] }
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["html_reports"] }
 futures-task = "0.3.21"
 num_cpus = "1.13.1"
+num_enum = "0.5.7"
+serde_json = "1.0.79"
 tempfile = "3.2.0"
+tracing-subscriber = { version = "0.3.11", default-features = false, features = ["env-filter", "fmt"] }

--- a/src/persist-client/examples/maelstrom.rs
+++ b/src/persist-client/examples/maelstrom.rs
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! An adaptor to Jepsen Maelstrom's txn-list-append workload
+pub mod api;
+pub mod node;
+pub mod services;
+pub mod txn;
+
+/// An adaptor to Jepsen Maelstrom's txn-list-append workload
+///
+/// Example usage:
+///
+///     cargo build --example persistcli && java -jar /path/to/maelstrom.jar test -w txn-list-append --bin ./target/debug/examples/persistcli maelstrom
+///
+/// The [Maelstrom docs] are a great place to start for an understanding of
+/// the specifics of what's going on here.
+///
+/// [maelstrom docs]: https://github.com/jepsen-io/maelstrom/tree/v0.2.1#documentation
+#[derive(Debug, Clone, clap::Parser)]
+pub struct Args {
+    /// Blob to use, defaults to Maelstrom lin-kv service
+    #[clap(long)]
+    blob_uri: Option<String>,
+
+    /// Consensus to use, defaults to Maelstrom lin-kv service
+    #[clap(long)]
+    consensus_uri: Option<String>,
+
+    /// How much unreliability to inject into Blob and Consensus usage
+    ///
+    /// This value must be in [0, 1]. 0 means no-op, 1 means complete
+    /// unreliability.
+    #[clap(long, default_value_t = 0.05)]
+    unreliability: f64,
+}

--- a/src/persist-client/examples/maelstrom/api.rs
+++ b/src/persist-client/examples/maelstrom/api.rs
@@ -1,0 +1,278 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Types used in the Maelstrom API
+//!
+//! These are documented in Maelstrom's [protocol], [workloads], and [services]
+//! docs.
+//!
+//! [protocol]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/protocol.md
+//! [workloads]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/workloads.md
+//! [services]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/services.md
+
+use std::str::FromStr;
+
+use num_enum::{IntoPrimitive, TryFromPrimitive};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MsgId(pub usize);
+
+impl MsgId {
+    pub fn next(&self) -> Self {
+        MsgId(self.0 + 1)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeId(pub String);
+
+// A struct that exactly matches the structure of the Maelstrom json. Used as an
+// intermediary so we can map it into real rust enums (as opposed to the value
+// of the first field determining the structure of the other two).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TxnOpHelper(pub String, pub u64, pub Value);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "TxnOpHelper", into = "TxnOpHelper")]
+pub enum ReqTxnOp {
+    Append { key: u64, val: u64 },
+    Read { key: u64 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "TxnOpHelper")]
+pub enum ResTxnOp {
+    Append { key: u64, val: u64 },
+    Read { key: u64, val: Vec<u64> },
+}
+
+/// <https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/protocol.md#message-bodies>
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum Body {
+    #[serde(rename = "error")]
+    Error {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        msg_id: Option<MsgId>,
+        in_reply_to: MsgId,
+        code: ErrorCode,
+        text: String,
+    },
+
+    #[serde(rename = "init")]
+    ReqInit {
+        msg_id: MsgId,
+        node_id: NodeId,
+        node_ids: Vec<NodeId>,
+    },
+    #[serde(rename = "init_ok")]
+    ResInit { msg_id: MsgId, in_reply_to: MsgId },
+
+    #[serde(rename = "txn")]
+    ReqTxn { msg_id: MsgId, txn: Vec<ReqTxnOp> },
+    #[serde(rename = "txn_ok")]
+    ResTxn {
+        msg_id: MsgId,
+        in_reply_to: MsgId,
+        txn: Vec<ResTxnOp>,
+    },
+
+    #[serde(rename = "read")]
+    ReqLinKvRead { msg_id: MsgId, key: Value },
+    #[serde(rename = "read_ok")]
+    ResLinKvRead {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        msg_id: Option<MsgId>,
+        in_reply_to: MsgId,
+        value: Value,
+    },
+
+    #[serde(rename = "write")]
+    ReqLinKvWrite {
+        msg_id: MsgId,
+        key: Value,
+        value: Value,
+    },
+    #[serde(rename = "write_ok")]
+    ResLinKvWrite {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        msg_id: Option<MsgId>,
+        in_reply_to: MsgId,
+    },
+
+    #[serde(rename = "cas")]
+    ReqLinKvCaS {
+        msg_id: MsgId,
+        key: Value,
+        from: Value,
+        to: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        create_if_not_exists: Option<bool>,
+    },
+    #[serde(rename = "cas_ok")]
+    ResLinKvCaS {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        msg_id: Option<MsgId>,
+        in_reply_to: MsgId,
+    },
+}
+
+impl Body {
+    pub fn in_reply_to(&self) -> Option<MsgId> {
+        match self {
+            Body::Error { in_reply_to, .. } => Some(*in_reply_to),
+            Body::ResLinKvRead { in_reply_to, .. } => Some(*in_reply_to),
+            Body::ResLinKvWrite { in_reply_to, .. } => Some(*in_reply_to),
+            Body::ResLinKvCaS { in_reply_to, .. } => Some(*in_reply_to),
+            _ => None,
+        }
+    }
+}
+
+/// <https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/protocol.md#messages>
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Msg {
+    pub src: NodeId,
+    pub dest: NodeId,
+    pub body: Body,
+}
+
+impl FromStr for Msg {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map_err(|err| err.to_string())
+    }
+}
+
+impl std::fmt::Display for Msg {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&serde_json::to_string(self).expect("msg wasn't json-able"))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MaelstromError {
+    pub code: ErrorCode,
+    pub text: String,
+}
+
+impl std::fmt::Display for MaelstromError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}: {}", self.code, self.text)
+    }
+}
+
+impl std::error::Error for MaelstromError {}
+
+/// <https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/protocol.md#errors>
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, IntoPrimitive, TryFromPrimitive)]
+#[serde(try_from = "usize", into = "usize")]
+#[repr(usize)]
+pub enum ErrorCode {
+    Timeout = 0,
+    NodeNotFound = 1,
+    NotSupported = 10,
+    TemporarilyUnavailable = 11,
+    MalformedRequest = 12,
+    Crash = 13,
+    Abort = 14,
+    KeyDoesNotExist = 20,
+    KeyAlreadyExists = 21,
+    PreconditionFailed = 22,
+    TxnConflict = 30,
+}
+
+mod from_impls {
+    use std::fmt::Debug;
+
+    use mz_persist::location::ExternalError;
+    use mz_persist_client::error::InvalidUsage;
+    use serde_json::Value;
+    use tracing::debug;
+
+    use crate::maelstrom::api::{ErrorCode, MaelstromError, ReqTxnOp, ResTxnOp, TxnOpHelper};
+
+    impl TryFrom<TxnOpHelper> for ReqTxnOp {
+        type Error = String;
+
+        fn try_from(value: TxnOpHelper) -> Result<Self, Self::Error> {
+            let TxnOpHelper(f, key, val) = value;
+            match f.as_str() {
+                "r" => match val {
+                    Value::Null => Ok(ReqTxnOp::Read { key }),
+                    x => Err(format!("unexpected read value: {}", x)),
+                },
+                "append" => match val {
+                    Value::Number(x) => match x.as_u64() {
+                        Some(val) => Ok(ReqTxnOp::Append { key, val }),
+                        None => Err(format!("unexpected append value: {}", x)),
+                    },
+                    x => Err(format!("unexpected append value: {}", x)),
+                },
+                x => Err(format!("format txn type: {}", x)),
+            }
+        }
+    }
+
+    impl From<ReqTxnOp> for TxnOpHelper {
+        fn from(value: ReqTxnOp) -> Self {
+            match value {
+                ReqTxnOp::Read { key } => TxnOpHelper("r".into(), key, Value::Null),
+                ReqTxnOp::Append { key, val } => {
+                    TxnOpHelper("append".into(), key, Value::from(val))
+                }
+            }
+        }
+    }
+
+    impl From<ResTxnOp> for TxnOpHelper {
+        fn from(value: ResTxnOp) -> Self {
+            match value {
+                ResTxnOp::Read { key, val } => TxnOpHelper("r".into(), key, Value::from(val)),
+                ResTxnOp::Append { key, val } => {
+                    TxnOpHelper("append".into(), key, Value::from(val))
+                }
+            }
+        }
+    }
+
+    impl From<ExternalError> for MaelstromError {
+        fn from(x: ExternalError) -> Self {
+            if x.is_timeout() {
+                // Toss a debug log in here so that, with RUST_BACKTRACE=1, we
+                // can more easily see where timeouts are coming from. Perhaps
+                // better to to attach the backtrace to the MaelstromError.
+                debug!("creating timeout: {:?}", x);
+                MaelstromError {
+                    code: ErrorCode::Timeout,
+                    text: x.to_string(),
+                }
+            } else {
+                MaelstromError {
+                    code: ErrorCode::Crash,
+                    text: x.to_string(),
+                }
+            }
+        }
+    }
+
+    impl<T: Debug> From<InvalidUsage<T>> for MaelstromError {
+        fn from(x: InvalidUsage<T>) -> Self {
+            // ErrorCode::Abort means this definitely didn't happen. Maelstrom
+            // will call us out on it if this is a lie.
+            MaelstromError {
+                code: ErrorCode::Abort,
+                text: x.to_string(),
+            }
+        }
+    }
+}

--- a/src/persist-client/examples/maelstrom/node.rs
+++ b/src/persist-client/examples/maelstrom/node.rs
@@ -1,0 +1,436 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A driver for interacting with Maelstrom
+//!
+//! This translates input into requests and requests into output. It also
+//! handles issuing Maelstrom [service] requests. It's very roughly based off of
+//! the node in Maelstrom's [ruby examples].
+//!
+//! [service]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/services.md
+//! [ruby examples]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/demo/ruby/node.rb
+
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::sync::{Arc, Mutex};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::oneshot;
+use tracing::{info, trace};
+
+use mz_persist::location::ExternalError;
+use mz_persist_client::ShardId;
+
+use crate::maelstrom::api::{Body, ErrorCode, MaelstromError, Msg, MsgId, NodeId};
+use crate::maelstrom::Args;
+
+/// An implementor of a Maelstrom [workload].
+///
+/// [workload]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/workload.md
+#[async_trait]
+pub trait Service: Sized + Send + Sync {
+    /// Construct this service.
+    ///
+    /// Maelstrom services are available via the [Handle].
+    async fn init(args: &Args, handle: &Handle) -> Result<Self, MaelstromError>;
+
+    /// Respond to a single request.
+    ///
+    /// Implementations must either panic or respond by calling
+    /// [Handle::send_res] exactly once.
+    async fn eval(&self, handle: Handle, src: NodeId, req: Body);
+}
+
+/// Runs the RPC loop, accepting Maelstrom workload requests, issuing responses,
+/// and communicating with Maelstrom services.
+pub fn run<R, W, S>(args: Args, read: R, write: W) -> Result<(), anyhow::Error>
+where
+    R: BufRead,
+    W: Write + Send + Sync + 'static,
+    S: Service + 'static,
+{
+    let mut node = Node::<S>::new(args, write);
+    for line in read.lines() {
+        let line = line.map_err(|err| anyhow!("req read failed: {}", err))?;
+        trace!("raw: [{}]", line);
+        let req: Msg = line
+            .parse()
+            .map_err(|err| anyhow!("invalid req {}: {}", err, line))?;
+        if req.body.in_reply_to().is_none() {
+            info!("req: {}", req);
+        } else {
+            trace!("req: {}", req);
+        }
+        node.handle(req);
+    }
+    Ok(())
+}
+
+struct Node<S>
+where
+    S: Service + 'static,
+{
+    args: Args,
+    core: Arc<Mutex<Core>>,
+    node_id: Option<NodeId>,
+    service: Arc<AsyncInitOnceWaitable<Arc<S>>>,
+}
+
+impl<S> Node<S>
+where
+    S: Service + 'static,
+{
+    fn new<W>(args: Args, write: W) -> Self
+    where
+        W: Write + Send + Sync + 'static,
+    {
+        let core = Core {
+            write: Box::new(write),
+            next_msg_id: MsgId(0),
+            callbacks: HashMap::new(),
+        };
+        Node {
+            args,
+            core: Arc::new(Mutex::new(core)),
+            node_id: None,
+            service: Arc::new(AsyncInitOnceWaitable::new()),
+        }
+    }
+
+    pub fn handle(&mut self, msg: Msg) {
+        // If we've been initialized (i.e. have a NodeId), respond to the
+        // message.
+        if let Some(node_id) = self.node_id.as_ref() {
+            // This message is not for us
+            if node_id != &msg.dest {
+                return;
+            }
+
+            let handle = Handle {
+                node_id: node_id.clone(),
+                core: Arc::clone(&self.core),
+            };
+
+            let body = match handle.maybe_handle_service_res(&msg.src, msg.body) {
+                Ok(()) => return,
+                Err(x) => x,
+            };
+
+            let service = Arc::clone(&self.service);
+            let _ = mz_ore::task::spawn(|| format!("maelstrom::handle"), async move {
+                let service = service.get().await;
+                let () = service.eval(handle, msg.src, body).await;
+            });
+            return;
+        }
+
+        // Otherwise, if we haven't yet been initialized, then the only message
+        // type we are allowed to process is ReqInit.
+        match msg.body {
+            Body::ReqInit {
+                msg_id, node_id, ..
+            } => {
+                // Set the NodeId.
+                self.node_id = Some(node_id.clone());
+                let handle = Handle {
+                    node_id,
+                    core: Arc::clone(&self.core),
+                };
+
+                // Respond to the init req.
+                //
+                // NB: This must come _before_ service init! We want service
+                // init to be able to use Maelstrom services, but Maelstrom
+                // doesn't make services available to nodes that haven't yet
+                // responded to init.
+                let in_reply_to = msg_id;
+                handle.send_res(msg.src, move |msg_id| Body::ResInit {
+                    msg_id,
+                    in_reply_to,
+                });
+
+                // Tricky! Run the service init in a task in case it uses
+                // Maelstrom services. This is because Maelstrom services return
+                // responses on stdin, which means we need to be processing the
+                // run loop concurrently with this. This is also the reason for
+                // the AsyncInitOnceWaitable nonsense.
+                let args = self.args.clone();
+                let service_init = Arc::clone(&self.service);
+                let _ = mz_ore::task::spawn(|| format!("maelstrom::init"), async move {
+                    let service = match S::init(&args, &handle).await {
+                        Ok(x) => x,
+                        Err(err) => {
+                            // If service initialization fails, there's nothing
+                            // to do but panic. Any retries should be pushed
+                            // into the impl of `init`.
+                            panic!("service initialization failed: {}", err);
+                        }
+                    };
+                    service_init.init_once(Arc::new(service)).await;
+                });
+            }
+            // All other reqs are a no-op. We can't even error without a NodeId.
+            _ => {}
+        }
+    }
+}
+
+struct Core {
+    write: Box<dyn Write + Send + Sync>,
+    next_msg_id: MsgId,
+    callbacks: HashMap<MsgId, oneshot::Sender<Body>>,
+}
+
+impl std::fmt::Debug for Core {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Destructure the struct to be defensive against new fields.
+        let Core {
+            write: _,
+            next_msg_id,
+            callbacks,
+        } = self;
+        f.debug_struct("Core")
+            .field("next_msg_id", &next_msg_id)
+            .field("callbacks", &callbacks.keys().collect::<Vec<_>>())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Core {
+    fn alloc_msg_id(&mut self) -> MsgId {
+        self.next_msg_id = self.next_msg_id.next();
+        self.next_msg_id
+    }
+}
+
+/// A handle to interact with Node.
+#[derive(Debug, Clone)]
+pub struct Handle {
+    node_id: NodeId,
+    core: Arc<Mutex<Core>>,
+}
+
+impl Handle {
+    /// Send a response to Maelstrom.
+    ///
+    /// `dest` should be the `src` of the response. To make a service request,
+    /// use [Self::send_service_req] instead.
+    pub fn send_res<BodyFn: FnOnce(MsgId) -> Body>(&self, dest: NodeId, res_fn: BodyFn) {
+        let mut core = self.core.lock().expect("mutex poisoned");
+        let msg_id = core.alloc_msg_id();
+        let res = Msg {
+            src: self.node_id.clone(),
+            dest,
+            body: res_fn(msg_id),
+        };
+        info!("res: {}", res);
+        write!(core.write.as_mut(), "{}\n", res).expect("res write failed");
+    }
+
+    /// Issue a service request to Maelstrom.
+    ///
+    /// `dest` should be the service name. To respond to a request, use
+    /// [Self::send_res] instead.
+    pub async fn send_service_req<BodyFn: FnOnce(MsgId) -> Body>(
+        &self,
+        dest: NodeId,
+        req_fn: BodyFn,
+    ) -> Body {
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut core = self.core.lock().expect("mutex poisoned");
+            let msg_id = core.alloc_msg_id();
+            core.callbacks.insert(msg_id, tx);
+            let req = Msg {
+                src: self.node_id.clone(),
+                dest,
+                body: req_fn(msg_id),
+            };
+            trace!("svc: {}", req);
+            write!(core.write.as_mut(), "{}\n", req).expect("req write failed");
+        }
+        rx.await.expect("internal error: callback oneshot dropped")
+    }
+
+    /// Attempts to handle a msg as a service response, returning it back if it
+    /// isn't one.
+    pub fn maybe_handle_service_res(&self, src: &NodeId, msg: Body) -> Result<(), Body> {
+        let in_reply_to = match msg.in_reply_to() {
+            Some(x) => x,
+            None => return Err(msg),
+        };
+
+        let mut core = self.core.lock().expect("mutex poisoned");
+        let callback = match core.callbacks.remove(&in_reply_to) {
+            Some(x) => x,
+            None => {
+                self.send_res(src.clone(), |msg_id| Body::Error {
+                    msg_id: Some(msg_id),
+                    in_reply_to,
+                    code: ErrorCode::MalformedRequest,
+                    text: format!("no callback expected for {:?}", in_reply_to),
+                });
+                return Ok(());
+            }
+        };
+
+        if let Err(_) = callback.send(msg) {
+            // The caller is no longer listening. This is safe to ignore.
+            return Ok(());
+        }
+
+        Ok(())
+    }
+
+    /// Returns a [ShardId] for this Maelstrom run.
+    ///
+    /// Uses Maelstrom services to ensure all nodes end up with the same id.
+    pub async fn maybe_init_shard_id(&self) -> Result<ShardId, MaelstromError> {
+        let proposal = ShardId::new();
+        let key = "SHARD";
+        loop {
+            let from = Value::Null;
+            let to = Value::from(proposal.to_string());
+            match self
+                .lin_kv_compare_and_set(Value::from(key), from, to, Some(true))
+                .await
+            {
+                Ok(()) => {
+                    info!("initialized maelstrom shard to {}", proposal);
+                    return Ok(proposal);
+                }
+                Err(MaelstromError {
+                    code: ErrorCode::PreconditionFailed,
+                    ..
+                }) => match self.lin_kv_read(Value::from(key)).await? {
+                    Some(value) => {
+                        let value = value.as_str().ok_or_else(|| {
+                            ExternalError::from(anyhow!("invalid SHARD {}", value))
+                        })?;
+                        let shard_id = value.parse::<ShardId>().map_err(|err| {
+                            ExternalError::from(anyhow!("invalid SHARD {}: {}", value, err))
+                        })?;
+                        info!("fetched maelstrom shard id {}", shard_id);
+                        return Ok(shard_id);
+                    }
+                    None => continue,
+                },
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    /// Issues a Maelstrom lin-kv service read request.
+    pub async fn lin_kv_read(&self, key: Value) -> Result<Option<Value>, MaelstromError> {
+        let dest = NodeId("lin-kv".to_string());
+        let res = self
+            .send_service_req(dest, move |msg_id| Body::ReqLinKvRead { msg_id, key })
+            .await;
+        match res {
+            Body::Error {
+                code: ErrorCode::KeyDoesNotExist,
+                ..
+            } => Ok(None),
+            Body::Error { code, text, .. } => Err(MaelstromError { code, text }),
+            Body::ResLinKvRead { value, .. } => Ok(Some(value)),
+            res => unimplemented!("unsupported res: {:?}", res),
+        }
+    }
+
+    /// Issues a Maelstrom lin-kv service write request.
+    pub async fn lin_kv_write(&self, key: Value, value: Value) -> Result<(), MaelstromError> {
+        let dest = NodeId("lin-kv".to_string());
+        let res = self
+            .send_service_req(dest, move |msg_id| Body::ReqLinKvWrite {
+                msg_id,
+                key,
+                value,
+            })
+            .await;
+        match res {
+            Body::Error { code, text, .. } => Err(MaelstromError { code, text }),
+            Body::ResLinKvWrite { .. } => Ok(()),
+            res => unimplemented!("unsupported res: {:?}", res),
+        }
+    }
+
+    /// Issues a Maelstrom lin-kv service cas request.
+    pub async fn lin_kv_compare_and_set(
+        &self,
+        key: Value,
+        from: Value,
+        to: Value,
+        create_if_not_exists: Option<bool>,
+    ) -> Result<(), MaelstromError> {
+        trace!(
+            "lin_kv_compare_and_set key={:?} from={:?} to={:?} create_if_not_exists={:?}",
+            key,
+            from,
+            to,
+            create_if_not_exists
+        );
+        let dest = NodeId("lin-kv".to_string());
+        let res = self
+            .send_service_req(dest, move |msg_id| Body::ReqLinKvCaS {
+                msg_id,
+                key,
+                from,
+                to,
+                create_if_not_exists,
+            })
+            .await;
+        match res {
+            Body::Error { code, text, .. } => Err(MaelstromError { code, text }),
+            Body::ResLinKvCaS { .. } => Ok(()),
+            res => unimplemented!("unsupported res: {:?}", res),
+        }
+    }
+}
+
+/// A helper for a value that is initialized once, but used from many async
+/// places.
+///
+/// This name sure is a mouthful. Anyone have a suggestion?
+#[derive(Debug)]
+struct AsyncInitOnceWaitable<T: Clone> {
+    core: tokio::sync::Mutex<(Option<T>, Vec<oneshot::Sender<T>>)>,
+}
+
+impl<T: Clone> AsyncInitOnceWaitable<T> {
+    pub fn new() -> Self {
+        let core = (None, Vec::new());
+        AsyncInitOnceWaitable {
+            core: tokio::sync::Mutex::new(core),
+        }
+    }
+
+    pub async fn init_once(&self, t: T) {
+        let mut core = self.core.lock().await;
+        assert!(core.0.is_none(), "init called more than once");
+        core.0 = Some(t.clone());
+        for tx in core.1.drain(..) {
+            let _ = tx.send(t.clone());
+        }
+    }
+
+    pub async fn get(&self) -> T {
+        let rx = {
+            let mut core = self.core.lock().await;
+            if let Some(x) = core.0.as_ref() {
+                return x.clone();
+            }
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            core.1.push(tx);
+            rx
+        };
+        rx.await.expect("internal error: waiter oneshot dropped")
+    }
+}

--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -1,0 +1,347 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Implementations of Maelstrom services as persist external durability
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+use mz_persist::location::{Atomicity, BlobMulti, Consensus, ExternalError, SeqNo, VersionedData};
+
+use crate::maelstrom::api::{ErrorCode, MaelstromError};
+use crate::maelstrom::node::Handle;
+
+/// An adaptor for [VersionedData] that implements [Serialize] and
+/// [Deserialize].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct MaelstromVersionedData {
+    seqno: u64,
+    data: Vec<u8>,
+}
+
+/// Implementation of [Consensus] backed by the Maelstrom lin-kv service.
+#[derive(Debug)]
+pub struct MaelstromConsensus {
+    handle: Handle,
+    // A cache of SeqNo -> the data for that SeqNo. Here because the [Consensus]
+    // interface uses only a SeqNo for expected/from, but the lin-kv Maelstrom
+    // service requires the whole VersionedData. This is only used to hydrate
+    // the expected/from in the impl of `compare_and_set`.
+    //
+    // This cache exists primarily to keep our usage of maelstrom services
+    // "clean". Instead of the cache, we could use the consensus `head` call to
+    // hydrate SeqNos, but it's really nice to have a 1:1 relationship between
+    // Consensus calls and Maelstrom service calls when looking at the Lamport
+    // diagrams that Maelstrom emits.
+    //
+    // It also secondarily means that more stale expectations make it to the
+    // Maelstrom CaS call (with the `head` alternative we'd discover some then),
+    // but this is mostly a side benefit.
+    cache: Mutex<HashMap<(String, SeqNo), Vec<u8>>>,
+}
+
+impl MaelstromConsensus {
+    pub fn new(handle: Handle) -> Arc<dyn Consensus + Send + Sync> {
+        Arc::new(MaelstromConsensus {
+            handle,
+            cache: Mutex::new(HashMap::new()),
+        }) as Arc<dyn Consensus + Send + Sync>
+    }
+
+    pub async fn hydrate_seqno(
+        &self,
+        deadline: Instant,
+        key: &str,
+        expected: SeqNo,
+    ) -> Result<Result<VersionedData, Option<VersionedData>>, ExternalError> {
+        if let Some(data) = self.cache.lock().await.get(&(key.to_string(), expected)) {
+            let value = VersionedData {
+                seqno: expected.clone(),
+                data: data.clone(),
+            };
+            return Ok(Ok(value));
+        }
+
+        // It wasn't in the cache (must have been set by another process), fetch
+        // head and see if that matches.
+        match self.head(deadline, key).await? {
+            Some(current) if current.seqno == expected => Ok(Ok(current)),
+            x => Ok(Err(x)),
+        }
+    }
+}
+
+#[async_trait]
+impl Consensus for MaelstromConsensus {
+    async fn head(
+        &self,
+        _deadline: Instant,
+        key: &str,
+    ) -> Result<Option<VersionedData>, ExternalError> {
+        // TODO: Use the deadline.
+        let value = match self
+            .handle
+            .lin_kv_read(Value::from(format!("consensus/{}", key)))
+            .await
+            .map_err(anyhow::Error::new)?
+        {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+        let value = VersionedData::from(MaelstromVersionedData::try_from(&value)?);
+        self.cache
+            .lock()
+            .await
+            .insert((key.to_string(), value.seqno), value.data.clone());
+        Ok(Some(value))
+    }
+
+    async fn compare_and_set(
+        &self,
+        deadline: Instant,
+        key: &str,
+        expected: Option<SeqNo>,
+        new: VersionedData,
+    ) -> Result<Result<(), Option<VersionedData>>, ExternalError> {
+        let create_if_not_exists = expected.is_none();
+
+        let from = match expected {
+            Some(expected) => match self.hydrate_seqno(deadline, key, expected).await? {
+                Ok(x) => Value::from(&MaelstromVersionedData::from(x)),
+                Err(x) => return Ok(Err(x)),
+            },
+            None => Value::Null,
+        };
+        let new = MaelstromVersionedData::from(new);
+        let to = Value::from(&new);
+        // TODO: Use the deadline.
+        let cas_res = self
+            .handle
+            .lin_kv_compare_and_set(
+                Value::from(format!("consensus/{}", key)),
+                from,
+                to,
+                Some(create_if_not_exists),
+            )
+            .await;
+        match cas_res {
+            Ok(()) => {
+                self.cache
+                    .lock()
+                    .await
+                    .insert((key.to_string(), SeqNo(new.seqno)), new.data.clone());
+                Ok(Ok(()))
+            }
+            Err(MaelstromError {
+                code: ErrorCode::PreconditionFailed,
+                ..
+            }) => {
+                // TODO: Parse the current value out of the error string instead
+                // of another service fetch.
+                let current = self.head(deadline, key).await?;
+                Ok(Err(current))
+            }
+            Err(err) => Err(ExternalError::from(anyhow::Error::new(err))),
+        }
+    }
+
+    async fn scan(
+        &self,
+        _deadline: Instant,
+        _key: &str,
+        _from: SeqNo,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
+        unimplemented!("not yet used")
+    }
+
+    async fn truncate(
+        &self,
+        _deadline: Instant,
+        _key: &str,
+        _seqno: SeqNo,
+    ) -> Result<(), ExternalError> {
+        // No-op until we implement `scan`.
+        Ok(())
+    }
+}
+
+/// Implementation of [BlobMulti] backed by the Maelstrom lin-kv service.
+#[derive(Debug)]
+pub struct MaelstromBlobMulti {
+    handle: Handle,
+}
+
+impl MaelstromBlobMulti {
+    pub fn new(handle: Handle) -> Arc<dyn BlobMulti + Send + Sync> {
+        Arc::new(MaelstromBlobMulti { handle }) as Arc<dyn BlobMulti + Send + Sync>
+    }
+}
+
+#[async_trait]
+impl BlobMulti for MaelstromBlobMulti {
+    async fn get(&self, _deadline: Instant, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+        // TODO: Use the deadline.
+        let value = match self
+            .handle
+            .lin_kv_read(Value::from(format!("blob/{}", key)))
+            .await
+            .map_err(anyhow::Error::new)?
+        {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+        let value = value
+            .as_str()
+            .ok_or_else(|| anyhow!("invalid blob at {}", key))?;
+        let value = serde_json::from_str(value)
+            .map_err(|err| anyhow!("invalid blob at {}: {}", key, err))?;
+        Ok(Some(value))
+    }
+
+    async fn list_keys(&self, _deadline: Instant) -> Result<Vec<String>, ExternalError> {
+        unimplemented!("not yet used")
+    }
+
+    async fn set(
+        &self,
+        _deadline: Instant,
+        key: &str,
+        value: Vec<u8>,
+        _atomic: Atomicity,
+    ) -> Result<(), ExternalError> {
+        // lin_kv_write is always atomic, so we're free to ignore the atomic
+        // param.
+        let value = serde_json::to_string(&value).expect("failed to serialize value");
+        // TODO: Use the deadline.
+        self.handle
+            .lin_kv_write(Value::from(format!("blob/{}", key)), Value::from(value))
+            .await
+            .map_err(anyhow::Error::new)?;
+        Ok(())
+    }
+
+    async fn delete(&self, _deadline: Instant, _key: &str) -> Result<(), ExternalError> {
+        unimplemented!("not yet used")
+    }
+}
+
+/// Implementation of [BlobMulti] that caches get calls.
+///
+/// NB: It intentionally does not store successful set calls in the cache, so
+/// that a blob gets fetched at least once (exercising those code paths).
+#[derive(Debug)]
+pub struct CachingBlobMulti {
+    blob: Arc<dyn BlobMulti + Send + Sync>,
+    cache: Mutex<HashMap<String, Vec<u8>>>,
+}
+
+impl CachingBlobMulti {
+    pub fn new(blob: Arc<dyn BlobMulti + Send + Sync>) -> Arc<dyn BlobMulti + Send + Sync> {
+        Arc::new(CachingBlobMulti {
+            blob,
+            cache: Mutex::new(HashMap::new()),
+        }) as Arc<dyn BlobMulti + Send + Sync>
+    }
+}
+
+#[async_trait]
+impl BlobMulti for CachingBlobMulti {
+    async fn get(&self, deadline: Instant, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+        // Fetch the cached value if there is one.
+        let cache = self.cache.lock().await;
+        if let Some(value) = cache.get(key) {
+            return Ok(Some(value.clone()));
+        }
+        // Make sure not to hold the cache lock across the forwarded `get` call.
+        drop(cache);
+
+        // We didn't get a cache hit, fetch the value and update the cache.
+        let value = self.blob.get(deadline, key).await?;
+        if let Some(value) = &value {
+            // Everything in persist is write-once modify-never, so until we add
+            // support for deletions to CachingBlobMulti, we're free to blindly
+            // overwrite whatever is in the cache.
+            self.cache
+                .lock()
+                .await
+                .insert(key.to_owned(), value.clone());
+        }
+
+        Ok(value)
+    }
+
+    async fn list_keys(&self, deadline: Instant) -> Result<Vec<String>, ExternalError> {
+        self.blob.list_keys(deadline).await
+    }
+
+    async fn set(
+        &self,
+        deadline: Instant,
+        key: &str,
+        value: Vec<u8>,
+        atomic: Atomicity,
+    ) -> Result<(), ExternalError> {
+        // Intentionally don't put this in the cache on set, so that this blob
+        // gets fetched at least once (exercising those code paths).
+        self.blob.set(deadline, key, value.clone(), atomic).await
+    }
+
+    async fn delete(&self, _deadline: Instant, _key: &str) -> Result<(), ExternalError> {
+        unimplemented!("not yet used")
+    }
+}
+
+mod from_impls {
+    use mz_persist::location::{ExternalError, SeqNo, VersionedData};
+    use serde_json::Value;
+
+    use crate::maelstrom::services::MaelstromVersionedData;
+
+    impl From<VersionedData> for MaelstromVersionedData {
+        fn from(x: VersionedData) -> Self {
+            MaelstromVersionedData {
+                seqno: x.seqno.0,
+                data: x.data,
+            }
+        }
+    }
+
+    impl From<MaelstromVersionedData> for VersionedData {
+        fn from(x: MaelstromVersionedData) -> Self {
+            VersionedData {
+                seqno: SeqNo(x.seqno),
+                data: x.data,
+            }
+        }
+    }
+
+    impl From<&MaelstromVersionedData> for Value {
+        fn from(x: &MaelstromVersionedData) -> Self {
+            let json = serde_json::to_string(x).expect("MaelstromVersionedData wasn't valid json");
+            serde_json::from_str(&json).expect("MaelstromVersionedData wasn't valid json")
+        }
+    }
+
+    impl TryFrom<&Value> for MaelstromVersionedData {
+        type Error = ExternalError;
+
+        fn try_from(x: &Value) -> Result<Self, Self::Error> {
+            let json = serde_json::to_string(x)
+                .map_err(|err| ExternalError::from(anyhow::Error::new(err)))?;
+            serde_json::from_str(&json).map_err(|err| ExternalError::from(anyhow::Error::new(err)))
+        }
+    }
+}

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -1,0 +1,517 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! An implementation of the Maelstrom txn-list-append workload using persist
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::lattice::Lattice;
+use timely::order::TotalOrder;
+use timely::progress::{Antichain, Timestamp};
+use timely::PartialOrder;
+use tokio::sync::Mutex;
+use tracing::{debug, info, trace};
+
+use mz_persist::cfg::{BlobMultiConfig, ConsensusConfig};
+use mz_persist::location::{BlobMulti, Consensus, ExternalError};
+use mz_persist::unreliable::{UnreliableBlobMulti, UnreliableConsensus};
+use mz_persist_client::read::{Listen, ListenEvent, ReadHandle};
+use mz_persist_client::write::WriteHandle;
+use mz_persist_client::{PersistClient, ShardId};
+
+use crate::maelstrom::api::{Body, ErrorCode, MaelstromError, NodeId, ReqTxnOp, ResTxnOp};
+use crate::maelstrom::node::{Handle, Service};
+use crate::maelstrom::services::{CachingBlobMulti, MaelstromBlobMulti, MaelstromConsensus};
+use crate::maelstrom::Args;
+
+pub fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
+    let read = std::io::stdin();
+    let write = std::io::stdout();
+
+    crate::maelstrom::node::run::<_, _, TransactorService>(args, read.lock(), write)?;
+    Ok(())
+}
+
+/// Key of the persist shard used by [Transactor]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MaelstromKey(u64);
+
+/// Val of the persist shard used by [Transactor]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MaelstromVal(Vec<u64>);
+
+/// An implementation of read-write transactions on top of persist
+///
+/// This executes Maelstrom [txn-list-append] transactions. The timestamp
+/// selection is modeled after Materialize's SQL implementation.
+///
+/// [txn-list-append]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/workloads.md#workload-txn-list-append
+///
+/// A persist shard is maintained that directly represents a key-value map as it
+/// evolves over time. (Our real SQL implementation would likely instead
+/// maintain a WAL of updates to multiple tables.) Each transaction has
+/// associated timestamps:
+///
+/// - `read_ts`: at which the contents of the map are read (inclusive)
+/// - `write_ts`: at which txn mutations (if any) are written
+/// - `expected_upper`: the upper bound of the previous txn
+/// - `new_upper`: the upper bound after this transaction commits, if it does
+///
+/// To keep things simple, `write_ts` is always `read_ts+1`, `expected_upper` is
+/// `antichain[write_ts]`, and `new_upper` is `antichain[write_ts+1]`.
+///
+/// Transactions are "committed" by using `[WriteHandle::compare_and_append]`,
+/// which atomically:
+/// - verifies that `expected_upper` matches
+/// - writes the updates
+/// - advances the upper to `new_upper`.
+///
+/// This guarantees that all transactions are linearized with each txn's
+/// `read_ts` equal to the previous txn's `write_ts`. If two transactions race
+/// by reading at the same `read_ts` and writing at the same `write_ts`, the
+/// `compare_and_append` guarantees that only one of them succeeds and the other
+/// must retry with new timestamps.
+///
+/// Upon first use, the persist shard is initialized by advancing the upper to
+/// `antichain[T::minimum() + 1]`. This allows the first txn to use 0 as the
+/// `read_ts` and 1 as the `write_ts`.
+///
+/// Similarly modeling Materialize, the since of the shard is kept following the
+/// upper. To keep things simple, this is done by a fixed offset. This exercises
+/// persist compaction.
+///
+/// To ensure that both [ReadHandle::snapshot] and [ReadHandle::listen] are
+/// exercised, when a txn reads the state at `read_ts`, it artificially picks an
+/// `as_of` timestamp in `[since, read_ts]` and splits up the read data between
+/// snapshot and listen along this timestamp.
+#[derive(Debug)]
+pub struct Transactor {
+    read: ReadHandle<MaelstromKey, MaelstromVal, u64, i64>,
+    write: WriteHandle<MaelstromKey, MaelstromVal, u64, i64>,
+
+    since_ts: u64,
+    read_ts: u64,
+}
+
+impl Transactor {
+    pub async fn new(client: &PersistClient, shard_id: ShardId) -> Result<Self, MaelstromError> {
+        let (mut write, read) = client.open(shard_id).await?;
+        let since_ts = Self::extract_ts(read.since())?;
+        let read_ts = Self::maybe_init_shard(&mut write).await?;
+        Ok(Transactor {
+            read,
+            write,
+            since_ts,
+            read_ts,
+        })
+    }
+
+    /// Initializes the shard, if it hasn't been already, and returns the read
+    /// timestamp.
+    async fn maybe_init_shard(
+        write: &mut WriteHandle<MaelstromKey, MaelstromVal, u64, i64>,
+    ) -> Result<u64, MaelstromError> {
+        debug!("Transactor::maybe_init");
+        const EMPTY_UPDATES: &[((MaelstromKey, MaelstromVal), u64, i64)] = &[];
+        let ts_min = u64::minimum();
+        let initial_upper = Antichain::from_elem(ts_min);
+        let new_upper = Antichain::from_elem(ts_min + 1);
+        let cas_res = write
+            .compare_and_append(EMPTY_UPDATES, initial_upper.clone(), new_upper)
+            .await??;
+        let read_ts = match cas_res {
+            Ok(()) => 0,
+            Err(current) => Self::extract_ts(&current.0)? - 1,
+        };
+        Ok(read_ts)
+    }
+
+    pub async fn transact(
+        &mut self,
+        req_ops: &[ReqTxnOp],
+    ) -> Result<Vec<ResTxnOp>, MaelstromError> {
+        loop {
+            trace!("transact req={:?}", req_ops);
+            let state = self.read().await?;
+            debug!("transact req={:?} state={:?}", req_ops, state);
+            let (writes, res_ops) = Self::eval_txn(&state, req_ops);
+
+            // NB: We do the CaS even if writes is empty, so that read-only txns
+            // are also linearizable.
+            let write_ts = self.read_ts + 1;
+            let updates = writes.iter().map(|(k, v, diff)| ((k, v), &write_ts, diff));
+            let expected_upper = Antichain::from_elem(write_ts);
+            let new_upper = Antichain::from_elem(write_ts + 1);
+            // TODO: Wrap the compare_and_append in a retry_timeouts call, too.
+            // I tried but got tripped up trying to make an async FnMut work.
+            let cas_res = self
+                .write
+                .compare_and_append(updates, expected_upper.clone(), new_upper)
+                .await??;
+            match cas_res {
+                Ok(()) => {
+                    self.read_ts = write_ts;
+                    self.advance_since().await;
+                    return Ok(res_ops);
+                }
+                // We lost the CaS race, try again.
+                Err(current) => {
+                    info!(
+                        "transact lost the CaS race, retrying: {:?} vs {:?}",
+                        expected_upper, current
+                    );
+                    self.read_ts = Self::extract_ts(&current.0)? - 1;
+                    continue;
+                }
+            }
+        }
+    }
+
+    async fn read(&self) -> Result<HashMap<MaelstromKey, MaelstromVal>, MaelstromError> {
+        // We're reading as of read_ts, but we can split the read between the
+        // snapshot and listen at any ts in `[since_ts, read_ts]`. Intentionally
+        // pick one that uses a combination of both to get coverage.
+        let as_of = Antichain::from_elem(self.read_ts);
+        assert!(self.read_ts >= self.since_ts);
+        let snap_ts = self.since_ts + (self.read_ts - self.since_ts) / 2;
+        let snap_as_of = Antichain::from_elem(snap_ts);
+
+        let mut snap = self
+            .read
+            .snapshot(snap_as_of.clone())
+            .await
+            .map_err(|since| MaelstromError {
+                code: ErrorCode::Abort,
+                text: format!(
+                    "snapshot cannot serve requested as_of {} since is {:?}",
+                    snap_ts,
+                    since.0.as_option(),
+                ),
+            })?;
+        let listen = self
+            .read
+            .listen(snap_as_of)
+            .await
+            .map_err(|since| MaelstromError {
+                code: ErrorCode::Abort,
+                text: format!(
+                    "listen cannot serve requested as_of {} since is {:?}",
+                    snap_ts,
+                    since.0.as_option(),
+                ),
+            })?;
+
+        let mut updates = Vec::new();
+        while let Some(mut dataz) = snap.next().await {
+            updates.append(&mut dataz);
+        }
+        trace!(
+            "read updates from snapshot as_of {}: {:?}",
+            snap_ts,
+            updates
+        );
+        let listen_updates = Self::listen_through(listen, &as_of).await?;
+        trace!(
+            "read updates from listener as_of {} through {}: {:?}",
+            snap_ts,
+            self.read_ts,
+            listen_updates
+        );
+        updates.extend(listen_updates);
+
+        // Compute the contents of the collection as of `as_of`.
+        for (_, t, _) in updates.iter_mut() {
+            t.advance_by(as_of.borrow());
+        }
+        consolidate_updates(&mut updates);
+
+        Self::extract_state_map(self.read_ts, updates)
+    }
+
+    async fn listen_through(
+        mut listen: Listen<MaelstromKey, MaelstromVal, u64, i64>,
+        frontier: &Antichain<u64>,
+    ) -> Result<
+        Vec<(
+            (Result<MaelstromKey, String>, Result<MaelstromVal, String>),
+            u64,
+            i64,
+        )>,
+        ExternalError,
+    > {
+        let mut ret = Vec::new();
+        loop {
+            for event in listen.next().await {
+                match event {
+                    ListenEvent::Progress(x) => {
+                        // NB: Unlike the snapshot as_of, a listener frontier is
+                        // not inclusive, so we have to wait until it's > our
+                        // as_of to be sure we have everything.
+                        if PartialOrder::less_than(frontier, &x) {
+                            return Ok(ret);
+                        }
+                    }
+                    ListenEvent::Updates(x) => {
+                        // We want the collection at as_of, so skip anything
+                        // past that.
+                        ret.extend(x.into_iter().filter(|(_, ts, _)| !frontier.less_than(ts)));
+                    }
+                }
+            }
+        }
+    }
+
+    fn extract_state_map(
+        read_ts: u64,
+        updates: Vec<(
+            (Result<MaelstromKey, String>, Result<MaelstromVal, String>),
+            u64,
+            i64,
+        )>,
+    ) -> Result<HashMap<MaelstromKey, MaelstromVal>, MaelstromError> {
+        let mut ret = HashMap::new();
+        for ((k, v), _, d) in updates {
+            if d != 1 {
+                return Err(MaelstromError {
+                    code: ErrorCode::Crash,
+                    text: format!("invalid read at time {}", read_ts),
+                });
+            }
+            let k = k.map_err(|err| MaelstromError {
+                code: ErrorCode::Crash,
+                text: format!("invalid key {}", err),
+            })?;
+            let v = v.map_err(|err| MaelstromError {
+                code: ErrorCode::Crash,
+                text: format!("invalid val {}", err),
+            })?;
+            if ret.contains_key(&k) {
+                return Err(MaelstromError {
+                    code: ErrorCode::Crash,
+                    text: format!("unexpected duplicate key {:?}", k),
+                });
+            }
+            ret.insert(k, v);
+        }
+        Ok(ret)
+    }
+
+    fn eval_txn(
+        state: &HashMap<MaelstromKey, MaelstromVal>,
+        req_ops: &[ReqTxnOp],
+    ) -> (Vec<(MaelstromKey, MaelstromVal, i64)>, Vec<ResTxnOp>) {
+        let mut res_ops = Vec::new();
+        let mut updates = Vec::new();
+        let mut txn_state = HashMap::new();
+
+        for req_op in req_ops.iter() {
+            match req_op {
+                ReqTxnOp::Read { key } => {
+                    let current = txn_state
+                        .get(&MaelstromKey(*key))
+                        .or_else(|| state.get(&MaelstromKey(*key)));
+                    let val = current.cloned().unwrap_or_default().0;
+                    res_ops.push(ResTxnOp::Read { key: *key, val })
+                }
+                ReqTxnOp::Append { key, val } => {
+                    let current = txn_state
+                        .get(&MaelstromKey(*key))
+                        .or_else(|| state.get(&MaelstromKey(*key)));
+                    let mut vals = match current {
+                        Some(val) => {
+                            // Retract the value we're about to overwrite.
+                            updates.push((MaelstromKey(*key), val.clone(), -1));
+                            val.clone()
+                        }
+                        None => MaelstromVal::default(),
+                    };
+                    vals.0.push(*val);
+                    txn_state.insert(MaelstromKey(*key), vals.clone());
+                    updates.push((MaelstromKey(*key), vals, 1));
+                    res_ops.push(ResTxnOp::Append {
+                        key: key.clone(),
+                        val: *val,
+                    })
+                }
+            }
+        }
+
+        debug!(
+            "eval_txn\n  req={:?}\n  res={:?}\n  updates={:?}\n  state={:?}\n  txn_state={:?}",
+            req_ops, res_ops, updates, state, txn_state
+        );
+        (updates, res_ops)
+    }
+
+    async fn advance_since(&mut self) {
+        // To keep things interesting, advance the since.
+        const SINCE_LAG: u64 = 10;
+        let new_since = self.read_ts.saturating_sub(SINCE_LAG);
+        debug!("downgrading since to {}", new_since);
+        self.read
+            .downgrade_since(Antichain::from_elem(new_since))
+            .await;
+        self.since_ts = new_since;
+    }
+
+    fn extract_ts<T: TotalOrder + Copy>(frontier: &Antichain<T>) -> Result<T, MaelstromError> {
+        frontier.as_option().copied().ok_or_else(|| MaelstromError {
+            code: ErrorCode::Crash,
+            text: "shard unexpectedly closed".into(),
+        })
+    }
+}
+
+/// An adaptor to implement [Service] using [Transactor]
+#[derive(Debug)]
+pub struct TransactorService(pub Arc<Mutex<Transactor>>);
+
+#[async_trait]
+impl Service for TransactorService {
+    async fn init(args: &Args, handle: &Handle) -> Result<Self, MaelstromError> {
+        // Use the Maelstrom services to initialize a new random ShardId (so we
+        // can repeatedly run tests against the same Blob and Consensus without
+        // conflicting) and communicate it between processes.
+        let shard_id = handle.maybe_init_shard_id().await?;
+
+        // Make sure the seed is recomputed each time through the retry
+        // closure, so we don't retry the same deterministic timeouts.
+        let seed: u64 = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos()
+            .into();
+
+        // Construct requested Blob.
+        let blob = match &args.blob_uri {
+            Some(blob_uri) => BlobMultiConfig::try_from(blob_uri).await?.open().await?,
+            None => MaelstromBlobMulti::new(handle.clone()),
+        };
+        let blob = Arc::new(UnreliableBlobMulti::new_from_seed(
+            seed,
+            // It doesn't particularly matter what we set should_happen and
+            // should_timeout to for blobs, so set them to match Consensus.
+            1.0 - args.unreliability,
+            args.unreliability,
+            blob,
+        )) as Arc<dyn BlobMulti + Send + Sync>;
+        // Normal production persist usage (even including a real SQL txn impl)
+        // isn't particularly benefitted by a cache, so we don't have one baked
+        // into persist. In contrast, our Maelstrom transaction model
+        // intentionally exercises both a new snapshot and new listener on each
+        // txn. As a result, without a cache, things would be terribly slow,
+        // unreliable would cause more retries than are interesting, and the
+        // Lamport diagrams that Maelstrom generates would be noisy.
+        let blob = CachingBlobMulti::new(blob);
+
+        // Construct requested Consensus.
+        let consensus = match &args.consensus_uri {
+            Some(consensus_uri) => {
+                ConsensusConfig::try_from(consensus_uri)
+                    .await?
+                    .open()
+                    .await?
+            }
+            None => MaelstromConsensus::new(handle.clone()),
+        };
+        let consensus = Arc::new(UnreliableConsensus::new_from_seed(
+            seed,
+            // It doesn't particularly matter what we set should_happen to, so
+            // we do this to have a convenient single tunable param.
+            1.0 - args.unreliability,
+            // Set should_timeout to `args.unreliability` so that once we split
+            // ExternalErrors into determinate vs indeterminate, then
+            // `args.unreliability` will also be the fraction of txns that it's
+            // not save for Maelstrom to retry (b/c indeterminate error in
+            // Consensus CaS).
+            args.unreliability,
+            consensus,
+        )) as Arc<dyn Consensus + Send + Sync>;
+
+        // Wire up the TransactorService.
+        let client = PersistClient::new(blob, consensus).await?;
+        let transactor = Transactor::new(&client, shard_id).await?;
+        let service = TransactorService(Arc::new(Mutex::new(transactor)));
+        Ok(service)
+    }
+
+    async fn eval(&self, handle: Handle, src: NodeId, req: Body) {
+        match req {
+            Body::ReqTxn { msg_id, txn } => {
+                let in_reply_to = msg_id;
+                match self.0.lock().await.transact(&txn).await {
+                    Ok(txn) => handle.send_res(src, |msg_id| Body::ResTxn {
+                        msg_id,
+                        in_reply_to,
+                        txn,
+                    }),
+                    Err(MaelstromError { code, text }) => {
+                        handle.send_res(src, |msg_id| Body::Error {
+                            msg_id: Some(msg_id),
+                            in_reply_to,
+                            code,
+                            text,
+                        })
+                    }
+                }
+            }
+            req => unimplemented!("unsupported req: {:?}", req),
+        }
+    }
+}
+
+mod codec_impls {
+    use mz_persist_types::Codec;
+
+    use crate::maelstrom::txn::{MaelstromKey, MaelstromVal};
+
+    impl Codec for MaelstromKey {
+        fn codec_name() -> String {
+            "MaelstromKey".into()
+        }
+
+        fn encode<B>(&self, buf: &mut B)
+        where
+            B: bytes::BufMut,
+        {
+            let bytes = serde_json::to_vec(&self.0).expect("failed to encode key");
+            buf.put(bytes.as_slice());
+        }
+
+        fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+            Ok(MaelstromKey(
+                serde_json::from_slice(buf).map_err(|err| err.to_string())?,
+            ))
+        }
+    }
+
+    impl Codec for MaelstromVal {
+        fn codec_name() -> String {
+            "MaelstromVal".into()
+        }
+
+        fn encode<B>(&self, buf: &mut B)
+        where
+            B: bytes::BufMut,
+        {
+            let bytes = serde_json::to_vec(&self.0).expect("failed to encode val");
+            buf.put(bytes.as_slice());
+        }
+
+        fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+            Ok(MaelstromVal(
+                serde_json::from_slice(buf).map_err(|err| err.to_string())?,
+            ))
+        }
+    }
+}

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -1,0 +1,67 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+#![warn(missing_debug_implementations)]
+#![warn(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss
+)]
+
+//! Persist command-line utilities
+
+use std::sync::Once;
+
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
+
+pub mod maelstrom;
+
+#[derive(Debug, clap::Parser)]
+#[clap(about = "Persist command-line utilities", long_about = None)]
+struct Args {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum Command {
+    Maelstrom(crate::maelstrom::Args),
+}
+
+#[tokio::main]
+async fn main() {
+    // This doesn't use [mz_ore::test::init_logging] because Maelstrom requires
+    // that all logging goes to stderr.
+    init_logging();
+
+    let args: Args = mz_ore::cli::parse_args();
+
+    let res = match args.command {
+        Command::Maelstrom(args) => crate::maelstrom::txn::run(args),
+    };
+    if let Err(err) = res {
+        eprintln!("error: {:#}", err);
+        std::process::exit(1);
+    }
+}
+
+static LOG_INIT: Once = Once::new();
+
+fn init_logging() {
+    LOG_INIT.call_once(|| {
+        let default_level = "info";
+        let filter = EnvFilter::try_from_env("MZ_LOG_FILTER")
+            .or_else(|_| EnvFilter::try_new(default_level))
+            .unwrap();
+        FmtSubscriber::builder()
+            .with_env_filter(filter)
+            .with_writer(std::io::stderr)
+            .init();
+    });
+}

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -88,6 +88,7 @@ struct Args {
 
 const MIB: u64 = 1024 * 1024;
 
+// TODO: Move this to be a subcommand of persistcli.
 fn main() {
     mz_ore::test::init_logging();
 

--- a/src/persist-client/src/examples/persistent_source_example.rs
+++ b/src/persist-client/src/examples/persistent_source_example.rs
@@ -82,7 +82,8 @@ async fn run() -> Result<(), Box<dyn Error>> {
 
     let source = SequentialSource::new(2, source_wait_time);
 
-    // TODO: Turn this into a standalone binary, with arguments that specify a persist location.
+    // TODO: Move this to be a subcommand of persistcli, with arguments that
+    // specify a persist location.
     let persist = persist_client(
         "file:///tmp/persistent_source_example/blob",
         "sqlite:///tmp/persistent_source_example/sqlite-consensus",

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -520,6 +520,34 @@ mod tests {
     }
 
     #[test]
+    fn downgrade_since() {
+        let mut state = State::<(), (), u64, i64>::new(ShardId::new());
+        let reader = ReaderId::new();
+        let _ = state.collections.register(SeqNo::minimum(), &reader);
+        // Greater
+        assert_eq!(
+            state
+                .collections
+                .downgrade_since(&reader, &Antichain::from_elem(2)),
+            Continue(Since(Antichain::from_elem(2)))
+        );
+        // Equal
+        assert_eq!(
+            state
+                .collections
+                .downgrade_since(&reader, &Antichain::from_elem(2)),
+            Continue(Since(Antichain::from_elem(2)))
+        );
+        // Less (no-op)
+        assert_eq!(
+            state
+                .collections
+                .downgrade_since(&reader, &Antichain::from_elem(1)),
+            Continue(Since(Antichain::from_elem(2)))
+        );
+    }
+
+    #[test]
     fn empty_batch_optimization() {
         mz_ore::test::init_logging();
 


### PR DESCRIPTION
[Maelstrom] is a wrapper around the gold standard of distributed
correctness testing, [Jepsen]. Jepsen normally requires quite a bit of
custom code to generate interesting work, interact with a system, and
validate the results. Maelstrom wraps Jepsen and abstracts some common
distributed systems [workloads] and interacts with the process begin
testing using a JSON API over stdin/stdout. This makes Maelstrom much
less flexible than Jepsen, but FAR easier to use.

[jepsen]: https://github.com/jepsen-io/jepsen
[maelstrom]: https://github.com/jepsen-io/maelstrom
[workloads]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/workloads.md

We model persist as Maelstrom's [txn-list-append] workload. The
timestamp selection is modeled after Materialize's SQL implementation.

[txn-list-append]: https://github.com/jepsen-io/maelstrom/blob/v0.2.1/doc/workloads.md#workload-txn-list-append

A persist shard is maintained that directly represents a key-value map
as it evolves over time. (Our real SQL implementation would likely
instead maintain a WAL of updates to multiple tables.) Each transaction
has associated timestamps:

- `read_ts`: at which the contents of the map are read
- `write_ts`: at which txn mutations (if any) are written
- `expected_upper`: the upper bound of the previous txn
- `new_upper`: the upper bound after this transaction commits, if it
  does

To keep things simple, `write_ts` is always `read_ts+1`,
`expected_upper` is `antichain[write_ts]`, and `new_upper` is
`antichain[write_ts+1]`.

Transactions are "committed" by using
`[WriteHandle::compare_and_append]`, which atomically:
- verifies that `expected_upper` matches
- writes the updates
- advances the upper to `new_upper`.

This guarantees that all transactions are linearized with each txn's
`read_ts` equal to the previous txn's `write_ts`. If two transactions
race by reading at the same `read_ts` and writing at the same
`write_ts`, the `compare_and_append` guarantees that only one of them
succeeds and the other must retry at new timestamps.

Similarly modeling Materialize, the since of the shard is kept following
the upper. To keep things simple, this is done by a fixed offset. This
exercises persist compaction.

To ensure that both [ReadHandle::snapshot] and [ReadHandle::listen] are
exercised, when a txn reads the state at `read_ts`, it artificially
picks an `as_of` timestamp in `[since, read_ts]` and uses both of them
for the read.

To ensure test coverage of retries, we use the persist Unreliable*
wrappers.

If any of this doesn't make sense, the [Maelstrom docs] are a great
place to start for an understanding of the specifics of what's going on
here.

[maelstrom docs]: https://github.com/jepsen-io/maelstrom/tree/v0.2.1#documentation

Touches #11977

### Motivation

  * This PR adds a known-desirable feature.

Touches #11977

### Tips for reviewer

I tried to spread comments around on the unobvious bits, but as always it's hard to predict what is or isn't obvious to someone that didn't write the code. Please over-communicate on parts that you had to think about as you wrap your head around this so I can add more commentary on them.

It'd also be nice to make this easier to run/hook it up in CI with mzcompose stuff, but it'd probably take me a while and I think getting some work in on errors/retries/timeouts is more pressing. I plan to circle back here at some point.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
