### PR TITLE
coord: don't warn on peek response for unknown peek

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -829,10 +829,9 @@ impl<S: Append + 'static> Coordinator<S> {
                     if uuids.is_empty() {
                         self.client_pending_peeks.remove(&conn_id);
                     }
-                } else if response != PeekResponse::Canceled {
-                    // Cancel is handled by handle_cancel, so do not need to log them here.
-                    warn!("Received a PeekResponse without a pending peek: {uuid}");
                 }
+                // Cancellation may cause us to receive responses for peeks no
+                // longer in `self.pending_peeks`, so we quietly ignore them.
             }
             ControllerResponse::TailResponse(sink_id, response) => {
                 // We use an `if let` here because the peek could have been canceled already.

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -427,7 +427,18 @@ where
             .await
             .map_err(ComputeError::from)
     }
+
     /// Cancels existing peek requests.
+    ///
+    /// Canceling a peek is best effort. The caller may see any of the following
+    /// after canceling a peek request:
+    ///
+    ///   * A `PeekResponse::Rows` indicating that the cancellation request did
+    ///    not take effect in time and the query succeeded.
+    ///
+    ///   * A `PeekResponse::Canceled` affirming that the peek was canceled.
+    ///
+    ///   * No `PeekResponse` at all.
     pub async fn cancel_peeks(&mut self, uuids: &BTreeSet<Uuid>) -> Result<(), ComputeError> {
         self.remove_peeks(uuids.iter().cloned()).await?;
         self.compute


### PR DESCRIPTION
This can legitimately happen if a peek response is canceled, as
cancellation does not guarantee that a `PeekResponse::Canceled` will not
be produced. Add some text to `cancel_peeks` about this situation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a nit reported in Slack.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
