### PR TITLE
persist: overhaul timeouts, errors, retries

### DIFF
--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -24,7 +24,6 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -753,7 +752,7 @@ struct ReadHandleWrapper<T: Timestamp + Lattice + Codec64> {
 impl<T: Timestamp + Lattice + Codec64> CollectionReadHandle<T> for ReadHandleWrapper<T> {
     async fn downgrade_since(&mut self, since: Antichain<T>) -> Result<(), StorageError> {
         self.read_handle
-            .downgrade_since(Duration::from_secs(60), since)
+            .downgrade_since(since)
             .await
             .map_err(|e| StorageError::ClientError(anyhow!("external persist error: {:?}", e)))?
             .expect("invalid usage");

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -751,12 +751,7 @@ struct ReadHandleWrapper<T: Timestamp + Lattice + Codec64> {
 #[async_trait]
 impl<T: Timestamp + Lattice + Codec64> CollectionReadHandle<T> for ReadHandleWrapper<T> {
     async fn downgrade_since(&mut self, since: Antichain<T>) -> Result<(), StorageError> {
-        self.read_handle
-            .downgrade_since(since)
-            .await
-            .map_err(|e| StorageError::ClientError(anyhow!("external persist error: {:?}", e)))?
-            .expect("invalid usage");
-
+        self.read_handle.downgrade_since(since).await;
         Ok(())
     }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1254,10 +1254,7 @@ pub mod sources {
         /// shard. Returns `None` if this type of connector doesn't write to persist.
         pub async fn get_read_handle<T: Timestamp + Lattice + Codec64>(
             &self,
-        ) -> Result<
-            Option<ReadHandle<Row, Row, T, mz_repr::Diff>>,
-            mz_persist::location::ExternalError,
-        > {
+        ) -> Result<Option<ReadHandle<Row, Row, T, mz_repr::Diff>>, anyhow::Error> {
             let result = match self {
                 SourceConnector::External {
                     connector: ExternalSourceConnector::Persist(persist_connector),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1268,14 +1268,12 @@ pub mod sources {
                         consensus_uri: persist_connector.consensus_uri.clone(),
                     };
 
-                    let timeout = Duration::from_secs(60);
+                    let (blob, consensus) = location.open().await?;
 
-                    let (blob, consensus) = location.open(timeout).await?;
-
-                    let persist_client = PersistClient::new(timeout, blob, consensus).await?;
+                    let persist_client = PersistClient::new(blob, consensus).await?;
 
                     let (_write, read) = persist_client
-                        .open::<Row, Row, T, mz_repr::Diff>(timeout, persist_connector.shard_id)
+                        .open::<Row, Row, T, mz_repr::Diff>(persist_connector.shard_id)
                         .await?;
 
                     Some(read)

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -419,7 +419,7 @@ mod raw_persist_benchmark {
             let (_, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
             let listen = reader
                 .listen(Antichain::from_elem(0))
-                .await?
+                .await
                 .expect("cannot serve requested as_of");
             readers.push(Box::new(listen) as Box<dyn BenchmarkReader + Send + Sync>);
         }
@@ -455,7 +455,7 @@ mod raw_persist_benchmark {
             // record with the record count to avoid having to actually count
             // the number of records..
             let mut count = 0;
-            let events = self.next().await?;
+            let events = self.next().await;
 
             for event in events {
                 if let ListenEvent::Progress(t) = event {

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -85,7 +85,6 @@ struct Args {
     shard_id: Option<String>,
 }
 
-const NO_TIMEOUT: Duration = Duration::from_secs(1_000_000);
 const MIB: u64 = 1024 * 1024;
 
 fn main() {
@@ -115,8 +114,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         blob_uri: args.blob_uri.clone(),
         consensus_uri: args.consensus_uri.clone(),
     };
-    let (blob, consensus) = location.open(NO_TIMEOUT).await?;
-    let persist = PersistClient::new(NO_TIMEOUT, blob, consensus).await?;
+    let (blob, consensus) = location.open().await?;
+    let persist = PersistClient::new(blob, consensus).await?;
 
     let num_records_total = args.records_per_second * args.runtime_seconds;
     let data_generator =
@@ -387,8 +386,6 @@ mod api {
 }
 
 mod raw_persist_benchmark {
-    use std::time::Duration;
-
     use async_trait::async_trait;
     use mz_persist::indexed::columnar::ColumnarRecords;
     use mz_persist_client::read::{Listen, ListenEvent};
@@ -397,7 +394,6 @@ mod raw_persist_benchmark {
     use timely::progress::Antichain;
 
     use crate::api::{BenchmarkReader, BenchmarkWriter};
-    use crate::NO_TIMEOUT;
 
     pub async fn setup_raw_persist(
         persist: PersistClient,
@@ -413,19 +409,15 @@ mod raw_persist_benchmark {
     > {
         let mut writers = vec![];
         for _ in 0..num_writers {
-            let (writer, _) = persist
-                .open::<Vec<u8>, Vec<u8>, u64, i64>(NO_TIMEOUT, id)
-                .await?;
+            let (writer, _) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
 
             writers.push(Box::new(writer) as Box<dyn BenchmarkWriter + Send + Sync>);
         }
 
         let mut readers = vec![];
         for _ in 0..num_readers {
-            let (_, reader) = persist
-                .open::<Vec<u8>, Vec<u8>, u64, i64>(NO_TIMEOUT, id)
-                .await?;
-            let listen = reader.listen(NO_TIMEOUT, Antichain::from_elem(0)).await??;
+            let (_, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
+            let listen = reader.listen(Antichain::from_elem(0)).await??;
             readers.push(Box::new(listen) as Box<dyn BenchmarkReader + Send + Sync>);
         }
 
@@ -445,7 +437,7 @@ mod raw_persist_benchmark {
             let batch = batch
                 .iter()
                 .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d));
-            self.append(NO_TIMEOUT, batch, new_upper)
+            self.append(batch, new_upper)
                 .await??
                 .expect("invalid current upper");
 
@@ -460,9 +452,7 @@ mod raw_persist_benchmark {
             // record with the record count to avoid having to actually count
             // the number of records..
             let mut count = 0;
-            // TODO: setting a smaller deadline (of say 1 second), causes failures
-            // sometimes.
-            let events = self.next(Duration::from_millis(100_000)).await?;
+            let events = self.next().await?;
 
             for event in events {
                 if let ListenEvent::Progress(t) = event {

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -121,7 +121,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let data_generator =
         DataGenerator::new(num_records_total, args.record_size_bytes, args.batch_size);
     let shard_id = match args.shard_id {
-        Some(shard_id) => ShardId::from_str(&shard_id)?,
+        Some(shard_id) => ShardId::from_str(&shard_id).map_err(anyhow::Error::msg)?,
         None => ShardId::new(),
     };
     let (writers, readers) = match args.benchmark_type {
@@ -417,7 +417,10 @@ mod raw_persist_benchmark {
         let mut readers = vec![];
         for _ in 0..num_readers {
             let (_, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
-            let listen = reader.listen(Antichain::from_elem(0)).await??;
+            let listen = reader
+                .listen(Antichain::from_elem(0))
+                .await?
+                .expect("cannot serve requested as_of");
             readers.push(Box::new(listen) as Box<dyn BenchmarkReader + Send + Sync>);
         }
 

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -9,39 +9,104 @@
 
 //! Errors for the crate
 
-use mz_persist::location::SeqNo;
+use std::fmt::Debug;
+
+use mz_persist::location::ExternalError;
+use timely::progress::Antichain;
+
+use crate::ShardId;
+
+/// An indication of whether the given error type indicates an operation
+/// _definitely_ failed or if it _maybe_ failed.
+///
+/// This is more commonly called definite and indefinite, but "definite" already
+/// means something very specific within Materialize.
+pub trait Determinacy {
+    /// Whether errors of this type are determinate or indeterminate.
+    ///
+    /// True indicates a determinate error: one where the operation definitely
+    /// failed.
+    ///
+    /// False indicates an indeterminate error: one where the operation may have
+    /// failed, but may have succeeded (the most common example being a
+    /// timeout).
+    const DETERMINANT: bool;
+}
+
+// TODO: Some ExternalErrors actually are determinate (e.g. Postgres errors on
+// txn conflict). We should split it so that these operations can be retried in
+// more places.
+impl Determinacy for ExternalError {
+    const DETERMINANT: bool = false;
+}
 
 /// An error resulting from invalid usage of the API.
 #[derive(Debug)]
-pub struct InvalidUsage(pub anyhow::Error);
+#[cfg_attr(test, derive(PartialEq))]
+pub enum InvalidUsage<T> {
+    /// Append bounds were invalid
+    InvalidBounds {
+        /// The given lower bound
+        lower: Antichain<T>,
+        /// The given upper bound
+        upper: Antichain<T>,
+    },
+    /// An update was not within valid bounds
+    UpdateNotWithinBounds {
+        /// Timestamp of the update
+        ts: T,
+        /// The given lower bound
+        lower: Antichain<T>,
+        /// The given upper bound
+        upper: Antichain<T>,
+    },
+    /// A [crate::read::SnapshotSplit] was given to
+    /// [crate::read::ReadHandle::snapshot_iter] from a different shard
+    SnapshotNotFromThisShard {
+        /// The shard of the snapshot
+        snapshot_shard: ShardId,
+        /// The shard of the handle
+        handle_shard: ShardId,
+    },
+    /// The requested codecs don't match the actual ones in durable storage.
+    CodecMismatch {
+        /// The requested (K, V, T, D) codecs.
+        requested: (String, String, String, String),
+        /// The actual (K, V, T, D) codecs in durable storage.
+        actual: (String, String, String, String),
+    },
+}
 
-impl std::fmt::Display for InvalidUsage {
+impl<T: Debug> std::fmt::Display for InvalidUsage<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid usage: {}", self.0)
+        match self {
+            InvalidUsage::InvalidBounds { lower, upper } => {
+                write!(f, "invalid bounds [{:?}, {:?})", lower, upper)
+            }
+            InvalidUsage::UpdateNotWithinBounds { ts, lower, upper } => write!(
+                f,
+                "timestamp {:?} not with bounds [{:?}, {:?})",
+                ts, lower, upper
+            ),
+            InvalidUsage::SnapshotNotFromThisShard {
+                snapshot_shard,
+                handle_shard,
+            } => write!(
+                f,
+                "snapshot was from {} not {}",
+                snapshot_shard, handle_shard
+            ),
+            InvalidUsage::CodecMismatch { requested, actual } => write!(
+                f,
+                "requested codecs {:?} did not match ones in durable storage {:?}",
+                requested, actual
+            ),
+        }
     }
 }
 
-impl std::error::Error for InvalidUsage {}
+impl<T: Debug> std::error::Error for InvalidUsage<T> {}
 
-/// An impl of PartialEq purely for convenience in tests and debug assertions.
-#[cfg(test)]
-impl PartialEq for InvalidUsage {
-    fn eq(&self, other: &Self) -> bool {
-        self.to_string() == other.to_string()
-    }
+impl<T> Determinacy for InvalidUsage<T> {
+    const DETERMINANT: bool = true;
 }
-
-/// A sentinel indicating that a state transition was a no-op.
-#[derive(Debug)]
-pub struct NoOp {
-    /// The version of the state at which the input was evaluated to be a no-op.
-    pub seqno: SeqNo,
-}
-
-impl std::fmt::Display for NoOp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "no-op: {:?}", self.seqno)
-    }
-}
-
-impl std::error::Error for NoOp {}

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -11,7 +11,6 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 
 use anyhow::anyhow;
 use url::Url;
@@ -33,15 +32,12 @@ pub enum BlobMultiConfig {
 
 impl BlobMultiConfig {
     /// Opens the associated implementation of [BlobMulti].
-    pub async fn open(
-        self,
-        deadline: Instant,
-    ) -> Result<Arc<dyn BlobMulti + Send + Sync>, ExternalError> {
+    pub async fn open(self) -> Result<Arc<dyn BlobMulti + Send + Sync>, ExternalError> {
         match self {
-            BlobMultiConfig::File(config) => FileBlobMulti::open(deadline, config)
+            BlobMultiConfig::File(config) => FileBlobMulti::open(config)
                 .await
                 .map(|x| Arc::new(x) as Arc<dyn BlobMulti + Send + Sync>),
-            BlobMultiConfig::S3(config) => S3BlobMulti::open(deadline, config)
+            BlobMultiConfig::S3(config) => S3BlobMulti::open(config)
                 .await
                 .map(|x| Arc::new(x) as Arc<dyn BlobMulti + Send + Sync>),
         }
@@ -106,10 +102,7 @@ pub enum ConsensusConfig {
 
 impl ConsensusConfig {
     /// Opens the associated implementation of [Consensus].
-    pub async fn open(
-        self,
-        _deadline: Instant,
-    ) -> Result<Arc<dyn Consensus + Send + Sync>, ExternalError> {
+    pub async fn open(self) -> Result<Arc<dyn Consensus + Send + Sync>, ExternalError> {
         match self {
             ConsensusConfig::Sqlite(config) => SqliteConsensus::open(config)
                 .map(|x| Arc::new(x) as Arc<dyn Consensus + Send + Sync>),

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -532,7 +532,7 @@ pub struct FileBlobMulti {
 
 impl FileBlobMulti {
     /// Opens the given location for non-exclusive read-write access.
-    pub async fn open(_deadline: Instant, config: FileBlobConfig) -> Result<Self, ExternalError> {
+    pub async fn open(config: FileBlobConfig) -> Result<Self, ExternalError> {
         let base_dir = config.base_dir;
         fs::create_dir_all(&base_dir).map_err(Error::from)?;
         let core = FileBlobCore {
@@ -606,8 +606,6 @@ fn file_storage_lock(lockfile_path: &Path, new_lock: LockInfo) -> Result<File, E
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use crate::location::tests::{blob_impl_test, blob_multi_impl_test, log_impl_test};
 
     use super::*;
@@ -631,11 +629,10 @@ mod tests {
 
     #[tokio::test]
     async fn file_blob_multi() -> Result<(), ExternalError> {
-        let no_timeout = Instant::now() + Duration::from_secs(1_000_000);
         let temp_dir = tempfile::tempdir().map_err(Error::from)?;
         blob_multi_impl_test(move |path| {
             let instance_dir = temp_dir.path().join(path);
-            FileBlobMulti::open(no_timeout, instance_dir.into())
+            FileBlobMulti::open(instance_dir.into())
         })
         .await
     }

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -146,7 +146,7 @@ impl std::fmt::Display for ExternalError {
 impl std::error::Error for ExternalError {}
 
 /// An impl of PartialEq purely for convenience in tests and debug assertions.
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 impl PartialEq for ExternalError {
     fn eq(&self, other: &Self) -> bool {
         self.to_string() == other.to_string()

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -685,7 +685,7 @@ pub fn plan_create_source(
             let connector = ExternalSourceConnector::Persist(PersistSourceConnector {
                 consensus_uri: consensus_uri.clone(),
                 blob_uri: blob_uri.clone(),
-                shard_id: collection_id.parse()?,
+                shard_id: collection_id.parse().map_err(anyhow::Error::msg)?,
             });
 
             (
@@ -2222,7 +2222,7 @@ fn persist_sink_builder(
     Ok(SinkConnectorBuilder::Persist(PersistSinkConnectorBuilder {
         consensus_uri,
         blob_uri,
-        shard_id: shard_id.parse()?,
+        shard_id: shard_id.parse().map_err(anyhow::Error::msg)?,
         value_desc,
     }))
 }

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -13,7 +13,7 @@ use std::any::Any;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use futures_util::Stream as FuturesStream;
 use timely::dataflow::operators::{Concat, Map, OkErr};
@@ -73,42 +73,40 @@ where
             return;
         }
 
-        let timeout = Duration::from_secs(60);
-
         let persist_location = PersistLocation {
             consensus_uri: consensus_uri,
             blob_uri: blob_uri,
         };
 
-        let (blob, consensus) = persist_location.open(timeout).await?;
+        let (blob, consensus) = persist_location.open().await?;
 
         let persist_client =
-            PersistClient::new(timeout, blob, consensus).await?;
+            PersistClient::new(blob, consensus).await?;
 
 
         let (_write, read) =
-            persist_client.open::<Row, Row, Timestamp, Diff>(timeout, shard_id).await?;
+            persist_client.open::<Row, Row, Timestamp, Diff>(shard_id).await?;
 
             let mut snapshot_iter = read
-                .snapshot(timeout, as_of.clone())
+                .snapshot(as_of.clone())
                 .await?
                 .expect("invalid usage");
 
 
             // First, yield all the updates from the snapshot.
-            while let Some(next) = snapshot_iter.next(timeout).await? {
+            while let Some(next) = snapshot_iter.next().await? {
                 yield ListenEvent::Updates(next);
             }
 
             // Then, listen continously and yield any new updates. This loop is expected to never
             // finish.
             let mut listen = read
-                .listen(timeout, as_of)
+                .listen(as_of)
                 .await?
                 .expect("invalid usage");
 
             loop {
-                let next = listen.next(timeout).await?;
+                let next = listen.next().await?;
                 for event in next {
                     yield event;
                 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -474,8 +474,7 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                 .expect("Reported frontier missing!");
 
             // TODO: Make these parts of the code async?
-            let observed_frontier =
-                futures_executor::block_on(write_handle.fetch_recent_upper()).unwrap();
+            let observed_frontier = futures_executor::block_on(write_handle.fetch_recent_upper());
 
             // Only do a thing if it *advances* the frontier, not just *changes* the frontier.
             // This is protection against `frontier` lagging behind what we have conditionally reported.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -221,20 +221,16 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                                 consensus_uri: persist_connector.consensus_uri.clone(),
                             };
 
-                            let timeout = Duration::from_secs(60);
-
                             // TODO: Make these parts async aware?
                             let (blob, consensus) =
-                                futures_executor::block_on(location.open(timeout)).unwrap();
+                                futures_executor::block_on(location.open()).unwrap();
 
-                            let persist_client = futures_executor::block_on(PersistClient::new(
-                                timeout, blob, consensus,
-                            ))
-                            .unwrap();
+                            let persist_client =
+                                futures_executor::block_on(PersistClient::new(blob, consensus))
+                                    .unwrap();
 
                             let (write, _read) = futures_executor::block_on(
                                 persist_client.open::<Row, Row, mz_repr::Timestamp, mz_repr::Diff>(
-                                    timeout,
                                     persist_connector.shard_id,
                                 ),
                             )
@@ -478,10 +474,8 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                 .expect("Reported frontier missing!");
 
             // TODO: Make these parts of the code async?
-            let observed_frontier = futures_executor::block_on(
-                write_handle.fetch_recent_upper(Duration::from_secs(60)),
-            )
-            .unwrap();
+            let observed_frontier =
+                futures_executor::block_on(write_handle.fetch_recent_upper()).unwrap();
 
             // Only do a thing if it *advances* the frontier, not just *changes* the frontier.
             // This is protection against `frontier` lagging behind what we have conditionally reported.


### PR DESCRIPTION
See individual commits for details.

Summary:
- persist methods no longer have timeouts and instead retry indefinitely. Instead, persist Futures offer "cancel on drop" semantic and users are free to wrap them in tokio::time::timeout.
- persist now returns ExternalError in only a few exceptional places, most notably WriteHandle::compare_and_append. This is because WriteHandle::compare_and_append is not always safe to retry depending on the usage pattern. We should be able to structure timestamp binding, source, and sink code so it's always safe to retry, but SQL txns will have to pass the error back to the user (or risk double committing the txn). Once we introduce a determinate/indeterminate split for ExternalError, WriteHandle::compare_and_append could also retry determinate errors and only send back indeterminate ones (the opposite of Location::open).
- InvalidUsage is now statically derivable from arguments. It should be safe for well-behaved users to `.expect("invalid persist usage")` on InvalidUsage.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

This diff is big here, but it should be straightforward to review this commit by commit.

We could also move the InvalidUsage panic inside persist, but I didn't here because errors make our tests easier. I'm willing to revisit this if others feel strongly.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
