### PR TITLE
sql: remove Kafka config that relies on env vars

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -325,8 +325,7 @@ Field                                   | Value  | Description
 `security_protocol`                     | `text` | Use `plaintext`, `ssl`, `sasl_plaintext` or `sasl_ssl` to connect to the Kafka cluster.
 `sasl_mechanisms`                       | `text` | The SASL mechanism to use for authentication. Supported: `PLAIN`, `SCRAM-SHA-256`, `SCRAM-SHA-512`.
 `sasl_username`                         | `text` | Your SASL username, if any. Required if `sasl_mechanisms` is `PLAIN`.
-`sasl_password`                         | `text` | Your SASL password, if any. Required if `sasl_mechanisms` is `PLAIN`.<br/><br/>This option stores the password in Materialize's on-disk catalog. For an alternative, use `sasl_password_env`.
-`sasl_password_env`                     | `text` | Use the value stored in the named environment variable as the value for `sasl_password`. <br/><br/>This option does not store the password on-disk in Materialize's catalog, but requires the environment variable's presence to boot Materialize.
+`sasl_password`                         | `text` | Your SASL password, if any. Required if `sasl_mechanisms` is `PLAIN`.<br/><br/>This option stores the password in Materialize's on-disk catalog.
 
 ## Examples
 

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -15,7 +15,7 @@ use std::fs::File;
 use std::io::Read;
 use std::sync::{Arc, Mutex};
 
-use anyhow::bail;
+use anyhow::{anyhow, bail};
 
 use mz_kafka_util::client::MzClientContext;
 use mz_ore::task;
@@ -34,7 +34,6 @@ enum ValType {
     // Number with range [lower, upper]
     Number(i32, i32),
     Boolean,
-    EnvVar,
 }
 
 impl ValType {
@@ -52,7 +51,6 @@ impl ValType {
                 Ok(parsed_n) if *lower <= parsed_n && parsed_n <= *upper => n.to_string(),
                 _ => bail!("must be a number between {} and {}", lower, upper),
             },
-            (ValType::EnvVar, Value::String(v)) => std::env::var(v)?,
             _ => bail!("unexpected value type"),
         })
     }
@@ -65,9 +63,6 @@ struct Config {
     val_type: ValType,
     transform: fn(String) -> String,
     default: Option<String>,
-    // If set, look for an environment variable named `<name>_env` to possibly
-    // define the named setting.
-    include_env_var: bool,
 }
 
 impl Config {
@@ -77,7 +72,6 @@ impl Config {
             val_type,
             transform: convert::identity,
             default: None,
-            include_env_var: false,
         }
     }
 
@@ -105,32 +99,13 @@ impl Config {
 
     /// Allows for returning a default value for this configuration option
     fn set_default(mut self, d: Option<String>) -> Self {
-        assert!(
-            !self.include_env_var,
-            "cannot currently both set default values and include environment variables on the same config"
-        );
         self.default = d;
-        self
-    }
-
-    /// Allows for returning a default value for this configuration option
-    fn include_env_var(mut self) -> Self {
-        assert!(
-            self.default.is_none(),
-            "cannot currently both set default values and include environment variables on the same config"
-        );
-        self.include_env_var = true;
         self
     }
 
     /// Get the appropriate String to use as the Kafka config key.
     fn get_kafka_config_key(&self) -> String {
         self.name.replace('_', ".")
-    }
-
-    /// Gets the key to lookup for configs that support environment variable lookups.
-    fn get_env_var_key(&self) -> String {
-        format!("{}_env", self.name)
     }
 }
 
