### PR TITLE
bin/doc: fix index page rendering

### DIFF
--- a/bin/doc
+++ b/bin/doc
@@ -46,84 +46,98 @@ crates=$(cargo metadata --format-version=1 \
 cat > "$target"/doc/index.html <<EOF
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <title>materialize - Rust</title>
-    <link rel="stylesheet" type="text/css" href="normalize.css">
-    <link rel="stylesheet" type="text/css" href="rustdoc.css" id="mainThemeStyle">
-    <link rel="stylesheet" type="text/css" href="dark.css">
-    <link rel="stylesheet" type="text/css" href="light.css" id="themeStyle">
-    <script src="storage.js"></script>
-    <noscript>
-        <link rel="stylesheet" href="noscript.css">
-    </noscript>
-    <link rel="shortcut icon" href="favicon.ico">
-    <style type="text/css">
-        #crate-search {
-            background-image: url("down-arrow.svg");
-        }
-    </style>
-</head>
-
-<body class="rustdoc mod">
-    <!--[if lte IE 8]><div class="warning">This old browser is unsupported and will most likely display funky things.</div><![endif]-->
-    <nav class="sidebar">
-        <div class="sidebar-menu">&#9776;</div>
-        <a href='index.html'><div class='logo-container'><img src='rust-logo.png' alt='logo'></div></a>
-        <p class='location'>Home</p>
-        <div class="sidebar-elems">
-        </div>
-    </nav>
-    <div class="theme-picker">
-        <button id="theme-picker" aria-label="Pick another theme!"><img src="brush.svg" width="18" alt="Pick another theme!"></button>
-        <div id="theme-choices"></div>
-    </div>
-    <script src="theme.js"></script>
-    <nav class="sub">
-        <form class="search-form js-only">
-            <div class="search-container">
-                <div>
-                    <select id="crate-search">
-                        <option value="All crates">All crates</option>
-                    </select>
-                    <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press ‘S’ to search, ‘?’ for more options…" type="search">
-                </div>
-                <a id="settings-menu" href="settings.html"><img src="wheel.svg" width="18" alt="Change settings"></a>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta name="generator" content="rustdoc">
+        <meta name="description" content="API documentation for Materialize.">
+        <meta name="keywords" content="rust, rustlang, rust-lang, materialize">
+        <title>Materialize - Rust</title>
+        <link rel="preload" as="font" type="font/woff2" crossorigin href="SourceSerif4-Regular.ttf.woff2">
+        <link rel="preload" as="font" type="font/woff2" crossorigin href="FiraSans-Regular.woff2">
+        <link rel="preload" as="font" type="font/woff2" crossorigin href="FiraSans-Medium.woff2">
+        <link rel="preload" as="font" type="font/woff2" crossorigin href="SourceCodePro-Regular.ttf.woff2">
+        <link rel="preload" as="font" type="font/woff2" crossorigin href="SourceSerif4-Bold.ttf.woff2">
+        <link rel="preload" as="font" type="font/woff2" crossorigin href="SourceCodePro-Semibold.ttf.woff2">
+        <link rel="stylesheet" type="text/css" href="normalize.css">
+        <link rel="stylesheet" type="text/css" href="rustdoc.css" id="mainThemeStyle">
+        <link rel="stylesheet" type="text/css" href="ayu.css" disabled>
+        <link rel="stylesheet" type="text/css" href="dark.css" disabled>
+        <link rel="stylesheet" type="text/css" href="light.css" id="themeStyle">
+        <script id="default-settings" ></script><script src="storage.js"></script><script src="crates.js"></script><script defer src="main.js"></script>
+        <noscript>
+            <link rel="stylesheet" href="noscript.css">
+        </noscript>
+        <link rel="alternate icon" type="image/png" href="favicon-16x16.png">
+        <link rel="alternate icon" type="image/png" href="favicon-32x32.png">
+        <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    </head>
+    <body class="rustdoc mod crate">
+        <!--[if lte IE 11]>
+        <div class="warning">This old browser is unsupported and will most likely display funky things.</div>
+        <![endif]-->
+        <nav class="mobile-topbar">
+            <button class="sidebar-menu-toggle">&#9776;</button>
+            <a class="sidebar-logo" href="index.html">
+                <div class="logo-container"><img class="rust-logo" src="rust-logo.svg" alt="logo"></div>
+            </a>
+            <h2 class="location"></h2>
+        </nav>
+        <nav class="sidebar">
+            <a class="sidebar-logo" href="index.html">
+                <div class="logo-container"><img class="rust-logo" src="rust-logo.svg" alt="logo"></div>
+            </a>
+            <div class="sidebar-elems">
+                <div id="sidebar-vars" data-name="materialize" data-ty="root" data-relpath=""></div>
+                <script>
+                    addEventListener("DOMContentLoaded", function () {
+                        initSidebarItems({});
+                    });
+                </script>
             </div>
