### PR TITLE
bin/materialized: Only set RUSTFLAGS if needed

### DIFF
--- a/bin/materialized
+++ b/bin/materialized
@@ -50,7 +50,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-RUSTFLAGS=$rustflags cargo ${channel:+"$channel"} build "${build_flags[@]}" --bin storaged --bin computed --bin "$bin"
+${rustflags:+"RUSTFLAGS=$rustflags"} cargo ${channel:+"$channel"} build "${build_flags[@]}" --bin storaged --bin computed --bin "$bin"
 if $release; then
     target/release/"$bin" "${positional_args[@]}"
 else


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug. Prevent full rebuilds when using other cargo interactions.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
