### PR TITLE
optimization testing: update expr-test-util doc + test runner simplifications

### DIFF
--- a/src/expr-test-util/README.md
+++ b/src/expr-test-util/README.md
@@ -2,9 +2,11 @@
 
 ## Limitations
 
-`EvalError`s are not yet supported and thus scalar subqueries are not
-supported.
-https://github.com/MaterializeInc/materialize/issues/7657
+Inherits whatever limitations are in [repr-test-util](../repr-test-util), namely
+that support for different types of Datums is incomplete. Follow the
+documentation for
+[test_spec_to_row](https://dev.materialize.com/api/rust/repr_test_util/fn.test_spec_to_row.html)
+to see which types of Datums are currently supported.
 
 ## Syntax
 
@@ -34,6 +36,9 @@ The following variants of `MirRelationExpr` have non-standard syntax:
     <RelationType>
     )
     ```
+
+The `TestCatalog` has following commands.
+* `(defsource <name> <RelationType>)` - defines source `<name>` with schema `<RelationType>`
 
 ## Unit testing
 

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -23,6 +23,8 @@ use mz_ore::str::separated;
 use mz_repr::{ColumnType, GlobalId, RelationType, Row, ScalarType};
 use mz_repr_test_util::*;
 
+/// Contains the type information required to build a [MirRelationExpr] and
+/// all types it depends on.
 pub static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
     let mut rti = ReflectedTypeInfo::default();
     EvalError::add_to_reflected_type_info(&mut rti);
@@ -30,7 +32,7 @@ pub static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
     rti
 });
 
-/// Builds a `MirScalarExpr` from a string.
+/// Builds a [MirScalarExpr] from a string.
 ///
 /// See [mz_lowertest::to_json] for the syntax.
 pub fn build_scalar(s: &str) -> Result<MirScalarExpr, String> {
@@ -42,7 +44,7 @@ pub fn build_scalar(s: &str) -> Result<MirScalarExpr, String> {
     )
 }
 
-/// Builds a `MirRelationExpr` from a string.
+/// Builds a [MirRelationExpr] from a string.
 ///
 /// See [mz_lowertest::to_json] for the syntax.
 pub fn build_rel(s: &str, catalog: &TestCatalog) -> Result<MirRelationExpr, String> {
@@ -54,10 +56,10 @@ pub fn build_rel(s: &str, catalog: &TestCatalog) -> Result<MirRelationExpr, Stri
     )
 }
 
-/// Pretty-print the MirRelationExpr.
+/// Pretty-print the [MirRelationExpr].
 ///
 /// If format contains "types", then add types to the pretty-printed
-/// `MirRelationExpr`.
+/// [MirRelationExpr].
 pub fn generate_explanation(
     humanizer: &dyn ExprHumanizer,
     rel: &MirRelationExpr,
@@ -72,12 +74,12 @@ pub fn generate_explanation(
     explanation.to_string()
 }
 
-/// Turns the json version of a MirRelationExpr into the [mz_lowertest::to_json]
+/// Turns the json version of a [MirRelationExpr] into the [mz_lowertest::to_json]
 /// syntax.
 ///
 /// The return value is a tuple of:
-/// 1. The translated MirRelationExpr.
-/// 2. The commands to register sources referenced by the MirRelationExpr with
+/// 1. The translated [MirRelationExpr].
+/// 2. The commands to register sources referenced by the [MirRelationExpr] with
 ///    the test catalog.
 pub fn json_to_spec(rel_json: &str, catalog: &TestCatalog) -> (String, Vec<String>) {
     let mut ctx = MirRelationExprDeserializeContext::new(&catalog);
@@ -156,7 +158,7 @@ impl<'a> TestCatalog {
     /// Handles instructions to modify the catalog.
     ///
     /// Currently supported commands:
-    /// * `(defsource [types_of_cols] [[optional_sets_of_key_cols]])`
+    /// * `(defsource [types_of_cols] [[optional_sets_of_key_cols]])` -
     ///   insert a source into the catalog.
     pub fn handle_test_command(&mut self, spec: &str) -> Result<(), String> {
         let mut stream_iter = tokenize(spec)?.into_iter();
@@ -389,16 +391,16 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
     }
 }
 
-/// Extends the test case syntax to support `MirRelationExpr`s
+/// Extends the test case syntax to support [MirRelationExpr]s
 ///
 /// A new context should be created for the deserialization of each
-/// `MirRelationExpr` because the context stores state local to
-/// each `MirRelationExpr`.
+/// [MirRelationExpr] because the context stores state local to
+/// each [MirRelationExpr].
 ///
 /// Includes all the test case syntax extensions to support
-/// `MirScalarExpr`s.
+/// [MirScalarExpr]s.
 ///
-/// The following variants of `MirRelationExpr` have non-standard syntax:
+/// The following variants of [MirRelationExpr] have non-standard syntax:
 /// Let -> the syntax is `(let x <value> <body>)` where x is an ident that
 ///        should not match any existing ident in any Let statement in
 ///        `<value>`.

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -11,9 +11,11 @@ mod test {
     use mz_expr::canonicalize::{canonicalize_equivalences, canonicalize_predicates};
     use mz_expr::{MapFilterProject, MirScalarExpr};
     use mz_expr_test_util::*;
-    use mz_lowertest::{deserialize, tokenize};
+    use mz_lowertest::{deserialize, deserialize_optional, tokenize, MzReflect, ReflectedTypeInfo};
     use mz_ore::str::separated;
     use mz_repr::RelationType;
+
+    use serde::{Deserialize, Serialize};
 
     fn reduce(s: &str) -> Result<MirScalarExpr, String> {
         let mut input_stream = tokenize(&s)?.into_iter();
@@ -63,35 +65,35 @@ mod test {
         }
     }
 
+    #[derive(Deserialize, Serialize, MzReflect)]
+    enum MFPTestCommand {
+        Map(Vec<MirScalarExpr>),
+        Filter(Vec<MirScalarExpr>),
+        Project(Vec<usize>),
+        Optimize,
+    }
+
     /// Builds a [MapFilterProject] of a certain arity, then modifies it.
     /// The test syntax is `<input_arity> [<commands>]`
     /// The syntax for a command is `<name_of_command> [<args>]`
     fn test_mfp(s: &str) -> Result<MapFilterProject, String> {
         let mut input_stream = tokenize(&s)?.into_iter();
         let mut ctx = MirScalarExprDeserializeContext::default();
+        let mut rti = ReflectedTypeInfo::default();
         let input_arity: usize = deserialize(&mut input_stream, "usize", &RTI, &mut ctx)?;
         let mut mfp = MapFilterProject::new(input_arity);
-        while let Some(proc_macro2::TokenTree::Ident(ident)) = input_stream.next() {
-            match &ident.to_string()[..] {
-                "map" => {
-                    let map: Vec<MirScalarExpr> =
-                        deserialize(&mut input_stream, "Vec<MirScalarExpr>", &RTI, &mut ctx)?;
-                    mfp = mfp.map(map);
-                }
-                "filter" => {
-                    let filter: Vec<MirScalarExpr> =
-                        deserialize(&mut input_stream, "Vec<MirScalarExpr>", &RTI, &mut ctx)?;
-                    mfp = mfp.filter(filter);
-                }
-                "project" => {
-                    let project: Vec<usize> =
-                        deserialize(&mut input_stream, "Vec<usize>", &RTI, &mut ctx)?;
-                    mfp = mfp.project(project);
-                }
-                "optimize" => mfp.optimize(),
-                unsupported => {
-                    return Err(format!("Unsupport MFP command {}", unsupported));
-                }
+        MFPTestCommand::add_to_reflected_type_info(&mut rti);
+        while let Some(command) = deserialize_optional::<MFPTestCommand, _, _>(
+            &mut input_stream,
+            "MFPTestCommand",
+            &rti,
+            &mut ctx,
+        )? {
+            match command {
+                MFPTestCommand::Map(map) => mfp = mfp.map(map),
+                MFPTestCommand::Filter(filter) => mfp = mfp.filter(filter),
+                MFPTestCommand::Project(project) => mfp = mfp.project(project),
+                MFPTestCommand::Optimize => mfp.optimize(),
             }
         }
         Ok(mfp)

--- a/src/expr/tests/testdata/mfp
+++ b/src/expr/tests/testdata/mfp
@@ -8,13 +8,13 @@
 # by the Apache License, Version 2.0.
 
 # The syntax for an mfp test is `<input_arity> [<commands>]`
-# The syntax for a command is `<name_of_command> [<args>]`
+# The syntax for a command is `(<name_of_command> [<args>])`
 
 mfp
 1
-map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)]
-filter [(call_binary eq #2 3)]
-project [0 1 2]
+(map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)])
+(filter [(call_binary eq #2 3)])
+(project [0 1 2])
 optimize
 ----
 [(#0 + 1) (#1 + 1)]
@@ -23,9 +23,9 @@ optimize
 
 mfp
 1
-map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)]
-filter [(call_binary eq #2 3)]
-project [2]
+(map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)])
+(filter [(call_binary eq #2 3)])
+(project [2])
 optimize
 ----
 [((#0 + 1) + 1)]
@@ -34,9 +34,9 @@ optimize
 
 mfp
 1
-map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)]
-filter [(call_binary eq #1 3)]
-project [2]
+(map [(call_binary add_int64 #0 1) (call_binary add_int64 (call_binary add_int64 #0 1) 1)])
+(filter [(call_binary eq #1 3)])
+(project [2])
 optimize
 ----
 [(#0 + 1) (#1 + 1)]

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -320,7 +320,7 @@ impl RustType<ProtoColumnName> for ColumnName {
 /// });
 /// let desc = RelationDesc::new(relation_type, names);
 /// ```
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
 pub struct RelationDesc {
     typ: RelationType,
     names: Vec<ColumnName>,

--- a/src/sql/tests/querymodel/basic
+++ b/src/sql/tests/querymodel/basic
@@ -548,7 +548,7 @@ from (select false as a, null as b, null as c) x"
 }
 
 cat
