### PR TITLE
coord: allow configuring postgres stash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,6 +2865,7 @@ dependencies = [
  "mz-secrets",
  "mz-secrets-filesystem",
  "mz-secrets-kubernetes",
+ "mz-stash",
  "native-tls",
  "nix",
  "num_cpus",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -18,6 +18,7 @@ use anyhow::bail;
 use chrono::{DateTime, TimeZone, Utc};
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use mz_stash::{Append, Sqlite};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, MutexGuard};
@@ -53,7 +54,6 @@ use mz_sql::plan::{
     CreateTablePlan, CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
 };
 use mz_sql::DEFAULT_SCHEMA;
-use mz_stash::Append;
 use mz_transform::Optimizer;
 use uuid::Uuid;
 
@@ -104,11 +104,23 @@ const SYSTEM_USER: &str = "mz_system";
 /// The catalog also maintains special "ambient schemas": virtual schemas,
 /// implicitly present in all databases, that house various system views.
 /// The big examples of ambient schemas are `pg_catalog` and `mz_catalog`.
-#[derive(Debug, Clone)]
-pub struct Catalog {
+#[derive(Debug)]
+pub struct Catalog<S> {
     state: CatalogState,
-    storage: Arc<Mutex<storage::Connection>>,
+    storage: Arc<Mutex<storage::Connection<S>>>,
     transient_revision: u64,
+}
+
+// Implement our own Clone because derive can't unless S is Clone, which it's
+// not (hence the Arc).
+impl<S> Clone for Catalog<S> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            storage: Arc::clone(&self.storage),
+            transient_revision: self.transient_revision,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -630,8 +642,8 @@ impl CatalogState {
 }
 
 #[derive(Debug)]
-pub struct ConnCatalog<'a> {
-    catalog: &'a Catalog,
+pub struct ConnCatalog<'a, S> {
+    catalog: &'a Catalog<S>,
     conn_id: u32,
     compute_instance: String,
     database: Option<DatabaseId>,
@@ -640,7 +652,7 @@ pub struct ConnCatalog<'a> {
     prepared_statements: Option<&'a HashMap<String, PreparedStatement>>,
 }
 
-impl ConnCatalog<'_> {
+impl<S> ConnCatalog<'_, S> {
     pub fn conn_id(&self) -> u32 {
         self.conn_id
     }
