### PR TITLE
ore: remove mz_log_messages_total metric

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -214,18 +214,14 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 }
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
-    let metrics_registry = mz_ore::metrics::MetricsRegistry::new();
-    let mut _tracing_stream = mz_ore::tracing::configure(
-        mz_ore::tracing::TracingConfig {
-            log_filter: &args.log_filter,
-            opentelemetry_endpoint: None,
-            opentelemetry_headers: None,
-            prefix: args.log_process_name.then(|| "computed"),
-            #[cfg(feature = "tokio-console")]
-            tokio_console: false,
-        },
-        &metrics_registry,
-    )
+    let mut _tracing_stream = mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
+        log_filter: &args.log_filter,
+        opentelemetry_endpoint: None,
+        opentelemetry_headers: None,
+        prefix: args.log_process_name.then(|| "computed"),
+        #[cfg(feature = "tokio-console")]
+        tokio_console: false,
+    })
     .await?;
 
     if args.workers == 0 {

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -502,17 +502,15 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     // Avoid adding code above this point, because panics in that code won't get
     // handled by the custom panic handler.
     let metrics_registry = MetricsRegistry::new();
-    let mut tracing_stream = runtime.block_on(mz_ore::tracing::configure(
-        mz_ore::tracing::TracingConfig {
+    let mut tracing_stream =
+        runtime.block_on(mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
             log_filter: &args.log_filter,
             opentelemetry_endpoint: args.opentelemetry_endpoint.as_deref(),
             opentelemetry_headers: args.opentelemetry_headers.as_deref(),
             prefix: None,
             #[cfg(feature = "tokio-console")]
             tokio_console: args.tokio_console,
-        },
-        &metrics_registry,
-    ))?;
+        }))?;
     panic::set_hook(Box::new(handle_panic));
 
     // Initialize fail crate for failpoint support

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -66,7 +66,6 @@ task = ["tokio", "tokio/tracing"]
 tracing_ = [
   "ansi_term",
   "atty",
-  "metrics",
   "tracing",
   "tracing-subscriber",
   "tracing-subscriber/ansi",

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -138,18 +138,14 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 }
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
-    let metrics_registry = mz_ore::metrics::MetricsRegistry::new();
-    let mut _tracing_stream = mz_ore::tracing::configure(
-        mz_ore::tracing::TracingConfig {
-            log_filter: &args.log_filter,
-            opentelemetry_endpoint: None,
-            opentelemetry_headers: None,
-            prefix: args.log_process_name.then(|| "storaged"),
-            #[cfg(feature = "tokio-console")]
-            tokio_console: false,
-        },
-        &metrics_registry,
-    )
+    let mut _tracing_stream = mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
+        log_filter: &args.log_filter,
+        opentelemetry_endpoint: None,
+        opentelemetry_headers: None,
+        prefix: args.log_process_name.then(|| "storaged"),
+        #[cfg(feature = "tokio-console")]
+        tokio_console: false,
+    })
     .await?;
 
     if args.workers == 0 {


### PR DESCRIPTION
In a cloud only world, we no longer need to expose a convenience metric
for tracking the number of error logs emitted. Instead we can stream our
logs to Honeycomb and set up whatever alerts we want there.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes code that is no longer important in Materialize Platform.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
