### PR TITLE
doc: fix `md` format and update url link

### DIFF
--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -926,5 +926,5 @@ submit a PR to fix it!
 [rust-rdkafka]: https://github.com/fede1024/rust-rdkafka
 [rust-prometheus]: https://github.com/MaterializeInc/rust-prometheus
 [rust-postgres]: https://github.com/sfackler/rust-postgres
-[sqlparser]: https://github.com/ballista-compute/sqlparser-rs
+[sqlparser]: https://github.com/sqlparser-rs/sqlparser-rs
 [Tokio]: https://tokio.rs

--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -235,7 +235,7 @@ This repository has the following basic structure:
     <https://materialize.com/docs>.
   * **`misc`** contains a variety of supporting tools and projects. Some
     highlights:
-    * **`misc/dbt-materialize` contains the Materialize [dbt] adapter.
+    * **`misc/dbt-materialize`** contains the Materialize [dbt] adapter.
     * **`misc/python`** contains Python developer tools, like
       [mzbuild](mzbuild.md).
     * **`misc/nix`** contains an experimental [Nix] configuration for


### PR DESCRIPTION
## Main issue
1.  Fix md format in `doc/developer/guide.md`
2. The final destination of two are the same, it is intend to avoid redirect