### PR TITLE
doc/developer: avoid file sources in style guide

### DIFF
--- a/doc/developer/style.md
+++ b/doc/developer/style.md
@@ -66,7 +66,7 @@ of queries that obey the spacing rules
 
 ```sql
 CREATE TABLE t (a varchar(40));
-CREATE SOURCE test FROM FILE 'test.csv' WITH (tail = true) FORMAT BYTES;
+CREATE SOURCE test FROM KAFKA BROKER 'localhost:9092' TOPIC 'top' WITH (config_param = 'yes') FORMAT BYTES;
 SELECT coalesce(1, NULL, 2);
 SELECT CAST (1 AS text); -- note the space after CAST
 SELECT (1 + 2) - (7 * 4);
@@ -76,7 +76,7 @@ and several queries that don't:
 
 ```sql
 CREATE TABLE t (a varchar (40));
-CREATE SOURCE test FROM FILE 'test.csv' WITH(tail=true);
+CREATE SOURCE test FROM KAFKA BROKER 'localhost:9092' TOPIC 'top' WITH(tail=true);
 SELECT coalesce (1, NULL,2);
 SELECT CAST(1 AS text);
 SELECT 1+2;


### PR DESCRIPTION
File sources are getting removed in #12409, so avoid mentioning them in
the style guide.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing docs.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
