### PR TITLE
mzcompose: add 'pause' and 'unpause' methods

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -664,6 +664,26 @@ class Composition:
         """
         self.invoke("kill", f"-s{signal}", *services)
 
+    def pause(self, *services: str) -> None:
+        """Pause service containers.
+
+        Delegates to `docker-compose pause`. See that command's help for details.
+
+        Args:
+            services: The names of services in the composition.
+        """
+        self.invoke("pause", *services)
+
+    def unpause(self, *services: str) -> None:
+        """Unpause service containers
+
+        Delegates to `docker-compose unpause`. See that command's help for details.
+
+        Args:
+            services: The names of services in the composition.
+        """
+        self.invoke("unpause", *services)
+
     def rm(
         self, *services: str, stop: bool = True, destroy_volumes: bool = True
     ) -> None:


### PR DESCRIPTION
Since c.kill(signal="STOP") does not seem to have effect, one needs
to call docker-compose pause and unpause directly.

  * This PR adds a feature that has not yet been specified.

pausing and unpausing is needed to test cluster isolation -- if the containers from cluster1 are paused, cluster2 should continue to operate.