### PR TITLE
pgwire: check for conn close while waiting for rows

### DIFF
--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -44,6 +44,6 @@ pub mod catalog;
 pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
-pub use crate::command::{Canceled, ExecuteResponse, StartupMessage, StartupResponse};
+pub use crate::command::{Canceled, ExecuteResponse, RowsFuture, StartupMessage, StartupResponse};
 pub use crate::coord::{serve, Config, PeekResponseUnary};
 pub use crate::error::CoordError;

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -17,7 +17,7 @@ use std::mem;
 
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::OwnedMutexGuard;
 
 use mz_dataflow_types::client::ComputeInstanceId;
@@ -26,7 +26,6 @@ use mz_repr::{Datum, Diff, GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 
-use crate::command::RowsFuture;
 use crate::coord::{CoordTimestamp, PeekResponseUnary};
 use crate::error::CoordError;
 
@@ -524,13 +523,6 @@ impl InProgressRows {
 
 /// A channel of batched rows.
 pub type RowBatchStream = UnboundedReceiver<PeekResponseUnary>;
-
-/// Converts a RowsFuture to a RowBatchStream.
-pub async fn row_future_to_stream(rows: RowsFuture) -> RowBatchStream {
-    let (tx, rx) = unbounded_channel();
-    tx.send(rows.await).expect("send must succeed");
-    rx
-}
 
 /// The transaction status of a session.
 ///


### PR DESCRIPTION
Long running queries where the client disconnects before the query is
ready would previously keep the query around until it was ready. In the
case of permanently failing queries (like using mz_panic), these would
never return and leak resources. Worse, we would never be able to tell
compute to cancel the query to exit its crash loop (in the mz_panic case
or, say, an OOM loop).

Detect a disconnected client and terminate the connection, which will
propagate a cancel through the rest of the stack.

Fixes #12546

### Motivation

  * This PR fixes a recognized bug. #12546

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
