### PR TITLE
materialized,dataflow-types: use postgres for timestamp bindings stash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,6 +4124,7 @@ dependencies = [
  "mz-kinesis-util",
  "mz-ore",
  "mz-pgrepr",
+ "mz-postgres-util",
  "mz-repr",
  "mz-sql",
  "mz-sql-parser",

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -146,6 +146,12 @@ impl Postgres {
             .await?;
         if let Some(schema) = &self.schema {
             client
+                .execute(
+                    format!("CREATE SCHEMA IF NOT EXISTS {schema}").as_str(),
+                    &[],
+                )
+                .await?;
+            client
                 .execute(format!("SET search_path TO {schema}").as_str(), &[])
                 .await?;
         }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -42,6 +42,7 @@ mz-kafka-util = { path = "../kafka-util" }
 mz-kinesis-util = { path = "../kinesis-util" }
 mz-ore = { path = "../ore", features = ["task"] }
 mz-pgrepr = { path = "../pgrepr" }
+mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -212,12 +212,12 @@ impl State {
             client
                 .batch_execute(
                     "
-                                CREATE TABLE fence AS SELECT * FROM public.fence;
-                                CREATE TABLE collections AS SELECT * FROM public.collections;
-                                CREATE TABLE data AS SELECT * FROM public.data;
-                                CREATE TABLE sinces AS SELECT * FROM public.sinces;
-                                CREATE TABLE uppers AS SELECT * FROM public.uppers;
-                            ",
+                        CREATE TABLE fence AS SELECT * FROM catalog.fence;
+                        CREATE TABLE collections AS SELECT * FROM catalog.collections;
+                        CREATE TABLE data AS SELECT * FROM catalog.data;
+                        CREATE TABLE sinces AS SELECT * FROM catalog.sinces;
+                        CREATE TABLE uppers AS SELECT * FROM catalog.uppers;
+                    ",
                 )
                 .await?;
 

--- a/src/testdrive/src/action/verify_timestamp_compaction.rs
+++ b/src/testdrive/src/action/verify_timestamp_compaction.rs
@@ -20,10 +20,11 @@ use mz_ore::retry::Retry;
 use mz_sql::catalog::SessionCatalog;
 use mz_sql::names::PartialObjectName;
 use mz_stash::Stash;
+use tokio_postgres::NoTls;
 
 use crate::action::{Action, ControlFlow, State};
 use crate::parser::BuiltinCommand;
-use crate::util::mz_data::mzdata_copy;
+use crate::util::mz_data::catalog_copy;
 
 pub struct VerifyTimestampCompactionAction {
     source: String,
@@ -74,29 +75,97 @@ impl Action for VerifyTimestampCompactionAction {
         } else {
             // Unwrap is safe because this is known to be Some.
             let item_id = item_id.unwrap()?;
-            let path = state.materialized_data_path.as_ref().unwrap();
-            let temp_mzdata = mzdata_copy(path)?;
-            let path = temp_mzdata.path();
+            let copy_schema = format!("mz_storage_copy_{}", state.seed);
             let initial_highest_base = Arc::new(AtomicU64::new(u64::MAX));
+            let materialized_catalog_postgres_stash =
+                state.materialized_catalog_postgres_stash.clone();
+            let materialized_data_path = state.materialized_data_path.clone();
             Retry::default()
                 .initial_backoff(Duration::from_secs(1))
                 .max_duration(Duration::from_secs(30))
                 .retry_async_canceling(|retry_state| {
                     let initial_highest = Arc::clone(&initial_highest_base);
+                    let copy_schema = copy_schema.clone();
+                    let materialized_catalog_postgres_stash =materialized_catalog_postgres_stash.clone();
+                    let materialized_data_path = materialized_data_path.clone();
+                    // We would like to use a wrapper like state.with_catalog_copy, but we actually
+                    // need the specific stash impl here because we have to access it via a
+                    // collection, which means it's not object safe and so can't be a Box dyn. For
+                    // now just duplicate the stash copy code until we do something like remove
+                    // sqlite completely.
                     async move {
-                        let mut stash = mz_stash::Sqlite::open(&path.join("storage"))?;
-                        let collection = stash
-                            .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}")).await?;
-                        let bindings: Vec<(PartitionId, u64, MzOffset)> = stash.iter(collection).await?
-                            .into_iter()
-                            .map(|((pid, _), ts, offset)| {
-                                (
-                                    pid,
-                                    ts.try_into().unwrap_or_else(|_| panic!()),
-                                    MzOffset { offset },
-                                )
-                            })
-                            .collect();
+                        let bindings: Vec<(PartitionId, u64, MzOffset)> =
+                            if let Some(url) = &materialized_catalog_postgres_stash {
+
+                                let (client, connection) = tokio_postgres::connect(url, NoTls).await?;
+                                mz_ore::task::spawn(|| "tokio-postgres testdrive connection", async move {
+                                    if let Err(e) = connection.await {
+                                        panic!("postgres stash connection error: {}", e);
+                                    }
+                                });
+
+                                client
+                                    .execute(format!("CREATE SCHEMA {copy_schema}").as_str(), &[])
+                                    .await?;
+                                client
+                                    .execute(format!("SET search_path TO {copy_schema}").as_str(), &[])
+                                    .await?;
+                                client
+                                    .batch_execute(
+                                        "
+                                            CREATE TABLE fence AS SELECT * FROM storage.fence;
+                                            CREATE TABLE collections AS SELECT * FROM storage.collections;
+                                            CREATE TABLE data AS SELECT * FROM storage.data;
+                                            CREATE TABLE sinces AS SELECT * FROM storage.sinces;
+                                            CREATE TABLE uppers AS SELECT * FROM storage.uppers;
+                                        ",
+                                    )
+                                    .await?;
+
+                                let tls = mz_postgres_util::make_tls(&tokio_postgres::Config::new()).unwrap();
+                                let mut stash = mz_stash::Postgres::new(url.clone(), Some(copy_schema.clone()), tls).await?;
+                                let collection = stash
+                                    .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}"))
+                                    .await?;
+                                let bindings: Vec<(PartitionId, u64, MzOffset)> = stash
+                                    .iter(collection)
+                                    .await?
+                                    .into_iter()
+                                    .map(|((pid, _), ts, offset)| {
+                                        (
+                                            pid,
+                                            ts.try_into().unwrap_or_else(|_| panic!()),
+                                            MzOffset { offset },
+                                        )
+                                    })
+                                    .collect();
+                                client
+                                    .execute(format!("DROP SCHEMA {copy_schema} CASCADE").as_str(), &[])
+                                    .await?;
+                                bindings
+                            } else if let Some(path) = &materialized_data_path {
+                                let temp_mzdata = catalog_copy(path)?;
+                                let path = temp_mzdata.path();
+                                let mut stash = mz_stash::Sqlite::open(path)?;
+                                let collection = stash
+                                    .collection::<PartitionId, ()>(&format!("timestamp-bindings-{item_id}"))
+                                    .await?;
+                                let bindings: Vec<(PartitionId, u64, MzOffset)> = stash
+                                    .iter(collection)
+                                    .await?
+                                    .into_iter()
+                                    .map(|((pid, _), ts, offset)| {
+                                        (
+                                            pid,
+                                            ts.try_into().unwrap_or_else(|_| panic!()),
+                                            MzOffset { offset },
+                                        )
+                                    })
+                                    .collect();
+                                bindings
+                            } else {
+                                unreachable!()
+                            };
 
                         // We consider progress to be eventually compacting at least up to the original highest
                         // timestamp binding.

--- a/src/testdrive/src/util/mz_data.rs
+++ b/src/testdrive/src/util/mz_data.rs
@@ -12,20 +12,6 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 const STASH_DB_NAME: &str = "stash";
-const STORAGE_DB_NAME: &str = "storage";
-
-/// Creates a temporary copy of Materialize's mzdata databases
-///
-/// This is useful because running validations against the catalog can conflict with the running
-/// Materialize instance. Therefore it's better to run validations on a copy of the catalog.
-pub fn mzdata_copy(catalog_path: &PathBuf) -> Result<TempDir, anyhow::Error> {
-    let temp_dir = tempfile::tempdir()?;
-    fs::copy(
-        catalog_path.join(STORAGE_DB_NAME),
-        temp_dir.path().join(STORAGE_DB_NAME),
-    )?;
-    Ok(temp_dir)
-}
 
 /// Creates a temporary copy of Materialize's mzdata's sqlite stash database
 ///


### PR DESCRIPTION
Use the same configuration for timestamp bindings and catalog stashes,
but with different filenames (sqlite) or schemas (postgres). We can
separate them if needed in the future.

### Motivation

  * This PR adds a feature that has not yet been specified.

Timestamp bindings were still always using sqlite as their stack storage. Having them share configuration with the catalog allows for a single postgres and no local disk to serve materialized.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
