### PR TITLE
doc/developer: correct glitches in cluster replica design

### DIFF
--- a/doc/developer/design/20220413_cluster_replica.md
+++ b/doc/developer/design/20220413_cluster_replica.md
@@ -20,10 +20,10 @@ create_cluster_stmt ::=
     [<inline_replica> [, <inline_replica> ...]]
 
 create_cluster_replica_stmt ::=
-  CREATE CLUSTER REPLICA <name> FOR <cluster>
+  CREATE CLUSTER REPLICA <cluster_name>.<replica_name>
     [<replica_option> [, <replica_option> ...]]
 
-inline_replica ::= REPLICA <name> [<replica_option> [, <replica_option> ...]]
+inline_replica ::= REPLICA <name> [(<replica_option> [, <replica_option> ...])]
 
 replica_option ::=
     | SIZE '<size>'
@@ -49,7 +49,7 @@ command line option.
 The `DROP CLUSTER REPLICA` statement will be added:
 
 ```
-DROP CLUSTER REPLICA [IF EXISTS] <name>
+DROP CLUSTER REPLICA [IF EXISTS] <cluster-name>.<replica-name>
 ```
 
 It will have the usual semantics for a `DROP` operation.


### PR DESCRIPTION
Noticed by @sploiselle in #12132:

  * Inline replica specifications were ambiguous. Fix by requiring
    inline replica options to be wrapped in parenthesis.

  * `DROP CLUSTER REPLICA` did not indicate which cluster's replica to
    drop. Fix by adding a `FOR <cluster>` cluase to the statement.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes bugs in a design doc that were reported in #12132.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
