### PR TITLE
sqllogictest: avoid file sources for data loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3977,6 +3977,7 @@ dependencies = [
  "chrono",
  "clap",
  "fallible-iterator",
+ "futures",
  "junit-report",
  "lazy_static",
  "materialized",

--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -106,6 +106,21 @@ connections.
 The output is one line per row, one "COMPLETE X" (where X is the
 number of affected rows) per statement, or an error message.
 
+### `copy` extension
+
+The `copy` directive executes a [`COPY FROM`](https://materialize.com/docs/sql/copy-from/)
+statement. For example, the following directive
+
+```
+copy table path/to/file.csv
+```
+
+pipes the contents of file.csv to the following SQL statement:
+
+```
+COPY table FROM STDIN
+```
+
 ### modes
 
 We have extended sqllogictest to have the concept of the "mode." There are two

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 clap = { version = "3.1.15", features = ["derive"] }
 fallible-iterator = "0.2.0"
+futures = "0.3.21"
 junit-report = "0.7.1"
 lazy_static = "1.0.0"
 materialized = { path = "../materialized", default-features = false }

--- a/src/sqllogictest/src/ast.rs
+++ b/src/sqllogictest/src/ast.rs
@@ -136,6 +136,11 @@ pub enum Record<'a> {
     HashThreshold { threshold: u64 },
     /// A `halt` directive.
     Halt,
+    /// A `copy` directive.
+    Copy {
+        table_name: &'a str,
+        tsv_path: &'a str,
+    },
 }
 
 /// Specifies the dialect of a sqllogictest file. Different sqllogictest runners

--- a/src/sqllogictest/src/parser.rs
+++ b/src/sqllogictest/src/parser.rs
@@ -135,6 +135,15 @@ impl<'a> Parser<'a> {
                 self.parse_record()
             }
 
+            "copy" => Ok(Record::Copy {
+                table_name: words
+                    .next()
+                    .ok_or_else(|| anyhow!("load directive missing table name"))?,
+                tsv_path: words
+                    .next()
+                    .ok_or_else(|| anyhow!("load directive missing TSV path"))?,
+            }),
+
             other => bail!("Unexpected start of record: {}", other),
         }
     }

--- a/test/sqllogictest/postgres/rowtypes.slt
+++ b/test/sqllogictest/postgres/rowtypes.slt
@@ -186,35 +186,26 @@ select ROW(1,2) in (ROW(3,4), ROW(1,2::int8));
 true
 
 statement ok
-CREATE SOURCE tenk1_src FROM FILE 'test/sqllogictest/postgres/testdata/tenk.data'
-WITH (timestamp_frequency_ms=1) FORMAT CSV WITH 16 COLUMNS DELIMITED BY E'\t'
+CREATE TABLE tenk1 (
+  unique1 int4,
+  unique2 int4,
+  two int4,
+  four int4,
+  ten int4,
+  twenty int4,
+  hundred int4,
+  thousand int4,
+  twothousand int4,
+  fivethous int4,
+  tenthous int4,
+  odd int4,
+  even int4,
+  stringu1 text,
+  stringu2 text,
+  string4 text
+)
 
-statement ok
-CREATE MATERIALIZED VIEW tenk1 AS SELECT
-  column1::int4 AS unique1,
-  column2::int4 AS unique2,
-  column3::int4 AS two,
-  column4::int4 AS four,
-  column5::int4 AS ten,
-  column6::int4 AS twenty,
-  column7::int4 AS hundred,
-  column8::int4 AS thousand,
-  column9::int4 AS twothousand,
-  column10::int4 AS fivethous,
-  column11::int4 AS tenthous,
-  column12::int4 AS odd,
-  column13::int4 AS even,
-  column14::text AS stringu1,
-  column15::text AS stringu2,
-  column16::text AS string4
-  FROM tenk1_src
-
-# Wait for asynchronous ingestion to complete.
-query TI rowsort
-SELECT 'tenk1', count(*) FROM tenk1
-AS OF 18446744073709551615
-----
-tenk1 10000
+copy tenk1 test/sqllogictest/postgres/testdata/tenk.data
 
 # Check row comparison with a subselect
 

