### PR TITLE
persist: fix correctness bug in snapshot when as_of >= upper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,7 @@ dependencies = [
  "clap",
  "differential-dataflow",
  "futures-executor",
+ "futures-task",
  "mz-ore",
  "mz-persist",
  "mz-persist-types",

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -22,3 +22,6 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.34"
 uuid = { version = "0.8.2", features = ["v4"] }
+
+[dev-dependencies]
+futures-task = "0.3.21"


### PR DESCRIPTION
Snapshot was meant to block until the requested data is ready, but
before this fix, if passed an as_of that was >= upper, it would
immediately return whatever it currently had. This is a correctness bug.

While in here, addressed a related TODO about only fetching state if we
can't immediately serve the snapshot.

When I first saw this, I thought a similar issue might be present in
Listen, but I added test coverage and Listen seems to be okay.

Fixes #12131
Touches #11977

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
