### PR TITLE
persist: make file impls properly async

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -50,7 +50,7 @@ rusqlite = { version = "0.27.0", features = ["bundled"] }
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.17.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.17.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
 tracing = "0.1.34"
 url = "2.2.2"

--- a/src/persist/benches/writer.rs
+++ b/src/persist/benches/writer.rs
@@ -28,8 +28,8 @@ use timely::progress::Antichain;
 use tokio::runtime::Runtime as AsyncRuntime;
 
 use mz_persist::client::WriteReqBuilder;
-use mz_persist::error::Error;
-use mz_persist::file::{FileBlob, FileLog};
+use mz_persist::error::{Error, ErrorLog};
+use mz_persist::file::FileBlob;
 use mz_persist::gen::persist::ProtoBatchFormat;
 use mz_persist::indexed::background::{CompactTraceReq, Maintainer};
 use mz_persist::indexed::cache::BlobCache;
@@ -40,12 +40,6 @@ use mz_persist::location::{Atomicity, Blob, BlobRead, LockInfo, Log, SeqNo};
 use mz_persist::mem::MemRegistry;
 use mz_persist::pfuture::{PFuture, PFutureHandle};
 use mz_persist::workload::{self, DataGenerator};
-
-fn new_file_log(name: &str, parent: &Path) -> FileLog {
-    let file_log_dir = parent.join(name);
-    FileLog::new(file_log_dir, LockInfo::new_no_reentrance(name.to_owned()))
-        .expect("creating a FileLog cannot fail")
-}
 
 fn new_file_blob(name: &str, parent: &Path) -> FileBlob {
     let file_blob_dir = parent.join(name);
@@ -91,13 +85,6 @@ pub fn bench_log(g: &mut BenchmarkGroup<'_, WallTime>) {
         bench_write_sync(&mut mem_log, data.clone(), b)
     });
     mem_log.close().expect("failed to close mem_log");
-
-    // Create a directory that will automatically be dropped after the test finishes.
-    let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
-    let mut file_log = new_file_log("file_log_write_sync", temp_dir.path());
-    g.bench_function("file_sync", |b| {
-        bench_write_sync(&mut file_log, data.clone(), b)
-    });
 }
 
 pub fn bench_blob_set(data: &DataGenerator, g: &mut BenchmarkGroup<'_, WallTime>) {
@@ -353,7 +340,7 @@ pub fn bench_indexed_drain(data: &DataGenerator, g: &mut BenchmarkGroup<'_, Wall
 
     // Create a directory that will automatically be dropped after the test finishes.
     let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
-    let file_log = new_file_log("indexed_write_drain_log", temp_dir.path());
+    let log = ErrorLog;
     let file_blob = new_file_blob("indexed_write_drain_blob", temp_dir.path());
 
     let async_runtime = Arc::new(AsyncRuntime::new().unwrap());
@@ -366,7 +353,7 @@ pub fn bench_indexed_drain(data: &DataGenerator, g: &mut BenchmarkGroup<'_, Wall
         None,
     );
     let file_indexed =
-        Indexed::new(file_log, blob_cache, metrics).expect("failed to create file indexed");
+        Indexed::new(log, blob_cache, metrics).expect("failed to create file indexed");
     bench_writes_indexed_inner(data, g, "file", file_indexed).expect("running benchmark failed");
 }
 

--- a/src/persist/examples/kafka_upsert.rs
+++ b/src/persist/examples/kafka_upsert.rs
@@ -23,8 +23,8 @@ use tracing::info;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NowFn, SYSTEM_TIME};
 use mz_persist::client::{MultiWriteHandle, RuntimeClient, StreamReadHandle};
-use mz_persist::error::Error as PersistError;
-use mz_persist::file::{FileBlob, FileLog};
+use mz_persist::error::{Error as PersistError, ErrorLog};
+use mz_persist::file::FileBlob;
 use mz_persist::location::{Blob, LockInfo};
 use mz_persist::operators::stream::{AwaitFrontier, Seal};
 use mz_persist::operators::upsert::{PersistentUpsert, PersistentUpsertConfig};
