### PR TITLE
Plumb librdkafka log level through storage layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.7.2",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid 1.0.0",
 ]
@@ -3978,6 +3979,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tower-http",
+ "tracing",
  "uuid 1.0.0",
  "walkdir",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -8,4 +8,6 @@ disallowed-methods = [
     { path = "tokio::runtime::Handle::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::runtime::Runtime::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::runtime::Runtime::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    # Use the wrapper that sets the log level correctly
+    { path = "rdkafka::config::ClientConfig::new", reason = "use the `client::create_new_client_config` wrapper in `kafka_util` instead" },
 ]

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -17,7 +17,6 @@ use futures::sink::SinkExt;
 use futures::stream::TryStreamExt;
 use http::HeaderMap;
 use mz_build_info::{build_info, BuildInfo};
-use mz_dataflow_types::sources::AwsExternalId;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 use tokio::net::TcpListener;
@@ -27,6 +26,7 @@ use tracing_subscriber::filter::Targets;
 
 use mz_dataflow_types::client::{ComputeClient, GenericClient};
 use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
+use mz_dataflow_types::ConnectorContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 
@@ -254,10 +254,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         experimental_mode: false,
         metrics_registry: MetricsRegistry::new(),
         now: SYSTEM_TIME.clone(),
-        aws_external_id: args
-            .aws_external_id
-            .map(AwsExternalId::ISwearThisCameFromACliArgOrEnvVariable)
-            .unwrap_or(AwsExternalId::NotProvided),
+        connector_context: ConnectorContext::from_cli_args(&args.log_filter, args.aws_external_id),
     };
 
     let serve_config = ServeConfig {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -26,6 +26,7 @@ use tokio::sync::mpsc;
 
 use mz_dataflow_types::client::{ComputeCommand, ComputeResponse};
 use mz_dataflow_types::logging::LoggingConfig;
+use mz_dataflow_types::ConnectorContext;
 use mz_dataflow_types::{DataflowError, PeekResponse, TailResponse};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage::boundary::ComputeReplay;
@@ -63,6 +64,9 @@ pub struct ComputeState {
     pub sink_metrics: SinkBaseMetrics,
     /// The logger, from Timely's logging framework, if logs are enabled.
     pub materialized_logger: Option<logging::materialized::Logger>,
+    /// Configuration for sink connectors.
+    // TODO: remove when sinks move to storage.
+    pub connector_context: ConnectorContext,
 }
 
 /// A wrapper around [ComputeState] with a live timely worker and response channel.

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -31,7 +31,7 @@ use mz_dataflow_types::client::{
 use mz_dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_dataflow_types::sinks::{SinkConnector, SinkConnectorBuilder, SinkEnvelope};
 use mz_dataflow_types::sources::{
-    AwsExternalId, ConnectorInner, ExternalSourceConnector, SourceConnector, Timeline,
+    ConnectorInner, ExternalSourceConnector, SourceConnector, Timeline,
 };
 use mz_expr::{ExprHumanizer, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
@@ -1377,7 +1377,6 @@ impl<S: Append> Catalog<S> {
                     cluster_id: config.storage.cluster_id(),
                     session_id: Uuid::new_v4(),
                     build_info: config.build_info,
-                    aws_external_id: config.aws_external_id.clone(),
                     timestamp_frequency: config.timestamp_frequency,
                     now: config.now.clone(),
                 },
@@ -1917,7 +1916,6 @@ impl<S: Append> Catalog<S> {
             storage,
             experimental_mode,
             build_info: &DUMMY_BUILD_INFO,
-            aws_external_id: AwsExternalId::NotProvided,
             timestamp_frequency: Duration::from_secs(1),
             now,
             skip_migrations: true,

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -10,7 +10,6 @@
 use std::time::Duration;
 
 use mz_build_info::BuildInfo;
-use mz_dataflow_types::sources::AwsExternalId;
 use mz_ore::metrics::MetricsRegistry;
 
 use crate::catalog::storage;
@@ -24,10 +23,6 @@ pub struct Config<'a, S> {
     pub experimental_mode: Option<bool>,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
-    /// An [External ID][] to use for all AWS AssumeRole operations.
-    ///
-    /// [External ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
-    pub aws_external_id: AwsExternalId,
     /// Timestamp frequency to use for CREATE SOURCE
     pub timestamp_frequency: Duration,
     /// Function to generate wall clock now; can be mocked.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -99,10 +99,10 @@ use mz_dataflow_types::client::{
 };
 use mz_dataflow_types::sinks::{SinkAsOf, SinkConnector, SinkDesc, TailSinkConnector};
 use mz_dataflow_types::sources::{
-    AwsExternalId, ExternalSourceConnector, PostgresSourceConnector, SourceConnector, Timeline,
+    ExternalSourceConnector, PostgresSourceConnector, SourceConnector, Timeline,
 };
 use mz_dataflow_types::{
-    BuildDesc, DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, Update,
+    BuildDesc, ConnectorContext, DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, Update,
 };
 use mz_expr::{
     permutation_for_arrangement, CollectionPlan, ExprHumanizer, MirRelationExpr, MirScalarExpr,
@@ -233,12 +233,12 @@ pub struct Config<S> {
     pub logical_compaction_window: Option<Duration>,
     pub experimental_mode: bool,
     pub build_info: &'static BuildInfo,
-    pub aws_external_id: AwsExternalId,
     pub metrics_registry: MetricsRegistry,
     pub now: NowFn,
     pub secrets_controller: Box<dyn SecretsController>,
     pub availability_zones: Vec<String>,
     pub replica_sizes: ClusterReplicaSizeMap,
+    pub connector_context: ConnectorContext,
 }
 
 struct PendingPeek {
@@ -363,6 +363,9 @@ pub struct Coordinator<S> {
     replica_sizes: ClusterReplicaSizeMap,
     /// Valid availability zones for replicas.
     availability_zones: Vec<String>,
+
+    /// Extra context to pass through to connector creation.
+    connector_context: ConnectorContext,
 }
 
 /// Metadata about an active connection.
@@ -627,9 +630,13 @@ impl<S: Append + 'static> Coordinator<S> {
                             panic!("sink already initialized during catalog boot")
                         }
                     };
-                    let connector = sink_connector::build(builder.clone(), entry.id())
-                        .await
-                        .with_context(|| format!("recreating sink {}", entry.name()))?;
+                    let connector = sink_connector::build(
+                        builder.clone(),
+                        entry.id(),
+                        self.connector_context.clone(),
+                    )
+                    .await
+                    .with_context(|| format!("recreating sink {}", entry.name()))?;
                     self.handle_sink_connector_ready(
                         entry.id(),
                         entry.oid(),
@@ -1410,8 +1417,8 @@ impl<S: Append + 'static> Coordinator<S> {
                     match mz_sql::connectors::populate_connectors(stmt, &catalog, &mut vec![]) {
                         Ok(stmt) => mz_sql::pure::purify_create_source(
                             self.now(),
-                            self.catalog.config().aws_external_id.clone(),
                             stmt,
+                            self.connector_context.clone(),
                         ),
                         Err(e) => return tx.send(Err(e.into()), session),
                     };
@@ -2355,6 +2362,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // main coordinator thread when the future completes.
         let connector_builder = sink.connector_builder;
         let internal_cmd_tx = self.internal_cmd_tx.clone();
+        let connector_context = self.connector_context.clone();
         task::spawn(
             || format!("sink_connector_ready:{}", sink.from),
             async move {
@@ -2364,7 +2372,8 @@ impl<S: Append + 'static> Coordinator<S> {
                         tx,
                         id,
                         oid,
-                        result: sink_connector::build(connector_builder, id).await,
+                        result: sink_connector::build(connector_builder, id, connector_context)
+                            .await,
                         compute_instance,
                     }))
                     .expect("sending to internal_cmd_tx cannot fail");
@@ -4711,12 +4720,12 @@ pub async fn serve<S: Append + 'static>(
         logical_compaction_window,
         experimental_mode,
         build_info,
-        aws_external_id,
         metrics_registry,
         now,
         secrets_controller,
         replica_sizes,
         availability_zones,
+        connector_context,
     }: Config<S>,
 ) -> Result<(Handle, Client), CoordError> {
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
@@ -4726,7 +4735,6 @@ pub async fn serve<S: Append + 'static>(
         storage,
         experimental_mode: Some(experimental_mode),
         build_info,
-        aws_external_id,
         timestamp_frequency,
         now: now.clone(),
         skip_migrations: false,
@@ -4766,6 +4774,7 @@ pub async fn serve<S: Append + 'static>(
                 secrets_controller,
                 replica_sizes,
                 availability_zones,
+                connector_context,
             };
             let bootstrap = handle.block_on(coord.bootstrap(builtin_table_updates));
             let ok = bootstrap.is_ok();

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -28,7 +28,7 @@ mz-ccsr = { path = "../ccsr" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore" }
+mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-orchestrator = { path = "../orchestrator" }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
@@ -47,6 +47,7 @@ tokio-serde = { version = "0.8.0", features = ["bincode"] }
 tokio-stream = " 0.1.8"
 tokio-util = { version = "0.7.2", features = ["codec"] }
 tracing = "0.1.34"
+tracing-subscriber = "0.3.11"
 url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.0.0", features = ["serde", "v4"] }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -26,7 +26,6 @@ use rdkafka::error::KafkaError;
 use rdkafka::producer::{BaseRecord, Producer, ThreadedProducer};
 use rdkafka::types::RDKafkaErrorCode;
 use rdkafka::util::Timeout;
-use rdkafka::ClientConfig;
 use serde_json::Map;
 use url::Url;
 
@@ -695,7 +694,7 @@ async fn main() -> anyhow::Result<()> {
             let mut key_gen = key_gen.clone();
             let mut value_gen = value_gen.clone();
             let producer: ThreadedProducer<mz_kafka_util::client::MzClientContext> =
-                ClientConfig::new()
+                mz_kafka_util::client::create_new_client_config_simple()
                     .set("bootstrap.servers", args.bootstrap_server.to_string())
                     .create_with_context(mz_kafka_util::client::MzClientContext)
                     .unwrap();

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -14,10 +14,11 @@ use std::time::Duration;
 use anyhow::bail;
 use mz_ore::collections::CollectionExt;
 use rdkafka::client::Client;
+use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::ConsumerContext;
 use rdkafka::producer::{DefaultProducerContext, DeliveryResult, ProducerContext};
 use rdkafka::ClientContext;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, warn, Level};
 
 /// A `ClientContext` implementation that uses `tracing` instead of `log` macros.
 ///
@@ -89,4 +90,57 @@ pub fn get_partitions<C: ClientContext>(
     }
 
     Ok(meta_topic.partitions().iter().map(|x| x.id()).collect())
+}
+
+/// A simpler version of [`create_new_client_config`] that defaults
+/// the `log_level` to `INFO` and should only be used in tests.
+pub fn create_new_client_config_simple() -> ClientConfig {
+    create_new_client_config(tracing::Level::INFO)
+}
+
+/// Build a new [`rdkafka`] [`ClientConfig`] with its `log_level` set correctly
+/// based on the passed through [`tracing::Level`]. This level should be
+/// determined for `target: "librdkafka"`.
+pub fn create_new_client_config(tracing_level: Level) -> ClientConfig {
+    #[allow(clippy::disallowed_methods)]
+    let mut config = ClientConfig::new();
+
+    let level = if tracing_level >= Level::DEBUG {
+        RDKafkaLogLevel::Debug
+    } else if tracing_level >= Level::INFO {
+        RDKafkaLogLevel::Info
+    } else if tracing_level >= Level::WARN {
+        RDKafkaLogLevel::Warning
+    } else {
+        RDKafkaLogLevel::Error
+    };
+    // WARNING WARNING WARNING
+    //
+    // For whatever reason, if you change this `target` to something else, this
+    // log line might break. I (guswynn) did some extensive investigation with
+    // the tracing folks, and we learned that this edge case only happens with
+    // 1. a different target
+    // 2. only this file (so far as I can tell)
+    // 3. only in certain subscriber combinations
+    // 4. only if the `tracing-log` feature is on.
+    //
+    // Our conclusion was that one of our dependencies is doing something
+    // problematic with `log`.
+    //
+    // For now, this works, and prints a nice log line exactly when we want it.
+    //
+    // TODO(guswynn): when we can remove `tracing-log`, remove this warning
+    tracing::debug!(target: "librdkafka", level = ?level, "Determined log level for librdkafka");
+    config.set_log_level(level);
+
+    // Patch the librdkafka debug log system into the Rust `log` ecosystem. This
+    // is a very simple integration at the moment; enabling `debug`-level logs
+    // for the `librdkafka` target enables the full firehouse of librdkafka
+    // debug logs. We may want to investigate finer-grained control.
+    if tracing_level >= Level::DEBUG {
+        tracing::debug!(target: "librdkafka", "Enabling debug logs for rdkafka");
+        config.set("debug", "all");
+    }
+
+    config
 }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -49,7 +49,7 @@ use uuid::Uuid;
 use materialized::{
     OrchestratorBackend, OrchestratorConfig, SecretsControllerConfig, TlsConfig, TlsMode,
 };
-use mz_dataflow_types::sources::AwsExternalId;
+use mz_dataflow_types::ConnectorContext;
 use mz_frontegg_auth::{FronteggAuthentication, FronteggConfig};
 use mz_orchestrator_kubernetes::{KubernetesImagePullPolicy, KubernetesOrchestratorConfig};
 use mz_orchestrator_process::ProcessOrchestratorConfig;
@@ -472,7 +472,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     // handled by the custom panic handler.
     let metrics_registry = MetricsRegistry::new();
     runtime.block_on(mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
-        log_filter: args.log_filter,
+        log_filter: args.log_filter.clone(),
         opentelemetry_endpoint: args.opentelemetry_endpoint,
         opentelemetry_headers: args
             .opentelemetry_header
@@ -747,14 +747,11 @@ max log level: {max_log_level}",
         orchestrator,
         secrets_controller: Some(secrets_controller),
         experimental_mode: args.experimental,
-        aws_external_id: args
-            .aws_external_id
-            .map(AwsExternalId::ISwearThisCameFromACliArgOrEnvVariable)
-            .unwrap_or(AwsExternalId::NotProvided),
         metrics_registry,
         now: SYSTEM_TIME.clone(),
         replica_sizes,
         availability_zones: args.availability_zone,
+        connector_context: ConnectorContext::from_cli_args(&args.log_filter, args.aws_external_id),
     }))?;
 
     eprintln!(

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -25,7 +25,6 @@ use tokio::runtime::Runtime;
 use tower_http::cors::AllowOrigin;
 
 use materialized::{OrchestratorBackend, OrchestratorConfig, TlsMode};
-use mz_dataflow_types::sources::AwsExternalId;
 use mz_frontegg_auth::FronteggAuthentication;
 use mz_orchestrator_process::ProcessOrchestratorConfig;
 use mz_ore::id_gen::PortAllocator;
@@ -44,7 +43,6 @@ lazy_static! {
 #[derive(Clone)]
 pub struct Config {
     data_directory: Option<PathBuf>,
-    aws_external_id: AwsExternalId,
     logging_granularity: Option<Duration>,
     tls: Option<materialized::TlsConfig>,
     frontegg: Option<FronteggAuthentication>,
@@ -58,7 +56,6 @@ impl Default for Config {
     fn default() -> Config {
         Config {
             data_directory: None,
-            aws_external_id: AwsExternalId::NotProvided,
             logging_granularity: Some(Duration::from_secs(1)),
             tls: None,
             frontegg: None,
@@ -164,7 +161,6 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             linger: false,
         },
         secrets_controller: None,
-        aws_external_id: config.aws_external_id,
         listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         tls: config.tls,
         frontegg: config.frontegg,
@@ -175,6 +171,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         cors_allowed_origin: AllowOrigin::list([]),
         replica_sizes: Default::default(),
         availability_zones: Default::default(),
+        connector_context: Default::default(),
     }))?;
     let server = Server {
         inner,

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -54,6 +54,7 @@ pub mod now;
 pub mod option;
 pub mod panic;
 pub mod path;
+#[cfg_attr(nightly_doc_features, doc(cfg(feature = "process")))]
 pub mod result;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "network")))]
 #[cfg(feature = "network")]

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -19,7 +19,7 @@ use opentelemetry::sdk::{trace, Resource};
 use opentelemetry::KeyValue;
 use tonic::metadata::MetadataMap;
 use tonic::transport::Endpoint;
