### PR TITLE
stash: make async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,6 +3354,7 @@ dependencies = [
  "mz-persist-types",
  "mz-pgrepr",
  "mz-repr",
+ "mz-stash",
  "num",
  "num_enum",
  "ordered-float",
@@ -4018,15 +4019,18 @@ name = "mz-stash"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "criterion",
  "differential-dataflow",
+ "futures",
  "mz-ore",
  "mz-persist-types",
  "num",
- "postgres",
  "rusqlite",
  "tempfile",
  "timely",
+ "tokio",
+ "tokio-postgres",
 ]
 
 [[package]]

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -18,6 +18,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use tempfile::TempDir;
 
 use mz_coord::catalog::{Catalog, CatalogItem, Op, Table, SYSTEM_CONN_ID};
@@ -31,6 +33,7 @@ use mz_sql::names::{
 };
 use mz_sql::plan::{PlanContext, QueryContext, QueryLifetime, StatementContext};
 use mz_sql::DEFAULT_SCHEMA;
+use tokio::sync::Mutex;
 
 // This morally tests the name resolution stuff, but we need access to a
 // catalog.
@@ -39,72 +42,91 @@ use mz_sql::DEFAULT_SCHEMA;
 async fn datadriven() {
     datadriven::walk_async("tests/testdata", |mut f| async {
         let data_dir = TempDir::new().unwrap();
-        let mut catalog = Catalog::open_debug(data_dir.path(), NOW_ZERO.clone())
-            .await
-            .unwrap();
-        f.run(|test_case| -> String {
-            match test_case.directive.as_str() {
-                "add-table" => {
-                    let id = catalog.allocate_user_id().unwrap();
-                    let oid = catalog.allocate_oid().unwrap();
-                    let database_id = catalog
-                        .resolve_database(DEFAULT_DATABASE_NAME)
-                        .unwrap()
-                        .id();
-                    let database_spec = ResolvedDatabaseSpecifier::Id(database_id);
-                    let schema_spec = catalog
-                        .resolve_schema_in_database(&database_spec, DEFAULT_SCHEMA, SYSTEM_CONN_ID)
-                        .unwrap()
-                        .id
-                        .clone();
-                    catalog
-                        .transact(
-                            vec![Op::CreateItem {
-                                id,
-                                oid,
-                                name: QualifiedObjectName {
-                                    qualifiers: ObjectQualifiers {
-                                        database_spec,
-                                        schema_spec,
+        // The datadriven API takes an `FnMut` closure, and can't express to Rust that
+        // it will finish polling each returned future before calling the closure
+        // again, so we have to wrap the catalog in a share-able type. Datadriven
+        // could be changed to maybe take some context that it passes as a &mut to each
+        // test_case invocation, act on a stream of test_cases, or take and return a
+        // Context. This is just a test, so the performance hit of this doesn't matter
+        // (and in practice there will be no contention).
+        let catalog = Arc::new(Mutex::new(
+            Catalog::open_debug(data_dir.path(), NOW_ZERO.clone())
+                .await
+                .unwrap(),
+        ));
+        f.run_async(|test_case| {
+            let catalog = Arc::clone(&catalog);
+            async move {
+                let mut catalog = catalog.lock().await;
+                match test_case.directive.as_str() {
+                    "add-table" => {
+                        let id = catalog.allocate_user_id().await.unwrap();
+                        let oid = catalog.allocate_oid().await.unwrap();
+                        let database_id = catalog
+                            .resolve_database(DEFAULT_DATABASE_NAME)
+                            .unwrap()
+                            .id();
+                        let database_spec = ResolvedDatabaseSpecifier::Id(database_id);
+                        let schema_spec = catalog
+                            .resolve_schema_in_database(
+                                &database_spec,
+                                DEFAULT_SCHEMA,
+                                SYSTEM_CONN_ID,
+                            )
+                            .unwrap()
+                            .id
+                            .clone();
+                        catalog
+                            .transact(
+                                vec![Op::CreateItem {
+                                    id,
+                                    oid,
+                                    name: QualifiedObjectName {
+                                        qualifiers: ObjectQualifiers {
+                                            database_spec,
+                                            schema_spec,
+                                        },
+                                        item: test_case.input.trim_end().to_string(),
                                     },
-                                    item: test_case.input.trim_end().to_string(),
-                                },
-                                item: CatalogItem::Table(Table {
-                                    create_sql: "TODO".to_string(),
-                                    desc: RelationDesc::empty(),
-                                    defaults: vec![Expr::null(); 0],
-                                    conn_id: None,
-                                    depends_on: vec![],
-                                }),
-                            }],
-                            |_| Ok(()),
-                        )
-                        .unwrap();
-                    format!("{}\n", id)
-                }
-                "resolve" => {
-                    let sess = Session::dummy();
-                    let catalog = catalog.for_session(&sess);
-
-                    let parsed = mz_sql::parse::parse(&test_case.input).unwrap();
-                    let pcx = &PlanContext::zero();
-                    let scx = StatementContext::new(Some(pcx), &catalog);
-                    let mut qcx =
-                        QueryContext::root(&scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
-                    let q = parsed[0].clone();
-                    let q = match q {
-                        Statement::Select(s) => s.query,
-                        _ => unreachable!(),
-                    };
-                    let resolved = resolve_names(&mut qcx, q);
-                    match resolved {
-                        Ok(q) => format!("{}\n", q),
-                        Err(e) => format!("error: {}\n", e),
+                                    item: CatalogItem::Table(Table {
+                                        create_sql: "TODO".to_string(),
+                                        desc: RelationDesc::empty(),
+                                        defaults: vec![Expr::null(); 0],
+                                        conn_id: None,
+                                        depends_on: vec![],
+                                    }),
+                                }],
+                                |_| Ok(()),
+                            )
+                            .await
+                            .unwrap();
+                        format!("{}\n", id)
                     }
+                    "resolve" => {
+                        let sess = Session::dummy();
+                        let catalog = catalog.for_session(&sess);
+
+                        let parsed = mz_sql::parse::parse(&test_case.input).unwrap();
+                        let pcx = &PlanContext::zero();
+                        let scx = StatementContext::new(Some(pcx), &catalog);
+                        let mut qcx =
+                            QueryContext::root(&scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
+                        let q = parsed[0].clone();
+                        let q = match q {
+                            Statement::Select(s) => s.query,
+                            _ => unreachable!(),
+                        };
+                        let resolved = resolve_names(&mut qcx, q);
+                        match resolved {
+                            Ok(q) => format!("{}\n", q),
+                            Err(e) => format!("error: {}\n", e),
+                        }
+                    }
+                    dir => panic!("unhandled directive {}", dir),
                 }
-                dir => panic!("unhandled directive {}", dir),
             }
-        });
+        })
+        .await;
         f
     })
     .await;

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -31,6 +31,7 @@ mz-ore = { path = "../ore" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
 mz-persist-types = { path = "../persist-types" }
+mz-stash = { path = "../stash" }
 num = "0.4.0"
 num_enum = "0.5.7"
 ordered-float = { version = "2.10.0", features = ["serde"] }

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -255,7 +255,8 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let coord_storage = mz_coord::catalog::storage::Connection::open(
         &config.data_directory,
         Some(config.experimental_mode),
-    )?;
+    )
+    .await?;
 
     // Initialize orchestrator.
     let orchestrator: Box<dyn Orchestrator> = match config.orchestrator.backend {

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -15,15 +15,18 @@ harness = false
 # harness = false
 
 [dependencies]
+async-trait = "0.1.53"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+futures = "0.3.21"
 mz-ore = { path = "../ore" }
 mz-persist-types = { path = "../persist-types" }
-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 num = "0.4.0"
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 
 [dev-dependencies]
 anyhow = "1.0.57"
-tempfile = "3.3.0"
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = [ "html_reports" ] }
+tempfile = "3.3.0"
+tokio = { version = "1.17.0", features = ["macros"] }

--- a/src/stash/benches/sqlite.rs
+++ b/src/stash/benches/sqlite.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// TODO: Make this work with the async API.
+fn main() {}
+/*
 use std::iter::{repeat, repeat_with};
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -125,3 +128,4 @@ criterion_group!(
     bench_consolidation_large
 );
 criterion_main!(benches);
+*/

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -12,16 +12,17 @@
 use std::cmp;
 use std::marker::PhantomData;
 
-use postgres::{Client, Transaction};
+use async_trait::async_trait;
+use futures::future::BoxFuture;
 use timely::progress::Antichain;
 use timely::PartialOrder;
+use tokio_postgres::{Client, Transaction};
 
-use mz_persist_types::Codec;
 use timely::progress::frontier::AntichainRef;
 
 use crate::{
-    AntichainFormatter, Append, AppendBatch, Diff, Id, InternalStashError, Stash, StashCollection,
-    StashError, Timestamp,
+    AntichainFormatter, Append, AppendBatch, Data, Diff, Id, InternalStashError, Stash,
+    StashCollection, StashError, Timestamp,
 };
 
 const SCHEMA: &str = "
@@ -64,34 +65,59 @@ pub struct Postgres {
     epoch: i64,
 }
 
+impl std::fmt::Debug for Postgres {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Postgres")
+            .field("epoch", &self.epoch)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Postgres {
     /// Opens the stash stored at the specified path.
-    pub fn open(mut conn: Client) -> Result<Postgres, StashError> {
-        conn.batch_execute("SET default_transaction_isolation = serializable")?;
-        let mut tx = conn.transaction()?;
+    pub async fn open(mut conn: Client) -> Result<Postgres, StashError> {
+        conn.batch_execute("SET default_transaction_isolation = serializable")
+            .await?;
+        let tx = conn.transaction().await?;
         let fence_oid: Option<u32> = tx
             // `to_regclass` returns the regclass (OID) of the named object (table) or NULL
             // if it doesn't exist. This is a check for "does the fence table exist".
-            .query_one("SELECT to_regclass('fence')::oid", &[])?
+            .query_one("SELECT to_regclass('fence')::oid", &[])
+            .await?
             .get(0);
         if fence_oid.is_none() {
-            tx.batch_execute(SCHEMA)?;
+            tx.batch_execute(SCHEMA).await?;
         }
         // Bump the epoch, which will cause any previous connection to fail.
         let epoch = tx
-            .query_one("UPDATE fence SET epoch=epoch+1 RETURNING epoch", &[])?
+            .query_one("UPDATE fence SET epoch=epoch+1 RETURNING epoch", &[])
+            .await?
             .get(0);
-        tx.commit()?;
+        tx.commit().await?;
         Ok(Postgres { conn, epoch })
     }
 
-    /// Construct a fenced transaction.
-    fn transact<F, T>(&mut self, f: F) -> Result<T, StashError>
+    /// Construct a fenced transaction, which will cause this Stash to fail if
+    /// another connection is opened to it.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// async fn x(&mut self) -> Result<(), StashError> {
+    ///     self.transact(move |tx| {
+    ///         Box::pin(async move {
+    ///             // Use tx.
+    ///         })
+    ///     })
+    ///     .await
+    //  }
+    /// ```
+    async fn transact<F, T>(&mut self, f: F) -> Result<T, StashError>
     where
-        F: FnOnce(&mut Transaction) -> Result<T, StashError>,
+        F: for<'a> FnOnce(&'a mut Transaction) -> BoxFuture<'a, Result<T, StashError>>,
     {
-        let mut tx = self.conn.transaction()?;
-        let current: i64 = tx.query_one("SELECT epoch FROM fence", &[])?.get(0);
+        let mut tx = self.conn.transaction().await?;
+        let current: i64 = tx.query_one("SELECT epoch FROM fence", &[]).await?.get(0);
         if current != self.epoch {
             return Err(InternalStashError::Fence(format!(
                 "unexpected fence {}, expected {}",
@@ -99,44 +125,48 @@ impl Postgres {
             ))
             .into());
         }
-        let res = f(&mut tx)?;
-        tx.commit()?;
+        let res = f(&mut tx).await?;
+        tx.commit().await?;
         Ok(res)
     }
 
-    fn since_tx(
-        tx: &mut Transaction,
+    async fn since_tx(
+        tx: &mut Transaction<'_>,
         collection_id: Id,
     ) -> Result<Antichain<Timestamp>, StashError> {
         let since: Option<Timestamp> = tx
             .query_one(
                 "SELECT since FROM sinces WHERE collection_id = $1",
                 &[&collection_id],
-            )?
+            )
+            .await?
             .get("since");
         Ok(Antichain::from_iter(since))
     }
 
-    fn upper_tx(
-        tx: &mut Transaction,
+    async fn upper_tx(
+        tx: &mut Transaction<'_>,
         collection_id: Id,
     ) -> Result<Antichain<Timestamp>, StashError> {
         let upper: Option<Timestamp> = tx
             .query_one(
                 "SELECT upper FROM uppers WHERE collection_id = $1",
                 &[&collection_id],
-            )?
+            )
+            .await?
             .get("upper");
         Ok(Antichain::from_iter(upper))
     }
 
-    fn seal_batch_tx<'a, I>(tx: &mut Transaction, seals: I) -> Result<(), StashError>
+    async fn seal_batch_tx<'a, I>(tx: &mut Transaction<'_>, seals: I) -> Result<(), StashError>
     where
         I: Iterator<Item = (Id, &'a Antichain<Timestamp>)>,
     {
-        let update_stmt = tx.prepare("UPDATE uppers SET upper = $1 WHERE collection_id = $2")?;
+        let update_stmt = tx
+            .prepare("UPDATE uppers SET upper = $1 WHERE collection_id = $2")
+            .await?;
         for (collection_id, new_upper) in seals {
-            let upper = Self::upper_tx(tx, collection_id)?;
+            let upper = Self::upper_tx(tx, collection_id).await?;
             if PartialOrder::less_than(new_upper, &upper) {
                 return Err(StashError::from(format!(
                     "seal request {} is less than the current upper frontier {}",
@@ -144,24 +174,27 @@ impl Postgres {
                     AntichainFormatter(&upper),
                 )));
             }
-            tx.execute(&update_stmt, &[&new_upper.as_option(), &collection_id])?;
+            tx.execute(&update_stmt, &[&new_upper.as_option(), &collection_id])
+                .await?;
         }
         Ok(())
     }
 
-    fn update_many_tx<I>(
-        tx: &mut Transaction,
+    async fn update_many_tx<I>(
+        tx: &mut Transaction<'_>,
         collection_id: Id,
         entries: I,
     ) -> Result<(), StashError>
     where
         I: Iterator<Item = ((Vec<u8>, Vec<u8>), Timestamp, Diff)>,
     {
-        let upper = Self::upper_tx(tx, collection_id)?;
-        let insert_stmt = tx.prepare(
-            "INSERT INTO data (collection_id, key, value, time, diff)
+        let upper = Self::upper_tx(tx, collection_id).await?;
+        let insert_stmt = tx
+            .prepare(
+                "INSERT INTO data (collection_id, key, value, time, diff)
              VALUES ($1, $2, $3, $4, $5)",
-        )?;
+            )
+            .await?;
         for ((key, value), time, diff) in entries {
             if !upper.less_equal(&time) {
                 return Err(StashError::from(format!(
@@ -170,300 +203,397 @@ impl Postgres {
                     AntichainFormatter(&upper)
                 )));
             }
-            tx.execute(&insert_stmt, &[&collection_id, &key, &value, &time, &diff])?;
+            tx.execute(&insert_stmt, &[&collection_id, &key, &value, &time, &diff])
+                .await?;
         }
         Ok(())
     }
 }
 
+#[async_trait]
 impl Stash for Postgres {
-    fn collection<K, V>(&mut self, name: &str) -> Result<StashCollection<K, V>, StashError>
+    async fn collection<K, V>(&mut self, name: &str) -> Result<StashCollection<K, V>, StashError>
     where
-        K: Codec + Ord,
-        V: Codec + Ord,
+        K: Data,
+        V: Data,
     {
-        self.transact(|tx| {
-            let collection_id_opt: Option<_> = tx
-                .query_one(
-                    "SELECT collection_id FROM collections WHERE name = $1",
-                    &[&name],
-                )
-                .map(|row| row.get("collection_id"))
-                .ok();
+        let name = name.to_string();
+        self.transact(move |tx| {
+            Box::pin(async move {
+                let collection_id_opt: Option<_> = tx
+                    .query_one(
+                        "SELECT collection_id FROM collections WHERE name = $1",
+                        &[&name],
+                    )
+                    .await
+                    .map(|row| row.get("collection_id"))
+                    .ok();
 
-            let collection_id = match collection_id_opt {
-                Some(id) => id,
-                None => {
-                    let collection_id = tx
+                let collection_id = match collection_id_opt {
+                    Some(id) => id,
+                    None => {
+                        let collection_id = tx
                         .query_one(
                             "INSERT INTO collections (name) VALUES ($1) RETURNING collection_id",
                             &[&name],
-                        )?
+                        )
+                        .await?
                         .get("collection_id");
-                    tx.execute(
-                        "INSERT INTO sinces (collection_id, since) VALUES ($1, $2)",
-                        &[&collection_id, &Timestamp::MIN],
-                    )?;
-                    tx.execute(
-                        "INSERT INTO uppers (collection_id, upper) VALUES ($1, $2)",
-                        &[&collection_id, &Timestamp::MIN],
-                    )?;
-                    collection_id
-                }
-            };
+                        tx.execute(
+                            "INSERT INTO sinces (collection_id, since) VALUES ($1, $2)",
+                            &[&collection_id, &Timestamp::MIN],
+                        )
+                        .await?;
+                        tx.execute(
+                            "INSERT INTO uppers (collection_id, upper) VALUES ($1, $2)",
+                            &[&collection_id, &Timestamp::MIN],
+                        )
+                        .await?;
+                        collection_id
+                    }
+                };
 
-            Ok(StashCollection {
-                id: collection_id,
-                _kv: PhantomData,
+                Ok(StashCollection {
+                    id: collection_id,
+                    _kv: PhantomData,
+                })
             })
         })
+        .await
     }
 
-    fn iter<K, V>(
+    async fn iter<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
     ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
     where
-        K: Codec + Ord,
-        V: Codec + Ord,
+        K: Data,
+        V: Data,
     {
-        self.transact(|tx| {
-            let since = match Self::since_tx(tx, collection.id)?.into_option() {
-                Some(since) => since,
-                None => {
-                    return Err(StashError::from(
-                        "cannot iterate collection with empty since frontier",
-                    ));
-                }
-            };
-            let mut rows = tx
-                .query(
-                    "SELECT key, value, time, diff FROM data
+        self.transact(move |tx| {
+            Box::pin(async move {
+                let since = match Self::since_tx(tx, collection.id).await?.into_option() {
+                    Some(since) => since,
+                    None => {
+                        return Err(StashError::from(
+                            "cannot iterate collection with empty since frontier",
+                        ));
+                    }
+                };
+                let mut rows = tx
+                    .query(
+                        "SELECT key, value, time, diff FROM data
                     WHERE collection_id = $1",
-                    &[&collection.id],
-                )?
-                .into_iter()
-                .map(|row| {
-                    let key_buf: Vec<_> = row.try_get("key")?;
-                    let value_buf: Vec<_> = row.try_get("value")?;
-                    let key = K::decode(&key_buf)?;
-                    let value = V::decode(&value_buf)?;
-                    let time = row.try_get("time")?;
-                    let diff = row.try_get("diff")?;
-                    Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            differential_dataflow::consolidation::consolidate_updates(&mut rows);
-            Ok(rows)
+                        &[&collection.id],
+                    )
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        let key_buf: Vec<_> = row.try_get("key")?;
+                        let value_buf: Vec<_> = row.try_get("value")?;
+                        let key = K::decode(&key_buf)?;
+                        let value = V::decode(&value_buf)?;
+                        let time = row.try_get("time")?;
+                        let diff = row.try_get("diff")?;
+                        Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                differential_dataflow::consolidation::consolidate_updates(&mut rows);
+                Ok(rows)
+            })
         })
+        .await
     }
 
-    fn iter_key<K, V>(
+    async fn iter_key<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
         key: &K,
     ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
     where
-        K: Codec + Ord,
-        V: Codec + Ord,
+        K: Data,
+        V: Data,
     {
         let mut key_buf = vec![];
         key.encode(&mut key_buf);
-        self.transact(|tx| {
-            let since = match Self::since_tx(tx, collection.id)?.into_option() {
-                Some(since) => since,
-                None => {
-                    return Err(StashError::from(
-                        "cannot iterate collection with empty since frontier",
-                    ));
-                }
-            };
-            let mut rows = tx
-                .query(
-                    "SELECT value, time, diff FROM data
+        self.transact(move |tx| {
+            Box::pin(async move {
+                let since = match Self::since_tx(tx, collection.id).await?.into_option() {
+                    Some(since) => since,
+                    None => {
+                        return Err(StashError::from(
+                            "cannot iterate collection with empty since frontier",
+                        ));
+                    }
+                };
+                let mut rows = tx
+                    .query(
+                        "SELECT value, time, diff FROM data
                     WHERE collection_id = $1 AND key = $2",
-                    &[&collection.id, &key_buf],
-                )?
-                .into_iter()
-                .map(|row| {
-                    let value_buf: Vec<_> = row.try_get("value")?;
-                    let value = V::decode(&value_buf)?;
-                    let time = row.try_get("time")?;
-                    let diff = row.try_get("diff")?;
-                    Ok::<_, StashError>((value, cmp::max(time, since), diff))
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            differential_dataflow::consolidation::consolidate_updates(&mut rows);
-            Ok(rows)
+                        &[&collection.id, &key_buf],
+                    )
+                    .await?
+                    .into_iter()
+                    .map(|row| {
+                        let value_buf: Vec<_> = row.try_get("value")?;
+                        let value = V::decode(&value_buf)?;
+                        let time = row.try_get("time")?;
+                        let diff = row.try_get("diff")?;
+                        Ok::<_, StashError>((value, cmp::max(time, since), diff))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                differential_dataflow::consolidation::consolidate_updates(&mut rows);
+                Ok(rows)
+            })
         })
+        .await
     }
 
-    fn update_many<K: Codec, V: Codec, I>(
+    async fn update_many<K, V, I>(
         &mut self,
         collection: StashCollection<K, V>,
         entries: I,
     ) -> Result<(), StashError>
     where
-        I: IntoIterator<Item = ((K, V), Timestamp, Diff)>,
+        K: Data,
+        V: Data,
+        I: IntoIterator<Item = ((K, V), Timestamp, Diff)> + Send,
+        I::IntoIter: Send,
     {
-        let entries = entries.into_iter().map(|((key, value), time, diff)| {
-            let mut key_buf = vec![];
-            let mut value_buf = vec![];
-            key.encode(&mut key_buf);
-            value.encode(&mut value_buf);
-            ((key_buf, value_buf), time, diff)
-        });
-        self.transact(|tx| Self::update_many_tx(tx, collection.id, entries))
+        let entries = entries
+            .into_iter()
+            .map(|((key, value), time, diff)| {
+                let mut key_buf = vec![];
+                let mut value_buf = vec![];
+                key.encode(&mut key_buf);
+                value.encode(&mut value_buf);
+                ((key_buf, value_buf), time, diff)
+            })
+            .collect::<Vec<_>>();
+
+        self.transact(move |tx| {
+            Box::pin(Self::update_many_tx(tx, collection.id, entries.into_iter()))
+        })
+        .await
     }
 
-    fn seal<K, V>(
+    async fn seal<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
-        new_upper: AntichainRef<Timestamp>,
-    ) -> Result<(), StashError> {
-        self.seal_batch(&[(collection, new_upper.to_owned())])
+        new_upper: AntichainRef<'_, Timestamp>,
+    ) -> Result<(), StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        self.seal_batch(&[(collection, new_upper.to_owned())]).await
     }
 
-    fn seal_batch<K, V>(
+    async fn seal_batch<K, V>(
         &mut self,
         seals: &[(StashCollection<K, V>, Antichain<Timestamp>)],
-    ) -> Result<(), StashError> {
+    ) -> Result<(), StashError>
+    where
+        K: Data,
+        V: Data,
+    {
         let seals = seals
             .iter()
-            .map(|(collection, frontier)| (collection.id, frontier));
-        self.transact(|tx| Self::seal_batch_tx(tx, seals))
+            .map(|(collection, frontier)| (collection.id, frontier.clone()))
+            .collect::<Vec<_>>();
+        self.transact(move |tx| {
+            Box::pin(
+                async move { Self::seal_batch_tx(tx, seals.iter().map(|d| (d.0, &d.1))).await },
+            )
+        })
+        .await
     }
 
-    fn compact<K, V>(
-        &mut self,
+    async fn compact<'a, K, V>(
+        &'a mut self,
         collection: StashCollection<K, V>,
-        new_since: AntichainRef<Timestamp>,
-    ) -> Result<(), StashError> {
+        new_since: AntichainRef<'a, Timestamp>,
+    ) -> Result<(), StashError>
+    where
+        K: Data,
+        V: Data,
+    {
         self.compact_batch(&[(collection, new_since.to_owned())])
+            .await
     }
 
-    fn compact_batch<K, V>(
+    async fn compact_batch<K, V>(
         &mut self,
         compactions: &[(StashCollection<K, V>, Antichain<Timestamp>)],
-    ) -> Result<(), StashError> {
+    ) -> Result<(), StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let compactions = compactions.to_owned();
         self.transact(|tx| {
-            let compact_stmt =
-                tx.prepare("UPDATE sinces SET since = $1 WHERE collection_id = $2")?;
-            for (collection, new_since) in compactions {
-                let since = Self::since_tx(tx, collection.id)?;
-                let upper = Self::upper_tx(tx, collection.id)?;
-                if PartialOrder::less_than(&upper, new_since) {
-                    return Err(StashError::from(format!(
-                        "compact request {} is greater than the current upper frontier {}",
-                        AntichainFormatter(new_since),
-                        AntichainFormatter(&upper)
-                    )));
+            Box::pin(async {
+                let compact_stmt = tx
+                    .prepare("UPDATE sinces SET since = $1 WHERE collection_id = $2")
+                    .await?;
+                for (collection, new_since) in compactions {
+                    let since = Self::since_tx(tx, collection.id).await?;
+                    let upper = Self::upper_tx(tx, collection.id).await?;
+                    if PartialOrder::less_than(&upper, &new_since) {
+                        return Err(StashError::from(format!(
+                            "compact request {} is greater than the current upper frontier {}",
+                            AntichainFormatter(&new_since),
+                            AntichainFormatter(&upper)
+                        )));
+                    }
+                    if PartialOrder::less_than(&new_since, &since) {
+                        return Err(StashError::from(format!(
+                            "compact request {} is less than the current since frontier {}",
+                            AntichainFormatter(&new_since),
+                            AntichainFormatter(&since)
+                        )));
+                    }
+                    tx.execute(&compact_stmt, &[&new_since.as_option(), &collection.id])
+                        .await?;
                 }
-                if PartialOrder::less_than(new_since, &since) {
-                    return Err(StashError::from(format!(
-                        "compact request {} is less than the current since frontier {}",
-                        AntichainFormatter(new_since),
-                        AntichainFormatter(&since)
-                    )));
-                }
-                tx.execute(&compact_stmt, &[&new_since.as_option(), &collection.id])?;
-            }
-            Ok(())
+                Ok(())
+            })
         })
+        .await
     }
 
-    fn consolidate<K, V>(&mut self, collection: StashCollection<K, V>) -> Result<(), StashError> {
-        self.consolidate_batch(&[collection])
+    async fn consolidate<'a, K, V>(
+        &'a mut self,
+        collection: StashCollection<K, V>,
+    ) -> Result<(), StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        self.consolidate_batch(&[collection]).await
     }
 
-    fn consolidate_batch<K, V>(
+    async fn consolidate_batch<K, V>(
         &mut self,
         collections: &[StashCollection<K, V>],
-    ) -> Result<(), StashError> {
+    ) -> Result<(), StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        let collections = collections.to_owned();
         self.transact(|tx| {
-            let consolidation_stmt = tx.prepare(
-                "DELETE FROM data
+            Box::pin(async {
+                let consolidation_stmt = tx
+                    .prepare(
+                        "DELETE FROM data
                 WHERE collection_id = $1 AND time <= $2
                 RETURNING key, value, diff",
-            )?;
-            let insert_stmt = tx.prepare(
-                "INSERT INTO data (collection_id, key, value, time, diff)
+                    )
+                    .await?;
+                let insert_stmt = tx
+                    .prepare(
+                        "INSERT INTO data (collection_id, key, value, time, diff)
                 VALUES ($1, $2, $3, $4, $5)",
-            )?;
-            let drop_stmt = tx.prepare("DELETE FROM data WHERE collection_id = $1")?;
+                    )
+                    .await?;
+                let drop_stmt = tx
+                    .prepare("DELETE FROM data WHERE collection_id = $1")
+                    .await?;
 
-            for collection in collections {
-                let since = Self::since_tx(tx, collection.id)?.into_option();
-                match since {
-                    Some(since) => {
-                        let mut updates = tx
-                            .query(&consolidation_stmt, &[&collection.id, &since])?
-                            .into_iter()
-                            .map(|row| {
-                                let key = row.try_get("key")?;
-                                let value = row.try_get("value")?;
-                                let diff = row.try_get("diff")?;
-                                Ok::<_, StashError>(((key, value), since, diff))
-                            })
-                            .collect::<Result<Vec<((Vec<u8>, Vec<u8>), i64, i64)>, _>>()?;
-                        differential_dataflow::consolidation::consolidate_updates(&mut updates);
-                        for ((key, value), time, diff) in updates {
-                            tx.execute(
-                                &insert_stmt,
-                                &[&collection.id, &key, &value, &time, &diff],
-                            )?;
+                for collection in collections {
+                    let since = Self::since_tx(tx, collection.id).await?.into_option();
+                    match since {
+                        Some(since) => {
+                            let mut updates = tx
+                                .query(&consolidation_stmt, &[&collection.id, &since])
+                                .await?
+                                .into_iter()
+                                .map(|row| {
+                                    let key = row.try_get("key")?;
+                                    let value = row.try_get("value")?;
+                                    let diff = row.try_get("diff")?;
+                                    Ok::<_, StashError>(((key, value), since, diff))
+                                })
+                                .collect::<Result<Vec<((Vec<u8>, Vec<u8>), i64, i64)>, _>>()?;
+                            differential_dataflow::consolidation::consolidate_updates(&mut updates);
+                            for ((key, value), time, diff) in updates {
+                                tx.execute(
+                                    &insert_stmt,
+                                    &[&collection.id, &key, &value, &time, &diff],
+                                )
+                                .await?;
+                            }
+                        }
+                        None => {
+                            tx.execute(&drop_stmt, &[&collection.id]).await?;
                         }
                     }
-                    None => {
-                        tx.execute(&drop_stmt, &[&collection.id])?;
-                    }
                 }
-            }
 
-            Ok(())
+                Ok(())
+            })
         })
+        .await
     }
 
     /// Reports the current since frontier.
-    fn since<K, V>(
+    async fn since<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
-    ) -> Result<Antichain<Timestamp>, StashError> {
-        self.transact(|tx| Self::since_tx(tx, collection.id))
+    ) -> Result<Antichain<Timestamp>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        self.transact(|tx| Box::pin(Self::since_tx(tx, collection.id)))
+            .await
     }
 
     /// Reports the current upper frontier.
-    fn upper<K, V>(
+    async fn upper<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
-    ) -> Result<Antichain<Timestamp>, StashError> {
-        self.transact(|tx| Self::upper_tx(tx, collection.id))
+    ) -> Result<Antichain<Timestamp>, StashError>
+    where
+        K: Data,
+        V: Data,
+    {
+        self.transact(|tx| Box::pin(Self::upper_tx(tx, collection.id)))
+            .await
     }
 }
 
-impl From<postgres::Error> for StashError {
-    fn from(e: postgres::Error) -> StashError {
+impl From<tokio_postgres::Error> for StashError {
+    fn from(e: tokio_postgres::Error) -> StashError {
         StashError {
             inner: InternalStashError::Postgres(e),
         }
     }
 }
 
+#[async_trait]
 impl Append for Postgres {
-    fn append<I>(&mut self, batches: I) -> Result<(), StashError>
+    async fn append<I>(&mut self, batches: I) -> Result<(), StashError>
     where
-        I: IntoIterator<Item = AppendBatch>,
+        I: IntoIterator<Item = AppendBatch> + Send + 'static,
+        I::IntoIter: Send,
     {
-        self.transact(|tx| {
-            for batch in batches {
-                let upper = Self::upper_tx(tx, batch.collection_id)?;
-                if upper != batch.lower {
-                    return Err("unexpected lower".into());
+        self.transact(move |tx| {
+            Box::pin(async move {
+                for batch in batches {
+                    let upper = Self::upper_tx(tx, batch.collection_id).await?;
+                    if upper != batch.lower {
+                        return Err("unexpected lower".into());
+                    }
+                    Self::update_many_tx(tx, batch.collection_id, batch.entries.into_iter())
+                        .await?;
+                    Self::seal_batch_tx(tx, std::iter::once((batch.collection_id, &batch.upper)))
+                        .await?;
                 }
-                Self::update_many_tx(tx, batch.collection_id, batch.entries.into_iter())?;
-                Self::seal_batch_tx(tx, std::iter::once((batch.collection_id, &batch.upper)))?;
-            }
-            Ok(())
+                Ok(())
+            })
         })
+        .await
     }
 }

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -79,8 +79,8 @@ impl Action for VerifyTimestampCompactionAction {
 
                         let mut stash = mz_stash::Sqlite::open(&path.join("storage"))?;
                         let collection = stash
-                            .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}"))?;
-                        let bindings: Vec<(PartitionId, u64, MzOffset)> = stash.iter(collection)?
+                            .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}")).await?;
+                        let bindings: Vec<(PartitionId, u64, MzOffset)> = stash.iter(collection).await?
                             .into_iter()
                             .map(|((pid, _), ts, offset)| {
                                 (


### PR DESCRIPTION
The postgres stash impl can't be used from async code (like the
Coordinator) because the postgres crate is a wrapper around an async
crate, so we have to make the whole stash async instead.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
