### PR TITLE
ci: Make the trim_pipeline depend on build

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -50,6 +50,7 @@ steps:
     if: build.source == "ui"
     agents:
       queue: linux
+    depends_on: build-x86_64
 
   - wait: ~
     if: build.source == "ui"


### PR DESCRIPTION
In order to avoid race conditions and failed builds, the build
step should complete prior to trim_pipeline
### Motivation


  * This PR fixes a previously unreported bug.
 ** Custom runs of Nightly are failing in mysterious ways