### PR TITLE
Remove default compute instance constant

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -53,8 +53,6 @@ include!(concat!(env!("OUT_DIR"), "/mz_dataflow_types.client.rs"));
 // might not like to bake in this decision based on a SQLite limitation.
 // See #11123.
 pub type ComputeInstanceId = i64;
-/// A default value whose use we can track down and remove later.
-pub const DEFAULT_COMPUTE_INSTANCE_ID: ComputeInstanceId = 1;
 
 /// Instance configuration
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION

### Motivation

This PR fixes a recognized bug: Cancellations are directed at the correct compute instance instead of the compute instance with ID 1.

Fixes #12247

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
