### PR TITLE
testdrive: fail when expected errors don't match

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -326,32 +326,36 @@ The syntax is identical, however the statement will not be retried on error:
 
 ## Executing a statement that is expected to return an error
 
+Specify a statement that is expected to return an error with the `!` sigil. For
+example:
+
 ```
 ! SELECT * FROM no_such_table
 contains:unknown catalog item
 ```
 
-The expected error string is provided after the statement and `testdrive` will retry the statement until the expected error is returned or a timeout occurs.
+The expected error is specified after the statement. `testdrive` will retry the
+statement until the expected error is returned or a timeout occurs.
 
-The full error above would have been `ERROR:  unknown catalog item 'no_such_table'` but the match specifier `contains` ensures that the substring `unknown catalog item` will match and the test will pass.
-
-There are three match specifiers: `contains`, `exact`, and `regex`.
-
-The alternatives would be written as:
+In the example above, the full error returned by Materialize is:
 
 ```
-! SELECT * FROM no_such_table
-exact: ERROR:  unknown catalog item 'no_such_table'
+ERROR:  unknown catalog item 'no_such_table'
 ```
 
-or:
+The `contains:` prefix in the expected error means that the presence of the
+substring `unknown catalog item` in the error message is considered a pass.
 
-```
-! SELECT * FROM no_such_table
-regex: unknown catalog.*no_such_table
-```
+There are four types of error expectations:
 
-It is possible to include variables in expected errors:
+  * `contains:STRING` expects any error message containing `STRING`.
+  * `exact:STRING` expects an error message that is exactly `STRING`.
+  * `regex:REGEX` expects an error message that matches the regex `REGEX`.
+  * `timeout` expects the query to time out.
+
+
+You can include include variables in `contains`, `exact`, and `regex`
+expectations:
 
 ```
 $ set table_name=no_table
@@ -360,7 +364,10 @@ $ SELECT * FROM ${table_name}
 exact:ERROR:  unknown catalog item '${table_name}'
 ```
 
-And for regex matches all variables match literally, they are not treated as regular expression patterns. A variable valued `my.+name` will match the string `my.+name`, not `my friend's name`.
+With regex matches, the values of any interpolated variables are matched
+literally, i.e.,  their values are *not* treated as regular expression patterns.
+For example, a variable with value `my.+name` will match the string `my.+name`,
+not `my friend's name`.
 
 ## Executing statements in multiple sessions
 

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -75,7 +75,7 @@ disruptions_disabled = [
 > INSERT INTO panic_table VALUES ('panic!');
 
 ! INSERT INTO panic_table SELECT mz_internal.mz_panic(f1) FROM panic_table;
-contains: deadline has elapsed
+timeout
 """,
         ),
     ),


### PR DESCRIPTION
@philip-stoev I'm sure there are some busted test files already, but I'm opening this PR to have CI find them for us. I'm on vacation this week, so I might need your help getting those test failures fixed up. The sooner we get this in the better, or people will keep sneaking failing code changes past testdrive!

----

Due to a bug in #12228, testdrive no longer fails when a SQL query does
not match its expected error. This commit fixes the bug.

The feature added in #12228--the ability to assert that a SQL query will
timeout--is preserved, but with new syntax. Rather than string matching
on a "deadline is exceeded" error message, a new `timeout` error
expectation is added. See the updated documentation within for details.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
