### PR TITLE
deps: move back to a fork of prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,9 +2362,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -5028,8 +5028,7 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc03e116981ff7d8da8e5c220e374587b98d294af7ba7dd7fda761158f00086f"
+source = "git+https://github.com/MaterializeInc/prost.git?branch=v0.10#28cff98c6ad1f514ea9afc5e773a44746f75e32d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5038,12 +5037,10 @@ dependencies = [
 [[package]]
 name = "prost-build"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a1118354442de7feb8a2a76f3d80ef01426bd45542c8c1fdffca41a758f846"
+source = "git+https://github.com/MaterializeInc/prost.git?branch=v0.10#28cff98c6ad1f514ea9afc5e773a44746f75e32d"
 dependencies = [
  "bytes",
  "cfg-if",
- "cmake",
  "heck",
  "itertools",
  "lazy_static",
@@ -5052,6 +5049,7 @@ dependencies = [
  "petgraph",
  "prost",
  "prost-types",
+ "protobuf-src",
  "regex",
  "tempfile",
  "which",
@@ -5060,8 +5058,7 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+source = "git+https://github.com/MaterializeInc/prost.git?branch=v0.10#28cff98c6ad1f514ea9afc5e773a44746f75e32d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -5087,8 +5084,7 @@ dependencies = [
 [[package]]
 name = "prost-types"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+source = "git+https://github.com/MaterializeInc/prost.git?branch=v0.10#28cff98c6ad1f514ea9afc5e773a44746f75e32d"
 dependencies = [
  "bytes",
  "prost",
@@ -6385,9 +6381,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d17087af5c80e5d5fc8ba9878e60258065a0a757e35efe7a05b7904bece1943"
+checksum = "d9263bf4c9bfaae7317c1c2faf7f18491d2fe476f70c414b73bf5d445b00ffa1"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,7 @@ debug = 1
 [patch.crates-io]
 opentelemetry = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git" }
 opentelemetry-otlp = { git = "https://github.com/MaterializeInc/opentelemetry-rust.git" }
+prost = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
+prost-build = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
+prost-derive = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
+prost-types = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }

--- a/deny.toml
+++ b/deny.toml
@@ -143,8 +143,12 @@ allow-git = [
     # Waiting on https://github.com/AltSysrq/proptest/pull/264.
     "https://github.com/MaterializeInc/proptest.git",
 
-    # Waiting on https://github.com/open-telemetry/opentelemetry-rust/pull/783.
+    # Waiting on https://github.com/open-telemetry/opentelemetry-rust/pull/783
+    # to make it into a release.
     "https://github.com/MaterializeInc/opentelemetry-rust.git",
+
+    # Works around https://github.com/tokio-rs/prost/issues/653.
+    "https://github.com/MaterializeInc/prost.git",
 
     # Dependencies that we control upstream whose official releases we don't
     # care about.


### PR DESCRIPTION
prost v0.10.0 can optionally compile `protoc` from source. Unfortunately
this compilation sporadically fails in CI and on scratch machines.
Rather than attempt to debug the failure, which appears to be a race
condition in protobuf's CMake build system, switch back to our fork of
prost. Our fork uses protobuf's autotools build system, which has proven
to be more reliable.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
