### PR TITLE
materialized: correct persist consensus URL

### DIFF
--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -12,4 +12,4 @@
 set -euo pipefail
 
 pg_ctlcluster 14 materialize start
-exec materialized --listen-addr=0.0.0.0:6875 "$@"
+exec materialized --listen-addr=0.0.0.0:6875 --persist-consensus-url postgresql://materialize@%2Ftmp "$@"


### PR DESCRIPTION
In the Docker container, PostgreSQL uses /tmp as the Unix domain socket
directory rather than /var/lib/postgresql.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
