### PR TITLE
coord,dataflow: stop returning canceled responses from compute

### DIFF
--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -14,7 +14,6 @@ use std::time::Instant;
 use tokio::sync::{mpsc, oneshot, watch};
 use uuid::Uuid;
 
-use mz_dataflow_types::PeekResponseUnary;
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::IdAllocator;
 use mz_ore::thread::JoinOnDropHandle;
@@ -25,6 +24,7 @@ use crate::command::{
     Canceled, Command, ExecuteResponse, Response, SimpleExecuteResponse, SimpleResult,
     StartupResponse,
 };
+use crate::coord::PeekResponseUnary;
 use crate::error::CoordError;
 use crate::session::{EndTransactionAction, PreparedStatement, Session};
 

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -16,13 +16,13 @@ use derivative::Derivative;
 use serde::Serialize;
 use tokio::sync::oneshot;
 
-use mz_dataflow_types::PeekResponseUnary;
 use mz_ore::str::StrExt;
 use mz_repr::{GlobalId, Row, ScalarType};
 use mz_sql::ast::{FetchDirection, NoticeSeverity, ObjectType, Raw, Statement};
 use mz_sql::plan::ExecuteTimeout;
 use tokio::sync::watch;
 
+use crate::coord::PeekResponseUnary;
 use crate::error::CoordError;
 use crate::session::{EndTransactionAction, RowBatchStream, Session};
 

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -45,5 +45,5 @@ pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{Canceled, ExecuteResponse, StartupMessage, StartupResponse};
-pub use crate::coord::{serve, Config};
+pub use crate::coord::{serve, Config, PeekResponseUnary};
 pub use crate::error::CoordError;

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -17,7 +17,6 @@ use std::mem;
 
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
-use mz_dataflow_types::PeekResponseUnary;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::sync::OwnedMutexGuard;
 
@@ -28,7 +27,7 @@ use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 
 use crate::command::RowsFuture;
-use crate::coord::CoordTimestamp;
+use crate::coord::{CoordTimestamp, PeekResponseUnary};
 use crate::error::CoordError;
 
 mod vars;

--- a/src/coord/src/tail.rs
+++ b/src/coord/src/tail.rs
@@ -9,10 +9,12 @@
 
 //! Implementations around supporting the TAIL protocol with the dataflow layer
 
-use mz_dataflow_types::{PeekResponseUnary, TailResponse};
+use mz_dataflow_types::TailResponse;
 use mz_repr::adt::numeric;
 use mz_repr::{Datum, Row};
 use tokio::sync::mpsc;
+
+use crate::coord::PeekResponseUnary;
 
 /// A description of a pending tail from coord's perspective
 pub(crate) struct PendingTail {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -36,17 +36,6 @@ pub enum PeekResponse {
     Canceled,
 }
 
-/// The response from a `Peek`, with row multiplicities represented in unary.
-///
-/// Note that each `Peek` expects to generate exactly one `PeekResponse`, i.e.
-/// we expect a 1:1 contract between `Peek` and `PeekResponseUnary`.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub enum PeekResponseUnary {
-    Rows(Vec<Row>),
-    Error(String),
-    Canceled,
-}
-
 impl PeekResponse {
     pub fn unwrap_rows(self) -> Vec<(Row, NonZeroUsize)> {
         match self {

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -29,8 +29,7 @@ use mz_coord::session::{
     row_future_to_stream, EndTransactionAction, InProgressRows, Portal, PortalState,
     RowBatchStream, Session, TransactionStatus,
 };
-use mz_coord::ExecuteResponse;
-use mz_dataflow_types::PeekResponseUnary;
+use mz_coord::{ExecuteResponse, PeekResponseUnary};
 use mz_frontegg_auth::FronteggAuthentication;
 use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
@@ -1341,7 +1340,7 @@ where
                     _ = time::sleep_until(deadline.unwrap_or_else(time::Instant::now)), if deadline.is_some() => FetchResult::Rows(None),
                     _ = self.coord_client.canceled() => FetchResult::Canceled,
                     batch = rows.remaining.recv() => match batch {
-                        None=>FetchResult::Rows(None),
+                        None => FetchResult::Rows(None),
                         Some(PeekResponseUnary::Rows(rows)) => FetchResult::Rows(Some(rows)),
                         Some(PeekResponseUnary::Error(err)) => FetchResult::Error(err),
                         Some(PeekResponseUnary::Canceled) => FetchResult::Canceled,


### PR DESCRIPTION
Change the cancel protocol between coord and controller so that coord
no longer waits for cancel peek messages from the controller. Remove
the entire enum variant and introduce a new type so it is clear that
the compute layer has no ability to send a cancel response.

Fixes #11507

### Motivation

  * This PR fixes a recognized bug. #11507

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
