### PR TITLE
catalog-compat: Disable the catalog compat test

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -34,7 +34,6 @@ steps:
           - { value: aws-config }
           - { value: zippy-kafka-sources }
           - { value: secrets }
-          - { value: catalog-compat }
           - { value: unused-deps }
         multiple: true
         required: false
@@ -259,18 +258,6 @@ steps:
           composition: persistence
           run: failpoints
     skip: Persistence tests disabled
-
-  - id: catalog-compat
-    label: Catalog compatibility test
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_mzcompose_*.xml
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: catalog-compat
-          run: catalog-compat
 
   - id: unused-deps
     label: Unused dependencies


### PR DESCRIPTION
The upgrade scenarios that were tested by this test are no longer
supported. Furthermore, the 0.7 binary that is being used now
asserts in code that is no longer present in the current Mz version.

The test/catalog-compat directory is being kept at this time so
that any relevant individual test cases from it can be migrated to
a future upgrade framework.

### Motivation

This PR fixes a previously unreported bug.

The catalog-compat test is panicking in CI with an assertion in v0.7.0 . Given that
upgrades between non-Platform and Platform will not be supported, it does not make
sense to run that test in Nightly any longer.