### PR TITLE
[coord] Enable multi-statement alter secret transactions

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1367,6 +1367,12 @@ impl<S: Append + 'static> Coordinator<S> {
                         // is always safe.
                     }
 
+                    Statement::AlterSecret(_)
+                        if self.secrets_controller.supports_multi_statement_txn() =>
+                    {
+                        // if the controller supports this, its safe combine
+                    }
+
                     // Statements below must by run singly (in Started).
                     Statement::AlterIndex(_)
                     | Statement::AlterSecret(_)
@@ -1753,7 +1759,10 @@ impl<S: Append + 'static> Coordinator<S> {
                 tx.send(self.sequence_alter_index_reset_options(plan).await, session);
             }
             Plan::AlterSecret(plan) => {
-                tx.send(self.sequence_alter_secret(&session, plan).await, session);
+                tx.send(
+                    self.sequence_alter_secret(&mut session, plan).await,
+                    session,
+                );
             }
             Plan::DiscardTemp => {
                 self.drop_temp_items(session.conn_id()).await;
@@ -2901,6 +2910,9 @@ impl<S: Append + 'static> Coordinator<S> {
                             0 => {},
                             _ => unreachable!("multi-table write transaction should fail immediately when the second table is added to the transaction"),
                         }
+                    }
+                    TransactionOps::Secrets(secrets) => {
+                        self.secrets_controller.apply(secrets).await?
                     }
                     _ => {}
                 }
@@ -4204,19 +4216,17 @@ impl<S: Append + 'static> Coordinator<S> {
 
     async fn sequence_alter_secret(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         plan: AlterSecretPlan,
     ) -> Result<ExecuteResponse, CoordError> {
         let AlterSecretPlan { id, mut secret_as } = plan;
 
         let payload = self.extract_secret(session, &mut secret_as)?;
 
-        self.secrets_controller
-            .apply(vec![SecretOp::Ensure {
-                id,
-                contents: payload,
-            }])
-            .await?;
+        session.add_transaction_ops(TransactionOps::Secrets(vec![SecretOp::Ensure {
+            id,
+            contents: payload,
+        }]))?;
 
         Ok(ExecuteResponse::AlteredObject(ObjectType::Secret))
     }

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -134,6 +134,8 @@ pub enum CoordError {
     WriteOnlyTransaction,
     /// The transaction only supports single table writes
     MultiTableWriteTransaction,
+    /// The transaction is in secrets-only mode.
+    SecretsOnlyTransaction,
 }
 
 impl CoordError {
@@ -369,6 +371,7 @@ impl fmt::Display for CoordError {
             CoordError::MultiTableWriteTransaction => {
                 f.write_str("write transactions only support writes to a single table")
             }
+            CoordError::SecretsOnlyTransaction => f.write_str("transaction in secrets-only mode"),
         }
     }
 }

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -23,6 +23,7 @@ use tokio::sync::OwnedMutexGuard;
 use mz_dataflow_types::client::ComputeInstanceId;
 use mz_pgrepr::Format;
 use mz_repr::{Datum, Diff, GlobalId, Row, ScalarType};
+use mz_secrets::SecretOp;
 use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 
@@ -216,6 +217,12 @@ impl<T: CoordTimestamp> Session<T> {
                         _ => {
                             return Err(CoordError::WriteOnlyTransaction);
                         }
+                    },
+                    TransactionOps::Secrets(secret_txn_ops) => match add_ops {
+                        TransactionOps::Secrets(mut add_secret_ops) => {
+                            secret_txn_ops.append(&mut add_secret_ops);
+                        }
+                        _ => return Err(CoordError::SecretsOnlyTransaction),
                     },
                 }
             }
@@ -648,6 +655,8 @@ pub enum TransactionOps<T> {
     /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must only do
     /// other writes.
     Writes(Vec<WriteOp>),
+    /// This transaction has had a secrets DDL operation and must only do other secrets operations
+    Secrets(Vec<SecretOp>),
 }
 
 /// An `INSERT` waiting to be committed.

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -415,6 +415,7 @@ impl ErrorResponse {
             // code, so it's probably the best choice.
             CoordError::WriteOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::MultiTableWriteTransaction => SqlState::INVALID_TRANSACTION_STATE,
+            CoordError::SecretsOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
         };
         ErrorResponse {
             severity,

--- a/src/secrets-filesystem/src/lib.rs
+++ b/src/secrets-filesystem/src/lib.rs
@@ -62,4 +62,8 @@ impl SecretsController for FilesystemSecretsController {
 
         return Ok(());
     }
+
+    fn supports_multi_statement_txn(&self) -> bool {
+        false
+    }
 }

--- a/src/secrets-kubernetes/src/lib.rs
+++ b/src/secrets-kubernetes/src/lib.rs
@@ -173,4 +173,8 @@ impl SecretsController for KubernetesSecretsController {
 
         return Ok(());
     }
+
+    fn supports_multi_statement_txn(&self) -> bool {
+        true
+    }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -23,6 +23,7 @@ pub trait SecretsController: Send + Sync {
     /// they cannot apply atomically.
     async fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), anyhow::Error>;
 
+    /// Returns true, if the controller supports multiple ops in a single atomic apply call
     fn supports_multi_statement_txn(&self) -> bool;
 }
 

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -22,9 +22,12 @@ pub trait SecretsController: Send + Sync {
     /// Implementations are permitted to reject combinations of operations which
     /// they cannot apply atomically.
     async fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), anyhow::Error>;
+
+    fn supports_multi_statement_txn(&self) -> bool;
 }
 
 /// An operation on a [`SecretsController`].
+#[derive(Debug, Clone, PartialEq)]
 pub enum SecretOp {
     /// Create or update the contents of a secret.
     Ensure {


### PR DESCRIPTION
It is desirable that a user can alter multiple secrets in one atomic operation. For example, one might want to change the CA along with the server certificate, or client certificate.

The FS SecretsController does not support atomic transactions on multiple secrets, but the Kubernetes controller does.

This PR only allows the mutation of multiple secrets via the `alter` statement. Neither `drop` nor `create` can be mixed in a single transaction.

### Motivation
This PR adds a known-desirable feature.

### Testing

- I have tested this manually with the Kubernetes controller.
- I have tested this manually by temporarily enabling multi-statement transactions on the FS.
- Once the k8s test framework has landed, this needs automated tests
