### PR TITLE
dataflow-types: enable `join_plan_protobuf_roundtrip` test

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -928,6 +928,8 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(4))]
+
         #[test]
         fn peek_protobuf_roundtrip(expect in any::<Peek>() ) {
             let actual = protobuf_roundtrip::<_, ProtoPeek>(&expect);

--- a/src/dataflow-types/src/plan/join/mod.rs
+++ b/src/dataflow-types/src/plan/join/mod.rs
@@ -122,8 +122,7 @@ impl From<&JoinClosure> for ProtoJoinClosure {
                 .into_iter()
                 .map(Into::into)
                 .collect(),
-            // TODO(lluki): Implement me once #11970 is fixed
-            before: None,
+            before: Some((&x.before).into()),
         }
     }
 }
@@ -429,7 +428,6 @@ impl JoinBuildState {
 mod tests {
     use super::*;
     use mz_repr::proto::protobuf_roundtrip;
-    use proptest::prelude::*;
 
     proptest! {
         #[test]

--- a/src/dataflow-types/src/plan/join/mod.rs
+++ b/src/dataflow-types/src/plan/join/mod.rs
@@ -430,6 +430,8 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2))]
+
         #[test]
         fn join_plan_protobuf_roundtrip(expect in any::<JoinPlan>() ) {
             let actual = protobuf_roundtrip::<_, ProtoJoinPlan>(&expect);


### PR DESCRIPTION
### Motivation

Handles the part of #11927 that was not covered by the original PR (#12044)

### Tips for reviewer

In order to make this work, I had to do a number of things:

- Provide custom `Arbitrary` implementations for the `JoinPlan` subtypes.
- Change the custom `Arbitrary` implementation for `MirScalarExpr` so it does not use `TupleUnion` strategies which occupy a lot of stack space and are the default selection for `prop_oneof!` macro calls with less than 10 elements.
- Set `#![proptest_config(ProptestConfig::with_cases(2))]` for `protobuf_roundtrip` tests that generate data which contains `MirScalarExpr` values (currenlty, `peek_protobuf_roundtrip` and `join_plan_protobuf_roundtrip`). This ensures that the tests will not take more than 60 seconds in the CI/CD run.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A
