### PR TITLE
persist: remove Codec impl for Result

### DIFF
--- a/src/persist-types/src/codec_impls.rs
+++ b/src/persist-types/src/codec_impls.rs
@@ -67,46 +67,6 @@ impl Codec for Vec<u8> {
     }
 }
 
-const RESULT_OK: u8 = 0;
-const RESULT_ERR: u8 = 1;
-impl<T: Codec, E: Codec> Codec for Result<T, E> {
-    fn codec_name() -> String {
-        "Result".into()
-    }
-
-    fn encode<B>(&self, buf: &mut B)
-    where
-        B: BufMut,
-    {
-        match self {
-            Ok(r) => {
-                buf.put(&[RESULT_OK][..]);
-                r.encode(buf);
-            }
-            Err(err) => {
-                buf.put(&[RESULT_ERR][..]);
-                err.encode(buf);
-            }
-        }
-    }
-
-    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
-        let typ = buf[0];
-        let result = match typ {
-            RESULT_OK => {
-                let result_slice = &buf[1..(buf.len())];
-                Ok(T::decode(result_slice)?)
-            }
-            RESULT_ERR => {
-                let err_slice = &buf[1..(buf.len())];
-                Err(E::decode(err_slice)?)
-            }
-            typ => return Err(format!("Unexpected Result variant: {}.", typ)),
-        };
-        Ok(result)
-    }
-}
-
 impl Codec64 for i64 {
     fn codec_name() -> String {
         "i64".to_owned()
@@ -132,44 +92,5 @@ impl Codec64 for u64 {
 
     fn decode(buf: [u8; 8]) -> Self {
         u64::from_le_bytes(buf)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::Codec;
-
-    #[test]
-    fn test_result_ok_roundtrip() -> Result<(), String> {
-        let original: Result<String, String> = Ok("ciao!".to_string());
-        let mut encoded = Vec::new();
-        original.encode(&mut encoded);
-        let decoded: Result<String, String> = Result::decode(&encoded)?;
-
-        assert_eq!(decoded, original);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_result_err_roundtrip() -> Result<(), String> {
-        let original: Result<String, String> = Err("ciao!".to_string());
-        let mut encoded = Vec::new();
-        original.encode(&mut encoded);
-        let decoded: Result<String, String> = Result::decode(&encoded)?;
-
-        assert_eq!(decoded, original);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_result_decoding_error() -> Result<(), String> {
-        let encoded = vec![42];
-        let decoded: Result<Result<String, String>, String> = Result::decode(&encoded);
-
-        assert_eq!(decoded, Err("Unexpected Result variant: 42.".to_string()));
-
-        Ok(())
     }
 }


### PR DESCRIPTION
It's unused now that the old persist+source integration has been removed
and has always been a bit of a footgun. Anything that would have used
this should probably use proto.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
