### PR TITLE
limits: Allow the KafkaPartitions scenario more time to complete

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -175,7 +175,8 @@ class KafkaPartitions(Generator):
 
     @classmethod
     def body(cls) -> None:
-        print("$ set-sql-timeout duration=120s")
+        # gh#12193 : topic_metadata_refresh_interval_ms is not observed so a default refresh interval of 300s applies
+        print("$ set-sql-timeout duration=360s")
         print('$ set key-schema={"type": "string"}')
         print(
             '$ set value-schema={"type": "record", "name": "r", "fields": [{"name": "f1", "type": "string"}]}'


### PR DESCRIPTION
Due to gh#12193, the topic_metadata_refresh_interval_ms=1000 option is not
respected. Give the scenario plenty of time to complete with the default
refresh interval of 300s.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly Limits is failing