### PR TITLE
doc/user: add release notes for v0.26.1

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -7,7 +7,8 @@ pygmentsUseClasses = true
 # Keep the releases in reverse order of their release date. The first release
 # in the list is assumed to be the most recent.
 versions = [
-  { name = "v0.26.0", date = "13 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
+  { name = "v0.26.1", date = "29 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
+  { name = "v0.26.0", date = "13 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.25.0", date = "31 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.24.0", date = "24 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.23.0", date = "18 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -7,7 +7,7 @@ pygmentsUseClasses = true
 # Keep the releases in reverse order of their release date. The first release
 # in the list is assumed to be the most recent.
 versions = [
-  { name = "v0.26.1", date = "29 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
+  { name = "v0.26.1", date = "05 May 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
   { name = "v0.26.0", date = "13 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.25.0", date = "31 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.24.0", date = "24 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -21,11 +21,27 @@ the PR description instead. They will be migrated here during the release
 process by the release notes team.
 {{< /comment >}}
 
-{{% version-header v0.26.0 %}}
+{{% version-header v0.26.1 %}}
 
-v0.26.0 is a **long-term support (LTS)** release of Materialize. We will support
+v0.26.1 is a **long-term support (LTS)** release of Materialize. We will support
 the v0.26 series through at least August 31, 2022, issuing patch releases as
 necessary to address severe bugs and security vulnerabilities.
+
+- Support configuring the
+  [`search_path`](https://www.postgresql.org/docs/14/runtime-config-client.html#GUC-SEARCH-PATH)
+  session parameter.
+
+- Fix a bug that could cause dataflows to fail to reuse existing
+  [arrangements](/overview/arrangements) {{% gh 11793 %}}.
+
+- Fix a bug that caused the
+  [memory usage visualization](/ops/monitoring#memory-usage-visualization)
+  to fail due to a cross-origin resource sharing (CORS) misconfiguration
+  {{% gh 11817 %}}.
+
+- Avoid leaking memory when an index is dropped {{% gh 11949 %}}.
+
+{{% version-header v0.26.0 %}}
 
 - **Breaking change.** Change the return type of the
   [`list_length`](/sql/functions/#list-func) function from [`bigint`] to

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -21,11 +21,13 @@ the PR description instead. They will be migrated here during the release
 process by the release notes team.
 {{< /comment >}}
 
-{{% version-header v0.26.1 %}}
-
-v0.26.1 is a **long-term support (LTS)** release of Materialize. We will support
-the v0.26 series through at least August 31, 2022, issuing patch releases as
+{{< note >}}
+v0.26 is a **long-term support (LTS)** release of Materialize. We will support
+the v0.26.x series through at least August 31 2022, issuing **patch releases** as
 necessary to address severe bugs and security vulnerabilities.
+{{</ note >}}
+
+{{% version-header v0.26.1 %}}
 
 - Support configuring the
   [`search_path`](https://www.postgresql.org/docs/14/runtime-config-client.html#GUC-SEARCH-PATH)


### PR DESCRIPTION
Just a draft for now. We may need to add another change to v0.26.1.

### Motivation

* Weekly release notes PR.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
