### PR TITLE
persist: add a handle to new Unreliable* impls

### DIFF
--- a/src/persist/src/golden_test.rs
+++ b/src/persist/src/golden_test.rs
@@ -170,7 +170,7 @@ fn current_state(reqs: &[Input]) -> Result<(PersistState, String), Error> {
     impl StartRuntime for GoldenStartRuntime {
         fn start_runtime(
             &mut self,
-            unreliable: crate::unreliable::UnreliableHandle,
+            unreliable: crate::unreliable::UnreliableHandleOld,
         ) -> Result<RuntimeClient, Error> {
             let blob = self.0.blob_no_reentrance()?;
             let blob = UnreliableBlob::from_handle(blob, unreliable);

--- a/src/persist/src/indexed/mod.rs
+++ b/src/persist/src/indexed/mod.rs
@@ -1424,7 +1424,7 @@ mod tests {
     use crate::indexed::snapshot::SnapshotExt;
     use crate::mem::{MemBlob, MemLog, MemRegistry};
     use crate::pfuture::PFuture;
-    use crate::unreliable::{UnreliableBlob, UnreliableHandle, UnreliableLog};
+    use crate::unreliable::{UnreliableBlob, UnreliableHandleOld, UnreliableLog};
 
     use super::*;
 
@@ -1463,7 +1463,7 @@ mod tests {
     }
 
     fn indexed_and_maintainer(
-        unreliable: UnreliableHandle,
+        unreliable: UnreliableHandleOld,
     ) -> Result<
         (
             Indexed<UnreliableLog<MemLog>, UnreliableBlob<MemBlob>>,
@@ -1599,7 +1599,7 @@ mod tests {
     }
 
     fn trace_compaction_setup(
-        unreliable: UnreliableHandle,
+        unreliable: UnreliableHandleOld,
     ) -> Result<
         (
             Indexed<UnreliableLog<MemLog>, UnreliableBlob<MemBlob>>,
@@ -1658,7 +1658,7 @@ mod tests {
     /// specifically for trace compaction requests.
     #[test]
     fn trace_compaction() -> Result<(), Error> {
-        let mut unreliable = UnreliableHandle::default();
+        let mut unreliable = UnreliableHandleOld::default();
         let (mut i, maintainer, id) = trace_compaction_setup(unreliable.clone())?;
 
         let reqs = i.step()?;
@@ -1749,7 +1749,7 @@ mod tests {
     /// request). This test is expected to panic when run with
     /// cfg!(debug_assertions).
     fn trace_compaction_unexpected_nonmatching_response() -> Result<(), Error> {
-        let unreliable = UnreliableHandle::default();
+        let unreliable = UnreliableHandleOld::default();
         let (mut i, maintainer, _) = trace_compaction_setup(unreliable)?;
 
         let reqs = i.step()?;
@@ -1772,7 +1772,7 @@ mod tests {
     /// no request is in flight for the given stream. This test is expected to panic when
     /// run with cfg!(debug_assertions).
     fn trace_compaction_unexpected_response() -> Result<(), Error> {
-        let unreliable = UnreliableHandle::default();
+        let unreliable = UnreliableHandleOld::default();
         let (mut i, maintainer, id) = trace_compaction_setup(unreliable)?;
 
         let reqs = i.step()?;
@@ -1797,7 +1797,7 @@ mod tests {
     /// even when no requests are in flight for that stream. This test is expected to
     /// panic when run with cfg!(debug_assertions).
     fn trace_compaction_unexpected_error_response() -> Result<(), Error> {
-        let unreliable = UnreliableHandle::default();
+        let unreliable = UnreliableHandleOld::default();
         let (mut i, _, id) = trace_compaction_setup(unreliable)?;
 
         let reqs = i.step()?;
@@ -2085,7 +2085,7 @@ mod tests {
             (("2".into(), "".into()), 1, 1),
         ];
 
-        let mut unreliable = UnreliableHandle::default();
+        let mut unreliable = UnreliableHandleOld::default();
         let mut i = MemRegistry::new().indexed_unreliable(unreliable.clone())?;
         let id = block_on(|res| i.register("0", "", "", res))?;
 

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -112,7 +112,7 @@ impl SeqNo {
 /// that the operation _definitely did NOT succeed_ (e.g. permission denied).
 #[derive(Debug)]
 pub struct Determinate {
-    inner: anyhow::Error,
+    pub(crate) inner: anyhow::Error,
 }
 
 impl std::fmt::Display for Determinate {
@@ -127,7 +127,7 @@ impl std::error::Error for Determinate {}
 /// that the operation _might have succeeded_ (e.g. timeout).
 #[derive(Debug)]
 pub struct Indeterminate {
-    inner: anyhow::Error,
+    pub(crate) inner: anyhow::Error,
 }
 
 impl std::fmt::Display for Indeterminate {

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -31,7 +31,7 @@ use crate::location::{
     VersionedData,
 };
 use crate::runtime::{self, RuntimeConfig};
-use crate::unreliable::{UnreliableBlob, UnreliableHandle, UnreliableLog};
+use crate::unreliable::{UnreliableBlob, UnreliableHandleOld, UnreliableLog};
 
 #[derive(Debug)]
 struct MemLogCore {
@@ -451,10 +451,10 @@ impl MemRegistry {
     }
 
     /// Returns a [RuntimeClient] with unreliable storage backed by the given
-    /// [`UnreliableHandle`].
+    /// [`UnreliableHandleOld`].
     pub fn indexed_unreliable(
         &mut self,
-        unreliable: UnreliableHandle,
+        unreliable: UnreliableHandleOld,
     ) -> Result<Indexed<UnreliableLog<MemLog>, UnreliableBlob<MemBlob>>, Error> {
         let log = self.log_no_reentrance()?;
         let log = UnreliableLog::from_handle(log, unreliable.clone());
@@ -488,10 +488,10 @@ impl MemRegistry {
     }
 
     /// Open a [RuntimeClient] with unreliable storage backed by the given
-    /// [`UnreliableHandle`].
+    /// [`UnreliableHandleOld`].
     pub fn runtime_unreliable(
         &mut self,
-        unreliable: UnreliableHandle,
+        unreliable: UnreliableHandleOld,
     ) -> Result<RuntimeClient, Error> {
         let log = self.log_no_reentrance()?;
         let log = UnreliableLog::from_handle(log, unreliable.clone());

--- a/src/persist/src/operators/source.rs
+++ b/src/persist/src/operators/source.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::error::Error;
     use crate::mem::MemRegistry;
     use crate::operators::split_ok_err;
-    use crate::unreliable::UnreliableHandle;
+    use crate::unreliable::UnreliableHandleOld;
 
     use super::*;
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn initial_error_handling() -> Result<(), Error> {
-        let mut unreliable = UnreliableHandle::default();
+        let mut unreliable = UnreliableHandleOld::default();
         let p = MemRegistry::new().runtime_unreliable(unreliable.clone())?;
         unreliable.make_unavailable();
         let (_, read) = p.create_or_load::<(), ()>("test_name");

--- a/src/persist/src/operators/stream.rs
+++ b/src/persist/src/operators/stream.rs
@@ -512,7 +512,7 @@ mod tests {
     use crate::error::Error;
     use crate::indexed::ListenEvent;
     use crate::mem::MemRegistry;
-    use crate::unreliable::UnreliableHandle;
+    use crate::unreliable::UnreliableHandleOld;
 
     use super::*;
 
@@ -626,7 +626,7 @@ mod tests {
     fn seal_frontier_advance_only_on_success() -> Result<(), Error> {
         mz_ore::test::init_logging();
         let mut registry = MemRegistry::new();
-        let mut unreliable = UnreliableHandle::default();
+        let mut unreliable = UnreliableHandleOld::default();
         let p = registry.runtime_unreliable(unreliable.clone())?;
 
         timely::execute_directly(move |worker| {
@@ -679,7 +679,7 @@ mod tests {
     fn regression_9419_seal_close() -> Result<(), Error> {
         mz_ore::test::init_logging();
         let mut registry = MemRegistry::new();
-        let mut unreliable = UnreliableHandle::default();
+        let mut unreliable = UnreliableHandleOld::default();
         let p = registry.runtime_unreliable(unreliable.clone())?;
 
         timely::execute_directly(move |worker| {

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -11,7 +11,7 @@
 
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Instant, UNIX_EPOCH};
 
 use async_trait::async_trait;
 use rand::prelude::SmallRng;
@@ -216,56 +216,100 @@ where
     }
 }
 
+#[derive(Debug)]
+struct UnreliableCore {
+    rng: SmallRng,
+    should_happen: f64,
+    should_timeout: f64,
+    // TODO: Delays, what else?
+}
+
+/// A handle for controlling the behavior of an unreliable delegate.
+#[derive(Clone, Debug)]
+pub struct UnreliableHandle {
+    core: Arc<Mutex<UnreliableCore>>,
+}
+
+impl Default for UnreliableHandle {
+    fn default() -> Self {
+        let seed = UNIX_EPOCH
+            .elapsed()
+            .map_or(0, |x| u64::from(x.subsec_nanos()));
+        Self::new(seed, 0.95, 0.05)
+    }
+}
+
+impl UnreliableHandle {
+    /// Returns a new [UnreliableHandle].
+    pub fn new(seed: u64, should_happen: f64, should_timeout: f64) -> Self {
+        assert!(should_happen >= 0.0);
+        assert!(should_happen <= 1.0);
+        assert!(should_timeout >= 0.0);
+        assert!(should_timeout <= 1.0);
+        let core = UnreliableCore {
+            rng: SmallRng::seed_from_u64(seed),
+            should_happen,
+            should_timeout,
+        };
+        UnreliableHandle {
+            core: Arc::new(Mutex::new(core)),
+        }
+    }
+
+    /// Cause all later calls to sometimes return an error.
+    pub fn partially_available(&self, should_happen: f64, should_timeout: f64) {
+        assert!(should_happen >= 0.0);
+        assert!(should_happen <= 1.0);
+        assert!(should_timeout >= 0.0);
+        assert!(should_timeout <= 1.0);
+        let mut core = self.core.lock().expect("mutex poisoned");
+        core.should_happen = should_happen;
+        core.should_timeout = should_timeout;
+    }
+
+    /// Cause all later calls to return an error.
+    pub fn totally_unavailable(&self) {
+        self.partially_available(0.0, 1.0);
+    }
+
+    /// Cause all later calls to succeed.
+    pub fn totally_available(&self) {
+        self.partially_available(1.0, 0.0);
+    }
+
+    fn should_happen(&self) -> bool {
+        let mut core = self.core.lock().expect("mutex poisoned");
+        let should_happen = core.should_happen;
+        core.rng.gen_bool(should_happen)
+    }
+
+    fn should_timeout(&self) -> bool {
+        let mut core = self.core.lock().expect("mutex poisoned");
+        let should_timeout = core.should_timeout;
+        core.rng.gen_bool(should_timeout)
+    }
+}
+
 /// An unreliable delegate to [BlobMulti].
 #[derive(Debug)]
 pub struct UnreliableBlobMulti {
-    rng: tokio::sync::Mutex<SmallRng>,
-    should_happen: f64,
-    should_timeout: f64,
+    handle: UnreliableHandle,
     blob: Arc<dyn BlobMulti + Send + Sync>,
 }
 
 impl UnreliableBlobMulti {
     /// Returns a new [UnreliableBlobMulti].
-    ///
-    /// TODO: Once we turn down the old persist API, return an
-    /// [UnreliableHandleOld] with the previous totally available or unavailable
-    /// behavior, plus the new partially available behavior
-    ///
-    /// TODO: Ditto the unreliability should be set via [UnreliableHandleOld].
-    pub fn new_from_seed(
-        seed: u64,
-        should_happen: f64,
-        should_timeout: f64,
-        blob: Arc<dyn BlobMulti + Send + Sync>,
-    ) -> Self {
-        assert!(should_happen >= 0.0);
-        assert!(should_happen <= 1.0);
-        assert!(should_timeout >= 0.0);
-        assert!(should_timeout <= 1.0);
-        UnreliableBlobMulti {
-            rng: tokio::sync::Mutex::new(SmallRng::seed_from_u64(seed)),
-            should_happen,
-            should_timeout,
-            blob,
-        }
-    }
-
-    async fn should_happen(&self) -> bool {
-        self.rng.lock().await.gen_bool(self.should_happen)
-    }
-
-    async fn should_timeout(&self) -> bool {
-        self.rng.lock().await.gen_bool(self.should_timeout)
+    pub fn new(blob: Arc<dyn BlobMulti + Send + Sync>, handle: UnreliableHandle) -> Self {
+        UnreliableBlobMulti { handle, blob }
     }
 }
 
 #[async_trait]
 impl BlobMulti for UnreliableBlobMulti {
     async fn get(&self, deadline: Instant, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.blob.get(deadline, key).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -273,9 +317,9 @@ impl BlobMulti for UnreliableBlobMulti {
     }
 
     async fn list_keys(&self, deadline: Instant) -> Result<Vec<String>, ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.blob.list_keys(deadline).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -289,9 +333,9 @@ impl BlobMulti for UnreliableBlobMulti {
         value: Vec<u8>,
         atomic: Atomicity,
     ) -> Result<(), ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.blob.set(deadline, key, value, atomic).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -299,9 +343,9 @@ impl BlobMulti for UnreliableBlobMulti {
     }
 
     async fn delete(&self, deadline: Instant, key: &str) -> Result<(), ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.blob.delete(deadline, key).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -312,44 +356,14 @@ impl BlobMulti for UnreliableBlobMulti {
 /// An unreliable delegate to [Consensus].
 #[derive(Debug)]
 pub struct UnreliableConsensus {
-    rng: tokio::sync::Mutex<SmallRng>,
-    should_happen: f64,
-    should_timeout: f64,
+    handle: UnreliableHandle,
     consensus: Arc<dyn Consensus + Send + Sync>,
 }
 
 impl UnreliableConsensus {
     /// Returns a new [UnreliableConsensus].
-    ///
-    /// TODO: Once we turn down the old persist API, return an
-    /// [UnreliableHandleOld] with the previous totally available or unavailable
-    /// behavior, plus the new partially available behavior
-    ///
-    /// TODO: Ditto the unreliability should be set via [UnreliableHandleOld].
-    pub fn new_from_seed(
-        seed: u64,
-        should_happen: f64,
-        should_timeout: f64,
-        consensus: Arc<dyn Consensus + Send + Sync>,
-    ) -> Self {
-        assert!(should_happen >= 0.0);
-        assert!(should_happen <= 1.0);
-        assert!(should_timeout >= 0.0);
-        assert!(should_timeout <= 1.0);
-        UnreliableConsensus {
-            rng: tokio::sync::Mutex::new(SmallRng::seed_from_u64(seed)),
-            should_happen,
-            should_timeout,
-            consensus,
-        }
-    }
-
-    async fn should_happen(&self) -> bool {
-        self.rng.lock().await.gen_bool(self.should_happen)
-    }
-
-    async fn should_timeout(&self) -> bool {
-        self.rng.lock().await.gen_bool(self.should_timeout)
+    pub fn new(consensus: Arc<dyn Consensus + Send + Sync>, handle: UnreliableHandle) -> Self {
+        UnreliableConsensus { consensus, handle }
     }
 }
 
@@ -360,9 +374,9 @@ impl Consensus for UnreliableConsensus {
         deadline: Instant,
         key: &str,
     ) -> Result<Option<VersionedData>, ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.consensus.head(deadline, key).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -376,12 +390,12 @@ impl Consensus for UnreliableConsensus {
         expected: Option<SeqNo>,
         new: VersionedData,
     ) -> Result<Result<(), Option<VersionedData>>, ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self
                 .consensus
                 .compare_and_set(deadline, key, expected, new)
                 .await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -394,9 +408,9 @@ impl Consensus for UnreliableConsensus {
         key: &str,
         from: SeqNo,
     ) -> Result<Vec<VersionedData>, ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.consensus.scan(deadline, key, from).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -409,9 +423,9 @@ impl Consensus for UnreliableConsensus {
         key: &str,
         seqno: SeqNo,
     ) -> Result<(), ExternalError> {
-        if self.should_happen().await {
+        if self.handle.should_happen() {
             let res = self.consensus.truncate(deadline, key, seqno).await;
-            if !self.should_timeout().await {
+            if !self.handle.should_timeout() {
                 return res;
             }
         }
@@ -421,8 +435,10 @@ impl Consensus for UnreliableConsensus {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::location::Atomicity::RequireAtomic;
-    use crate::mem::{MemBlob, MemLog};
+    use crate::mem::{MemBlob, MemBlobMulti, MemBlobMultiConfig, MemConsensus, MemLog};
 
     use super::*;
 
@@ -465,5 +481,70 @@ mod tests {
         handle.make_available();
         assert!(blob.set("a", b"3".to_vec(), RequireAtomic).await.is_ok());
         assert!(blob.get("a").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn unreliable_blob_multi() {
+        let blob = Arc::new(MemBlobMulti::open(MemBlobMultiConfig::default()))
+            as Arc<dyn BlobMulti + Send + Sync>;
+        let handle = UnreliableHandle::default();
+        let blob = UnreliableBlobMulti::new(blob, handle.clone());
+        let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
+
+        // Use a fixed seed so this test doesn't flake.
+        {
+            (*handle.core.lock().expect("mutex poisoned")).rng = SmallRng::seed_from_u64(0);
+        }
+
+        // By default, it's partially reliable.
+        let mut succeeded = 0;
+        for _ in 0..100 {
+            if blob.get(deadline, "a").await.is_ok() {
+                succeeded += 1;
+            }
+        }
+        // Intentionally have pretty loose bounds so this assertion doesn't
+        // become a maintenance burden if the rng impl changes.
+        assert!(succeeded > 50 && succeeded < 99, "succeeded={}", succeeded);
+
+        // Reliable doesn't error.
+        handle.totally_available();
+        assert!(blob.get(deadline, "a").await.is_ok());
+
+        // Unreliable does error.
+        handle.totally_unavailable();
+        assert!(blob.get(deadline, "a").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn unreliable_consensus() {
+        let consensus = Arc::new(MemConsensus::default()) as Arc<dyn Consensus + Send + Sync>;
+        let handle = UnreliableHandle::default();
+        let consensus = UnreliableConsensus::new(consensus, handle.clone());
+        let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
+
+        // Use a fixed seed so this test doesn't flake.
+        {
+            (*handle.core.lock().expect("mutex poisoned")).rng = SmallRng::seed_from_u64(0);
+        }
+
+        // By default, it's partially reliable.
+        let mut succeeded = 0;
+        for _ in 0..100 {
+            if consensus.head(deadline, "key").await.is_ok() {
+                succeeded += 1;
+            }
+        }
+        // Intentionally have pretty loose bounds so this assertion doesn't
+        // become a maintenance burden if the rng impl changes.
+        assert!(succeeded > 50 && succeeded < 99, "succeeded={}", succeeded);
+
+        // Reliable doesn't error.
+        handle.totally_available();
+        assert!(consensus.head(deadline, "key").await.is_ok());
+
+        // Unreliable does error.
+        handle.totally_unavailable();
+        assert!(consensus.head(deadline, "key").await.is_err());
     }
 }

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -24,26 +24,26 @@ use crate::location::{
 };
 
 #[derive(Debug)]
-struct UnreliableCore {
+struct UnreliableCoreOld {
     unavailable: bool,
     // TODO: Delays, what else?
 }
 
 /// A handle for controlling the behavior of an unreliable delegate.
 #[derive(Clone, Debug)]
-pub struct UnreliableHandle {
-    core: Arc<Mutex<UnreliableCore>>,
+pub struct UnreliableHandleOld {
+    core: Arc<Mutex<UnreliableCoreOld>>,
 }
 
-impl Default for UnreliableHandle {
+impl Default for UnreliableHandleOld {
     fn default() -> Self {
-        UnreliableHandle {
-            core: Arc::new(Mutex::new(UnreliableCore { unavailable: false })),
+        UnreliableHandleOld {
+            core: Arc::new(Mutex::new(UnreliableCoreOld { unavailable: false })),
         }
     }
 }
 
-impl UnreliableHandle {
+impl UnreliableHandleOld {
     fn check_unavailable(&self, details: &str) -> Result<(), Error> {
         let unavailable = self
             .core
@@ -58,7 +58,7 @@ impl UnreliableHandle {
     }
 
     /// Cause all later operators to return an "unavailable" error.
-    pub fn make_unavailable(&mut self) -> &mut UnreliableHandle {
+    pub fn make_unavailable(&mut self) -> &mut UnreliableHandleOld {
         self.core
             .lock()
             .expect("never panics while holding lock")
@@ -67,7 +67,7 @@ impl UnreliableHandle {
     }
 
     /// Cause all later operators to succeed.
-    pub fn make_available(&mut self) -> &mut UnreliableHandle {
+    pub fn make_available(&mut self) -> &mut UnreliableHandleOld {
         self.core
             .lock()
             .expect("never panics while holding lock")
@@ -79,20 +79,20 @@ impl UnreliableHandle {
 /// An unreliable delegate to [Log].
 #[derive(Debug)]
 pub struct UnreliableLog<L> {
-    handle: UnreliableHandle,
+    handle: UnreliableHandleOld,
     log: L,
 }
 
 impl<L: Log> UnreliableLog<L> {
     /// Returns a new [UnreliableLog] and a handle for controlling it.
-    pub fn new(log: L) -> (Self, UnreliableHandle) {
-        let h = UnreliableHandle::default();
+    pub fn new(log: L) -> (Self, UnreliableHandleOld) {
+        let h = UnreliableHandleOld::default();
         let log = Self::from_handle(log, h.clone());
         (log, h)
     }
 
     /// Returns a new [UnreliableLog] sharing the given handle.
-    pub fn from_handle(log: L, handle: UnreliableHandle) -> Self {
+    pub fn from_handle(log: L, handle: UnreliableHandleOld) -> Self {
         UnreliableLog { handle, log }
     }
 }
@@ -131,27 +131,27 @@ impl<L: Log> Log for UnreliableLog<L> {
 /// Configuration for opening an [UnreliableBlob].
 #[derive(Debug)]
 pub struct UnreliableBlobConfig<B: Blob> {
-    handle: UnreliableHandle,
+    handle: UnreliableHandleOld,
     blob: B::Config,
 }
 
 /// An unreliable delegate to [Blob].
 #[derive(Debug)]
 pub struct UnreliableBlob<B> {
-    handle: UnreliableHandle,
+    handle: UnreliableHandleOld,
     blob: B,
 }
 
 impl<B: BlobRead> UnreliableBlob<B> {
     /// Returns a new [UnreliableBlob] and a handle for controlling it.
-    pub fn new(blob: B) -> (Self, UnreliableHandle) {
-        let h = UnreliableHandle::default();
+    pub fn new(blob: B) -> (Self, UnreliableHandleOld) {
+        let h = UnreliableHandleOld::default();
         let blob = Self::from_handle(blob, h.clone());
         (blob, h)
     }
 
     /// Returns a new [UnreliableLog] sharing the given handle.
-    pub fn from_handle(blob: B, handle: UnreliableHandle) -> Self {
+    pub fn from_handle(blob: B, handle: UnreliableHandleOld) -> Self {
         UnreliableBlob { handle, blob }
     }
 }
@@ -229,10 +229,10 @@ impl UnreliableBlobMulti {
     /// Returns a new [UnreliableBlobMulti].
     ///
     /// TODO: Once we turn down the old persist API, return an
-    /// [UnreliableHandle] with the previous totally available or unavailable
+    /// [UnreliableHandleOld] with the previous totally available or unavailable
     /// behavior, plus the new partially available behavior
     ///
-    /// TODO: Ditto the unreliability should be set via [UnreliableHandle].
+    /// TODO: Ditto the unreliability should be set via [UnreliableHandleOld].
     pub fn new_from_seed(
         seed: u64,
         should_happen: f64,
@@ -322,10 +322,10 @@ impl UnreliableConsensus {
     /// Returns a new [UnreliableConsensus].
     ///
     /// TODO: Once we turn down the old persist API, return an
-    /// [UnreliableHandle] with the previous totally available or unavailable
+    /// [UnreliableHandleOld] with the previous totally available or unavailable
     /// behavior, plus the new partially available behavior
     ///
-    /// TODO: Ditto the unreliability should be set via [UnreliableHandle].
+    /// TODO: Ditto the unreliability should be set via [UnreliableHandleOld].
     pub fn new_from_seed(
         seed: u64,
         should_happen: f64,


### PR DESCRIPTION
This will allow toggling availability back and forth, which we'll be
able to use to write a number of otherwise difficult to write unit
tests. Keep the partially available mode and use it as the default

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The first commit is an entirely mechanical rename, so should be much easier to review commit-by-commit.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
