### PR TITLE
fix(plan): add check with duplicate column name in `plan_create_source`

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -916,6 +916,11 @@ pub fn plan_create_source(
 
     desc = plan_utils::maybe_rename_columns(format!("source {}", name), desc, &col_names)?;
 
+    let names: Vec<_> = desc.iter_names().cloned().collect();
+    if let Some(dup) = names.iter().duplicates().next() {
+        bail!("column {} specified more than once", dup.as_str().quoted());
+    }
+
     // Apply user-specified key constraint
     if let Some(KeyConstraint::PrimaryKeyNotEnforced { columns }) = key_constraint.clone() {
         let key_columns = columns

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -496,10 +496,10 @@ impl Action for FailSqlAction {
 impl FailSqlAction {
     async fn try_redo(&self, state: &State, query: &str) -> Result<(), anyhow::Error> {
         match state.pgclient.query(query, &[]).await {
-            Ok(_) => bail!("query succeeded, but expected {}", self.expected_error,),
+            Ok(_) => bail!("query succeeded, but expected {}", self.expected_error),
             Err(err) => match err.source().and_then(|err| err.downcast_ref::<DbError>()) {
                 Some(err) => {
-                    let mut err_string = err.to_string();
+                    let mut err_string = err.message().to_string();
                     if let Some(regex) = &state.regex {
                         err_string = regex
                             .replace_all(&err_string, state.regex_replacement.as_str())

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -131,33 +131,14 @@ $ set schemaheaders={
 
 $ kafka-create-topic topic=headers_conflict
 
-> CREATE MATERIALIZED SOURCE headers_conflict
+! CREATE MATERIALIZED SOURCE headers_conflict
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
   'testdrive-headers_conflict-${testdrive.seed}'
   KEY FORMAT AVRO USING SCHEMA '${keyschema}'
   VALUE FORMAT AVRO USING SCHEMA '${schemaheaders}'
   INCLUDE HEADERS
   ENVELOPE UPSERT
-
-# conflict!!
-! SELECT headers from headers_conflict
-contains:column reference "headers" is ambiguous
-
-# both columns exist
-> SHOW COLUMNS from headers_conflict
-name       nullable  type
--------------------------
-headers    false     list
-headers    false     text
-key        false     text
-
-$ kafka-ingest format=avro topic=headers_conflict key-format=avro key-schema=${keyschema} schema=${schemaheaders} headers={"gus": "hmm"}
-{"key": "fish"} {"headers": "value"}
-
-> SELECT count(*) from headers_conflict
-count
------
-1
+contains: column "headers" specified more than once
 
 # No meaningful way to get data out in td because of the ambiguous name
 # + weird type

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -65,19 +65,12 @@ contains:INCLUDE TOPIC not yet supported
   INCLUDE TIMESTAMP as myts, TOPIC
 contains:INCLUDE TOPIC not yet supported
 
-> CREATE MATERIALIZED SOURCE avro_data_conflict
+! CREATE MATERIALIZED SOURCE avro_data_conflict
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'
   KEY FORMAT AVRO USING SCHEMA '${conflictkeyschema}'
   VALUE FORMAT AVRO USING SCHEMA '${schema}'
   INCLUDE KEY
-
-! SELECT id, b FROM avro_data_conflict
-contains:column reference "id" is ambiguous
-
-> SELECT * FROM avro_data_conflict
-id id b
--------
-1 2 3
+contains: column "id" specified more than once
 
 > CREATE MATERIALIZED SOURCE avro_data_explicit (key_id, id, b)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-${testdrive.seed}'

--- a/test/testdrive/kafka-upsert-sources-new-syntax.td
+++ b/test/testdrive/kafka-upsert-sources-new-syntax.td
@@ -264,19 +264,19 @@ $ set keyschema2={
     "name": "Key2",
     "fields": [
         {"name": "f3", "type": ["null", "string"]},
-        {"name": "f1", "type": ["null", "string"]}
+        {"name": "f4", "type": ["null", "string"]}
     ]
   }
 
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
-{"f3": {"string": "fire"}, "f1": {"string": "yang"}} {"f1": "dog", "f2": 42}
-{"f3": null, "f1": {"string": "yin"}} {"f1": "sheep", "f2": 53}
-{"f3": {"string": "water"}, "f1": null} {"f1":"plesiosaur", "f2": 224}
-{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "turtle", "f2": 34}
-{"f3": null, "f1": {"string": "yin"}} {"f1": "sheep", "f2": 54}
-{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "snake", "f2": 68}
-{"f3": {"string": "water"}, "f1": null} {"f1": "crocodile", "f2": 7}
-{"f3": {"string": "earth"}, "f1":{"string": "dao"}}
+{"f3": {"string": "fire"}, "f4": {"string": "yang"}} {"f1": "dog", "f2": 42}
+{"f3": null, "f4": {"string": "yin"}} {"f1": "sheep", "f2": 53}
+{"f3": {"string": "water"}, "f4": null} {"f1":"plesiosaur", "f2": 224}
+{"f3": {"string": "earth"}, "f4": {"string": "dao"}} {"f1": "turtle", "f2": 34}
+{"f3": null, "f4": {"string": "yin"}} {"f1": "sheep", "f2": 54}
+{"f3": {"string": "earth"}, "f4": {"string": "dao"}} {"f1": "snake", "f2": 68}
+{"f3": {"string": "water"}, "f4": null} {"f1": "crocodile", "f2": 7}
+{"f3": {"string": "earth"}, "f4":{"string": "dao"}}
 
 > CREATE SOURCE realtimeavroavro (f3, f4, f1, f2)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
@@ -303,21 +303,21 @@ water     <null>  crocodile      7
   ENVELOPE UPSERT
 
 > SELECT * FROM realtimeavroavro_ff
-f3        f1        f1           f2
+f3        f4        f1           f2
 -----------------------------------
 <null>    yin       sheep        54
 water     <null>    crocodile    7
 
 # ensure that having deletion on a key that never existed does not break anything
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
-{"f3": {"string": "fire"}, "f1": {"string": "yin"}}
-{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "pigeon", "f2": 10}
-{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "owl", "f2": 15}
-{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "rhinoceros", "f2": 211}
-{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "chicken", "f2": 47}
-{"f3": null, "f1":{"string": "yin"}}
-{"f3": null, "f1":{"string": "yin"}} {"f1":"dog", "f2": 243}
-{"f3": {"string": "water"}, "f1": null}
+{"f3": {"string": "fire"}, "f4": {"string": "yin"}}
+{"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "pigeon", "f2": 10}
+{"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "owl", "f2": 15}
+{"f3": {"string": "earth"}, "f4": {"string": "dao"}} {"f1": "rhinoceros", "f2": 211}
+{"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "chicken", "f2": 47}
+{"f3": null, "f4":{"string": "yin"}}
+{"f3": null, "f4":{"string": "yin"}} {"f1":"dog", "f2": 243}
+{"f3": {"string": "water"}, "f4": null}
 
 > select * from realtimeavroavro_view
 f3         f4          f1             f2
@@ -510,7 +510,7 @@ librairie 10
   ENVELOPE UPSERT
 
 > SELECT * FROM include_metadata
-f3        f1        f1           f2   partition  offset
+f3        f4        f1           f2   partition  offset
 -------------------------------------------------------
 <null>    yin       dog          243   0         15
 air       qi        chicken      47    0         13

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -265,19 +265,19 @@ $ set keyschema2={
     "name": "Key2",
     "fields": [
         {"name": "f3", "type": ["null", "string"]},
-        {"name": "f1", "type": ["null", "string"]}
+        {"name": "f4", "type": ["null", "string"]}
     ]
   }
 
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
-{"f3": {"string": "fire"}, "f1": {"string": "yang"}} {"f1": "dog", "f2": 42}
-{"f3": null, "f1": {"string": "yin"}} {"f1": "sheep", "f2": 53}
-{"f3": {"string": "water"}, "f1": null} {"f1":"plesiosaur", "f2": 224}
-{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "turtle", "f2": 34}
-{"f3": null, "f1": {"string": "yin"}} {"f1": "sheep", "f2": 54}
-{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "snake", "f2": 68}
-{"f3": {"string": "water"}, "f1": null} {"f1": "crocodile", "f2": 7}
-{"f3": {"string": "earth"}, "f1":{"string": "dao"}}
+{"f3": {"string": "fire"}, "f4": {"string": "yang"}} {"f1": "dog", "f2": 42}
+{"f3": null, "f4": {"string": "yin"}} {"f1": "sheep", "f2": 53}
+{"f3": {"string": "water"}, "f4": null} {"f1":"plesiosaur", "f2": 224}
+{"f3": {"string": "earth"}, "f4": {"string": "dao"}} {"f1": "turtle", "f2": 34}
+{"f3": null, "f4": {"string": "yin"}} {"f1": "sheep", "f2": 54}
+{"f3": {"string": "earth"}, "f4": {"string": "dao"}} {"f1": "snake", "f2": 68}
+{"f3": {"string": "water"}, "f4": null} {"f1": "crocodile", "f2": 7}
+{"f3": {"string": "earth"}, "f4":{"string": "dao"}}
 
 > CREATE SOURCE realtimeavroavro (f3, f4, f1, f2)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
@@ -303,21 +303,21 @@ water     <null>  crocodile      7
   ENVELOPE UPSERT FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > SELECT * FROM realtimeavroavro_ff
-f3        f1        f1           f2
+f3        f4        f1           f2
 -----------------------------------
 <null>    yin       sheep        54
 water     <null>    crocodile    7
 
 # ensure that having deletion on a key that never existed does not break anything
 $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
-{"f3": {"string": "fire"}, "f1": {"string": "yin"}}
-{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "pigeon", "f2": 10}
-{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "owl", "f2": 15}
-{"f3": {"string": "earth"}, "f1": {"string": "dao"}} {"f1": "rhinoceros", "f2": 211}
-{"f3": {"string": "air"}, "f1":{"string": "qi"}} {"f1": "chicken", "f2": 47}
-{"f3": null, "f1":{"string": "yin"}}
-{"f3": null, "f1":{"string": "yin"}} {"f1":"dog", "f2": 243}
-{"f3": {"string": "water"}, "f1": null}
+{"f3": {"string": "fire"}, "f4": {"string": "yin"}}
+{"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "pigeon", "f2": 10}
+{"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "owl", "f2": 15}
+{"f3": {"string": "earth"}, "f4": {"string": "dao"}} {"f1": "rhinoceros", "f2": 211}
+{"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "chicken", "f2": 47}
+{"f3": null, "f4":{"string": "yin"}}
+{"f3": null, "f4":{"string": "yin"}} {"f1":"dog", "f2": 243}
+{"f3": {"string": "water"}, "f4": null}
 
 > select * from realtimeavroavro_view
 f3         f4          f1             f2
@@ -623,4 +623,4 @@ $ set ambiguous-schema={
 ! CREATE MATERIALIZED SOURCE input_pkne (f1, f2, f1, PRIMARY KEY (f1) NOT ENFORCED)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${ambiguous-schema}' ENVELOPE NONE
-contains:Ambiguous column in source key constraint: f1
+exact:column "f1" specified more than once


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
As issue #11637 say, we should prohibit duplicate column names when `create source`.
So we need add a column check in `plan_create_source` which behavior is the same as `create_view`
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
