### PR TITLE
storage: add type-safe wrapper around Stash

### DIFF
--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -13,7 +13,6 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::marker::{Send, Sync};
 use std::rc::Rc;
 use std::sync::Arc;
 


### PR DESCRIPTION
We'll soon store differently typed collections in the stash that must
have names that never clash and also that are always instantiated with
the correct types.

This patch adds a type-safe wrapper around a generic stash that can
ensure that.
