### PR TITLE
bin/cluster-dev: remove secrets-controller=kubernetes arg

### DIFF
--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -76,7 +76,6 @@ spec:
             - --computed-image=$(bin/mzimage spec --dev computed)
             - --data-directory=/data
             - --orchestrator=kubernetes
-            - --secrets-controller=kubernetes
             - --orchestrator-service-label=materialize.cloud/example1=label1
             - --orchestrator-service-label=materialize.cloud/example2=label2
             - --kubernetes-image-pull-policy=never


### PR DESCRIPTION
The `secrets-controller` arg has been superseded by the `orchestrator` arg in https://github.com/MaterializeInc/materialize/pull/12106.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
