### PR TITLE
Update Rust to 1.61

### DIFF
--- a/src/avro-derive/Cargo.toml
+++ b/src/avro-derive/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 authors = ["Brennan Vincent <brennan@umanwizard.com>"]
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 
 [lib]
 proc-macro = true

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 license = "Apache-2.0"
 repository = "https://github.com/MaterializeInc/materialize"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 autobenches = false
 
 [dependencies]

--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-billing-demo"
 description = "Microservice demo using Materialize to power a real-time billing usecase"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/build-info/Cargo.toml
+++ b/src/build-info/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-build-info"
 description = "Metadata about a Materialize build."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-ccsr"
 description = "Confluent-compatible schema registry API client."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-compute"
 description = "Materialize's compute layer."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/compute/src/sink/kafka.rs
+++ b/src/compute/src/sink/kafka.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// TODO(#12634): Remove override.
+#![allow(clippy::await_holding_lock)]
+
 use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::cmp;

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -7,6 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// TODO(#12635): Remove override.
+#![allow(clippy::await_holding_refcell_ref)]
+
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-coord"
 description = "Coordinates client requests with the dataflow layer."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/dataflow-bin/Cargo.toml
+++ b/src/dataflow-bin/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-dataflow-bin"
 description = "Utility binaries for the dataflow crate."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-dataflow-types"
 description = "Types for the dataflow crate."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-expr-test-util"
 description = "Utilities for creating objects in the expr crate for testing"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-expr"
 description = "The core expression language for Materialize."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [[bench]]

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -4,7 +4,7 @@ description = "Authentication interfaces to Frontegg."
 version = "0.0.0"
 edition = "2021"
 publish = false
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 
 [dependencies]
 anyhow = "1.0.57"

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-http-util"
 description = "Utilities for running HTTP servers in Materialize."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-interchange"
 description = "Translations for various data serialization formats."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [[bench]]

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-kafka-util"
 description = "Utilities for working with Kafka."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/kinesis-util/Cargo.toml
+++ b/src/kinesis-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-kinesis-util"
 description = "AWS Kinesis utilities."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/lowertest-derive/Cargo.toml
+++ b/src/lowertest-derive/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-lowertest-derive"
 description = "Macros to support unit testing of lower parts of the stack"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [lib]

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-lowertest"
 description = "Utilities for testing lower layers of the Materialize stack"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.26.1-dev"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 default-run = "materialized"
 

--- a/src/metabase/Cargo.toml
+++ b/src/metabase/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-metabase"
 description = "An API client for Metabase."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/npm/Cargo.toml
+++ b/src/npm/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-npm"
 description = "A lightweight JavaScript package manager, like npm."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-orchestrator-kubernetes"
 description = "Service orchestration via Kubernetes."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-orchestrator-process"
 description = "Service orchestration via local processes for development."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-orchestrator"
 description = "Service orchestration."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -4,7 +4,7 @@ description = "Internal utility libraries for Materialize."
 version = "0.0.0"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-persist-client"
 description = "Client for Materialize pTVC durability system"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 autoexamples = false
 # Since we intentionally will only ever have one bench target, auto discovery of

--- a/src/persist-types/Cargo.toml
+++ b/src/persist-types/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-persist-types"
 description = "Types for the persist crate."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 # NB: This is meant to be a strong, independent abstraction boundary. Please

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-persist"
 description = "Abstraction for Materialize dataplane persistence."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 # Since we intentionally will only ever have one bench target, auto discovery of
 # benches is unnecessary. Turning it off allows us to have helper code in

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -798,6 +798,8 @@ impl Consensus for MemConsensus {
 
 #[cfg(test)]
 mod tests {
+    // TODO(#12633): Remove override.
+    #![allow(clippy::await_holding_lock)]
     use crate::location::tests::{
         blob_impl_test, blob_multi_impl_test, consensus_impl_test, log_impl_test,
     };

--- a/src/pgcopy/Cargo.toml
+++ b/src/pgcopy/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-pgcopy"
 description = "Encoding/decoding of PostgreSQL COPY formats."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/pgrepr/Cargo.toml
+++ b/src/pgrepr/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-pgrepr"
 description = "Representation of and serialization for PostgreSQL data types."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/pgtest/Cargo.toml
+++ b/src/pgtest/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-pgtest"
 description = "Postgres wire protocol test framework."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-pgwire"
 description = "A server for the PostgreSQL wire protocol."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/pid-file/Cargo.toml
+++ b/src/pid-file/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-pid-file"
 description = "PID file management."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-postgres-util"
 description = "Internal postgres utility library for Materialize."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-prof"
 description = "CPU and memory profiling tools."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/repr-test-util/Cargo.toml
+++ b/src/repr-test-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-repr-test-util"
 description = "Utilities for creating objects in the repr crate for testing"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-repr"
 description = "The core data types for Materialize."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [[bench]]

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-s3-datagen"
 description = "Generate S3 test data."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/secrets-filesystem/Cargo.toml
+++ b/src/secrets-filesystem/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-secrets-filesystem"
 description = "Local Filesystem Secrets Controller"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/secrets-kubernetes/Cargo.toml
+++ b/src/secrets-kubernetes/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-secrets-kubernetes"
 description = "Secrets Controller via Kubernetes."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-secrets"
 description = "Secrets Controller"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -4,7 +4,7 @@ description = "The lexer and parser for Materialize's SQL dialect."
 version = "0.0.0"
 exclude = ["tests/testdata"]
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-sql"
 description = "SQL–dataflow translation."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-sqllogictest"
 description = "A driver for sqllogictest, a SQL correctness testing framework."
 version = "0.0.1"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-stash"
 description = "Durable metadata storage."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [[bench]]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-storage"
 description = "Materialize's storage layer."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/storaged/Cargo.toml
+++ b/src/storaged/Cargo.toml
@@ -3,7 +3,7 @@ name = "storaged"
 description = "Materialize's storage server."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-testdrive"
 description = "Integration test driver for Materialize."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-timely-util"
 description = "Utilities for working with Timely."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-transform"
 description = "Transformations of Materialize expressions."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/src/walkabout/Cargo.toml
+++ b/src/walkabout/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-walkabout"
 description = "AST visitor generation."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/test/metabase/smoketest/Cargo.toml
+++ b/test/metabase/smoketest/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-metabase-smoketest"
 description = "A simple smoke test for Metabase and Materialize."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-perf-kinesis"
 description = "Tool to test Materialize's performance with AWS Kinesis."
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]

--- a/test/test-util/Cargo.toml
+++ b/test/test-util/Cargo.toml
@@ -3,7 +3,7 @@ name = "mz-test-util"
 description = "Utilities for testing Materialize"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.61.0"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
### Motivation

This PR adds a feature that has not yet been specified: Upgrade to Rust 1.61

The clippy lints `await_holding_lock` and `await_holding_refcell_ref` got stricter or were enabled, and I had to disable them in a few places to pass checks. I filed #12633, #12634, and #12635 to fix the implementation.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