@@ -142,35 +117,10 @@ fn extract(
     for config in configs {
         // Look for config.name
         let value = match input.remove(config.name) {
-            Some(v) => match config.val_type.process_val(&v) {
-                Ok(v) => {
-                    // Ensure env var variant wasn't also included.
-                    if config.include_env_var && input.get(&config.get_env_var_key()).is_some() {
-                        bail!(
-                            "Invalid WITH options: cannot specify both {} and {} options at the same time",
-                            config.name,
-                            config.get_env_var_key()
-                        )
-                    }
-
-                    v
-                }
-                Err(e) => bail!("Invalid WITH option {}={}: {}", config.name, v, e),
-            },
-            // If config.name is not a key and config permits it, look for an
-            // environment variable.
-            None if config.include_env_var => match input.remove(&config.get_env_var_key()) {
-                Some(v) => match ValType::EnvVar.process_val(&v) {
-                    Ok(v) => v,
-                    Err(e) => bail!(
-                        "Invalid WITH option {}={}: {}",
-                        config.get_env_var_key(),
-                        v,
-                        e
-                    ),
-                },
-                None => continue,
-            },
+            Some(v) => config
+                .val_type
+                .process_val(&v)
+                .map_err(|e| anyhow!("Invalid WITH option {}={}: {}", config.name, v, e))?,
             // Check for default values
             None => match &config.default {
                 Some(v) => v.to_string(),
@@ -220,7 +170,7 @@ pub fn extract_config(
             Config::string("isolation_level").set_default(Some(String::from("read_committed"))),
             Config::string("security_protocol"),
             Config::string("sasl_username"),
-            Config::string("sasl_password").include_env_var(),
+            Config::string("sasl_password"),
             // For historical reasons, we allow `sasl_mechanisms` to be lowercase or
             // mixed case, while librdkafka requires all uppercase (e.g., `PLAIN`,
             // not `plain`).
@@ -228,7 +178,7 @@ pub fn extract_config(
             Config::path("ssl_ca_location"),
             Config::path("ssl_certificate_location"),
             Config::path("ssl_key_location"),
-            Config::string("ssl_key_password").include_env_var(),
+            Config::string("ssl_key_password"),
             Config::new("transaction_timeout_ms", ValType::Number(0, i32::MAX)),
             Config::new("enable_idempotence", ValType::Boolean),
             Config::new(

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -89,7 +89,7 @@ $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
       security_protocol = 'SASL_SSL',
       sasl_mechanisms = 'PLAIN',
       sasl_username = 'materialize',
-      sasl_password_env = 'SASL_PASSWORD',
+      sasl_password = 'sekurity',
       ssl_ca_location = '/share/secrets/ca.crt'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -130,16 +130,6 @@ a
 #---
 #1
 #2
-#
-#> CREATE CONNECTOR sasl_env_pw_connector
-#  FOR KAFKA BROKER '${testdrive.kafka-addr}'
-#  WITH (
-#      security_protocol = 'SASL_SSL',
-#      sasl_mechanisms = 'PLAIN',
-#      sasl_username = 'materialize',
-#      sasl_password_env = 'SASL_PASSWORD',
-#      ssl_ca_location = '/share/secrets/ca.crt'
-#  )
 #
 #> CREATE MATERIALIZED SOURCE connector_env_pw_data
 #  FROM KAFKA CONNECTOR sasl_env_pw_connector

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -39,7 +39,6 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
       security_protocol = 'SASL_SSL',
       sasl_mechanisms = 'PLAIN',
       sasl_username = 'materialize',
-      sasl_password = 'sekurity',
       sasl_password_env = 'SASL_PASSWORD',
       ssl_ca_location = '/share/secrets/ca.crt'
   )
@@ -48,37 +47,4 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
       ssl_ca_location = '/share/secrets/ca.crt'
   )
   ENVELOPE DEBEZIUM
-contains:Invalid WITH options: cannot specify both sasl_password and sasl_password_env options at the same time
-
-! CREATE MATERIALIZED SOURCE data
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (
-      security_protocol = 'SASL_SSL',
-      sasl_mechanisms = 'PLAIN',
-      sasl_username = 'materialize',
-      sasl_password_env = 'SASL_PASSWORD',
-      sasl_password = 'sekurity',
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  WITH (
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  ENVELOPE DEBEZIUM
-contains:Invalid WITH options: cannot specify both sasl_password and sasl_password_env options at the same time
-
-! CREATE MATERIALIZED SOURCE data
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (
-      security_protocol = 'SASL_SSL',
-      sasl_mechanisms = 'PLAIN',
-      sasl_username = 'materialize',
-      sasl_password_env = 'DNE',
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  WITH (
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  ENVELOPE DEBEZIUM
-contains:Invalid WITH option sasl_password_env='DNE': environment variable not found
+contains:unexpected parameters for CREATE SOURCE: sasl_password_env

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -76,9 +76,6 @@ SERVICES = [
         bootstrap_server_type="SSL",
     ),
     Materialized(
-        environment=[
-            "SSL_KEY_PASSWORD=mzmzmz",
-        ],
         volumes_extra=["secrets:/share/secrets"],
     ),
     Testdrive(

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -97,7 +97,7 @@ $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
       ssl_key_location = '/share/secrets/materialized.key',
       ssl_certificate_location = '/share/secrets/materialized.crt',
       ssl_ca_location = '/share/secrets/ca.crt',
-      ssl_key_password_env = 'SSL_KEY_PASSWORD'
+      ssl_key_password = 'mzmzmz'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH (
@@ -121,7 +121,7 @@ $ kafka-verify format=avro sink=materialize.public.env_pw_snk sort-messages=true
       ssl_key_location = '/share/secrets/materialized.key',
       ssl_certificate_location = '/share/secrets/materialized.crt',
       ssl_ca_location = '/share/secrets/ca.crt',
-      ssl_key_password_env = 'SSL_KEY_PASSWORD'
+      ssl_key_password = 'mzmzmz'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH (
@@ -140,7 +140,7 @@ exact:error publishing kafka schemas for sink: unable to publish value schema to
       ssl_key_location = '/share/secrets/materialized.key',
       ssl_certificate_location = '/share/secrets/materialized.crt',
       ssl_ca_location = '/share/secrets/ca.crt',
-      ssl_key_password_env = 'SSL_KEY_PASSWORD'
+      ssl_key_password = 'mzmzmz'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM

--- a/test/kafka-ssl/with-options-errors.td
+++ b/test/kafka-ssl/with-options-errors.td
@@ -70,41 +70,4 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
       username = "materialize",
       password = "sekurity"
   )
-contains:Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_env options at the same time
-
-! CREATE SINK env_pw_snk FROM data
-  INTO KAFKA BROKER 'kafka' TOPIC 'snk'
-  WITH (
-      security_protocol = 'SSL',
-      ssl_key_location = '/share/secrets/materialized.key',
-      ssl_certificate_location = '/share/secrets/materialized.crt',
-      ssl_ca_location = '/share/secrets/ca.crt',
-      ssl_key_password_env = 'SSL_KEY_PASSWORD',
-      ssl_key_password = 'mzmzmz'
-  )
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  WITH (
-      ssl_key_location = '/share/secrets/materialized.key',
-      ssl_certificate_location = '/share/secrets/materialized.crt',
-      ssl_ca_location = '/share/secrets/ca.crt',
-      username = "materialize",
-      password = "sekurity"
-  )
-contains:Invalid WITH options: cannot specify both ssl_key_password and ssl_key_password_env options at the same time
-
-! CREATE MATERIALIZED SOURCE data
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (
-      security_protocol = 'SASL_SSL',
-      sasl_mechanisms = 'PLAIN',
-      sasl_username = 'materialize',
-      ssl_key_password_env = 'DNE',
-      ssl_ca_location = '/share/secrets/ca.crt'
-  )
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  WITH (
-      username = "materialize",
-      password = "sekurity"
-  )
-  ENVELOPE DEBEZIUM
-contains:Invalid WITH option ssl_key_password_env='DNE': environment variable not found
+contains:unexpected parameters for CREATE SINK: ssl_key_password_env


### PR DESCRIPTION
These environment options should no longer be supported in platform.

### Motivation

This PR fixes a recognized bug. Fixes #12450

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - When creating Kafka sources and sinks, remove the ability to read passwords from environment variables (`sasl_password_env`, `ssl_key_password`); users can not configure environment variables in Materialize Platform.
