### PR TITLE
dataflow-types,expr: use fewer cases for some `protobuf_roundtrip` tests

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -931,7 +931,7 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(4))]
+        #![proptest_config(ProptestConfig::with_cases(32))]
 
         #[test]
         fn peek_protobuf_roundtrip(expect in any::<Peek>() ) {

--- a/src/dataflow-types/src/plan/join/mod.rs
+++ b/src/dataflow-types/src/plan/join/mod.rs
@@ -430,7 +430,7 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(2))]
+        #![proptest_config(ProptestConfig::with_cases(32))]
 
         #[test]
         fn join_plan_protobuf_roundtrip(expect in any::<JoinPlan>() ) {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1804,6 +1804,8 @@ mod tests {
     use mz_repr::proto::protobuf_roundtrip;
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
         #[test]
         fn mfp_plan_protobuf_roundtrip(expect in any::<MfpPlan>()) {
             let actual = protobuf_roundtrip::<_, ProtoMfpPlan>(&expect);

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1316,6 +1316,7 @@ pub mod plan {
 
     use std::collections::HashMap;
 
+    use proptest::prelude::*;
     use proptest_derive::Arbitrary;
     use serde::{Deserialize, Serialize};
 
@@ -1454,8 +1455,10 @@ pub mod plan {
         /// Normal predicates to evaluate on `&[Datum]` and expect `Ok(Datum::True)`.
         mfp: SafeMfpPlan,
         /// Expressions that when evaluated lower-bound `MzLogicalTimestamp`.
+        #[proptest(strategy = "prop::collection::vec(any::<MirScalarExpr>(), 0..2)")]
         lower_bounds: Vec<MirScalarExpr>,
         /// Expressions that when evaluated upper-bound `MzLogicalTimestamp`.
+        #[proptest(strategy = "prop::collection::vec(any::<MirScalarExpr>(), 0..2)")]
         upper_bounds: Vec<MirScalarExpr>,
     }
 


### PR DESCRIPTION
Use 32 arbitrary input cases (instead of the default 256) for `protobuf_roundtrip` tests that take a lot of time per instance.

The following tests currently fall into this category:

- Tests that rely on `MapFilterProject`.
- Tests that rely on `JoinPlan`.

### Motivation

   * This PR refactors existing code.

Address leftovers from #11970 and #11740.

### Tips for reviewer

With those changes, running all `protobuf_roundtrip` tests takes ~17 seconds on my machine.

```bash
for i in {1..8}; do time cargo test -p mz-dataflow-types -p mz-expr -p mz-repr protobuf_roundtrip -- --nocapture > /dev/null 2>/dev/null; done
```
results in
```
23,563 total 
17,850 total 
19,684 total 
16,505 total 
17,672 total 
15,691 total 
15,261 total 
19,026 total 
```

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A