### PR TITLE
mzcompose: Update Redpanda to v22.1.3

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -249,7 +249,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v21.11.13",
+        version: str = "v22.1.3",
         image: Optional[str] = None,
         aliases: Optional[List[str]] = None,
         ports: Optional[List[int]] = None,
@@ -280,7 +280,6 @@ class Redpanda(Service):
             "--node-id=0",
             "--check=false",
             '--set "redpanda.enable_transactions=true"',
-            '--set "redpanda.enable_idempotence=true"',
             '--set "redpanda.auto_create_topics_enabled=false"',
             f"--advertise-kafka-addr kafka:{ports[0]}",
         ]


### PR DESCRIPTION
### Motivation

Update Redpanda to [v22.1.3](https://github.com/redpanda-data/redpanda/releases/tag/v22.1.3) the latest release - many features and fixes, `idempotence` is now on by default.

Signed-off-by: Ben Pope <ben@redpanda.com>

### Tips for reviewer

As of d807e771e695ae6b7e96824da018b47a90c693e5 I see a new failure, but it was fixed in a6ef2866462b9c34c53c9f60f413353f69ae8d2d
```
> CREATE SINK bad_schema_registry FROM src INTO KAFKA BROKER 'kafka:9092' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'kafka:9092'
query error matches; continuing
> CREATE SINK bad_schema_registry FROM src INTO KAFKA BROKER 'kafka:9092' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://kafka:9092'
^^^ +++
sinks.td:63:1: error: expected error containing 'unable to publish value schema to registry in kafka sink', but got 'deadline has elapsed'
     |
  62 | # Invalid in that the address is not for a schema registry
  63 | ! CREATE SINK bad_schema_registry FROM src
     | ^
```

The failure exists on previous releases of Redpanda, as well, so it's a change in behaviour of Materialize.

I didn't see any obvious reason why that commit changes the behaviour in a way that breaks the test.

### Changes in [force-push](https://github.com/MaterializeInc/materialize/compare/1883654c01a20e39f6997c64a5d5c7441de56ca9..85367dd082f54c93424206430219e135460f7e88)

I've rebased past #12421 to see if it helped, it did not.

### Changes in [force-push](https://github.com/MaterializeInc/materialize/compare/85367dd082f54c93424206430219e135460f7e88..98161f5be19700e079b0f361ee0be93d2f839f44)

I've rebased past #12438 so this is now expected to pass.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

mzcompose: Update Redpanda to [v22.1.3](https://github.com/redpanda-data/redpanda/releases/tag/v22.1.3)