-use tracing::{Event, Subscriber};
+use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::filter::{LevelFilter, Targets};
 use tracing_subscriber::fmt::format::{format, Format, Writer};
 use tracing_subscriber::fmt::{self, FmtContext, FormatEvent, FormatFields};
@@ -145,6 +145,21 @@ pub async fn configure(config: TracingConfig) -> Result<(), anyhow::Error> {
     .await?;
 
     Ok(())
+}
+
+/// Returns the level of a specific target from a [`Targets`].
+pub fn target_level(targets: &Targets, target: &str) -> Level {
+    if targets.would_enable(target, &Level::TRACE) {
+        Level::TRACE
+    } else if targets.would_enable(target, &Level::DEBUG) {
+        Level::DEBUG
+    } else if targets.would_enable(target, &Level::INFO) {
+        Level::INFO
+    } else if targets.would_enable(target, &Level::WARN) {
+        Level::WARN
+    } else {
+        Level::ERROR
+    }
 }
 
 /// A wrapper around a `tracing_subscriber` `Format` that

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -19,10 +19,10 @@ use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc, MIN_DATETIME};
 use lazy_static::lazy_static;
-use mz_dataflow_types::sources::{AwsExternalId, SourceConnector};
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_dataflow_types::client::ComputeInstanceId;
+use mz_dataflow_types::sources::SourceConnector;
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
@@ -207,8 +207,6 @@ pub struct CatalogConfig {
     pub experimental_mode: bool,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
-    /// An external ID to be supplied to all AWS AssumeRole operations.
-    pub aws_external_id: AwsExternalId,
     /// Default timestamp frequency for CREATE SOURCE
     pub timestamp_frequency: Duration,
     /// Function that returns a wall clock now time; can safely be mocked to return
@@ -602,7 +600,6 @@ lazy_static! {
         session_id: Uuid::from_u128(0),
         experimental_mode: true,
         build_info: &DUMMY_BUILD_INFO,
-        aws_external_id: AwsExternalId::NotProvided,
         timestamp_frequency: Duration::from_secs(1),
         now: NOW_ZERO.clone(),
     };

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail};
 
