### PR TITLE
persist/materialized: default to using postgres for consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,7 +2888,9 @@ dependencies = [
  "tower-http",
  "tracing",
  "url",
+ "urlencoding",
  "uuid",
+ "whoami",
 ]
 
 [[package]]
@@ -6827,6 +6829,16 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -72,8 +72,8 @@ test_cases = [
             "--tls-ca=/secrets/ca.crt",
         ],
         dbt_env={
-            "DBT_SSLCERT": "/secrets/materialized.crt",
-            "DBT_SSLKEY": "/secrets/materialized.key",
+            "DBT_SSLCERT": "/secrets/postgres.crt",
+            "DBT_SSLKEY": "/secrets/postgres.key",
             "DBT_SSLROOTCERT": "/secrets/ca.crt",
         },
     ),

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -220,6 +220,7 @@ class Composition:
         compose.setdefault("volumes", {}).update(
             {
                 "mzdata": None,
+                "postgres": None,
                 "tmp": None,
                 "secrets": None,
             }

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -17,7 +17,11 @@ DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.3"
 DEFAULT_DEBEZIUM_VERSION = "1.9"
 LINT_DEBEZIUM_VERSIONS = ["1.4", "1.5", "1.6"]
 
-DEFAULT_MZ_VOLUMES = ["mzdata:/share/mzdata", "tmp:/share/tmp"]
+DEFAULT_MZ_VOLUMES = [
+    "mzdata:/mzdata",
+    "postgres:/var/lib/postgresql",
+    "tmp:/share/tmp",
+]
 
 
 class Materialized(Service):
@@ -29,7 +33,7 @@ class Materialized(Service):
         port: Union[int, str] = 6875,
         extra_ports: List[int] = [],
         memory: Optional[str] = None,
-        data_directory: str = "/share/mzdata",
+        data_directory: str = "/mzdata",
         timestamp_frequency: str = "100ms",
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
@@ -551,7 +555,7 @@ class Testdrive(Service):
             entrypoint.append(f"--aws-endpoint={aws_endpoint}")
 
         if validate_data_dir:
-            entrypoint.append("--validate-data-dir=/share/mzdata")
+            entrypoint.append("--validate-data-dir=/mzdata")
 
         if validate_postgres_stash:
             entrypoint.append(

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -95,7 +95,9 @@ tokio-stream = { version = "0.1.8", features = ["net"] }
 tower-http = { version = "0.2.5", features = ["cors"] }
 tracing = "0.1.34"
 url = "2.2.2"
+urlencoding = "2.1.0"
 uuid = "0.8.2"
+whoami = "1.2.1"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 # According to jemalloc developers, `background_threads` should always be

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -10,8 +10,23 @@
 MZFROM ubuntu-base
 
 # We install sqlite3 to allow debugging of the catalog file, if necessary.
-RUN apt-get update && apt-get -qy install ca-certificates curl sqlite3 tini
+RUN apt-get update \
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        ca-certificates \
+        curl \
+        postgresql-14 \
+        sqlite3 \
+        tini \
+    && useradd --system --create-home materialize \
+    && pg_dropcluster 14 main \
+    && pg_createcluster 14 materialize --user=materialize \
+    && pg_ctlcluster 14 materialize start \
+    && su materialize -c "createdb materialize" \
+    && mkdir /mzdata \
+    && chown materialize /mzdata
 
-COPY storaged computed materialized /usr/local/bin/
+COPY storaged computed materialized entrypoint.sh /usr/local/bin/
 
-ENTRYPOINT ["tini", "--", "materialized", "--listen-addr=0.0.0.0:6875"]
+USER materialize
+
+ENTRYPOINT ["tini", "--", "entrypoint.sh"]

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -7,16 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM ubuntu-base
+set -euo pipefail
 
-RUN apt-get update \
-    && apt-get -qy install ca-certificates tini \
-    && useradd --system --create-home materialize \
-    && mkdir /mzdata \
-    && chown materialize /mzdata
-
-COPY materialized /usr/local/bin/
-
-USER materialize
-
-ENTRYPOINT ["tini", "--", "materialized", "--listen-addr=0.0.0.0:6875"]
+pg_ctlcluster 14 materialize start
+exec materialized --listen-addr=0.0.0.0:6875 "$@"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -651,12 +651,17 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
             Some(blob_url) => blob_url.to_string(),
         },
         consensus_uri: match args.persist_consensus_url {
-            // TODO: need to handle non-UTF-8 paths here.
-            None => format!(
-                "sqlite://{}/{}/persist/consensus",
-                cwd.display(),
-                data_directory.display()
-            ),
+            None => {
+                #[cfg(target_os = "macos")]
+                let host = "/tmp";
+                #[cfg(not(target_os = "macos"))]
+                let host = "/var/run/postgresql";
+                format!(
+                    "postgres://{}@{}",
+                    urlencoding::encode(&whoami::username()),
+                    urlencoding::encode(host),
+                )
+            }
             Some(consensus_url) => consensus_url.to_string(),
         },
     };

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -23,7 +23,7 @@ ENV PROTOC /usr/local/bin/protoc
 WORKDIR /workdir
 
 RUN mkdir -p /share/tmp && chmod 777 /share/tmp
