### PR TITLE
mzcompose: Allow dynamically-defined clusters in mzcompose workflows

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -92,7 +92,7 @@ For additional details on mzcompose, consult doc/developer/mzbuild.md.""",
     ConfigCommand.register(parser, subparsers)
     CreateCommand.register(parser, subparsers)
     DescribeCommand().register(parser, subparsers)
-    DownCommand.register(parser, subparsers)
+    DownCommand().register(parser, subparsers)
     EventsCommand.register(parser, subparsers)
     ExecCommand.register(parser, subparsers)
     GenShortcutsCommand().register(parser, subparsers)
@@ -611,7 +611,19 @@ To see the available workflows, run:
 BuildCommand = DockerComposeCommand("build", "build or rebuild services")
 ConfigCommand = DockerComposeCommand("config", "validate and view the Compose file")
 CreateCommand = DockerComposeCommand("create", "create services", runs_containers=True)
-DownCommand = DockerComposeCommand("down", "stop and remove resources")
+
+
+class DownCommand(DockerComposeCommand):
+    def __init__(self) -> None:
+        super().__init__("down", "Stop and remove containers, networks")
+
+    def run(self, args: argparse.Namespace) -> Any:
+        # --remove-orphans needs to be in effect at all times otherwise
+        # services added to a composition after the fact will not be cleaned up
+        args.unknown_subargs.append("--remove-orphans")
+        super().run(args)
+
+
 EventsCommand = DockerComposeCommand(
     "events", "receive real time events from containers"
 )


### PR DESCRIPTION
This patch allows clusters to be created within workflows as needed
without having to be pre-declarede in the SERVICES section of the
composition.

The following changes were made:
* c.override() allows new services to be defined that did not exist
  in the original SERVICES section

* The constructor of Computed() has been enhanced to allow more of
  the required command-line options to be figured out internally
  rather than specified manually by the caller.

* --remove-orphans is now passed to docker-compose down at every
  opportunity in order to clean up any dynamically-created services.

### Motivation

  * This PR adds a feature that has not yet been specified.
We need to be able to set up clusters within a mzcompose workflow without having to declare them in advance.

### Tips for reviewer

@benesch the `test/c/mzcompose.py` file contains an example test that covers the new functionality. Once the rest of the PR is approved, I will remove this example test and convert existing tests and frameworks to the new approach.