### PR TITLE
test: Update the Kafka versions tested by kafka-matrix to include 7.1.1

### DIFF
--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -18,11 +18,13 @@ from materialize.mzcompose.services import (
 )
 
 CONFLUENT_PLATFORM_VERSIONS = [
-    "4.0.0",
-    "5.0.0",
-    "6.0.2",
-    "6.1.2",
-    "6.2.0",
+    "4.1.4",
+    "5.5.0",
+    "6.0.6",
+    "6.1.5",
+    "6.2.4",
+    "7.0.3",
+    "7.1.1",
     "latest",
 ]
 


### PR DESCRIPTION
- include recently-released major versions
- update previous major versions to their latest minor version

### Motivation
  * This PR fixes a previously unreported bug.
  ** The kafka-matrix test was not testing the latest Kafka major and minor versions