### PR TITLE
persist: upgrade ReadHandle drop without expire log to warn

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -23,7 +23,7 @@ use mz_persist::retry::Retry;
 use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 use uuid::Uuid;
 
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
@@ -617,7 +617,7 @@ where
                 self.reader_id
             );
         } else {
-            info!("ReadHandle {} dropped without being explicitly expired, falling back to lease timeout", self.reader_id);
+            warn!("ReadHandle {} dropped without being explicitly expired, falling back to lease timeout", self.reader_id);
         }
     }
 }


### PR DESCRIPTION
Requested by Jan to make it more obvious that one should take a look.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
