### PR TITLE
dataflow-types: Protobuf support for ComputeResponse.

### DIFF
--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -74,23 +74,23 @@ message ProtoComputeResponse {
         repeated ProtoUpdate updates = 2;
     }
 
-    message ProtoFrontierUppersEnum {
+    message ProtoFrontierUppersKind {
         repeated ProtoTrace traces = 1;
     }
 
-    message ProtoPeekResponseEnum {
+    message ProtoPeekResponseKind {
         mz_repr.proto.ProtoU128 id = 1;
         mz_dataflow_types.types.ProtoPeekResponse resp = 2;
     }
 
-    message ProtoTailResponseEnum {
+    message ProtoTailResponseKind {
         mz_repr.global_id.ProtoGlobalId id = 1;
         mz_dataflow_types.types.ProtoTailResponse resp = 2;
     }
 
     oneof kind {
-        ProtoFrontierUppersEnum frontier_uppers = 1;
-        ProtoPeekResponseEnum peek_response = 2;
-        ProtoTailResponseEnum tail_response = 3;
+        ProtoFrontierUppersKind frontier_uppers = 1;
+        ProtoPeekResponseKind peek_response = 2;
+        ProtoTailResponseKind tail_response = 3;
     }
 }

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -62,3 +62,35 @@ message ProtoComputeCommand {
         ProtoCancelPeeks cancel_peeks = 6;
     }
 }
+
+message ProtoComputeResponse {
+    message ProtoUpdate {
+        uint64 timestamp = 1;
+        int64 diff = 2;
+    }
+
+    message ProtoTrace {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        repeated ProtoUpdate updates = 2;
+    }
+
+    message ProtoFrontierUppersEnum {
+        repeated ProtoTrace traces = 1;
+    }
+
+    message ProtoPeekResponseEnum {
+        mz_repr.proto.ProtoU128 id = 1;
+        mz_dataflow_types.types.ProtoPeekResponse resp = 2;
+    }
+
+    message ProtoTailResponseEnum {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        mz_dataflow_types.types.ProtoTailResponse resp = 2;
+    }
+
+    oneof kind {
+        ProtoFrontierUppersEnum frontier_uppers = 1;
+        ProtoPeekResponseEnum peek_response = 2;
+        ProtoTailResponseEnum tail_response = 3;
+    }
+}

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -587,7 +587,7 @@ impl From<&ComputeResponse<mz_repr::Timestamp>> for ProtoComputeResponse {
         ProtoComputeResponse {
             kind: Some(match x {
                 ComputeResponse::FrontierUppers(traces) => {
-                    FrontierUppers(ProtoFrontierUppersEnum {
+                    FrontierUppers(ProtoFrontierUppersKind {
                         traces: traces
                             .iter()
                             .map(|(id, trace)| ProtoTrace {
@@ -606,11 +606,11 @@ impl From<&ComputeResponse<mz_repr::Timestamp>> for ProtoComputeResponse {
                             .collect(),
                     })
                 }
-                ComputeResponse::PeekResponse(id, resp) => PeekResponse(ProtoPeekResponseEnum {
+                ComputeResponse::PeekResponse(id, resp) => PeekResponse(ProtoPeekResponseKind {
                     id: Some(id.into_proto()),
                     resp: Some(resp.into()),
                 }),
-                ComputeResponse::TailResponse(id, resp) => TailResponse(ProtoTailResponseEnum {
+                ComputeResponse::TailResponse(id, resp) => TailResponse(ProtoTailResponseKind {
                     id: Some(id.into()),
                     resp: Some(resp.into()),
                 }),
@@ -642,12 +642,12 @@ impl TryFrom<ProtoComputeResponse> for ComputeResponse<mz_repr::Timestamp> {
                     .collect::<Result<Vec<_>, TryFromProtoError>>()?,
             )),
             Some(PeekResponse(resp)) => Ok(ComputeResponse::PeekResponse(
-                resp.id.from_proto_if_some("ProtoPeekResponseEnum::id")?,
-                resp.resp.try_into_if_some("ProtoPeekResponseEnum::resp")?,
+                resp.id.from_proto_if_some("ProtoPeekResponseKind::id")?,
+                resp.resp.try_into_if_some("ProtoPeekResponseKind::resp")?,
             )),
             Some(TailResponse(resp)) => Ok(ComputeResponse::TailResponse(
-                resp.id.try_into_if_some("ProtoTailResponseEnum::id")?,
-                resp.resp.try_into_if_some("ProtoTailResponseEnum::resp")?,
+                resp.id.try_into_if_some("ProtoTailResponseKind::id")?,
+                resp.resp.try_into_if_some("ProtoTailResponseKind::resp")?,
             )),
             None => Err(TryFromProtoError::missing_field(
                 "ProtoComputeResponse::kind",

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -593,6 +593,8 @@ impl From<&ComputeResponse<mz_repr::Timestamp>> for ProtoComputeResponse {
                             .map(|(id, trace)| ProtoTrace {
                                 id: Some(id.into()),
                                 updates: trace
+                                    // Clone because the `iter()` expects
+                                    // `trace` to be mutable.
                                     .clone()
                                     .iter()
                                     .map(|(t, d)| ProtoUpdate {

--- a/src/dataflow-types/src/types.proto
+++ b/src/dataflow-types/src/types.proto
@@ -18,6 +18,9 @@ import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
 import "repr/src/proto.proto";
 import "repr/src/relation_and_scalar.proto";
+import "repr/src/row.proto";
+
+import "google/protobuf/empty.proto";
 
 package mz_dataflow_types.types;
 
@@ -71,4 +74,40 @@ message ProtoSourceInstanceArguments {
 message ProtoLinearOperator {
     repeated mz_expr.scalar.ProtoMirScalarExpr predicates = 1;
     repeated uint64 projection = 2;
+}
+
+message ProtoPeekResponse {
+    message ProtoRow {
+        mz_repr.row.ProtoRow row = 1;
+        uint64 diff = 2;
+    }
+
+    message ProtoRows {
+        repeated ProtoRow rows = 1;
+    }
+
+    oneof kind {
+        ProtoRows rows = 1;
+        string error = 2;
+        google.protobuf.Empty canceled = 3;
+    }
+}
+
+message ProtoTailBatch {
+    message ProtoUpdate {
+        uint64 timestamp = 1;
+        mz_repr.row.ProtoRow row = 2;
+        int64 diff = 3;
+    }
+
+    mz_persist.gen.persist.ProtoU64Antichain lower = 1;
+    mz_persist.gen.persist.ProtoU64Antichain upper = 2;
+    repeated ProtoUpdate updates = 3;
+}
+
+message ProtoTailResponse {
+    oneof kind {
+        ProtoTailBatch batch = 1;
+        mz_persist.gen.persist.ProtoU64Antichain dropped_at = 2;
+    }
 }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -67,7 +67,7 @@ impl From<&PeekResponse> for ProtoPeekResponse {
                         .iter()
                         .map(|(r, d)| ProtoRow {
                             row: Some(r.into()),
-                            diff: usize::from(*d).into_proto(),
+                            diff: d.into_proto(),
                         })
                         .collect(),
                 }),
@@ -90,7 +90,7 @@ impl TryFrom<ProtoPeekResponse> for PeekResponse {
                     .map(|row| {
                         Ok((
                             row.row.try_into_if_some("ProtoRow::row")?,
-                            usize::from_proto(row.diff)?.try_into()?,
+                            NonZeroUsize::from_proto(row.diff)?,
                         ))
                     })
                     .collect::<Result<Vec<_>, TryFromProtoError>>()?,

--- a/src/repr/src/proto.rs
+++ b/src/repr/src/proto.rs
@@ -186,6 +186,18 @@ impl ProtoRepr for Uuid {
     }
 }
 
+impl ProtoRepr for std::num::NonZeroUsize {
+    type Repr = u64;
+
+    fn into_proto(self: Self) -> Self::Repr {
+        usize::from(self).into_proto()
+    }
+
+    fn from_proto(repr: Self::Repr) -> Result<Self, TryFromProtoError> {
+        Ok(usize::from_proto(repr)?.try_into()?)
+    }
+}
+
 pub fn any_uuid() -> impl Strategy<Value = Uuid> {
     (0..u128::MAX).prop_map(Uuid::from_u128)
 }


### PR DESCRIPTION
### Motivation
  * This PR implements an existing feature.
  
Closes #12461.

### Tips for reviewer

The only non-trivial aspect of this PR are that:
* `ComputeResponse::FrontierUppers` uses [`timely::progress::change_batch::ChangeBatch`](https://docs.rs/timely/latest/timely/progress/change_batch/struct.ChangeBatch.html), which does not expose its internals and only has a mutable iterator.
* `PeekResponse::Rows` uses [`std::num::NonZeroUsize`](https://doc.rust-lang.org/stable/std/num/struct.NonZeroUsize.html), which `proptest` does not have an implementation of `Arbitrary` for.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing behavior changes.
