### PR TITLE
doc/user: point to Cube.js docs

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -128,6 +128,13 @@ parent = 'commands'
 url = '/sql/create-source'
 
 [[menu.main]]
+identifier = "tools-and-integrations"
+name = "Overview"
+parent = "integrations"
+url = "/integrations"
+weight = 5
+
+[[menu.main]]
 identifier = "integration-guides"
 name = "Integration Guides"
 parent = "integrations"

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -220,7 +220,7 @@ The level of support for these tools will improve as we extend the coverage of `
 
 | Service | Support level | Notes |  |
 | --- | --- | --- | --- |
-| Cube.js | {{< supportLevel alpha >}} | The Cube.js PostgreSQL driver [can be modified](https://github.com/rongfengliang/cubejs-materialize-driver) to work with Materialize. A Cube.js driver for Materialize is in [active development](https://github.com/cube-js/cube.js/pull/4320). | [](#notify) |
+| Cube.js | {{< supportLevel alpha >}} | Connect using the [Materialize driver](https://cube.dev/docs/config/databases). | [](#notify) |
 
 ### Reverse ETL
 


### PR DESCRIPTION
Change the Cube.js entry in Tools and Integrations after the integration launch. 🎉 We should add a guide to our docs as a follow-up!