### PR TITLE
ci: Add Localstack to the cluster and kafka-matrix nightly jobs

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -14,6 +14,7 @@ from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Computed,
     Kafka,
+    Localstack,
     Materialized,
     SchemaRegistry,
     Testdrive,
@@ -24,6 +25,7 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
+    Localstack(),
     Computed(
         name="computed_1",
         options="--workers 2 --processes 2 --process 0 computed_1:2102 computed_2:2102 --storage-addr materialized:2101",
@@ -63,7 +65,9 @@ def workflow_default(c: Composition) -> None:
 
 def workflow_nightly(c: Composition) -> None:
     """Run cluster testdrive"""
-    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
+    c.start_and_wait_for_tcp(
+        services=["zookeeper", "kafka", "schema-registry", "localstack"]
+    )
     # Skip tests that use features that are not supported yet.
     files = spawn.capture(
         [

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -10,6 +10,7 @@
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Kafka,
+    Localstack,
     Materialized,
     SchemaRegistry,
     Testdrive,
@@ -31,10 +32,13 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
+    Localstack(),
 ]
 
 
 def workflow_default(c: Composition) -> None:
+    c.start_and_wait_for_tcp(services=["localstack"])
+
     for version in CONFLUENT_PLATFORM_VERSIONS:
         print(f"==> Testing Confluent Platform {version}")
         confluent_platform_services = [


### PR DESCRIPTION
Now that various tests have been converted from file sources to S3,
the presence of S3 is a requirement across the board.
### Motivation

  * This PR fixes a previously unreported bug.
  ** kafka-matrix and cluster Nightly jobs were failing