### PR TITLE
persist: add tests for empty upper and since

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -261,6 +261,8 @@ mod tests {
 
     use super::*;
 
+    pub const EMPTY: &'static [((String, String), u64, i64)] = &[];
+
     pub async fn new_test_client() -> PersistClient {
         let blob = Arc::new(MemBlobMulti::open(MemBlobMultiConfig::default()));
         let consensus = Arc::new(MemConsensus::default());


### PR DESCRIPTION
Also fix a bug that Chae found a bit ago where passing an empty
antichain for both expected_upper and new_upper panics instead of
returning an error.

### Tips for reviewer

Lots of expected behaviors up for debate here.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
