### PR TITLE
storaged,computed,materialized: use stable UID/GID in Docker image

### DIFF
--- a/src/compute/ci/Dockerfile
+++ b/src/compute/ci/Dockerfile
@@ -9,8 +9,13 @@
 
 MZFROM ubuntu-base
 
-RUN apt-get update && apt-get -qy install ca-certificates curl tini
+RUN apt-get update \
+    && apt-get -qy install ca-certificates curl tini \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize
 
 COPY computed /usr/local/bin/
+
+USER materialize
 
 ENTRYPOINT ["tini", "--", "computed", "--listen-addr=0.0.0.0:2100"]

--- a/src/materialized/ci-slim/Dockerfile
+++ b/src/materialized/ci-slim/Dockerfile
@@ -11,7 +11,8 @@ MZFROM ubuntu-base
 
 RUN apt-get update \
     && apt-get -qy install ca-certificates tini \
-    && useradd --system --create-home materialize \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize \
     && mkdir /mzdata \
     && chown materialize /mzdata
 

--- a/src/materialized/ci/Dockerfile
+++ b/src/materialized/ci/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update \
         postgresql-14 \
         sqlite3 \
         tini \
-    && useradd --system --create-home materialize \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize \
     && pg_dropcluster 14 main \
     && pg_createcluster 14 materialize --user=materialize \
     && pg_ctlcluster 14 materialize start \

--- a/src/storage/ci/Dockerfile
+++ b/src/storage/ci/Dockerfile
@@ -9,8 +9,13 @@
 
 MZFROM ubuntu-base
 
-RUN apt-get update && apt-get -qy install ca-certificates curl tini
+RUN apt-get update \
+    && apt-get -qy install ca-certificates curl tini \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize
 
 COPY storaged /usr/local/bin/
+
+USER materialize
 
 ENTRYPOINT ["tini", "--", "storaged", "--listen-addr=0.0.0.0:2100"]


### PR DESCRIPTION
Use the stable 999 UID and GID for the "materialize" user in the
materialized, materialized-slim, storaged, and computed Docker images.
Having a stable UID/GID will prevent a painful migration later if the
Ubuntu base image changes how UIDs/GIDs are assigned; "999" seems to be
a loose Docker convention and is used by both the mysql and postgres
Docker images.

Note that using a less-privileged user is new behavior for the storaged
and computed images that bring it in line with the materialized and
materialized-slim images.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