-RUN mkdir -p /share/mzdata && chmod 777 /share/mzdata
+RUN mkdir -p /mzdata && chmod 777 /mzdata
 
 VOLUME /share/tmp
-VOLUME /share/mzdata
+VOLUME /mzdata

--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -26,13 +26,13 @@ services:
         ipv4_address: 10.0.0.12
     command:
       --listen-addr 0.0.0.0:6875
-      --data-directory=/share/mzdata
+      --data-directory=/mzdata
       --experimental
       --timestamp-frequency 100ms
       --no-sigbus-sigsegv-backtraces
     image: antithesis-materialized:${ANT_IMAGE_TAG}
     volumes:
-      - mzdata:/share/mzdata:rw
+      - mzdata:/mzdata:rw
       - tmp:/share/tmp:rw
   atp-testdrive:
     hostname: atp-testdrive
@@ -63,7 +63,7 @@ services:
     image: antithesis-testdrive:${ANT_IMAGE_TAG}
     init: true
     volumes:
-      - mzdata:/share/mzdata:rw
+      - mzdata:/mzdata:rw
       - tmp:/share/tmp:rw
 
 volumes:

--- a/test/cluster/README.md
+++ b/test/cluster/README.md
@@ -41,7 +41,7 @@ docker run -p 2101:2101 -p 6876:6876 materialize/dataflowd:latest --workers 2 --
 On `coord`, run:
 
 ```
-docker run -v /share/mzdata -p 6875:6875 materialize/coordd:latest -D /share/mzdata dataflow1:6876 dataflow2:6876
+docker run -v /mzdata -p 6875:6875 materialize/coordd:latest dataflow1:6876 dataflow2:6876
 ```
 
 Then connect to the coordinator via psql:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -49,7 +49,7 @@ SERVICES = [
     Materialized(extra_ports=[2101]),
     Testdrive(
         volumes=[
-            "mzdata:/share/mzdata",
+            "mzdata:/mzdata",
             "tmp:/share/tmp",
             ".:/workdir/smoke",
             "../testdrive:/workdir/testdrive",

--- a/test/secrets/mzcompose.py
+++ b/test/secrets/mzcompose.py
@@ -25,7 +25,7 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ `stat -c \"%a\" /share/mzdata/secrets` == '700' ]] && exit 0 || exit 1",
+        "[[ `stat -c \"%a\" /mzdata/secrets` == '700' ]] && exit 0 || exit 1",
     )
 
     c.sql("CREATE SECRET secret AS 's3cret'")
@@ -34,7 +34,7 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ `cat /share/mzdata/secrets/*` == 's3cret' ]] && exit 0 || exit 1",
+        "[[ `cat /mzdata/secrets/*` == 's3cret' ]] && exit 0 || exit 1",
     )
 
     # Check that the file permissions are restrictive
@@ -42,7 +42,7 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ `stat -c \"%a\" /share/mzdata/secrets/*` == '600' ]] && exit 0 || exit 1",
+        "[[ `stat -c \"%a\" /mzdata/secrets/*` == '600' ]] && exit 0 || exit 1",
     )
 
     # Check that alter secret gets reflected on disk
@@ -51,7 +51,7 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ `cat /share/mzdata/secrets/*` == 'tops3cret' ]] && exit 0 || exit 1",
+        "[[ `cat /mzdata/secrets/*` == 'tops3cret' ]] && exit 0 || exit 1",
     )
 
     # check that replacing the file did not change permissions
@@ -59,7 +59,7 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ `stat -c \"%a\" /share/mzdata/secrets/*` == '600' ]] && exit 0 || exit 1",
+        "[[ `stat -c \"%a\" /mzdata/secrets/*` == '600' ]] && exit 0 || exit 1",
     )
 
     # Rename should not change the contents on disk
@@ -70,7 +70,7 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ `cat /share/mzdata/secrets/*` == 'tops3cret' ]] && exit 0 || exit 1",
+        "[[ `cat /mzdata/secrets/*` == 'tops3cret' ]] && exit 0 || exit 1",
     )
 
     c.sql("DROP SECRET renamed_secret")
@@ -79,5 +79,5 @@ def workflow_default(c: Composition) -> None:
         "materialized",
         "bash",
         "-c",
-        "[[ -z `ls -A /share/mzdata/secrets` ]] && exit 0 || exit 1",
+        "[[ -z `ls -A /mzdata/secrets` ]] && exit 0 || exit 1",
     )

--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -178,7 +178,8 @@ done
 
 echo $SSL_SECRET > secrets/cert_creds
 
-# Ensure files are readable for any user
+# Ensure files are readable for any user.
 chmod -R a+r secrets/
-# Keys are only user-accessible
-chmod -R og-rwx secrets/*.key
+# The PostgreSQL key must be only user accessible to satisfy PostgreSQL's
+# security checks.
+chmod -R og-rwx secrets/postgres.key

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -183,7 +183,7 @@ def test_upgrade_from_version(
         f"--var=upgrade-from-version={from_version}",
         temp_dir,
         seed,
-        "--validate-data-dir=/share/mzdata",
+        "--validate-data-dir=/mzdata",
         f"check-{style}from-{version_glob}-{filter}.td",
     )
 


### PR DESCRIPTION
Default the persist consensus URI to use a local PostgreSQL instance via
a Unix domain socket.

Supersedes #12420.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
