### PR TITLE
mzbuild: Alow multiple binaries per container

### DIFF
--- a/ci/test/cargo-test/image/mzbuild.yml
+++ b/ci/test/cargo-test/image/mzbuild.yml
@@ -15,9 +15,5 @@ pre-image:
       protobuf-src:
         install: protobuf-install
   - type: cargo-build
-    bin: storaged
-  - type: cargo-build
-    bin: computed
-  - type: cargo-build
-    bin: materialized
+    bin: [storaged, computed, materialized]
   - type: cargo-test

--- a/src/materialized/ci/mzbuild.yml
+++ b/src/materialized/ci/mzbuild.yml
@@ -10,11 +10,5 @@
 name: materialized
 pre-image:
   - type: cargo-build
-    bin: storaged
-    strip: false
-  - type: cargo-build
-    bin: computed
-    strip: false
-  - type: cargo-build
-    bin: materialized
+    bin: [storaged, computed, materialized]
     strip: false

--- a/src/sqllogictest/ci/mzbuild.yml
+++ b/src/sqllogictest/ci/mzbuild.yml
@@ -10,8 +10,4 @@
 name: sqllogictest
 pre-image:
   - type: cargo-build
-    bin: storaged
-  - type: cargo-build
-    bin: computed
-  - type: cargo-build
-    bin: sqllogictest
+    bin: [storaged, computed, sqllogictest]

--- a/test/antithesis/materialized/.gitignore
+++ b/test/antithesis/materialized/.gitignore
@@ -1,2 +1,4 @@
 materialized
+storaged
+computed
 libvoidstar.so

--- a/test/antithesis/materialized/Dockerfile
+++ b/test/antithesis/materialized/Dockerfile
@@ -14,6 +14,6 @@ RUN apt-get update && apt-get -qy install ca-certificates
 COPY libvoidstar.so /usr/lib
 RUN ldconfig
 
-COPY materialized /usr/local/bin/
+COPY materialized computed storaged /usr/local/bin/
 
 ENTRYPOINT ["materialized", "--log-file=stderr"]

--- a/test/antithesis/materialized/mzbuild.yml
+++ b/test/antithesis/materialized/mzbuild.yml
@@ -11,7 +11,7 @@ name: antithesis-materialized
 publish: false
 pre-image:
   - type: cargo-build
-    bin: materialized
+    bin: [materialized, storaged, computed]
     strip: false
     rustflags: [
       "-Cpasses=sancov-module",


### PR DESCRIPTION
Allow the 'bin' field in a mzbuild.yml to specify more than one
binary.

This is needed in order to package all binaries in a single
container for Antithesis without having three separate identical
rustflags sections in antithesis/materialized/mzbuild.yml

### Motivation

  * This PR fixes a previously unreported bug.
The Antithesis tests could not start because storaged and computed were missing from the container.