### PR TITLE
doc/user: remove warning about CREATE INDEX being an advanced feature

### DIFF
--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -8,10 +8,6 @@ menu:
     parent: 'commands'
 ---
 
-{{< warning >}} This is an advanced feature. Running `CREATE MATERIALIZED VIEW` automatically
-creates an index which will eagerly materialize a view, so most users **will not**
-need to manually create indexes. {{< /warning >}}
-
 `CREATE INDEX` creates an in-memory index on a source or view.
 
 -   For materialized views, this creates additional indexes.


### PR DESCRIPTION
We shouldn't scare folks off from creating indexes. Doing so can be
essential for performance.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
