### PR TITLE
dataflow-types: absorb timestamp binding feedback into single response

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -262,6 +262,15 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_mzcompose_*.xml
+    # Materialize versions v0.7.1 - v0.9.2 no longer run on our CI agents due to
+    # a bug in procfs v0.9.1 [0] which causes it to fail to parse kernel patch
+    # versions that are larger than 256. So we just disable this test.
+    # Unfortunate, but qe continue to have decent upgrade coverage via the
+    # upgrade test, and we're not planning to backport anything that touches the
+    # catalog persistence code to v0.26.
+    #
+    # [0]: https://github.com/eminence/procfs/issues/136
+    soft_fail: true
     plugins:
       - ./ci/plugins/mzcompose:
           composition: catalog-compat

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -397,9 +397,18 @@ pub struct LinearizedTimestampBindingFeedback<T = mz_repr::Timestamp> {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct TimestampBindingFeedback<T = mz_repr::Timestamp> {
     /// Durability frontier changes
-    pub changes: Vec<(GlobalId, ChangeBatch<T>)>,
+    pub changes: BTreeMap<GlobalId, ChangeBatch<T>>,
     /// Timestamp bindings for all of those frontier changes
-    pub bindings: Vec<(GlobalId, Vec<(PartitionId, T, MzOffset)>)>,
+    pub bindings: BTreeMap<GlobalId, Vec<(PartitionId, T, MzOffset)>>,
+}
+
+impl<T> Default for TimestampBindingFeedback<T> {
+    fn default() -> TimestampBindingFeedback<T> {
+        TimestampBindingFeedback {
+            changes: BTreeMap::new(),
+            bindings: BTreeMap::new(),
+        }
+    }
 }
 
 /// Responses that the worker/dataflow can provide back to the coordinator.

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -276,6 +276,8 @@ where
                 let response = response?;
                 match &response {
                     Some(StorageResponse::TimestampBindings(feedback)) => {
+                        println!("got feedback {:?}", feedback);
+
                         self.storage_controller
                             .update_write_frontiers(&feedback.changes)
                             .await?;

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -13,6 +13,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::iter;
+use std::mem;
 
 use async_trait::async_trait;
 use differential_dataflow::Hashable;
@@ -28,6 +29,7 @@ use mz_repr::{Diff, Row};
 
 use crate::client::{
     ComputeCommand, ComputeResponse, GenericClient, PeekResponse, StorageCommand, StorageResponse,
+    TimestampBindingFeedback,
 };
 use crate::{DataflowDescription, TailResponse};
 
@@ -147,6 +149,10 @@ pub struct PartitionedStorageState<T> {
     parts: usize,
     /// Upper frontiers for sources.
     uppers: HashMap<GlobalId, MutableAntichain<T>>,
+    /// The timestamp bindings that are currently being absorbed.
+    pending_timestamp_bindings: TimestampBindingFeedback<T>,
+    /// The number of timestamp bindings seen.
+    seen_timestamp_bindings: usize,
 }
 
 impl<T> Partitionable<StorageCommand<T>, StorageResponse<T>>
@@ -160,6 +166,8 @@ where
         PartitionedStorageState {
             parts,
             uppers: HashMap::new(),
+            pending_timestamp_bindings: TimestampBindingFeedback::default(),
+            seen_timestamp_bindings: 0,
         }
     }
 }
@@ -214,29 +222,33 @@ where
         response: StorageResponse<T>,
     ) -> Option<Result<StorageResponse<T>, anyhow::Error>> {
         match response {
-            // Avoid multiple retractions of minimum time, to present as updates from one worker.
-            StorageResponse::TimestampBindings(mut feedback) => {
-                for (id, changes) in feedback.changes.iter_mut() {
-                    if let Some(frontier) = self.uppers.get_mut(id) {
+            // Absorb responses from each worker into a single response.
+            StorageResponse::TimestampBindings(feedback) => {
+                println!("deep feedback {:?}", feedback);
+                for (id, mut changes) in feedback.changes {
+                    if let Some(frontier) = self.uppers.get_mut(&id) {
                         let iter = frontier.update_iter(changes.drain());
-                        changes.extend(iter);
-                    } else {
-                        changes.clear();
+                        self.pending_timestamp_bindings
+                            .changes
+                            .entry(id)
+                            .or_default()
+                            .extend(iter);
                     }
                 }
-                // The following block implements a `list.retain()` of non-empty change batches.
-                // This is more verbose than `list.retain()` because that method cannot mutate
-                // its argument, and `is_empty()` may need to do this (as it is lazily compacted).
-                let mut cursor = 0;
-                while let Some((_id, changes)) = feedback.changes.get_mut(cursor) {
-                    if changes.is_empty() {
-                        feedback.changes.swap_remove(cursor);
-                    } else {
-                        cursor += 1;
-                    }
+                for (id, bindings) in feedback.bindings {
+                    self.pending_timestamp_bindings
+                        .bindings
+                        .entry(id)
+                        .or_default()
+                        .extend(bindings);
                 }
-
-                Some(Ok(StorageResponse::TimestampBindings(feedback)))
+                self.seen_timestamp_bindings += 1;
+                if self.seen_timestamp_bindings % self.parts == 0 {
+                    let response = mem::take(&mut self.pending_timestamp_bindings);
+                    Some(Ok(StorageResponse::TimestampBindings(response)))
+                } else {
+                    None
+                }
             }
             // TODO(guswynn): is this the correct implementation?
             StorageResponse::LinearizedTimestamps(feedback) => {


### PR DESCRIPTION
The implementation is a bit hacky. @frankmcsherry maybe you have a better implementation to suggest?

----

When running with N workers, Materialize would generate N
TimestampBindingFeedback responses per timestamping interval, resulting
in N fsyncs every timestamping interval. A combination of a slow disk
and many workers could therefore result in the coordinator thread
spending 100% of its time writing timestamp bindings to disk and never
processing any client commands.

This commit batches together the timestamp binding feedback from all
workers into one response, so we only need to write to disk once per
timestamping interval.

Fixes MaterializeInc/product#151.

### Motivation

  * This PR fixes a recognized bug.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
