### PR TITLE
Augment storage and compute commands with storage metadata 

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -28,6 +28,7 @@ use timely::dataflow::{Scope, ScopeParent};
 use timely::progress::timestamp::Refines;
 use timely::progress::{Antichain, Timestamp};
 
+use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::{DataflowDescription, DataflowError};
 use mz_dataflow_types::{ErrSpine, RowSpine, TraceErrHandle, TraceRowHandle};
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
@@ -84,7 +85,10 @@ where
     S::Timestamp: Lattice + Refines<mz_repr::Timestamp>,
 {
     /// Creates a new empty Context.
-    pub fn for_dataflow<Plan>(dataflow: &DataflowDescription<Plan>, dataflow_id: usize) -> Self {
+    pub fn for_dataflow<Plan>(
+        dataflow: &DataflowDescription<Plan, CollectionMetadata>,
+        dataflow_id: usize,
+    ) -> Self {
         let as_of_frontier = dataflow
             .as_of
             .clone()

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -113,6 +113,7 @@ use timely::dataflow::Scope;
 use timely::progress::Timestamp;
 use timely::worker::Worker as TimelyWorker;
 
+use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::*;
 use mz_expr::Id;
 use mz_ore::collections::CollectionExt as IteratorExt;
@@ -140,7 +141,7 @@ mod top_k;
 pub fn build_compute_dataflow<A: Allocate, B: ComputeReplay>(
     timely_worker: &mut TimelyWorker<A>,
     compute_state: &mut ComputeState,
-    dataflow: DataflowDescription<mz_dataflow_types::plan::Plan>,
+    dataflow: DataflowDescription<mz_dataflow_types::plan::Plan, CollectionMetadata>,
     boundary: &mut B,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -4977,7 +4977,7 @@ pub mod fast_path_peek {
 
     #[derive(Debug)]
     pub struct PeekDataflowPlan<T> {
-        desc: mz_dataflow_types::DataflowDescription<mz_dataflow_types::Plan<T>, T>,
+        desc: mz_dataflow_types::DataflowDescription<mz_dataflow_types::Plan<T>, (), T>,
         id: GlobalId,
         key: Vec<MirScalarExpr>,
         permutation: HashMap<usize, usize>,

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -29,17 +29,19 @@ use timely::progress::ChangeBatch;
 use tracing::trace;
 use uuid::Uuid;
 
+use mz_expr::{PartitionId, RowSetFinishing};
+use mz_repr::{GlobalId, Row};
+
 use crate::logging::LoggingConfig;
 use crate::{
     sources::{MzOffset, SourceDesc},
     DataflowDescription, PeekResponse, SourceInstanceDesc, TailResponse, Update,
 };
-use mz_expr::{PartitionId, RowSetFinishing};
-use mz_repr::{GlobalId, Row};
 
 pub mod controller;
 pub use controller::Controller;
 
+use self::controller::storage::CollectionMetadata;
 use self::controller::ClusterReplicaSizeConfig;
 
 pub mod partitioned;
@@ -166,7 +168,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Subsequent commands may arbitrarily compact the arrangements;
     /// the dataflow runners are responsible for ensuring that they can
     /// correctly maintain the dataflows.
-    CreateDataflows(Vec<DataflowDescription<crate::plan::Plan<T>, T>>),
+    CreateDataflows(Vec<DataflowDescription<crate::plan::Plan<T>, CollectionMetadata, T>>),
     /// Enable compaction in compute-managed collections.
     ///
     /// Each entry in the vector names a collection and provides a frontier after which
@@ -194,6 +196,8 @@ pub struct CreateSourceCommand<T> {
     pub since: Antichain<T>,
     /// Any previously stored timestamp bindings
     pub ts_bindings: Vec<(PartitionId, T, crate::sources::MzOffset)>,
+    /// Additional storage controller metadata needed to ingest this source
+    pub storage_metadata: CollectionMetadata,
 }
 
 /// A command to render a single source
@@ -206,7 +210,7 @@ pub struct RenderSourcesCommand<T> {
     /// An optional frontier to which the input should be advanced.
     pub as_of: Option<Antichain<T>>,
     /// Sources instantiations made available to the dataflow.
-    pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc>,
+    pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc<CollectionMetadata>>,
 }
 
 /// Commands related to the ingress and egress of collections.

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 
 use mz_repr::GlobalId;
 
+use crate::client::controller::storage::CollectionMetadata;
 use crate::client::{ComputeClient, ComputeCommand, ComputeResponse, GenericClient};
 use crate::{DataflowDescription, Plan};
 
@@ -49,7 +50,7 @@ pub struct ComputeCommandReconcile<T, C> {
     /// `DropInstance` command.
     created: bool,
     /// Dataflows by ID.
-    dataflows: HashMap<GlobalId, DataflowDescription<Plan<T>, T>>,
+    dataflows: HashMap<GlobalId, DataflowDescription<Plan<T>, CollectionMetadata, T>>,
     /// Outstanding peek identifiers, to guide responses (and which to suppress).
     peeks: HashSet<uuid::Uuid>,
     /// Stash of responses to send back to the controller.

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -76,7 +76,7 @@ pub struct Update<T = mz_repr::Timestamp> {
 }
 
 /// A commonly used name for dataflows contain MIR expressions.
-pub type DataflowDesc = DataflowDescription<OptimizedMirRelationExpr>;
+pub type DataflowDesc = DataflowDescription<OptimizedMirRelationExpr, ()>;
 
 /// An association of a global identifier to an expression.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -91,11 +91,13 @@ pub struct BuildDesc<P> {
 /// context-dependent options like the ability to apply filtering and
 /// projection to the records as they emerge.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SourceInstanceDesc {
+pub struct SourceInstanceDesc<M> {
     /// A description of the source to construct.
     pub description: crate::types::sources::SourceDesc,
     /// Arguments for this instantiation of the source.
     pub arguments: SourceInstanceArguments,
+    /// Additional metadata required by a storage instance to read this source
+    pub storage_metadata: M,
 }
 
 /// Per-source construction arguments.
@@ -130,9 +132,9 @@ impl<T> SourceInstanceRequest<T> {
 
 /// A description of a dataflow to construct and results to surface.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct DataflowDescription<P, T = mz_repr::Timestamp> {
+pub struct DataflowDescription<P, S = (), T = mz_repr::Timestamp> {
     /// Sources instantiations made available to the dataflow.
-    pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc>,
+    pub source_imports: BTreeMap<GlobalId, SourceInstanceDesc<S>>,
     /// Indexes made available to the dataflow.
     pub index_imports: BTreeMap<GlobalId, (IndexDesc, RelationType)>,
     /// Views and indexes to be built and stored in the local context.
@@ -157,7 +159,7 @@ pub struct DataflowDescription<P, T = mz_repr::Timestamp> {
     pub id: uuid::Uuid,
 }
 
-impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
+impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
     /// Creates a new dataflow description with a human-readable name.
     pub fn new(name: String) -> Self {
         Self {
@@ -192,6 +194,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
             id,
             SourceInstanceDesc {
                 description,
+                storage_metadata: (),
                 arguments: SourceInstanceArguments { operators: None },
             },
         );
@@ -281,7 +284,7 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, T> {
     }
 }
 
-impl<P, T> DataflowDescription<P, T>
+impl<P, S, T> DataflowDescription<P, S, T>
 where
     P: CollectionPlan,
 {
@@ -366,7 +369,7 @@ where
     }
 }
 
-impl<P: PartialEq, T: timely::PartialOrder> DataflowDescription<P, T> {
+impl<P: PartialEq, S: PartialEq, T: timely::PartialOrder> DataflowDescription<P, S, T> {
     /// Determine if a dataflow description is compatible with this dataflow description.
     ///
     /// Compatible dataflows have equal exports, imports, and objects to build. The `as_of` of

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -96,7 +96,8 @@ pub struct SourceInstanceDesc<M> {
     pub description: crate::types::sources::SourceDesc,
     /// Arguments for this instantiation of the source.
     pub arguments: SourceInstanceArguments,
-    /// Additional metadata required by a storage instance to read this source
+    /// Additional metadata used by storage instances to render this source instance and by the
+    /// storage client of a compute instance to read it.
     pub storage_metadata: M,
 }
 

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -285,11 +285,6 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
                             "--listen-addr={}:{}",
                             default_listen_host, my_ports["controller"]
                         ),
-                        format!("--persist-blob-url={}", config.persist_location.blob_uri),
-                        format!(
-                            "--persist-consensus-url={}",
-                            config.persist_location.consensus_uri
-                        ),
                     ];
                     if config.orchestrator.linger {
                         storage_opts.push(format!("--linger"))

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -350,6 +350,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let storage_controller = mz_dataflow_types::client::controller::storage::Controller::new(
         storage_client,
         config.data_directory,
+        config.persist_location,
     );
     let dataflow_controller =
         mz_dataflow_types::client::Controller::new(orchestrator, storage_controller);

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -84,7 +84,7 @@ pub(crate) mod r#impl {
 ///
 /// This structure can be durably written down or transmitted for use by other
 /// processes. This location can contain any number of persist shards.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PersistLocation {
     /// Uri string that identifies the blob store.
     pub blob_uri: String,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -112,6 +112,7 @@ use timely::dataflow::Scope;
 use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
+use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::*;
 use mz_ore::collections::CollectionExt as IteratorExt;
 use mz_repr::GlobalId;
@@ -132,7 +133,7 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
     storage_state: &mut StorageState,
     debug_name: &str,
     as_of: Option<Antichain<mz_repr::Timestamp>>,
-    source_imports: BTreeMap<GlobalId, SourceInstanceDesc>,
+    source_imports: BTreeMap<GlobalId, SourceInstanceDesc<CollectionMetadata>>,
     dataflow_id: uuid::Uuid,
     boundary: &mut B,
 ) {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -25,6 +25,7 @@ use timely::dataflow::operators::unordered_input::UnorderedHandle;
 use timely::dataflow::operators::{ActivateCapability, Map, OkErr, Operator, UnorderedInput};
 use timely::dataflow::Scope;
 
+use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::sources::{encoding::*, *};
 use mz_dataflow_types::*;
 use mz_expr::{PartitionId, SourceInstanceId};
@@ -145,10 +146,11 @@ pub fn render_source<G>(
     as_of_frontier: &timely::progress::Antichain<mz_repr::Timestamp>,
     SourceInstanceDesc {
         description: src,
+        storage_metadata,
         arguments: SourceInstanceArguments {
             operators: mut linear_operators,
         },
-    }: SourceInstanceDesc,
+    }: SourceInstanceDesc<CollectionMetadata>,
     storage_state: &mut crate::storage_state::StorageState,
     scope: &mut G,
     src_id: GlobalId,
@@ -451,6 +453,7 @@ where
                                                 as_of_frontier,
                                                 SourceInstanceDesc {
                                                     description: tx_src_desc,
+                                                    storage_metadata,
                                                     arguments: SourceInstanceArguments {
                                                         operators: None,
                                                     },

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -15,7 +15,6 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use crossbeam_channel::TryRecvError;
-use mz_persist_client::PersistClient;
 use timely::communication::initialize::WorkerGuards;
 use timely::communication::Allocate;
 use timely::worker::Worker as TimelyWorker;
@@ -47,8 +46,6 @@ pub struct Config {
     pub metrics_registry: MetricsRegistry,
     /// An external ID to use for all AWS AssumeRole operations.
     pub aws_external_id: AwsExternalId,
-    /// A client to the persist library.
-    pub persist_client: PersistClient,
 }
 
 /// A handle to a running dataflow server.


### PR DESCRIPTION
In order to decouple storage and compute some amount of metadata must be communicated to each one through their command streams as a means of rendezvous.

This is currently just the persist location but in the future it will include a list of persist shards, the shard for the timestamp bindings collection, etc.