### PR TITLE
expr: Support MapFilterProject, et al

### DIFF
--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -9,6 +9,7 @@
 
 fn main() {
     prost_build::Config::new()
+        .extern_path(".mz_expr.linear", "::mz_expr")
         .extern_path(".mz_expr.relation", "::mz_expr")
         .extern_path(".mz_expr.scalar", "::mz_expr")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
 import "repr/src/proto.proto";
+import "expr/src/linear.proto";
 import "expr/src/relation.proto";
 
 package mz_dataflow_types.client;
@@ -22,5 +23,5 @@ message ProtoPeek {
     mz_repr.proto.ProtoUuid uuid = 3;
     uint64 timestamp = 4;
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
-    // TODO(lluki): Add MFP once #11970 is in
+    mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
 }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -34,7 +34,7 @@ use crate::{
     sources::{MzOffset, SourceDesc},
     DataflowDescription, PeekResponse, SourceInstanceDesc, TailResponse, Update,
 };
-use mz_expr::{safe_mfp_stub, PartitionId, RowSetFinishing};
+use mz_expr::{PartitionId, RowSetFinishing};
 use mz_repr::{GlobalId, Row};
 
 pub mod controller;
@@ -125,6 +125,7 @@ impl From<&Peek> for ProtoPeek {
             uuid: Some(x.uuid.into_proto()),
             timestamp: x.timestamp,
             finishing: Some((&x.finishing).into()),
+            map_filter_project: Some((&x.map_filter_project).into()),
         }
     }
 }
@@ -142,8 +143,9 @@ impl TryFrom<ProtoPeek> for Peek {
             )?,
             timestamp: x.timestamp,
             finishing: x.finishing.try_into_if_some("ProtoPeek::finishing")?,
-            // TODO(lluki): Replace this function with some TryFrom<Proto..> once #11970 is fixed
-            map_filter_project: safe_mfp_stub(),
+            map_filter_project: x
+                .map_filter_project
+                .try_into_if_some("ProtoPeek::map_filter_project")?,
         })
     }
 }

--- a/src/dataflow-types/src/plan/join.proto
+++ b/src/dataflow-types/src/plan/join.proto
@@ -12,6 +12,7 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
+import "expr/src/linear.proto";
 import "expr/src/scalar.proto";
 
 package mz_dataflow_types.plan.join;
@@ -32,9 +33,7 @@ message ProtoJoinClosureEquivalents {
 }
 message ProtoJoinClosure {
     repeated ProtoMirScalarVec ready_equivalences = 1;
-    // TODO(lluki): Uncomment when #11970 is fixed
-    // ProtoSafeMfpPlan before = 2;
-    google.protobuf.Empty before = 2;
+    mz_expr.linear.ProtoSafeMfpPlan before = 2;
 }
 
 message ProtoLinearStagePlan {

--- a/src/dataflow-types/src/plan/join/mod.rs
+++ b/src/dataflow-types/src/plan/join/mod.rs
@@ -35,7 +35,7 @@ pub mod linear_join;
 
 use std::collections::HashMap;
 
-use mz_repr::proto::TryFromProtoError;
+use mz_repr::proto::{TryFromProtoError, TryIntoIfSome};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -121,8 +121,7 @@ impl TryFrom<ProtoJoinClosure> for JoinClosure {
                 .map(TryFrom::try_from)
                 .collect::<Result<_, TryFromProtoError>>()?,
 
-            // TODO(lluki): Implement me once #11970 is fixed
-            before: mz_expr::safe_mfp_stub(),
+            before: x.before.try_into_if_some("ProtoJoinClosure::before")?,
         })
     }
 }

--- a/src/dataflow-types/src/plan/reduce.proto
+++ b/src/dataflow-types/src/plan/reduce.proto
@@ -12,8 +12,9 @@
 syntax = "proto3";
 
 import "google/protobuf/empty.proto";
-import "expr/src/scalar.proto";
+import "expr/src/linear.proto";
 import "expr/src/relation.proto";
+import "expr/src/scalar.proto";
 
 package mz_dataflow_types.plan.reduce;
 
