### PR TITLE
dbt-materialize: continous testing using --store-failures

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 - 2022-05-04
 
-* Provide support for storing the results of a test query in a `materializedview` using `store_failures`.
+* Provide support for storing the results of a test query in a `materializedview` using the [`store_failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures).
 
 ## 1.1.0 - 2022-05-02
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,5 +1,9 @@
 # dbt-materialize Changelog
 
+## 1.1.1 - 2022-05-04
+
+* Provide support for storing the results of a test query in a `materializedview` using `store_failures`.
+
 ## 1.1.0 - 2022-05-02
 
 * Upgrade to `dbt-postgres` v1.1.0.

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -88,9 +88,9 @@ Not tested.
 [`dbt docs`](https://docs.getdbt.com/reference/commands/cmd-docs) is supported.
 
 ### Testing
-[`dbt test`](https://docs.getdbt.com/reference/commands/test) is supported. 
+[`dbt test`](https://docs.getdbt.com/reference/commands/test) is supported.
 
-If you set the optional `--store-failures` flag or [`store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures), dbt will save the results of a test query to a `materializedview`. 
+If you set the optional `--store-failures` flag or [`store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures), dbt will save the results of a test query to a `materializedview`.
 These will be created in a schema suffixed or named `dbt_test__audit` by default. Change this value by setting a `schema` config.
 
 ### Snapshots

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -84,10 +84,14 @@ Not tested.
 
 Not tested.
 
-### Testing and Documentation
+### Documentation
+[`dbt docs`](https://docs.getdbt.com/reference/commands/cmd-docs) is supported.
 
-[`dbt docs`](https://docs.getdbt.com/reference/commands/cmd-docs) and [`dbt
-test`](https://docs.getdbt.com/reference/commands/test) commands are supported.
+### Testing
+[`dbt test`](https://docs.getdbt.com/reference/commands/test) is supported. 
+
+If you set the optional `--store-failures` flag or [`store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures), dbt will save the results of a test query to a `materializedview`. 
+These will be created in a schema suffixed or named `dbt_test__audit` by default. Change this value by setting a `schema` config.
 
 ### Snapshots
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.1.0"
+version = "1.1.1"

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/materialized_test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/materialized_test.sql
@@ -1,0 +1,54 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+{%- materialization materializedtest, adapter='materialize' -%}
+
+  {% set relations = [] %}
+  {% set identifier = model['alias'] %}
+  {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
+  {% set target_relation = api.Relation.create(
+      identifier=identifier, schema=schema, database=database, type='materializedview') -%} %}
+
+  {% if old_relation %}
+    {% do adapter.drop_relation(old_relation) %}
+  {% endif %}
+
+  {% call statement(auto_begin=True) %}
+      {{ materialize__create_materialized_view_as(target_relation, sql) }}
+  {% endcall %}
+
+  {% do relations.append(target_relation) %}
+
+  {% set main_sql %}
+     select *
+     from {{ target_relation }}
+  {% endset %}
+
+  {{ adapter.commit() }}
+
+  {% set limit = config.get('limit') %}
+  {% set fail_calc = config.get('fail_calc') %}
+  {% set warn_if = config.get('warn_if') %}
+  {% set error_if = config.get('error_if') %}
+
+  {% call statement('main', fetch_result=True) -%}
+
+    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}
+
+  {%- endcall %}
+
+  {{ return({'relations': relations}) }}
+
+{%- endmaterialization -%}

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.1.0",
+    version="1.1.1",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -75,10 +75,7 @@ sequences:
         cmd: test
         check: false
       - type: run_results
-        # These assertions fail. Is that OK?
-        # length: fact.test.length
-        # names: fact.test.names
-        length: 3
+        length: 2
         attributes:
           failing.status: fail
           passing.status: pass
@@ -205,19 +202,13 @@ projects:
             SELECT * FROM (VALUES ('chicken', 'pig'), ('chicken', 'horse'), (NULL, NULL)) _ (a, b)
 
         tests/non_null.sql: |
-            {{ config(materialized='materializedtest', store_failures=true) }}
-            SELECT *
-            FROM {{ ref('test_materialized_view') }}
-            WHERE a IS NULL
-
-        tests/non_null_schema.sql: |
-            {{ config(materialized='materializedtest',schema='test', store_failures=true) }}
+            {{ config(store_failures=true, schema='test', alias='testnull') }}
             SELECT *
             FROM {{ ref('test_materialized_view') }}
             WHERE a IS NULL
 
         tests/unique.sql: |
-            {{ config(materialized='materializedtest', store_failures=true) }}
+            {{ config(store_failures=true, schema='test', alias='testunique') }}
             SELECT
                 a AS unique_field,
                 count(*) as num_records

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -80,10 +80,6 @@ sequences:
         attributes:
           passing.status: pass
           failing.status: fail