-use mz_kafka_util::client::MzClientContext;
+use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::task;
 use rdkafka::client::ClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
@@ -204,8 +204,9 @@ pub async fn create_consumer(
     broker: &str,
     topic: &str,
     options: &BTreeMap<String, String>,
+    librdkafka_log_level: tracing::Level,
 ) -> Result<Arc<BaseConsumer<KafkaErrCheckContext>>, anyhow::Error> {
-    let mut config = rdkafka::ClientConfig::new();
+    let mut config = create_new_client_config(librdkafka_log_level);
     config.set("bootstrap.servers", broker);
     for (k, v) in options {
         config.set(k, v);

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 use anyhow::{bail, Context};
 use itertools::Itertools;
 
-use mz_dataflow_types::sources::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
+use mz_dataflow_types::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
 use mz_repr::ColumnName;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -23,7 +23,7 @@ use crate::DEFAULT_SCHEMA;
 use chrono::MIN_DATETIME;
 use lazy_static::lazy_static;
 use mz_build_info::DUMMY_BUILD_INFO;
-use mz_dataflow_types::sources::{AwsExternalId, SourceConnector};
+use mz_dataflow_types::sources::SourceConnector;
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
@@ -42,7 +42,6 @@ lazy_static! {
         session_id: Uuid::from_u128(0),
         experimental_mode: false,
         build_info: &DUMMY_BUILD_INFO,
-        aws_external_id: AwsExternalId::NotProvided,
         timestamp_frequency: Duration::from_secs(1),
         now: NOW_ZERO.clone(),
     };

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -32,5 +32,6 @@ time = "0.3.9"
 tokio = "1.18.2"
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
 tower-http = { version = "0.3.3", features = ["cors"] }
+tracing = "0.1.34"
 uuid = "1.0.0"
 walkdir = "2.3.2"

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -57,7 +57,6 @@ use tower_http::cors::AllowOrigin;
 use uuid::Uuid;
 
 use materialized::{OrchestratorBackend, OrchestratorConfig};
-use mz_dataflow_types::sources::AwsExternalId;
 use mz_orchestrator_process::ProcessOrchestratorConfig;
 use mz_ore::id_gen::PortAllocator;
 use mz_ore::metrics::MetricsRegistry;
@@ -579,7 +578,6 @@ impl Runner {
                 linger: false,
             },
             secrets_controller: None,
-            aws_external_id: AwsExternalId::NotProvided,
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             tls: None,
             frontegg: None,
@@ -590,6 +588,7 @@ impl Runner {
             now: SYSTEM_TIME.clone(),
             replica_sizes: Default::default(),
             availability_zones: Default::default(),
+            connector_context: Default::default(),
         };
         let server = materialized::serve(mz_config).await?;
         let client = connect(&server).await;

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -138,7 +138,6 @@ pub fn build_storage_dataflow<A: Allocate, B: StorageCapture>(
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Source dataflow: {debug_name}");
-
     timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
         // The scope.clone() occurs to allow import in the region.
         // We build a region here to establish a pattern of a scope inside the dataflow,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -271,7 +271,6 @@ where
                 base_metrics: &storage_state.source_metrics,
                 storage_metadata,
                 as_of: as_of_frontier.clone(),
-                aws_external_id: storage_state.aws_external_id.clone(),
             };
 
             // Pubnub and Postgres are `SimpleSource`s, so they produce _raw_ sources
@@ -307,7 +306,7 @@ where
                         let ((ok, err), cap) = source::create_raw_source::<_, KafkaSourceReader>(
                             base_source_config,
                             &connector,
-                            storage_state.aws_external_id.clone(),
+                            storage_state.connector_context.clone(),
                         );
                         ((SourceType::Delimited(ok), err), cap)
                     }
@@ -318,7 +317,7 @@ where
                         >(
                             base_source_config,
                             &connector,
-                            storage_state.aws_external_id.clone(),
+                            storage_state.connector_context.clone(),
                         );
                         ((SourceType::Delimited(ok), err), cap)
                     }
