### PR TITLE
*: add missing aws sdk features

### DIFF
--- a/src/kinesis-util/Cargo.toml
+++ b/src/kinesis-util/Cargo.toml
@@ -7,4 +7,4 @@ rust-version = "1.60.0"
 publish = false
 
 [dependencies]
-aws-sdk-kinesis = { version = "0.10.1", default-features = false, features = ["native-tls"] }
+aws-sdk-kinesis = { version = "0.10.1", default-features = false, features = ["native-tls", "rt-tokio"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = { version = "1.0.57", features = ["backtrace"] }
 arrow2 = { version = "0.11.2", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.53"
 aws-config = { version = "0.10.1", default-features = false, features = ["native-tls"] }
-aws-sdk-s3 = { version = "0.10.1", default-features = false }
+aws-sdk-s3 = { version = "0.10.1", default-features = false, features = ["native-tls", "rt-tokio"]  }
 aws-types = "0.10.1"
 base64 = "0.13.0"
 bytes = "1.1.0"

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.57"
 aws-config = { version = "0.10.1", default-features = false, features = ["native-tls"] }
-aws-sdk-kinesis = { version = "0.10.1", default-features = false }
+aws-sdk-kinesis = { version = "0.10.1", default-features = false, features = ["native-tls", "rt-tokio"] }
 bytes = "1.1.0"
 clap = { version = "3.1.15", features = ["derive"] }
 futures = "0.3.21"


### PR DESCRIPTION
The AWS SDK crates need the "native-tls" and "rt-tokio" features
enabled. This often goes unnoticed due to the way Cargo unions all
features together, but becomes important when selecting a single crate
to build/test with the `-p` flag.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
