### PR TITLE
persist: advance the timestamp of snapshot's output to its as_of

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -152,7 +152,7 @@ where
             for chunk in batch_part.updates {
                 for ((k, v), t, d) in chunk.iter() {
                     // TODO: Get rid of the to_le_bytes.
-                    let t = T::decode(t.to_le_bytes());
+                    let mut t = T::decode(t.to_le_bytes());
                     if self.as_of.less_than(&t) {
                         // This happens to be in the batch, but it would get
                         // covered by a listen started at the same as_of.
@@ -164,6 +164,7 @@ where
                     if desc.upper().less_equal(&t) {
                         continue;
                     }
+                    t.advance_by(self.as_of.borrow());
                     let k = K::decode(k);
                     let v = V::decode(v);
                     // TODO: Get rid of the to_le_bytes.


### PR DESCRIPTION
Compaction allows us to forward the batches in the snapshot to the as_of
(technically to the since). Actually do this forwarding inside
SnapshotIter so that code can't accidentally rely on timestamps not
being forwarded (which will break once compaction is added).

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
