### PR TITLE
Disallow untargeted introspection queries

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -624,7 +624,7 @@ impl CatalogState {
                     ExternalSourceConnector::Kinesis(_) => Volatile,
                     _ => Unknown,
                 },
-                SourceConnector::Local { .. } => Volatile,
+                SourceConnector::Local { .. } | SourceConnector::Log => Volatile,
             },
             CatalogItem::Index(_) | CatalogItem::View(_) | CatalogItem::Sink(_) => {
                 // Volatility follows trinary logic like SQL. If even one
@@ -1498,9 +1498,7 @@ impl<S: Append> Catalog<S> {
                         name.clone(),
                         CatalogItem::Source(Source {
                             create_sql: "TODO".to_string(),
-                            connector: mz_dataflow_types::sources::SourceConnector::Local {
-                                timeline: Timeline::EpochMilliseconds,
-                            },
+                            connector: mz_dataflow_types::sources::SourceConnector::Log,
                             desc: log.variant.desc(),
                             depends_on: vec![],
                         }),

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -2146,6 +2146,9 @@ pub mod sources {
 
         /// A local "source" is fed by a local input handle.
         Local { timeline: Timeline },
+
+        /// A source for compute logging data.
+        Log,
     }
 
     impl SourceConnector {
@@ -2174,6 +2177,7 @@ pub mod sources {
             match self {
                 SourceConnector::External { connector, .. } => connector.name(),
                 SourceConnector::Local { .. } => "local",
+                SourceConnector::Log => "log",
             }
         }
 
@@ -2181,6 +2185,7 @@ pub mod sources {
             match self {
                 SourceConnector::External { timeline, .. } => timeline.clone(),
                 SourceConnector::Local { timeline, .. } => timeline.clone(),
+                SourceConnector::Log => Timeline::EpochMilliseconds,
             }
         }
 
@@ -2218,6 +2223,7 @@ pub mod sources {
                 }
                 SourceConnector::External { .. } => None,
                 SourceConnector::Local { .. } => None,
+                SourceConnector::Log => None,
             };
 
             Ok(result)

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -410,6 +410,7 @@ impl ErrorResponse {
             CoordError::UnmaterializableFunction(_) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unsupported(..) => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::Unstructured(_) => SqlState::INTERNAL_ERROR,
+            CoordError::UntargetedLogRead { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             // It's not immediately clear which error code to use here because a
             // "write-only transaction" and "single table write transaction" are
             // not things in Postgres. This error code is the generic "bad txn thing"

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1865,6 +1865,9 @@ pub fn plan_create_views(
                 SourceConnector::Local { .. } => {
                     bail!("cannot generate views from local sources")
                 }
+                SourceConnector::Log => {
+                    bail!("cannot generate views from log sources")
+                }
             }
         }
     }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -183,7 +183,7 @@ where
     match src.connector.clone() {
         // Create a new local input (exposed as TABLEs to users). Data is inserted
         // via Command::Insert commands. Defers entirely to `render_table`
-        SourceConnector::Local { .. } => {
+        SourceConnector::Local { .. } | SourceConnector::Log => {
             let mut table = render_table(as_of_frontier, scope);
 
             let table_state = match storage_state.table_state.get_mut(&src_id) {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -116,7 +116,7 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
             StorageCommand::CreateSources(sources) => {
                 for source in sources {
                     match &source.desc.connector {
-                        SourceConnector::Local { .. } => {
+                        SourceConnector::Local { .. } | SourceConnector::Log => {
                             self.storage_state.table_state.insert(
                                 source.id,
                                 TableState {

--- a/test/sqllogictest/select_target_replica.slt
+++ b/test/sqllogictest/select_target_replica.slt
@@ -36,39 +36,32 @@ a b
 
 # Verify that SELECTs on introspection tables work.
 
-query I
+statement ok
 SELECT * FROM mz_materializations
-----
 
 # Verify that we are always hitting the same replica.
 # We check that the number of peeks in mz_peek_durations (which is a
 # replica-specific introspection source) increases by one with every query.
 # We sleep between checks to give dataflow logging time to catch up.
 
-query I
+statement ok
 SELECT mz_internal.mz_sleep(0.1)
-----
-NULL
 
 query I
 SELECT sum(count) FROM mz_peek_durations
 ----
 2
 
-query I
+statement ok
 SELECT mz_internal.mz_sleep(0.1)
-----
-NULL
 
 query I
 SELECT sum(count) FROM mz_peek_durations
 ----
 3
 
-query I
+statement ok
 SELECT mz_internal.mz_sleep(0.1)
-----
-NULL
 
 query I
 SELECT sum(count) FROM mz_peek_durations
@@ -93,7 +86,35 @@ SET cluster_replica = unknown
 query error cluster replica 'test.unknown' does not exist
 SELECT * FROM test
 
+# Verify that untargeted introspection queries are disallowd.
+
+statement ok
+SET cluster_replica = ''
+
+query error log source reads must target a replica
+SELECT * FROM mz_materializations
+
+statement ok
+CREATE MATERIALIZED VIEW introspection_view AS SELECT * FROM mz_materializations
+
+query error log source reads must target a replica
+SELECT * FROM introspection_view
+
+# Verify that introspection queries on unreplicated clusters are allowed.
+
+statement ok
+DROP CLUSTER REPLICA test.replica_b;
+
+statement ok
+SELECT * FROM mz_materializations
+
+statement ok
+SELECT * FROM introspection_view
+
 # Clean up.
+
+statement ok
+DROP VIEW introspection_view
 
 statement ok
 DROP CLUSTER test

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -373,23 +373,23 @@ mz_worker_materialization_frontiers
 > SHOW FULL SOURCES FROM mz_catalog
 name                                          type   materialized  volatility  connector_type
 ---------------------------------------------------------------------------------------------
-mz_arrangement_sharing_internal               system true          volatile    local
-mz_arrangement_batches_internal               system true          volatile    local
-mz_arrangement_records_internal               system true          volatile    local
-mz_dataflow_channels                          system true          volatile    local
-mz_dataflow_operator_addresses                system true          volatile    local
-mz_dataflow_operator_reachability_internal    system true          volatile    local
-mz_dataflow_operators                         system true          volatile    local
-mz_materialization_dependencies               system true          volatile    local
-mz_materializations                           system true          volatile    local
-mz_message_counts_received_internal           system true          volatile    local
-mz_message_counts_sent_internal               system true          volatile    local
-mz_peek_active                                system true          volatile    local
-mz_peek_durations                             system true          volatile    local
-mz_scheduling_elapsed_internal                system true          volatile    local
-mz_scheduling_histogram_internal              system true          volatile    local
-mz_scheduling_parks_internal                  system true          volatile    local
-mz_worker_materialization_frontiers           system true          volatile    local
+mz_arrangement_sharing_internal               system true          volatile    log
+mz_arrangement_batches_internal               system true          volatile    log
+mz_arrangement_records_internal               system true          volatile    log
+mz_dataflow_channels                          system true          volatile    log
+mz_dataflow_operator_addresses                system true          volatile    log
+mz_dataflow_operator_reachability_internal    system true          volatile    log
+mz_dataflow_operators                         system true          volatile    log
+mz_materialization_dependencies               system true          volatile    log
+mz_materializations                           system true          volatile    log
+mz_message_counts_received_internal           system true          volatile    log
+mz_message_counts_sent_internal               system true          volatile    log
+mz_peek_active                                system true          volatile    log
+mz_peek_durations                             system true          volatile    log
+mz_scheduling_elapsed_internal                system true          volatile    log
+mz_scheduling_histogram_internal              system true          volatile    log
+mz_scheduling_parks_internal                  system true          volatile    log
+mz_worker_materialization_frontiers           system true          volatile    log
 
 > SHOW TABLES FROM mz_catalog
 mz_array_types


### PR DESCRIPTION
See commits for details.

### Motivation

Which of the following best describes the motivation behind this PR?

  * This PR adds a known-desirable feature.

    Part of #12520.

### Tips for reviewer

The first commit splits a new `SourceConnector::Log` variant from `SourceConnector::Local`, to make it possible to identify log sources in the dependency analysis (second commit). This is certainly not the only way to implement this, we could also add a flag to `SourceConnector::Local` or track log source IDs somewhere else in the catalog. Let me know if you think another solution would be better!

The error messages for `UntargetetLogRead` are supposed to be as clear as possible, since we don't plan to add additional documentation for this feature. Suggestions on how to improve these are welcome.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Renames the `mz_sources.connector_type` value of log sources from "local" to "log".
