### PR TITLE
persist: split ExternalError into Determinate and Indeterminate variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,6 +3623,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "lazy_static",
+ "libsqlite3-sys",
  "md-5",
  "mz-build-info",
  "mz-ore",

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -11,7 +11,7 @@
 
 use std::fmt::Debug;
 
-use mz_persist::location::ExternalError;
+use mz_persist::location::{Determinate, ExternalError, Indeterminate};
 use timely::progress::Antichain;
 
 use crate::ShardId;
@@ -33,9 +33,16 @@ pub trait Determinacy {
     const DETERMINANT: bool;
 }
 
-// TODO: Some ExternalErrors actually are determinate (e.g. Postgres errors on
-// txn conflict). We should split it so that these operations can be retried in
-// more places.
+impl Determinacy for Determinate {
+    const DETERMINANT: bool = true;
+}
+
+impl Determinacy for Indeterminate {
+    const DETERMINANT: bool = false;
+}
+
+// An external error's variant declares whether it's determinate, but at the
+// type level we have to fall back to indeterminate.
 impl Determinacy for ExternalError {
     const DETERMINANT: bool = false;
 }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -242,6 +242,10 @@ where
     /// sink code so it is always safe to retry [ExternalError]s, but SQL txns
     /// will have to pass the error back to the user (or risk double committing
     /// the txn).
+    ///
+    /// TODO: This already retries [mz_persist::location::Determinate] errors,
+    /// so the signature could be changed to only return Indeterminate, but
+    /// leaving it as ExternalError for now to save churn on storage PR rebases.
     pub async fn compare_and_append<SB, KB, VB, TB, DB, I>(
         &mut self,
         updates: I,

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -47,6 +47,7 @@ openssl-sys = { version = "0.9.72", features = ["vendored"] }
 prost = "0.10.1"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
+libsqlite3-sys = { version = "0.24.0" }
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }


### PR DESCRIPTION
When a BlobMulti or Consensus impl knows an ExternalError is
Determinate, there are more opportunities to retry it. Critically, this
includes the "database is locked" error that can arise from concurrent
use of sqlite. This commit greatly reduces the number of ExternalErrors
the bubble up to WriteHandle::compare_and_append users when sqlite is
used as the Consensus impl.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
