### PR TITLE
persist: make `append` functions accept a lot more types

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -93,9 +93,10 @@ where
             futures_executor::block_on(PersistClient::new(timeout, blob, consensus))
                 .expect("cannot open client");
 
-        let (write, _read) =
-            futures_executor::block_on(persist_client.open(timeout, self.shard_id))
-                .expect("could not open persist shard");
+        let (write, _read) = futures_executor::block_on(
+            persist_client.open::<Row, Row, Timestamp, Diff>(timeout, self.shard_id),
+        )
+        .expect("could not open persist shard");
 
         let write = Rc::new(RefCell::new(Some(write)));
         let write_weak = Rc::downgrade(&write);

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -442,17 +442,12 @@ mod raw_persist_benchmark {
             let new_upper = Antichain::from_elem(max_ts + 1);
 
             // TODO: figure out the right way to do this without the extra allocations.
-            let batch: Vec<_> = batch
+            let batch = batch
                 .iter()
-                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d))
-                .collect();
-            self.append(
-                NO_TIMEOUT,
-                batch.iter().map(|((k, v), t, d)| ((&*k, &*v), &*t, &*d)),
-                new_upper,
-            )
-            .await??
-            .expect("invalid current upper");
+                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d));
+            self.append(NO_TIMEOUT, batch, new_upper)
+                .await??
+                .expect("invalid current upper");
 
             Ok(())
         }

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -461,9 +461,13 @@ mod tests {
         // live entries in consensus.
         const NUM_BATCHES: u64 = 100;
         for idx in 0..NUM_BATCHES {
-            let updates = vec![((idx.to_string(), ()), idx, 1)];
             write
-                .compare_and_append_slice(&updates, idx, idx + 1)
+                .compare_and_append(
+                    NO_TIMEOUT,
+                    [((idx.to_string(), ()), idx, 1)],
+                    Antichain::from_elem(idx),
+                    Antichain::from_elem(idx + 1),
+                )
                 .await??
                 .expect("invalid current upper");
         }


### PR DESCRIPTION
The previous API required that the user came up with an iterator of
references to values but that meant that every called that had owned
values had to write unecessary boilerplate. For example if a user had a
`Vec<((K, V), T, D)>` ready to go they would need to first make this an
iterator over `&((K, V), T, D)` and then use a map adaptor to convert
that to an iterator over `((&K, &V), &T, &D)`.

This patch changes the `append` APIs to accept any combination of owned
and borrowed values (a total of 32 combinations) which makes calling
these APIs much nicer.

The original usecase for this change isn't visible in this PR because it
is part of the larger https://github.com/MaterializeInc/materialize/pull/12216 PR, but I thought I'd break it up for
easier review. You can see however how the usage becomes nicer in
`persist_open_loop_benchmark.rs` and also in
`src/persist-client/src/lib.rs`.