### PR TITLE
backport: materialized: Allow setting a password prefix

### DIFF
--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -28,6 +28,8 @@ pub struct FronteggConfig<'a> {
     pub now: NowFn,
     /// Number of seconds before which to attempt to renew an expiring token.
     pub refresh_before_secs: i64,
+    /// Prefix that is expected to be present on all passwords.
+    pub password_prefix: String,
 }
 
 #[derive(Clone, Derivative)]
@@ -40,6 +42,7 @@ pub struct FronteggAuthentication {
     now: NowFn,
     validation: Validation,
     refresh_before_secs: i64,
+    password_prefix: String,
 }
 
 pub const REFRESH_SUFFIX: &str = "/token/refresh";
@@ -59,6 +62,7 @@ impl FronteggAuthentication {
             now: config.now,
             validation,
             refresh_before_secs: config.refresh_before_secs,
+            password_prefix: config.password_prefix,
         })
     }
 
@@ -82,6 +86,9 @@ impl FronteggAuthentication {
         &self,
         password: &str,
     ) -> Result<ApiTokenResponse, anyhow::Error> {
+        let password = password
+            .strip_prefix(&self.password_prefix)
+            .ok_or_else(|| anyhow::anyhow!("invalid password format"))?;
         let (client_id, secret) = if password.len() == 43 || password.len() == 44 {
             // If it's exactly 43 or 44 bytes, assume we have base64-encoded
             // UUID bytes without or with padding, respectively.

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -379,6 +379,14 @@ pub struct Args {
         hide = true
     )]
     frontegg_api_token_url: Option<String>,
+    /// A common string prefix that is expected to be present at the beginning of passwords.
+    #[clap(
+        long,
+        env = "MZ_FRONTEGG_PASSWORD_PREFIX",
+        requires = "frontegg-tenant",
+        hide = true
+    )]
+    frontegg_password_prefix: Option<String>,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
     /// specified origin.
     #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN", hide = true)]
@@ -628,6 +636,7 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                 tenant_id,
                 now: mz_ore::now::SYSTEM_TIME.clone(),
                 refresh_before_secs: 60,
+                password_prefix: args.frontegg_password_prefix.unwrap_or_default(),
             })
         })
         .transpose()?;

--- a/src/materialized/tests/auth.rs
+++ b/src/materialized/tests/auth.rs
@@ -247,7 +247,10 @@ fn run_tests<'a>(header: &str, server: &util::Server, tests: &[TestCase<'a>]) {
                 configure,
                 assert,
             } => {
-                println!("pgwire user={} ssl_mode={:?}", user, ssl_mode);
+                println!(
+                    "pgwire user={} password={:?} ssl_mode={:?}",
+                    user, password, ssl_mode
+                );
 
                 let pg_client = server
                     .pg_config()
@@ -498,9 +501,10 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
         tenant_id,
         now: SYSTEM_TIME.clone(),
         refresh_before_secs: REFRESH_BEFORE_SECS as i64,
+        password_prefix: "mzauth_".to_string(),
     })?;
     let frontegg_user = "user@_.com";
-    let frontegg_password = &format!("{client_id}{secret}");
+    let frontegg_password = &format!("mzauth_{client_id}{secret}");
 
     let wait_for_refresh = || {
         let expected = *frontegg_server.refreshes.lock().unwrap() + 1;
@@ -637,9 +641,10 @@ fn test_auth() -> Result<(), Box<dyn Error>> {
         tenant_id,
         now,
         refresh_before_secs: 0,
+        password_prefix: "mzauth_".to_string(),
     })?;
     let frontegg_user = "user@_.com";
-    let frontegg_password = &format!("{client_id}{secret}");
+    let frontegg_password = &format!("mzauth_{client_id}{secret}");
     let frontegg_basic = Authorization::basic(frontegg_user, frontegg_password);
     let frontegg_header_basic = make_header(frontegg_basic);
 
@@ -747,7 +752,10 @@ fn test_auth() -> Result<(), Box<dyn Error>> {
                     let mut buf = vec![];
                     buf.extend(client_id.as_bytes());
                     buf.extend(secret.as_bytes());
-                    Some(&base64::encode_config(buf, base64::URL_SAFE))
+                    Some(&format!(
+                        "mzauth_{}",
+                        base64::encode_config(buf, base64::URL_SAFE)
+                    ))
                 },
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -760,7 +768,10 @@ fn test_auth() -> Result<(), Box<dyn Error>> {
                     let mut buf = vec![];
                     buf.extend(client_id.as_bytes());
                     buf.extend(secret.as_bytes());
-                    Some(&base64::encode_config(buf, base64::URL_SAFE_NO_PAD))
+                    Some(&format!(
+                        "mzauth_{}",
+                        base64::encode_config(buf, base64::URL_SAFE_NO_PAD)
+                    ))
                 },
                 ssl_mode: SslMode::Require,
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
@@ -771,8 +782,8 @@ fn test_auth() -> Result<(), Box<dyn Error>> {
                 user: frontegg_user,
                 password: {
                     let mut password = frontegg_password.clone();
-                    password.insert(3, '-');
-                    password.insert_str(12, "@#!");
+                    password.insert(10, '-');
+                    password.insert_str(15, "@#!");
                     Some(&password.clone())
                 },
                 ssl_mode: SslMode::Require,
@@ -850,6 +861,31 @@ fn test_auth() -> Result<(), Box<dyn Error>> {
                 user: frontegg_user,
                 scheme: Scheme::HTTPS,
                 headers: &make_header(Authorization::basic(frontegg_user, "bad password")),
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Err(Box::new(|code, message| {
+                    assert_eq!(code, Some(StatusCode::UNAUTHORIZED));
+                    assert_eq!(message, "unauthorized");
+                })),
+            },
+            // Bad password prefix.
+            TestCase::Pgwire {
+                user: frontegg_user,
+                password: Some(&format!("mznope_{client_id}{secret}")),
+                ssl_mode: SslMode::Require,
+                configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
+                assert: Assert::Err(Box::new(|err| {
+                    let err = err.unwrap_db_error();
+                    assert_eq!(err.message(), "invalid password");
+                    assert_eq!(*err.code(), SqlState::INVALID_PASSWORD);
+                })),
+            },
+            TestCase::Http {
+                user: frontegg_user,
+                scheme: Scheme::HTTPS,
+                headers: &make_header(Authorization::basic(
+                    frontegg_user,
+                    &format!("mznope_{client_id}{secret}"),
+                )),
                 configure: Box::new(|b| Ok(b.set_verify(SslVerifyMode::NONE))),
                 assert: Assert::Err(Box::new(|code, message| {
                     assert_eq!(code, Some(StatusCode::UNAUTHORIZED));


### PR DESCRIPTION
@benesch @antifuchs I went ahead and backported https://github.com/MaterializeInc/materialize/pull/12279 while I already had my repo set up for it. To test this, I relied only on the unit tests

cherry-pick was clean minus a few error handling changes!

see https://github.com/MaterializeInc/materialize/issues/11933

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

None?
