### PR TITLE
repr: use `ProtoNaiveDate` instead of `ProtoDate` in `row.proto`

### DIFF
--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -20,6 +20,7 @@ fn main() {
                 "repr/src/adt/array.proto",
                 "repr/src/adt/char.proto",
                 "repr/src/adt/datetime.proto",
+                "repr/src/adt/interval.proto",
                 "repr/src/adt/numeric.proto",
                 "repr/src/adt/regex.proto",
                 "repr/src/adt/varchar.proto",

--- a/src/repr/src/adt/interval.proto
+++ b/src/repr/src/adt/interval.proto
@@ -1,0 +1,19 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+package mz_repr.adt.interval;
+
+message ProtoInterval {
+    // A possibly negative number of months.
+    int32 months = 1;
+    int32 days = 2;
+    int64 micros = 3;
+}

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -19,6 +19,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::adt::datetime::DateTimeField;
 use crate::adt::numeric::{DecimalLike, Numeric};
+use crate::proto::TryFromProtoError;
+
+include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.interval.rs"));
 
 /// An interval of time meant to express SQL intervals.
 ///
@@ -45,6 +48,28 @@ impl Default for Interval {
             days: 0,
             micros: 0,
         }
+    }
+}
+
+impl From<&Interval> for ProtoInterval {
+    fn from(x: &Interval) -> Self {
+        ProtoInterval {
+            months: x.months,
+            days: x.days,
+            micros: x.micros,
+        }
+    }
+}
+
+impl TryFrom<ProtoInterval> for Interval {
+    type Error = TryFromProtoError;
+
+    fn try_from(repr: ProtoInterval) -> Result<Self, Self::Error> {
+        Ok(Interval {
+            months: repr.months,
+            days: repr.days,
+            micros: repr.micros,
+        })
     }
 }
 

--- a/src/repr/src/chrono.proto
+++ b/src/repr/src/chrono.proto
@@ -23,7 +23,10 @@ message ProtoNaiveDate {
 }
 
 message ProtoNaiveTime {
+    // The number of seconds since midnight
     uint32 secs = 1;
+    // Additional fractional seconds since midnight in nanosecond granularity.
+    // This can can exceed 1,000,000,000 in order to represent the leap second.
     uint32 frac = 2;
 }
 