@@ -326,7 +325,7 @@ where
                         let ((ok, err), cap) = source::create_raw_source::<_, S3SourceReader>(
                             base_source_config,
                             &connector,
-                            storage_state.aws_external_id.clone(),
+                            storage_state.connector_context.clone(),
                         );
                         ((SourceType::ByteStream(ok), err), cap)
                     }
@@ -335,7 +334,7 @@ where
                         let ((ok, err), cap) = source::create_raw_source::<_, PubNubSourceReader>(
                             base_source_config,
                             &connector,
-                            storage_state.aws_external_id.clone(),
+                            storage_state.connector_context.clone(),
                         );
                         ((SourceType::Row(ok), err), cap)
                     }

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -21,7 +21,7 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 
 use mz_dataflow_types::client::{LocalClient, LocalStorageClient, StorageCommand, StorageResponse};
-use mz_dataflow_types::sources::AwsExternalId;
+use mz_dataflow_types::ConnectorContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 
@@ -44,8 +44,8 @@ pub struct Config {
     pub now: NowFn,
     /// Metrics registry through which dataflow metrics will be reported.
     pub metrics_registry: MetricsRegistry,
-    /// An external ID to use for all AWS AssumeRole operations.
-    pub aws_external_id: AwsExternalId,
+    /// Configuration for source and sink connectors.
+    pub connector_context: ConnectorContext,
 }
 
 /// A handle to a running dataflow server.
