### PR TITLE
expr,dataflow-types: enable `peek_protobuf_roundtrip` test

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -924,9 +924,7 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
-        // TODO: This will only work once we have implemented MfpPlan #11970
         #[test]
-        #[ignore]
         fn peek_protobuf_roundtrip(expect in any::<Peek>() ) {
             let actual = protobuf_roundtrip::<_, ProtoPeek>(&expect);
             assert!(actual.is_ok());


### PR DESCRIPTION
Add the bits of #11971 that were omitted from #12187.

### Motivation

#12187 was merged with ignored `peek_protobuf_roundtrip` due to stack overflow issues. This PR provides a custom `Arbitrary` implementation for `MapFilterProject` that ensures that this issue is resolved.

### Tips for reviewer

I used a custom strategy that limits the number of elements in the `expressions`, `predicates`, and `projection` vectors, similar to what @lluki suggested in private communication for `AvailableCollections`.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A