### PR TITLE
tracing: use common tracing setup for computed and storaged

### DIFF
--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -26,7 +26,7 @@ mz-dataflow-types = { path = "../dataflow-types" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
@@ -59,6 +59,7 @@ prost-build = { version = "0.10.1", features = ["vendored"] }
 [features]
 default = ["jemalloc"]
 jemalloc = ["tikv-jemallocator", "mz-prof/jemalloc"]
+tokio-console = ["mz-ore/tokio-console"]
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -22,7 +22,6 @@ use serde::ser::Serialize;
 use tokio::net::TcpListener;
 use tokio::select;
 use tracing::info;
-use tracing_subscriber::EnvFilter;
 
 use mz_dataflow_types::client::{ComputeClient, GenericClient};
 use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
@@ -108,6 +107,19 @@ struct Args {
     /// Where to write a pid lock file. Should only be used for local process orchestrators.
     #[clap(long, value_name = "PATH")]
     pid_file_location: Option<PathBuf>,
+
+    // === Logging options. ===
+    /// Which log messages to emit. See `materialized`'s help for more
+    /// info.
+    ///
+    /// The default value for this option is "info".
+    #[clap(
+        long,
+        env = "COMPUTED_LOG_FILTER",
+        value_name = "FILTER",
+        default_value = "info"
+    )]
+    log_filter: String,
 }
 
 #[tokio::main]
@@ -198,12 +210,18 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 }
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_env("COMPUTED_LOG_FILTER")
-                .unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
+    let metrics_registry = mz_ore::metrics::MetricsRegistry::new();
+    let mut _tracing_stream = mz_ore::tracing::configure(
+        mz_ore::tracing::TracingConfig {
+            log_filter: &args.log_filter,
+            opentelemetry_endpoint: None,
+            opentelemetry_headers: None,
+            #[cfg(feature = "tokio-console")]
+            tokio_console: false,
+        },
+        &metrics_registry,
+    )
+    .await?;
 
     if args.workers == 0 {
         bail!("--workers must be greater than 0");

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -141,8 +141,8 @@ default = ["jemalloc"]
 # WARNING: For development use only! When enabled, may allow unrestricted read
 # access to the file system.
 dev-web = []
-tokio-console = ["mz-ore/tokio-console"]
 jemalloc = ["mz-prof/jemalloc", "tikv-jemallocator"]
+tokio-console = ["mz-ore/tokio-console"]
 
 [package.metadata.cargo-udeps.ignore]
 # sysctl is only used on macOS.

--- a/src/storaged/Cargo.toml
+++ b/src/storaged/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "3.1.15", features = ["derive", "env"] }
 futures = "0.3.21"
 mz-build-info = { path = "../build-info" }
 mz-dataflow-types = { path = "../dataflow-types" }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pid-file = { path = "../pid-file" }
 mz-prof = { path = "../prof", features = [ "jemalloc" ] }
@@ -36,3 +36,4 @@ tikv-jemallocator = { version = "0.4.3", features = ["profiling", "stats", "unpr
 [features]
 default = ["jemalloc"]
 jemalloc = ["tikv-jemallocator", "mz-prof/jemalloc"]
+tokio-console = ["mz-ore/tokio-console"]


### PR DESCRIPTION
Currently, storaged and computed have basic tracing setups. In the future, we will be doing more complex setups in the shared `mz-ore` tracing module, so this pr move storaged

- The primarily, NOTICEABLE change for this pr is that without `--log-file=stderr`, `bin/materialized` will only log `WARN` and above log lines from all processes to stderr, with the rest going to `mzdata/materialized.log`. I considered the old behavior, where, `WARN` mz logs went to stderr, and all computed/storaged logs went to stdout, a bug, as it does not match the previous single-binary experience. To facilitate this, the process orchestrator needed to pass flags down. I will need to announce this behavioral change in slack.

- Note that I have not yet seen any kind of skew problem from multiple processing writing to the same file.

- This pr does NOT setup `tokio-console` or `opentelemetry` for computed and storaged. This pr prepares us for that. Those will require more complex port and flag handling.

### Motivation


   * This PR refactors existing code.

see above

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
