### PR TITLE
persist: use txns to implement PostgresConsensus

### DIFF
--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use tokio_postgres::types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
-use tokio_postgres::{Client as PostgresClient, NoTls};
+use tokio_postgres::{Client as PostgresClient, IsolationLevel, NoTls, Transaction};
 
 use mz_ore::task;
 
@@ -25,13 +25,18 @@ use crate::error::Error;
 use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
 
 const SCHEMA: &str = "
-SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE;
-
-CREATE TABLE IF NOT EXISTS consensus (
+CREATE TABLE IF NOT EXISTS tail (
     shard text NOT NULL,
     sequence_number bigint NOT NULL,
     data bytea NOT NULL,
     PRIMARY KEY(shard, sequence_number)
+);
+
+CREATE TABLE IF NOT EXISTS head (
+    shard text NOT NULL,
+    sequence_number bigint NOT NULL,
+    data bytea NOT NULL,
+    PRIMARY KEY(shard)
 );
 ";
 
@@ -143,6 +148,35 @@ impl PostgresConsensus {
             _handle: handle,
         })
     }
+
+    async fn tx<'a>(
+        &self,
+        client: &'a mut PostgresClient,
+    ) -> Result<Transaction<'a>, ExternalError> {
+        let tx = client
+            .build_transaction()
+            .isolation_level(IsolationLevel::Serializable)
+            .start()
+            .await?;
+        Ok(tx)
+    }
+
+    async fn head_tx(
+        &self,
+        tx: &Transaction<'_>,
+        key: &str,
+    ) -> Result<Option<VersionedData>, ExternalError> {
+        let q = "SELECT sequence_number, data FROM head WHERE shard = $1";
+
+        let row = match tx.query_opt(q, &[&key]).await? {
+            Some(row) => row,
+            None => return Ok(None),
+        };
+
+        let seqno: SeqNo = row.try_get("sequence_number")?;
+        let data: Vec<u8> = row.try_get("data")?;
+        Ok(Some(VersionedData { seqno, data }))
+    }
 }
 
 #[async_trait]