@@ -55,7 +55,7 @@ fn run(args: Vec<String>) -> Result<(), Box<dyn Error>> {
 
     let persist = {
         let lock_info = LockInfo::new("kafka_upsert".into(), "nonce".into())?;
-        let log = FileLog::new(base_dir.join("log"), lock_info.clone())?;
+        let log = ErrorLog;
         let blob = FileBlob::open_exclusive(base_dir.join("blob").into(), lock_info)?;
         runtime::start(
             RuntimeConfig::default(),

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -11,9 +11,7 @@
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, ErrorKind, Read, Seek, SeekFrom, Write as StdWrite};
-use std::ops::Range;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use async_trait::async_trait;
@@ -22,255 +20,7 @@ use fail::fail_point;
 use mz_ore::cast::CastFrom;
 
 use crate::error::Error;
-use crate::location::{Atomicity, Blob, BlobMulti, BlobRead, ExternalError, LockInfo, Log, SeqNo};
-
-/// Inner struct handles to separate files that store the data and metadata about the
-/// most recently truncated sequence number for [FileLog].
-#[derive(Debug)]
-struct FileLogCore {
-    dataz: File,
-    metadata: File,
-}
-
-/// A naive implementation of [Log] backed by files.
-#[derive(Debug)]
-pub struct FileLog {
-    base_dir: Option<PathBuf>,
-    dataz: Arc<Mutex<FileLogCore>>,
-    seqno: Range<SeqNo>,
-    buf: Vec<u8>,
-}
-
-impl FileLog {
-    const DATA_PATH: &'static str = "DATA";
-    const LOCKFILE_PATH: &'static str = "LOCK";
-    const METADATA_PATH: &'static str = "META";
-
-    /// Returns a new [FileLog] which stores files under the given dir.
-    ///
-    /// To ensure directory-wide mutual exclusion, a LOCK file is placed in
-    /// base_dir at construction time. If this file already exists (indicating
-    /// that another FileLog is already using the dir), an error is returned
-    /// from `new`.
-    ///
-    /// The contents of `lock_info` are stored in the LOCK file and should
-    /// include anything that would help debug an unexpected LOCK file, such as
-    /// version, ip, worker number, etc.
-    ///
-    /// The data is stored in a separate file, and is formatted as a sequential list of
-    /// chunks corresponding to each write. Each chunk consists of:
-    /// `length` - A 64 bit unsigned int (little-endian) indicating the size of `data`.
-    /// `data` - `length` bytes of data.
-    /// `sequence_number` - A 64 bit unsigned int (little-endian) indicating the sequence number
-    /// assigned to `data`.
-    ///
-    /// Additionally, the metadata about the last truncated sequence number is stored in a
-    /// metadata file, which only ever contains a single 64 bit unsigned integer (also little-endian)
-    /// that indicates the most recently truncated offset (ie all offsets less than this are truncated).
-    pub fn new<P: AsRef<Path>>(base_dir: P, lock_info: LockInfo) -> Result<Self, Error> {
-        let base_dir = base_dir.as_ref();
-        fs::create_dir_all(&base_dir)?;
-        {
-            // TODO: flock this for good measure?
-            let _ = file_storage_lock(&Self::lockfile_path(&base_dir), lock_info)?;
-        }
-        let data_path = Self::data_path(&base_dir);
-        let mut data_file = OpenOptions::new()
-            .append(true)
-            .read(true)
-            .create(true)
-            .open(&data_path)?;
-
-        let metadata_path = Self::metadata_path(&base_dir);
-        let mut metadata_file = OpenOptions::new()
-            .write(true)
-            .read(true)
-            .create(true)
-            .open(&metadata_path)?;
-
-        // Retrieve the last truncated sequence number from the metadata file
-        // unless that file was just created, in which case default to 0.
-        let mut bytes = Vec::new();
-        metadata_file.read_to_end(&mut bytes)?;
-        let len = bytes.len();
-        let seqno_start = if len != 0 {
-            let mut bytes = &bytes[..];
-            let mut buf = [0u8; 8];
-            // Decode sequence number
-            bytes.read_exact(&mut buf).map_err(|e| {
-                format!(
-                    "could not read log metadata file: found {} bytes (expected 8) {:?}",
-                    len, e,
-                )
-            })?;
-            SeqNo(u64::from_le_bytes(buf))
-        } else {
-            metadata_file.write_all(&0u64.to_le_bytes())?;
-            metadata_file.sync_all()?;
-            SeqNo(0)
-        };
-
-        // Retrieve the most recently written sequence number in the log,
-        // unless the log is empty in which case default to 0.
-        let seqno_end = {
-            let len = data_file.metadata()?.len();
-
-            if len > 0 {
-                let mut buf = [0u8; 8];
-                data_file.seek(SeekFrom::End(-8))?;
-                data_file.read_exact(&mut buf)?;
-                // NB: seqno_end is exclusive, so we have to add one to the
-                // seqno of the most recent write to reconstruct it.
-                SeqNo(u64::from_le_bytes(buf) + 1)
-            } else {
-                SeqNo(0)
-            }
-        };
-
-        if seqno_start > seqno_end {
-            return Err(format!(
-                "invalid sequence number range found for file log: start: {:?} end: {:?}",
-                seqno_start, seqno_end,
-            )
-            .into());
-        }
-
-        Ok(FileLog {
-            base_dir: Some(base_dir.to_owned()),
-            dataz: Arc::new(Mutex::new(FileLogCore {
-                dataz: data_file,
-                metadata: metadata_file,
-            })),
-            seqno: seqno_start..seqno_end,
-            buf: Vec::new(),
-        })
-    }
-
-    fn lockfile_path(base_dir: &Path) -> PathBuf {
-        base_dir.join(Self::LOCKFILE_PATH)
-    }
-
-    fn data_path(base_dir: &Path) -> PathBuf {
-        base_dir.join(Self::DATA_PATH)
-    }
-
-    fn metadata_path(base_dir: &Path) -> PathBuf {
-        base_dir.join(Self::METADATA_PATH)
-    }
-
-    fn ensure_open(&self) -> Result<PathBuf, Error> {
-        self.base_dir
-            .clone()
-            .ok_or_else(|| return Error::from("FileLog unexpectedly closed"))
-    }
-}
-
-impl Log for FileLog {
-    fn write_sync(&mut self, buf: Vec<u8>) -> Result<SeqNo, Error> {
-        self.ensure_open()?;
-
-        let write_seqno = self.seqno.end;
-        self.seqno = self.seqno.start..SeqNo(write_seqno.0 + 1);
-        // Write length prefixed data, and then the sequence number.
-        let len = u64::cast_from(buf.len());
-
-        // NB: the write buffer never shrinks, and this pattern may not be what we want
-        // under write workloads with rare very large writes.
-        self.buf.clear();
-        self.buf.extend(&len.to_le_bytes());
-        self.buf.extend(buf);
-        self.buf.extend(&write_seqno.0.to_le_bytes());
-
-        let mut guard = self.dataz.lock()?;
-        guard.dataz.write_all(&self.buf)?;
-        guard.dataz.sync_all()?;
-        Ok(write_seqno)
-    }
-
-    fn snapshot<F>(&self, mut logic: F) -> Result<Range<SeqNo>, Error>
-    where
-        F: FnMut(SeqNo, &[u8]) -> Result<(), Error>,
-    {
-        self.ensure_open()?;
-        let mut bytes = Vec::new();
-
-        {
-            let mut guard = self.dataz.lock()?;
-            // This file was opened with append mode, so any future writes
-            // will reset the file cursor to the end before writing.
-            guard.dataz.seek(SeekFrom::Start(0))?;
-            guard.dataz.read_to_end(&mut bytes)?;
-        }
-
-        let mut bytes = &bytes[..];
-        let mut len_raw = [0u8; 8];
-        while !bytes.is_empty() {
-            // Decode the data
-            bytes.read_exact(&mut len_raw)?;
-            let data_len = u64::from_le_bytes(len_raw);
-            // TODO: could reuse the underlying buffer here to avoid allocating each time.
-            let mut data = vec![0u8; usize::cast_from(data_len)];
-            bytes.read_exact(&mut data[..])?;
-
-            // Decode sequence number
-            bytes.read_exact(&mut len_raw)?;
-            let seqno = SeqNo(u64::from_le_bytes(len_raw));
-
-            if seqno < self.seqno.start {
-                // This record has already been truncated so we can ignore it.
-                continue;
-            } else if seqno >= self.seqno.end {
-                return Err(format!(
-                    "invalid sequence number {:?} found for log containing {:?}",
-                    seqno, self.seqno
-                )
-                .into());
-            }
-
-            logic(seqno, &data)?;
-        }
-        Ok(self.seqno.clone())
-    }
-
-    /// Logically truncates the log so that future reads ignore writes at sequence numbers
-    /// less than `upper`.
-    ///
-    /// TODO: actually reclaim disk space as part of truncating.
-    fn truncate(&mut self, upper: SeqNo) -> Result<(), Error> {
-        self.ensure_open()?;
-        // TODO: Test the edge cases here.
-        if upper <= self.seqno.start || upper > self.seqno.end {
-            return Err(format!(
-                "invalid truncation {:?} for log containing: {:?}",
-                upper, self.seqno
-            )
-            .into());
-        }
-        self.seqno = upper..self.seqno.end;
-
-        let mut guard = self.dataz.lock()?;
-        guard.metadata.seek(SeekFrom::Start(0))?;
-        guard.metadata.set_len(0)?;
-        guard
-            .metadata
-            .write_all(&self.seqno.start.0.to_le_bytes())?;
-        guard.metadata.sync_all()?;
-
-        Ok(())
-    }
-
-    fn close(&mut self) -> Result<bool, Error> {
-        if let Ok(base_dir) = self.ensure_open() {
-            let lockfile_path = Self::lockfile_path(&base_dir);
-            fs::remove_file(lockfile_path)?;
-            self.base_dir = None;
-            Ok(true)
-        } else {
-            // Already closed. Close implementations must be idempotent.
-            Ok(false)
-        }
-    }
-}
+use crate::location::{Atomicity, Blob, BlobMulti, BlobRead, ExternalError, LockInfo};
 
 /// Configuration for opening a [FileBlob] or [FileBlobRead].
 #[derive(Debug)]
@@ -606,7 +356,7 @@ fn file_storage_lock(lockfile_path: &Path, new_lock: LockInfo) -> Result<File, E
 
 #[cfg(test)]
 mod tests {
-    use crate::location::tests::{blob_impl_test, blob_multi_impl_test, log_impl_test};
+    use crate::location::tests::{blob_impl_test, blob_multi_impl_test};
 
     use super::*;
 
@@ -635,15 +385,6 @@ mod tests {
             FileBlobMulti::open(instance_dir.into())
         })
         .await
-    }
-
-    #[test]
-    fn file_log() -> Result<(), Error> {
-        let temp_dir = tempfile::tempdir()?;
-        log_impl_test(move |t| {
-            let instance_dir = temp_dir.path().join(t.path);
-            FileLog::new(instance_dir, (t.reentrance_id, "file_log_test").into())
-        })
     }
 
     #[test]

--- a/src/persist/src/nemesis/direct.rs
+++ b/src/persist/src/nemesis/direct.rs
@@ -568,7 +568,7 @@ mod tests {
     use tokio::runtime::Runtime as AsyncRuntime;
 
     use crate::error::ErrorLog;
-    use crate::file::{FileBlob, FileLog};
+    use crate::file::FileBlob;
     use crate::location::Blob;
     use crate::mem::MemRegistry;
     use crate::nemesis::generator::GeneratorConfig;
@@ -594,8 +594,8 @@ mod tests {
 
     impl StartRuntime for TempDir {
         fn start_runtime(&mut self, unreliable: UnreliableHandle) -> Result<RuntimeClient, Error> {
-            let (log_dir, blob_dir) = (self.path().join("log"), self.path().join("blob"));
-            let log = FileLog::new(log_dir, ("reentrance0", "direct_file").into())?;
+            let blob_dir = self.path().join("blob");
+            let log = ErrorLog;
             let log = UnreliableLog::from_handle(log, unreliable.clone());
             let blob =
                 FileBlob::open_exclusive(blob_dir.into(), ("reentrance0", "direct_file").into())?;


### PR DESCRIPTION
They were making blocking io calls inside async fns, which is the single
biggest async no-no. In practice, this seemed to be causing Jan some
problems:

https://github.com/MaterializeInc/materialize/pull/12296#issuecomment-1121348255


Benchmarks on a persist-benchmarking machine are close enough modulo raw
read throughput.

    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    MZ_PERSIST_RECORD_COUNT_SMALL=64 MZ_PERSIST_RECORD_SIZE_BYTES_SMALL=1024 MZ_PERSIST_BATCH_MAX_COUNT_SMALL=8
    writer/blob_set/file/50MiB
                            time:   [375.04 ms 375.39 ms 375.75 ms]
                            thrpt:  [133.07 MiB/s 133.20 MiB/s 133.32 MiB/s]
                     change:
                            time:   [-0.2699% -0.1670% -0.0478%] (p = 0.00 < 0.05)
                            thrpt:  [+0.0478% +0.1673% +0.2707%]
                            Change within noise threshold.
    min_latency/writes/file_pg/64KiB
                            time:   [43.332 ms 43.937 ms 44.627 ms]
                            change: [-7.5992% -5.6975% -3.5844%] (p = 0.00 < 0.05)
                            Performance has improved.
    min_latency/write_to_listen/file_pg/64KiB
                            time:   [53.623 ms 54.677 ms 56.024 ms]
                            change: [+1.5183% +3.8579% +6.5973%] (p = 0.00 < 0.05)
                            Performance has regressed.

Large writes look _much_ slower on my laptop, but macos fsync lies so
who knows. Small writes (what we care about for local testdrive
latencies) seem to be roughly unaffected.

    MZ_PERSIST_RECORD_COUNT=819200 MZ_PERSIST_RECORD_SIZE_BYTES=64 MZ_PERSIST_BATCH_MAX_COUNT=131072
    MZ_PERSIST_RECORD_COUNT_SMALL=64 MZ_PERSIST_RECORD_SIZE_BYTES_SMALL=1024 MZ_PERSIST_BATCH_MAX_COUNT_SMALL=8
    writer/blob_set/file/50MiB
                            time:   [178.44 ms 199.48 ms 222.82 ms]
                            thrpt:  [224.39 MiB/s 250.66 MiB/s 280.20 MiB/s]
                     change:
                            time:   [+45.222% +83.912% +134.56%] (p = 0.00 < 0.05)
                            thrpt:  [-57.368% -45.626% -31.140%]
                            Performance has regressed.
    min_latency/writes/file_pg/64KiB
                            time:   [187.01 ms 190.30 ms 194.20 ms]
                            change: [-0.1144% +2.5643% +4.9402%] (p = 0.06 > 0.05)
                            No change in performance detected.
    min_latency/write_to_listen/file_pg/64KiB
                            time:   [299.23 ms 301.28 ms 303.53 ms]
                            change: [-1.6206% -0.3970% +0.8536%] (p = 0.54 > 0.05)
                            No change in performance detected.
### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