-        </form>
-    </nav>
-    <section id="main" class="content">
-        <h1 class='fqn'>
-            <span class='in-band'>Materialize documentation</span>
-        </h1>
-        <p>This is the home of Materialize's internal API documentation.</p>
-        <h2>Important crates</h2>
-        <table>
-            $crates
-        </table>
-    </section>
-    <section id="search" class="content hidden"></section>
-    <section class="footer"></section>
-    <script>
-        window.rootPath = "./";
-        window.currentCrate = "materialize";
-    </script>
-    <script src="aliases.js"></script>
-    <script src="main.js"></script>
-    <script defer src="search-index.js"></script>
-</body>
-
+        </nav>
+        <main>
+            <div class="width-limiter">
+                <div class="sub-container">
+                    <a class="sub-logo-container" href="index.html"><img class="rust-logo" src="rust-logo.svg" alt="logo"></a>
+                    <nav class="sub">
+                        <div class="theme-picker hidden">
+                            <button id="theme-picker" aria-label="Pick another theme!" aria-haspopup="menu" title="themes"><img width="22" height="22" alt="Pick another theme!" src="brush.svg"></button>
+                            <div id="theme-choices" role="menu"></div>
+                        </div>
+                        <form class="search-form">
+                            <div class="search-container"><span></span><input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press ‘S’ to search, ‘?’ for more options…" type="search"><button type="button" id="help-button" title="help">?</button><a id="settings-menu" href="settings.html" title="settings"><img width="22" height="22" alt="Change settings" src="wheel.svg"></a></div>
+                        </form>
+                    </nav>
+                </div>
+                <section id="main-content" class="content">
+                    <h1 class='fqn'>
+                        <span class='in-band'>Materialize documentation</span>
+                    </h1>
+                    <p>This is the home of Materialize's internal API documentation.</p>
+                    <h2>Important crates</h2>
+                    <table>
+                        $crates
+                    </table>
+                </section>
+                <section id="search" class="content hidden"></section>
+            </div>
+        </main>
+        <div id="rustdoc-vars" data-root-path="." data-current-crate="materialize" data-resource-suffix="" data-themes="ayu,dark,light"></div>
+    </body>
 </html>
+
 EOF
 
 # Make the logo link to the nice homepage we just created. Otherwise it just
 # links to the root of whatever crate you happen to be looking at.
 cat >> "$target"/doc/main.js <<EOF
 ;
-var el = document.querySelector("img[alt=logo]").closest("a");
-if (el.href != "index.html") {
-    el.href = "../index.html";
+for (const logo of document.querySelectorAll("img[alt=logo]")) {
+    var link = logo.closest("a");
+    if (link.href != "index.html") {
+        link.href = "../index.html";
+    }
 }
 EOF
 


### PR DESCRIPTION
The template Rustdoc uses changes in a recent version of Rust, so we
need to adapt our custom index page rendering too.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
