### PR TITLE
persist: remove libsqlite3_sys dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,7 +3617,6 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "lazy_static",
- "libsqlite3-sys",
  "md-5",
  "mz-build-info",
  "mz-ore",

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -47,7 +47,6 @@ openssl-sys = { version = "0.9.73", features = ["vendored"] }
 prost = "0.10.3"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rusqlite = { version = "0.27.0", features = ["bundled"] }
-libsqlite3-sys = { version = "0.24.2" }
 semver = "1.0.9"
 serde = { version = "1.0.137", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -18,8 +18,8 @@ use std::time::Instant;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use futures_executor::block_on;
-use libsqlite3_sys::ErrorCode;
 use mz_persist_types::Codec;
+use rusqlite::ffi::ErrorCode;
 use serde::{Deserialize, Serialize};
 use tokio_postgres::error::SqlState;
 use tracing::info;
@@ -226,7 +226,7 @@ impl From<std::io::Error> for ExternalError {
 impl From<rusqlite::Error> for ExternalError {
     fn from(x: rusqlite::Error) -> Self {
         let code = match x {
-            rusqlite::Error::SqliteFailure(libsqlite3_sys::Error { code, .. }, _) => code,
+            rusqlite::Error::SqliteFailure(rusqlite::ffi::Error { code, .. }, _) => code,
             _ => {
                 return ExternalError::Indeterminate(Indeterminate {
                     inner: anyhow::Error::new(x),


### PR DESCRIPTION
It's re-exported within rusqlite as rusqlite::ffi, but I didn't realize
that when I wrote this.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
