### PR TITLE
Revert "deps: unfork rust-prometheus" for LTS branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ dependencies = [
  "mz-pgtest",
  "mz-pgwire",
  "mz-pid-file",
+ "mz-process-collector",
  "mz-prof",
  "mz-repr",
  "mz-sql",
@@ -3881,6 +3882,17 @@ dependencies = [
  "postgres-openssl",
  "tokio",
  "tokio-postgres",
+]
+
+[[package]]
+name = "mz-process-collector"
+version = "0.0.0"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "mz-ore",
+ "procfs",
+ "prometheus",
 ]
 
 [[package]]
@@ -4986,13 +4998,12 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e344cafeaeefe487300c361654bcfc85db3ac53619eeccced29f5ea18c4c70"
+checksum = "0941606b9934e2d98a3677759a971756eb821f75764d0e0d26946d08e74d9104"
 dependencies = [
  "bitflags",
  "byteorder",
- "flate2",
  "hex",
  "lazy_static",
  "libc",
@@ -5000,17 +5011,14 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+version = "0.10.0"
+source = "git+https://github.com/MaterializeInc/rust-prometheus.git#8bd8207fd0ac3ebb594a0832e5e5a70ddd8e1a60"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
- "libc",
- "memchr",
  "parking_lot 0.11.1",
- "procfs",
+ "regex",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "src/lowertest",
     "src/materialized",
     "src/metabase",
+    "src/process-collector",
     "src/mzcloud-cli",
     "src/ore",
     "src/orchestrator",

--- a/deny.toml
+++ b/deny.toml
@@ -139,6 +139,7 @@ allow-git = [
     # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
     "https://github.com/MaterializeInc/rust-postgres.git",
     "https://github.com/MaterializeInc/rust-postgres-array.git",
+    "https://github.com/MaterializeInc/rust-prometheus.git",
 
     # Waiting on https://github.com/tokio-rs/prost/pull/576.
     "https://github.com/MaterializeInc/prost.git",

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -39,7 +39,7 @@ mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-transform = { path = "../transform" }
 postgres-types = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
-prometheus = { version = "0.13.0", default-features = false }
+prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prost = "0.9.0"
 protobuf-native = "0.2.1"
 rand = "0.8.5"

--- a/src/dataflow/Cargo.toml
+++ b/src/dataflow/Cargo.toml
@@ -45,7 +45,7 @@ mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
 mz-timely-util = { path = "../timely-util" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres", branch = "mz-0.7.2" }
-prometheus = { version = "0.13.0", default-features = false }
+prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 prost = "0.9.0"
 pubnub-hyper = { git = "https://github.com/MaterializeInc/pubnub-rust", default-features = false }
 rand = "0.8.5"

--- a/src/dataflow/src/sink/kafka.rs
+++ b/src/dataflow/src/sink/kafka.rs
@@ -22,7 +22,6 @@ use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::{StreamExt, TryFutureExt};
 use itertools::Itertools;
 use mz_interchange::json::JsonEncoder;
-use prometheus::core::AtomicU64;
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
@@ -63,6 +62,7 @@ use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use super::KafkaBaseMetrics;
 use crate::compute::render::sinks::SinkRender;
+use prometheus::core::{AtomicI64 as PrometheusAtomicI64, AtomicU64 as PrometheusAtomicU64};
 
 impl<G> SinkRender<G> for KafkaSinkConnector
 where
@@ -152,10 +152,10 @@ where
 
 /// Per-Kafka sink metrics.
 pub struct SinkMetrics {
-    messages_sent_counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    message_send_errors_counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    message_delivery_errors_counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    rows_queued: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    messages_sent_counter: DeleteOnDropCounter<'static, PrometheusAtomicI64, Vec<String>>,
+    message_send_errors_counter: DeleteOnDropCounter<'static, PrometheusAtomicI64, Vec<String>>,
+    message_delivery_errors_counter: DeleteOnDropCounter<'static, PrometheusAtomicI64, Vec<String>>,
+    rows_queued: DeleteOnDropGauge<'static, PrometheusAtomicU64, Vec<String>>,
 }
 
 impl SinkMetrics {

--- a/src/dataflow/src/storage/decode/metrics/mod.rs
+++ b/src/dataflow/src/storage/decode/metrics/mod.rs
@@ -8,14 +8,14 @@
 // by the Apache License, Version 2.0.
 
 use mz_ore::metrics::MetricsRegistry;
-use mz_ore::{metric, metrics::raw::IntCounterVec};
+use mz_ore::{metric, metrics::raw::UIntCounterVec};
 
 use crate::storage::decode::{DataDecoderInner, PreDelimitedFormat};
 
 /// Metrics specific to a single worker.
 #[derive(Clone, Debug)]
 pub struct DecodeMetrics {
-    events_read: IntCounterVec,
+    events_read: UIntCounterVec,
 }
 
 impl DecodeMetrics {

--- a/src/dataflow/src/storage/source/metrics.rs
+++ b/src/dataflow/src/storage/source/metrics.rs
@@ -15,18 +15,19 @@
 //! appropriate source.
 
 use mz_ore::metric;
-use mz_ore::metrics::{IntCounter, IntCounterVec, IntGaugeVec, MetricsRegistry, UIntGaugeVec};
-use prometheus::core::{AtomicI64, GenericCounterVec};
+use mz_ore::metrics::{
+    IntCounterVec, IntGaugeVec, MetricsRegistry, UIntCounter, UIntCounterVec, UIntGaugeVec,
+};
 
 /// The base metrics set for the s3 module.
 #[derive(Clone, Debug)]
 pub(crate) struct S3Metrics {
-    pub(crate) objects_downloaded: IntCounterVec,
-    pub(crate) objects_duplicate: IntCounterVec,
-    pub(crate) bytes_downloaded: IntCounterVec,
-    pub(crate) messages_ingested: IntCounterVec,
+    pub(crate) objects_downloaded: UIntCounterVec,
+    pub(crate) objects_duplicate: UIntCounterVec,
+    pub(crate) bytes_downloaded: UIntCounterVec,
+    pub(crate) messages_ingested: UIntCounterVec,
 
-    pub(crate) objects_discovered: IntCounterVec,
+    pub(crate) objects_discovered: UIntCounterVec,
 }
 
 impl S3Metrics {
@@ -108,7 +109,7 @@ pub(super) struct PartitionSpecificMetrics {
     pub(super) offset_ingested: IntGaugeVec,
     pub(super) offset_received: IntGaugeVec,
     pub(super) closed_ts: UIntGaugeVec,
-    pub(super) messages_ingested: GenericCounterVec<AtomicI64>,
+    pub(super) messages_ingested: IntCounterVec,
     pub(super) partition_offset_max: IntGaugeVec,
 }
 
@@ -147,12 +148,12 @@ impl PartitionSpecificMetrics {
 
 #[derive(Clone, Debug)]
 pub(super) struct PostgresSourceSpecificMetrics {
-    pub(super) total_messages: IntCounterVec,
-    pub(super) transactions: IntCounterVec,
-    pub(super) ignored_messages: IntCounterVec,
-    pub(super) insert_messages: IntCounterVec,
-    pub(super) update_messages: IntCounterVec,
-    pub(super) delete_messages: IntCounterVec,
+    pub(super) total_messages: UIntCounterVec,
+    pub(super) transactions: UIntCounterVec,
+    pub(super) ignored_messages: UIntCounterVec,
+    pub(super) insert_messages: UIntCounterVec,
+    pub(super) update_messages: UIntCounterVec,
+    pub(super) delete_messages: UIntCounterVec,
     pub(super) tables_in_publication: UIntGaugeVec,
     pub(super) wal_lsn: UIntGaugeVec,
 }
@@ -215,7 +216,7 @@ pub struct SourceBaseMetrics {
     pub(crate) s3: S3Metrics,
     pub(crate) kinesis: KinesisMetrics,
 
-    pub(crate) bytes_read: IntCounter,
+    pub(crate) bytes_read: UIntCounter,
 }
 
 impl SourceBaseMetrics {

--- a/src/dataflow/src/storage/source/mod.rs
+++ b/src/dataflow/src/storage/source/mod.rs
@@ -437,7 +437,7 @@ pub fn responsible_for(
 /// Source-specific Prometheus metrics
 pub struct SourceMetrics {
     /// Number of times an operator gets scheduled
-    operator_scheduled_counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    operator_scheduled_counter: DeleteOnDropCounter<'static, AtomicI64, Vec<String>>,
     /// Value of the capability associated with this source
     capability: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     /// Per-partition Prometheus metrics.

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -64,6 +64,7 @@ mz-orchestrator = { path = "../orchestrator" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-pgwire = { path = "../pgwire" }
 mz-pid-file = { path = "../pid-file" }
+mz-process-collector = { path = "../process-collector" }
 mz-prof = { path = "../prof" }
 mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
@@ -72,7 +73,7 @@ num_cpus = "1.13.1"
 openssl = { version = "0.10.38", features = ["vendored"] }
 openssl-sys = { version = "0.9.72", features = ["vendored"] }
 os_info = "3.2.0"
-prometheus = { version = "0.13.0", default-features = false, features = ["process"] }
+prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
 rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "libz-static"] }
 reqwest = { version = "0.11.10", features = ["json"] }
 rlimit = "0.8.1"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -703,6 +703,9 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
         })
     };
 
+    // Configure prometheus process metrics.
+    mz_process_collector::register_default_process_collector(&metrics_registry);
+
     // When inside a cgroup with a cpu limit,
     // the logical cpus can be lower than the physical cpus.
     let memory_limit = detect_memory_limit().unwrap_or(MemoryLimit {

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -28,7 +28,7 @@ lazy_static = "1.4.0"
 openssl = { version = "0.10.38", features = ["vendored"], optional = true }
 paste = "1.0.7"
 pin-project = "1.0.0"
-prometheus = { version = "0.13.0", default-features = false, optional = true }
+prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false, optional = true }
 smallvec = { version = "1.8.0", optional = true }
 stacker = { version = "0.1.14", optional = true }
 tokio = { version = "1.17.0", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }

--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -22,11 +22,11 @@
 //! reduce the verbosity a little bit. A typical subsystem will look like the following:
 //!
 //! ```rust
-//! # use mz_ore::metrics::{MetricsRegistry, IntCounter};
+//! # use mz_ore::metrics::{MetricsRegistry, UIntCounter};
 //! # use mz_ore::metric;
 //! #[derive(Debug, Clone)] // Note that prometheus metrics can safely be cloned
 //! struct Metrics {
-//!     pub bytes_sent: IntCounter,
+//!     pub bytes_sent: UIntCounter,
 //! }
 //!
 //! impl Metrics {
@@ -161,10 +161,6 @@ impl<M: HistogramVecExt> HistogramVecExt for DeleteOnDropWrapper<M> {
     }
 }
 
-/// The unsigned integer version of [`Gauge`]. Provides better performance if
-/// metric values are all unsigned integers.
-pub type UIntGauge = GenericGauge<AtomicU64>;
-
 /// Delete-on-drop shadow of Prometheus [prometheus::CounterVec].
 pub type CounterVec = DeleteOnDropWrapper<prometheus::CounterVec>;
 /// Delete-on-drop shadow of Prometheus [prometheus::Gauge].
@@ -175,20 +171,17 @@ pub type HistogramVec = DeleteOnDropWrapper<prometheus::HistogramVec>;
 pub type IntCounterVec = DeleteOnDropWrapper<prometheus::IntCounterVec>;
 /// Delete-on-drop shadow of Prometheus [prometheus::IntGaugeVec].
 pub type IntGaugeVec = DeleteOnDropWrapper<prometheus::IntGaugeVec>;
-/// Delete-on-drop shadow of Prometheus [raw::UIntGaugeVec].
-pub type UIntGaugeVec = DeleteOnDropWrapper<raw::UIntGaugeVec>;
+/// Delete-on-drop shadow of Prometheus [prometheus::UIntCounterVec].
+pub type UIntCounterVec = DeleteOnDropWrapper<prometheus::UIntCounterVec>;
+/// Delete-on-drop shadow of Prometheus [prometheus::UIntGaugeVec].
+pub type UIntGaugeVec = DeleteOnDropWrapper<prometheus::UIntGaugeVec>;
 
-pub use prometheus::{Counter, Histogram, IntCounter, IntGauge};
-
-/// Access to non-delete-on-drop vector types
+pub use prometheus::{Counter, Histogram, IntCounter, IntGauge, UIntCounter, UIntGauge};
 pub mod raw {
-    use prometheus::core::{AtomicU64, GenericGaugeVec};
-
-    /// The unsigned integer version of [`GaugeVec`](prometheus::GaugeVec).
-    /// Provides better performance if metric values are all unsigned integers.
-    pub type UIntGaugeVec = GenericGaugeVec<AtomicU64>;
-
-    pub use prometheus::{CounterVec, HistogramVec, IntCounterVec, IntGaugeVec};
+    //! Access to non-delete-on-drop vector types
+    pub use prometheus::{
+        CounterVec, HistogramVec, IntCounterVec, IntGaugeVec, UIntCounterVec, UIntGaugeVec,
+    };
 }
 
 impl MetricsRegistry {

--- a/src/ore/src/metrics/delete_on_drop.rs
+++ b/src/ore/src/metrics/delete_on_drop.rs
@@ -376,7 +376,7 @@ impl<P: Atomic> GaugeVecExt for GenericGaugeVec<P> {
 
 #[cfg(test)]
 mod test {
-    use prometheus::core::{AtomicI64, AtomicU64};
+    use prometheus::core::AtomicI64;
     use prometheus::IntGaugeVec;
 
     use super::super::{IntCounterVec, MetricsRegistry};
@@ -409,7 +409,7 @@ mod test {
 
         let string_labels: Vec<String> = ["owned"].iter().map(ToString::to_string).collect();
         struct Ownership {
-            counter: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+            counter: DeleteOnDropCounter<'static, AtomicI64, Vec<String>>,
         }
         let metric_owned = Ownership {
             counter: vec.get_delete_on_drop_counter(string_labels),

--- a/src/ore/src/metrics/tests.rs
+++ b/src/ore/src/metrics/tests.rs
@@ -18,7 +18,7 @@ use super::*;
 #[test]
 fn metrics_registry() {
     let reg = MetricsRegistry::new();
-    let counter: IntCounter = reg.register(metric!(
+    let counter: UIntCounter = reg.register(metric!(
         name: "test_counter",
         help: "a counter for testing"
     ));
@@ -31,11 +31,11 @@ fn metrics_registry() {
 #[test]
 fn anon_metrics_registry() {
     let reg = MetricsRegistry::new();
-    let counter_anon: ThirdPartyMetric<IntCounter> = reg.register_third_party_visible(metric!(
+    let counter_anon: ThirdPartyMetric<UIntCounter> = reg.register_third_party_visible(metric!(
         name: "test_counter_third_party",
         help: "an third_party counter for testing"
     ));
-    let counter_reg: IntCounter = reg.register(metric!(
+    let counter_reg: UIntCounter = reg.register(metric!(
         name: "test_counter_normal",
         help: "a regular counter for testing"
     ));
@@ -53,7 +53,7 @@ fn anon_metrics_registry() {
 #[test]
 fn thirdparty_metric_vecs() {
     let reg = MetricsRegistry::new();
-    let cv: ThirdPartyMetric<raw::IntCounterVec> = reg.register_third_party_visible(metric!(
+    let cv: ThirdPartyMetric<raw::UIntCounterVec> = reg.register_third_party_visible(metric!(
         name: "test_counter_third_party",
         help: "an third_party counter for testing",
         var_labels: ["label"],

--- a/src/persist/src/indexed/metrics.rs
+++ b/src/persist/src/indexed/metrics.rs
@@ -10,16 +10,16 @@
 //! Persistence related monitoring metrics.
 
 use mz_ore::metric;
-use mz_ore::metrics::{Counter, IntCounter, MetricsRegistry, ThirdPartyMetric, UIntGauge};
+use mz_ore::metrics::{Counter, MetricsRegistry, ThirdPartyMetric, UIntCounter, UIntGauge};
 
 /// Persistence related monitoring metrics for blob storage.
 #[derive(Clone, Debug)]
 pub struct BlobMetricsByType {
-    pub(crate) blob_write_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) blob_write_bytes: ThirdPartyMetric<IntCounter>,
+    pub(crate) blob_write_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_write_bytes: ThirdPartyMetric<UIntCounter>,
     pub(crate) blob_write_seconds: ThirdPartyMetric<Counter>,
-    pub(crate) blob_delete_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) blob_delete_bytes: ThirdPartyMetric<IntCounter>,
+    pub(crate) blob_delete_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_delete_bytes: ThirdPartyMetric<UIntCounter>,
     pub(crate) blob_delete_seconds: ThirdPartyMetric<Counter>,
 }
 
@@ -71,39 +71,39 @@ pub struct Metrics {
     pub(crate) trace_blob_bytes: ThirdPartyMetric<UIntGauge>,
 
     // TODO: pub(crate) cmd_queue_seconds: ThirdPartyMetric<UIntGauge>,
-    pub(crate) cmd_queue_in: ThirdPartyMetric<IntCounter>,
+    pub(crate) cmd_queue_in: ThirdPartyMetric<UIntCounter>,
 
-    pub(crate) cmd_run_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) cmd_run_count: ThirdPartyMetric<UIntCounter>,
     pub(crate) cmd_run_seconds: ThirdPartyMetric<Counter>,
-    pub(crate) cmd_failed_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) cmd_failed_count: ThirdPartyMetric<UIntCounter>,
     pub(crate) cmd_step_seconds: ThirdPartyMetric<Counter>,
-    pub(crate) cmd_step_error_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) cmd_step_error_count: ThirdPartyMetric<UIntCounter>,
 
     // TODO: Break these down by unsealed/trace/meta? We'll have to restructure
     // the code a bit but that seems fine.
-    pub(crate) compaction_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) compaction_count: ThirdPartyMetric<UIntCounter>,
     pub(crate) compaction_seconds: ThirdPartyMetric<Counter>,
-    pub(crate) compaction_write_bytes: ThirdPartyMetric<IntCounter>,
-    pub(crate) trace_compaction_error_response_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) trace_compaction_skipped_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) compaction_write_bytes: ThirdPartyMetric<UIntCounter>,
+    pub(crate) trace_compaction_error_response_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) trace_compaction_skipped_count: ThirdPartyMetric<UIntCounter>,
 
     // TODO: Tag cmd_process_count with cmd type and remove this?
-    pub(crate) cmd_write_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) cmd_write_record_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) cmd_write_record_bytes: ThirdPartyMetric<IntCounter>,
+    pub(crate) cmd_write_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) cmd_write_record_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) cmd_write_record_bytes: ThirdPartyMetric<UIntCounter>,
 
     pub(crate) unsealed: BlobMetricsByType,
     pub(crate) trace: BlobMetricsByType,
     pub(crate) meta: BlobMetricsByType,
-    pub(crate) blob_write_error_quota_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) blob_write_error_other_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) blob_write_error_quota_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_write_error_other_count: ThirdPartyMetric<UIntCounter>,
 
     // TODO: pub(crate) blob_read_cache_bytes: ThirdPartyMetric<UIntGauge>,
     // TODO: pub(crate) blob_read_cache_entry_count: ThirdPartyMetric<UIntGauge>,
-    pub(crate) blob_read_cache_hit_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) blob_read_cache_miss_count: ThirdPartyMetric<IntCounter>,
-    pub(crate) blob_read_cache_fetch_bytes: ThirdPartyMetric<IntCounter>,
-    // TODO: pub(crate) blob_read_error_count: ThirdPartyMetric<IntCounter>,
+    pub(crate) blob_read_cache_hit_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_read_cache_miss_count: ThirdPartyMetric<UIntCounter>,
+    pub(crate) blob_read_cache_fetch_bytes: ThirdPartyMetric<UIntCounter>,
+    // TODO: pub(crate) blob_read_error_count: ThirdPartyMetric<UIntCounter>,
 }
 
 impl Metrics {

--- a/src/pgwire/src/metrics.rs
+++ b/src/pgwire/src/metrics.rs
@@ -9,15 +9,15 @@
 
 use mz_ore::{
     metric,
-    metrics::{raw::HistogramVec, IntCounter, MetricsRegistry},
+    metrics::{raw::HistogramVec, MetricsRegistry, UIntCounter},
 };
 
 #[derive(Clone, Debug)]
 pub struct Metrics {
     pub command_durations: HistogramVec,
-    pub bytes_sent: IntCounter,
-    pub rows_returned: IntCounter,
-    pub query_count: IntCounter,
+    pub bytes_sent: UIntCounter,
+    pub rows_returned: UIntCounter,
+    pub query_count: UIntCounter,
 }
 
 impl Metrics {

--- a/src/process-collector/Cargo.toml
+++ b/src/process-collector/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mz-process-collector"
+description = "Customized collection of Prometheus process metrics."
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.59.0"
+publish = false
+
+[dependencies]
+lazy_static = "1.4.0"
+libc = "0.2.121"
+mz-ore = { path = "../ore" }
+prometheus = { git = "https://github.com/MaterializeInc/rust-prometheus.git", default-features = false }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { version = "0.12.0", default-features = false }

--- a/src/process-collector/src/lib.rs
+++ b/src/process-collector/src/lib.rs
@@ -1,0 +1,69 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! # Detailed metrics for the current process
+//!
+//! This crate replaces the [rust-prometheus][] `process` feature, which is
+//! designed to exactly match the fields documented as part of the [Prometheus
+//! process metrics][prom-process].
+//!
+//! This currently only works on linux, due to library support.
+//!
+//! ## Recommended usage
+//!
+//! Initialize this exactly once at program startup, and then handle scrapes
+//! [following the prometheus instructions]:
+//!
+//! ```
+//! # use mz_ore::metrics::MetricsRegistry;
+//! # fn handle_scrapes() {}
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let registry = MetricsRegistry::new();
+//!     mz_process_collector::register_default_process_collector(&registry);
+//!
+//!     handle_scrapes();
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Do *not* use this in combination with the `process` feature in the
+//! `rust-prometheus` library, the metrics will clobber each other.
+//!
+//! ## Extra Metrics
+//!
+//! In addition to everything provided by rust-prometheus, this library exports:
+//!
+//! * Per-thread name cpu time: `process_thread_cpu_seconds_total{thread_name}`
+//! * Count of threads with the same name: `process_thread_count{thread_name}`
+//!
+//! [rust-prometheus]: https://github.com/tikv/rust-prometheus/
+//! [prom-process]: https://prometheus.io/docs/instrumenting/writing_clientlibs/#process-metrics
+//! [following the prometheus instructions]: https://docs.rs/prometheus/0.10.0/prometheus/#basic-example
+
+use mz_ore::metrics::MetricsRegistry;
+
+#[cfg(target_os = "linux")]
+mod process_collector;
+
+#[cfg(target_os = "linux")]
+pub use process_collector::ProcessCollector;
+
+/// Configure a [`ProcessCollector`] to export prometheus metrics in the [default registry]
+///
+/// [default registry]: https://docs.rs/prometheus/0.10.0/prometheus/fn.default_registry.html
+#[cfg(target_os = "linux")]
+pub fn register_default_process_collector(registry: &MetricsRegistry) {
+    let pc = ProcessCollector::for_self();
+    registry.register_collector(pc);
+}
+
+/// Since the target os is not linux, this does nothing
+#[cfg(not(target_os = "linux"))]
+pub fn register_default_process_collector(_: &MetricsRegistry) {}

--- a/src/process-collector/src/process_collector.rs
+++ b/src/process-collector/src/process_collector.rs
@@ -1,0 +1,444 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+//
+// Portions of this file are derived from the rust-prometheus project.
+// The original source code was retrieved on November 10th, 2020 from:
+//
+//     https://github.com/tikv/rust-prometheus/blob/200c362e5e58442230334d6126817fcceed47c25/src/process_collector.rs
+//
+// The original source code is licensed under the Apache 2.0 license, a copy of
+// which can be found in the LICENSE file at the root of this repository.
+
+//! Monitor a process.
+//!
+//! This module only supports **Linux** platform.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use lazy_static::lazy_static;
+
+use prometheus::core::{Collector, Desc};
+use prometheus::proto;
+use prometheus::{Counter, CounterVec, Gauge, GaugeVec, Opts};
+
+/// Six metrics per ProcessCollector.
+const METRICS_NUMBER: usize = 9;
+/// The `pid_t` data type represents process IDs.
+use libc::pid_t;
+
+/// A collector which exports the current state of
+/// process metrics including cpu, memory and file descriptor usage as well as
+/// the process start time for the given process id.
+#[derive(Debug)]
+pub struct ProcessCollector {
+    pid: pid_t,
+    descs: Vec<Desc>,
+    cpu_total: Mutex<Counter>,
+    open_fds: Gauge,
+    max_fds: Gauge,
+    vsize: Gauge,
+    rss: Gauge,
+    swap: Gauge,
+    threads: ThreadsCollector,
+    start_time: Gauge,
+    system_swap: Gauge,
+    system_swap_free: Gauge,
+}
+
+impl ProcessCollector {
+    /// Create a `ProcessCollector` with the given process id and namespace.
+    pub fn new<S: Into<String>>(pid: pid_t, namespace: S) -> ProcessCollector {
+        let namespace = namespace.into();
+        let mut descs = Vec::new();
+
+        let cpu_total = Counter::with_opts(
+            Opts::new(
+                "process_cpu_seconds_total",
+                "Total user and system CPU time spent in \
+                 seconds.",
+            )
+            .namespace(namespace.clone()),
+        )
+        .unwrap();
+        descs.extend(cpu_total.desc().into_iter().cloned());
+
+        let open_fds = Gauge::with_opts(
+            Opts::new("process_open_fds", "Number of open file descriptors.")
+                .namespace(namespace.clone()),
+        )
+        .unwrap();
+        descs.extend(open_fds.desc().into_iter().cloned());
+
+        let max_fds = Gauge::with_opts(
+            Opts::new(
+                "process_max_fds",
+                "Maximum number of open file descriptors.",
+            )
+            .namespace(namespace.clone()),
+        )
+        .unwrap();
+        descs.extend(max_fds.desc().into_iter().cloned());
+
+        let vsize = Gauge::with_opts(
+            Opts::new(
+                "process_virtual_memory_bytes",
+                "Virtual memory size in bytes.",
+            )
+            .namespace(namespace.clone()),
+        )
+        .unwrap();
+        descs.extend(vsize.desc().into_iter().cloned());
+
+        let rss = Gauge::with_opts(
+            Opts::new(
+                "process_resident_memory_bytes",
+                "Resident memory size in bytes.",
+            )
+            .namespace(namespace.clone()),
+        )
+        .unwrap();
+        descs.extend(rss.desc().into_iter().cloned());
+
+        let swap = Gauge::with_opts(
+            Opts::new(
+                "process_swap_memory_bytes",
+                "Swapped out memory size in bytes.",
+            )
+            .namespace(namespace.clone()),
+        )
+        .unwrap();
+        descs.extend(swap.desc().into_iter().cloned());
+
+        let start_time = Gauge::with_opts(
+            Opts::new(
+                "process_start_time_seconds",
+                "Start time of the process since unix epoch \
+                 in seconds.",
+            )
+            .namespace(namespace),
+        )
+        .unwrap();
+        descs.extend(start_time.desc().into_iter().cloned());
+
+        let system_swap = Gauge::with_opts(Opts::new(
+            "system_swap_memory_bytes",
+            "Total amount of swap configured on the system",
+        ))
+        .unwrap();
+        descs.extend(system_swap.desc().into_iter().cloned());
+        let system_swap_free = Gauge::with_opts(Opts::new(
+            "system_swap_memory_free_bytes",
+            "Amount of swap available for use on the system",
+        ))
+        .unwrap();
+        descs.extend(system_swap_free.desc().into_iter().cloned());
+
+        let threads = ThreadsCollector::new(pid);
+        descs.extend(threads.desc().into_iter().cloned());
+
+        ProcessCollector {
+            pid,
+            descs,
+            cpu_total: Mutex::new(cpu_total),
+            open_fds,
+            max_fds,
+            vsize,
+            rss,
+            swap,
+            threads,
+            start_time,
+            system_swap,
+            system_swap_free,
+        }
+    }
+
+    /// Return a `ProcessCollector` of the calling process.
+    pub fn for_self() -> ProcessCollector {
+        let pid = unsafe { libc::getpid() };
+        ProcessCollector::new(pid, "")
+    }
+}
+
+impl Collector for ProcessCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        let p = match procfs::process::Process::new(self.pid) {
+            Ok(p) => p,
+            Err(..) => {
+                // we can't construct a Process object, so there's no stats to gather
+                return Vec::new();
+            }
+        };
+
+        // file descriptors
+        if let Ok(fd_list) = p.fd() {
+            self.open_fds.set(fd_list.len() as f64);
+        }
+        if let Ok(limits) = p.limits() {
+            if let procfs::process::LimitValue::Value(max) = limits.max_open_files.soft_limit {
+                self.max_fds.set(max as f64)
+            }
+        }
+
+        // memory
+        self.vsize.set(p.stat.vsize as f64);
+        self.rss.set(p.stat.rss as f64 * *PAGESIZE);
+        if let Ok(status) = p.status() {
+            if let Some(swap) = status.vmswap {
+                self.swap.set(swap as f64);
+            }
+        }
+
+        // swap
+        if let Ok(status) = p.status() {
+            if let Some(vmswap_kib) = status.vmswap {
+                let vmswap = vmswap_kib * 1024;
+                self.swap.set(vmswap as f64);
+            }
+        }
+
+        if let Ok(s) = procfs::Meminfo::new() {
+            self.system_swap.set(s.swap_total as f64);
+            self.system_swap_free.set(s.swap_free as f64);
+        }
+
+        // proc_start_time
+        if let Some(boot_time) = *BOOT_TIME {
+            self.start_time
+                .set(p.stat.starttime as f64 / *CLK_TCK + boot_time);
+        }
+
+        // cpu
+        let cpu_total_mfs = {
+            let cpu_total = self.cpu_total.lock().unwrap();
+            let delta = collect_cpu_stat(&cpu_total, &p.stat);
+            if delta > 0.0 {
+                cpu_total.inc_by(delta);
+            }
+            cpu_total.collect()
+        };
+
+        // collect MetricFamilys.
+        let threads = self.threads.collect();
+        let mut mfs = Vec::with_capacity(METRICS_NUMBER + threads.len());
+        mfs.extend(cpu_total_mfs);
+        mfs.extend(self.open_fds.collect());
+        mfs.extend(self.max_fds.collect());
+        mfs.extend(self.vsize.collect());
+        mfs.extend(self.rss.collect());
+        mfs.extend(self.swap.collect());
+        mfs.extend(self.start_time.collect());
+        mfs.extend(self.system_swap.collect());
+        mfs.extend(self.system_swap_free.collect());
+        mfs.extend(threads);
+        mfs
+    }
+}
+
+#[derive(Debug)]
+struct ThreadsCollector {
+    inner: Mutex<TcInner>,
+
+    descs: Vec<Desc>,
+}
+
+#[derive(Debug)]
+struct TcInner {
+    known_threads: HashMap<String, ThreadStats>,
+    pid: pid_t,
+
+    total_cpu_vec: CounterVec,
+    thread_count_vec: GaugeVec,
+}
+
+impl ThreadsCollector {
+    fn new(pid: pid_t) -> ThreadsCollector {
+        let known_threads = HashMap::new();
+        let total_cpu_vec = CounterVec::new(
+            Opts::new(
+                "process_thread_cpu_seconds_total",
+                "The total time spent by all threads with this name.",
+            ),
+            &["thread_name"],
+        )
+        .unwrap();
+        let thread_count_vec = GaugeVec::new(
+            Opts::new("process_thread_count", "Number of threads with this name"),
+            &["thread_name"],
+        )
+        .unwrap();
+
+        let mut descs = Vec::new();
+        descs.extend(thread_count_vec.desc().into_iter().cloned());
+        descs.extend(total_cpu_vec.desc().into_iter().cloned());
+
+        ThreadsCollector {
+            inner: Mutex::new(TcInner {
+                known_threads,
+                pid,
+                total_cpu_vec,
+                thread_count_vec,
+            }),
+            descs,
+        }
+    }
+}
+
+impl Collector for ThreadsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        let mut tc = self.inner.lock().unwrap();
+        let p = match procfs::process::Process::new(tc.pid) {
+            Ok(p) => p,
+            Err(..) => {
+                // we can't construct a Process object, so there's no stats to gather
+                return Vec::new();
+            }
+        };
+
+        if let Ok(threads) = p.tasks() {
+            // Thread errors can happen when the thread is completed while we're inspecting
+            for thread in threads.flat_map(|t_result| t_result) {
+                let name = match thread.stat() {
+                    Ok(stat) => stat.comm,
+                    Err(_) => continue,
+                };
+                let stats = match tc.known_threads.get_mut(&name) {
+                    Some(thread) => thread,
+                    None => {
+                        let total_cpu = tc.total_cpu_vec.with_label_values(&[&name]);
+                        let thread_count = tc.thread_count_vec.with_label_values(&[&name]);
+                        tc.known_threads
+                            // use entry instead of insert to get a reference to
+                            // the newly inserted stats
+                            .entry(name.clone())
+                            .or_insert_with(|| ThreadStats::new(total_cpu, thread_count))
+                    }
+                };
+                stats.update(&thread);
+            }
+        }
+
+        let mut mfs = Vec::new();
+        for (_, ts) in tc.known_threads.iter_mut() {
+            ts.finish(&mut mfs);
+        }
+        mfs
+    }
+}
+
+#[derive(Debug)]
+struct ThreadStats {
+    total_cpu: Counter,
+    count: Gauge,
+    local_total: u64,
+    local_count: f64,
+}
+
+impl ThreadStats {
+    fn new(total_cpu: Counter, count: Gauge) -> ThreadStats {
+        ThreadStats {
+            total_cpu,
+            count,
+            local_total: 0,
+            local_count: 0.0,
+        }
+    }
+
+    fn update(&mut self, thread: &procfs::process::Task) {
+        self.local_count += 1.0;
+        if let Ok(stat) = thread.stat() {
+            self.local_total += stat.utime + stat.stime;
+        }
+    }
+
+    /// Extend metric families with data for threads that were found on this last iteration
+    fn finish(&mut self, metric_families: &mut Vec<proto::MetricFamily>) {
+        if self.local_count != 0.0 {
+            self.count.set(self.local_count);
+            let past = self.total_cpu.get();
+            let total = self.local_total as f64 / *CLK_TCK;
+            let delta = total - past;
+            if delta > 0.0 {
+                self.total_cpu.inc_by(delta);
+            }
+            self.local_count = 0.0;
+            self.local_total = 0;
+
+            metric_families.extend(self.count.collect());
+            metric_families.extend(self.total_cpu.collect());
+        }
+    }
+}
+
+fn collect_cpu_stat(cpu_total: &Counter, stat: &procfs::process::Stat) -> f64 {
+    let total = (stat.utime + stat.stime) as f64 / *CLK_TCK;
+    let past = cpu_total.get();
+    total - past
+}
+
+lazy_static! {
+    // getconf CLK_TCK
+    static ref CLK_TCK: f64 = {
+        unsafe {
+            libc::sysconf(libc::_SC_CLK_TCK) as f64
+        }
+    };
+
+    // getconf PAGESIZE
+    static ref PAGESIZE: f64 = {
+        unsafe {
+            libc::sysconf(libc::_SC_PAGESIZE) as f64
+        }
+    };
+}
+
+lazy_static! {
+    static ref BOOT_TIME: Option<f64> = procfs::boot_time_secs().ok().map(|i| i as f64);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prometheus::Registry;
+
+    #[test]
+    fn test_process_collector() {
+        let pc = ProcessCollector::for_self();
+        {
+            // Ensure that we have at least the right number of metrics
+            let descs = pc.desc();
+            assert!(
+                descs.len() >= super::METRICS_NUMBER,
+                "{} >= {}",
+                descs.len(),
+                super::METRICS_NUMBER,
+            );
+            let mfs = pc.collect();
+            assert!(
+                mfs.len() >= super::METRICS_NUMBER,
+                "{} >= {}",
+                mfs.len(),
+                super::METRICS_NUMBER,
+            );
+        }
+
+        let r = Registry::new();
+        let res = r.register(Box::new(pc));
+        assert!(res.is_ok());
+        r.gather();
+    }
+}


### PR DESCRIPTION
I have NO idea WHY prometheus metrics ONLY work when you run mz as a docker image, but I was able to test
`tags/v0.26.0` locally with `bin/mzimage` and saw no metrics, and with this revert, I saw metrics, so I believe this fix this issue reported in slack

I still think we should have the customer confirm after merging!

### Motivation

  * This PR fixes a recognized bug.
https://materializeinc.slack.com/archives/C02LJ9EJP9S/p1652282705564379


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - tested locally

### Release notes
This should be included in a new LTS release minor version, see https://github.com/MaterializeInc/materialize/issues/11933
