### PR TITLE
Pass CLI args to bin/{materialized,sqllogictest}

### DIFF
--- a/bin/materialized
+++ b/bin/materialized
@@ -11,4 +11,4 @@
 #
 # materialized — build and run materialized and its constituent services.
 
-exec "$(dirname "$0")"/run materialized
+exec "$(dirname "$0")"/run materialized "$@"

--- a/bin/sqllogictest
+++ b/bin/sqllogictest
@@ -11,4 +11,4 @@
 #
 # sqllogictest — build and run sqllogictest and its constituent services.
 
-exec "$(dirname "$0")"/run sqllogictest
+exec "$(dirname "$0")"/run sqllogictest "$@"

--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -160,7 +160,7 @@ made up for by a much faster execution.
 To add logging for tests, append `-vv`, e.g.:
 
 ```shell
-$ bin/sqllogictest [--release] -vv -- test/sqllogictest/TESTFILE.slt
+$ bin/sqllogictest [--release] -- test/sqllogictest/TESTFILE.slt -vv
 ```
 
 There are currently three classes of sqllogictest files:


### PR DESCRIPTION
Looks like an oversight in #12544.

### Motivation

  * This PR fixes a previously unreported bug.

    Command line arguments are not forwarded by the `bin/{materialized,sqllogictest}` scripts.

    Specifically, running `bin/sqllogictest -- some.slt` fails with: 
    ```
    error: The following required arguments were not provided:
        <PATH>...
    ```

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).