### PR TITLE
otel: add tracing to peeks in pgwire and coord

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -15,7 +15,6 @@ use std::sync::{Arc, Mutex};
 use anyhow::bail;
 use futures::sink::SinkExt;
 use futures::stream::TryStreamExt;
-use http::HeaderMap;
 use mz_build_info::{build_info, BuildInfo};
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -220,8 +219,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
         log_filter: args.log_filter.clone(),
-        opentelemetry_endpoint: None,
-        opentelemetry_headers: HeaderMap::new(),
+        opentelemetry_config: None,
         prefix: args.log_process_name.then(|| "computed".into()),
         #[cfg(feature = "tokio-console")]
         tokio_console: false,

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -23,7 +23,7 @@ mz-ccsr = { path = "../ccsr" }
 mz-dataflow-types = { path = "../dataflow-types" }
 mz-expr = { path = "../expr" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-types = { path = "../persist-types" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -359,7 +359,6 @@ impl CatalogState {
             })
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     fn insert_item(
         &mut self,
         id: GlobalId,

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.3"
 mz-coord = { path = "../coord" }
 mz-expr = { path = "../expr" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -86,6 +86,7 @@ impl Server {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn handle_connection<A>(&self, conn: A) -> Result<(), anyhow::Error>
     where
         A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin + fmt::Debug + 'static,

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -16,7 +16,6 @@ use std::sync::{Arc, Mutex};
 use anyhow::bail;
 use futures::sink::SinkExt;
 use futures::stream::TryStreamExt;
-use http::HeaderMap;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use tokio::net::TcpListener;
@@ -145,8 +144,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
         log_filter: args.log_filter.clone(),
-        opentelemetry_endpoint: None,
-        opentelemetry_headers: HeaderMap::new(),
+        opentelemetry_config: None,
         prefix: args.log_process_name.then(|| "storaged".into()),
         #[cfg(feature = "tokio-console")]
         tokio_console: false,


### PR DESCRIPTION
This pr does 2 things:

- Instruments the common-case path for ordinary `peeks`
- Shows how we can and should instrument all queries and connections going into the future

It accomplishes this by:
- Adding `tracing::instrument` to various functions in mz-pgwire and mz-coord
  - These are `level = "debug"` to avoid polluting the default log experience
- Use a `HashMap` `opentelemetry::propagation::{Injector, Extractor};` wrapper to move the trace context around when things are moved back and forth different places in coord and pgwire over channels

It makes the following decisions (for now)
- Only meaningfully instrument `Peek` executions for now
- Trace propagation only ever happens within the coord/materialized process (once we have grpc we can propagate to compute)
- Don't ever shutdown the trace provider, as we don't currently have a clean shutdown place to do so (cc @benesch )
- Decides to parent all queries to a single root connection span. This is mostly related to tradeoffs in the honeycomb ui (cc @antifuchs):
  - opentel "links" instead of parenting works, but you can't render sub-linked traces together
  - "parenting" renders the whole trace nicely, but you can't meaningfully zoom in on a query part of the execution in the trace waterfall view
  - Before the connection root closes, query sub-traces 
  - We definitely need to play with this. Its possible that for local use, the jaeger ui is better, but i am not sure it works with otlp, so we will have to add a `--jaeger` flag or something

### Motivation

  * This PR adds a known-desirable feature.

works on [12230](https://github.com/MaterializeInc/materialize/issues/12230)

### Tips for reviewer

See above

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - tested locally 

### Release notes

None
