### PR TITLE
storage: Update table state using extend

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -250,11 +250,11 @@ impl<'a, A: Allocate, B: StorageCapture> ActiveStorageState<'a, A, B> {
                         .retain(|input| input.capability.upgrade().is_some());
 
                     // Stash the data for use by future renders of the table.
-                    for update in updates {
-                        table_state
-                            .data
-                            .push((update.row, update.timestamp, update.diff));
-                    }
+                    table_state.data.extend(
+                        updates
+                            .into_iter()
+                            .map(|update| (update.row, update.timestamp, update.diff)),
+                    );
 
                     // Consolidate the data in the table if it's doubled in size
                     // since the last consolidation.


### PR DESCRIPTION
This reduces realloc calls as the target data can allocate enough capacity.

This PR fixes a previously unreported bug: Avoid reallocations on table updates.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