-(defsource x ([int32 int64 int32] [[0] [1 2]]) [a b c])
+(defsource x (([int32 int64 int32] [[0] [1 2]]) [a b c]) )
 ----
 ok
 

--- a/src/sql/tests/querymodel/hirroundtrip
+++ b/src/sql/tests/querymodel/hirroundtrip
@@ -107,8 +107,8 @@ select x.a from (select true as a) x left join (select false as b) y on x.a;
 ----
 
 cat
-(defsource x [int32 int64 int32] [a b c])
-(defsource y [int32 int64 int32] [a b c])
+(defsource x ([int32 int64 int32] [a b c]))
+(defsource y ([int32 int64 int32] [a b c]))
 ----
 ok
 

--- a/src/sql/tests/querymodel/lowering
+++ b/src/sql/tests/querymodel/lowering
@@ -158,8 +158,8 @@ from (select 10 as a, 5 as b, 'world' as c, 'realm' as d) x
 ----
 
 cat
-(defsource x ([(int32 false) int64 int32] [[0]]) [a b c])
-(defsource y ([(int32 false) int32] [[0]]) [a b])
+(defsource x (([(int32 false) int64 int32] [[0]]) [a b c]))
+(defsource y (([(int32 false) int32] [[0]]) [a b]))
 ----
 ok
 

