### PR TITLE
dataflow-types: Add protobuf support for Peek

### DIFF
--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -13,12 +13,14 @@ fn main() {
         .extern_path(".mz_expr.scalar", "::mz_expr")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.proto", "::mz_repr::proto")
+        .extern_path(".mz_repr.row", "::mz_repr")
         .type_attribute(
             ".mz_dataflow_types.postgres_source",
             "#[derive(Eq, serde::Serialize, serde::Deserialize)]",
         )
         .compile_protos(
             &[
+                "dataflow-types/src/client.proto",
                 "dataflow-types/src/logging.proto",
                 "dataflow-types/src/postgres_source.proto",
                 "dataflow-types/src/plan/join.proto",

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -1,0 +1,26 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "repr/src/global_id.proto";
+import "repr/src/row.proto";
+import "repr/src/proto.proto";
+import "expr/src/relation.proto";
+
+package mz_dataflow_types.client;
+
+message ProtoPeek {
+    mz_repr.global_id.ProtoGlobalId id = 1;
+    mz_repr.row.ProtoRow key = 2;
+    mz_repr.proto.ProtoUuid uuid = 3;
+    uint64 timestamp = 4;
+    mz_expr.relation.ProtoRowSetFinishing finishing = 5;
+    // TODO(lluki): Add MFP once #11970 is in
+}

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -47,7 +47,7 @@ pub use relation::{
     MirRelationExpr, ProtoAggregateExpr, RowSetFinishing, WindowFrame, WindowFrameBound,
     WindowFrameUnits, RECURSION_LIMIT,
 };
-pub use relation::{ProtoAggregateFunc, ProtoColumnOrder};
+pub use relation::{ProtoAggregateFunc, ProtoColumnOrder, ProtoRowSetFinishing};
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};
 pub use scalar::{ProtoDomainLimit, ProtoEvalError, ProtoMirScalarExpr};

--- a/src/expr/src/relation.proto
+++ b/src/expr/src/relation.proto
@@ -119,6 +119,13 @@ message ProtoAggregateFunc {
     }
 }
 
+message ProtoRowSetFinishing {
+    repeated ProtoColumnOrder order_by = 1;
+    optional uint64 limit = 2;
+    uint64 offset = 3;
+    repeated uint64 project = 4;
+}
+
 message ProtoTableFunc {
     message ProtoWrap {
         repeated mz_repr.relation_and_scalar.ProtoColumnType types = 1;

--- a/src/repr/src/proto.proto
+++ b/src/repr/src/proto.proto
@@ -15,3 +15,8 @@ message ProtoU128{
     uint64 hi = 1;
     uint64 lo = 2;
 }
+
+message ProtoUuid {
+    uint64 hi = 1;
+    uint64 lo = 2;
+}

--- a/src/repr/src/proto.rs
+++ b/src/repr/src/proto.rs
@@ -11,6 +11,7 @@
 
 use mz_ore::cast::CastFrom;
 use std::{char::CharTryFromError, num::TryFromIntError};
+use uuid::Uuid;
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.proto.rs"));
 
@@ -152,6 +153,21 @@ impl ProtoRepr for u128 {
 
     fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
         Ok((repr.hi as u128) << 64 | (repr.lo as u128))
+    }
+}
+
+impl ProtoRepr for Uuid {
+    type Repr = ProtoUuid;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        let val = self.as_u128();
+        let lo = (val & (u64::MAX as u128)) as u64;
+        let hi = (val >> 64) as u64;
+        ProtoUuid { hi, lo }
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        Ok(Uuid::from_u128((repr.hi as u128) << 64 | (repr.lo as u128)))
     }
 }
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -15,11 +15,13 @@ use std::fmt::{self, Debug};
 use std::mem::{size_of, transmute};
 use std::str;
 
-use chrono::{DateTime, Datelike, NaiveDate, NaiveTime, Timelike, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use mz_ore::soft_assert;
 use mz_ore::vec::Vector;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use ordered_float::OrderedFloat;
+use proptest::prelude::*;
+use proptest::strategy::{BoxedStrategy, Just, Strategy};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use uuid::Uuid;
@@ -97,6 +99,42 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.row.rs"));
 #[derive(Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Row {
     data: SmallVec<[u8; Self::SIZE]>,
+}
+
+impl Arbitrary for Row {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Row>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        let datums = prop_oneof![
+            Just(Datum::Null),
+            Just(Datum::False),
+            Just(Datum::Int16(0)),
+            Just(Datum::Int32(0)),
+            Just(Datum::Int64(0)),
+            Just(Datum::Float32(OrderedFloat(0.0))),
+            Just(Datum::Float64(OrderedFloat(0.0))),
+            Just(Datum::Date(NaiveDate::from_ymd(1, 1, 1))),
+            Just(Datum::Timestamp(NaiveDateTime::from_timestamp(0, 0))),
+            Just(Datum::TimestampTz(DateTime::from_utc(
+                NaiveDateTime::from_timestamp(0, 0),
+                Utc
+            ))),
+            Just(Datum::Interval(Interval::default())),
+            Just(Datum::Bytes(&[])),
+            Just(Datum::String("")),
+            Just(Datum::JsonNull),
+        ];
+
+        datums
+            .prop_map(|x| {
+                let mut row = Row::default();
+                let mut packer = row.packer();
+                packer.push(x);
+                row
+            })
+            .boxed()
+    }
 }
 
 // Implement Clone manually to use SmallVec's more efficient from_slice.

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 use crate::adt::array::ArrayDimension;
 use crate::adt::interval::Interval;
 use crate::adt::numeric::Numeric;
+use crate::proto::TryFromProtoError;
 use crate::row::proto_datum::DatumType;
 use crate::row::{
     ProtoArray, ProtoArrayDimension, ProtoDate, ProtoDatum, ProtoDatumOther, ProtoDict,
@@ -291,6 +292,16 @@ impl TryFrom<&ProtoRow> for Row {
             packer.try_push_proto(d)?;
         }
         Ok(row)
+    }
+}
+
+impl TryFrom<ProtoRow> for Row {
+    type Error = TryFromProtoError;
+
+    fn try_from(x: ProtoRow) -> Result<Self, Self::Error> {
+        //TODO(lluki): Revisit this when we fix #12125
+        (&x).try_into()
+            .map_err(TryFromProtoError::RowConversionError)
     }
 }
 


### PR DESCRIPTION
Add Protobuf support for `Peek` client command.

Related to #11971

For full fix, requires implementing #11970 

### Tips for reviewer

Possibly the `any_uuid` strategy could be moved to a better location.


### Testing

 - Testing is implemented, but tests are currently `#[ignore]` because they need #11970 (SafeMfpPlan) to be correct.

### Release notes

None
