### PR TITLE
tests: Do not rely on the kafka TCP port for unrelated tests

### DIFF
--- a/test/testdrive/schema-registry-network-errors.td
+++ b/test/testdrive/schema-registry-network-errors.td
@@ -41,23 +41,3 @@ contains:URL scheme is not allowed
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}/no-such-path'
   ENVELOPE NONE
 contains:fetching latest schema for subject 'foo-value' from registry: subject not found
-
-#
-# HTTP connection to a non-HTTP port port
-#
-
-! CREATE MATERIALIZED SOURCE foo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://${testdrive.kafka-addr}'
-  ENVELOPE NONE
-contains:error sending request for url
-
-#
-# HTTPS connection to a non-HTTPS port
-#
-
-! CREATE MATERIALIZED SOURCE foo
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'foo'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://${testdrive.kafka-addr}'
-  ENVELOPE NONE
-contains:error sending request for url

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -48,10 +48,6 @@ name
 ----
 
 # We should refuse to create a sink with an invalid schema registry URL.
-# We use the Kafka address as the invalid schema registry address, as it is
-# known to immediately produce an error. Previous attempts used
-# `example.com:8080` and `materialize.com:8080` which can blackhole the request
-# for minutes rather than surfacing an error in a timely manner.
 
 # Invalid in that the address is not well formed
 ! CREATE SINK bad_schema_registry FROM src
@@ -59,10 +55,16 @@ name
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.kafka-addr}'
 contains:cannot construct a CCSR client with a cannot-be-a-base URL
 
+# Invalid in that the address points to an invalid host
+! CREATE SINK bad_schema_registry FROM src
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://no-such-host'
+contains:unable to publish value schema to registry in kafka sink
+
 # Invalid in that the address is not for a schema registry
 ! CREATE SINK bad_schema_registry FROM src
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://${testdrive.kafka-addr}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialized:6875'
 contains:unable to publish value schema to registry in kafka sink
 
 > SHOW SINKS


### PR DESCRIPTION
Tests that needed to specify a bogus schema registry URL were using
the kafka TCP port in the expecation that Kafka will quickly close
the socket.

This assumption however is unfortunately not true for Redpanda, where
the socket remains open forever without a discernible timeout, causing
such tests to fail in unexpected ways.

The fix is to remove any tests that were abusing the kafka port in
this manner. There is no other suitable service within the testdrive
composition that such tests could be directed to.


### Motivation


  * This PR fixes a previously unreported bug.
** Redpanda CI was red