### PR TITLE
doc/developer: fix typo in guide-testing

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -160,7 +160,7 @@ made up for by a much faster execution.
 To add logging for tests, append `-vv`, e.g.:
 
 ```shell
-$ bin/sqllogictest [--release] -- test/TESTFILE.slt -vv
+$ bin/sqllogictest [--release] -vv -- test/sqllogictest/TESTFILE.slt
 ```
 
 There are currently three classes of sqllogictest files:


### PR DESCRIPTION
This PR corrects the position of the `-vv` flag in the example invocation of `bin/sqllogictest`.

### Motivation

* This PR improves developer docs.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).