### PR TITLE
storage: downgrade since in persist_source

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -85,8 +85,8 @@ where
         let persist_client = futures_executor::block_on(persist_location.open())
             .expect("cannot open persist client");
 
-        let (write, _read) = futures_executor::block_on(
-            persist_client.open::<Row, Row, Timestamp, Diff>(self.shard_id),
+        let write = futures_executor::block_on(
+            persist_client.open_writer::<Row, Row, Timestamp, Diff>(self.shard_id),
         )
         .expect("could not open persist shard");
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1732,8 +1732,8 @@ pub mod sources {
 
                     let persist_client = location.open().await?;
 
-                    let (_write, read) = persist_client
-                        .open::<Row, Row, T, mz_repr::Diff>(persist_connector.shard_id)
+                    let read = persist_client
+                        .open_reader::<Row, Row, T, mz_repr::Diff>(persist_connector.shard_id)
                         .await?;
 
                     Some(read)

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -77,8 +77,8 @@ where
 
         let persist_client = persist_location.open().await?;
 
-        let (_write, mut read) = persist_client
-            .open::<Row, Row, Timestamp, Diff>(shard_id)
+        let mut read = persist_client
+            .open_reader::<Row, Row, Timestamp, Diff>(shard_id)
             .await?;
 
         /// Aggressively downgrade `since`, to not hold back compaction.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -225,10 +225,11 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                             let persist_client =
                                 futures_executor::block_on(location.open()).unwrap();
 
-                            let (write, _read) = futures_executor::block_on(
-                                persist_client.open::<Row, Row, mz_repr::Timestamp, mz_repr::Diff>(
-                                    persist_connector.shard_id,
-                                ),
+                            let write = futures_executor::block_on(
+                                persist_client
+                                    .open_writer::<Row, Row, mz_repr::Timestamp, mz_repr::Diff>(
+                                        persist_connector.shard_id,
+                                    ),
                             )
                             .unwrap();
 


### PR DESCRIPTION
This PR adds code to `persist_source` to downgrade the persist collection's `since`. This is required to make compaction work (once it gets enabled).

### Motivation

  * This PR fixes a previously unreported bug.

    Previously, `persist_source` would hold back compaction of the persist collection by never advancing the `since` frontier.

### Tips for reviewer

I fixed the formatting, which makes the diff unhelpful. It gets better when you ignore whitespace! The only actual change is the addition of the `downgrade_since` calls.

This is just something I stumbled upon when thinking about introspection sources. There is no urgent need to merge this.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).