### PR TITLE
ci/deploy: Add information box about additional pushed tags

### DIFF
--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -9,13 +9,11 @@
 
 import os
 from pathlib import Path
-from typing import List
 
 import boto3
 import semver
 
 from materialize import cargo, ci_util, deb, git, mzbuild, spawn
-from materialize.mzbuild import DependencySet
 from materialize.xcompile import Arch
 
 from . import deploy_util

--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -108,6 +108,11 @@ def publish_multiarch_images(tag: str, dependency_sets: List[DependencySet]) -> 
             ["docker", "manifest", "create", name, *(image.spec() for image in images)]
         )
         spawn.runv(["docker", "manifest", "push", name])
+    markdown = f"""Pushed tag `{tag}`"""
+    spawn.runv(
+        ["buildkite-agent", "annotate", "--style=info", f"--context=build-tags-{tag}"],
+        stdin=markdown.encode(),
+    )
 
 
 if __name__ == "__main__":

--- a/ci/deploy/linux.py
+++ b/ci/deploy/linux.py
@@ -50,16 +50,16 @@ def main() -> None:
 
     if buildkite_tag:
         # On tag builds, always tag the images as such.
-        publish_multiarch_images(buildkite_tag, deps)
+        mzbuild.publish_multiarch_images(buildkite_tag, deps)
 
         # Also tag the images as `latest` if this is the latest version.
         version = semver.VersionInfo.parse(buildkite_tag.lstrip("v"))
         latest_version = next(t for t in git.get_version_tags() if t.prerelease is None)
         if version == latest_version:
-            publish_multiarch_images("latest", deps)
+            mzbuild.publish_multiarch_images("latest", deps)
     else:
-        publish_multiarch_images("unstable", deps)
-        publish_multiarch_images(f'unstable-{git.rev_parse("HEAD")}', deps)
+        mzbuild.publish_multiarch_images("unstable", deps)
+        mzbuild.publish_multiarch_images(f'unstable-{git.rev_parse("HEAD")}', deps)
 
     print("--- Uploading binary tarball")
     for repo in repos:
@@ -96,22 +96,6 @@ def publish_deb(arch: Arch, version: str) -> None:
             "generic",
             filename,
         ]
-    )
-
-
-def publish_multiarch_images(tag: str, dependency_sets: List[DependencySet]) -> None:
-    for images in zip(*dependency_sets):
-        names = set(image.image.name for image in images)
-        assert len(names) == 1, "dependency sets did not contain identical images"
-        name = f"materialize/{next(iter(names))}:{tag}"
-        spawn.runv(
-            ["docker", "manifest", "create", name, *(image.spec() for image in images)]
-        )
-        spawn.runv(["docker", "manifest", "push", name])
-    markdown = f"""Pushed tag `{tag}`"""
-    spawn.runv(
-        ["buildkite-agent", "annotate", "--style=info", f"--context=build-tags-{tag}"],
-        stdin=markdown.encode(),
     )
 
 

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -29,9 +29,7 @@ def main() -> None:
     print("--- Acquiring mzbuild images")
     deps = repo.resolve_dependencies(image for image in repo if image.publish)
     deps.ensure()
-
-    mzbuild.publish_multiarch_images(f'devel-{git.rev_parse("HEAD")}', deps)
-    annotate_buildkite_with_tags(repo.rd.arch, [deps])
+    annotate_buildkite_with_tags(repo.rd.arch, deps)
 
     print("--- Staging Debian package")
     if os.environ["BUILDKITE_BRANCH"] == "main":

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import boto3
 
-from materialize import cargo, ci_util, deb, mzbuild, spawn
+from materialize import cargo, ci_util, deb, git, mzbuild, spawn
 from materialize.xcompile import Arch
 
 from ..deploy.deploy_util import APT_BUCKET, apt_materialized_path
@@ -29,7 +29,9 @@ def main() -> None:
     print("--- Acquiring mzbuild images")
     deps = repo.resolve_dependencies(image for image in repo if image.publish)
     deps.ensure()
-    annotate_buildkite_with_tags(repo.rd.arch, deps)
+
+    mzbuild.publish_multiarch_images(f'devel-{git.rev_parse("HEAD")}', deps)
+    annotate_buildkite_with_tags(repo.rd.arch, [deps])
 
     print("--- Staging Debian package")
     if os.environ["BUILDKITE_BRANCH"] == "main":

