### PR TITLE
compute: Stop emitting zero-diffs in differential logging

### DIFF
--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -88,7 +88,7 @@ pub fn construct<A: Allocate>(
                         match datum {
                             DifferentialEvent::Batch(event) => {
                                 arrangement_batches_session
-                                    .give(&cap, ((event.operator, worker), time_ms, Diff::from(1)));
+                                    .give(&cap, ((event.operator, worker), time_ms, 1));
                                 arrangement_records_session.give(
                                     &cap,
                                     (
@@ -100,10 +100,8 @@ pub fn construct<A: Allocate>(
                             }
                             DifferentialEvent::Merge(event) => {
                                 if let Some(done) = event.complete {
-                                    arrangement_batches_session.give(
-                                        &cap,
-                                        ((event.operator, worker), time_ms, Diff::from(-1)),
-                                    );
+                                    arrangement_batches_session
+                                        .give(&cap, ((event.operator, worker), time_ms, -1));
                                     let diff = Diff::try_from(done).unwrap()
                                         - Diff::try_from(event.length1 + event.length2).unwrap();
                                     arrangement_records_session
@@ -111,10 +109,8 @@ pub fn construct<A: Allocate>(
                                 }
                             }
                             DifferentialEvent::Drop(event) => {
-                                arrangement_batches_session.give(
-                                    &cap,
-                                    ((event.operator, worker), time_ms, Diff::from(-1)),
-                                );
+                                arrangement_batches_session
+                                    .give(&cap, ((event.operator, worker), time_ms, -1));
                                 arrangement_records_session.give(
                                     &cap,
                                     (

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -89,14 +89,11 @@ pub fn construct<A: Allocate>(
                             DifferentialEvent::Batch(event) => {
                                 arrangement_batches_session
                                     .give(&cap, ((event.operator, worker), time_ms, 1));
-                                arrangement_records_session.give(
-                                    &cap,
-                                    (
-                                        (event.operator, worker),
-                                        time_ms,
-                                        Diff::try_from(event.length).unwrap(),
-                                    ),
-                                );
+                                let diff = Diff::try_from(event.length).unwrap();
+                                if diff != 0 {
+                                    arrangement_records_session
+                                        .give(&cap, ((event.operator, worker), time_ms, diff));
+                                }
                             }
                             DifferentialEvent::Merge(event) => {
                                 if let Some(done) = event.complete {
@@ -104,32 +101,27 @@ pub fn construct<A: Allocate>(
                                         .give(&cap, ((event.operator, worker), time_ms, -1));
                                     let diff = Diff::try_from(done).unwrap()
                                         - Diff::try_from(event.length1 + event.length2).unwrap();
-                                    arrangement_records_session
-                                        .give(&cap, ((event.operator, worker), time_ms, diff));
+                                    if diff != 0 {
+                                        arrangement_records_session
+                                            .give(&cap, ((event.operator, worker), time_ms, diff));
+                                    }
                                 }
                             }
                             DifferentialEvent::Drop(event) => {
                                 arrangement_batches_session
                                     .give(&cap, ((event.operator, worker), time_ms, -1));
-                                arrangement_records_session.give(
-                                    &cap,
-                                    (
-                                        (event.operator, worker),
-                                        time_ms,
-                                        -Diff::try_from(event.length).unwrap(),
-                                    ),
-                                );
+                                let diff = -Diff::try_from(event.length).unwrap();
+                                if diff != 0 {
+                                    arrangement_records_session
+                                        .give(&cap, ((event.operator, worker), time_ms, diff));
+                                }
                             }
                             DifferentialEvent::MergeShortfall(_) => {}
                             DifferentialEvent::TraceShare(event) => {
-                                sharing_session.give(
-                                    &cap,
-                                    (
-                                        (event.operator, worker),
-                                        time_ms,
-                                        Diff::try_from(event.diff).unwrap(),
-                                    ),
-                                );
+                                let diff = Diff::try_from(event.diff).unwrap();
+                                assert!(diff != 0);
+                                sharing_session
+                                    .give(&cap, ((event.operator, worker), time_ms, diff));
                             }
                         }
                     }

--- a/src/compute/src/logging/materialized.rs
+++ b/src/compute/src/logging/materialized.rs
@@ -27,7 +27,7 @@ use uuid::Uuid;
 use mz_dataflow_types::KeysValsHandle;
 use mz_dataflow_types::RowSpine;
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
-use mz_repr::{Datum, DatumVec, Diff, GlobalId, Row, Timestamp};
+use mz_repr::{Datum, DatumVec, GlobalId, Row, Timestamp};
 use mz_timely_util::activator::RcActivator;
 use mz_timely_util::replay::MzReplay;
 
@@ -213,7 +213,7 @@ pub fn construct<A: Allocate>(
                                         peek_duration_session.give((
                                             (key.0, elapsed_ns.next_power_of_two()),
                                             time_ms,
-                                            Diff::from(1),
+                                            1,
                                         ));
                                     } else {
                                         error!(


### PR DESCRIPTION
This PR ensures that the differential logging dataflow doesn't produce zero-diff updates, which can lead to issues if downstream operators don't accept zero-diffs.

### Motivation

   * This PR refactors existing code.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).
