### PR TITLE
mz-dataflow-types: Add protobuf for `Plan`

### DIFF
--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -12,6 +12,7 @@ fn main() {
         .extern_path(".mz_expr.linear", "::mz_expr")
         .extern_path(".mz_expr.relation", "::mz_expr")
         .extern_path(".mz_expr.scalar", "::mz_expr")
+        .extern_path(".mz_expr.id", "::mz_expr")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
         .extern_path(".mz_repr.proto", "::mz_repr::proto")
         .extern_path(".mz_repr.row", "::mz_repr")

--- a/src/dataflow-types/src/plan.proto
+++ b/src/dataflow-types/src/plan.proto
@@ -93,7 +93,7 @@ message ProtoPlan {
         mz_expr.relation.ProtoTableFunc func = 2;
         repeated mz_expr.scalar.ProtoMirScalarExpr exprs = 3;
         mz_expr.linear.ProtoMapFilterProject mfp = 4;
-        ProtoPlanInputKey key = 5;
+        ProtoPlanInputKey input_key = 5;
    }
 
    message ProtoPlanJoin {
@@ -102,15 +102,15 @@ message ProtoPlan {
    }
 
    message ProtoPlanReduce {
-        ProtoPlan reduce = 1;
+        ProtoPlan input = 1;
         mz_dataflow_types.plan.reduce.ProtoKeyValPlan key_val_plan = 2;
         mz_dataflow_types.plan.reduce.ProtoReducePlan plan = 3;
-        ProtoPlanInputKey key = 4;
+        ProtoPlanInputKey input_key = 4;
    }
 
    message ProtoPlanTopK {
         ProtoPlan input = 1;
-        mz_dataflow_types.plan.top_k.ProtoTopKPlan plan = 2;
+        mz_dataflow_types.plan.top_k.ProtoTopKPlan top_k_plan = 2;
    }
 
    message ProtoPlanThreshold {
@@ -141,6 +141,6 @@ message ProtoPlan {
         ProtoPlan negate = 9;
         ProtoPlanThreshold threshold = 10;
         ProtoPlanUnion union = 11;
-        ProtoPlanArrangeBy arrany_by = 12;
+        ProtoPlanArrangeBy arrange_by = 12;
    }
 }

--- a/src/dataflow-types/src/plan.proto
+++ b/src/dataflow-types/src/plan.proto
@@ -47,16 +47,16 @@ message ProtoPlan {
    message ProtoRowDiff {
         mz_repr.row.ProtoRow row = 1;
         uint64 timestamp = 2;
-        int64 diff = 3; 
+        int64 diff = 3;
    }
 
    message ProtoRowDiffVec {
-        repeated ProtoRowDiff rows = 1; 
+        repeated ProtoRowDiff rows = 1;
    }
 
    message ProtoPlanConstant {
         oneof result {
-            ProtoRowDiffVec rows = 1; 
+            ProtoRowDiffVec rows = 1;
             mz_expr.scalar.ProtoEvalError err = 2;
         }
    }
@@ -69,7 +69,7 @@ message ProtoPlan {
 
    message ProtoPlanLet {
         mz_expr.id.ProtoLocalId id = 1;
-        ProtoPlan value = 2; 
+        ProtoPlan value = 2;
         ProtoPlan body  = 3;
    }
 
@@ -135,7 +135,7 @@ message ProtoPlan {
         ProtoPlanLet let = 3;
         ProtoPlanMfp mfp = 4;
         ProtoPlanFlatMap flat_map = 5;
-        ProtoPlanJoin join = 6; 
+        ProtoPlanJoin join = 6;
         ProtoPlanReduce reduce = 7;
         ProtoPlanTopK top_k = 8;
         ProtoPlan negate = 9;

--- a/src/dataflow-types/src/plan.proto
+++ b/src/dataflow-types/src/plan.proto
@@ -12,6 +12,8 @@
 syntax = "proto3";
 
 import "expr/src/scalar.proto";
+import "expr/src/linear.proto";
+import "repr/src/row.proto";
 import "google/protobuf/empty.proto";
 
 package mz_dataflow_types.plan;
@@ -31,4 +33,18 @@ message ProtoArrangement {
 message ProtoAvailableCollections {
     bool raw = 1;
     repeated ProtoArrangement arranged = 2;
+}
+
+message ProtoGetPlan {
+    message ProtoGetPlanArrangement {
+        repeated mz_expr.scalar.ProtoMirScalarExpr key = 1;
+        mz_repr.row.ProtoRow seek = 2;
+        mz_expr.linear.ProtoMapFilterProject mfp = 3;
+    };
+
+    oneof kind {
+        google.protobuf.Empty pass_arrangements = 1;
+        ProtoGetPlanArrangement arrangement = 2;
+        mz_expr.linear.ProtoMapFilterProject collection = 3;
+    }
 }

--- a/src/dataflow-types/src/plan.proto
+++ b/src/dataflow-types/src/plan.proto
@@ -11,28 +11,22 @@
 
 syntax = "proto3";
 
-import "expr/src/scalar.proto";
+import "dataflow-types/src/plan/join.proto";
+import "dataflow-types/src/plan/reduce.proto";
+import "dataflow-types/src/plan/threshold.proto";
+import "dataflow-types/src/plan/top_k.proto";
+import "expr/src/id.proto";
 import "expr/src/linear.proto";
+import "expr/src/relation.proto";
+import "expr/src/scalar.proto";
 import "repr/src/row.proto";
 import "google/protobuf/empty.proto";
 
 package mz_dataflow_types.plan;
 
-message ProtoArrangement {
-    message ProtoArrangementPermutation {
-        uint64 key = 1;
-        uint64 val = 2;
-    };
-
-    repeated mz_expr.scalar.ProtoMirScalarExpr all_columns = 1;
-    repeated ProtoArrangementPermutation  permutation = 2;
-    repeated uint64 thinning = 3;
-
-};
-
 message ProtoAvailableCollections {
     bool raw = 1;
-    repeated ProtoArrangement arranged = 2;
+    repeated mz_dataflow_types.plan.threshold.ProtoArrangement arranged = 2;
 }
 
 message ProtoGetPlan {
@@ -47,4 +41,106 @@ message ProtoGetPlan {
         ProtoGetPlanArrangement arrangement = 2;
         mz_expr.linear.ProtoMapFilterProject collection = 3;
     }
+}
+
+message ProtoPlan {
+   message ProtoRowDiff {
+        mz_repr.row.ProtoRow row = 1;
+        uint64 timestamp = 2;
+        int64 diff = 3; 
+   }
+
+   message ProtoRowDiffVec {
+        repeated ProtoRowDiff rows = 1; 
+   }
+
+   message ProtoPlanConstant {
+        oneof result {
+            ProtoRowDiffVec rows = 1; 
+            mz_expr.scalar.ProtoEvalError err = 2;
+        }
+   }
+
+   message ProtoPlanGet {
+        mz_expr.id.ProtoId id = 1;
+        ProtoAvailableCollections keys = 2;
+        ProtoGetPlan plan = 3;
+   }
+
+   message ProtoPlanLet {
+        mz_expr.id.ProtoLocalId id = 1;
+        ProtoPlan value = 2; 
+        ProtoPlan body  = 3;
+   }
+
+   message ProtoPlanInputKeyVal {
+        repeated mz_expr.scalar.ProtoMirScalarExpr key = 1;
+        mz_repr.row.ProtoRow val = 2;
+   }
+
+   message ProtoPlanMfp {
+        ProtoPlan input = 1;
+        mz_expr.linear.ProtoMapFilterProject mfp = 2;
+        ProtoPlanInputKeyVal input_key_val = 3;
+   }
+
+   message ProtoPlanInputKey {
+        repeated mz_expr.scalar.ProtoMirScalarExpr key = 1;
+   }
+
+   message ProtoPlanFlatMap {
+        ProtoPlan input = 1;
+        mz_expr.relation.ProtoTableFunc func = 2;
+        repeated mz_expr.scalar.ProtoMirScalarExpr exprs = 3;
+        mz_expr.linear.ProtoMapFilterProject mfp = 4;
+        ProtoPlanInputKey key = 5;
+   }
+
+   message ProtoPlanJoin {
+        repeated ProtoPlan inputs = 1;
+        mz_dataflow_types.plan.join.ProtoJoinPlan plan = 2;
+   }
+
+   message ProtoPlanReduce {
+        ProtoPlan reduce = 1;
+        mz_dataflow_types.plan.reduce.ProtoKeyValPlan key_val_plan = 2;
+        mz_dataflow_types.plan.reduce.ProtoReducePlan plan = 3;
+        ProtoPlanInputKey key = 4;
+   }
+
+   message ProtoPlanTopK {
+        ProtoPlan input = 1;
+        mz_dataflow_types.plan.top_k.ProtoTopKPlan plan = 2;
+   }
+
+   message ProtoPlanThreshold {
+        ProtoPlan input = 1;
+        mz_dataflow_types.plan.threshold.ProtoThresholdPlan threshold_plan = 2;
+   }
+
+   message ProtoPlanUnion {
+        repeated ProtoPlan inputs = 1;
+   }
+
+   message ProtoPlanArrangeBy {
+        ProtoPlan input = 1;
+        ProtoAvailableCollections forms = 2;
+        ProtoPlanInputKey input_key = 3;
+        mz_expr.linear.ProtoMapFilterProject input_mfp = 4;
+   }
+
+   oneof kind {
+        ProtoPlanConstant constant = 1;
+        ProtoPlanGet get = 2;
+        ProtoPlanLet let = 3;
+        ProtoPlanMfp mfp = 4;
+        ProtoPlanFlatMap flat_map = 5;
+        ProtoPlanJoin join = 6; 
+        ProtoPlanReduce reduce = 7;
+        ProtoPlanTopK top_k = 8;
+        ProtoPlan negate = 9;
+        ProtoPlanThreshold threshold = 10;
+        ProtoPlanUnion union = 11;
+        ProtoPlanArrangeBy arrany_by = 12;
+   }
 }

--- a/src/dataflow-types/src/plan/join.proto
+++ b/src/dataflow-types/src/plan/join.proto
@@ -11,7 +11,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
 import "expr/src/linear.proto";
 import "expr/src/scalar.proto";
 

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -18,7 +18,6 @@ use std::collections::BTreeSet;
 use std::collections::HashMap;
 
 use mz_ore::soft_panic_or_log;
-use mz_repr::proto::ProtoRepr;
 use mz_repr::proto::TryFromProtoError;
 use mz_repr::proto::TryIntoIfSome;
 use proptest::arbitrary::Arbitrary;
@@ -117,51 +116,6 @@ pub(crate) fn any_arranged_thin(
         HashMap::<usize, usize>::arbitrary(),
         Vec::<usize>::arbitrary(),
     )
-}
-
-impl From<&(Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>)> for ProtoArrangement {
-    fn from(x: &(Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>)) -> Self {
-        use proto_arrangement::ProtoArrangementPermutation;
-        Self {
-            all_columns: x.0.iter().map(Into::into).collect(),
-            permutation: x
-                .1
-                .iter()
-                .map(|x| ProtoArrangementPermutation {
-                    key: x.0.into_proto(),
-                    val: x.1.into_proto(),
-                })
-                .collect(),
-            thinning: x.2.iter().map(|x| x.into_proto()).collect(),
-        }
-    }
-}
-
-impl TryFrom<ProtoArrangement> for (Vec<MirScalarExpr>, HashMap<usize, usize>, Vec<usize>) {
-    type Error = TryFromProtoError;
-
-    fn try_from(x: ProtoArrangement) -> Result<Self, Self::Error> {
-        let perm: Result<HashMap<usize, usize>, TryFromProtoError> = x
-            .permutation
-            .iter()
-            .map(|x| {
-                let key = usize::from_proto(x.key);
-                let val = usize::from_proto(x.val);
-                Ok((key?, val?))
-            })
-            .collect();
-        Ok((
-            x.all_columns
-                .into_iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<_, _>>()?,
-            perm?,
-            x.thinning
-                .into_iter()
-                .map(usize::from_proto)
-                .collect::<Result<_, _>>()?,
-        ))
-    }
 }
 
 impl From<&AvailableCollections> for ProtoAvailableCollections {

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -1796,6 +1796,7 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
+       #![proptest_config(ProptestConfig::with_cases(10))]
        #[test]
        fn available_collections_protobuf_roundtrip(expect in any::<AvailableCollections>() ) {
             let actual = protobuf_roundtrip::<_, ProtoAvailableCollections>(&expect);
@@ -1805,7 +1806,7 @@ mod tests {
     }
 
     proptest! {
-       #![proptest_config(ProptestConfig::with_cases(100))]
+       #![proptest_config(ProptestConfig::with_cases(10))]
        #[test]
        fn get_plan_protobuf_roundtrip(expect in any::<GetPlan>()) {
             let actual = protobuf_roundtrip::<_, ProtoGetPlan>(&expect);
@@ -1816,7 +1817,7 @@ mod tests {
     }
 
     proptest! {
-       #![proptest_config(ProptestConfig::with_cases(1))]
+       #![proptest_config(ProptestConfig::with_cases(32))]
        #[test]
        fn plan_protobuf_roundtrip(expect in any::<Plan>()) {
             let actual = protobuf_roundtrip::<_, ProtoPlan>(&expect);

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -446,7 +446,7 @@ impl Arbitrary for Plan {
                 prop::collection::vec(inner.clone(), 0..2).prop_map(|x| Plan::Union { inputs: x }),
                 //Plan::ArrangeBy
                 (
-                    inner.clone(),
+                    inner,
                     any::<AvailableCollections>(),
                     any::<Option<Vec<MirScalarExpr>>>(),
                     any::<MapFilterProject>()
@@ -714,8 +714,7 @@ impl TryFrom<ProtoPlan> for Plan {
                 id: proto.id.try_into_if_some("ProtoPlanLet::id")?,
                 value: proto.value.try_into_if_some("ProtoPlanLet::value")?,
                 body: proto.body.try_into_if_some("ProtoPlanLet::body")?,
-            }
-            .into(),
+            },
             Mfp(proto) => Plan::Mfp {
                 input: proto.input.try_into_if_some("ProtoPlanMfp::input")?,
                 input_key_val: input_kv_try_into(proto.input_key_val)?,

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -1358,6 +1358,7 @@ pub fn linear_to_mfp(
 mod tests {
     use super::*;
     use mz_repr::proto::protobuf_roundtrip;
+    use proptest::prelude::*;
 
     proptest! {
        #[test]

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -370,49 +370,50 @@ impl Arbitrary for Plan {
         let leaf = prop::strategy::Union::new(vec![constant.boxed(), get.boxed()]).boxed();
 
         leaf.prop_recursive(2, 4, 5, |inner| {
-            prop_oneof![
+            prop::strategy::Union::new(vec![
                 //Plan::Let
-                (any::<LocalId>(), inner.clone(), inner.clone()).prop_map(|(id, value, body)| {
-                    Plan::Let {
+                (any::<LocalId>(), inner.clone(), inner.clone())
+                    .prop_map(|(id, value, body)| Plan::Let {
                         id,
                         value: value.into(),
                         body: body.into(),
-                    }
-                }),
+                    })
+                    .boxed(),
                 //Plan::Mfp
                 (
                     inner.clone(),
                     any::<MapFilterProject>(),
-                    any::<Option<(Vec<MirScalarExpr>, Option<Row>)>>()
+                    any::<Option<(Vec<MirScalarExpr>, Option<Row>)>>(),
                 )
                     .prop_map(|(input, mfp, input_key_val)| Plan::Mfp {
                         input: input.into(),
                         mfp,
-                        input_key_val
-                    }),
+                        input_key_val,
+                    })
+                    .boxed(),
                 //Plan::FlatMap
                 (
                     inner.clone(),
                     any::<TableFunc>(),
                     any::<Vec<MirScalarExpr>>(),
                     any::<MapFilterProject>(),
-                    any::<Option<Vec<MirScalarExpr>>>()
+                    any::<Option<Vec<MirScalarExpr>>>(),
                 )
-                    .prop_map(|(input, func, exprs, mfp, input_key)| {
-                        Plan::FlatMap {
-                            input: input.into(),
-                            func,
-                            exprs,
-                            mfp,
-                            input_key,
-                        }
-                    }),
+                    .prop_map(|(input, func, exprs, mfp, input_key)| Plan::FlatMap {
+                        input: input.into(),
+                        func,
+                        exprs,
+                        mfp,
+                        input_key,
+                    })
+                    .boxed(),
                 //Plan::Join
                 (
                     prop::collection::vec(inner.clone(), 0..2),
-                    any::<JoinPlan>()
+                    any::<JoinPlan>(),
                 )
-                    .prop_map(|(inputs, plan)| Plan::Join { inputs, plan }),
+                    .prop_map(|(inputs, plan)| Plan::Join { inputs, plan })
+                    .boxed(),
                 //Plan::Reduce
                 (
                     inner.clone(),
@@ -420,46 +421,51 @@ impl Arbitrary for Plan {
                     any::<ReducePlan>(),
                     any::<Option<Vec<MirScalarExpr>>>(),
                 )
-                    .prop_map(|(input, key_val_plan, plan, input_key)| {
-                        Plan::Reduce {
-                            input: input.into(),
-                            key_val_plan,
-                            plan,
-                            input_key,
-                        }
-                    }),
+                    .prop_map(|(input, key_val_plan, plan, input_key)| Plan::Reduce {
+                        input: input.into(),
+                        key_val_plan,
+                        plan,
+                        input_key,
+                    })
+                    .boxed(),
                 //Plan::TopK
-                (inner.clone(), any::<TopKPlan>()).prop_map(|(input, top_k_plan)| Plan::TopK {
-                    input: input.into(),
-                    top_k_plan
-                }),
+                (inner.clone(), any::<TopKPlan>())
+                    .prop_map(|(input, top_k_plan)| Plan::TopK {
+                        input: input.into(),
+                        top_k_plan,
+                    })
+                    .boxed(),
                 //Plan::Negate
-                inner.clone().prop_map(|x| Plan::Negate { input: x.into() }),
+                inner
+                    .clone()
+                    .prop_map(|x| Plan::Negate { input: x.into() })
+                    .boxed(),
                 //Plan::Threshold
-                (inner.clone(), any::<ThresholdPlan>()).prop_map(|(input, threshold_plan)| {
-                    Plan::Threshold {
+                (inner.clone(), any::<ThresholdPlan>())
+                    .prop_map(|(input, threshold_plan)| Plan::Threshold {
                         input: input.into(),
                         threshold_plan,
-                    }
-                }),
+                    })
+                    .boxed(),
                 // Plan::Union
-                prop::collection::vec(inner.clone(), 0..2).prop_map(|x| Plan::Union { inputs: x }),
+                prop::collection::vec(inner.clone(), 0..2)
+                    .prop_map(|x| Plan::Union { inputs: x })
+                    .boxed(),
                 //Plan::ArrangeBy
                 (
                     inner,
                     any::<AvailableCollections>(),
                     any::<Option<Vec<MirScalarExpr>>>(),
-                    any::<MapFilterProject>()
+                    any::<MapFilterProject>(),
                 )
-                    .prop_map(|(input, forms, input_key, input_mfp)| {
-                        Plan::ArrangeBy {
-                            input: input.into(),
-                            forms,
-                            input_key,
-                            input_mfp,
-                        }
+                    .prop_map(|(input, forms, input_key, input_mfp)| Plan::ArrangeBy {
+                        input: input.into(),
+                        forms,
+                        input_key,
+                        input_mfp,
                     })
-            ]
+                    .boxed(),
+            ])
         })
         .boxed()
     }

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -1358,7 +1358,6 @@ pub fn linear_to_mfp(
 mod tests {
     use super::*;
     use mz_repr::proto::protobuf_roundtrip;
-    use proptest::prelude::*;
 
     proptest! {
        #[test]

--- a/src/dataflow-types/src/plan/reduce.proto
+++ b/src/dataflow-types/src/plan/reduce.proto
@@ -11,10 +11,10 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
 import "expr/src/linear.proto";
 import "expr/src/relation.proto";
 import "expr/src/scalar.proto";
+import "google/protobuf/empty.proto";
 
 package mz_dataflow_types.plan.reduce;
 

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -73,6 +73,7 @@ use mz_repr::proto::TryFromProtoError;
 use mz_repr::proto::TryIntoIfSome;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy};
 use proptest::strategy::Strategy;
+use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -828,7 +829,7 @@ impl ReducePlan {
 }
 
 /// Plan for extracting keys and values in preparation for a reduction.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct KeyValPlan {
     /// Extracts the columns used as the key.
     pub key_plan: mz_expr::SafeMfpPlan,

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -841,7 +841,7 @@ impl From<&KeyValPlan> for ProtoKeyValPlan {
     fn from(x: &KeyValPlan) -> Self {
         Self {
             key_plan: Some((&x.key_plan).into()),
-            val_plan: Some((&x.key_plan).into()),
+            val_plan: Some((&x.val_plan).into()),
         }
     }
 }

--- a/src/dataflow-types/src/plan/threshold.proto
+++ b/src/dataflow-types/src/plan/threshold.proto
@@ -11,13 +11,25 @@
 
 syntax = "proto3";
 
-import "dataflow-types/src/plan.proto";
+import "expr/src/scalar.proto";
 
 package mz_dataflow_types.plan.threshold;
 
 message ProtoThresholdPlan {
    oneof kind {
-       mz_dataflow_types.plan.ProtoArrangement basic = 1;
-       mz_dataflow_types.plan.ProtoArrangement retractions = 2;
+       ProtoArrangement basic = 1;
+       ProtoArrangement retractions = 2;
    }
 }
+
+message ProtoArrangement {
+    message ProtoArrangementPermutation {
+        uint64 key = 1;
+        uint64 val = 2;
+    };
+
+    repeated mz_expr.scalar.ProtoMirScalarExpr all_columns = 1;
+    repeated ProtoArrangementPermutation  permutation = 2;
+    repeated uint64 thinning = 3;
+
+};

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -30,6 +30,7 @@ pub mod visit;
 pub use relation::canonicalize;
 
 pub use id::{Id, LocalId, PartitionId, SourceInstanceId};
+pub use id::{ProtoId, ProtoLocalId};
 pub use linear::{
     memoize_expr,
     plan::{MfpPlan, SafeMfpPlan},
@@ -44,7 +45,7 @@ pub use relation::{
     MirRelationExpr, ProtoAggregateExpr, RowSetFinishing, WindowFrame, WindowFrameBound,
     WindowFrameUnits, RECURSION_LIMIT,
 };
-pub use relation::{ProtoAggregateFunc, ProtoColumnOrder, ProtoRowSetFinishing};
+pub use relation::{ProtoAggregateFunc, ProtoColumnOrder, ProtoRowSetFinishing, ProtoTableFunc};
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};
 pub use scalar::{ProtoDomainLimit, ProtoEvalError, ProtoMirScalarExpr};


### PR DESCRIPTION
Add Protobuf support for `Plan`

Fixes #11739 

Proptest revealed a typo bug in an unrelated type, KeyValPlan, fixed here 57e1993e779993fe9d31a8087dea1d6c283df7de

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None