--- a/ci/test/build.py
+++ b/ci/test/build.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import boto3
 
-from materialize import cargo, ci_util, deb, git, mzbuild, spawn
+from materialize import cargo, ci_util, deb, mzbuild, spawn
 from materialize.xcompile import Arch
 
 from ..deploy.deploy_util import APT_BUCKET, apt_materialized_path

--- a/ci/test/dev_tag.py
+++ b/ci/test/dev_tag.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+
+from materialize import git, mzbuild
+from materialize.xcompile import Arch
+
+
+def main() -> None:
+    repos = [
+        mzbuild.Repository(Path("."), Arch.X86_64),
+        mzbuild.Repository(Path("."), Arch.AARCH64),
+    ]
+    print(f"--- Tagging development Docker images")
+    deps = [
+        repo.resolve_dependencies(image for image in repo if image.publish)
+        for repo in repos
+    ]
+    mzbuild.publish_multiarch_images(f'devel-{git.rev_parse("HEAD")}', deps)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -38,6 +38,18 @@ steps:
     agents:
       queue: builder-linux-aarch64
 
+  - id: devel-docker-tags
+    label: Tag development docker images
+    command: bin/ci-builder run stable bin/pyactivate -m ci.test.dev_tag
+    inputs:
+      - "*"
+    depends_on:
+      - build-x86_64
+      - build-aarch64
+    timeout_in_minutes: 10
+    agents:
+      queue: linux-x86_64
+
   - id: lint-fast
     label: Lint and rustfmt
     command: bin/ci-builder run stable ci/test/lint-fast.sh

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -839,3 +839,25 @@ class Repository:
 
     def __iter__(self) -> Iterator[Image]:
         return iter(self.images.values())
+
+
+def publish_multiarch_images(tag: str, dependency_sets: List[DependencySet]) -> None:
+    """Publishes a set of docker images under a given tag."""
+    for images in zip(*dependency_sets):
+        names = set(image.image.name for image in images)
+        assert len(names) == 1, "dependency sets did not contain identical images"
+        name = f"materialize/{next(iter(names))}:{tag}"
+        spawn.runv(
+            ["docker", "manifest", "create", name, *(image.spec() for image in images)]
+        )
+        spawn.runv(["docker", "manifest", "push", name])
+        markdown = f"""Pushed tag `{tag}`"""
+        spawn.runv(
+            [
+                "buildkite-agent",
+                "annotate",
+                "--style=info",
+                f"--context=build-tags-{tag}",
+            ],
+            stdin=markdown.encode(),
+        )

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -852,7 +852,7 @@ def publish_multiarch_images(tag: str, dependency_sets: List[DependencySet]) -> 
         )
         spawn.runv(["docker", "manifest", "push", name])
     print(f"--- Nofifying for tag {tag}")
-    markdown = f"""Pushed tag `{tag}`"""
+    markdown = f"""Pushed images with Docker tag `{tag}`"""
     spawn.runv(
         [
             "buildkite-agent",

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -851,13 +851,14 @@ def publish_multiarch_images(tag: str, dependency_sets: List[DependencySet]) -> 
             ["docker", "manifest", "create", name, *(image.spec() for image in images)]
         )
         spawn.runv(["docker", "manifest", "push", name])
-        markdown = f"""Pushed tag `{tag}`"""
-        spawn.runv(
-            [
-                "buildkite-agent",
-                "annotate",
-                "--style=info",
-                f"--context=build-tags-{tag}",
-            ],
-            stdin=markdown.encode(),
-        )
+    print(f"--- Nofifying for tag {tag}")
+    markdown = f"""Pushed tag `{tag}`"""
+    spawn.runv(
+        [
+            "buildkite-agent",
+            "annotate",
+            "--style=info",
+            f"--context=build-tags-{tag}",
+        ],
+        stdin=markdown.encode(),
+    )


### PR DESCRIPTION
This PR adds another informational message to buildkite builds, writing the names of any multi-arch docker tags, and adds a build step that adds `devel-<SHA>` tags to any commit that gets built in buildkite (so that it becomes possible to spin up cloud platform environments from a pull request).

### Motivation

   * This PR refactors existing code.

Allows us to more easily spin up "test" environments in our cloud platform testing.

### Testing

The results of this should be very visible on the buildkite page for this PR's head commit. I am making it a draft for now, hope that something useful gets pushed.

### Release notes

No user-visible changes