### PR TITLE
Use passed in AWS external ID as a prefix

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -28,7 +28,7 @@ use mz_repr::proto::{any_uuid, FromProtoIfSome, ProtoRepr, TryFromProtoError, Tr
 use mz_repr::{Diff, GlobalId, RelationType, Row};
 
 use crate::client::controller::storage::CollectionMetadata;
-use crate::types::aws::AwsExternalId;
+use crate::types::aws::AwsExternalIdPrefix;
 use crate::types::sinks::SinkDesc;
 use crate::types::sources::SourceDesc;
 use crate::Plan;
@@ -535,20 +535,22 @@ pub mod aws {
         }
     }
 
-    /// An [external ID] to use for all AWS AssumeRole operations.
+    /// A prefix for an [external ID] to use for all AWS AssumeRole operations.
+    /// It should be concatenanted with a non-user-provided suffix identifying the source or sink.
+    /// The ID used for the suffix should never be reused if the source or sink is deleted.
     ///
     /// **WARNING:** it is critical for security that this ID is **not**
     /// provided by end users of Materialize. It must be provided by the
     /// operator of the Materialize service.
     ///
     /// This type protects against accidental construction of an
-    /// `AwsExternalId`. The only approved way to construct an `AwsExternalId`
+    /// `AwsExternalIdPrefix`. The only approved way to construct an `AwsExternalIdPrefix`
     /// is via [`ConnectorContext::from_cli_args`].
     ///
     /// [`ConnectorContext::from_cli_args`]: crate::ConnectorContext::from_cli_args
     /// [external ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-    pub struct AwsExternalId(pub(super) String);
+    pub struct AwsExternalIdPrefix(pub(super) String);
 
     /// AWS configuration overrides for a source or sink.
     ///
@@ -680,7 +682,11 @@ pub mod aws {
     impl AwsConfig {
         /// Loads the AWS SDK configuration object from the environment, then
         /// applies the overrides from this object.
-        pub async fn load(&self, external_id: Option<&AwsExternalId>) -> aws_types::SdkConfig {
+        pub async fn load(
+            &self,
+            external_id_prefix: Option<&AwsExternalIdPrefix>,
+            external_id_suffix: &str,
+        ) -> aws_types::SdkConfig {
             use aws_config::default_provider::credentials::DefaultCredentialsChain;
             use aws_config::default_provider::region::DefaultRegionChain;
             use aws_config::sts::AssumeRoleProvider;
@@ -731,8 +737,9 @@ pub mod aws {
                 if let Some(region) = &region {
                     role = role.region(region.clone());
                 }
-                if let Some(external_id) = external_id {
-                    role = role.external_id(&external_id.0);
+                if let Some(external_id_prefix) = external_id_prefix {
+                    role = role
+                        .external_id(&format!("{}-{}", external_id_prefix.0, external_id_suffix));
                 }
                 cred_provider = SharedCredentialsProvider::new(role.build(cred_provider));
             }
@@ -756,8 +763,8 @@ pub mod aws {
 pub struct ConnectorContext {
     /// The level for librdkafka's logs.
     pub librdkafka_log_level: tracing::Level,
-    /// An external ID to use for all AWS AssumeRole operations.
-    pub aws_external_id: Option<AwsExternalId>,
+    /// A prefix for an external ID to use for all AWS AssumeRole operations.
+    pub aws_external_id_prefix: Option<AwsExternalIdPrefix>,
 }
 
 impl ConnectorContext {
@@ -767,14 +774,14 @@ impl ConnectorContext {
     /// provided by the operator of the Materialize service (i.e., via a CLI
     /// argument or environment variable) and not the end user of Materialize
     /// (e.g., via a configuration option in a SQL statement). See
-    /// [`AwsExternalId`] for details.
+    /// [`AwsExternalIdPrefix`] for details.
     pub fn from_cli_args(
         filter: &tracing_subscriber::filter::Targets,
-        aws_external_id: Option<String>,
+        aws_external_id_prefix: Option<String>,
     ) -> ConnectorContext {
         ConnectorContext {
             librdkafka_log_level: mz_ore::tracing::target_level(filter, "librdkafka"),
-            aws_external_id: aws_external_id.map(AwsExternalId),
+            aws_external_id_prefix: aws_external_id_prefix.map(AwsExternalIdPrefix),
         }
     }
 }
@@ -783,7 +790,7 @@ impl Default for ConnectorContext {
     fn default() -> ConnectorContext {
         ConnectorContext {
             librdkafka_log_level: tracing::Level::INFO,
-            aws_external_id: None,
+            aws_external_id_prefix: None,
         }
     }
 }

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -374,11 +374,11 @@ pub struct Args {
     catalog_postgres_stash: String,
 
     // === AWS options. ===
-    /// An external ID to be supplied to all AWS AssumeRole operations.
+    /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
     #[clap(long, value_name = "ID")]
-    aws_external_id: Option<String>,
+    aws_external_id_prefix: Option<String>,
 
     /// The endpoint to send opentelemetry traces to.
     /// If not provided, tracing is not sent.
@@ -738,7 +738,10 @@ max log level: {max_log_level}",
         now: SYSTEM_TIME.clone(),
         replica_sizes,
         availability_zones: args.availability_zone,
-        connector_context: ConnectorContext::from_cli_args(&args.log_filter, args.aws_external_id),
+        connector_context: ConnectorContext::from_cli_args(
+            &args.log_filter,
+            args.aws_external_id_prefix,
+        ),
     }))?;
 
     eprintln!(

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -520,7 +520,7 @@ async fn validate_aws_credentials(
     config: &AwsConfig,
     external_id_prefix: Option<&AwsExternalIdPrefix>,
 ) -> Result<(), anyhow::Error> {
-    let config = config.load(external_id_prefix, "").await;
+    let config = config.load(external_id_prefix, None).await;
     let sts_client = aws_sdk_sts::Client::new(&config);
     let _ = sts_client
         .get_caller_identity()

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -278,11 +278,7 @@ async fn create_state(
     ),
     anyhow::Error,
 > {
-    // TODO what to use for the source ID?
-    let config = c
-        .aws
-        .load(aws_external_id_prefix, &format!("{}", source_id))
-        .await;
+    let config = c.aws.load(aws_external_id_prefix, Some(&source_id)).await;
     let kinesis_client = aws_sdk_kinesis::Client::new(&config);
 
     let shard_set = mz_kinesis_util::get_shard_ids(&kinesis_client, &c.stream_name).await?;


### PR DESCRIPTION
Instead of using the external ID as passed in, use it as a prefix with
the source or sink ID appended.

This should play nicer with RBAC, in case customers want to allow only
certain sources or sinks to assume their AWS role.

Part 1 of https://github.com/MaterializeInc/cloud/issues/2837

### Motivation

  * This PR adds a known-desirable feature.

Part 1 of https://github.com/MaterializeInc/cloud/issues/2837

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
