### PR TITLE
upgrade tonic to support native-tls again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,9 +6381,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fb54bf1e446f44d870d260d99957e7d11fb9d0a0f5bd1a662ad1411cc103f9"
+checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -45,7 +45,7 @@ tracing-subscriber = { version = "0.3.11", default-features = false, features = 
 atty = { version = "0.2.14", optional = true }
 tracing = { version = "0.1.34", optional = true }
 tracing-opentelemetry = { version = "0.17", optional = true }
-tonic = { version = "0.7.0", features = ["transport"], optional = true }
+tonic = { version = "0.7.2", features = ["transport"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2.10", features = ["alpn"], optional = true }
 hyper = { version = "0.14.18", features = ["http1", "server"], optional = true }


### PR DESCRIPTION
### Motivation
`MZ_OPENTELEMETRY_ENDPOINT="https://api.honeycomb.io"` works again, and i wanted to beat dependenbot

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