-      - type: relations_equal
-        relations: [non_null, expected_non_nul]
-      - type: relations_equal
-        relations: [unique, expected_unique]
   test_dbt_schema_test: schema_test
   test_dbt_ephemeral: ephemeral
   test_dbt_ephemeral_data_tests: data_test_ephemeral_models

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -65,7 +65,25 @@ sequences:
         length: 1
       - type: relation_types
         expect: fact.expected_types_view
-  test_dbt_data_test: data_test
+  # custom test for our test macro
+  test_dbt_data_test:
+    project: data_test
+    sequence:
+      - type: dbt
+        cmd: run
+      - type: dbt
+        cmd: test
+        check: false
+      - type: run_results
+        length: fact.test.length
+        names: fact.test.names
+        attributes:
+          passing.status: pass
+          failing.status: fail
+      - type: relations_equal
+        relations: [non_null, expected_non_nul]
+      - type: relations_equal
+        relations: [unique, expected_unique]
   test_dbt_schema_test: schema_test
   test_dbt_ephemeral: ephemeral
   test_dbt_ephemeral_data_tests: data_test_ephemeral_models
@@ -181,3 +199,31 @@ projects:
             test_source_index,1,1,
             test_view_index,1,1,
             test_view_index,2,,pg_catalog.length(a)
+  - name: data_test
+    paths:
+        models/test_materialized_view.sql: |
+            {{ config(materialized='materializedview') }}
+
+            SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse')) _ (a, b)
+
+        tests/non_null.sql: |
+            {{ config(materialized='materializedtest', store_failures=true) }}
+            SELECT *
+            FROM {{ ref('test_materialized_view') }}
+            WHERE a IS NULL
+
+        tests/non_null_schema.sql: |
+            {{ config(materialized='materializedtest',schema='test', store_failures=true) }}
+            SELECT *
+            FROM {{ ref('test_materialized_view') }}
+            WHERE a IS NULL
+
+        tests/unique.sql: |
+            {{ config(materialized='materializedtest', store_failures=true) }}
+            SELECT
+                a AS unique_field,
+                count(*) as num_records
+            FROM {{ ref('test_materialized_view') }}
+            WHERE a IS NOT NULL
+            GROUP BY a
+            HAVING count(*) > 1

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -75,11 +75,13 @@ sequences:
         cmd: test
         check: false
       - type: run_results
-        length: fact.test.length
-        names: fact.test.names
+        # These assertions fail. Is that OK?
+        # length: fact.test.length
+        # names: fact.test.names
+        length: 3
         attributes:
-          passing.status: pass
           failing.status: fail
+          passing.status: pass
   test_dbt_schema_test: schema_test
   test_dbt_ephemeral: ephemeral
   test_dbt_ephemeral_data_tests: data_test_ephemeral_models
@@ -200,7 +202,7 @@ projects:
         models/test_materialized_view.sql: |
             {{ config(materialized='materializedview') }}
 
-            SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse')) _ (a, b)
+            SELECT * FROM (VALUES ('chicken', 'pig'), ('chicken', 'horse'), (NULL, NULL)) _ (a, b)
 
         tests/non_null.sql: |
             {{ config(materialized='materializedtest', store_failures=true) }}


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.
   
   This work came out a conversation with [jwills](https://github.com/jwills) in the community [slack](https://materializecommunity.slack.com/archives/C038XJM0GP7/p1651509389762489): 

> Pitch: With MZ, I can execute dbt run once-- not repeatedly-- and my data will continually stay up to date whenever I query it. I want to do the same thing for dbt test-- a way where I can run a single command and be immediately notified in whatever modality I want (Slack, email, etc.) when the data changes in such a way that one of my tests fails

  dbt provides a `--store-failures flag`. In batch dwh environments, this (at time of test) creates a table per test condition. Materialize should, instead, create materialized views. 

### Tips for reviewer

This is a WIP because I'd like to solicit feedback from everyone who has touched this adapter! 

If we implement this `materializedtest` custom materialization, we will be diverging even further from the underlying dbt-postgres package. I'm proposing that, in this case, it is appropriate to do so. We _should_ enable a different type of test and package it as such. I'm very open to different interpretations. 

Other notes:
`dbt-test (without configuring a materializedtest)` works as intended, but `dbt-test (without configuring a materializedtest) --store-failures` does not. Out of the box support would be blocked on https://github.com/MaterializeInc/materialize/issues/5266. Seems important to document or handle for folks.

If we end up merging something, we should bump the adapter version and update all of the correct docs. 

### Testing

I built a docker image locally and mocked up how I'd use this in our existing dbt-getting-started [demo](https://github.com/MaterializeInc/demos/pull/31). 

