### PR TITLE
coord: add missing SessionVar::end_transaction calls

### DIFF
--- a/src/coord/src/session/vars.rs
+++ b/src/coord/src/session/vars.rs
@@ -463,7 +463,7 @@ impl Vars {
             application_name,
             client_encoding: _,
             client_min_messages,
-            cluster: _,
+            cluster,
             database,
             date_style: _,
             extra_float_digits,
@@ -476,16 +476,18 @@ impl Vars {
             server_version_num: _,
             sql_safe_updates,
             standard_conforming_strings: _,
-            timezone: _,
+            timezone,
             transaction_isolation: _,
         } = self;
         application_name.end_transaction(action);
         client_min_messages.end_transaction(action);
+        cluster.end_transaction(action);
         database.end_transaction(action);
+        extra_float_digits.end_transaction(action);
         qgm_optimizations.end_transaction(action);
         search_path.end_transaction(action);
-        extra_float_digits.end_transaction(action);
         sql_safe_updates.end_transaction(action);
+        timezone.end_transaction(action);
     }
 
     /// Returns the value of the `application_name` configuration parameter.


### PR DESCRIPTION
This PR adds missing calls to `SessionVar::end_transaction`, as required to make `LOCAL` session variables behave correctly in transactions.

### Motivation

  * This PR fixes a previously unreported bug.

    The bug is reproduced by this SQL session:

    ```sql
    materialize=> SHOW CLUSTER;
     cluster
    ---------
     default
    (1 row)

    materialize=> BEGIN;
    BEGIN
    materialize=*> SET LOCAL CLUSTER = foo;
    SET 
    materialize=*> SHOW CLUSTER;
     cluster
    ---------
     foo
    (1 row)

    materialize=*> COMMIT;
    COMMIT
    materialize=> SHOW CLUSTER;
     cluster
    ---------
     foo
    (1 row)
    ```

    The last `SHOW CLUSTER` should return `default`.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).