### PR TITLE
compute: wire up a persist client on initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 
@@ -3241,6 +3242,7 @@ dependencies = [
  "mz-kafka-util",
  "mz-ore",
  "mz-persist",
+ "mz-persist-client",
  "mz-persist-types",
  "mz-pgrepr",
  "mz-postgres-util",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -43,6 +43,7 @@ timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-fe
 tokio = { version = "1.17.0", features = ["fs", "rt", "sync"] }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
+url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["serde", "v4"] }
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -23,6 +23,7 @@ use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, LocalClient, Lo
 use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
+use mz_persist_client::PersistClient;
 use mz_storage::boundary::ComputeReplay;
 
 use crate::compute_state::ActiveComputeState;
@@ -44,6 +45,8 @@ pub struct Config {
     pub metrics_registry: MetricsRegistry,
     /// An external ID to use for all AWS AssumeRole operations.
     pub aws_external_id: AwsExternalId,
+    /// A client to the persist library.
+    pub persist_client: PersistClient,
 }
 
 /// A handle to a running dataflow server.

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -28,6 +28,7 @@ mz-kafka-util = { path = "../kafka-util" }
 mz-ore = { path = "../ore", features = ["task"] }
 mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
+mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -34,6 +34,7 @@ use timely::progress::Timestamp;
 use tokio_stream::StreamMap;
 
 use mz_orchestrator::{CpuLimit, MemoryLimit, Orchestrator, ServiceConfig, ServicePort};
+use mz_persist_client::PersistLocation;
 use mz_persist_types::Codec64;
 
 use crate::client::GenericClient;
@@ -57,6 +58,8 @@ pub struct OrchestratorConfig {
     pub computed_image: String,
     /// The storage address that compute instances should connect to.
     pub storage_addr: String,
+    /// The persist location that compute instances should connect to.
+    pub persist_location: PersistLocation,
     /// Whether or not process should die when connection with ADAPTER is lost.
     pub linger: bool,
 }
@@ -173,6 +176,7 @@ where
                     orchestrator,
                     computed_image,
                     storage_addr,
+                    persist_location,
                     linger,
                 } = &self.orchestrator;
 
@@ -194,6 +198,11 @@ where
                                         ),
                                         format!("--processes={}", size_config.scale),
                                         format!("--workers={}", size_config.workers),
+                                        format!("--persist-blob-url={}", persist_location.blob_uri),
+                                        format!(
+                                            "--persist-consensus-url={}",
+                                            persist_location.consensus_uri
+                                        ),
                                     ];
                                     compute_opts.extend(hosts_ports.iter().map(|(host, ports)| {
                                         format!("{host}:{}", ports["compute"])

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -319,6 +319,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         orchestrator,
         computed_image: config.orchestrator.computed_image,
         storage_addr: storage_service.addresses("compute").into_element(),
+        persist_location: config.persist_location,
         linger: config.orchestrator.linger,
     };
 


### PR DESCRIPTION
### Motivation

This is a piece of the big storage/compute separation PR that I split off. The compute instances will need to be spun up with command line flags that specify the persist location they should expect to find the collections stored by the storage controller so this patch wires this up.
