### PR TITLE
persist: separate writing updates to blob store from appending to shard metadata

### DIFF
--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -149,7 +149,9 @@ impl Transactor {
             // NB: We do the CaS even if writes is empty, so that read-only txns
             // are also linearizable.
             let write_ts = self.read_ts + 1;
-            let updates = writes.iter().map(|(k, v, diff)| ((k, v), &write_ts, diff));
+            let updates = writes
+                .into_iter()
+                .map(|(k, v, diff)| ((k, v), write_ts, diff));
             let expected_upper = Antichain::from_elem(write_ts);
             let new_upper = Antichain::from_elem(write_ts + 1);
             // TODO: Wrap the compare_and_append in a retry_timeouts call, too.

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -459,8 +459,9 @@ mod raw_persist_benchmark {
             // TODO: figure out the right way to do this without the extra allocations.
             let batch = batch
                 .iter()
-                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d));
-            self.append(batch, self.upper().clone(), new_upper)
+                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d))
+                .collect::<Vec<_>>();
+            self.append(batch.iter(), self.upper().clone(), new_upper)
                 .await??
                 .expect("invalid current upper");
 

--- a/src/persist-client/src/bin/persist_open_loop_benchmark.rs
+++ b/src/persist-client/src/bin/persist_open_loop_benchmark.rs
@@ -118,14 +118,12 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     };
     let persist = location.open().await?;
 
