### PR TITLE
materialized: avoid file sources in some tests

### DIFF
--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -17,7 +17,7 @@ use mz_ore::retry::Retry;
 use reqwest::{blocking::Client, StatusCode, Url};
 use serde_json::json;
 
-use crate::util::{KAFKA_ADDRS, PostgresErrorExt};
+use crate::util::{PostgresErrorExt, KAFKA_ADDRS};
 
 pub mod util;
 


### PR DESCRIPTION
File sources are slated for removal (#11875). Remove/port a few more tests that use file sources. Details in commit messages.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
