### PR TITLE
computed,storaged,materialized: simplify and unify panic handling

### DIFF
--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -34,6 +34,9 @@ SERVICES = [
                 "AWS_SESSION_TOKEN",
             ],
             "volumes": ["../../../:/workdir"],
+            "ulimits": {
+                "core": 0,
+            },
         },
     ),
 ]

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -926,6 +926,9 @@ class ServiceConfig(TypedDict, total=False):
     TODO(benesch): this should use a nested TypedDict.
     """
 
+    ulimits: Dict[str, Any]
+    """Override the default ulimits for a container."""
+
     working_dir: str
     """Overrides the container's working directory."""
 

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -216,6 +216,8 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 }
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
+    mz_ore::panic::set_abort_on_panic();
+
     mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
         log_filter: args.log_filter.clone(),
         opentelemetry_endpoint: None,

--- a/src/materialized/src/bin/materialized/sys.rs
+++ b/src/materialized/src/bin/materialized/sys.rs
@@ -9,13 +9,7 @@
 
 //! System support functions.
 
-use std::alloc::{self, Layout};
-use std::io::{self, Write};
-use std::process;
-use std::ptr;
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-use anyhow::{bail, Context};
+use anyhow::Context;
 use nix::errno;
 use nix::sys::signal;
 use tracing::trace;
@@ -101,70 +95,6 @@ pub fn adjust_rlimits() {
     }
 }
 
