### PR TITLE
sqllogictest: avoid file source in information schema test

### DIFF
--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -19,7 +19,9 @@ statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT 1
 
 statement ok
-CREATE SOURCE s FROM FILE '/dev/null' FORMAT BYTES
+CREATE SOURCE s FROM PUBNUB
+SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+CHANNEL 'pubnub-market-orders';
 
 query TTTT colnames
 SELECT * FROM information_schema.tables ORDER BY table_name


### PR DESCRIPTION
File sources are slated for removal (#11875). Port an SLT file that was
using a file source incidentally to use a PubNub source instead. The
contents of this source don't matter; just its existence.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