@@ -89,4 +90,9 @@ message ProtoReductionType {
         google.protobuf.Empty hierarchical = 2;
         google.protobuf.Empty basic = 3;
     }
+}
+
+message ProtoKeyValPlan {
+    mz_expr.linear.ProtoSafeMfpPlan key_plan = 1;
+    mz_expr.linear.ProtoSafeMfpPlan val_plan = 2;
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -793,6 +793,26 @@ pub struct KeyValPlan {
     pub val_plan: mz_expr::SafeMfpPlan,
 }
 
+impl From<&KeyValPlan> for ProtoKeyValPlan {
+    fn from(x: &KeyValPlan) -> Self {
+        Self {
+            key_plan: Some((&x.key_plan).into()),
+            val_plan: Some((&x.key_plan).into()),
+        }
+    }
+}
+
+impl TryFrom<ProtoKeyValPlan> for KeyValPlan {
+    type Error = TryFromProtoError;
+
+    fn try_from(x: ProtoKeyValPlan) -> Result<Self, Self::Error> {
+        Ok(Self {
+            key_plan: x.key_plan.try_into_if_some("ProtoKeyValPlan::key_plan")?,
+            val_plan: x.val_plan.try_into_if_some("ProtoKeyValPlan::val_plan")?,
+        })
+    }
+}
+
 impl KeyValPlan {
     /// Create a new [KeyValPlan] from aggregation arguments.
     pub fn new(

--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -24,6 +24,7 @@ fn main() {
         .compile_protos(
             &[
                 "expr/src/id.proto",
+                "expr/src/linear.proto",
                 "expr/src/relation.proto",
                 "expr/src/relation/func.proto",
                 "expr/src/scalar.proto",

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -24,9 +24,6 @@ mod linear;
 mod relation;
 mod scalar;
 
-// TODO(lluki): Remove me once #11970 is implemented
-pub use linear::plan::safe_mfp_stub;
-
 pub mod explain;
 pub mod visit;
 
@@ -37,7 +34,7 @@ pub use linear::{
     memoize_expr,
     plan::{MfpPlan, SafeMfpPlan},
     util::{join_permutations, permutation_for_arrangement},
-    MapFilterProject,
+    MapFilterProject, ProtoMapFilterProject, ProtoMfpPlan, ProtoSafeMfpPlan,
 };
 pub use relation::func::{AggregateFunc, LagLeadType, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};

--- a/src/expr/src/linear.proto
+++ b/src/expr/src/linear.proto
@@ -1,0 +1,37 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+import "expr/src/scalar.proto";
+
+package mz_expr.linear;
+
+message ProtoMapFilterProject {
+    message ProtoPredicate {
+        uint64 column_to_apply = 1;
+        mz_expr.scalar.ProtoMirScalarExpr predicate = 2;
+    }
+    repeated mz_expr.scalar.ProtoMirScalarExpr expressions = 1;
+    repeated ProtoPredicate predicates = 2;
+    repeated uint64 projection = 3;
+    uint64 input_arity = 4;
+}
+
+message ProtoSafeMfpPlan {
+    ProtoMapFilterProject mfp = 1;
+}
+
+message ProtoMfpPlan {
+    ProtoSafeMfpPlan mfp = 1;
+    repeated mz_expr.scalar.ProtoMirScalarExpr lower_bounds = 2;
+    repeated mz_expr.scalar.ProtoMirScalarExpr upper_bounds = 3;
+}


### PR DESCRIPTION
Translation into and from protobuf is now supported for 
* `KeyValPlan`
* `MapFilterProject`
* `SafeMfpPlan`
* `MfpPlan`

Testing for `MapFilterProject`, `SafeMfpPlan`, and `MfpPlan` is currently done by automatically deriving `Arbitrary`. It doesn't crash on my computer, but I'm not happy with it, and I think we need a custom implementation to get rid of the stack overflow in the `Peek` test. Have not yet tested whether or not the `JoinPlan` test has a stack overflow. 

### Motivation

  * This PR adds a known-desirable feature.
Relates to #11970.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing changes.
