### PR TITLE
doc/developer: update and restructure guide

### DIFF
--- a/bin/unused-deps
+++ b/bin/unused-deps
@@ -9,13 +9,14 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# san — prints (possible) unused dependencies for all members of the workspace
-#
-# Example usages:
-#
-#     $ bin/unused-deps
+# unused-deps — prints unused dependencies for all Rust crates.
 
-# Requires https://github.com/est31/cargo-udeps and a (working) nightly toolchain
+# Requires https://github.com/est31/cargo-udeps and a working nightly toolchain.
+#
+# cargo-udeps occasionally produces false positives, especially with
+# dependencies that are used only on certain platforms. To ignore these
+# dependencies, see:
+# https://github.com/est31/cargo-udeps#ignoring-some-of-the-dependencies.
 
 set -euo pipefail
 

--- a/doc/developer/README.md
+++ b/doc/developer/README.md
@@ -28,9 +28,6 @@ land, and then browsed as reference material as you skill up on the codebase.
 * [debugging.md](debugging.md) is a guide to debugging Materialize using
   rust-gdb / rust-lldb.
 
-* [demos.md](demos.md) explains the two tiers of demos in this codebase and
-  how to add a new one.
-
 * Our diagnostics guide is a work in progress. The sections we have so far are
   themselves works in progress. Feel free to add to them if you think up of
   something useful.
@@ -56,6 +53,9 @@ land, and then browsed as reference material as you skill up on the codebase.
 
 * [mzbuild.md](mzbuild.md) describes the custom build system we use to manage
   our Docker images and Docker Compose configurations.
+
+* [publishing.md](publishing.md) details how to publish packages, like Rust
+  crates or Docker images.
 
 * [reading.md](reading.md) contains a reading list.
 

--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -36,7 +36,7 @@ The unit/integration test suite uses the standard test framework that ships with
 Cargo. You can run the full test suite like so:
 
 ```shell
-$ cargo test
+$ bin/cargo-test
 ```
 
 Some of the packages have tests that depend on ZooKeeper, Kafka, and the
@@ -77,7 +77,7 @@ runs the tests that match the specified pattern. For example, to only run tests
 with `avro` in their name:
 
 ```shell
-$ cargo test -- avro
+$ bin/cargo-test -- avro
 ```
 
 As mentioned above, the Rust unit/integration tests follow the standard

--- a/doc/developer/publishing-packages.md
+++ b/doc/developer/publishing-packages.md
@@ -1,0 +1,27 @@
+# Publishing packages
+
+Several components of Materialize are distributed as packages for
+
+## Docker images
+
+Use [mzbuild](mzbuild.md) to build and push Docker images to the
+[materialize](https://hub.docker.com/u/materialize) Docker Hub organization.
+When you add a new publishable mzbuild image, you'll need an infrastructure
+admin to create the Docker Hub repository—ask in #eng-infra if you don't have
+the required permissions.
+
+## Rust crates
+
+Before publishing internal Rust crates to `crates.io`(https://crates.io/), be
+sure to indicate that `MaterializeInc` is the reponsible maintainer by running
+the following command:
+
+```shell
+cargo owner --add github:MaterializeInc:crate-owners
+```
+
+## PyPI
+
+Use the [`materializeinc`](https://pypi.org/user/materializeinc/) PyPI user to
+upload and update Materialize's Python packages on PyPI. Login information can
+be found in the shared 1Password account.


### PR DESCRIPTION
Update and restructure the developer guide for the Materialize Platform
world. The introduction is reworded to note that Materialize consists of
several services in Rust, plus a bunch of tooling in Python and Bash.
The "Editors and IDEs" and "Debugging" sections are moved under
"Developer tools". The "Code structure" section growsn an overview of
the driectoreis in the repository. The "Publishing code changes" is
moved to a separate document because it is rarely relevant. Various dead
links are removed.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
