### PR TITLE
Remove seemingly dubious logic from `Partitioned::recv`.

### DIFF
--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -96,8 +96,6 @@ where
                     self.seen_errors += 1;
                     if (self.seen_errors % parts) == 0 {
                         return Err(e);
-                    } else {
-                        return Ok(None);
                     }
                 }
                 Ok(response) => {


### PR DESCRIPTION
Returning `Ok(None)` here signals end of stream; clients might never
poll the stream again, and thus might never be notified of an error.

Instead we should mirror the logic in the `Ok` branch -- continue
processing messages until we have enough information to return an
error.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

I have a hunch that this might fix #12233 .

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
