### PR TITLE
coord: Fix panic on concurrent DDL

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5355,9 +5355,11 @@ pub mod read_holds {
             // Update STORAGE read policies.
             let mut policy_changes = Vec::new();
             for id in storage_ids.iter() {
-                let read_needs = self.read_capability.get_mut(id).unwrap();
-                read_needs.holds.update_iter(Some((time, -1)));
-                policy_changes.push((*id, read_needs.policy()));
+                // It's possible that a concurrent DDL statement has already dropped this GlobalId
+                if let Some(read_needs) = self.read_capability.get_mut(id) {
+                    read_needs.holds.update_iter(Some((time, -1)));
+                    policy_changes.push((*id, read_needs.policy()));
+                }
             }
             self.dataflow_client
                 .storage_mut()
@@ -5367,9 +5369,11 @@ pub mod read_holds {
             // Update COMPUTE read policies
             let mut policy_changes = Vec::new();
             for id in compute_ids.iter() {
-                let read_needs = self.read_capability.get_mut(id).unwrap();
-                read_needs.holds.update_iter(Some((time, -1)));
-                policy_changes.push((*id, read_needs.policy()));
+                // It's possible that a concurrent DDL statement has already dropped this GlobalId
+                if let Some(read_needs) = self.read_capability.get_mut(id) {
+                    read_needs.holds.update_iter(Some((time, -1)));
+                    policy_changes.push((*id, read_needs.policy()));
+                }
             }
             self.dataflow_client
                 .compute_mut(compute_instance)

--- a/test/testdrive/concurrent-ddl.td
+++ b/test/testdrive/concurrent-ddl.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test concurrent DDL transactions
+
+> CREATE TABLE foo (a INT)
+> INSERT INTO foo VALUES (42)
+> BEGIN
+> SELECT * FROM foo
+42
+
+$ postgres-connect name=ddl url=postgres://materialize:materialize@${testdrive.materialized-addr}
+
+$ postgres-execute connection=ddl
+DROP TABLE foo
+
+! SELECT * FROM foo
+contains:unknown catalog item 'foo'
+
+> ROLLBACK

--- a/test/testdrive/concurrent-ddl.td
+++ b/test/testdrive/concurrent-ddl.td
@@ -24,3 +24,17 @@ DROP TABLE foo
 contains:unknown catalog item 'foo'
 
 > ROLLBACK
+
+
+> CREATE TABLE foo (a INT)
+> INSERT INTO foo VALUES (42)
+> BEGIN
+> SELECT * FROM foo
+42
+
+$ postgres-connect name=ddl url=postgres://materialize:materialize@${testdrive.materialized-addr}
+
+$ postgres-execute connection=ddl
+DROP TABLE foo
+
+> COMMIT


### PR DESCRIPTION
Read transactions have read holds on certain GlobalIds.
These read holds are maintained by to Coordinator in the txn_reads
struct field. The Coordinator also maintains read capabilities for each
GlobalId in a struct field called read_capability. When a table or
source is dropped, the GlobalId is removed from the read_capability
field, but the read holds by any outstanding transactions are not
removed. This means that when the transaction goes to commit, it will
try and remove a read hold from a non-existent GlobalId and panic.

This commit updates the commit logic to only remove read holds from
GlobalIds that still exist.

If the read transaction tried to read from the GlobalId after it was
deleted, then it would have already ABORTed with an unknown item error.
If the read transaction didn't try to read from the GlobalId after it
was deleted, then it will COMMIT successfully. Neither of these
scenarios violate any consistency guarantees.

Fixes #12283

### Motivation
This PR fixes a recognized bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fixes panic caused by concurrent DDL statements.
