### PR TITLE
materialized: Allow setting a password prefix

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -333,6 +333,14 @@ pub struct Args {
         hide = true
     )]
     frontegg_api_token_url: Option<String>,
+    /// A common string prefix that is expected to be present at the beginning of passwords.
+    #[clap(
+        long,
+        env = "MZ_FRONTEGG_PASSWORD_PREFIX",
+        requires = "frontegg-tenant",
+        hide = true
+    )]
+    frontegg_password_prefix: Option<String>,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
     /// specified origin.
     #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN", hide = true)]
@@ -555,6 +563,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                 tenant_id,
                 now: mz_ore::now::SYSTEM_TIME.clone(),
                 refresh_before_secs: 60,
+                password_prefix: args.frontegg_password_prefix.unwrap_or_default(),
             }))
         }
         _ => unreachable!("clap enforced"),


### PR DESCRIPTION
In order to participate in github's secret scanning program, we need to be able to identify potential platform passwords. This is easiest if they come with a fairly unique prefix, and that requires that the materialized protocol be able to detect and enforce that prefix.

This change adds a configurable prefix for frontegg auth and removes the prefix (erroring if it's not present).

### Motivation

  * This PR adds a feature that has not yet been specified.

When adding frontegg auth in #10577, I missed that we mandate a key format that can't be easily matched by systems like the [GitHub secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program#identify-your-secrets-and-create-regular-expressions). We'll want to ensure our users don't check keys into their source-control systems, so this should ensure we can formulate an easy prefix-based regex.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

I added a test, but could not run it locally (the auth tests just hang... probably a local setup problem). Hopefully they will work in CI.

### Release notes

No user-facing behavioral changes outside Materialize Cloud.