### PR TITLE
testdrive: remove last usage of file sources

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -7,7 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ file-append path=static.csv
+$ s3-create-bucket bucket=test
+
+$ s3-put-object bucket=test key=static.csv
 city,state,zip
 Rochester,NY,14618
 New York,NY,10004
@@ -16,93 +18,140 @@ place""",CA,92679
 
 # We should refuse to create a source with invalid WITH options
 ! CREATE SOURCE invalid_with_option
-  FROM FILE '${testdrive.temp-dir}/static.csv'
-  WITH (badoption=true)
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}',
+    badoption = true
+  )
   FORMAT CSV WITH 3 COLUMNS
 contains:unexpected parameters for CREATE SOURCE: badoption
 
-! CREATE SOURCE mismatched_column_count
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+> CREATE MATERIALIZED SOURCE mismatched_column_count
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH 2 COLUMNS
-contains:Specified column count (WITH 2 COLUMNS) does not match number of columns in CSV file (3)
+! SELECT * FROM mismatched_column_count
+contains:CSV error at record number 1: expected 2 columns, got 3.
 
 > CREATE MATERIALIZED SOURCE matching_column_names
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names where zip = '14618'
-city state zip mz_line_no
+city state zip mz_record
 -------------------------
 Rochester NY 14618 1
 
 > CREATE MATERIALIZED SOURCE matching_column_names_alias (a, b, c)
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names_alias where c = '14618'
-a b c mz_line_no
+a b c mz_record
 ----------------
 Rochester NY 14618 1
 
-! CREATE SOURCE mismatched_column_names
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+> CREATE MATERIALIZED SOURCE mismatched_column_names
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH HEADER (cities, country, zip)
-contains:Header columns do not match named columns from CREATE SOURCE statement. First mismatched columns: cities != city
+! SELECT * FROM mismatched_column_names
+contains:first mismatched column at index 1 expected=cities actual="city"
 
-! CREATE SOURCE mismatched_column_names_count
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+> CREATE MATERIALIZED SOURCE mismatched_column_names_count
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH HEADER (cities, state)
-contains:Named column count (2) does not match number of columns discovered (3)
+! SELECT * FROM mismatched_column_names_count
+contains:CSV error at record number 1: expected 2 columns, got 3
 
 # Static CSV without headers.
 > CREATE MATERIALIZED SOURCE static_csv
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH 3 COLUMNS
 
 > SELECT * FROM static_csv
-column1        column2  column3  mz_line_no
+column1        column2  column3  mz_record
 --------------------------------------------
 city           state     zip     1
 Rochester      NY        14618   2
 "New York"     NY        10004   3
 "bad,\nplace\""  CA        92679   4
 
-> CREATE SOURCE static_csv_nothing_demanded_src
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+! CREATE SOURCE static_csv_nothing_demanded_src
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH HEADER
-
-> CREATE MATERIALIZED VIEW static_csv_nothing_demanded AS
-  SELECT true FROM static_csv_nothing_demanded_src
-
-> SELECT * FROM static_csv_nothing_demanded
-true
-true
-true
+exact:CSV WITH HEADER for S3 sources requires specifying the header columns
 
 # The timestamp chosen when reading from a static CSV should be the end of time,
 # since the definition of "static" means "will never change again".
 > SELECT count(*), mz_logical_timestamp() FROM static_csv
 4  18446744073709551615
 
-# Static CSV with automatic headers.
-> CREATE MATERIALIZED SOURCE static_csv_header
-  FROM FILE '${testdrive.temp-dir}/static.csv'
-  FORMAT CSV WITH HEADER
-
-> SELECT * FROM static_csv_header
-city           state     zip     mz_line_no
---------------------------------------------
-Rochester      NY        14618   1
-"New York"     NY        10004   2
-"bad,\nplace\""  CA        92679   3
-
 # Static CSV with manual headers.
 > CREATE MATERIALIZED SOURCE static_csv_manual_header (city_man, state_man, zip_man)
-  FROM FILE '${testdrive.temp-dir}/static.csv'
-  FORMAT CSV WITH HEADER
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM static_csv_manual_header
-city_man       state_man  zip_man  mz_line_no
+city_man       state_man  zip_man  mz_record
 ---------------------------------------------
 Rochester      NY         14618    1
 "New York"     NY         10004    2
@@ -110,99 +159,86 @@ Rochester      NY         14618    1
 
 # Dynamic CSV with automatic headers.
 
-$ file-append path=dynamic.csv
-city,state,zip
+$ kafka-create-topic topic=dynamic
 
-> CREATE MATERIALIZED SOURCE dynamic_csv
-  FROM FILE '${testdrive.temp-dir}/dynamic.csv' WITH (tail = true)
-  FORMAT CSV WITH HEADER
+> CREATE MATERIALIZED SOURCE dynamic_csv (city, state, zip)
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dynamic-${testdrive.seed}'
+  FORMAT CSV WITH 3 COLUMNS
 
 > SELECT * FROM dynamic_csv
 
-$ file-append path=dynamic.csv
+$ kafka-ingest topic=dynamic format=bytes
 Rochester,NY,14618
 
 > SELECT * FROM dynamic_csv
-city           state     zip     mz_line_no
---------------------------------------------
+city           state     zip     mz_offset
+------------------------------------------
 Rochester      NY        14618   1
 
-$ file-append path=dynamic.csv
+$ kafka-ingest topic=dynamic format=bytes
 New York,NY,10004
 
 > SELECT * FROM dynamic_csv
-city           state     zip     mz_line_no
---------------------------------------------
+city           state     zip     mz_offset
+------------------------------------------
 Rochester      NY        14618   1
 "New York"     NY        10004   2
 
-$ file-append path=deleting.csv
-city,state,zip
-Tucson,AZ,85719
-
-> CREATE SOURCE deleting_csv
-  FROM FILE '${testdrive.temp-dir}/deleting.csv'
-  FORMAT CSV WITH HEADER
-
-$ file-delete path=deleting.csv
-
-> CREATE INDEX i ON deleting_csv(city,state,zip)
-
-! SELECT * FROM deleting_csv
-regex:Source error: .*: file IO: file source: unable to open file at path
-
-! CREATE SOURCE should_fail FROM FILE '/'
-contains:/ is a directory.
-
 # Static malformed CSV
-$ file-append path=malformed.csv
-Dollars,Category
+$ s3-put-object bucket=test key=malformed.csv
+dollars,category
 5161669,Clothing&Shoes
 1000000000
 ,badrow
 badint,
 
 > CREATE MATERIALIZED SOURCE malformed_csv
-  FROM FILE '${testdrive.temp-dir}/malformed.csv'
-  FORMAT CSV WITH HEADER
+  FROM S3 DISCOVER OBJECTS MATCHING 'malformed.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM malformed_csv
 contains:Decode error: Text: CSV error at record number 3: expected 2 columns, got 1.
 
 # Static non-utf-8 CSV
-$ file-append path=bad-text.csv
-Dollars,Category
+$ s3-put-object bucket=test key=bad-text.csv
+dollars,category
 5161669,\x80
 
 > CREATE MATERIALIZED SOURCE bad_text_csv
-  FROM FILE '${testdrive.temp-dir}/bad-text.csv'
-  FORMAT CSV WITH HEADER
+  FROM S3 DISCOVER OBJECTS MATCHING 'bad-text.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH HEADER (dollars, category)
 
 ! SELECT * FROM bad_text_csv
 contains:Decode error: Text: CSV error at record number 2: invalid UTF-8
-
-# CSV file with comma in header
-
-$ file-append path=header-delimiter.csv
-"interesting,id",name
-1,blat
-
-> CREATE MATERIALIZED SOURCE header_delimited
-  FROM FILE '${testdrive.temp-dir}/header-delimiter.csv'
-  FORMAT CSV WITH HEADER
-
-> SELECT * FROM header_delimited
-interesting,id name mz_line_no
-------------------------------
-1 blat 1
 
 # Declare a key constraint (PRIMARY KEY NOT ENFORCED)
 
 $ kafka-create-topic topic=static-csv-pkne-sink
 
 > CREATE MATERIALIZED SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
-  FROM FILE '${testdrive.temp-dir}/static.csv'
-  FORMAT CSV WITH HEADER
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
+  FORMAT CSV WITH HEADER (city, state, zip)
 
 > CREATE SINK static_csv_pkne_sink FROM static_csv_pkne
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'static-csv-pkne-sink'
@@ -210,6 +246,6 @@ $ kafka-create-topic topic=static-csv-pkne-sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-verify format=avro sink=materialize.public.static_csv_pkne_sink sort-messages=true
-{"zip": "10004"} {"city": "New York", "state": "NY", "zip": "10004", "mz_line_no": 2}
-{"zip": "14618"} {"city": "Rochester", "state": "NY", "zip": "14618", "mz_line_no": 1}
-{"zip": "92679"} {"city": "bad,\nplace\"", "state": "CA", "zip": "92679", "mz_line_no": 3}
+{"zip": "10004"} {"city": "New York", "state": "NY", "zip": "10004", "mz_record": 2}
+{"zip": "14618"} {"city": "Rochester", "state": "NY", "zip": "14618", "mz_record": 1}
+{"zip": "92679"} {"city": "bad,\nplace\"", "state": "CA", "zip": "92679", "mz_record": 3}

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -50,10 +50,18 @@ exact:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
 exact:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
 
 # even the csv header validation doesn't happen before this error
-$ file-append path=static.csv
+$ s3-create-bucket bucket=test
+$ s3-put-object bucket=test key=static.csv
 
 ! CREATE SOURCE headers_src
-  FROM FILE '${testdrive.temp-dir}/static.csv'
+  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  WITH (
+    region = '${testdrive.aws-region}',
+    endpoint = '${testdrive.aws-endpoint}',
+    access_key_id = '${testdrive.aws-access-key-id}',
+    secret_access_key = '${testdrive.aws-secret-access-key}',
+    token = '${testdrive.aws-token}'
+  )
   FORMAT CSV WITH HEADER (city, state, zip)
   INCLUDE HEADERS
 exact:INCLUDE HEADERS with non-Kafka sources not supported


### PR DESCRIPTION
File sources are slated for removal (#11875). Port the last few
testdrive tests that only used file sources incidentally to use S3/Kafka
sources instead.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
