### PR TITLE
persist: remove per-writer state

### DIFF
--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -434,8 +434,7 @@ mod raw_persist_benchmark {
 
         let mut readers = vec![];
         for _ in 0..num_readers {
-            let (writer, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
-            writer.expire().await;
+            let (_writer, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
 
             let listen = reader
                 .listen(Antichain::from_elem(0))

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -33,7 +33,7 @@ use uuid::Uuid;
 use crate::error::InvalidUsage;
 use crate::r#impl::machine::Machine;
 use crate::read::{ReadHandle, ReaderId};
-use crate::write::{WriteHandle, WriterId};
+use crate::write::WriteHandle;
 
 pub mod error;
 mod examples;
@@ -207,14 +207,12 @@ impl PersistClient {
     {
         trace!("Client::open shard_id={:?}", shard_id);
         let mut machine = Machine::new(shard_id, Arc::clone(&self.consensus)).await?;
-        let (writer_id, reader_id) = (WriterId::new(), ReaderId::new());
-        let (shard_upper, read_cap) = machine.register(&writer_id, &reader_id).await;
+        let reader_id = ReaderId::new();
+        let (shard_upper, read_cap) = machine.register(&reader_id).await;
         let writer = WriteHandle {
-            writer_id,
             machine: machine.clone(),
             blob: Arc::clone(&self.blob),
             upper: shard_upper.0,
-            explicitly_expired: false,
         };
         let reader = ReadHandle {
             reader_id,
@@ -756,14 +754,6 @@ mod tests {
         assert_eq!(
             format!("{:?}", ShardId([0u8; 16])),
             "ShardId(00000000-0000-0000-0000-000000000000)"
-        );
-        assert_eq!(
-            format!("{}", WriterId([0u8; 16])),
-            "w00000000-0000-0000-0000-000000000000"
-        );
-        assert_eq!(
-            format!("{:?}", WriterId([0u8; 16])),
-            "WriterId(00000000-0000-0000-0000-000000000000)"
         );
         assert_eq!(
             format!("{}", ReaderId([0u8; 16])),


### PR DESCRIPTION
Previous changes removes the per-writer upper, so there is no there is
no more state we keep for writers.

This basically removes "dead code", no tests or nothing are needed.