--- a/src/sql/tests/querymodel/rewrite/simplify_outer_joins
+++ b/src/sql/tests/querymodel/rewrite/simplify_outer_joins
@@ -8,9 +8,9 @@
 # by the Apache License, Version 2.0.
 
 cat
-(defsource x [int32 int32] [f1 f2])
-(defsource y [int32 int32 int32 int32] [f1 f2 f3 f4])
-(defsource z [int32 int32] [f1 f2])
+(defsource x ([int32 int32] [f1 f2]))
+(defsource y ([int32 int32 int32 int32] [f1 f2 f3 f4]))
+(defsource z ([int32 int32] [f1 f2]))
 ----
 ok
 


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Hide whitespace.

The first commit contains a long-overdue update to the description of the limitations of the expr-test-util crate. It also adds a comment to `expr-test-util::RTI` and turns a bunch of references to `Mir*Expr` to links.

Commits 2 through 4 are all attempts at making test runners in different places simpler. and can be rejected if reviewers do not think that the test runner has been simplified. 
* In Commit 2, the act of deserializing a `RelationType` plus a `Vec` of `ColumnNames` and then constructing a `RelationDesc` out of those two elements has been replaced with deserializing a `RelationDesc` directly. This results in the need for an additional pair of parentheses around the two elements. 
* Commit 3 replaces interpreting `TokenTree`s with deserializing a `MFPTestCommand`. This results in the need to add an additional pair of parentheses around each command. Personally, I think this change is fine since it allows each command to be visually separated from the one after.
* Commit 4 replaces interpreting `TokenTree`s with deserializing a `TestCatalogCommand`. There is no test syntax change. 

Commit 5 adds to the `lowertest` recommendations on testing. Commit 5 can be amended if any of commits 2-4 are rejected.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user-facing changes.