### PR TITLE
Enable replica-targeted SELECTs

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -43,7 +43,7 @@ use crate::sink::SinkBaseMetrics;
 /// This state is restricted to the COMPUTE state, the deterministic, idempotent work
 /// done between data ingress and egress.
 pub struct ComputeState {
-    /// The ID of the replica whis worker belongs to.
+    /// The ID of the replica this worker belongs to.
     pub replica_id: ReplicaId,
     /// The traces available for sharing across dataflows.
     pub traces: TraceManager,
@@ -169,9 +169,10 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                 }
             }
 
-            ComputeCommand::Peek { peek, on_replica } => {
+            ComputeCommand::Peek(peek) => {
                 // Only handle peeks that are not targeted at a different replica.
-                if on_replica.is_none() || on_replica == Some(self.compute_state.replica_id) {
+                let target = peek.target_replica;
+                if target.is_none() || target == Some(self.compute_state.replica_id) {
                     // Acquire a copy of the trace suitable for fulfilling the peek.
                     let mut trace_bundle = self.compute_state.traces.get(&peek.id).unwrap().clone();
                     let timestamp_frontier = Antichain::from_elem(peek.timestamp);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -24,7 +24,7 @@ use timely::progress::ChangeBatch;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::mpsc;
 
-use mz_dataflow_types::client::{ComputeCommand, ComputeResponse};
+use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, ReplicaId};
 use mz_dataflow_types::logging::LoggingConfig;
 use mz_dataflow_types::ConnectorContext;
 use mz_dataflow_types::{DataflowError, PeekResponse, TailResponse};
@@ -43,6 +43,8 @@ use crate::sink::SinkBaseMetrics;
 /// This state is restricted to the COMPUTE state, the deterministic, idempotent work
 /// done between data ingress and egress.
 pub struct ComputeState {
+    /// The ID of the replica whis worker belongs to.
+    pub replica_id: ReplicaId,
     /// The traces available for sharing across dataflows.
     pub traces: TraceManager,
     /// Tokens that should be dropped when a dataflow is dropped to clean up
@@ -85,7 +87,10 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
     /// Entrypoint for applying a compute command.
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         match cmd {
-            ComputeCommand::CreateInstance(logging) => {
+            ComputeCommand::CreateInstance {
+                replica_id: _,
+                logging,
+            } => {
                 if let Some(logging) = logging {
                     self.initialize_logging(&logging);
                 }
@@ -164,37 +169,37 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                 }
             }
 
-            ComputeCommand::Peek {
-                peek,
-                on_replica: _,
-            } => {
-                // Acquire a copy of the trace suitable for fulfilling the peek.
-                let mut trace_bundle = self.compute_state.traces.get(&peek.id).unwrap().clone();
-                let timestamp_frontier = Antichain::from_elem(peek.timestamp);
-                let empty_frontier = Antichain::new();
-                trace_bundle
-                    .oks_mut()
-                    .set_logical_compaction(timestamp_frontier.borrow());
-                trace_bundle
-                    .errs_mut()
-                    .set_logical_compaction(timestamp_frontier.borrow());
-                trace_bundle
-                    .oks_mut()
-                    .set_physical_compaction(empty_frontier.borrow());
-                trace_bundle
-                    .errs_mut()
-                    .set_physical_compaction(empty_frontier.borrow());
-                // Prepare a description of the peek work to do.
-                let mut peek = PendingPeek { peek, trace_bundle };
-                // Log the receipt of the peek.
-                if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
-                    logger.log(ComputeEvent::Peek(peek.as_log_event(), true));
-                }
-                // Attempt to fulfill the peek.
-                if let Some(response) = peek.seek_fulfillment(&mut Antichain::new()) {
-                    self.send_peek_response(peek, response);
-                } else {
-                    self.compute_state.pending_peeks.push(peek);
+            ComputeCommand::Peek { peek, on_replica } => {
+                // Only handle peeks that are not targeted at a different replica.
+                if on_replica.is_none() || on_replica == Some(self.compute_state.replica_id) {
+                    // Acquire a copy of the trace suitable for fulfilling the peek.
+                    let mut trace_bundle = self.compute_state.traces.get(&peek.id).unwrap().clone();
+                    let timestamp_frontier = Antichain::from_elem(peek.timestamp);
+                    let empty_frontier = Antichain::new();
+                    trace_bundle
+                        .oks_mut()
+                        .set_logical_compaction(timestamp_frontier.borrow());
+                    trace_bundle
+                        .errs_mut()
+                        .set_logical_compaction(timestamp_frontier.borrow());
+                    trace_bundle
+                        .oks_mut()
+                        .set_physical_compaction(empty_frontier.borrow());
+                    trace_bundle
+                        .errs_mut()
+                        .set_physical_compaction(empty_frontier.borrow());
+                    // Prepare a description of the peek work to do.
+                    let mut peek = PendingPeek { peek, trace_bundle };
+                    // Log the receipt of the peek.
+                    if let Some(logger) = self.compute_state.materialized_logger.as_mut() {
+                        logger.log(ComputeEvent::Peek(peek.as_log_event(), true));
+                    }
+                    // Attempt to fulfill the peek.
+                    if let Some(response) = peek.seek_fulfillment(&mut Antichain::new()) {
+                        self.send_peek_response(peek, response);
+                    } else {
+                        self.compute_state.pending_peeks.push(peek);
+                    }
                 }
             }
             ComputeCommand::CancelPeeks { uuids } => {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -164,7 +164,10 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
                 }
             }
 
-            ComputeCommand::Peek(peek) => {
+            ComputeCommand::Peek {
+                peek,
+                on_replica: _,
+            } => {
                 // Acquire a copy of the trace suitable for fulfilling the peek.
                 let mut trace_bundle = self.compute_state.traces.get(&peek.id).unwrap().clone();
                 let timestamp_frontier = Antichain::from_elem(peek.timestamp);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -87,11 +87,8 @@ impl<'a, A: Allocate, B: ComputeReplay> ActiveComputeState<'a, A, B> {
     /// Entrypoint for applying a compute command.
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         match cmd {
-            ComputeCommand::CreateInstance {
-                replica_id: _,
-                logging,
-            } => {
-                if let Some(logging) = logging {
+            ComputeCommand::CreateInstance(config) => {
+                if let Some(logging) = config.logging {
                     self.initialize_logging(&logging);
                 }
             }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -191,9 +191,9 @@ where
             for cmd in cmds {
                 let mut should_drop_compute = false;
                 match &cmd {
-                    ComputeCommand::CreateInstance { replica_id, .. } => {
+                    ComputeCommand::CreateInstance(config) => {
                         self.compute_state = Some(ComputeState {
-                            replica_id: *replica_id,
+                            replica_id: config.replica_id,
                             traces: TraceManager::new(
                                 self.metrics_bundle.1.clone(),
                                 self.timely_worker.index(),

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -191,8 +191,9 @@ where
             for cmd in cmds {
                 let mut should_drop_compute = false;
                 match &cmd {
-                    ComputeCommand::CreateInstance(_logging) => {
+                    ComputeCommand::CreateInstance { replica_id, .. } => {
                         self.compute_state = Some(ComputeState {
+                            replica_id: *replica_id,
                             traces: TraceManager::new(
                                 self.metrics_bundle.1.clone(),
                                 self.timely_worker.index(),

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3037,8 +3037,8 @@ impl<S: Append + 'static> Coordinator<S> {
             .catalog
             .resolve_compute_instance(session.vars().cluster())?;
 
-        let replica_name = session.vars().cluster_replica();
-        let replica_id = replica_name
+        let compute_replica_name = session.vars().cluster_replica();
+        let compute_replica = compute_replica_name
             .map(|name| {
                 compute_instance
                     .replica_id_by_name
@@ -3245,7 +3245,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 conn_id,
                 source.arity(),
                 compute_instance,
-                replica_id,
+                compute_replica,
             )
             .await?;
 
@@ -5073,7 +5073,7 @@ pub mod fast_path_peek {
             conn_id: u32,
             source_arity: usize,
             compute_instance: ComputeInstanceId,
-            replica_id: Option<ReplicaId>,
+            compute_replica: Option<ReplicaId>,
         ) -> Result<crate::ExecuteResponse, CoordError> {
             // If the dataflow optimizes to a constant expression, we can immediately return the result.
             if let Plan::Constant(rows) = fast_path {
@@ -5211,7 +5211,7 @@ pub mod fast_path_peek {
                     timestamp,
                     finishing.clone(),
                     map_filter_project,
-                    replica_id,
+                    compute_replica,
                 )
                 .await
                 .unwrap();

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -122,6 +122,11 @@ pub enum CoordError {
     /// The named parameter is unknown to the system.
     UnknownParameter(String),
     UnknownPreparedStatement(String),
+    /// The named cluster replica does not exist.
+    UnknownClusterReplica {
+        cluster_name: String,
+        replica_name: String,
+    },
     /// A generic error occurred.
     //
     // TODO(benesch): convert all those errors to structured errors.
@@ -366,6 +371,13 @@ impl fmt::Display for CoordError {
             CoordError::UnknownPreparedStatement(name) => {
                 write!(f, "prepared statement {} does not exist", name.quoted())
             }
+            CoordError::UnknownClusterReplica {
+                cluster_name,
+                replica_name,
+            } => write!(
+                f,
+                "cluster replica '{cluster_name}.{replica_name}' does not exist"
+            ),
             CoordError::MultiTableWriteTransaction => {
                 f.write_str("write transactions only support writes to a single table")
             }

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -33,7 +33,8 @@ message ProtoPeek {
 
 message ProtoComputeCommand {
     message ProtoCreateInstanceKind {
-        mz_dataflow_types.logging.ProtoLoggingConfig logging = 1;
+        int64 replica_id = 1;
+        mz_dataflow_types.logging.ProtoLoggingConfig logging = 2;
     }
 
     message ProtoCreateDataflowsKind {

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -22,6 +22,11 @@ import "google/protobuf/empty.proto";
 
 package mz_dataflow_types.client;
 
+message ProtoInstanceConfig {
+    int64 replica_id = 1;
+    mz_dataflow_types.logging.ProtoLoggingConfig logging = 2;
+}
+
 message ProtoPeek {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_repr.row.ProtoRow key = 2;
@@ -33,11 +38,6 @@ message ProtoPeek {
 }
 
 message ProtoComputeCommand {
-    message ProtoCreateInstance {
-        int64 replica_id = 1;
-        mz_dataflow_types.logging.ProtoLoggingConfig logging = 2;
-    }
-
     message ProtoCreateDataflows {
         repeated mz_dataflow_types.types.ProtoDataflowDescription dataflows = 1;
     }
@@ -56,7 +56,7 @@ message ProtoComputeCommand {
     }
 
     oneof kind {
-        ProtoCreateInstance create_instance = 1;
+        ProtoInstanceConfig create_instance = 1;
         google.protobuf.Empty drop_instance = 2;
         ProtoCreateDataflows create_dataflows = 3;
         ProtoAllowCompaction allow_compaction = 4;

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -29,15 +29,16 @@ message ProtoPeek {
     uint64 timestamp = 4;
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
+    optional int64 target_replica = 7;
 }
 
 message ProtoComputeCommand {
-    message ProtoCreateInstanceKind {
+    message ProtoCreateInstance {
         int64 replica_id = 1;
         mz_dataflow_types.logging.ProtoLoggingConfig logging = 2;
     }
 
-    message ProtoCreateDataflowsKind {
+    message ProtoCreateDataflows {
         repeated mz_dataflow_types.types.ProtoDataflowDescription dataflows = 1;
     }
 
@@ -46,26 +47,21 @@ message ProtoComputeCommand {
         mz_persist.gen.persist.ProtoU64Antichain frontier = 2;
     }
 
-    message ProtoAllowCompactionKind {
+    message ProtoAllowCompaction {
         repeated ProtoCompaction collections = 1;
     }
 
-    message ProtoPeekKind {
-        ProtoPeek peek = 1;
-        optional int64 on_replica = 2;
-    }
-
-    message ProtoCancelPeeksKind {
+    message ProtoCancelPeeks {
         repeated mz_repr.proto.ProtoU128 uuids = 1;
     }
 
     oneof kind {
-        ProtoCreateInstanceKind create_instance = 1;
+        ProtoCreateInstance create_instance = 1;
         google.protobuf.Empty drop_instance = 2;
-        ProtoCreateDataflowsKind create_dataflows = 3;
-        ProtoAllowCompactionKind allow_compaction = 4;
-        ProtoPeekKind peek = 5;
-        ProtoCancelPeeksKind cancel_peeks = 6;
+        ProtoCreateDataflows create_dataflows = 3;
+        ProtoAllowCompaction allow_compaction = 4;
+        ProtoPeek peek = 5;
+        ProtoCancelPeeks cancel_peeks = 6;
     }
 }
 

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -23,8 +23,8 @@ import "google/protobuf/empty.proto";
 package mz_dataflow_types.client;
 
 message ProtoInstanceConfig {
-    int64 replica_id = 1;
-    mz_dataflow_types.logging.ProtoLoggingConfig logging = 2;
+    mz_dataflow_types.logging.ProtoLoggingConfig logging = 1;
+    int64 replica_id = 2;
 }
 
 message ProtoPeek {

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -32,11 +32,11 @@ message ProtoPeek {
 }
 
 message ProtoComputeCommand {
-    message ProtoCreateInstance {
+    message ProtoCreateInstanceKind {
         mz_dataflow_types.logging.ProtoLoggingConfig logging = 1;
     }
 
-    message ProtoCreateDataflows {
+    message ProtoCreateDataflowsKind {
         repeated mz_dataflow_types.types.ProtoDataflowDescription dataflows = 1;
     }
 
@@ -45,21 +45,26 @@ message ProtoComputeCommand {
         mz_persist.gen.persist.ProtoU64Antichain frontier = 2;
     }
 
-    message ProtoAllowCompaction {
+    message ProtoAllowCompactionKind {
         repeated ProtoCompaction collections = 1;
     }
 
-    message ProtoCancelPeeks {
+    message ProtoPeekKind {
+        ProtoPeek peek = 1;
+        optional int64 on_replica = 2;
+    }
+
+    message ProtoCancelPeeksKind {
         repeated mz_repr.proto.ProtoU128 uuids = 1;
     }
 
     oneof kind {
-        ProtoCreateInstance create_instance = 1;
+        ProtoCreateInstanceKind create_instance = 1;
         google.protobuf.Empty drop_instance = 2;
-        ProtoCreateDataflows create_dataflows = 3;
-        ProtoAllowCompaction allow_compaction = 4;
-        ProtoPeek peek = 5;
-        ProtoCancelPeeks cancel_peeks = 6;
+        ProtoCreateDataflowsKind create_dataflows = 3;
+        ProtoAllowCompactionKind allow_compaction = 4;
+        ProtoPeekKind peek = 5;
+        ProtoCancelPeeksKind cancel_peeks = 6;
     }
 }
 

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -180,7 +180,6 @@ impl TryFrom<ProtoPeek> for Peek {
 pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Indicates the creation of an instance, and is the first command for its compute instance.
     CreateInstance(InstanceConfig),
-
     /// Indicates the termination of an instance, and is the last command for its compute instance.
     DropInstance,
 
@@ -202,7 +201,6 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
 
     /// Peek at an arrangement.
     Peek(Peek<T>),
-
     /// Cancel the peeks associated with the given `uuids`.
     CancelPeeks {
         /// The identifiers of the peek requests to cancel.

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 use crate::client::controller::storage::{StorageController, StorageError};
 use crate::client::replicated::ActiveReplication;
-use crate::client::{ComputeClient, ComputeCommand, ComputeInstanceId, ReplicaId};
+use crate::client::{ComputeClient, ComputeCommand, ComputeInstanceId, InstanceConfig, ReplicaId};
 use crate::client::{GenericClient, Peek};
 use crate::logging::LoggingConfig;
 use crate::{DataflowDescription, SourceInstanceDesc};
@@ -161,10 +161,10 @@ where
         }
         let mut client = crate::client::replicated::ActiveReplication::default();
         client
-            .send(ComputeCommand::CreateInstance {
+            .send(ComputeCommand::CreateInstance(InstanceConfig {
                 replica_id: Default::default(),
                 logging: logging.clone(),
-            })
+            }))
             .await?;
 
         Ok(Self {

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -145,10 +145,7 @@ impl<T> ComputeControllerState<T>
 where
     T: Timestamp + Lattice,
 {
-    pub(super) async fn new(
-        // client: ActiveReplication<Box<dyn ComputeClient<T>>, T>,
-        logging: &Option<LoggingConfig>,
-    ) -> Result<Self, anyhow::Error> {
+    pub(super) async fn new(logging: &Option<LoggingConfig>) -> Result<Self, anyhow::Error> {
         let mut collections = BTreeMap::default();
         if let Some(logging_config) = logging.as_ref() {
             for id in logging_config.log_identifiers() {
@@ -164,7 +161,10 @@ where
         }
         let mut client = crate::client::replicated::ActiveReplication::default();
         client
-            .send(ComputeCommand::CreateInstance(logging.clone()))
+            .send(ComputeCommand::CreateInstance {
+                replica_id: Default::default(),
+                logging: logging.clone(),
+            })
             .await?;
 
         Ok(Self {

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -389,7 +389,7 @@ where
     /// In particular, this method installs and removes upper frontier maintenance.
     pub fn observe_command(&mut self, command: &ComputeCommand<T>) {
         match command {
-            ComputeCommand::CreateInstance { .. } | ComputeCommand::DropInstance => {
+            ComputeCommand::CreateInstance(_) | ComputeCommand::DropInstance => {
                 self.reset();
             }
             _ => (),

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -389,7 +389,7 @@ where
     /// In particular, this method installs and removes upper frontier maintenance.
     pub fn observe_command(&mut self, command: &ComputeCommand<T>) {
         match command {
-            ComputeCommand::CreateInstance(_) | ComputeCommand::DropInstance => {
+            ComputeCommand::CreateInstance { .. } | ComputeCommand::DropInstance => {
                 self.reset();
             }
             _ => (),

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -396,8 +396,8 @@ where
 /// contain replica-specific fields that must be adjusted before sending.
 fn specialize_command<T>(command: &mut ComputeCommand<T>, replica_id: ReplicaId) {
     // Tell new instances their replica ID.
-    if let ComputeCommand::CreateInstance { replica_id: id, .. } = command {
-        *id = replica_id;
+    if let ComputeCommand::CreateInstance(config) = command {
+        config.replica_id = replica_id;
     }
 
     // Replace dataflow identifiers with new unique ids.

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -246,7 +246,7 @@ where
             self.last_command_count = self.history.reduce(&self.peeks);
         }
 
-        // Clone the command for each target replica.
+        // Clone the command for each active replica.
         for (id, (tx, _)) in self.replicas.iter_mut() {
             let mut command = cmd.clone();
             specialize_command(&mut command, *id);

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -31,10 +31,10 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use mz_repr::GlobalId;
 
-use super::PeekResponse;
 use super::ReplicaId;
 use super::{ComputeClient, GenericClient};
 use super::{ComputeCommand, ComputeResponse};
+use super::{Peek, PeekResponse};
 
 /// Spawns a task that repeatedly sends messages back and forth
 /// between a client and its owner, and return channels to communicate with it.
@@ -197,8 +197,8 @@ where
     async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         // Update our tracking of peek commands.
         match &cmd {
-            ComputeCommand::Peek { peek, .. } => {
-                self.peeks.insert(peek.uuid);
+            ComputeCommand::Peek(Peek { uuid, .. }) => {
+                self.peeks.insert(*uuid);
             }
             ComputeCommand::CancelPeeks { uuids } => {
                 // Canceled peeks should not be further responded to.

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -164,18 +164,26 @@ where
     async fn absorb_command(&mut self, command: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         use ComputeCommand::*;
         match command {
-            CreateInstance(config) => {
+            CreateInstance {
+                replica_id,
+                logging,
+            } => {
                 // TODO: Handle `logging` correctly when reconnecting. We currently assume that the
                 // logging config stays the same.
                 if !self.created {
-                    if let Some(logging) = &config {
+                    if let Some(logging) = &logging {
                         for id in logging.log_identifiers() {
                             if !self.uppers.contains_key(&id) {
                                 self.start_tracking(id);
                             }
                         }
                     }
-                    self.client.send(CreateInstance(config)).await?;
+                    self.client
+                        .send(CreateInstance {
+                            replica_id,
+                            logging,
+                        })
+                        .await?;
                     self.created = true;
                 }
                 Ok(())

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -164,26 +164,18 @@ where
     async fn absorb_command(&mut self, command: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         use ComputeCommand::*;
         match command {
-            CreateInstance {
-                replica_id,
-                logging,
-            } => {
-                // TODO: Handle `logging` correctly when reconnecting. We currently assume that the
-                // logging config stays the same.
+            CreateInstance(config) => {
+                // TODO: Handle `config.logging` correctly when reconnecting. We currently assume
+                // that the logging config stays the same.
                 if !self.created {
-                    if let Some(logging) = &logging {
+                    if let Some(logging) = &config.logging {
                         for id in logging.log_identifiers() {
                             if !self.uppers.contains_key(&id) {
                                 self.start_tracking(id);
                             }
                         }
                     }
-                    self.client
-                        .send(CreateInstance {
-                            replica_id,
-                            logging,
-                        })
-                        .await?;
+                    self.client.send(CreateInstance(config)).await?;
                     self.created = true;
                 }
                 Ok(())

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -222,9 +222,11 @@ where
                 }
                 self.client.send(AllowCompaction(frontiers)).await
             }
-            Peek(peek) => {
+            Peek { peek, on_replica } => {
                 self.peeks.insert(peek.uuid);
-                self.client.send(ComputeCommand::Peek(peek)).await
+                self.client
+                    .send(ComputeCommand::Peek { peek, on_replica })
+                    .await
             }
             CancelPeeks { uuids } => {
                 for uuid in &uuids {

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -230,11 +230,9 @@ where
                 }
                 self.client.send(AllowCompaction(frontiers)).await
             }
-            Peek { peek, on_replica } => {
+            Peek(peek) => {
                 self.peeks.insert(peek.uuid);
-                self.client
-                    .send(ComputeCommand::Peek { peek, on_replica })
-                    .await
+                self.client.send(ComputeCommand::Peek(peek)).await
             }
             CancelPeeks { uuids } => {
                 for uuid in &uuids {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -406,7 +406,7 @@ impl ErrorResponse {
             CoordError::UnknownParameter(_) => SqlState::UNDEFINED_OBJECT,
             CoordError::UnknownPreparedStatement(_) => SqlState::UNDEFINED_PSTATEMENT,
             CoordError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
-            CoordError::UnknownClusterReplica { .. } => SqlState::FEATURE_NOT_SUPPORTED,
+            CoordError::UnknownClusterReplica { .. } => SqlState::UNDEFINED_OBJECT,
             CoordError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unstructured(_) => SqlState::INTERNAL_ERROR,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -406,6 +406,7 @@ impl ErrorResponse {
             CoordError::UnknownParameter(_) => SqlState::UNDEFINED_OBJECT,
             CoordError::UnknownPreparedStatement(_) => SqlState::UNDEFINED_PSTATEMENT,
             CoordError::UnknownLoginRole(_) => SqlState::INVALID_AUTHORIZATION_SPECIFICATION,
+            CoordError::UnknownClusterReplica { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unstructured(_) => SqlState::INTERNAL_ERROR,

--- a/test/sqllogictest/select_target_replica.slt
+++ b/test/sqllogictest/select_target_replica.slt
@@ -19,6 +19,7 @@ statement ok
 CREATE CLUSTER test
   REPLICA replica_a (SIZE '1'),
   REPLICA replica_b (SIZE '2')
+  WITH INTROSPECTION GRANULARITY '50 milliseconds'
 
 statement ok
 SET cluster = test
@@ -38,6 +39,51 @@ a b
 query I
 SELECT * FROM mz_materializations
 ----
+
+# Verify that we are always hitting the same replica.
+# We check that the number of peeks in mz_peek_durations (which is a
+# replica-specific introspection source) increases by one with every query.
+# We sleep between checks to give dataflow logging time to catch up.
+
+query I
+SELECT mz_internal.mz_sleep(0.1)
+----
+NULL
+
+query I
+SELECT sum(count) FROM mz_peek_durations
+----
+2
+
+query I
+SELECT mz_internal.mz_sleep(0.1)
+----
+NULL
+
+query I
+SELECT sum(count) FROM mz_peek_durations
+----
+3
+
+query I
+SELECT mz_internal.mz_sleep(0.1)
+----
+NULL
+
+query I
+SELECT sum(count) FROM mz_peek_durations
+----
+4
+
+# Verify that we see no prior peeks when targeting another replica.
+
+statement ok
+SET cluster_replica = replica_b
+
+query I
+SELECT sum(count) FROM mz_peek_durations
+----
+NULL
 
 # Verify that targeting an unknown replica fails.
 

--- a/test/sqllogictest/select_target_replica.slt
+++ b/test/sqllogictest/select_target_replica.slt
@@ -1,0 +1,48 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+CREATE TABLE test (a TEXT, b TEXT)
+
+statement ok
+INSERT INTO test VALUES('a', 'b')
+
+statement ok
+CREATE CLUSTER test
+  REPLICA replica_a (SIZE '1'),
+  REPLICA replica_b (SIZE '2')
+
+statement ok
+SET cluster = test
+
+statement ok
+SET cluster_replica = replica_a
+
+# Verify that simple SELECTs work.
+
+query TT
+SELECT * FROM test
+----
+a b
+
+# Verify that SELECTs on introspection tables work.
+
+query I
+SELECT * FROM mz_materializations
+----
+
+# Verify that targeting an unknown replica fails.
+
+statement ok
+SET cluster_replica = unknown
+
+query error cluster replica 'test.unknown' does not exist
+SELECT * FROM test

--- a/test/sqllogictest/select_target_replica.slt
+++ b/test/sqllogictest/select_target_replica.slt
@@ -92,3 +92,8 @@ SET cluster_replica = unknown
 
 query error cluster replica 'test.unknown' does not exist
 SELECT * FROM test
+
+# Clean up.
+
+statement ok
+DROP CLUSTER test

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -14,6 +14,7 @@ application_name            ""              "Sets the application name to be rep
 client_encoding             UTF8            "Sets the client's character set encoding (PostgreSQL)."
 client_min_messages         notice          "Sets the message levels that are sent to the client (PostgreSQL)."
 cluster                     <CLUSTER_NAME>  "Sets the current cluster (Materialize)."
+cluster_replica             ""              "Sets a target cluster replica for SELECT queries (Materialize)."
 database                    materialize     "Sets the current database (CockroachDB)."
 extra_float_digits          3               "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
 failpoints                  ""              "Allows failpoints to be dynamically activated."


### PR DESCRIPTION
This PR adds the ability to target SELECT queries to specific replicas. This will be our means to reliably collect compute introspection data for M1.

### Usage

To query introspection data from a replica, set the `cluster` and `cluster_replica` session variables accordingly:

```sql
CREATE CLUSTER test
  REPLICA replica_a (SIZE '1'),
  REPLICA replica_b (SIZE '2');
SET cluster = test;
SET cluster_replica = replica_a;
SELECT * from mz_materializations;
```

Note that all subsequent SELECTs will target that specific replica only. To revert back to targeting the whole cluster, set `cluster_replica` to the empty string:

```sql
SET cluster_replica = '';
```

(Once we have #12551 this syntax will be replaced with `SET cluster_replica = DEFAULT` or `RESET cluster_replica`.)

### Cleanup

For cleanup of outstanding peeks that have their target replica dropped, we rely on the corresponding `CancelPeek` to be issued when the client stops waiting for the query result. This does not currently work for all cases: https://github.com/MaterializeInc/materialize/issues/12546.

### Motivation

  * This PR adds a known-desirable feature.

   #12520 

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add the `cluster_replica` SQL session variable, which, if set, selects the replica that should be the sole target of subsequent `SELECT` queries. This is useful for collecting replica-specific introspection data. 