--- a/src/repr/src/chrono.proto
+++ b/src/repr/src/chrono.proto
@@ -16,8 +16,10 @@ message ProtoTz {
 }
 
 message ProtoNaiveDate {
-   int32 year = 1;
-   uint32 ordinal = 2;
+    // Year
+    int32 year = 1;
+    // Day-of-year (0..365)
+    uint32 ordinal = 2;
 }
 
 message ProtoNaiveTime {

--- a/src/repr/src/chrono.proto
+++ b/src/repr/src/chrono.proto
@@ -31,8 +31,15 @@ message ProtoNaiveTime {
 }
 
 message ProtoNaiveDateTime {
-    ProtoNaiveDate date = 1;
-    ProtoNaiveTime time = 2;
+    // Year
+    int32 year = 1;
+    // Day-of-year (0..365)
+    uint32 ordinal = 2;
+    // The number of seconds since midnight
+    uint32 secs = 3;
+    // Additional fractional seconds since midnight in nanosecond granularity.
+    // This can can exceed 1,000,000,000 in order to represent the leap second.
+    uint32 frac = 4;
 }
 
 message ProtoFixedOffset {

--- a/src/repr/src/row.proto
+++ b/src/repr/src/row.proto
@@ -46,7 +46,7 @@ message ProtoDatum {
         // Of these, I'd guess Timestamp and UUID are probably the first ones
         // we'd bless followed by Date and Time.
         mz_repr.chrono.ProtoNaiveDate date = 16;
-        ProtoTime time = 17;
+        mz_repr.chrono.ProtoNaiveTime time = 17;
         ProtoTimestamp timestamp = 18;
         ProtoInterval interval = 19;
         ProtoArray array = 20;
@@ -76,14 +76,6 @@ enum ProtoDatumOther {
     NUMERIC_POS_INF = 6;
     NUMERIC_NEG_INF = 7;
     NUMERIC_NA_N = 8;
-}
-
-message ProtoTime {
-    // The number of seconds since midnight
-    uint32 secs = 1;
-    // Additional fractional seconds since midnight in nanosecond granularity.
-    // This can can exceed 1,000,000,000 in order to represent the leap second.
-    uint32 nanos = 2;
 }
 
 message ProtoTimestamp {

--- a/src/repr/src/row.proto
+++ b/src/repr/src/row.proto
@@ -47,15 +47,16 @@ message ProtoDatum {
         // we'd bless followed by Date and Time.
         mz_repr.chrono.ProtoNaiveDate date = 16;
         mz_repr.chrono.ProtoNaiveTime time = 17;
-        ProtoTimestamp timestamp = 18;
-        ProtoInterval interval = 19;
-        ProtoArray array = 20;
-        ProtoRow list = 21;
-        ProtoDict dict = 22;
-        ProtoNumeric numeric = 23;
-        bytes uuid = 24;
-        uint32 uint32 = 25;
-        uint32 uint8 = 26;
+        mz_repr.chrono.ProtoNaiveDateTime timestamp = 18;
+        mz_repr.chrono.ProtoNaiveDateTime timestamp_tz = 19;
+        ProtoInterval interval = 20;
+        ProtoArray array = 21;
+        ProtoRow list = 22;
+        ProtoDict dict = 23;
+        ProtoNumeric numeric = 24;
+        bytes uuid = 25;
+        uint32 uint32 = 26;
+        uint32 uint8 = 27;
     }
 }
 
@@ -76,20 +77,6 @@ enum ProtoDatumOther {
     NUMERIC_POS_INF = 6;
     NUMERIC_NEG_INF = 7;
     NUMERIC_NA_N = 8;
-}
-
-message ProtoTimestamp {
-    // Year
-    int32 year = 1;
-    // Day-of-year (0..365)
-    uint32 ordinal = 2;
-    // The number of seconds since midnight
-    uint32 secs = 3;
-    // Additional fractional seconds since midnight in nanosecond granularity.
-    // This can can exceed 1,000,000,000 in order to represent the leap second.
-    uint32 nanos = 4;
-    // If true, this timestamp is in UTC. If false, this timestamp is zoneless.
-    bool is_tz = 5;
 }
 
 message ProtoInterval {

--- a/src/repr/src/row.proto
+++ b/src/repr/src/row.proto
@@ -10,6 +10,7 @@
 syntax = "proto3";
 
 import "repr/src/chrono.proto";
+import "repr/src/adt/interval.proto";
 
 package mz_repr.row;
 
@@ -49,7 +50,7 @@ message ProtoDatum {
         mz_repr.chrono.ProtoNaiveTime time = 17;
         mz_repr.chrono.ProtoNaiveDateTime timestamp = 18;
         mz_repr.chrono.ProtoNaiveDateTime timestamp_tz = 19;
-        ProtoInterval interval = 20;
+        mz_repr.adt.interval.ProtoInterval interval = 20;
         ProtoArray array = 21;
         ProtoRow list = 22;
         ProtoDict dict = 23;
@@ -77,13 +78,6 @@ enum ProtoDatumOther {
     NUMERIC_POS_INF = 6;
     NUMERIC_NEG_INF = 7;
     NUMERIC_NA_N = 8;
-}
-
-message ProtoInterval {
-    // A possibly negative number of months.
-    int32 months = 1;
-    int32 days = 2;
-    int64 micros = 3;
 }
 
 message ProtoArray {

--- a/src/repr/src/row.proto
+++ b/src/repr/src/row.proto
@@ -9,6 +9,8 @@
 
 syntax = "proto3";
 
+import "repr/src/chrono.proto";
+
 package mz_repr.row;
 
 message ProtoRow {
@@ -43,7 +45,7 @@ message ProtoDatum {
         //
         // Of these, I'd guess Timestamp and UUID are probably the first ones
         // we'd bless followed by Date and Time.
-        ProtoDate date = 16;
+        mz_repr.chrono.ProtoNaiveDate date = 16;
         ProtoTime time = 17;
         ProtoTimestamp timestamp = 18;
         ProtoInterval interval = 19;
@@ -74,13 +76,6 @@ enum ProtoDatumOther {
     NUMERIC_POS_INF = 6;
     NUMERIC_NEG_INF = 7;
     NUMERIC_NA_N = 8;
-}
-
-message ProtoDate {
-    // Year
-    int32 year = 1;
-    // Day-of-year (0..365)
-    uint32 ordinal = 2;
 }
 
 message ProtoTime {

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -22,12 +22,12 @@ use uuid::Uuid;
 use crate::adt::array::ArrayDimension;
 use crate::adt::interval::Interval;
 use crate::adt::numeric::Numeric;
-use crate::chrono::ProtoNaiveDate;
+use crate::chrono::{ProtoNaiveDate, ProtoNaiveTime};
 use crate::proto::TryFromProtoError;
 use crate::row::proto_datum::DatumType;
 use crate::row::{
     ProtoArray, ProtoArrayDimension, ProtoDatum, ProtoDatumOther, ProtoDict, ProtoDictElement,
-    ProtoInterval, ProtoNumeric, ProtoRow, ProtoTime, ProtoTimestamp,
+    ProtoInterval, ProtoNumeric, ProtoRow, ProtoTimestamp,
 };
 use crate::{Datum, Row, RowPacker};
 
@@ -77,9 +77,9 @@ impl<'a> From<Datum<'a>> for ProtoDatum {
                 year: x.year(),
                 ordinal: x.ordinal(),
             }),
-            Datum::Time(x) => DatumType::Time(ProtoTime {
+            Datum::Time(x) => DatumType::Time(ProtoNaiveTime {
                 secs: x.num_seconds_from_midnight(),
-                nanos: x.nanosecond(),
+                frac: x.nanosecond(),
             }),
             Datum::Timestamp(x) => DatumType::Timestamp(ProtoTimestamp {
                 year: x.date().year(),
@@ -216,7 +216,7 @@ impl RowPacker<'_> {
                 NaiveDate::from_proto(x.clone()).map_err(|e| e.to_string())?,
             )),
             Some(DatumType::Time(x)) => self.push(Datum::Time(
-                NaiveTime::from_num_seconds_from_midnight(x.secs, x.nanos),
+                NaiveTime::from_proto(x.clone()).map_err(|e| e.to_string())?,
             )),
             Some(DatumType::Timestamp(x)) => {
                 let date = NaiveDate::from_yo(x.year, x.ordinal);


### PR DESCRIPTION
Fixes #12333.

### Motivation

   * This PR refactors existing code.

Implements the items requested in #12333. See the issue description for details.

### Tips for reviewer

Each commit corresponds to an item from the #12333 list. 

#### Tips for the Persistence team reviewer

Due to the discrepancy between the `TryFrom` or `ProtoRepr::from_proto` signatures implemented by the commonly defined types on the one hand, and the call-by-reference argument `x: &ProtoDatum` in `RowPacker::try_push_proto`, after the refactor I had to call `.clone()` on the following variants:

- `DatumType::Date`
- `DatumType::Time`
- `DatumType::Timestamp`
- `DatumType::TimestampTz`
- `DatumType::Interval`

I can revert this bit of code, but this will come at the cost of duplication. In general, I have a follow-up item to try to unify the API.

Also, note that the change is backwards incompatible because of the following:

- The Protobuf representation of `DatumType::Timestamp` and `DatumType::TimestampTz` has changed.
- There is a new variant `ProtoDatum::TimestampTz`.
- I've kept the tag IDs sequential after adding the new variant.

Based on what I've heard from @lluki I think this was discussed offline and should be of no concern for **persist**.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Existing tests are passing after the refactor. Tested with:

```bash
cargo test -p mz-dataflow-types -p mz-expr -p mz-repr protobuf_roundtrip -- --nocapture
```

### Release notes

N/A