### PR TITLE
repr: introduce new `Proto$T`-conversion API

### DIFF
--- a/src/repr/src/proto.rs
+++ b/src/repr/src/proto.rs
@@ -307,3 +307,235 @@ where
     let vec = t.encode_to_vec();
     Ok(T::from_proto(U::decode(&*vec)?)?)
 }
+pub mod newapi {
+    use std::collections::HashMap;
+
+    use uuid::Uuid;
+
+    pub use super::TryFromProtoError;
+    use super::{CastFrom, ProtoU128};
+
+    /// A trait that declares that `Self::Proto` is the default
+    /// Protobuf representation for `Self`.
+    pub trait ProtoRepr: Sized + RustType<Self::Proto> {
+        type Proto: ::prost::Message;
+    }
+
+    /// A trait for representing a Rust type `Self` as a value of
+    /// type `Proto` for the purpose of serializing this
+    /// value as (part of) a Protobuf message.
+    ///
+    /// To encode a value, use [`RustType::into_proto()`] (which
+    /// should always be an infallible conversion).
+    ///
+    /// To decode a value, use the fallible [`RustType::from_proto()`].
+    /// Since the representation type can be "bigger" than the original,
+    /// decoding may fail, indicated by returning a [`TryFromProtoError`]
+    /// wrapped in a [`Result::Err`].
+    ///
+    /// Convenience syntax for the above methods is available from the
+    /// matching [`ProtoType`].
+    pub trait RustType<Proto>: Sized {
+        /// Convert a `Self` into a `Proto` value.
+        fn into_proto(self: &Self) -> Proto;
+
+        /// Consume and convert a `Proto` back into a `Self` value.
+        ///
+        /// Since `Proto` can be "bigger" than the original, this
+        /// may fail, indicated by returning a [`TryFromProtoError`]
+        /// wrapped in a [`Result::Err`].
+        fn from_proto(proto: Proto) -> Result<Self, TryFromProtoError>;
+    }
+
+    /// A trait that allows `Self` to be used as an entry in a
+    /// `Vec<Self>` representing a Rust `HashMap<K, V>`.
+    pub trait ProtoMapEntry<K, V> {
+        fn from_rust<'a>(entry: (&'a K, &'a V)) -> Self;
+        fn into_rust(self) -> Result<(K, V), TryFromProtoError>;
+    }
+
+    /// Blanket implementation for `Vec<R>` where `R` is a [`RustType`].
+    impl<K, V, T> RustType<Vec<T>> for HashMap<K, V>
+    where
+        K: std::cmp::Eq + std::hash::Hash,
+        T: ProtoMapEntry<K, V>,
+    {
+        fn into_proto(self: &Self) -> Vec<T> {
+            self.iter().map(T::from_rust).collect()
+        }
+
+        fn from_proto(proto: Vec<T>) -> Result<Self, TryFromProtoError> {
+            Ok(proto
+                .into_iter()
+                .map(T::into_rust)
+                .collect::<Result<HashMap<_, _>, _>>()?)
+        }
+    }
+
+    /// Blanket implementation for `Vec<R>` where `R` is a [`RustType`].
+    impl<R, P> RustType<Vec<P>> for Vec<R>
+    where
+        R: RustType<P>,
+    {
+        fn into_proto(self: &Self) -> Vec<P> {
+            self.iter().map(R::into_proto).collect()
+        }
+
+        fn from_proto(proto: Vec<P>) -> Result<Self, TryFromProtoError> {
+            proto
+                .into_iter()
+                .map(R::from_proto)
+                .collect::<Result<Vec<_>, _>>()
+        }
+    }
+
+    /// Blanket implementation for `Option<R>` where `R` is a [`RustType`].
+    impl<R, P> RustType<Option<P>> for Option<R>
+    where
+        R: RustType<P>,
+    {
+        fn into_proto(self: &Self) -> Option<P> {
+            self.as_ref().map(R::into_proto)
+        }
+
+        fn from_proto(proto: Option<P>) -> Result<Self, TryFromProtoError> {
+            proto.map(R::from_proto).transpose()
+        }
+    }
+
+    /// Blanket implementation for `Option<R>` where `R` is a [`RustType`].
+    impl<R, P> RustType<Box<P>> for Box<R>
+    where
+        R: RustType<P>,
+    {
+        fn into_proto(&self) -> Box<P> {
+            Box::new((**self).into_proto())
+        }
+
+        fn from_proto(proto: Box<P>) -> Result<Self, TryFromProtoError> {
+            (*proto).into_rust().map(Box::new)
+        }
+    }
+
+    impl RustType<u64> for usize {
+        fn into_proto(self: &Self) -> u64 {
+            u64::cast_from(*self)
+        }
+
+        fn from_proto(proto: u64) -> Result<Self, TryFromProtoError> {
+            usize::try_from(proto).map_err(TryFromProtoError::from)
+        }
+    }
+
+    impl RustType<u32> for char {
+        fn into_proto(self: &Self) -> u32 {
+            (*self).into()
+        }
+
+        fn from_proto(proto: u32) -> Result<Self, TryFromProtoError> {
+            char::try_from(proto).map_err(TryFromProtoError::from)
+        }
+    }
+
+    impl RustType<u32> for u8 {
+        fn into_proto(self: &Self) -> u32 {
+            *self as u32
+        }
+
+        fn from_proto(proto: u32) -> Result<Self, TryFromProtoError> {
+            u8::try_from(proto).map_err(TryFromProtoError::from)
+        }
+    }
+
+    impl RustType<ProtoU128> for u128 {
+        fn into_proto(self: &Self) -> ProtoU128 {
+            let lo = (self & (u64::MAX as u128)) as u64;
+            let hi = (self >> 64) as u64;
+            ProtoU128 { hi, lo }
+        }
+
+        fn from_proto(proto: ProtoU128) -> Result<Self, TryFromProtoError> {
+            Ok((proto.hi as u128) << 64 | (proto.lo as u128))
+        }
+    }
+
+    impl RustType<ProtoU128> for Uuid {
+        fn into_proto(self: &Self) -> ProtoU128 {
+            self.as_u128().into_proto()
+        }
+
+        fn from_proto(proto: ProtoU128) -> Result<Self, TryFromProtoError> {
+            Ok(Uuid::from_u128(u128::from_proto(proto)?))
+        }
+    }
+
+    impl RustType<u64> for std::num::NonZeroUsize {
+        fn into_proto(self: &Self) -> u64 {
+            usize::from(*self).into_proto()
+        }
+
+        fn from_proto(proto: u64) -> Result<Self, TryFromProtoError> {
+            Ok(usize::from_proto(proto)?.try_into()?)
+        }
+    }
+
+    /// The symmetric counterpart of [`RustType`], similar to
+    /// what [`Into`] is to [`From`].
+    ///
+    /// The `Rust` parameter is generic, as opposed to the `Proto`
+    /// associated type in [`RustType`] because the same Protobuf type
+    /// can be used to encode many different Rust types.
+    ///
+    /// Clients should only implement [`RustType`].
+    pub trait ProtoType<Rust>: Sized {
+        /// See [`RustType::from_proto`].
+        fn into_rust(self: Self) -> Result<Rust, TryFromProtoError>;
+
+        /// See [`RustType::into_proto`].
+        fn from_rust(rust: &Rust) -> Self;
+    }
+
+    /// Blanket implementation for [`ProtoType`], so clients only need
+    /// to implement [`RustType`].
+    impl<P, R> ProtoType<R> for P
+    where
+        R: RustType<P>,
+    {
+        #[inline]
+        fn into_rust(self: Self) -> Result<R, TryFromProtoError> {
+            R::from_proto(self)
+        }
+
+        #[inline]
+        fn from_rust(rust: &R) -> Self {
+            R::into_proto(rust)
+        }
+    }
+
+    /// Convenience syntax for trying to convert a `Self` value of type
+    /// `Option<U>` to `T` if the value is `Some(value)`, or returning
+    /// [`TryFromProtoError::MissingField`] if the value is `None`.
+    pub trait IntoRustIfSome<T> {
+        fn into_rust_if_some<S: ToString>(self, field: S) -> Result<T, TryFromProtoError>;
+    }
+
+    /// A blanket implementation for `Option<U>` where `U` is the
+    /// `RustType::Proto` type for `T`.
+    impl<R, P> IntoRustIfSome<R> for Option<P>
+    where
+        R: RustType<P>,
+    {
+        fn into_rust_if_some<S: ToString>(self, field: S) -> Result<R, TryFromProtoError> {
+            R::from_proto(self.ok_or_else(|| TryFromProtoError::missing_field(field))?)
+        }
+    }
+
+    pub fn protobuf_roundtrip<R, P>(val: &R) -> anyhow::Result<R>
+    where
+        P: ProtoType<R> + ::prost::Message + Default,
+    {
+        let vec = P::from_rust(&val).encode_to_vec();
+        let val = P::decode(&*vec)?.into_rust()?;
+        Ok(val)
+    }
+}


