### PR TITLE
refactor(catalog): make `get_catalog_content_version return` return `Option`

### DIFF
--- a/src/coord/src/catalog/migrate.rs
+++ b/src/coord/src/catalog/migrate.rs
@@ -46,13 +46,6 @@ where
 
 pub(crate) async fn migrate<S: Append>(catalog: &mut Catalog<S>) -> Result<(), anyhow::Error> {
     let mut storage = catalog.storage().await;
-    let catalog_version = storage.get_catalog_content_version().await?;
-    let _catalog_version = match Version::parse(&catalog_version) {
-        Ok(v) => v,
-        // Catalog content versions changed to semver after 0.8.3, so all
-        // non-semver versions are less than that.
-        Err(_) => Version::new(0, 0, 0),
-    };
     let mut tx = storage.transaction().await?;
     // First, do basic AST -> AST transformations.
     rewrite_items(&mut tx, |_stmt| Ok(()))?;

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -351,10 +351,8 @@ impl<S: Append> Connection<S> {
         }
     }
 
-    pub async fn get_catalog_content_version(&mut self) -> Result<String, Error> {
-        self.get_setting("catalog_content_version")
-            .await
-            .map(|v| v.unwrap_or_else(|| "new".to_string()))
+    pub async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error> {
+        Ok(self.get_setting("catalog_content_version").await?)
     }
 
     pub async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), Error> {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
As issue #12092 say, make `get_catalog_content_version` return `Option` obviously and let caller to handle `None` properly. It will be helpful for program maintainability.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