@@ -153,86 +187,60 @@ impl Consensus for PostgresConsensus {
         key: &str,
     ) -> Result<Option<VersionedData>, ExternalError> {
         // TODO: properly use the deadline argument.
-
-        let q = "SELECT sequence_number, data FROM consensus
-             WHERE shard = $1 ORDER BY sequence_number DESC LIMIT 1";
-        let client = self.client.lock().await;
-        let row = client.query_opt(&*q, &[&key]).await?;
-        let row = match row {
-            None => return Ok(None),
-            Some(row) => row,
-        };
-
-        let seqno: SeqNo = row.try_get("sequence_number")?;
-
-        let data: Vec<u8> = row.try_get("data")?;
-        Ok(Some(VersionedData { seqno, data }))
+        let mut client = self.client.lock().await;
+        let tx = self.tx(&mut client).await?;
+        let ret = self.head_tx(&tx, key).await?;
+        tx.commit().await?;
+        Ok(ret)
     }
 
     async fn compare_and_set(
         &self,
-        deadline: Instant,
+        _deadline: Instant,
         key: &str,
-        expected: Option<SeqNo>,
+        expected_seqno: Option<SeqNo>,
         new: VersionedData,
     ) -> Result<Result<(), Option<VersionedData>>, ExternalError> {
         // TODO: properly use the deadline argument.
-
-        if let Some(expected) = expected {
+        if let Some(expected) = expected_seqno {
             if new.seqno <= expected {
                 return Err(Error::from(
                         format!("new seqno must be strictly greater than expected. Got new: {:?} expected: {:?}",
                                  new.seqno, expected)).into());
             }
         }
+        let mut client = self.client.lock().await;
+        let tx = self.tx(&mut client).await?;
 
-        let result = if let Some(expected) = expected {
-            // Only insert the new row if:
-            // - sequence number expected is already present
-            // - expected corresponds to the most recent sequence number
-            //   i.e. there is no other sequence number > expected already
-            //   present.
-            //
-            // This query has also been written to execute within a single
-            // network round-trip (instead of a slightly simpler implementation
-            // that would call `BEGIN` and have multiple `SELECT` queries).
-            let q = "INSERT INTO consensus SELECT $1, $2, $3 WHERE
-                     EXISTS (
-                        SELECT * FROM consensus WHERE shard = $1 AND sequence_number = $4
-                     )
-                     AND NOT EXISTS (
-                         SELECT * FROM consensus WHERE shard = $1 AND sequence_number > $4
-                     )
-                     ON CONFLICT DO NOTHING";
-
-            let client = self.client.lock().await;
-
-            client
-                .execute(&*q, &[&key, &new.seqno, &new.data, &expected])
-                .await?
-        } else {
-            // Insert the new row as long as no other row exists for the same shard.
-            let q = "INSERT INTO consensus SELECT $1, $2, $3 WHERE
-                     NOT EXISTS (
-                         SELECT * FROM consensus WHERE shard = $1
-                     )
-                     ON CONFLICT DO NOTHING";
-            let client = self.client.lock().await;
-            client.execute(&*q, &[&key, &new.seqno, &new.data]).await?
+        let q = "DELETE FROM head WHERE shard = $1 RETURNING sequence_number, data";
+        let current_head = match tx.query_opt(q, &[&key]).await? {
+            Some(row) => {
+                let head = VersionedData {
+                    seqno: row.get(0),
+                    data: row.get(1),
+                };
+                Some(head)
+            }
+            None => None,
         };
 
-        if result == 1 {
-            Ok(Ok(()))
-        } else {
-            // It's safe to call head in a subsequent transaction rather than doing
-            // so directly in the same transaction because, once a given (seqno, data)
-            // pair exists for our shard, we enforce the invariants that
-            // 1. Our shard will always have _some_ data mapped to it.
-            // 2. All operations that modify the (seqno, data) can only increase
-            //    the sequence number.
-            let current = self.head(deadline, key).await?;
-            Ok(Err(current))
+        let current_seqno = current_head.as_ref().map(|h| h.seqno);
+        if current_seqno != expected_seqno {
+            // The DELETE will be rolled back since the transaction won't commit
+            return Ok(Err(current_head));
         }
+
+        if let Some(head) = current_head {
+            let q = "INSERT INTO tail VALUES ($1, $2, $3)";
+            tx.execute(q, &[&key, &head.seqno, &head.data]).await?;
+        }
+
+        let q = "INSERT INTO head VALUES ($1, $2, $3)";
+        tx.execute(q, &[&key, &new.seqno, &new.data]).await?;
+
+        tx.commit().await?;
+
+        Ok(Ok(()))
     }
 
     async fn scan(
@@ -241,20 +249,20 @@ impl Consensus for PostgresConsensus {
         key: &str,
         from: SeqNo,
     ) -> Result<Vec<VersionedData>, ExternalError> {
+        let mut client = self.client.lock().await;
+        let tx = self.tx(&mut client).await?;
         // TODO: properly use the deadline argument.
-
-        let q = "SELECT sequence_number, data FROM consensus
-             WHERE shard = $1 AND sequence_number >= $2
-             ORDER BY sequence_number";
-        let client = self.client.lock().await;
-        let rows = client.query(&*q, &[&key, &from]).await?;
+        let q = "SELECT sequence_number, data FROM tail
+                 WHERE shard = $1 AND sequence_number >= $2
+                 ORDER BY sequence_number";
+        let rows = tx.query(q, &[&key, &from]).await?;
         let mut results = vec![];
-
         for row in rows {
-            let seqno: SeqNo = row.try_get("sequence_number")?;
-            let data: Vec<u8> = row.try_get("data")?;
+            let seqno: SeqNo = row.get("sequence_number");
+            let data: Vec<u8> = row.get("data");
             results.push(VersionedData { seqno, data });
         }
+        results.extend(self.head_tx(&tx, key).await?);
 
         if results.is_empty() {
             Err(ExternalError::from(anyhow!(
@@ -262,6 +270,7 @@ impl Consensus for PostgresConsensus {
                 from
             )))
         } else {
+            tx.commit().await?;
             Ok(results)
         }
     }


### PR DESCRIPTION
We originally did everything as single statements to save network
roundtrips to aurora. However, #12487 seems to be revealing that we're
not getting the ordering we expect out of Postgres (concretely, we seem
to be seeing stale results from `head`). Using transactions seem to help
this. We probably want to go back to something closer to the original
impl for production, but for M1 (and certainly for getting 12216
merged), this should be okay.

On a persist-benchmarking machine

    MZ_PERSIST_RECORD_COUNT_SMALL=64 MZ_PERSIST_RECORD_SIZE_BYTES_SMALL=1024 MZ_PERSIST_BATCH_MAX_COUNT_SMALL=8
    consensus/compare_and_set/postgres/64KiB
                            time:   [1.6464 ms 1.6597 ms 1.6806 ms]
                            thrpt:  [37.189 MiB/s 37.658 MiB/s 37.961 MiB/s]
    consensus/concurrent_compare_and_set/postgres/64KiB
                            time:   [15.539 ms 15.817 ms 16.212 ms]
                            thrpt:  [30.842 MiB/s 31.611 MiB/s 32.178 MiB/s]

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
