### PR TITLE
stash: support retries and reconnects in postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4007,11 +4007,13 @@ dependencies = [
  "mz-ore",
  "mz-persist-types",
  "num",
+ "rand",
  "rusqlite",
  "tempfile",
  "timely",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/src/coord/src/catalog/error.rs
+++ b/src/coord/src/catalog/error.rs
@@ -89,7 +89,7 @@ more details, see https://materialize.com/docs/cli#experimental-mode"#
     FailpointReached(String),
     #[error("{0}")]
     Unstructured(String),
-    #[error("stash error: {0}")]
+    #[error(transparent)]
     Stash(#[from] mz_stash::StashError),
     #[error("stash in unexpected state")]
     UnexpectedStashState,

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -21,9 +21,12 @@ futures = "0.3.21"
 mz-ore = { path = "../ore" }
 mz-persist-types = { path = "../persist-types" }
 num = "0.4.0"
+rand = "0.8.5"
 rusqlite = { version = "0.27.0", features = ["bundled"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
+tokio = "1.17.0"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
+tracing = "0.1.34"
 
 [dev-dependencies]
 anyhow = "1.0.57"

--- a/test/stash/mzcompose
+++ b/test/stash/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/stash/mzcompose.py
+++ b/test/stash/mzcompose.py
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import time
+
+from materialize.mzcompose import Composition
+from materialize.mzcompose.services import Materialized, Postgres, Testdrive
+
+SERVICES = [
+    Materialized(),
+    Postgres(),
+    Testdrive(),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    materialized = Materialized(
+        options=["--catalog-postgres-stash", "postgres://postgres:postgres@postgres"],
+    )
+    postgres = Postgres(image="postgres:13.6")
+    testdrive = Testdrive()
+
+    with c.override(materialized, testdrive, postgres):
+        c.up("postgres")
+        c.wait_for_postgres()
+        c.start_and_wait_for_tcp(services=["materialized"])
+        c.wait_for_materialized("materialized")
+
+        c.sql("CREATE TABLE a (i INT)")
+
+        c.stop("postgres")
+        c.up("postgres")
+        c.wait_for_postgres()
+
+        c.sql("CREATE TABLE b (i INT)")
+
+        c.rm("postgres", stop=True, destroy_volumes=True)
+        c.up("postgres")
+        c.wait_for_postgres()
+
+        # Postgres cleared its database, so this should fail.
+        try:
+            c.sql("CREATE TABLE c (i INT)")
+            raise Exception("expected unreachable")
+        except Exception as e:
+            # Depending on timing, either of these errors can occur. The stash error comes
+            # from the stash complaining. The network error comes from pg8000 complaining
+            # because materialize panic'd.
+            if "stash error: db error" not in str(e) and "network error" not in str(e):
+                raise e


### PR DESCRIPTION
Teach the Postgres stash how to connect so that it can retry on failures.

### Motivation

  * This PR fixes a recognized bug. Item 9 from #12270.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
