### PR TITLE
ore,materialized: remove `--log-file` argument

### DIFF
--- a/doc/user/content/cli.md
+++ b/doc/user/content/cli.md
@@ -20,7 +20,6 @@ Flag | Default | Modifies
 [`--experimental`](#experimental-mode) | Disabled | *Dangerous.* Enable experimental features.
 [`--listen-addr`](#listen-address) | `0.0.0.0:6875` | The host and port on which to listen for HTTP and SQL connections
 [`-l`](#compaction-window) / [`--logical-compaction-window`](#compaction-window) | 1ms | The amount of historical detail to retain in arrangements
-[`--log-file`](#log-file) | [`mzdata`](#data-directory)`/materialized.log` | Where to emit log messages
 [`--log-filter`](#log-filter) | `info` | Which log messages to emit
 [`--tls-ca`](#tls-encryption) | N/A | Path to TLS certificate authority (CA) {{< version-added v0.7.1 />}}
 [`--tls-cert`](#tls-encryption) | N/A | Path to TLS certificate file
@@ -130,23 +129,7 @@ time for the configured duration. The default window is 1 millisecond.
 See the [Deployment section](/ops/optimization/#compaction) for guidance on tuning
 the compaction window.
 
-### Logging
-
-#### Log file
-
-The `--log-file` option specifies the path to a file in which Materialize will
-write its log messages. The value `stderr` is treated specially and specifies
-the standard error stream.
-
-If the option is unspecified, Materialize writes log messages to the
-`materialized.log` file in the [data directory](#data-directory) and
-additionally forwards any log messages at the `WARN` or `ERROR` levels to the
-standard error stream. Forwarding does not occur if you explicitly specify a log
-file.
-
-#### Log filter
-
-{{< version-added v0.7.2 />}}
+### Log filter
 
 The `--log-filter` option specifies which log messages Materialize will emit.
 Its value is a comma-separated list of filter directives. Each filter directive

--- a/misc/dist/materialized.service
+++ b/misc/dist/materialized.service
@@ -16,7 +16,7 @@ Type=exec
 User=_Materialize
 Group=_Materialize
 
-ExecStart=/usr/bin/materialized --data-directory /var/lib/materialize/mzdata --log-file=stderr
+ExecStart=/usr/bin/materialized --data-directory /var/lib/materialize/mzdata
 
 [Install]
 WantedBy=multi-user.target

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -14,4 +14,4 @@ RUN apt-get update && apt-get -qy install ca-certificates curl sqlite3 tini
 
 COPY storaged computed materialized /usr/local/bin/
 
-ENTRYPOINT ["tini", "--", "materialized", "--log-file=stderr", "--listen-addr=0.0.0.0:6875"]
+ENTRYPOINT ["tini", "--", "materialized", "--listen-addr=0.0.0.0:6875"]

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -194,12 +194,6 @@ pub struct Args {
     timestamp_frequency: Duration,
 
     // === Logging options. ===
-    /// Where to emit log messages.
-    ///
-    /// The special value "stderr" will emit messages to the standard error
-    /// stream. All other values are taken as file paths.
-    #[clap(long, env = "MZ_LOG_FILE", value_name = "PATH")]
-    log_file: Option<String>,
     /// Which log messages to emit.
     ///
     /// This value is a comma-separated list of filter directives. Each filter
@@ -497,10 +491,8 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut tracing_stream = runtime.block_on(mz_ore::tracing::configure(
         mz_ore::tracing::TracingConfig {
             log_filter: &args.log_filter,
-            log_file: args.log_file.as_deref(),
             opentelemetry_endpoint: args.opentelemetry_endpoint.as_deref(),
             opentelemetry_headers: args.opentelemetry_headers.as_deref(),
-            data_directory: &args.data_directory,
             #[cfg(feature = "tokio-console")]
             tokio_console: args.tokio_console,
         },

--- a/test/antithesis/materialized/Dockerfile
+++ b/test/antithesis/materialized/Dockerfile
@@ -16,4 +16,4 @@ RUN ldconfig
 
 COPY materialized computed storaged /usr/local/bin/
 
-ENTRYPOINT ["materialized", "--log-file=stderr"]
+ENTRYPOINT ["materialized"]


### PR DESCRIPTION
In a cloud native world, logs always go to stderr. So remove the
`--log-file` option to reduce complexity in our logging setup.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
