### PR TITLE
storage: replace `MessagePayload` with `Option<Vec<u8>>`

### DIFF
--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -52,31 +52,3 @@ pub use scalar::{AsColumnType, Datum, DatumType, ProtoScalarType, ScalarBaseType
 pub type Timestamp = u64;
 /// System-wide record count difference type.
 pub type Diff = i64;
-
-use serde::{Deserialize, Serialize};
-// This probably logically belongs in `dataflow`, but source caching looks at it,
-// so put it in `repr` instead.
-/// The payload delivered by a source connector; either bytes or an EOF marker.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, Hash, PartialEq, Ord, PartialOrd)]
-pub enum MessagePayload {
-    /// Data from the source connector.
-    // TODO(guswynn): Determine if `Vec` needs to be non-empty.
-    Data(Vec<u8>),
-    /// Forces the decoder to consider this a delimiter.
-    ///
-    /// For example, CSV records are normally terminated by a newline,
-    /// but files might not be newline-terminated; thus we need
-    /// the decoder to emit a CSV record when the end of a file is seen.
-    ///
-    // Note that the ordering here matters for the PartialOrd impl
-    EOF,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    #[test]
-    fn test_message_payload_ordering() {
-        assert!(MessagePayload::Data(vec![]) < MessagePayload::EOF);
-    }
-}

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -60,7 +60,6 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_ore::now::NowFn;
 use mz_ore::task;
-use mz_repr::MessagePayload;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_timely_util::operator::StreamExt;
 
@@ -355,19 +354,6 @@ impl MaybeLength for Value {
     }
 }
 
-impl MaybeLength for MessagePayload {
-    fn len(&self) -> Option<usize> {
-        match self {
-            MessagePayload::Data(data) => Some(data.len()),
-            MessagePayload::EOF => None,
-        }
-    }
-
-    fn is_empty(&self) -> bool {
-        false
-    }
-}
-
 impl<T: MaybeLength> MaybeLength for Option<T> {
     fn len(&self) -> Option<usize> {
         self.as_ref().and_then(|v| v.len())
@@ -510,7 +496,7 @@ pub struct SourceMessage<Key, Value> {
     pub headers: Option<Vec<(String, Option<Vec<u8>>)>>,
 }
 
-impl fmt::Debug for SourceMessage<(), MessagePayload> {
+impl fmt::Debug for SourceMessage<(), Option<Vec<u8>>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SourceMessage")
             .field("partition", &self.partition)


### PR DESCRIPTION
Traditionally the `MessagePayload` enum was used to represent the output
of non-delimited sources, i.e sources that output a stream of bytes.

The pattern of stream of bytes is already established in Rust by either
the family of `Read` traits, that fill up a provided buffer and return
the number of bytes written, or the `Iterator`/`Stream` traits that
return an `Option<Self::Item>` where the `Item` would be a `Vec<u8>` in
this case and `None` would represent the end of the stream.

Our own enum doesn't provide additional semantics than the ones conveyed
by the standard practice so this PR changes non-delimited sources to
produce `Option<Vec<u8>>` messages.

Fixes #12256

