### PR TITLE
persist: WIP use a connection pool in PostgresConsensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90d58a15f5acfe41afcac9775d8e92f2338d14482220c778c6e42aa77778182"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c668a58063c6331e3437e3146970943ad82b1b36169fd979bb2645ac2088209a"
+dependencies = [
+ "deadpool",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "debugid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3632,6 +3666,7 @@ dependencies = [
  "bytes",
  "criterion",
  "crossbeam-channel",
+ "deadpool-postgres",
  "differential-dataflow",
  "fail",
  "futures-util",
@@ -5377,6 +5412,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31b5c4033f8fdde8700e4657be2c497e7288f01515be52168c631e2e4d4086"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,5 @@ prost = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" 
 prost-build = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-derive = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-types = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/deny.toml
+++ b/deny.toml
@@ -54,6 +54,7 @@ name = "strum-macros"
 [[bans.deny]]
 name = "log"
 wrappers = [
+    "deadpool-postgres",
     "env_logger",
     "fail",
     "globset",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -28,6 +28,7 @@ aws-types = "0.12.0"
 base64 = "0.13.0"
 bytes = "1.1.0"
 crossbeam-channel = "0.5.4"
+deadpool-postgres = "0.10.2"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.0", features = ["failpoints"] }
 futures-util = "0.3.19"


### PR DESCRIPTION
Long-term, the connection limit will almost certainly be an issue, but
for now, this is the easiest way to get additional concurrency in the
persist Consensus impl used in development and CI. Hopefully, this will
be enough to get us through M1 and into M2.

Notably, this gets us good scaling up to the max pool size. We can do a
thing in 1.3ms and we can concurrently do the same thing 8X in a Runtime
with 8 thread and a pool with max 8 connections in 2.1ms. This should
help a lot with e.g. 22 system tables each advancing their frontier once
per second.

On a persist benchmarking machine

    MZ_PERSIST_RECORD_COUNT_SMALL=64 MZ_PERSIST_RECORD_SIZE_BYTES_SMALL=1024 MZ_PERSIST_BATCH_MAX_COUNT_SMALL=8
    consensus/compare_and_set/postgres/64KiB
                            time:   [1.3261 ms 1.3362 ms 1.3469 ms]
                            thrpt:  [46.404 MiB/s 46.776 MiB/s 47.131 MiB/s]
                     change:
                            time:   [-4.7604% +1.3972% +10.859%] (p = 0.77 > 0.05)
                            thrpt:  [-9.7957% -1.3780% +4.9983%]
                            No change in performance detected.
    consensus/concurrent_compare_and_set/postgres/64KiB
                            time:   [2.1304 ms 2.1728 ms 2.2393 ms]
                            thrpt:  [223.28 MiB/s 230.12 MiB/s 234.70 MiB/s]
                     change:
                            time:   [-84.453% -83.747% -83.012%] (p = 0.00 < 0.05)
                            thrpt:  [+488.65% +515.28% +543.20%]
                            Performance has improved.