### PR TITLE
doc/user: fix link to monitoring dashboard in LTS docs

### DIFF
--- a/doc/user/content/ops/monitoring.md
+++ b/doc/user/content/ops/monitoring.md
@@ -124,7 +124,7 @@ is no longer necessary, with the above command the dashboard will be available o
 {{</ tabs >}}
 
 [simplemon-hub]: https://hub.docker.com/repository/docker/materialize/dashboard
-[dashboard-json]: https://github.com/MaterializeInc/materialize/blob/main/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
+[dashboard-json]: https://github.com/MaterializeInc/materialize/blob/v0.26/misc/monitoring/dashboard/conf/grafana/dashboards/overview.json
 [graf-import]: https://grafana.com/docs/grafana/latest/reference/export_import/#importing-a-dashboard
 
 ## Health check


### PR DESCRIPTION
The monitoring dashboard is removed in main, but still referred to in
the LTS docs. Update the LTS docs to point at the monitoring dashboard
in the LTS branch.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a link in the LTS docs.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