@@ -661,11 +673,11 @@ impl ConnCatalog<'_> {
         let default_schemas = [
             (
                 ResolvedDatabaseSpecifier::Ambient,
-                SchemaSpecifier::Id(self.catalog.state().get_mz_catalog_schema_id().clone()),
+                SchemaSpecifier::Id(self.catalog.state.get_mz_catalog_schema_id().clone()),
             ),
             (
                 ResolvedDatabaseSpecifier::Ambient,
-                SchemaSpecifier::Id(self.catalog.state().get_pg_catalog_schema_id().clone()),
+                SchemaSpecifier::Id(self.catalog.state.get_pg_catalog_schema_id().clone()),
             ),
         ];
         for schema in default_schemas.into_iter() {
@@ -1141,12 +1153,50 @@ struct AllocatedBuiltinSystemIds<T> {
     migrated_builtins: Vec<(T, GlobalId)>,
 }
 
-impl Catalog {
+impl Catalog<Sqlite> {
+    /// Opens the catalog at `path` with parameters set appropriately for debug
+    /// contexts, like in tests.
+    ///
+    /// WARNING! This function can arbitrarily fail because it does not make any
+    /// effort to adjust the catalog's contents' structure or semantics to the
+    /// currently running version, i.e. it does not apply any migrations.
+    ///
+    /// This function should not be called in production contexts. Use
+    /// [`Catalog::open`] with appropriately set configuration parameters
+    /// instead.
+    pub async fn open_debug(
+        data_dir_path: &Path,
+        now: NowFn,
+    ) -> Result<Catalog<Sqlite>, anyhow::Error> {
+        let experimental_mode = None;
+        let metrics_registry = &MetricsRegistry::new();
+        let stash = mz_stash::Sqlite::open(&data_dir_path.join("stash"))?;
+        let storage = storage::Connection::open(stash, experimental_mode).await?;
+        let (catalog, _) = Self::open(Config {
+            storage,
+            experimental_mode,
+            safe_mode: false,
+            build_info: &DUMMY_BUILD_INFO,
+            aws_external_id: AwsExternalId::NotProvided,
+            timestamp_frequency: Duration::from_secs(1),
+            now,
+            skip_migrations: true,
+            metrics_registry,
+            disable_user_indexes: false,
+        })
+        .await?;
+        Ok(catalog)
+    }
+}
+
+impl<S: Append> Catalog<S> {
     /// Opens or creates a catalog that stores data at `path`.
     ///
     /// Returns the catalog and a list of updates to builtin tables that
     /// describe the initial state of the catalog.
-    pub async fn open(config: Config<'_>) -> Result<(Catalog, Vec<BuiltinTableUpdate>), Error> {
+    pub async fn open(
+        config: Config<'_, S>,
+    ) -> Result<(Catalog<S>, Vec<BuiltinTableUpdate>), Error> {
         let mut catalog = Catalog {
             state: CatalogState {
                 database_by_name: BTreeMap::new(),
@@ -1637,10 +1687,10 @@ impl Catalog {
     /// objects, which is necessary for at least one catalog migration.
     ///
     /// TODO(justin): it might be nice if these were two different types.
-    pub async fn load_catalog_items<'a, S: Append>(
+    pub async fn load_catalog_items<'a>(
         tx: &mut storage::Transaction<'a, S>,
-        c: &Catalog,
-    ) -> Result<Catalog, Error> {
+        c: &Catalog<S>,
+    ) -> Result<Catalog<S>, Error> {
         let mut c = c.clone();
         let items = tx.loaded_items();
         for (id, name, def) in items {
@@ -1672,37 +1722,7 @@ impl Catalog {
         Ok(c)
     }
 
-    /// Opens the catalog at `path` with parameters set appropriately for debug
-    /// contexts, like in tests.
-    ///
-    /// WARNING! This function can arbitrarily fail because it does not make any
-    /// effort to adjust the catalog's contents' structure or semantics to the
-    /// currently running version, i.e. it does not apply any migrations.
-    ///
-    /// This function should not be called in production contexts. Use
-    /// [`Catalog::open`] with appropriately set configuration parameters
-    /// instead.
-    pub async fn open_debug(data_dir_path: &Path, now: NowFn) -> Result<Catalog, anyhow::Error> {
-        let experimental_mode = None;
-        let metrics_registry = &MetricsRegistry::new();
-        let storage = storage::Connection::open(data_dir_path, experimental_mode).await?;
-        let (catalog, _) = Self::open(Config {
-            storage,
-            experimental_mode,
-            safe_mode: false,
-            build_info: &DUMMY_BUILD_INFO,
-            aws_external_id: AwsExternalId::NotProvided,
-            timestamp_frequency: Duration::from_secs(1),
-            now,
-            skip_migrations: true,
-            metrics_registry,
-            disable_user_indexes: false,
-        })
-        .await?;
-        Ok(catalog)
-    }
-
-    pub fn for_session<'a>(&'a self, session: &'a Session) -> ConnCatalog<'a> {
+    pub fn for_session<'a>(&'a self, session: &'a Session) -> ConnCatalog<'a, S> {
         let database = self
             .state
             .database_by_name
@@ -1727,7 +1747,7 @@ impl Catalog {
         }
     }
 
-    pub fn for_sessionless_user(&self, user: String) -> ConnCatalog {
+    pub fn for_sessionless_user(&self, user: String) -> ConnCatalog<S> {
         ConnCatalog {
             catalog: self,
             conn_id: SYSTEM_CONN_ID,
@@ -1744,11 +1764,11 @@ impl Catalog {
 
     // Leaving the system's search path empty allows us to catch issues
     // where catalog object names have not been normalized correctly.
-    pub fn for_system_session(&self) -> ConnCatalog {
+    pub fn for_system_session(&self) -> ConnCatalog<S> {
         self.for_sessionless_user(SYSTEM_USER.into())
     }
 
-    async fn storage<'a>(&'a self) -> MutexGuard<'a, storage::Connection> {
+    async fn storage<'a>(&'a self) -> MutexGuard<'a, storage::Connection<S>> {
         self.storage.lock().await
     }
 
@@ -3062,7 +3082,7 @@ impl From<PlanContext> for SerializedPlanContext {
     }
 }
 
-impl ConnCatalog<'_> {
+impl<S: Append> ConnCatalog<'_, S> {
     fn resolve_item_name(
         &self,
         name: &PartialObjectName,
@@ -3112,7 +3132,7 @@ impl ConnCatalog<'_> {
     }
 }
 
-impl ExprHumanizer for ConnCatalog<'_> {
+impl<S: Append> ExprHumanizer for ConnCatalog<'_, S> {
     fn humanize_id(&self, id: GlobalId) -> Option<String> {
         self.catalog
             .state
@@ -3190,7 +3210,7 @@ impl ExprHumanizer for ConnCatalog<'_> {
     }
 }
 
-impl SessionCatalog for ConnCatalog<'_> {
+impl<S: Append> SessionCatalog for ConnCatalog<'_, S> {
     fn active_user(&self) -> &str {
         &self.user
     }

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -17,9 +17,9 @@ use crate::catalog::storage;
 
 /// Configures a catalog.
 #[derive(Debug)]
-pub struct Config<'a> {
-    /// The connection to the SQLite database.
-    pub storage: storage::Connection,
+pub struct Config<'a, S> {
+    /// The connection to the stash.
+    pub storage: storage::Connection<S>,
     /// Whether to enable experimental mode.
     pub experimental_mode: Option<bool>,
     /// Whether to enable safe mode.

--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -44,7 +44,7 @@ where
     Ok(())
 }
 
-pub(crate) async fn migrate(catalog: &mut Catalog) -> Result<(), anyhow::Error> {
+pub(crate) async fn migrate<S: Append>(catalog: &mut Catalog<S>) -> Result<(), anyhow::Error> {
     let mut storage = catalog.storage().await;
     let catalog_version = storage.get_catalog_content_version().await?;
     let _catalog_version = match Version::parse(&catalog_version) {

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -77,6 +77,7 @@ use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
+use mz_stash::Append;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use timely::order::PartialOrder;
@@ -231,9 +232,9 @@ pub struct TimestampedUpdate {
 }
 
 /// Configures a coordinator.
-pub struct Config {
+pub struct Config<S> {
     pub dataflow_client: mz_dataflow_types::client::Controller,
-    pub storage: storage::Connection,
+    pub storage: storage::Connection<S>,
     pub timestamp_frequency: Duration,
     pub logical_compaction_window: Option<Duration>,
     pub experimental_mode: bool,
@@ -331,12 +332,12 @@ impl ConcreteComputeInstanceConfig {
 }
 
 /// Glues the external world to the Timely workers.
-pub struct Coordinator {
+pub struct Coordinator<S> {
     /// A client to a running dataflow cluster.
     dataflow_client: mz_dataflow_types::client::Controller,
     /// Optimizer instance for logical optimization of views.
     view_optimizer: Optimizer,
-    catalog: Catalog,
+    catalog: Catalog<S>,
     /// An in-memory WAL that stages writes before publishing them to Storage
     // TODO: this must be backed by some durable medium, e.g a STORAGE collection
     volatile_updates: HashMap<GlobalId, Vec<Update<Timestamp>>>,
@@ -442,7 +443,7 @@ macro_rules! guard_write_critical_section {
     };
 }
 
-impl Coordinator {
+impl<S: Append + 'static> Coordinator<S> {
     /// Assign a timestamp for a read from a local input. Reads following writes
     /// must be at a time >= the write's timestamp; we choose "equal to" for
     /// simplicity's sake and to open as few new timestamps as possible.
@@ -2982,8 +2983,8 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, CoordError> {
         // TODO: remove this function when sources are linearizable.
         // See: #11048.
-        fn check_no_unmaterialized_sources(
-            catalog: &Catalog,
+        fn check_no_unmaterialized_sources<S: Append>(
+            catalog: &Catalog<S>,
             id_bundle: &CollectionIdBundle,
             session: &Session,
         ) -> Result<(), CoordError> {
@@ -3265,7 +3266,7 @@ impl Coordinator {
             session.add_transaction_ops(TransactionOps::Tail)?;
         }
 
-        let make_sink_desc = |coord: &mut Coordinator, from, from_desc, uses| {
+        let make_sink_desc = |coord: &mut Coordinator<S>, from, from_desc, uses| {
             // Determine the frontier of updates to tail *from*.
             // Updates greater or equal to this frontier will be produced.
             let id_bundle = coord
@@ -4735,7 +4736,7 @@ impl Coordinator {
 ///
 /// Returns a handle to the coordinator and a client to communicate with the
 /// coordinator.
-pub async fn serve(
+pub async fn serve<S: Append + 'static>(
     Config {
         dataflow_client,
         storage,
@@ -4751,7 +4752,7 @@ pub async fn serve(
         secrets_controller,
         replica_sizes,
         availability_zones: _,
-    }: Config,
+    }: Config<S>,
 ) -> Result<(Handle, Client), CoordError> {
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
     let (internal_cmd_tx, internal_cmd_rx) = mpsc::unbounded_channel();
@@ -4911,8 +4912,8 @@ fn duration_to_timestamp_millis(d: Duration) -> Timestamp {
 /// This function is identical to sql::plan::describe except this is also
 /// supports describing FETCH statements which need access to bound portals
 /// through the session.
-pub fn describe(
-    catalog: &Catalog,
+pub fn describe<S: Append>(
+    catalog: &Catalog<S>,
     stmt: Statement<Raw>,
     param_types: &[Option<ScalarType>],
     session: &Session,
@@ -4967,6 +4968,7 @@ fn check_statement_safety(stmt: &Statement<Raw>) -> Result<(), CoordError> {
 pub mod fast_path_peek {
 
     use mz_dataflow_types::client::ComputeInstanceId;
+    use mz_stash::Append;
     use std::{collections::HashMap, num::NonZeroUsize};
     use uuid::Uuid;
 
@@ -5093,7 +5095,7 @@ pub mod fast_path_peek {
         }));
     }
 
-    impl crate::coord::Coordinator {
+    impl<S: Append + 'static> crate::coord::Coordinator<S> {
         /// Implements a peek plan produced by `create_plan` above.
         pub async fn implement_fast_path_peek(
             &mut self,
@@ -5302,7 +5304,7 @@ pub mod read_holds {
         pub(super) compute_instance: ComputeInstanceId,
     }
 
-    impl crate::coord::Coordinator {
+    impl<S> crate::coord::Coordinator<S> {
         /// Acquire read holds on the indicated collections at the indicated time.
         ///
         /// This method will panic if the holds cannot be acquired. In the future,
@@ -5426,7 +5428,7 @@ impl<T: timely::progress::Timestamp> ReadCapability<T> {
 }
 
 #[cfg(test)]
-impl Coordinator {
+impl<S: Append + 'static> Coordinator<S> {
     #[allow(dead_code)]
     async fn verify_ship_dataflow_no_error(&mut self) {
         // ship_dataflow, ship_dataflows, and finalize_dataflow are not allowed

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -27,6 +27,7 @@ use mz_ore::stack::maybe_grow;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{Datum, GlobalId, Row};
+use mz_stash::Append;
 
 use crate::catalog::{CatalogItem, CatalogState};
 use crate::coord::{CatalogTxn, Coordinator};
@@ -59,7 +60,7 @@ pub enum ExprPrepStyle<'a> {
     AsOf,
 }
 
-impl Coordinator {
+impl<S: Append> Coordinator<S> {
     /// Creates a new dataflow builder from the catalog and indexes in `self`.
     pub fn dataflow_builder(
         &self,

--- a/src/coord/src/coord/indexes.rs
+++ b/src/coord/src/coord/indexes.rs
@@ -13,6 +13,7 @@ use mz_dataflow_types::client::controller::ComputeController;
 use mz_dataflow_types::client::ComputeInstanceId;
 use mz_expr::MirScalarExpr;
 use mz_repr::GlobalId;
+use mz_stash::Append;
 use mz_transform::IndexOracle;
 
 use crate::catalog::{CatalogItem, CatalogState, Index};
@@ -27,7 +28,7 @@ pub struct ComputeInstanceIndexOracle<'a, T> {
     compute: ComputeController<'a, T>,
 }
 
-impl Coordinator {
+impl<S: Append> Coordinator<S> {
     /// Creates a new index oracle for the specified compute instance.
     pub fn index_oracle(
         &self,

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -70,6 +70,7 @@ mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 mz-secrets-filesystem = { path = "../secrets-filesystem" }
 mz-secrets-kubernetes = { path = "../secrets-kubernetes" }
+mz-stash = { path = "../stash" }
 native-tls = { version = "0.2.10", features = ["alpn"] }
 nix = "0.23.1"
 num_cpus = "1.13.1"

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -90,6 +90,7 @@ tempfile = "3.2.0"
 thiserror = "1.0.31"
 tokio = { version = "1.17.0", features = ["sync"] }
 tokio-openssl = "0.6.3"
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tokio-stream = { version = "0.1.8", features = ["net"] }
 tower-http = { version = "0.2.5", features = ["cors"] }
 tracing = "0.1.34"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -359,6 +359,9 @@ pub struct Args {
     /// directory.
     #[clap(long, env = "MZ_PERSIST_CONSENSUS_URL")]
     persist_consensus_url: Option<Url>,
+    /// Postgres catalog stash connection string.
+    #[clap(long, env = "MZ_CATALOG_POSTGRES_STASH", value_name = "POSTGRES_URL")]
+    catalog_postgres_stash: Option<String>,
 
     // === AWS options. ===
     /// An external ID to be supplied to all AWS AssumeRole operations.
@@ -654,6 +657,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
             Some(consensus_url) => consensus_url.to_string(),
         },
     };
+    let catalog_postgres_stash = args.catalog_postgres_stash;
 
     // When inside a cgroup with a cpu limit,
     // the logical cpus can be lower than the physical cpus.
@@ -751,6 +755,7 @@ max log level: {max_log_level}",
         cors_allowed_origin,
         data_directory,
         persist_location,
+        catalog_postgres_stash,
         orchestrator,
         secrets_controller: Some(secrets_controller),
         experimental_mode: args.experimental,

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -251,12 +251,11 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let listener = TcpListener::bind(&config.listen_addr).await?;
     let local_addr = listener.local_addr()?;
 
+    let stash = mz_stash::Sqlite::open(&config.data_directory.join("stash"))?;
+
     // Load the coordinator catalog from disk.
-    let coord_storage = mz_coord::catalog::storage::Connection::open(
-        &config.data_directory,
-        Some(config.experimental_mode),
-    )
-    .await?;
+    let coord_storage =
+        mz_coord::catalog::storage::Connection::open(stash, Some(config.experimental_mode)).await?;
 
     // Initialize orchestrator.
     let orchestrator: Box<dyn Orchestrator> = match config.orchestrator.backend {

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -150,6 +150,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             consensus_uri: format!("sqlite://{}/persist/consensus", data_directory.display()),
         },
         data_directory: data_directory.clone(),
+        catalog_postgres_stash: None,
         orchestrator: OrchestratorConfig {
             backend: OrchestratorBackend::Process(ProcessOrchestratorConfig {
                 image_dir: env::current_exe()?

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -564,6 +564,7 @@ impl Runner {
                 blob_uri: format!("file://{}/persist/blob", temp_dir.path().display()),
                 consensus_uri: format!("sqlite://{}/persist/consensus", temp_dir.path().display()),
             },
+            catalog_postgres_stash: None,
             orchestrator: OrchestratorConfig {
                 backend: OrchestratorBackend::Process(ProcessOrchestratorConfig {
                     image_dir: env::current_exe()?.parent().unwrap().to_path_buf(),


### PR DESCRIPTION
Allow configuring the coordinator to use postgres as a stash. Do not enable in tests yet due to various issues raised in #12270. Not safe to use yet.

### Motivation

  * This PR adds a known-desirable feature. #12207 

### Testing

- Untested for now.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a