### PR TITLE
*: standardize RUST_BACKTRACE handling

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -236,5 +236,8 @@ ENV CARGO_HOME=/cargo
 RUN mkdir /cargo && chmod 777 /cargo
 VOLUME /cargo
 
+# Ensure any Rust binaries that crash print a backtrace.
+ENV RUST_BACKTRACE=1
+
 # Make the image as small as possible.
 RUN find /workdir /root -mindepth 1 -maxdepth 1 -exec rm -rf {} +

--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -13,8 +13,6 @@
 
 set -euo pipefail
 
-export RUST_BACKTRACE=full
-
 mkdir -p target
 
 sqllogictest \

--- a/ci/test/cargo-test/image/run-tests
+++ b/ci/test/cargo-test/image/run-tests
@@ -11,8 +11,6 @@
 
 set -euo pipefail
 
-export RUST_BACKTRACE=full
-
 passed=0
 total=0
 

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -15,8 +15,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-ci_init
-
 ci_try bin/lint
 ci_try cargo --locked fmt -- --check
 ci_try cargo --locked deny check licenses bans sources

--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -15,8 +15,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-ci_init
-
 ci_try bin/xcompile cargo test --locked --doc
 # Intentionally run check last, since otherwise it won't use the cache.
 # https://github.com/rust-lang/rust-clippy/issues/3840

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -13,8 +13,6 @@
 
 set -euo pipefail
 
-export RUST_BACKTRACE=full
-
 tests=(
     test/sqllogictest/*.slt
     test/sqllogictest/qgm/*.slt

--- a/misc/images/ubuntu-base/Dockerfile
+++ b/misc/images/ubuntu-base/Dockerfile
@@ -8,3 +8,6 @@
 # by the Apache License, Version 2.0.
 
 FROM ubuntu:jammy-20220421
+
+# Ensure any Rust binaries that crash print a backtrace.
+ENV RUST_BACKTRACE=1

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -46,7 +46,6 @@ class Materialized(Service):
         if environment is None:
             environment = [
                 "MZ_SOFT_ASSERTIONS=1",
-                "RUST_BACKTRACE=1",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
                 # then accidentally dependent on the state of the host machine.
@@ -135,7 +134,6 @@ class Computed(Service):
             environment = [
                 "COMPUTED_LOG_FILTER",
                 "MZ_SOFT_ASSERTIONS=1",
-                "RUST_BACKTRACE=1",
             ]
 
         if volumes is None:
@@ -521,7 +519,6 @@ class Testdrive(Service):
             environment = [
                 "TMPDIR=/share/tmp",
                 "MZ_SOFT_ASSERTIONS=1",
-                "RUST_BACKTRACE=1",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
                 # then accidentally dependent on the state of the host machine.
@@ -623,12 +620,10 @@ class SqlLogicTest(Service):
         name: str = "sqllogictest-svc",
         mzbuild: str = "sqllogictest",
         environment: List[str] = [
-            "RUST_BACKTRACE=full",
             "PGUSER=postgres",
             "PGHOST=postgres",
             "PGPASSWORD=postgres",
             "MZ_SOFT_ASSERTIONS=1",
-            "RUST_BACKTRACE=1",
         ],
         volumes: List[str] = ["../..:/workdir"],
         depends_on: List[str] = ["postgres"],

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -98,10 +98,6 @@ try_finish() {
     exit 0
 }
 
-ci_init() {
-    export RUST_BACKTRACE=full
-}
-
 ci_collapsed_heading() {
     echo "---" "$@" >&2
 }

--- a/test/lang/js/test.sh
+++ b/test/lang/js/test.sh
@@ -21,8 +21,6 @@ cd test/lang/js
 
 yarn install --frozen-lockfile
 
-ci_init
-
 ci_try yarn run fmt-check
 ci_try yarn test
 


### PR DESCRIPTION
Rather than setting RUST_BACKTRACE=1 ad hoc across various shell scripts
and mzcompose files, set it in our Docker base images. That guarantees
that it applies across all of our infrastructure with a lot less code.

@philip-stoev as requested here: https://github.com/MaterializeInc/materialize/pull/12588#pullrequestreview-980400856

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
