### PR TITLE
persist: fix two "disk" leaks

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -267,13 +267,13 @@ mod tests {
 
     use super::*;
 
-    async fn new_test_client() -> Result<PersistClient, ExternalError> {
+    pub async fn new_test_client() -> Result<PersistClient, ExternalError> {
         let blob = Arc::new(MemBlobMulti::open(MemBlobMultiConfig::default()));
         let consensus = Arc::new(MemConsensus::default());
         PersistClient::new(NO_TIMEOUT, blob, consensus).await
     }
 
-    fn all_ok<'a, K, V, T, D, I>(
+    pub fn all_ok<'a, K, V, T, D, I>(
         iter: I,
         as_of: T,
     ) -> Vec<((Result<K, String>, Result<V, String>), T, D)>


### PR DESCRIPTION
Context: Petros had persist running overnight and woke up to 80GB in
Consensus and 41,000 blobs. The workload was committing 1 batch per
second (so perhaps 18 hours = 1 second = 64,800), most of them empty to
a single shard.

There are two bugs contributing to this, both of which are fixed here:

- Some of the original implementations of Consensus cleaned up after
  themselves by internally truncating everything less than X right after
  they committed X. They stopped doing this when the PR to add truncate
  and scan to Consensus got merged, but nothing was added at the time to
  replace them. This commit adds a truncate in apply_unbatched_cmd that
  removes everything but the most recent. We'll want to something else
  once we get to incremental state, but this is good enough for now.
- We write out blobs, even when they are empty. There's a fair amount of
  overhead in our Parquet-based format for updates. Additionally, for
  persist shards powering low-traffic sources, the overwhelming majority
  of batches will be empty because they're simply communicating
  progress. As a result, it's worthwhile to special case them. We
  already store blob keys for batches as a Vec to accommodate multiple
  parts (they're capped at 2GiB per columnar file), so it's a trivial
  optimization to avoid writing out the blob and store an empty list of
  keys in metadata.

After these two fixes, a test writing 64_800 batches, mostly empty but
with 1KiB of data every 1_000, into file blob and sqlite consensus used
260KB (66 files, exactly one per batch) in blob and 7.0MB in consensus.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
