### PR TITLE
dataflow-types: log connection errors that occur

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -113,7 +113,7 @@ struct Args {
 #[tokio::main]
 async fn main() {
     if let Err(err) = run(mz_ore::cli::parse_args()).await {
-        eprintln!("computed: {:#}", err);
+        eprintln!("computed: fatal: {:#}", err);
         process::exit(1);
     }
 }

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -109,7 +109,7 @@ struct Args {
 #[tokio::main]
 async fn main() {
     if let Err(err) = run(mz_ore::cli::parse_args()).await {
-        eprintln!("storaged: {:#}", err);
+        eprintln!("storaged: fatal: {:#}", err);
         process::exit(1);
     }
 }


### PR DESCRIPTION
Rather than just reporting "connection severed; reconnected", log the
actual connection error that occurred.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds logging that will help track down a bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
