### PR TITLE
persist/materialized: default to using postgres for consensus

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -651,12 +651,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
             Some(blob_url) => blob_url.to_string(),
         },
         consensus_uri: match args.persist_consensus_url {
-            // TODO: need to handle non-UTF-8 paths here.
-            None => format!(
-                "sqlite://{}/{}/persist/consensus",
-                cwd.display(),
-                data_directory.display()
-            ),
+            None => "postgres://postgres:postgres@postgres".to_string(),
             Some(consensus_url) => consensus_url.to_string(),
         },
     };

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -15,6 +15,7 @@ from materialize.mzcompose.services import (
     Kafka,
     Localstack,
     Materialized,
+    Postgres,
     Redpanda,
     SchemaRegistry,
     Testdrive,
@@ -25,6 +26,7 @@ from materialize.xcompile import Arch
 SERVICES = [
     Zookeeper(),
     Kafka(),
+    Postgres(),
     SchemaRegistry(),
     Redpanda(),
     Localstack(),
@@ -74,7 +76,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.redpanda:
         dependencies += ["redpanda"]
     else:
-        dependencies += ["zookeeper", "kafka", "schema-registry"]
+        dependencies += ["zookeeper", "kafka", "schema-registry", "postgres"]
 
     materialized = Materialized(
         options=["--persistent-user-tables"] if args.persistent_user_tables else [],


### PR DESCRIPTION
This commit also changes testdrive to use Postgres during CI.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
