### PR TITLE
update RustCrypto related deny.yml rules

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -44,13 +44,12 @@ name = "env_logger"
 [[bans.deny]]
 name = "protobuf"
 
-# The `md5` and `sha1` crates are not part of the RustCrypto project. Use
-# `md-5` and `sha-1` instead, despite their somewhat suspicious names.
+# The `md5` crate is not part of the RustCrypto project. Use `md-5` instead,
+# despite its somewhat suspicious name.
 [[bans.deny]]
 name = "md5"
+# waiting on https://github.com/awslabs/smithy-rs/pull/1404
 wrappers = ["aws-sdk-s3"]
-[[bans.deny]]
-name = "sha1"
 
 # Strum has suspect code quality and includes many unneeded features. Use
 # more targeted enum macro crates, e.g. `enum-kinds`.


### PR DESCRIPTION
Both `sha1` and `sha-1` names belong to RustCrypto. Sent a PR upstream to remove the `md5` exception