### PR TITLE
kafka-resumption: switch to use tables rather than file sources

### DIFF
--- a/test/kafka-resumption/during.td
+++ b/test/kafka-resumption/during.td
@@ -7,6 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=dynamic.csv
+$ kafka-ingest topic=input format=bytes
 San Francisco,CA,94114
 Brooklyn,NY,11217

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -21,15 +21,13 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 
-# Pick a non-default port to make sure nothing is accidentally going around the proxy
-KAFKA_SINK_PORT = 9091
 SERVICES = [
     Zookeeper(),
-    Kafka(port=KAFKA_SINK_PORT),
-    SchemaRegistry(kafka_servers=[("kafka", f"{KAFKA_SINK_PORT}")]),
+    Kafka(),
+    SchemaRegistry(),
     Materialized(),
     Toxiproxy(),
-    Testdrive(kafka_url="toxiproxy:9093", default_timeout="120s"),
+    Testdrive(default_timeout="120s"),
 ]
 
 #

--- a/test/kafka-resumption/setup.td
+++ b/test/kafka-resumption/setup.td
@@ -11,22 +11,21 @@ $ http-request method=POST url=http://toxiproxy:8474/proxies content-type=applic
 {
   "name": "kafka",
   "listen": "0.0.0.0:9093",
-  "upstream": "kafka:9091"
+  "upstream": "kafka:9092"
 }
 
-$ file-append path=dynamic.csv
-city,state,zip
+$ kafka-create-topic topic=input
+$ kafka-ingest topic=input format=bytes
 Rochester,NY,14618
+New York,NY,10004
 
-> CREATE SOURCE input
-  FROM FILE '${testdrive.temp-dir}/dynamic.csv'
-  WITH (tail=true)
-  FORMAT CSV WITH HEADER (city,state,zip)
+# The source intentionally does not go through toxiproxy.
+> CREATE SOURCE input (city, state, zip)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-${testdrive.seed}'
+  FORMAT CSV WITH 3 COLUMNS
+  INCLUDE OFFSET
 
 > CREATE SINK output FROM input
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output-byo-sink-${testdrive.seed}'
+  INTO KAFKA BROKER 'toxiproxy:9093' TOPIC 'output-byo-sink-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-
-$ file-append path=dynamic.csv
-New York,NY,10004

--- a/test/kafka-resumption/verify-success.td
+++ b/test/kafka-resumption/verify-success.td
@@ -7,14 +7,14 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=dynamic.csv
+$ kafka-ingest topic=input format=bytes
 Hanover,PA,17331
 
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
-{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "mz_line_no":4}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "mz_line_no":5}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "mz_line_no":2}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "mz_line_no":1}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "mz_line_no":3}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "mz_offset":4}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "mz_offset":5}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "mz_offset":2}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "mz_offset":1}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "mz_offset":3}},"transaction":{"id":"<TIMESTAMP>"}}


### PR DESCRIPTION
File sources are slated for removal (see #11875). Port the Kafka
resumption test to use tables rather than file sources, since it only
incidentally used file sources.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
