### PR TITLE
sql-parser: Don't accept FILE as a valid source connector

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2077,9 +2077,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector<Raw>, ParserError> {
-        match self
-            .expect_one_of_keywords(&[FILE, KAFKA, KINESIS, AVRO, S3, PERSIST, POSTGRES, PUBNUB])?
-        {
+        match self.expect_one_of_keywords(&[KAFKA, KINESIS, AVRO, S3, PERSIST, POSTGRES, PUBNUB])? {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
                 let subscribe_key = self.parse_literal_string()?;


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug: Don't accept `FILE` as a valid source connector. It was not removed by #12409.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
