### PR TITLE
persist: make sqlite consensus impl properly async

### DIFF
--- a/src/persist/benches/consensus.rs
+++ b/src/persist/benches/consensus.rs
@@ -112,7 +112,8 @@ pub fn bench_consensus_compare_and_set(
     // Create a directory that will automatically be dropped after the test finishes.
     {
         let temp_dir = tempfile::tempdir().expect("failed to create temp directory");
-        let sqlite_consensus = SqliteConsensus::open(temp_dir.path().join("db"))
+        let sqlite_consensus = runtime
+            .block_on(SqliteConsensus::open(temp_dir.path().join("db")))
             .expect("creating a SqliteConsensus cannot fail");
         let sqlite_consensus = Arc::new(sqlite_consensus);
         g.bench_with_input(
@@ -131,7 +132,8 @@ pub fn bench_consensus_compare_and_set(
     }
 
     // Only run Postgres benchmarks if the magic env vars are set.
-    if let Some(config) = futures_executor::block_on(PostgresConsensusConfig::new_for_test())
+    if let Some(config) = runtime
+        .block_on(PostgresConsensusConfig::new_for_test())
         .expect("failed to load postgres config")
     {
         let postgres_consensus = runtime

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -105,6 +105,7 @@ impl ConsensusConfig {
     pub async fn open(self) -> Result<Arc<dyn Consensus + Send + Sync>, ExternalError> {
         match self {
             ConsensusConfig::Sqlite(config) => SqliteConsensus::open(config)
+                .await
                 .map(|x| Arc::new(x) as Arc<dyn Consensus + Send + Sync>),
             ConsensusConfig::Postgres(config) => PostgresConsensus::open(config)
                 .await

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -839,7 +839,7 @@ mod tests {
 
     #[tokio::test]
     async fn mem_consensus() -> Result<(), ExternalError> {
-        consensus_impl_test(|| Ok(MemConsensus::default())).await
+        consensus_impl_test(|| async { Ok(MemConsensus::default()) }).await
     }
 
     // This test covers a regression that was affecting the nemesis tests where

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -327,7 +327,6 @@ mod tests {
             }
         };
 
-        consensus_impl_test(|| futures_executor::block_on(PostgresConsensus::open(config.clone())))
-            .await
+        consensus_impl_test(|| PostgresConsensus::open(config.clone())).await
     }
 }


### PR DESCRIPTION
It was making blocking io calls inside async fns, which is the single
biggest async no-no. This may be contributing to the slowness that
Petros is seeing in CI on 12216, but either way it needs to be fixed if
SqliteConsensus is going to be used until we can switch to Postgres for
Consensus in dev/CI.

While I'm in here, tweak the string formatting of the queries so that
rustfmt doesn't barf on them quite as much. It's still not great, but I
couldn't come up with anything better than this. Open to suggestions.

On a persist-benchmarking machine

    MZ_PERSIST_RECORD_COUNT_SMALL=64 MZ_PERSIST_RECORD_SIZE_BYTES_SMALL=1024 MZ_PERSIST_BATCH_MAX_COUNT_SMALL=8
    consensus/compare_and_set/sqlite/64KiB
                            time:   [7.8217 ms 7.9570 ms 8.1144 ms]
                            thrpt:  [7.7024 MiB/s 7.8547 MiB/s 7.9906 MiB/s]
                     change:
                            time:   [-3.1472% -0.6147% +2.0225%] (p = 0.64 > 0.05)
                            thrpt:  [-1.9824% +0.6185% +3.2495%]
                            No change in performance detected.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