-/// Attempts to enable backtraces when SIGBUS or SIGSEGV occurs.
-///
-/// In particular, this means producing backtraces on stack overflow, as stack
-/// overflow raises SIGBUS or SIGSEGV via guard pages. The approach here
-/// involves making system calls to handle SIGBUS/SIGSEGV on an alternate signal
-/// stack, which seems to work well in practice but may technically be undefined
-/// behavior.
-///
-/// Rust may someday do this by default. Follow:
-/// https://github.com/rust-lang/rust/issues/51405.
-pub fn enable_sigbus_sigsegv_backtraces() -> Result<(), anyhow::Error> {
-    // This code is derived from the code in the backtrace-on-stack-overflow
-    // crate, which is freely available under the terms of the Apache 2.0
-    // license. The modifications here provide better error messages if any of
-    // the various system calls fail.
-    //
-    // See: https://github.com/matklad/backtrace-on-stack-overflow
-
-    // NOTE(benesch): The stack size was chosen to match the default Rust thread
-    // stack size of 2MiB. Probably overkill, but we'd much rather have
-    // backtraces on stack overflow than squabble over a few megabytes. Using
-    // libc::SIGSTKSZ is tempting, but its default of 8KiB on my system makes me
-    // nervous. Rust code isn't used to running with a stack that small.
-    const STACK_SIZE: usize = 2 << 20;
-
-    // x86_64 and aarch64 require 16-byte alignment. Its hard to imagine other
-    // platforms that would have more stringent requirements.
-    const STACK_ALIGN: usize = 16;
-
-    // Allocate a stack.
-    let buf_layout =
-        Layout::from_size_align(STACK_SIZE, STACK_ALIGN).expect("layout known to be valid");
-    // SAFETY: layout has non-zero size and the uninitialized memory that is
-    // returned is never read (at least, not by Rust).
-    let buf = unsafe { alloc::alloc(buf_layout) };
-
-    // Request that signals be delivered to this alternate stack.
-    let stack = libc::stack_t {
-        ss_sp: buf as *mut libc::c_void,
-        ss_flags: 0,
-        ss_size: STACK_SIZE,
-    };
-    // SAFETY: `stack` is a valid pointer to a `stack_t` object and the second
-    // parameter, `old_ss`, is permitted to be `NULL` according to POSIX.
-    let ret = unsafe { libc::sigaltstack(&stack, ptr::null_mut()) };
-    if ret == -1 {
-        let errno = errno::from_i32(errno::errno());
-        bail!("failed to configure alternate signal stack: {}", errno);
-    }
-
-    // Install a handler for SIGSEGV.
-    let action = signal::SigAction::new(
-        signal::SigHandler::Handler(handle_sigbus_sigsegv),
-        signal::SaFlags::SA_NODEFER | signal::SaFlags::SA_ONSTACK,
-        signal::SigSet::empty(),
-    );
-    // SAFETY: see `handle_sigbus_sigsegv`.
-    unsafe { signal::sigaction(signal::SIGBUS, &action) }
-        .context("failed to install SIGBUS handler")?;
-    unsafe { signal::sigaction(signal::SIGSEGV, &action) }
-        .context("failed to install SIGSEGV handler")?;
-    Ok(())
-}
-
 pub fn enable_sigusr2_coverage_dump() -> Result<(), anyhow::Error> {
     let action = signal::SigAction::new(
         signal::SigHandler::Handler(handle_sigusr2_signal),
@@ -176,37 +106,6 @@ pub fn enable_sigusr2_coverage_dump() -> Result<(), anyhow::Error> {
         .context("failed to install SIGUSR2 handler")?;
 
     Ok(())
-}
-
-extern "C" fn handle_sigbus_sigsegv(_: i32) {
-    // SAFETY: this is is a signal handler function and technically must be
-    // "async-signal safe" [0]. That typically means no memory allocation, which
-    // means no panics or backtraces... but if we're here, we're already doomed
-    // by a segfault. So there is little harm to ignoring the rules and
-    // panicking. If we're successful, as we often are, the panic will be caught
-    // by our panic handler and displayed nicely with a backtrace that traces
-    // *through* the signal handler and includes the frames that led to the
-    // SIGSEGV.
-    //
-    // [0]: https://man7.org/linux/man-pages/man7/signal-safety.7.html
-
-    static SEEN: AtomicUsize = AtomicUsize::new(0);
-    match SEEN.fetch_add(1, Ordering::SeqCst) {
-        0 => {
-            // First SIGSEGV. See if we can defer to our slick panic handler,
-            // which will emit a backtrace and details on where to submit bugs.
-            panic!("received SIGSEGV or SIGBUS (maybe a stack overflow?)");
-        }
-        _ => {
-            // Second SIGSEGV, which means the panic handler itself segfaulted.
-            // This usually indicates that the memory allocator state is
-            // corrupt, which can happen if we overflow the stack while inside
-            // the allocator. Just try to eke out a message and crash.
-            let _ = io::stderr().write_all(b"SIGBUS or SIGSEGV while handling SIGSEGV or SIGBUS\n");
-            let _ = io::stderr().write_all(b"(maybe a stack overflow while allocating?)\n");
-            process::abort();
-        }
-    }
 }
 
 pub fn enable_termination_signal_cleanup() -> Result<(), anyhow::Error> {

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -141,6 +141,8 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 }
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
+    mz_ore::panic::set_abort_on_panic();
+
     mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
         log_filter: args.log_filter.clone(),
         opentelemetry_endpoint: None,

--- a/test/antithesis/driver/docker-compose.yml
+++ b/test/antithesis/driver/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       --data-directory=/mzdata
       --experimental
       --timestamp-frequency 100ms
-      --no-sigbus-sigsegv-backtraces
     image: antithesis-materialized:${ANT_IMAGE_TAG}
     volumes:
       - mzdata:/mzdata:rw


### PR DESCRIPTION
Remove all of the custom panic handling code from materialized. It never
worked quite right anyway. In particular, the code to print backtraces
on SIGSEGV often both failed to print a backtrace *and* inhibited using GDB to
get a backtrace.

Instead, this commit changes our three core services to call
`ore::panic::set_abort_on_panic` and nothing more. This ensures that a
crash in any thread will bring down the entire process, which is a much
better default than limping along with a panicked thread, which is what
Rust does by default.

What we lose is the nice message asking for a bug report, but that's
not nearly as important in a cloud native world--plus that message
tended to get lost in the spew of log messages when computed, storaged,
and materialized all simultaneously crash.

Fix #12583.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
