### PR TITLE
materialized: add slim Docker image variant

### DIFF
--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -23,7 +23,7 @@ eval "$(minikube docker-env --shell bash)"
 
 bin/mzimage acquire --dev storaged
 bin/mzimage acquire --dev computed
-bin/mzimage acquire --dev materialized
+bin/mzimage acquire --dev materialized-slim
 
 kubectl apply --context=minikube  -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: materialized
-        image: $(bin/mzimage spec --dev materialized)
+        image: $(bin/mzimage spec --dev materialized-slim)
         args:
             - --storaged-image=$(bin/mzimage spec --dev storaged)
             - --computed-image=$(bin/mzimage spec --dev computed)

--- a/src/materialized/ci-slim/.gitignore
+++ b/src/materialized/ci-slim/.gitignore
@@ -1,0 +1,1 @@
+/materialized

--- a/src/materialized/ci-slim/Dockerfile
+++ b/src/materialized/ci-slim/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+MZFROM ubuntu-base
+
+RUN apt-get update && apt-get -qy install ca-certificates tini
+
+COPY materialized /usr/local/bin/
+
+ENTRYPOINT ["tini", "--", "materialized", "--listen-addr=0.0.0.0:6875"]

--- a/src/materialized/ci-slim/mzbuild.yml
+++ b/src/materialized/ci-slim/mzbuild.yml
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+name: materialized-slim
+pre-image:
+  - type: cargo-build
+    bin: materialized
+    strip: false


### PR DESCRIPTION
Add a new Docker image variant called `materialized-slim`. This image
contains *only* `materialized`, and does not bundle `storaged` or
`computed`.

The idea is that this image will be used in Materialize Cloud where
`storaged` and `computed` are spawned via Kubernetes in separate pods.
The local process orchestrator will not work with `materialized-slim`,
as it will not be able to find `storaged` or `computed`.

The `materialized` image will remain as an all-in-one option for use in
developer environments and CI pipelines.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
