### PR TITLE
persist: add openssl_sys with the "vendored" feature to Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,6 +3649,7 @@ dependencies = [
  "mz-build-info",
  "mz-ore",
  "mz-persist-types",
+ "openssl-sys",
  "prost",
  "prost-build",
  "rand",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -44,6 +44,7 @@ mz-aws-util = { path = "../aws-util", features = ["s3"] }
 mz-build-info = { path = "../build-info" }
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "task"] }
 mz-persist-types = { path = "../persist-types" }
+openssl-sys = { version = "0.9.72", features = ["vendored"] }
 prost = "0.10.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -930,6 +930,15 @@ impl MinElapsed {
     }
 }
 
+// Make sure the "vendored" feature of the openssl_sys crate makes it into the
+// transitive dep graph of persist, so that we don't attempt to link against the
+// system OpenSSL library. Fake a usage of the crate here so that a good
+// samaritan doesn't remove our unused dep.
+#[allow(dead_code)]
+fn openssl_sys_hack() {
+    openssl_sys::init();
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::Error;


### PR DESCRIPTION
So that we don't attempt to link against the system OpenSSL library.
Fake a usage of the crate here so that a good samaritan doesn't remove
our unused dep.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
