### PR TITLE
storage: implement pubnub sources as `SourceReader`s

### DIFF
--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -110,7 +110,10 @@ pub fn serve_boundary<SC: StorageCapture, B: Fn(usize) -> SC + Send + Sync + 'st
         let timely_worker_index = timely_worker.index();
         let timely_worker_peers = timely_worker.peers();
         let storage_boundary = create_boundary(timely_worker_index);
+
+        // ensure tokio primitives are available on timely workers
         let _tokio_guard = tokio_executor.enter();
+
         let command_rx = command_channels.lock().unwrap()[timely_worker_index % config.workers]
             .take()
             .unwrap();

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -343,6 +343,16 @@ impl MaybeLength for Vec<u8> {
     }
 }
 
+impl MaybeLength for mz_repr::Row {
+    fn len(&self) -> Option<usize> {
+        Some(self.data().len())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.data().is_empty()
+    }
+}
+
 impl MaybeLength for Value {
     // Not possible to compute a size in bytes without recursively traversing the entire tree.
     fn len(&self) -> Option<usize> {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -134,10 +134,12 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                     rt_default.add_partition(PartitionId::None, None);
                     Some(rt_default)
                 }
+                ExternalSourceConnector::PubNub(_) => {
+                    rt_default.add_partition(PartitionId::None, None);
+                    Some(rt_default)
+                }
                 ExternalSourceConnector::Kafka(_) => Some(rt_default),
-                ExternalSourceConnector::Postgres(_)
-                | ExternalSourceConnector::PubNub(_)
-                | ExternalSourceConnector::Persist(_) => None,
+                ExternalSourceConnector::Postgres(_) | ExternalSourceConnector::Persist(_) => None,
             }
         } else {
             debug!(


### PR DESCRIPTION
We are moving away from the `SimpleSource` framework. Pubnub is one of the simpler sources, so it was relatively straightforward to switch, especially with the new `async fn next` option on `SourceReader`. 

The most subtle part of this pr is choosing the timestamp: We have to shrink the u64 timetoken to a i64 (we will also need to do this for postgres, and should probably switch to u64 across the codebase), and we skip the region field. See the inline comment for justification. If that justification, which is the result of unclear documentation ends up not working, we will need to rethink how we produce definiteness for pubnub

### Motivation

  * This PR adds a known-desirable feature.

timestamp bindings for pubnub

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - (our pubnub tests are minimal for now)

### Release notes

None
