### PR TITLE
slt: increase timeout to 600m

### DIFF
--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -10,7 +10,7 @@
 steps:
   - id: sqllogictest
     label: ":bulb: SQL logic tests"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 600
     artifact_paths: target/slt-summary.json
     agents:
       queue: linux-x86_64


### PR DESCRIPTION
Due to recent performance regressions, the full SLT does not complete
within the previous 5-hour timeout.

At the same time, the tests were previously passing, so they provide
value that we should try to preserve instead of disabling them.

### Motivation

  * This PR fixes a previously unreported bug.

Nightly full SLT tests are timing out in CI