@@ -104,7 +104,6 @@ pub fn serve_boundary<SC: StorageCapture, B: Fn(usize) -> SC + Send + Sync + 'st
 
     let tokio_executor = tokio::runtime::Handle::current();
     let now = config.now;
-    let aws_external_id = config.aws_external_id.clone();
 
     let worker_guards = timely::execute::execute(config.timely_config, move |timely_worker| {
         let timely_worker_index = timely_worker.index();
@@ -137,9 +136,9 @@ pub fn serve_boundary<SC: StorageCapture, B: Fn(usize) -> SC + Send + Sync + 'st
                 last_bindings_feedback: Instant::now(),
                 now: now.clone(),
                 source_metrics,
-                aws_external_id: aws_external_id.clone(),
                 timely_worker_index,
                 timely_worker_peers,
+                connector_context: config.connector_context.clone(),
             },
             storage_boundary,
             storage_response_tx,

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -21,16 +21,15 @@ use prometheus::core::AtomicI64;
 use timely::scheduling::SyncActivator;
 use tracing::error;
 
-use mz_dataflow_types::sources::{
-    encoding::SourceDataEncoding, AwsExternalId, ExternalSourceConnector, KinesisSourceConnector,
-    MzOffset,
-};
-use mz_dataflow_types::SourceErrorDetails;
+use mz_dataflow_types::aws::AwsExternalId;
+use mz_dataflow_types::sources::encoding::SourceDataEncoding;
+use mz_dataflow_types::sources::{ExternalSourceConnector, KinesisSourceConnector, MzOffset};
+use mz_dataflow_types::{ConnectorContext, SourceErrorDetails};
 use mz_expr::PartitionId;
 use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 use mz_repr::GlobalId;
 
-use crate::source::metrics::{KinesisMetrics, SourceBaseMetrics};
+use crate::source::metrics::KinesisMetrics;
 use crate::source::{NextMessage, SourceMessage, SourceReader, SourceReaderError};
 
 /// To read all data from a Kinesis stream, we need to continually update
@@ -128,17 +127,21 @@ impl SourceReader for KinesisSourceReader {
         _worker_count: usize,
         _consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        aws_external_id: AwsExternalId,
         _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _encoding: SourceDataEncoding,
-        base_metrics: SourceBaseMetrics,
+        metrics: crate::source::metrics::SourceBaseMetrics,
+        connector_context: ConnectorContext,
     ) -> Result<Self, anyhow::Error> {
         let kc = match connector {
             ExternalSourceConnector::Kinesis(kc) => kc,
             _ => unreachable!(),
         };
 
-        let state = block_on(create_state(&base_metrics.kinesis, kc, aws_external_id));
+        let state = block_on(create_state(
+            &metrics.kinesis,
+            kc,
+            connector_context.aws_external_id.as_ref(),
+        ));
         match state {
             Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok(KinesisSourceReader {
                 kinesis_client,
@@ -148,7 +151,7 @@ impl SourceReader for KinesisSourceReader {
                 shard_set,
                 stream_name,
                 processed_message_count: 0,
-                base_metrics: base_metrics.kinesis,
+                base_metrics: metrics.kinesis,
             }),
             Err(e) => Err(anyhow!("{}", e)),
         }
@@ -263,7 +266,7 @@ impl SourceReader for KinesisSourceReader {
 async fn create_state(
     base_metrics: &KinesisMetrics,
     c: KinesisSourceConnector,
-    aws_external_id: AwsExternalId,
+    aws_external_id: Option<&AwsExternalId>,
 ) -> Result<
     (
         KinesisClient,

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -17,13 +17,11 @@ use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport, PubNub};
 use timely::scheduling::SyncActivator;
 use tracing::info;
 
-use mz_dataflow_types::sources::{
-    encoding::SourceDataEncoding, AwsExternalId, ExternalSourceConnector, MzOffset,
-};
+use mz_dataflow_types::sources::{encoding::SourceDataEncoding, ExternalSourceConnector, MzOffset};
+use mz_dataflow_types::ConnectorContext;
 use mz_expr::PartitionId;
 use mz_repr::{Datum, GlobalId, Row};
 
-use super::metrics::SourceBaseMetrics;
 use crate::source::{SourceMessage, SourceReader, SourceReaderError};
 
 /// Information required to sync data from PubNub
@@ -45,10 +43,10 @@ impl SourceReader for PubNubSourceReader {
         _worker_count: usize,
         _consumer_activator: SyncActivator,
         connector: ExternalSourceConnector,
-        _aws_external_id: AwsExternalId,
         _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _encoding: SourceDataEncoding,
-        _metrics: SourceBaseMetrics,
+        _: crate::source::metrics::SourceBaseMetrics,
+        _: ConnectorContext,
     ) -> Result<Self, anyhow::Error> {
         let pubnub_conn = match connector {
             ExternalSourceConnector::PubNub(pubnub_conn) => pubnub_conn,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -25,8 +25,8 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 
 use mz_dataflow_types::client::{RenderSourcesCommand, StorageCommand, StorageResponse};
-use mz_dataflow_types::sources::AwsExternalId;
 use mz_dataflow_types::sources::{ExternalSourceConnector, SourceConnector};
+use mz_dataflow_types::ConnectorContext;
 use mz_ore::now::NowFn;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 
@@ -75,12 +75,12 @@ pub struct StorageState {
     pub now: NowFn,
     /// Metrics for the source-specific side of dataflows.
     pub source_metrics: SourceBaseMetrics,
-    /// An external ID to use for all AWS AssumeRole operations.
-    pub aws_external_id: AwsExternalId,
     /// Index of the associated timely dataflow worker.
     pub timely_worker_index: usize,
     /// Peers in the associated timely dataflow worker.
     pub timely_worker_peers: usize,
+    /// Configuration for source and sink connectors.
+    pub connector_context: ConnectorContext,
 }
 
 /// State about a single table.

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::env;
 use std::fmt;
 use std::path::PathBuf;
 use std::process;
@@ -25,7 +26,7 @@ use tracing_subscriber::filter::Targets;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::{GenericClient, StorageClient};
-use mz_dataflow_types::sources::AwsExternalId;
+use mz_dataflow_types::ConnectorContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_pid_file::PidFile;
@@ -178,10 +179,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         experimental_mode: false,
         metrics_registry: MetricsRegistry::new(),
         now: SYSTEM_TIME.clone(),
-        aws_external_id: args
-            .aws_external_id
-            .map(AwsExternalId::ISwearThisCameFromACliArgOrEnvVariable)
-            .unwrap_or(AwsExternalId::NotProvided),
+        connector_context: ConnectorContext::from_cli_args(&args.log_filter, args.aws_external_id),
     };
 
     let serve_config = ServeConfig {

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use mz_coord::catalog::{Catalog, ConnCatalog};
 use mz_coord::session::Session;
-use mz_kafka_util::client::MzClientContext;
+use mz_kafka_util::client::{create_new_client_config_simple, MzClientContext};
 use mz_ore::now::NOW_ZERO;
 use rand::Rng;
 use rdkafka::ClientConfig;
@@ -795,7 +795,7 @@ pub async fn create_state(
         use rdkafka::admin::{AdminClient, AdminOptions};
         use rdkafka::producer::FutureProducer;
 
-        let mut kafka_config = ClientConfig::new();
+        let mut kafka_config = create_new_client_config_simple();
         kafka_config.set("bootstrap.servers", &config.kafka_addr);
         kafka_config.set("group.id", "materialize-testdrive");
         kafka_config.set("auto.offset.reset", "earliest");

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -13,11 +13,10 @@ use std::time::Duration;
 
 use anyhow::Context;
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, TopicReplication};
-use rdkafka::config::ClientConfig;
 use rdkafka::error::KafkaError;
 use rdkafka::producer::{DeliveryFuture, FutureProducer, FutureRecord};
 
-use mz_kafka_util::client::MzClientContext;
+use mz_kafka_util::client::{create_new_client_config_simple, MzClientContext};
 
 pub struct KafkaClient {
     producer: FutureProducer<MzClientContext>,
@@ -30,7 +29,7 @@ impl KafkaClient {
         group_id: &str,
         configs: &[(&str, &str)],
     ) -> Result<KafkaClient, anyhow::Error> {
-        let mut config = ClientConfig::new();
+        let mut config = create_new_client_config_simple();
         config.set("bootstrap.servers", kafka_url);
         config.set("group.id", group_id);
         for (key, val) in configs {
@@ -53,7 +52,7 @@ impl KafkaClient {
         configs: &[(&str, &str)],
         timeout: Option<Duration>,
     ) -> Result<(), anyhow::Error> {
-        let mut config = ClientConfig::new();
+        let mut config = create_new_client_config_simple();
         config.set("bootstrap.servers", &self.kafka_url);
 
         let client = config


### PR DESCRIPTION
This is a retooling of #10875 to be as targeted (heh) as possible. Changes from that PR include:

  * Renaming `librdkafka_debug` to `librdkafka_log_level` everywhere, to reflect that the type is now a log level rather than a `bool`.
  * Removal of most changes in src/compute, to avoid needing the compute team's sign off. Only the sink code is touched now, which is meant to be in the storage layer anyway.
  * A single `ConnectorContext` is plumbed throughout the codebase, rather than the coordinator/storage layers using separate context types. I believe the fundamental abstraction here is this `ConnectorContext`. There is a bag of connector-specific options that is configured via CLI parameters rather than `CREATE SOURCE` parameters; both the storage layer and the coordinator need to carry around this same bag, since they both instantiate connectors.

Supersedes #10875.
Fixes #10441.


### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
