### PR TITLE
mzcompose: Handle aws_region and aws_endpoint in services.py

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -509,6 +509,8 @@ class Testdrive(Service):
         volume_workdir: str = ".:/workdir",
         propagate_uid_gid: bool = True,
         forward_buildkite_shard: bool = False,
+        aws_region: Optional[str] = None,
+        aws_endpoint: str = "http://localstack:4566",
     ) -> None:
         if environment is None:
             environment = [
@@ -540,6 +542,12 @@ class Testdrive(Service):
                 "--schema-registry-url=http://schema-registry:8081",
                 f"--materialized-url={materialized_url}",
             ]
+
+        if aws_region:
+            entrypoint.append(f"--aws-region={aws_region}")
+
+        if aws_endpoint and not aws_region:
+            entrypoint.append(f"--aws-endpoint={aws_endpoint}")
 
         if validate_data_dir:
             entrypoint.append("--validate-data-dir=/share/mzdata")

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -100,6 +100,10 @@ SERVICES = [
         volumes_extra=["secrets:/share/secrets"],
         # Required to install root certs above
         propagate_uid_gid=False,
+        # Required so that testdrive can load and validate the catalog
+        environment=[
+            "SSL_KEY_PASSWORD=mzmzmz",
+        ],
     ),
 ]
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -86,9 +86,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     testdrive = Testdrive(
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
-        entrypoint_extra=[f"--aws-region={args.aws_region}"]
-        if args.aws_region
-        else ["--aws-endpoint=http://localstack:4566"],
+        aws_region=args.aws_region,
     )
 
     with c.override(materialized, testdrive):


### PR DESCRIPTION
Handle AWS entirely in services.py so that dataflows can use
a localstack installation by default without having to construct
a command-line argument to testdrive

### Motivation

  * This PR adds a feature that has not yet been specified.
** testdrive will not take advantage of a localstack present in the composition unless an explicit command-line argument is constructed for the purpose. 