### PR TITLE
test: avoid file source in no format test

### DIFF
--- a/test/testdrive/kafka-sources.td
+++ b/test/testdrive/kafka-sources.td
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-mode cockroach
+# Test that Kafka sources with no format are disallowed.
 
-# Test that non-AOCF sources require a format
-statement error Source format must be specified
-CREATE SOURCE foo FROM FILE '/dev/null'
+! CREATE SOURCE s
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
+exact:Source format must be specified


### PR DESCRIPTION
File sources are on their way out (#11875). Port a test that only
incidentally used a file source to use a Kafka source instead.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