### PR DESCRIPTION
Add a more ergonomic and flexibile Protobuf conversion API in `mz_repr::proto::newapi`. Follow-up PRs will migrate existing code to this API, and we will then replace the code in `mz_repr::proto` with `mz_repr::proto::newapi`.


### Motivation

  * This PR adds a known-desirable feature.

    This is the first part of resolving #12579.

### Tips for reviewer

The basic ideas are summarized below:

- Use `RustType` (with a blanket implementation for `ProtoType`, similar to what `Into` is for `From`) in order to define the pair of mappings for [all classes of types](https://github.com/MaterializeInc/materialize/blob/c8409398f3648635d88d3f0dbf5eac7efe1bba2d/doc/developer/command_and_response_binary_encoding.md#type-classes) in a single trait rather than choosing between `ProtoRepr` and `From + TryFrom` as it is at the moment.
- Provide implementations for common simple and complex external types (`usize`, `NaiveDate`).
- Provide blanket implementations for common container types: `Box`, `Option`, `Vec`, `HashMap`.
- Provide a dedicated trait `ProtoRepr` that encodes the default `Proto$T` for a given `$T` (there can be many depending on the context), and use `ProtoRepr` as a trait bound in client code (for example, in #12516).

For motivation and details see #12579. 

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

Not handling this at the moment. The soundness of the new API will be checked once we migrate existing code and its tests.

### Release notes

N/A
