### PR TITLE
dbt-materialize: release `v1.1.0`

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dbt-materialize Changelog
 
+## 1.1.0 - 2022-04-30
+
+* Upgrade to `dbt-postgres` v.1.1.0.
+
 ## 1.0.5 - 2022-04-26
 
 * Deprecate support for custom index materialization.

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0 - 2022-04-30
 
-* Upgrade to `dbt-postgres` v.1.1.0.
+* Upgrade to `dbt-postgres` v1.1.0.
 
 ## 1.0.5 - 2022-04-26
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## 1.1.0 - 2022-04-30
+## 1.1.0 - 2022-05-02
 
 * Upgrade to `dbt-postgres` v1.1.0.
 

--- a/misc/dbt-materialize/MAINTAINERS.md
+++ b/misc/dbt-materialize/MAINTAINERS.md
@@ -1,5 +1,17 @@
 # Maintainer instructions
 
+## Versioning
+
+The `dbt-materialize` adapter should always match **major** and **minor** releases of `dbt-core` (i.e. if `dbt-core` v1.2.x is released, we should also bump `dbt-materialize` to v1.2.x). For patch releases, version numbers might differ and we should follow our own release cadence (i.e. if `dbt-core` v1.1.1 is released and `dbt-materialize` is on v1.1.5, that's legit).
+
+The following line in [`setup.py`](./setup.py#L42) guarantees that the adapter always installs the latest patch version of `dbt-postgres` and `dbt-core`:
+
+```
+ install_requires=["dbt-postgres~=1.1.0"],
+```
+
+See the [dbt documentation](https://docs.getdbt.com/docs/core-versions#how-we-version-adapter-plugins) for more details on versioning.
+
 ## Running tests locally
 
 1. Enter the `misc/dbt-materialize` directory:
@@ -39,18 +51,18 @@
    pytest
    ```
 
-7. Remember to re-install (`pip install .`) if you change the dbt-materialize
+7. Remember to re-install (`pip install .`) if you change the `dbt-materialize`
    Python code.
 
-## Tips and tricks
+### Tips and tricks
 
-All-in-one command to run after making a change to dbt-materialize:
+All-in-one command to run after making a change to `dbt-materialize`:
 
 ```shell
 pip install . && pytest
 ```
 
-If you want to test dbt-materialize against the latest changes to
+If you want to test `dbt-materialize` against the latest changes to
 `materialized`, build `materialized` from source:
 
 ```shell
@@ -83,7 +95,7 @@ pytest --no-drop-schema
 psql -h localhost -p 6875 -U materialize materialize
 ```
 
-Run dbt-materialize test suite via [mzcompose](../../doc/developer/mzbuild.md#mzcompose)
+Run the `dbt-materialize` test suite via [mzcompose](../../doc/developer/mzbuild.md#mzcompose)
 to match how it is run in CI:
 
 ```shell

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.0.5"
+version = "1.1.0"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.0.5",
+    version="1.1.0",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
@@ -39,7 +39,7 @@ setup(
             "include/materialize/macros/**/*.sql",
         ]
     },
-    install_requires=["dbt-postgres~=1.0.0"],
+    install_requires=["dbt-postgres~=1.1.0"],
     extras_require={
         "dev": ["pytest-dbt-adapter==0.6.0"],
     },


### PR DESCRIPTION
Cut a new release of `dbt-materialize` now that [`dbt-core` v1.1.0](https://github.com/dbt-labs/dbt-core/releases/tag/v1.1.0) has been released.

⚠️ The v1.1.0 release deprecates `pytest-dbt-adapter`, so we should port our test suite to the [new testing framework](https://docs.getdbt.com/docs/contributing/testing-a-new-adapter) as a follow-up.

### Motivation

* The adapter should match major and minor versions of `dbt-core`.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR adds a release note for any user-facing behavior changes.