### PR TITLE
ci,test: fix the Redpanda Nightly CI

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -100,18 +100,20 @@ steps:
     agents:
       queue: linux-x86_64
     plugins:
+      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          run: testdrive-redpanda-ci
+          args: [--redpanda, --aws-region=us-east-2]
 
   - id: redpanda-testdrive-aarch64
     label: ":panda_face: :racing_car: testdrive aarch64"
     agents:
       queue: linux-aarch64
     plugins:
+      - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          run: testdrive-redpanda-ci
+          args: [--redpanda, --aws-region=us-east-2]
 
   - id: upgrade
     label: "Upgrade testing"

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -76,6 +76,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     else:
         dependencies += ["zookeeper", "kafka", "schema-registry"]
 
+    if args.aws_region is None:
+        dependencies += ["localstack"]
+
     materialized = Materialized(
         options=["--persistent-user-tables"] if args.persistent_user_tables else [],
     )
@@ -98,16 +101,3 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ci_util.upload_junit_report(
                 "testdrive", Path(__file__).parent / junit_report
             )
-
-
-def workflow_testdrive_redpanda_ci(c: Composition) -> None:
-    """Run testdrive against files known to be supported by Redpanda."""
-
-    files = set(
-        # NOTE(benesch): invoking the shell like this to filter testdrive files is
-        # pretty gross. Let's not get into the habit of using this construction.
-        spawn.capture(
-            ["sh", "-c", "grep -lr '\$.*kafka-ingest' *.td"], cwd=Path(__file__).parent
-        ).split()
-    )
-    c.workflow("default", "--redpanda", *files)


### PR DESCRIPTION
```
commit ad7a3fb84433e7503b1838b7f27eff790dfeed17 (HEAD -> testdrive-localstack, origin/testdrive-localstack)
Author: Philip Stoev <pstoev@materialize.io>
Date:   Thu May 12 17:10:48 2022 +0200

    ci,test: Fix the Nightly redpanda jobs
    
    * Remove the dedicated Redpanda workflow as now Redpanda is able
      to run all the testdrive tests.
    
    * Run all the testdrive tests against Redpanda, and not just the
      ones containing $ kafka-ingest . This future-proofs the CI and
      makes sure that a future test that is somehow relevant (e.g.
      involves empty topics or Schema Registry operations, etc.) can
      not be introduced without being run against Redpanda
    
    * Configure the Redpanda jobs in Nightly CI to use AWS
    
    * Unless an actual AWS region is explicitly requested, make sure
      localstack is started in the testdrive workflow
```
### Motivation


  * This PR fixes a previously unreported bug.
  ** Nightly redpanda tests were failing in CI because they were not instructed to use an AWS region
  ** local executions of the testdrive workflow would fail because localstack was not started