### PR TITLE
test: don't start prometheus-sql-exporter

### DIFF
--- a/test/chbench/mzcompose.py
+++ b/test/chbench/mzcompose.py
@@ -82,7 +82,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def workflow_load_test(c: Composition) -> None:
     """Run CH-benCHmark with a selected amount of load against Materialize."""
-    c.up("prometheus-sql-exporter")
     c.workflow(
         "default",
         "--peek-conns=1",

--- a/test/perf-kinesis/mzcompose.py
+++ b/test/perf-kinesis/mzcompose.py
@@ -37,7 +37,6 @@ def workflow_default(c: Composition) -> None:
 
 def workflow_load_test(c: Composition) -> None:
     """Run the load generator with a hefty load in the background."""
-    c.up("prometheus-sql-exporter")
     run(c, args=[], detach=True)
 
 


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

    The prometheus-sql-exporter service was removed in #11840, so trying to start it now causes the respective workflows to fail with:

    ```
    ERROR: No such service: prometheus-sql-exporter
    ```

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).
