### PR TITLE
dataflow-types: Protobuf support for DataflowDescription.

### DIFF
--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -9,12 +9,14 @@
 
 fn main() {
     prost_build::Config::new()
+        .extern_path(".mz_expr.id", "::mz_expr")
         .extern_path(".mz_expr.linear", "::mz_expr")
         .extern_path(".mz_expr.relation", "::mz_expr")
         .extern_path(".mz_expr.scalar", "::mz_expr")
-        .extern_path(".mz_expr.id", "::mz_expr")
+        .extern_path(".mz_persist.gen.persist", "::mz_persist::gen::persist")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.proto", "::mz_repr::proto")
+        .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.row", "::mz_repr")
         .type_attribute(
             ".mz_dataflow_types.postgres_source",
@@ -23,6 +25,7 @@ fn main() {
         .compile_protos(
             &[
                 "dataflow-types/src/client.proto",
+                "dataflow-types/src/client/controller/storage.proto",
                 "dataflow-types/src/errors.proto",
                 "dataflow-types/src/logging.proto",
                 "dataflow-types/src/postgres_source.proto",
@@ -32,6 +35,7 @@ fn main() {
                 "dataflow-types/src/plan/reduce.proto",
                 "dataflow-types/src/plan/threshold.proto",
                 "dataflow-types/src/plan/top_k.proto",
+                "dataflow-types/src/types.proto",
             ],
             &[".."],
         )

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -30,6 +30,7 @@ use tracing::trace;
 use uuid::Uuid;
 
 use mz_expr::{PartitionId, RowSetFinishing};
+use mz_repr::proto::any_uuid;
 use mz_repr::{GlobalId, Row};
 
 use crate::logging::LoggingConfig;
@@ -103,10 +104,6 @@ pub struct Peek<T = mz_repr::Timestamp> {
     pub finishing: RowSetFinishing,
     /// Linear operation to apply in-line on each result.
     pub map_filter_project: mz_expr::SafeMfpPlan,
-}
-
-fn any_uuid() -> impl Strategy<Value = Uuid> {
-    (0..u128::MAX).prop_map(Uuid::from_u128)
 }
 
 impl From<&Peek> for ProtoPeek {

--- a/src/dataflow-types/src/client/controller/storage.proto
+++ b/src/dataflow-types/src/client/controller/storage.proto
@@ -1,0 +1,18 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+package mz_dataflow_types.client.controller.storage;
+
+message ProtoCollectionMetadata {
+    // TODO fill this out
+}

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -28,6 +28,7 @@ use std::path::PathBuf;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
+use mz_repr::proto::TryFromProtoError;
 use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::MutableAntichain;
@@ -49,6 +50,11 @@ use crate::client::{
 };
 use crate::sources::SourceDesc;
 use crate::Update;
+
+include!(concat!(
+    env!("OUT_DIR"),
+    "/mz_dataflow_types.client.controller.storage.rs"
+));
 
 #[async_trait]
 pub trait StorageController: Debug + Send {
@@ -140,6 +146,27 @@ pub trait StorageController: Debug + Send {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CollectionMetadata {
     pub persist_location: PersistLocation,
+}
+
+impl From<&CollectionMetadata> for ProtoCollectionMetadata {
+    // TODO: This is just a stub.
+    fn from(_: &CollectionMetadata) -> Self {
+        ProtoCollectionMetadata {}
+    }
+}
+
+impl TryFrom<ProtoCollectionMetadata> for CollectionMetadata {
+    // TODO: This is just a stub.
+    type Error = TryFromProtoError;
+
+    fn try_from(_value: ProtoCollectionMetadata) -> Result<Self, Self::Error> {
+        Ok(CollectionMetadata {
+            persist_location: PersistLocation {
+                blob_uri: "".to_string(),
+                consensus_uri: "".to_string(),
+            },
+        })
+    }
 }
 
 /// Controller state maintained for each storage instance.

--- a/src/dataflow-types/src/types.proto
+++ b/src/dataflow-types/src/types.proto
@@ -1,0 +1,74 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// See https://developers.google.com/protocol-buffers for what's going on here.
+
+syntax = "proto3";
+
+import "dataflow-types/src/client/controller/storage.proto";
+import "dataflow-types/src/plan.proto";
+import "expr/src/scalar.proto";
+import "persist/src/persist.proto";
+import "repr/src/global_id.proto";
+import "repr/src/proto.proto";
+import "repr/src/relation_and_scalar.proto";
+
+package mz_dataflow_types.types;
+
+message ProtoDataflowDescription {
+    message ProtoSourceImport {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        ProtoSourceInstanceDesc source_instance_desc = 2;
+    }
+
+    message ProtoIndex{
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        ProtoIndexDesc index_desc = 2;
+        mz_repr.relation_and_scalar.ProtoRelationType typ = 3;
+    }
+
+    message ProtoSinkExport {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        string sink_desc = 2;
+    }
+
+    repeated ProtoSourceImport source_imports = 1;
+    repeated ProtoIndex index_imports = 2;
+    repeated ProtoBuildDesc objects_to_build = 3;
+    repeated ProtoIndex index_exports = 4;
+    repeated ProtoSinkExport sink_exports = 5;
+    optional mz_persist.gen.persist.ProtoU64Antichain as_of = 6;
+    string debug_name = 7;
+    mz_repr.proto.ProtoU128 id = 8;
+}
+
+message ProtoIndexDesc {
+    mz_repr.global_id.ProtoGlobalId on_id = 1;
+    repeated mz_expr.scalar.ProtoMirScalarExpr key = 3;
+}
+
+message ProtoBuildDesc {
+    mz_repr.global_id.ProtoGlobalId id = 1;
+    mz_dataflow_types.plan.ProtoPlan plan = 2;
+}
+
+message ProtoSourceInstanceDesc {
+    string description = 1;
+    ProtoSourceInstanceArguments arguments = 2;
+    mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 3;
+}
+
+message ProtoSourceInstanceArguments {
+    optional ProtoLinearOperator operators = 1;
+}
+
+message ProtoLinearOperator {
+    repeated mz_expr.scalar.ProtoMirScalarExpr predicates = 1;
+    repeated uint64 projection = 2;
+}

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -116,6 +116,7 @@ impl TryFrom<ProtoBuildDesc> for BuildDesc<crate::plan::Plan> {
 /// projection to the records as they emerge.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SourceInstanceDesc<M> {
+    // TODO: have the proptest strategy be `any_source_desc_stub()`
     /// A description of the source to construct.
     pub description: crate::types::sources::SourceDesc,
     /// Arguments for this instantiation of the source.
@@ -595,6 +596,7 @@ pub mod sources {
     use mz_persist_client::read::ReadHandle;
     use mz_persist_client::{PersistLocation, ShardId};
     use mz_persist_types::Codec64;
+    use proptest::strategy::{Just, Strategy};
     use prost::Message;
     use serde::{Deserialize, Serialize};
     use timely::progress::Timestamp;
@@ -1381,6 +1383,18 @@ pub mod sources {
     pub struct SourceDesc {
         pub connector: SourceConnector,
         pub desc: RelationDesc,
+    }
+
+    /// A stub for generating arbitrary [SourceDesc].
+    /// Produces the simplest possible instance of it.
+    #[allow(dead_code)]
+    fn any_source_desc_stub() -> impl Strategy<Value = SourceDesc> {
+        Just(SourceDesc {
+            connector: SourceConnector::Local {
+                timeline: Timeline::EpochMilliseconds,
+            },
+            desc: RelationDesc::empty(),
+        })
     }
 
     /// A `SourceConnector` describes how data is produced for a source, be

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -95,7 +95,7 @@ impl ProtoRepr for regex::Regex {
     }
 
     fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
-        Ok(regex::Regex::new(&repr).map_err(TryFromProtoError::RegexError)?)
+        Ok(regex::Regex::new(&repr).map_err(TryFromProtoError::from)?)
     }
 }
 

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -38,8 +38,8 @@ pub mod util;
 pub use datum_vec::{DatumVec, DatumVecBorrow};
 pub use global_id::GlobalId;
 pub use relation::{
-    ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, RelationDesc,
-    RelationType,
+    ColumnName, ColumnType, NotNullViolation, ProtoColumnName, ProtoColumnType, ProtoRelationType,
+    RelationDesc, RelationType,
 };
 pub use row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -136,7 +136,7 @@ impl TryFrom<ProtoColumnType> for ColumnType {
 }
 
 /// The type of a relation.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct RelationType {
     /// The type for each column, in order.
     pub column_types: Vec<ColumnType>,
@@ -238,7 +238,7 @@ impl TryFrom<ProtoRelationType> for RelationType {
                     key_set
                         .keys
                         .into_iter()
-                        .map(|k| usize::from_proto(k))
+                        .map(usize::from_proto)
                         .collect::<Result<Vec<_>, _>>()
                 })
                 .collect::<Result<Vec<_>, _>>()?,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 use mz_lowertest::MzReflect;
 use mz_ore::str::StrExt;
 
-use crate::proto::{TryFromProtoError, TryIntoIfSome};
+use crate::proto::{ProtoRepr, TryFromProtoError, TryIntoIfSome};
 use crate::{Datum, ScalarType};
 
-pub use crate::relation_and_scalar::{ProtoColumnName, ProtoColumnType};
+pub use crate::relation_and_scalar::{ProtoColumnName, ProtoColumnType, ProtoRelationType};
 
 /// The type of a [`Datum`](crate::Datum).
 ///
@@ -202,6 +202,47 @@ impl RelationType {
         } else {
             (0..self.column_types.len()).collect()
         }
+    }
+}
+
+impl From<&RelationType> for ProtoRelationType {
+    fn from(x: &RelationType) -> Self {
+        use crate::relation_and_scalar::proto_relation_type::ProtoKey;
+        ProtoRelationType {
+            column_types: x.column_types.iter().map(Into::into).collect(),
+            keys: x
+                .keys
+                .iter()
+                .map(|key_set| ProtoKey {
+                    keys: key_set.iter().map(|k| k.into_proto()).collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<ProtoRelationType> for RelationType {
+    type Error = TryFromProtoError;
+
+    fn try_from(x: ProtoRelationType) -> Result<Self, Self::Error> {
+        Ok(RelationType {
+            column_types: x
+                .column_types
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
+            keys: x
+                .keys
+                .into_iter()
+                .map(|key_set| {
+                    key_set
+                        .keys
+                        .into_iter()
+                        .map(|k| usize::from_proto(k))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        })
     }
 }
 

--- a/src/repr/src/relation_and_scalar.proto
+++ b/src/repr/src/relation_and_scalar.proto
@@ -20,6 +20,13 @@ import "repr/src/adt/numeric.proto";
 import "repr/src/adt/varchar.proto";
 import "repr/src/global_id.proto";
 
+message ProtoRelationType {
+    message ProtoKey {
+        repeated uint64 keys = 1;
+    }
+    repeated ProtoColumnType column_types = 1;
+    repeated ProtoKey keys = 2;
+}
 
 message ProtoColumnName {
     optional string value = 1;


### PR DESCRIPTION
Relates to #12240.

### Tips for reviewer

Includes translation to and from protobuf for `DataflowDescription<Plan>` and all subtypes except for:
* `dataflow-types::plan::Plan`: I included a stub for this in the PR.
* `SourceDesc` + subtypes.
* `SinkDesc` + subtypes.

The protobuf code for `Antichain<u64>` lives in the `mz-persist` crate. I originally considered moving it to `mz-repr`, but `Antichain` belongs to the timely crate, which is not used by `mz-repr`.

### Testing

Need to tackle this. 

Edit 5/4: I tried to derive `Arbitrary` for `DataflowDescription<T>`, but I ran into a bunch of problems because of the generic `T`. In order to derive `Arbitrary` for `DataflowDescription<T>`, I must either
* create a strategy for `Antichain<T>` that  is limited to only produce single- and zero-element Antichains .
* create a strategy for `Antichain<T> where T: timely::PartialOrder` that produces Antichains with more than one element, but then I need to change `DataflowDescription<T>` to `DataflowDescription<T> where T: timely::PartialOrder`, which seems to then require a bunch of refactoring everywhere.

Antichain docs here: https://docs.rs/timely/latest/timely/progress/frontier/struct.Antichain.html

I think that the best we can do is `impl Arbitrary for DataflowDescription<mz_repr::Timestamp>`. We will also have to do `impl Arbitrary for SinkDesc<mz_repr::Timestamp>`.

### Release notes

No user-facing changes