### PR TITLE
[coord] Fix drop schema cascade with secrets

### DIFF
--- a/src/secrets-filesystem/src/lib.rs
+++ b/src/secrets-filesystem/src/lib.rs
@@ -6,7 +6,7 @@
 // As of the Change Date specified in that file, in accordance with
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
-use anyhow::Error;
+use anyhow::{bail, Error};
 use async_trait::async_trait;
 use mz_secrets::{SecretOp, SecretsController};
 use std::fs;
@@ -41,7 +41,9 @@ impl SecretsController for FilesystemSecretsController {
         for op in ops.iter() {
             match op {
                 SecretOp::Ensure { id, contents } => {
-                    assert_eq!(ops.len(), 1);
+                    if ops.len() > 1 {
+                        bail!("secrets controller does not support creating multiple secrets atomically")
+                    }
                     let file_path = self.secrets_storage_path.join(format!("{}", id));
                     let mut file = OpenOptions::new()
                         .mode(0o600)

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -165,3 +165,19 @@ CREATE SECRET t_secret AS 'text'
 
 statement OK
 ROLLBACK
+
+# Test dropping multiple secrets in a single operation
+statement OK
+create schema to_be_dropped
+
+statement OK
+CREATE SECRET to_be_dropped.secret1 as 'text'
+
+statement OK
+CREATE SECRET to_be_dropped.secret2 as 'text'
+
+statement OK
+CREATE SECRET to_be_dropped.secret3 as 'text'
+
+statement OK
+DROP SCHEMA to_be_dropped CASCADE


### PR DESCRIPTION
The filesystem controller can not execute multiple FS operations in a single atomic txn. 

Deletes are a special case. They are being executed as a post-commit event and once the coordinator reaches that code, the secrets can no longer be reached by any reader. This behavior is atomic in nature and the FS operations do not have to be.

On the other hand, Ensure has to be atomic, since a concurrent reader should not see torn FS transactions. Hence we enforce the limit of exactly 1 ensure (update/create) operation per txn

### Motivation
This PR fixes a previously unreported bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
