### PR TITLE
persist: return PersistClient directly from PersistLocation::open

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -21,7 +21,7 @@ use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
 
 use mz_dataflow_types::sinks::{PersistSinkConnector, SinkDesc};
-use mz_persist_client::{PersistClient, PersistLocation};
+use mz_persist_client::PersistLocation;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
@@ -82,11 +82,8 @@ where
         // "real" async context (such as our nice operator implementation below) because we need to
         // create the write handle before creating the operator because we want to share the handle
         // between the drop guard (which acts as the sink token) and the operator implementation.
-        let (blob, consensus) = futures_executor::block_on(persist_location.open())
-            .expect("cannot open persist location");
-
-        let persist_client = futures_executor::block_on(PersistClient::new(blob, consensus))
-            .expect("cannot open client");
+        let persist_client = futures_executor::block_on(persist_location.open())
+            .expect("cannot open persist client");
 
         let (write, _read) = futures_executor::block_on(
             persist_client.open::<Row, Row, Timestamp, Diff>(self.shard_id),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -406,7 +406,7 @@ pub mod sources {
     use globset::Glob;
     use http::Uri;
     use mz_persist_client::read::ReadHandle;
-    use mz_persist_client::{PersistClient, PersistLocation, ShardId};
+    use mz_persist_client::{PersistLocation, ShardId};
     use mz_persist_types::Codec64;
     use serde::{Deserialize, Serialize};
     use timely::progress::Timestamp;
@@ -1265,9 +1265,7 @@ pub mod sources {
                         consensus_uri: persist_connector.consensus_uri.clone(),
                     };
 
-                    let (blob, consensus) = location.open().await?;
-
-                    let persist_client = PersistClient::new(blob, consensus).await?;
+                    let persist_client = location.open().await?;
 
                     let (_write, read) = persist_client
                         .open::<Row, Row, T, mz_repr::Diff>(persist_connector.shard_id)

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -19,7 +19,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, error, info, trace};
 
 use mz_persist::workload::DataGenerator;
-use mz_persist_client::{PersistClient, PersistLocation, ShardId};
+use mz_persist_client::{PersistLocation, ShardId};
 
 use crate::api::{BenchmarkReader, BenchmarkWriter};
 
@@ -114,8 +114,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         blob_uri: args.blob_uri.clone(),
         consensus_uri: args.consensus_uri.clone(),
     };
-    let (blob, consensus) = location.open().await?;
-    let persist = PersistClient::new(blob, consensus).await?;
+    let persist = location.open().await?;
 
     let num_records_total = args.records_per_second * args.runtime_seconds;
     let data_generator =

--- a/src/persist-client/src/examples/persistent_source_example.rs
+++ b/src/persist-client/src/examples/persistent_source_example.rs
@@ -182,7 +182,7 @@ async fn persist_client(
         blob_uri: blob_uri.to_string(),
         consensus_uri: consensus_uri.to_string(),
     };
-    let (blob, consensus) = location.open().await?;
+    let (blob, consensus) = location.open_locations().await?;
     // TODO(aljoscha): Add the option to create unreliable wrappers of blob and persist.
     PersistClient::new(blob, consensus).await
 }

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -24,7 +24,7 @@ use tracing::trace;
 use mz_dataflow_types::{DataflowError, DecodeError, SourceError, SourceErrorDetails};
 use mz_expr::SourceInstanceId;
 use mz_persist_client::read::ListenEvent;
-use mz_persist_client::{PersistClient, PersistLocation, ShardId};
+use mz_persist_client::{PersistLocation, ShardId};
 use mz_repr::{Diff, Row, Timestamp};
 
 use crate::source::SourceStatus;
@@ -77,11 +77,7 @@ where
             blob_uri: blob_uri,
         };
 
-        let (blob, consensus) = persist_location.open().await?;
-
-        let persist_client =
-            PersistClient::new(blob, consensus).await?;
-
+        let persist_client = persist_location.open().await?;
 
         let (_write, read) =
             persist_client.open::<Row, Row, Timestamp, Diff>(shard_id).await?;

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use differential_dataflow::lattice::Lattice;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{PersistClient, PersistLocation};
+use mz_persist_client::PersistLocation;
 use timely::communication::Allocate;
 use timely::dataflow::operators::unordered_input::UnorderedHandle;
 use timely::dataflow::operators::ActivateCapability;
@@ -222,12 +222,8 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                             };
 
                             // TODO: Make these parts async aware?
-                            let (blob, consensus) =
-                                futures_executor::block_on(location.open()).unwrap();
-
                             let persist_client =
-                                futures_executor::block_on(PersistClient::new(blob, consensus))
-                                    .unwrap();
+                                futures_executor::block_on(location.open()).unwrap();
 
                             let (write, _read) = futures_executor::block_on(
                                 persist_client.open::<Row, Row, mz_repr::Timestamp, mz_repr::Diff>(


### PR DESCRIPTION
This simplifies the API a bit for external users, replacing two calls
always used together with one.

Leave around the old `PersistLocation::open` behavior as
`PersistLocation::open_locations` for our testing code.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
