### PR TITLE
[persist] use std::sync::mutex in sqlite impl

### DIFF
--- a/src/persist/src/sqlite.rs
+++ b/src/persist/src/sqlite.rs
@@ -19,6 +19,7 @@ use rusqlite::types::{FromSql, FromSqlError, ToSql, ToSqlOutput, Value, ValueRef
 use rusqlite::{named_params, params, Connection, Error as SqliteError, OptionalExtension};
 use std::sync::Mutex;
 
+use crate::error::Error as PersistError;
 use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
 
 const APPLICATION_ID: i32 = 0x0678_ef32; // chosen randomly
@@ -96,7 +97,7 @@ impl Consensus for SqliteConsensus {
         _deadline: Instant,
         key: &str,
     ) -> Result<Option<VersionedData>, ExternalError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(PersistError::from)?;
         let mut stmt = conn.prepare(
             "SELECT sequence_number, data FROM consensus
                  WHERE shard = $shard ORDER BY sequence_number DESC LIMIT 1",
@@ -126,7 +127,7 @@ impl Consensus for SqliteConsensus {
         }
 
         let result = if let Some(expected) = expected {
-            let conn = self.conn.lock().unwrap();
+            let conn = self.conn.lock().map_err(PersistError::from)?;
 
             // Only insert the new row if:
             // - sequence number expected is already present
@@ -152,7 +153,7 @@ impl Consensus for SqliteConsensus {
                 "$expected": expected,
             })?
         } else {
-            let conn = self.conn.lock().unwrap();
+            let conn = self.conn.lock().map_err(PersistError::from)?;
 
             // Insert the new row as long as no other row exists for the same shard.
             let mut stmt = conn.prepare_cached(
@@ -189,7 +190,7 @@ impl Consensus for SqliteConsensus {
         key: &str,
         from: SeqNo,
     ) -> Result<Vec<VersionedData>, ExternalError> {
-        let conn = self.conn.lock().unwrap();
+        let conn = self.conn.lock().map_err(PersistError::from)?;
         let mut stmt = conn.prepare_cached(
             "SELECT sequence_number, data FROM consensus
                  WHERE shard = $shard AND sequence_number >= $from
@@ -220,7 +221,7 @@ impl Consensus for SqliteConsensus {
         seqno: SeqNo,
     ) -> Result<(), ExternalError> {
         let result = {
-            let conn = self.conn.lock().unwrap();
+            let conn = self.conn.lock().map_err(PersistError::from)?;
             let mut stmt = conn.prepare_cached(
             "DELETE FROM consensus
              WHERE shard = $shard AND sequence_number < $sequence_number AND

--- a/src/persist/src/sqlite.rs
+++ b/src/persist/src/sqlite.rs
@@ -62,6 +62,7 @@ impl FromSql for SeqNo {
 /// Implementation of [Consensus] over a sqlite database.
 #[derive(Debug)]
 pub struct SqliteConsensus {
+    // N.B. tokio::sync::mutex seems to cause deadlocks.  See #12231.
     conn: Arc<Mutex<Connection>>,
 }
 


### PR DESCRIPTION
I'm hitting a hang while working on #11911.  I'm not able to quite work out why (seems to happen under heavy load, I can't find a place where the lock guard isn't dropped -- so it just seems like sometimes it just can't acquire the lock) but it does happen pretty reliably

### Motivation
  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] Existing tests should be sufficient

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - hopefully not!