### PR TITLE
Fix intermittent test failure caused by UnterminatedLikeEscapeSequence.

### DIFF
--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -216,7 +216,7 @@ pub fn any_matcher() -> impl Strategy<Value = Matcher> {
     // order of its appearance in the regex):
     // * Alphanumeric characters, both upper and lower-case.
     // * Control characters.
-    // * Punctuation.
+    // * Punctuation minus the escape character.
     // * Space characters.
     // * Multi-byte characters.
     // * _ and %, which are special characters for a like pattern.
@@ -226,7 +226,7 @@ pub fn any_matcher() -> impl Strategy<Value = Matcher> {
     // Syntax reference for LIKE here:
     // https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-LIKE
     (
-        r"([[:alnum:]]|[[:cntrl:]]|[[:punct:]]|[[:space:]]|华|_|%|(\\_)|(\\%)|(\\\\)){0, 50}",
+        r"([[:alnum:]]|[[:cntrl:]]|([[[:punct:]]&&[^\\]])|[[:space:]]|华|_|%|(\\_)|(\\%)|(\\\\)){0, 50}",
         bool::arbitrary(),
     )
         .prop_map(|(pattern, case_insensitive)| compile(&pattern, case_insensitive).unwrap())


### PR DESCRIPTION
### Motivation

This PR fixes a bug in randomized test generation.

The test generates a random sequence of characters and compiles it into a LIKE pattern. Occasionally, the random sequence of characters would contain a single `\`, which causes the LIKE pattern compilation to fail to compile. 

Fixes the test by taking the single `\` out of the pool of characters that can be put into the sequence.

Closes #12219.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing changes.
