### PR TITLE
Create compute cluster pods in parallel

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -333,6 +333,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 service_name: name.clone(),
                 replicas: Some(scale.get().try_into()?),
                 template: pod_template_spec,
+                pod_management_policy: Some("Parallel"),
                 ..Default::default()
             }),
             status: None,

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -333,7 +333,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 service_name: name.clone(),
                 replicas: Some(scale.get().try_into()?),
                 template: pod_template_spec,
-                pod_management_policy: Some("Parallel"),
+                pod_management_policy: Some("Parallel".to_string()),
                 ..Default::default()
             }),
             status: None,


### PR DESCRIPTION
The default StatefulSet pod management policy is to bring them up in sequence: However, if a 2xlarge cluster requires 12 pods and needs to autoscale up for every one of them, this is unnecessarily slow.

Instead, let's set the policy to "parallel" (materialized can manage), and tell the k8s management layer immediately how many pods to scale to.

### Motivation

  * This PR fixes a recognized bug.

This addresses parts of the cloud issue https://github.com/MaterializeInc/cloud/issues/2963 (spinning up 2xlarge clusters takes many minutes), but it's only part of the solution.

### Testing

To test, I'll have to create an environment with this revision of materialized and spin up some very large clusters. I expect this to work, but we'll see!

### Release notes

No user-facing changes.