### PR TITLE
limits test: Fix the limits test after Platform changes

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -51,6 +51,7 @@ class Materialized(Service):
                 "MZ_LOG_FILTER",
                 "STORAGED_LOG_FILTER",
                 "COMPUTED_LOG_FILTER",
+                "MZ_PROCESS_LISTEN_HOST=0.0.0.0",
             ]
 
         if forward_aws_credentials:

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -155,7 +155,7 @@ pub struct Args {
     computed_image: Option<String>,
     /// The host on which processes spawned by the process orchestrator listen
     /// for connections.
-    #[structopt(long, hide = true)]
+    #[clap(long, hide = true, env = "MZ_PROCESS_LISTEN_HOST")]
     process_listen_host: Option<String>,
     /// The image pull policy to use for services created by the Kubernetes
     /// orchestrator.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -44,7 +44,7 @@ SERVICES = [
         options="--workers 2 --processes 2 --process 1 computed_3:2102 computed_4:2102 --storage-addr materialized:2101 --linger --reconcile",
         ports=[2100, 2102],
     ),
-    Materialized(extra_ports=[2101], options="--process-listen-host=0.0.0.0"),
+    Materialized(extra_ports=[2101]),
     Testdrive(
         volumes=[
             "mzdata:/share/mzdata",

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1040,9 +1040,10 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "materialized"]
-    )
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+
+    c.up("materialized")
+    c.wait_for_materialized()
 
     c.up("testdrive", persistent=True)
 


### PR DESCRIPTION
- do not use c.start_and_wait_for_tcp() on the materialized service
  Use c.up() followed by wait_for_materalized()

- run all materialized instances with --process-listen-host=0.0.0.0

### Motivation
  * This PR fixes a previously unreported bug.
The Nightly limits test has started failing 

### Tips for reviewer

@andrioni I had to move your `--process-listen-host=0.0.0.0` line back to `mzcompose/services.py` so that it applies to all mzcompose-based tests. Git praise tells me that you had it there initially, but moved it to `test/cluster/mzcompose.py` instead for some reason.