### PR TITLE
doc/user: alias CREATE SOURCE into SQL Commands

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -122,6 +122,11 @@ identifier = 'sql-patterns'
 weight = 85
 
 [[menu.main]]
+name = "CREATE SOURCE"
+parent = 'commands'
+url = '/sql/create-source'
+
+[[menu.main]]
 identifier = "integration-guides"
 name = "Integration Guides"
 parent = "integrations"


### PR DESCRIPTION
Ensure `CREATE SOURCE` gets properly listed in SQL COMMANDS section of sidebar.

![image](https://user-images.githubusercontent.com/11527560/165759129-03a3d7e0-b02f-421d-bb96-ced760b62057.png)

The less-than-perfect compromise here is that clicking it still highlights the new "SOURCES" top-level menu.  I think the tradeoff of:

Pro:
- Source docs get proportionate importance in sidebar

Con:
- Users clicking `CREATE SOURCE` command get a sidebar that bounces up to the Source Docs section after they click it.


is a good one.