### PR TITLE
cluster: Tests around cluster isolation

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -157,6 +157,17 @@ steps:
     agents:
       queue: linux-x86_64
 
+  - id: cluster-isolation
+    label: Cluster isolation test
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    inputs: [test/cluster]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: cluster-isolation
+    agents:
+      queue: linux-x86_64
+
   - id: kafka-ssl
     label: Kafka SSL smoke test
     depends_on: build-x86_64

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -829,20 +829,25 @@ class Composition:
         )
 
     def testdrive(
-        self, input: str, service: str = "testdrive", persistent: bool = True
+        self,
+        input: str,
+        service: str = "testdrive",
+        persistent: bool = True,
+        args: List[str] = [],
     ) -> None:
         """Run a string as a testdrive script.
 
         Args:
+            args: Additional arguments to pass to testdrive
             service: Optional name of the testdrive service to use.
             input: The string to execute.
             persistent: Whether a persistent testdrive container will be used.
         """
 
         if persistent:
-            self.exec(service, stdin=input)
+            self.exec(service, *args, stdin=input)
         else:
-            self.run(service, stdin=input)
+            self.run(service, *args, stdin=input)
 
 
 class ServiceConfig(TypedDict, total=False):

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -42,6 +42,7 @@ class Materialized(Service):
         if environment is None:
             environment = [
                 "MZ_SOFT_ASSERTIONS=1",
+                "RUST_BACKTRACE=1",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
                 # then accidentally dependent on the state of the host machine.
@@ -130,6 +131,7 @@ class Computed(Service):
             environment = [
                 "COMPUTED_LOG_FILTER",
                 "MZ_SOFT_ASSERTIONS=1",
+                "RUST_BACKTRACE=1",
             ]
 
         if volumes is None:
@@ -507,6 +509,7 @@ class Testdrive(Service):
             environment = [
                 "TMPDIR=/share/tmp",
                 "MZ_SOFT_ASSERTIONS=1",
+                "RUST_BACKTRACE=1",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
                 # then accidentally dependent on the state of the host machine.
@@ -602,6 +605,7 @@ class SqlLogicTest(Service):
             "PGHOST=postgres",
             "PGPASSWORD=postgres",
             "MZ_SOFT_ASSERTIONS=1",
+            "RUST_BACKTRACE=1",
         ],
         volumes: List[str] = ["../..:/workdir"],
         depends_on: List[str] = ["postgres"],

--- a/test/cluster-isolation/mzcompose
+++ b/test/cluster-isolation/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -1,0 +1,233 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+from materialize import spawn
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import (
+    Computed,
+    Kafka,
+    Materialized,
+    SchemaRegistry,
+    Testdrive,
+    Zookeeper,
+)
+
+SERVICES = [Zookeeper(), Kafka(), SchemaRegistry(), Materialized(), Testdrive()]
+
+
+@dataclass
+class Disruption:
+    name: str
+    disruption: Callable
+
+
+disruptions = [
+    Disruption(
+        name="pause-one-computed",
+        disruption=lambda c: c.pause("computed_1_1"),
+    ),
+    Disruption(
+        name="kill-all-computed",
+        disruption=lambda c: c.kill("computed_1_1", "computed_1_2"),
+    ),
+    Disruption(
+        name="pause-in-materialized-view",
+        disruption=lambda c: c.testdrive(
+            """
+> SET cluster=cluster1
+
+> CREATE TABLE sleep_table (sleep INTEGER);
+
+> CREATE MATERIALIZED VIEW sleep_view AS SELECT mz_internal.mz_sleep(sleep) FROM sleep_table;
+
+> INSERT INTO sleep_table SELECT 1200 FROM generate_series(1,32)
+""",
+        ),
+    ),
+    Disruption(
+        name="drop-cluster",
+        disruption=lambda c: c.testdrive(
+            """
+> DROP CLUSTER cluster1
+""",
+        ),
+    ),
+]
+
+# computed: adapter hangs if cluster has panicked during INSERT ... SELECT #12251
+disruptions_disabled = [
+    Disruption(
+        name="panic-in-insert-select",
+        disruption=lambda c: c.testdrive(
+            """
+> CREATE TABLE panic_table (f1 TEXT);
+
+> INSERT INTO panic_table VALUES ('panic!');
+
+! INSERT INTO panic_table SELECT mz_internal.mz_panic(f1) FROM panic_table;
+contains: deadline has elapsed
+""",
+        ),
+    ),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    """Test cluster isolation by introducing faults of various kinds in cluster1
+    and then making sure that cluster2 continues to operate properly
+    """
+
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    for id, disruption in enumerate(disruptions):
+        run_test(c, disruption, id)
+
+
+def populate(c: Composition) -> None:
+    # Create some database objects
+    c.testdrive(
+        """
+> SET cluster=cluster1
+
+> CREATE TABLE t1 (f1 TEXT);
+
+> INSERT INTO t1 VALUES (1), (2);
+
+> CREATE VIEW v1 AS SELECT COUNT(*) AS c1 FROM t1;
+
+> CREATE DEFAULT INDEX i1 IN CLUSTER cluster2 ON v1;
+""",
+    )
+
+
+def validate(c: Composition) -> None:
+    # Validate that cluster2 continues to operate
+    c.testdrive(
+        """
+# Dataflows
+
+> SELECT * FROM v1;
+2
+
+# Tables
+
+> INSERT INTO t1 VALUES (3);
+
+> SELECT * FROM t1;
+1
+2
+3
+
+# Introspection tables
+
+> SHOW CLUSTERS LIKE 'cluster2'
+cluster2
+
+> SELECT name FROM mz_tables WHERE name = 't1';
+t1
+
+# DDL statements
+
+> CREATE MATERIALIZED VIEW v2 AS SELECT COUNT(*) AS c1 FROM t1;
+
+> SELECT * FROM v2;
+3
+
+> CREATE INDEX i2 IN CLUSTER cluster2 ON t1 (f1);
+
+> SELECT f1 FROM t1;
+1
+2
+3
+
+# Tables
+
+> CREATE TABLE t2 (f1 INTEGER);
+
+> INSERT INTO t2 VALUES (1);
+
+> INSERT INTO t2 SELECT * FROM t2;
+
+> SELECT * FROM t2;
+1
+1
+
+# Sources
+
+$ kafka-create-topic topic=source1 partitions=1
+$ kafka-ingest format=bytes topic=source1
+A
+
+> CREATE MATERIALIZED SOURCE source1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-source1-${testdrive.seed}'
+  FORMAT BYTES
+
+> SELECT * FROM source1
+A 1
+
+# Sinks
+
+> CREATE SINK sink1 FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'sink1'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-verify format=avro sink=materialize.public.sink1 sort-messages=true
+{"before": null, "after": {"row":{"c1": 3}}}
+""",
+    )
+
+
+def run_test(c: Composition, disruption: Disruption, id: int) -> None:
+    print(f"+++ Running disruption scenario {disruption.name}")
+
+    c.up("testdrive", persistent=True)
+    c.up("materialized")
+    c.wait_for_materialized(service="materialized")
+
+    nodes = [
+        Computed(name="computed_1_1", peers=["computed_1_1", "computed_1_2"]),
+        Computed(name="computed_1_2", peers=["computed_1_1", "computed_1_2"]),
+        Computed(name="computed_2_1", peers=["computed_2_1", "computed_2_2"]),
+        Computed(name="computed_2_2", peers=["computed_2_1", "computed_2_2"]),
+    ]
+
+    with c.override(*nodes):
+        c.up(*[n.name for n in nodes])
+
+        c.sql(
+            "CREATE CLUSTER cluster1 REPLICA replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100'));"
+        )
+
+        c.sql(
+            "CREATE CLUSTER cluster2 REPLICA replica1 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'));"
+        )
+
+        with c.override(
+            Testdrive(
+                validate_data_dir=False,
+                no_reset=True,
+                materialized_params={"cluster": "cluster2"},
+                seed=id,
+            )
+        ):
+            populate(c)
+
+            # Disrupt cluster1 by some means
+            disruption.disruption(c)
+
+            validate(c)
+
+        cleanup_list = ["materialized", "testdrive", *[n.name for n in nodes]]
+        c.kill(*cleanup_list)
+        c.rm(*cleanup_list, destroy_volumes=True)
+
+    c.rm_volumes("mzdata")


### PR DESCRIPTION
Test that if one cluster is disrupted in any way, the other
cluster can continue processing queries as usual.

### Motivation

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/materialize/issues/12220

### Tips for reviewer

@benesch I made some small changes to `c.testdrive()` so that I can pass `args` to the testdrive container in order to control the random seed.