### PR TITLE
persist: work around PostgreSQL bug in concurrent CREATE TABLE

### DIFF
--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -25,6 +25,17 @@ use crate::error::Error;
 use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
 
 const SCHEMA: &str = "
+-- Obtain an advisory lock before attempting to create the schema. This is
+-- necessary to work around concurrency bugs in `CREATE TABLE IF NOT EXISTS`
+-- in PostgreSQL.
+--
+-- See: https://github.com/MaterializeInc/materialize/issues/12560
+-- See: https://www.postgresql.org/message-id/CA%2BTgmoZAdYVtwBfp1FL2sMZbiHCWT4UPrzRLNnX1Nb30Ku3-gg%40mail.gmail.com
+-- See: https://stackoverflow.com/a/29908840
+--
+-- The lock ID was randomly generated.
+SELECT pg_advisory_xact_lock(135664303235462630);
+
 CREATE TABLE IF NOT EXISTS consensus (
     shard text NOT NULL,
     sequence_number bigint NOT NULL,


### PR DESCRIPTION
`CREATE TABLE IF NOT EXISTS` in PostgreSQL does not properly handle
concurrency and occasionally fails with the error

  duplicate key value violates unique constraint "pg_type_typname_nsp_index

if two tables execute the same `CREATE TABLE IF NOT EXISTS` statement at
the same time.

See: https://github.com/MaterializeInc/materialize/issues/12560
See: https://www.postgresql.org/message-id/CA%2BTgmoZAdYVtwBfp1FL2sMZbiHCWT4UPrzRLNnX1Nb30Ku3-gg%40mail.gmail.com

This commit works around the issue using the suggestion from the first
link: using an advisory lock in the transaction that executes the
`CREATE TABLE` statement.

Fix #12561.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