-    let num_records_total = args.records_per_second * args.runtime_seconds;
-    let data_generator =
-        DataGenerator::new(num_records_total, args.record_size_bytes, args.batch_size);
-    let shard_id = match args.shard_id {
+    let shard_id = match args.shard_id.clone() {
         Some(shard_id) => ShardId::from_str(&shard_id).map_err(anyhow::Error::msg)?,
         None => ShardId::new(),
     };
-    let (writers, readers) = match args.benchmark_type {
+
+    let (writers, readers) = match args.benchmark_type.clone() {
         BenchmarkType::RawWriter => {
             raw_persist_benchmark::setup_raw_persist(
                 persist,
@@ -138,18 +136,30 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         BenchmarkType::MzSourceModel => panic!("source model"),
     };
 
+    run_benchmark(args, writers, readers).await
+}
+
+async fn run_benchmark<W, R>(
+    args: Args,
+    writers: Vec<W>,
+    readers: Vec<R>,
+) -> Result<(), anyhow::Error>
+where
+    W: BenchmarkWriter + Send + Sync + 'static,
+    R: BenchmarkReader + Send + Sync + 'static,
+{
+    let num_records_total = args.records_per_second * args.runtime_seconds;
+    let data_generator =
+        DataGenerator::new(num_records_total, args.record_size_bytes, args.batch_size);
+
     let benchmark_description = format!("num-readers={} num-writers={} runtime-seconds={} records-per-second={} record-size-bytes={} batch-size={}",
                                         args.num_readers, args.num_writers, args.runtime_seconds, args.records_per_second,
                                         args.record_size_bytes, args.batch_size);
 
     info!("starting benchmark: {}", benchmark_description);
     let mut generator_handles: Vec<JoinHandle<Result<String, anyhow::Error>>> = vec![];
-    let mut write_handles: Vec<
-        JoinHandle<Result<(String, Box<dyn BenchmarkWriter + Send + Sync>), anyhow::Error>>,
-    > = vec![];
-    let mut read_handles: Vec<
-        JoinHandle<Result<(String, Box<dyn BenchmarkReader + Send + Sync>), anyhow::Error>>,
-    > = vec![];
+    let mut write_handles: Vec<JoinHandle<Result<String, anyhow::Error>>> = vec![];
+    let mut read_handles: Vec<JoinHandle<Result<(String, R), anyhow::Error>>> = vec![];
 
     // All workers should have the starting time (so they can consistently track progress
     // and reason about lag independently).
@@ -271,7 +281,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
                 trace!("writer {} received a batch. writing", idx);
                 let write_start = Instant::now();
-                writer.write(&batch).await?;
+                writer.write(batch).await?;
+
                 records_written += args.batch_size;
                 let write_latency = write_start.elapsed();
                 if write_latency > max_write_latency {
@@ -298,7 +309,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                 records_written,
                 max_write_latency.as_millis()
             );
-            Ok((finished, writer))
+
+            writer.finish().await.unwrap();
+
+            Ok(finished)
         });
 
         write_handles.push(writer_handle);
@@ -371,7 +385,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     }
     for handle in write_handles {
         match handle.await? {
-            Ok((finished, _)) => info!("{}", finished),
+            Ok(finished) => info!("{}", finished),
             Err(e) => error!("error: {:?}", e),
         }
     }
@@ -392,7 +406,13 @@ mod api {
     /// An interface to write a batch of data into a persistent system.
     #[async_trait]
     pub trait BenchmarkWriter {
-        async fn write(&mut self, batch: &ColumnarRecords) -> Result<(), anyhow::Error>;
+        /// Writes the given batch to this writer.
+        async fn write(&mut self, batch: ColumnarRecords) -> Result<(), anyhow::Error>;
+
+        /// Signals that we are finished writing to this [BenchmarkWriter]. This
+        /// will join any async tasks that might have been spawned for this
+        /// [BenchmarkWriter].
+        async fn finish(self) -> Result<(), anyhow::Error>;
     }
 
     /// An abstraction over a reader of data, which can report the number
@@ -405,11 +425,13 @@ mod api {
 
 mod raw_persist_benchmark {
     use async_trait::async_trait;
+    use timely::progress::Antichain;
+    use tokio::sync::mpsc::Sender;
+
     use mz_persist::indexed::columnar::ColumnarRecords;
     use mz_persist_client::read::{Listen, ListenEvent};
-    use mz_persist_client::write::WriteHandle;
     use mz_persist_client::{PersistClient, ShardId};
-    use timely::progress::Antichain;
+    use tokio::task::JoinHandle;
 
     use crate::api::{BenchmarkReader, BenchmarkWriter};
 
@@ -420,17 +442,16 @@ mod raw_persist_benchmark {
         num_readers: usize,
     ) -> Result<
         (
-            Vec<Box<dyn BenchmarkWriter + Send + Sync>>,
-            Vec<Box<dyn BenchmarkReader + Send + Sync>>,
+            Vec<RawBenchmarkWriter>,
+            Vec<Listen<Vec<u8>, Vec<u8>, u64, i64>>,
         ),
         anyhow::Error,
     > {
         let mut writers = vec![];
-        for _ in 0..num_writers {
-            let (writer, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
-            reader.expire().await;
+        for idx in 0..num_writers {
+            let writer = RawBenchmarkWriter::new(&persist, id, idx).await?;
 
-            writers.push(Box::new(writer) as Box<dyn BenchmarkWriter + Send + Sync>);
+            writers.push(writer);
         }
 
         let mut readers = vec![];
@@ -441,29 +462,111 @@ mod raw_persist_benchmark {
                 .listen(Antichain::from_elem(0))
                 .await
                 .expect("cannot serve requested as_of");
-            readers.push(Box::new(listen) as Box<dyn BenchmarkReader + Send + Sync>);
+            readers.push(listen);
         }
 
         Ok((writers, readers))
     }
 
-    #[async_trait]
-    impl BenchmarkWriter for WriteHandle<Vec<u8>, Vec<u8>, u64, i64> {
-        async fn write(&mut self, batch: &ColumnarRecords) -> Result<(), anyhow::Error> {
-            let max_ts = match batch.iter().last() {
-                Some((_, t, _)) => t,
-                None => return Ok(()),
-            };
-            let new_upper = Antichain::from_elem(max_ts + 1);
+    pub struct RawBenchmarkWriter {
+        tx: Option<Sender<ColumnarRecords>>,
+        #[allow(dead_code)]
+        handles: Vec<JoinHandle<()>>,
+    }
 
-            // TODO: figure out the right way to do this without the extra allocations.
-            let batch = batch
-                .iter()
-                .map(|((k, v), t, d)| ((k.to_vec(), v.to_vec()), t, d))
-                .collect::<Vec<_>>();
-            self.append(batch.iter(), self.upper().clone(), new_upper)
-                .await??
-                .expect("invalid current upper");
+    impl RawBenchmarkWriter {
+        async fn new(
+            persist: &PersistClient,
+            id: ShardId,
+            idx: usize,
+        ) -> Result<Self, anyhow::Error> {
+            let mut handles = Vec::<JoinHandle<()>>::new();
+            let (records_tx, mut records_rx) = tokio::sync::mpsc::channel::<ColumnarRecords>(2);
+            let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel(10);
+
+            let mut write = persist
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id)
+                .await?;
+
+            let handle = mz_ore::task::spawn(|| format!("writer-{}", idx), async move {
+                let mut current_upper = timely::progress::Timestamp::minimum();
+                while let Some(records) = records_rx.recv().await {
+                    let mut max_ts = 0;
+                    let current_upper_chain = Antichain::from_elem(current_upper);
+
+                    let mut builder = write.builder(records.len(), current_upper_chain);
+
+                    for ((k, v), t, d) in records.iter() {
+                        builder
+                            .add(&k.to_vec(), &v.to_vec(), &t, &d)
+                            .await
+                            .expect("invalid usage");
+
+                        max_ts = std::cmp::max(max_ts, t);
+                    }
+
+                    max_ts = max_ts + 1;
+                    let new_upper_chain = Antichain::from_elem(max_ts);
+                    current_upper = max_ts;
+
+                    let batch = builder
+                        .finish(new_upper_chain)
+                        .await
+                        .expect("invalid usage");
+
+                    match batch_tx.send(batch).await {
+                        Ok(_) => (),
+                        Err(e) => panic!("send error: {}", e),
+                    }
+                }
+            });
+            handles.push(handle);
+
+            let mut write = persist
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id)
+                .await?;
+
+            let handle = mz_ore::task::spawn(|| format!("appender-{}", idx), async move {
+                while let Some(batch) = batch_rx.recv().await {
+                    let lower = batch.lower().clone();
+                    let upper = batch.upper().clone();
+                    write
+                        .append_batch(batch, lower, upper)
+                        .await
+                        .expect("external durability failed")
+                        .expect("invalid usage")
+                        .expect("unexpected upper");
+                }
+            });
+            handles.push(handle);
+
+            let writer = RawBenchmarkWriter {
+                tx: Some(records_tx),
+                handles,
+            };
+
+            Ok(writer)
+        }
+    }
+
+    #[async_trait]
+    impl BenchmarkWriter for RawBenchmarkWriter {
+        async fn write(&mut self, batch: ColumnarRecords) -> Result<(), anyhow::Error> {
+            self.tx
+                .as_mut()
+                .expect("writer was already finished")
+                .send(batch)
+                .await
+                .expect("writer send error");
+            Ok(())
+        }
+
+        async fn finish(mut self) -> Result<(), anyhow::Error> {
+            self.tx.take().expect("already finished");
+
+            for handle in self.handles.drain(..) {
+                let () = handle.await?;
+            }
 
             Ok(())
         }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Borrow;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -23,12 +24,13 @@ use mz_persist::location::{Atomicity, BlobMulti, ExternalError};
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::trace;
+use tracing::{trace, warn};
 use uuid::Uuid;
 
 use crate::error::InvalidUsage;
 use crate::r#impl::machine::{retry_external, Machine, FOREVER};
 use crate::r#impl::state::Upper;
+use crate::ShardId;
 
 /// A "capability" granting the ability to apply updates to some shard at times
 /// greater or equal to `self.upper()`.
@@ -81,7 +83,7 @@ where
     }
 
     /// Applies `updates` to this shard and downgrades this handle's upper to
-    /// `new_upper`.
+    /// `upper`.
     ///
     /// The innermost `Result` is `Ok` if the updates were successfully written.
     /// If not, an `Upper` err containing the current writer upper is returned.
@@ -94,15 +96,14 @@ where
     /// data being written must be identical (in the sense of "definite"-ness).
     /// It's intended for replicated use by source ingestion, sinks, etc.
     ///
-    /// All times in `updates` must be greater or equal to `self.upper()` and
-    /// not greater or equal to `new_upper`. A `new_upper` of the empty
-    /// antichain "finishes" this shard, promising that no more data is ever
-    /// incoming.
+    /// All times in `updates` must be greater or equal to `lower` and not
+    /// greater or equal to `upper`. A `upper` of the empty antichain "finishes"
+    /// this shard, promising that no more data is ever incoming.
     ///
     /// `updates` may be empty, which allows for downgrading `upper` to
     /// communicate progress. It is possible to heartbeat a writer lease by
-    /// calling this with `new_upper` equal to `self.upper()` and an empty
-    /// `updates` (making the call a no-op).
+    /// calling this with `upper` equal to `self.upper()` and an empty `updates`
+    /// (making the call a no-op).
     ///
     /// This uses a bounded amount of memory, even when `updates` is very large.
     /// Individual records, however, should be small enough that we can
@@ -132,79 +133,12 @@ where
     {
         trace!("WriteHandle::append lower={:?} upper={:?}", lower, upper);
 
-        let upper = upper;
-        let since = Antichain::from_elem(T::minimum());
-        let mut desc = Description::new(lower.clone(), upper, since);
-
-        // TODO: Instead construct a Vec of batches here so it can be bounded
-        // memory usage (if updates is large).
-        let value = match Self::encode_batch(&desc, updates) {
-            Ok(x) => x,
-            Err(err) => return Ok(Err(err)),
-        };
-        let keys = if let Some(value) = value {
-            let key = Uuid::new_v4().to_string();
-            let () = retry_external("append::set", || async {
-                // If MultiBlob::set took value as a ref, then we wouldn't have
-                // to clone here.
-                self.blob
-                    .set(
-                        Instant::now() + FOREVER,
-                        &key,
-                        value.clone(),
-                        Atomicity::RequireAtomic,
-                    )
-                    .await
-            })
-            .await;
-            vec![key]
-        } else {
-            vec![]
+        let batch = match self.batch(updates, lower.clone(), upper.clone()).await {
+            Ok(batch) => batch,
+            Err(invalid_usage) => return Ok(Err(invalid_usage)),
         };
 
-        loop {
-            let res = self.machine.compare_and_append(&keys, &desc).await?;
-            match res {
-                Ok(Ok(_seqno)) => {
-                    self.upper = desc.upper().clone();
-                    return Ok(Ok(Ok(())));
-                }
-                // TODO(aljoscha): This seems useless now because we have to read from consensus to
-                // get an up-to-date version of the upper.
-                Ok(Err(_current_upper)) => {
-                    // If the state machine thinks that the shard upper is not far enough along, it
-                    // could be because the caller of this method has found out that it advanced
-                    // via some some side-channel that didn't update our local cache of the machine
-                    // state. So, fetch the latest state and try again if we indeed get something
-                    // different.
-                    self.machine.fetch_and_update_state().await;
-                    let current_upper = self.machine.upper();
-
-                    // We tried to to a non-contiguous append, that won't work.
-                    if PartialOrder::less_than(&current_upper, &lower) {
-                        self.upper = current_upper.clone();
-                        return Ok(Ok(Err(Upper(current_upper))));
-                    } else if PartialOrder::less_than(&current_upper, desc.upper()) {
-                        // Cut down the Description by advancing its lower to the current shard
-                        // upper and try again. IMPORTANT: We can only advance the lower, meaning
-                        // we cut updates away, we must not "extend" the batch by changing to a
-                        // lower that is not beyond the current lower. This invariant is checked by
-                        // the first if branch: if `!(current_upper < lower)` then it holds that
-                        // `lower <= current_upper`.
-                        desc = Description::new(
-                            current_upper,
-                            desc.upper().clone(),
-                            desc.since().clone(),
-                        );
-                    } else {
-                        // We already have updates past this batch's upper, the append is a no-op.
-                        self.upper = current_upper;
-                        return Ok(Ok(Ok(())));
-                    }
-                }
-                Err(err) => return Ok(Err(err)),
-            }
-        }
+        self.append_batch(batch, lower, upper).await
     }
 
     /// Applies `updates` to this shard and downgrades this handle's upper to
@@ -266,73 +200,233 @@ where
             new_upper
         );
 
+        let mut batch = match self
+            .batch(updates, expected_upper.clone(), new_upper.clone())
+            .await
+        {
+            Ok(batch) => batch,
+            Err(invalid_usage) => return Ok(Err(invalid_usage)),
+        };
+
+        match self
+            .compare_and_append_batch(&mut batch, expected_upper, new_upper)
+            .await
+        {
+            ok @ Ok(Ok(Ok(()))) => ok,
+            err @ _ => {
+                // We cannot delete the batch in compare_and_append_batch()
+                // because the caller owns the batch and might want to retry
+                // with a different `expected_upper`. In this function, we
+                // control the batch, so we have to delete it.
+                batch.delete().await?;
+                err
+            }
+        }
+    }
+
+    /// Appends the batch of updates to the shard and downgrades this handle's
+    /// upper to `upper`.
+    ///
+    /// The innermost `Result` is `Ok` if the updates were successfully written.
+    /// If not, an `Upper` err containing the current writer upper is returned.
+    /// If that happens, we also update our local `upper` to match the current
+    /// upper. This is useful in cases where a timeout happens in between a
+    /// successful write and returning that to the client.
+    ///
+    /// In contrast to [Self::compare_and_append_batch], multiple [WriteHandle]s
+    /// may be used concurrently to write to the same shard, but in this case,
+    /// the data being written must be identical (in the sense of
+    /// "definite"-ness). It's intended for replicated use by source ingestion,
+    /// sinks, etc.
+    ///
+    /// A `upper` of the empty antichain "finishes" this shard, promising that
+    /// no more data is ever incoming.
+    ///
+    /// The batch may be empty, which allows for downgrading `upper` to
+    /// communicate progress. It is possible to heartbeat a writer lease by
+    /// calling this with `upper` equal to `self.upper()` and an empty `updates`
+    /// (making the call a no-op).
+    ///
+    /// The clunky multi-level Result is to enable more obvious error handling
+    /// in the caller. See <http://sled.rs/errors.html> for details.
+    pub async fn append_batch(
+        &mut self,
+        mut batch: Batch<K, V, T, D>,
+        mut lower: Antichain<T>,
+        upper: Antichain<T>,
+    ) -> Result<Result<Result<(), Upper<T>>, InvalidUsage<T>>, ExternalError> {
+        trace!("Batch::append lower={:?} upper={:?}", lower, upper);
+
+        loop {
+            let res = self
+                .compare_and_append_batch(&mut batch, lower.clone(), upper.clone())
+                .await?;
+            match res {
+                Ok(Ok(())) => {
+                    self.upper = upper;
+                    return Ok(Ok(Ok(())));
+                }
+                Ok(Err(current_upper)) => {
+                    let Upper(current_upper) = current_upper;
+
+                    // We tried to to a non-contiguous append, that won't work.
+                    if PartialOrder::less_than(&current_upper, &lower) {
+                        self.upper = current_upper.clone();
+
+                        batch.delete().await?;
+
+                        return Ok(Ok(Err(Upper(current_upper))));
+                    } else if PartialOrder::less_than(&current_upper, &upper) {
+                        // Cut down the Description by advancing its lower to the current shard
+                        // upper and try again. IMPORTANT: We can only advance the lower, meaning
+                        // we cut updates away, we must not "extend" the batch by changing to a
+                        // lower that is not beyond the current lower. This invariant is checked by
+                        // the first if branch: if `!(current_upper < lower)` then it holds that
+                        // `lower <= current_upper`.
+                        lower = current_upper;
+                    } else {
+                        // We already have updates past this batch's upper, the append is a no-op.
+                        self.upper = current_upper;
+
+                        // Because we return a success result, the caller will
+                        // think that the batch was consumed or otherwise used,
+                        // so we have to delete it here.
+                        batch.delete().await?;
+
+                        return Ok(Ok(Ok(())));
+                    }
+                }
+                Err(err) => {
+                    batch.delete().await?;
+
+                    return Ok(Err(err));
+                }
+            }
+        }
+    }
+
+    /// Appends the batch of updates to the shard and downgrades this handle's
+    /// upper to `new_upper` iff the current global upper of this shard is
+    /// `expected_upper`.
+    ///
+    /// The innermost `Result` is `Ok` if the batch was successfully written. If
+    /// not, an `Upper` err containing the current global upper is returned.
+    ///
+    /// In contrast to [Self::append_batch], this linearizes mutations from all
+    /// writers. It's intended for use as an atomic primitive for timestamp
+    /// bindings, SQL tables, etc.
+    ///
+    /// A `new_upper` of the empty antichain "finishes" this shard, promising
+    /// that no more data is ever incoming.
+    ///
+    /// The batch may be empty, which allows for downgrading `upper` to
+    /// communicate progress. It is possible to heartbeat a writer lease by
+    /// calling this with `new_upper` equal to `self.upper()` and an empty
+    /// `updates` (making the call a no-op).
+    ///
+    /// IMPORTANT: In case of an erroneous result the caller is responsible for
+    /// the lifecycle of the `batch`. It can be deleted or it can be used to
+    /// retry with adjusted frontiers.
+    ///
+    /// The clunky multi-level Result is to enable more obvious error handling
+    /// in the caller. See <http://sled.rs/errors.html> for details.
+    ///
+    /// SUBTLE! Unlike the other methods, it is not always safe to retry
+    /// [ExternalError]s in compare_and_append (depends on the usage pattern).
+    /// We should be able to structure timestamp binding, source, and sink code
+    /// so it is always safe to retry [ExternalError]s, but SQL txns will have
+    /// to pass the error back to the user (or risk double committing the txn).
+    ///
+    /// TODO: This already retries [mz_persist::location::Determinate] errors,
+    /// so the signature could be changed to only return Indeterminate, but
+    /// leaving it as ExternalError for now to save churn on storage PR rebases.
+    pub async fn compare_and_append_batch(
+        &mut self,
+        batch: &mut Batch<K, V, T, D>,
+        expected_upper: Antichain<T>,
+        new_upper: Antichain<T>,
+    ) -> Result<Result<Result<(), Upper<T>>, InvalidUsage<T>>, ExternalError> {
+        trace!(
+            "Batch::compare_and_append expected_upper={:?} new_upper={:?}",
+            expected_upper,
+            new_upper
+        );
+
+        if self.machine.shard_id() != batch.shard_id {
+            return Ok(Err(InvalidUsage::BatchNotFromThisShard {
+                batch_shard: batch.shard_id,
+                handle_shard: self.machine.shard_id(),
+            }));
+        }
+
         let lower = expected_upper.clone();
         let upper = new_upper;
         let since = Antichain::from_elem(T::minimum());
         let desc = Description::new(lower, upper, since);
 
-        // TODO: Instead construct a Vec of batches here so it can be bounded
-        // memory usage (if updates is large).
-        let value = match Self::encode_batch(&desc, updates) {
-            Ok(x) => x,
-            Err(err) => return Ok(Err(err)),
-        };
-        let keys = if let Some(value) = value {
-            let key = Uuid::new_v4().to_string();
-            let () = retry_external("compare_and_append::set", || async {
-                // If MultiBlob::set took value as a ref, then we wouldn't have
-                // to clone here.
-                self.blob
-                    .set(
-                        Instant::now() + FOREVER,
-                        &key,
-                        value.clone(),
-                        Atomicity::RequireAtomic,
-                    )
-                    .await
-            })
-            .await;
-            vec![key]
-        } else {
-            vec![]
-        };
+        if !PartialOrder::less_equal(batch.desc.lower(), desc.lower())
+            || PartialOrder::less_than(batch.desc.upper(), desc.upper())
+        {
+            return Ok(Err(InvalidUsage::InvalidBatchBounds {
+                batch_lower: batch.desc.lower().clone(),
+                batch_upper: batch.desc.upper().clone(),
+                append_lower: desc.lower().clone(),
+                append_upper: desc.upper().clone(),
+            }));
+        }
 
-        loop {
-            let res = self.machine.compare_and_append(&keys, &desc).await?;
-            match res {
-                Ok(Ok(_seqno)) => {
-                    self.upper = desc.upper().clone();
-                    return Ok(Ok(Ok(())));
-                }
-                // TODO(aljoscha): This seems useless now because we have to read from consensus to
-                // get an up-to-date version of the upper.
-                Ok(Err(_current_upper)) => {
-                    // If the state machine thinks that the shard upper is not far enough along, it
-                    // could be because the caller of this method has found out that it advanced
-                    // via some some side-channel that didn't update our local cache of the machine
-                    // state. So, fetch the latest state and try again if we indeed get something
-                    // different.
-                    self.machine.fetch_and_update_state().await;
-                    let current_upper = self.machine.upper();
+        let res = self
+            .machine
+            .compare_and_append(&batch.blob_keys, &desc)
+            .await?;
 
-                    // We tried to to a compare_and_append with the wrong expected upper, that
-                    // won't work.
-                    if current_upper != expected_upper {
-                        self.upper = current_upper.clone();
-                        return Ok(Ok(Err(Upper(current_upper))));
-                    } else {
-                        // The upper stored in state was outdated. Retry after updating.
-                    }
-                }
-                Err(err) => return Ok(Err(err)),
+        match res {
+            Ok(Ok(_seqno)) => {
+                self.upper = desc.upper().clone();
+                batch.mark_consumed();
+                Ok(Ok(Ok(())))
             }
+            Ok(Err(current_upper)) => {
+                // We tried to to a compare_and_append with the wrong expected upper, that
+                // won't work. Update the cached upper to the current upper.
+                self.upper = current_upper.0.clone();
+                Ok(Ok(Err(current_upper)))
+            }
+            Err(err) => Ok(Err(err)),
         }
     }
 
-    fn encode_batch<SB, KB, VB, TB, DB, I>(
-        desc: &Description<T>,
+    /// Returns a [BatchBuilder] that can be used to write a batch of updates to
+    /// blob storage which can then be appended to this shard using
+    /// [Self::compare_and_append_batch] or [Self::append_batch].
+    ///
+    /// It is correct to create an empty batch, which allows for downgrading
+    /// `upper` to communicate progress. (see [Self::compare_and_append_batch]
+    /// or [Self::append_batch])
+    ///
+    /// The builder uses a bounded amount of memory, even when the number of
+    /// updates is very large. Individual records, however, should be small
+    /// enough that we can reasonably chunk them up: O(KB) is definitely fine,
+    /// O(MB) come talk to us.
+    pub fn builder(&mut self, size_hint: usize, lower: Antichain<T>) -> BatchBuilder<K, V, T, D> {
+        trace!("WriteHandle::builder lower={:?}", lower,);
+
+        BatchBuilder::new(
+            size_hint,
+            lower,
+            Arc::clone(&self.blob),
+            self.machine.shard_id().clone(),
+        )
+    }
+
+    /// Uploads the given `updates` as one `Batch` to the blob store and returns
+    /// a handle to the batch.
+    async fn batch<SB, KB, VB, TB, DB, I>(
+        &mut self,
         updates: I,
-    ) -> Result<Option<Vec<u8>>, InvalidUsage<T>>
+        lower: Antichain<T>,
+        upper: Antichain<T>,
+    ) -> Result<Batch<K, V, T, D>, InvalidUsage<T>>
     where
         SB: Borrow<((KB, VB), TB, DB)>,
         KB: Borrow<K>,
@@ -341,44 +435,240 @@ where
         DB: Borrow<D>,
         I: IntoIterator<Item = SB>,
     {
+        // WIP: Should we have logging for these helpers?
+        trace!("WriteHandle::batch lower={:?} upper={:?}", lower, upper);
+
         let iter = updates.into_iter();
-        let size_hint = iter.size_hint();
 
-        let (mut key_buf, mut val_buf) = (Vec::new(), Vec::new());
-        let mut builder = ColumnarRecordsVecBuilder::default();
-        for tuple in iter {
-            let ((k, v), t, d) = tuple.borrow();
+        // This uses the iter's size_hint's lower+1 to match the logic in Vec.
+        let (size_hint_lower, _) = iter.size_hint();
+
+        let mut builder = self.builder(size_hint_lower, lower.clone());
+
+        for update in iter {
+            let ((k, v), t, d) = update.borrow();
             let (k, v, t, d) = (k.borrow(), v.borrow(), t.borrow(), d.borrow());
-            if !desc.lower().less_equal(t) || desc.upper().less_equal(t) {
-                return Err(InvalidUsage::UpdateNotWithinBounds {
-                    ts: t.clone(),
-                    lower: desc.lower().clone(),
-                    upper: desc.upper().clone(),
-                });
+            match builder.add(k, v, t, d).await {
+                Ok(_) => (),
+                Err(invalid_usage) => return Err(invalid_usage),
             }
+        }
 
-            trace!("writing update {:?}", ((k, v), t, d));
-            key_buf.clear();
-            val_buf.clear();
-            K::encode(k, &mut key_buf);
-            V::encode(v, &mut val_buf);
-            // TODO: Get rid of the from_le_bytes.
-            let t = u64::from_le_bytes(T::encode(t));
-            let d = i64::from_le_bytes(D::encode(d));
+        builder.finish(upper.clone()).await
+    }
 
-            if builder.len() == 0 {
-                // Use the first record to attempt to pre-size the builder
-                // allocations. This uses the iter's size_hint's lower+1 to
-                // match the logic in Vec.
-                let (lower, _) = size_hint;
-                let additional = usize::saturating_add(lower, 1);
-                builder.reserve(additional, key_buf.len(), val_buf.len());
-            }
-            builder.push(((&key_buf, &val_buf), t, d))
+    /// Test helper for an [Self::append] call that is expected to succeed.
+    #[cfg(test)]
+    #[track_caller]
+    pub async fn expect_append<L, U>(&mut self, updates: &[((K, V), T, D)], lower: L, new_upper: U)
+    where
+        L: Into<Antichain<T>>,
+        U: Into<Antichain<T>>,
+    {
+        self.append(updates.iter(), lower.into(), new_upper.into())
+            .await
+            .expect("external durability failed")
+            .expect("invalid usage")
+            .expect("unexpected upper");
+    }
+
+    /// Test helper for a [Self::compare_and_append] call that is expected to
+    /// succeed.
+    #[cfg(test)]
+    #[track_caller]
+    pub async fn expect_compare_and_append(
+        &mut self,
+        updates: &[((K, V), T, D)],
+        expected_upper: T,
+        new_upper: T,
+    ) {
+        self.compare_and_append(
+            updates.iter().map(|((k, v), t, d)| ((k, v), t, d)),
+            Antichain::from_elem(expected_upper),
+            Antichain::from_elem(new_upper),
+        )
+        .await
+        .expect("external durability failed")
+        .expect("invalid usage")
+        .expect("unexpected upper")
+    }
+}
+
+/// A handle to a batch of updates that has been written to blob storage but
+/// which has not yet been appended to a shard.
+///
+/// A [Batch] needs to be marked as consumed or it needs to be deleted via [Self::delete].
+/// Otherwise, a dangling batch will leak and backing blobs will remain in blob storage.
+// TODO(aljoscha): Right now, we require batches to be manually marked as
+// consumed (when they're appended to a batch) or deleted. This is clunky and
+// prone to errors so we should replace it with lazy cleanup once we can use
+// async drop.
+#[derive(Debug)]
+pub struct Batch<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    /// [Description] of updates contained in this batch.
+    desc: Description<T>,
+
+    shard_id: ShardId,
+
+    /// Keys to blobs that make up this batch of updates.
+    blob_keys: Vec<String>,
+
+    /// Handle to the [BlobMulti] that the blobs of this batch were uploaded to.
+    blob: Arc<dyn BlobMulti + Send + Sync>,
+
+    // These provide a bit more safety against appending a batch with the wrong
+    // type to a shard.
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+impl<K, V, T, D> Drop for Batch<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    fn drop(&mut self) {
+        if self.blob_keys.len() > 0 {
+            warn!(
+                "un-consumed Batch, with {} dangling blob keys: {:?}",
+                self.blob_keys.len(),
+                self.blob_keys
+            );
+        }
+    }
+}
+
+impl<K, V, T, D> Batch<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    pub(crate) fn new(
+        blob: Arc<dyn BlobMulti + Send + Sync>,
+        shard_id: ShardId,
+        desc: Description<T>,
+        blob_keys: Vec<String>,
+    ) -> Self {
+        Self {
+            desc,
+            blob_keys,
+            shard_id,
+            blob,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// The `upper` of this [Batch].
+    pub fn upper(&self) -> &Antichain<T> {
+        self.desc.upper()
+    }
+
+    /// The `lower` of this [Batch].
+    pub fn lower(&self) -> &Antichain<T> {
+        self.desc.lower()
+    }
+
+    /// Marks the blobs that this batch handle points to as consumed, likely
+    /// because they were appended to a shard.
+    ///
+    /// Consumers of a blob need to make this explicit, so that we can log
+    /// warnings in case a batch is not used.
+    pub(crate) fn mark_consumed(&mut self) {
+        self.blob_keys.clear();
+    }
+
+    /// Deletes the blobs that make up this batch from the given blob store and
+    /// marks them as deleted.
+    pub async fn delete(mut self) -> Result<(), ExternalError> {
+        let deadline = Instant::now() + FOREVER;
+        for key in self.blob_keys.iter() {
+            self.blob.delete(deadline, key).await?;
+        }
+        self.blob_keys.clear();
+        Ok(())
+    }
+}
+
+/// A builder for [Batches](Batch) that allows adding updates piece by piece and
+/// then finishing it.
+#[derive(Debug)]
+pub struct BatchBuilder<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    size_hint: usize,
+    lower: Antichain<T>,
+    max_ts: T,
+
+    shard_id: ShardId,
+    records: ColumnarRecordsVecBuilder,
+    blob: Arc<dyn BlobMulti + Send + Sync>,
+
+    key_buf: Vec<u8>,
+    val_buf: Vec<u8>,
+
+    // These provide a bit more safety against appending a batch with the wrong
+    // type to a shard.
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+impl<K, V, T, D> BatchBuilder<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    pub(crate) fn new(
+        size_hint: usize,
+        lower: Antichain<T>,
+        blob: Arc<dyn BlobMulti + Send + Sync>,
+        shard_id: ShardId,
+    ) -> Self {
+        Self {
+            size_hint,
+            lower,
+            max_ts: T::minimum(),
+            records: ColumnarRecordsVecBuilder::default(),
+            blob,
+            shard_id,
+            key_buf: Vec::new(),
+            val_buf: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Finish writing this batch and return a handle to the written batch.
+    ///
+    /// This fails if any of the updates in this batch are beyond the given
+    /// `upper`.
+    pub async fn finish(self, upper: Antichain<T>) -> Result<Batch<K, V, T, D>, InvalidUsage<T>> {
+        if upper.less_equal(&self.max_ts) {
+            return Err(InvalidUsage::UpdateBeyondUpper {
+                max_ts: self.max_ts,
+                expected_upper: upper.clone(),
+            });
+        }
+
+        let since = Antichain::from_elem(T::minimum());
+        let desc = Description::new(self.lower, upper, since);
+
+        let updates = self.records.finish();
+
+        if updates.len() == 0 {
+            return Ok(Batch::new(
+                Arc::clone(&self.blob),
+                self.shard_id,
+                desc,
+                vec![],
+            ));
         }
 
         // TODO: Get rid of the from_le_bytes.
-        let desc = Description::new(
+        let encoded_desc = Description::new(
             Antichain::from(
                 desc.lower()
                     .elements()
@@ -403,57 +693,81 @@ where
         );
 
         let batch = BlobTraceBatchPart {
-            desc,
-            updates: builder.finish(),
+            desc: encoded_desc.clone(),
+            updates,
             index: 0,
         };
-        if batch.updates.len() == 0 {
-            return Ok(None);
-        }
 
         let mut buf = Vec::new();
         batch.encode(&mut buf);
-        Ok(Some(buf))
+
+        let key = Uuid::new_v4().to_string();
+        let () = retry_external("compare_and_append::set", || async {
+            // If MultiBlob::set took value as a ref, then we wouldn't have
+            // to clone here.
+            self.blob
+                .set(
+                    Instant::now() + FOREVER,
+                    &key,
+                    buf.clone(),
+                    Atomicity::RequireAtomic,
+                )
+                .await
+        })
+        .await;
+
+        let batch = Batch::new(
+            Arc::clone(&self.blob),
+            self.shard_id.clone(),
+            desc,
+            vec![key],
+        );
+
+        Ok(batch)
     }
 
-    /// Test helper for an [Self::append] call that is expected to succeed.
-    #[cfg(test)]
-    #[track_caller]
-    pub async fn expect_append<L, U>(&mut self, updates: &[((K, V), T, D)], lower: L, new_upper: U)
-    where
-        L: Into<Antichain<T>>,
-        U: Into<Antichain<T>>,
-    {
-        self.append(
-            updates.iter().map(|((k, v), t, d)| ((k, v), t, d)),
-            lower.into(),
-            new_upper.into(),
-        )
-        .await
-        .expect("external durability failed")
-        .expect("invalid usage")
-        .expect("unexpected upper");
-    }
+    /// Adds the given update to the batch.
+    ///
+    /// The update timestamp must be greater or equal to `lower` that was given
+    /// when creating this [BatchBuilder].
+    //
+    // NOTE: This function is async right now, even though it doesn't need it.
+    // We're keeping the option open in case we might need it in the future.
+    pub async fn add(&mut self, key: &K, val: &V, ts: &T, diff: &D) -> Result<(), InvalidUsage<T>> {
+        if !self.lower.less_equal(ts) {
+            return Err(InvalidUsage::UpdateNotBeyondLower {
+                ts: ts.clone(),
+                lower: self.lower.clone(),
+            });
+        }
 
-    /// Test helper for a [Self::compare_and_append] call that is expected to
-    /// succeed.
-    #[cfg(test)]
-    #[track_caller]
-    pub async fn expect_compare_and_append(
-        &mut self,
-        updates: &[((K, V), T, D)],
-        expected_upper: T,
-        new_upper: T,
-    ) {
-        self.compare_and_append(
-            updates.iter().map(|((k, v), t, d)| ((k, v), t, d)),
-            Antichain::from_elem(expected_upper),
-            Antichain::from_elem(new_upper),
-        )
-        .await
-        .expect("external durability failed")
-        .expect("invalid usage")
-        .expect("unexpected upper")
+        self.max_ts.join_assign(ts);
+
+        trace!("writing update {:?}", ((key, val), ts, diff));
+        self.key_buf.clear();
+        self.val_buf.clear();
+        K::encode(key, &mut self.key_buf);
+        V::encode(val, &mut self.val_buf);
+        // TODO: Get rid of the from_le_bytes.
+        let t = u64::from_le_bytes(T::encode(ts));
+        let d = i64::from_le_bytes(D::encode(diff));
+
+        if self.records.len() == 0 {
+            // Use the first record to attempt to pre-size the builder
+            // allocations.
+            let additional = usize::saturating_add(self.size_hint, 1);
+            self.records
+                .reserve(additional, self.key_buf.len(), self.val_buf.len());
+        }
+        self.records.push(((&self.key_buf, &self.val_buf), t, d));
+
+        // TODO(aljoscha): As of now, this batch builder doesn't have constant
+        // memory usage but scales with the number of added records. Instead of
+        // keeping one records builder around, we should periodically finish and
+        // flush the updates to a blob, store the blob key in the builder, and
+        // reset the records builder.
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
An `append()` (or `compare_and_append()`) call internally does two
separate steps:

1. write the batch of updates to a Blob implementation (S3, in
   production)
2. add a pointer to the new batch in the metadata (aka state machine),
   which we keep in a Consensus implementation

We don't currently retry the second step, so a failure can void the
complete append attempt, which has to be retried as a whole.

Now, we allow separating the two parts at the API level to allow writing
the batch of updates separately (which we can already retry internally
in the client) and then retry "appending" it into the shard metadata.

Background context: we don't retry the second step, because we cannot
ensure correctness for some usage patterns.

Closes #12468

### Tips for reviewer

I didn't add tests yet but I see two options for that:

1. Rewrite all existing tests to use the new API, add a sanity-check to make sure the old-style API works as expected
2. Leave all tests as they are, add sanity-check tests to make sure the new-style API works as expected

Option 2. would be less disruptive but feels wrong because the old-style APIs are really sugar on top of the new APIs, so it seems a sanity-check test is enough for them.

Option 1. is less disruptive in terms of number of lines of code we'd have to change. 

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.