--- a/test/sqllogictest/postgres/subselect.slt
+++ b/test/sqllogictest/postgres/subselect.slt
@@ -18,69 +18,51 @@
 # license, a copy of which can be found in the LICENSE file at the
 # root of this repository.
 
-# RT File sources don't work with SLT, as we cannot guarantee that they have been
-# fully ingested at any time other than Timestamp::MAX.
-halt
-
 mode cockroach
 
 statement ok
-CREATE SOURCE onek_src FROM FILE 'test/sqllogictest/postgres/testdata/onek.data'
-WITH (timestamp_frequency_ms=1) FORMAT CSV WITH 16 COLUMNS DELIMITED BY E'\t'
+CREATE TABLE onek (
+  unique1 int4,
+  unique2 int4,
+  two int4,
+  four int4,
+  ten int4,
+  twenty int4,
+  hundred int4,
+  thousand int4,
+  twothousand int4,
+  fivethous int4,
+  tenthous int4,
+  odd int4,
+  even int4,
+  stringu1 text,
+  stringu2 text,
+  string4 text
+)
+
+copy onek test/sqllogictest/postgres/testdata/onek.data
 
 statement ok
-CREATE MATERIALIZED VIEW onek AS SELECT
-  column1::int4 AS unique1,
-  column2::int4 AS unique2,
-  column3::int4 AS two,
-  column4::int4 AS four,
-  column5::int4 AS ten,
-  column6::int4 AS twenty,
-  column7::int4 AS hundred,
-  column8::int4 AS thousand,
-  column9::int4 AS twothousand,
-  column10::int4 AS fivethous,
-  column11::int4 AS tenthous,
-  column12::int4 AS odd,
-  column13::int4 AS even,
-  column14::text AS stringu1,
-  column15::text AS stringu2,
-  column16::text AS string4
-  FROM onek_src
+CREATE TABLE tenk1 (
+  unique1 int4,
+  unique2 int4,
+  two int4,
+  four int4,
+  ten int4,
+  twenty int4,
+  hundred int4,
+  thousand int4,
+  twothousand int4,
+  fivethous int4,
+  tenthous int4,
+  odd int4,
+  even int4,
+  stringu1 text,
+  stringu2 text,
+  string4 text
+)
 
-statement ok
-CREATE SOURCE tenk1_src FROM FILE 'test/sqllogictest/postgres/testdata/tenk.data'
-WITH (timestamp_frequency_ms=1) FORMAT CSV WITH 16 COLUMNS DELIMITED BY E'\t'
-
-statement ok
-CREATE MATERIALIZED VIEW tenk1 AS SELECT
-  column1::int4 AS unique1,
-  column2::int4 AS unique2,
-  column3::int4 AS two,
-  column4::int4 AS four,
-  column5::int4 AS ten,
-  column6::int4 AS twenty,
-  column7::int4 AS hundred,
-  column8::int4 AS thousand,
-  column9::int4 AS twothousand,
-  column10::int4 AS fivethous,
-  column11::int4 AS tenthous,
-  column12::int4 AS odd,
-  column13::int4 AS even,
-  column14::text AS stringu1,
-  column15::text AS stringu2,
-  column16::text AS string4
-  FROM tenk1_src
-
-# Wait for asynchronous ingestion to complete.
-query TI rowsort
-SELECT 'onek', count(*) FROM onek
-UNION ALL
-SELECT 'tenk1', count(*) FROM tenk1
-AS OF 18446744073709551615
-----
-onek 1000
-tenk1 10000
+copy tenk1 test/sqllogictest/postgres/testdata/tenk.data
 
 statement ok
 CREATE TABLE int4_tbl (f1 int)


### PR DESCRIPTION
File sources are slated for removal (#11875). This commit avoids using
file sources in sqllogictest to load data. Instead, sqllogictest learns
a new `copy` directive that executes a `COPY FROM STDIN` statement.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
