### PR TITLE
materialized: remove test_linearizable

### DIFF
--- a/src/materialized/tests/cli.rs
+++ b/src/materialized/tests/cli.rs
@@ -21,11 +21,16 @@ fn cmd() -> Command {
 /// changing and overwriting our custom version output.
 #[test]
 fn test_version() {
-    let expected_version = materialized::BUILD_INFO.human_version();
-    assert!(!expected_version.is_empty() && expected_version.starts_with('v'));
+    // We don't make assertions about the build SHA because caching in CI can
+    // cause the test binary and `materialized` to have different embedded SHAs.
+    let expected_version = materialized::BUILD_INFO.version;
+    assert!(!expected_version.is_empty());
     cmd()
         .arg("--version")
         .assert()
         .success()
-        .stdout(format!("materialized {}\n", expected_version));
+        .stdout(predicates::str::starts_with(format!(
+            "materialized v{}",
+            expected_version
+        )));
 }


### PR DESCRIPTION
This test has been broken and ignored for a very long time. With the
removal of file sources, it is now even more broken. So just remove it.
It will be replaced in due time by the work tracked in #11631.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
