### PR TITLE
computed: orchestrator configures http endpoint

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -222,6 +222,10 @@ where
                                             "--listen-addr={}:{}",
                                             default_listen_host, my_ports["controller"]
                                         ),
+                                        format!(
+                                            "--http-console-addr={}:{}",
+                                            default_listen_host, my_ports["http"]
+                                        ),
                                         format!("--processes={}", size_config.scale),
                                         format!("--workers={}", size_config.workers),
                                         "--log-process-name".to_string(),
@@ -245,6 +249,10 @@ where
                                     ServicePort {
                                         name: "compute".into(),
                                         port_hint: 2102,
+                                    },
+                                    ServicePort {
+                                        name: "http".into(),
+                                        port_hint: 2103,
                                     },
                                 ],
                                 cpu_limit: size_config.cpu_limit,

--- a/src/prof/src/http/templates/prof.html
+++ b/src/prof/src/http/templates/prof.html
@@ -26,7 +26,7 @@
         <button type="submit" name="action" value="activate">Activate</button>
       </form>
   {% endmatch %}
-  <a href="prof?action=dump_stats">Download stats</a>
+  <a href="?action=dump_stats">Download stats</a>
 {% when crate::http::MemProfilingStatus::Disabled %}
     <p>Jemalloc profiling is not available.</p>
     {% if std::env::consts::OS == "macos" %}


### PR DESCRIPTION
### Motivation

The HTTP endpoint for computed can be enabled manually, but not when
started through the orchestrator. Change it to assign a port by default.

Fix the link to access the jemalloc status dump.

### Testing

- [x] This PR has adequate test coverage/QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
