### PR TITLE
ignore DeprecationWarning in bin/pydoc

### DIFF
--- a/bin/pydoc
+++ b/bin/pydoc
@@ -9,9 +9,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# pyfmt — formats Python code with Black.
+# pydoc -- generates docs for python API
 
-exec "$(dirname "$0")"/pyactivate -Werror -m pdoc \
+exec "$(dirname "$0")"/pyactivate -Werror -Wignore::DeprecationWarning -m pdoc \
     --html --force \
     -c 'git_link_template="https://github.com/MaterializeInc/materialize/blob/{commit}/{path}#L{start_line}-L{end_line}"' \
     -o target/pydoc \


### PR DESCRIPTION
This is causing deployments to fail because the `docker` package relies on `distutils` somewhere.

See e.g. https://buildkite.com/materialize/deploy/builds/7032

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
