### PR TITLE
persist: implement `append()` in terms of `compare_and_append()`

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -97,20 +97,6 @@ where
         read_cap
     }
 
-    pub async fn append(
-        &mut self,
-        keys: &[String],
-        desc: &Description<T>,
-    ) -> Result<Result<SeqNo, Upper<T>>, ExternalError> {
-        let (seqno, res) = self
-            .apply_unbatched_cmd(|_, state| state.append(keys, desc))
-            .await?;
-        match res {
-            Ok(()) => Ok(Ok(seqno)),
-            Err(current_upper) => return Ok(Err(current_upper)),
-        }
-    }
-
     pub async fn compare_and_append(
         &mut self,
         keys: &[String],

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -86,34 +86,6 @@ where
         Continue(read_cap)
     }
 
-    pub fn append(&mut self, keys: &[String], desc: &Description<T>) -> ControlFlow<Upper<T>, ()> {
-        // Sanity check that the writer is sending appends that allow us to construct a contiguous
-        // history of batches.
-        let shard_upper = self.upper();
-        if PartialOrder::less_than(&shard_upper, desc.lower()) {
-            return Break(Upper(shard_upper));
-        }
-
-        // Construct a new desc for the part of this append that the shard
-        // didn't already know about: i.e. a lower of the *shard upper* to an
-        // upper of the *append upper*. This might truncate the data we're
-        // receiving now (if the shard upper is partially past the input desc)
-        // or even make it a no-op (if the shard upper is entirely past the
-        // input desc).
-        let lower = self.upper();
-        let desc = Description::new(lower, desc.upper().clone(), desc.since().clone());
-        if PartialOrder::less_equal(desc.upper(), desc.lower()) {
-            // No-op, but still commit the state change so that this gets
-            // linearized.
-            return Continue(());
-        }
-
-        self.push_batch(keys, &desc);
-        debug_assert_eq!(&self.upper(), desc.upper());
-
-        Continue(())
-    }
-
     pub fn compare_and_append(
         &mut self,
         keys: &[String],

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -169,7 +169,7 @@ where
 
         let upper = upper;
         let since = Antichain::from_elem(T::minimum());
-        let desc = Description::new(lower.clone(), upper, since);
+        let mut desc = Description::new(lower.clone(), upper, since);
 
         // TODO: Instead construct a Vec of batches here so it can be bounded
         // memory usage (if updates is large).
@@ -198,15 +198,15 @@ where
         };
 
         loop {
-            let res = self.machine.append(&keys, &desc).await?;
+            let res = self.machine.compare_and_append(&keys, &desc).await?;
             match res {
-                Ok(_seqno) => {
+                Ok(Ok(_seqno)) => {
                     self.upper = desc.upper().clone();
                     return Ok(Ok(Ok(())));
                 }
                 // TODO(aljoscha): This seems useless now because we have to read from consensus to
                 // get an up-to-date version of the upper.
-                Err(_current_upper) => {
+                Ok(Err(_current_upper)) => {
                     // If the state machine thinks that the shard upper is not far enough along, it
                     // could be because the caller of this method has found out that it advanced
                     // via some some side-channel that didn't update our local cache of the machine
@@ -219,10 +219,25 @@ where
                     if PartialOrder::less_than(&current_upper, &lower) {
                         self.upper = current_upper.clone();
                         return Ok(Ok(Err(Upper(current_upper))));
+                    } else if PartialOrder::less_than(&current_upper, desc.upper()) {
+                        // Cut down the Description by advancing its lower to the current shard
+                        // upper and try again. IMPORTANT: We can only advance the lower, meaning
+                        // we cut updates away, we must not "extend" the batch by changing to a
+                        // lower that is not beyond the current lower. This invariant is checked by
+                        // the first if branch: if `!(current_upper < lower)` then it holds that
+                        // `lower <= current_upper`.
+                        desc = Description::new(
+                            current_upper,
+                            desc.upper().clone(),
+                            desc.since().clone(),
+                        );
                     } else {
-                        // The upper stored in state was outdated. Retry after updating.
+                        // We already have updates past this batch's upper, the append is a no-op.
+                        self.upper = current_upper;
+                        return Ok(Ok(Ok(())));
                     }
                 }
+                Err(err) => return Ok(Err(err)),
             }
         }
     }


### PR DESCRIPTION
This cuts down the different code paths we maintain in `State` and
`Machine`.

Because we changed the semantics of `append()` and added all the nice
tests in previous commits, this change is simple and sweet!

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.