### PR TITLE
Add support for `SET <var> = DEFAULT` and `RESET <var>`

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -289,6 +289,7 @@ pub enum ExecuteResponse {
     /// The specified variable was set to a new value.
     SetVariable {
         name: String,
+        tag: &'static str,
     },
     /// A new transaction was started.
     StartedTransaction {

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -267,7 +267,7 @@ impl CoordError {
                 "Use `SET cluster_replica = <replica-name>` to target a specific replica in the \
                  active cluster. Note that subsequent `SELECT` queries will only be answered by \
                  the selected replica, which might reduce availability. To undo the replica \
-                 selection, use `SET cluster_replica = DEFAULT`.".into()),
+                 selection, use `RESET cluster_replica`.".into()),
             _ => None,
         }
     }

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -267,7 +267,7 @@ impl CoordError {
                 "Use `SET cluster_replica = <replica-name>` to target a specific replica in the \
                  active cluster. Note that subsequent `SELECT` queries will only be answered by \
                  the selected replica, which might reduce availability. To undo the replica \
-                 selection, use `SET cluster_replica = ''`.".into()),
+                 selection, use `SET cluster_replica = DEFAULT`.".into()),
             _ => None,
         }
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1188,7 +1188,7 @@ where
                 )
                 .await
             }
-            ExecuteResponse::SetVariable { name } => {
+            ExecuteResponse::SetVariable { name, tag } => {
                 // This code is somewhat awkwardly structured because we
                 // can't hold `var` across an await point.
                 let qn = name.to_string();
@@ -1206,7 +1206,7 @@ where
                 if let Some(msg) = msg {
                     self.send(msg).await?;
                 }
-                command_complete!("SET")
+                command_complete!("{}", tag)
             }
             ExecuteResponse::StartedTransaction { duplicated } => {
                 if duplicated {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1883,6 +1883,7 @@ impl_display!(TransactionIsolationLevel);
 pub enum SetVariableValue {
     Ident(Ident),
     Literal(Value),
+    Default,
 }
 
 impl AstDisplay for SetVariableValue {
@@ -1891,6 +1892,7 @@ impl AstDisplay for SetVariableValue {
         match self {
             Ident(ident) => f.write_node(ident),
             Literal(literal) => f.write_node(literal),
+            Default => f.write_str("DEFAULT"),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -62,6 +62,7 @@ pub enum Statement<T: AstInfo> {
     DropClusters(DropClustersStatement),
     DropClusterReplicas(DropClusterReplicasStatement),
     SetVariable(SetVariableStatement),
+    ResetVariable(ResetVariableStatement),
     ShowDatabases(ShowDatabasesStatement<T>),
     ShowSchemas(ShowSchemasStatement<T>),
     ShowObjects(ShowObjectsStatement<T>),
@@ -122,6 +123,7 @@ impl<T: AstInfo> AstDisplay for Statement<T> {
             Statement::DropClusters(stmt) => f.write_node(stmt),
             Statement::DropClusterReplicas(stmt) => f.write_node(stmt),
             Statement::SetVariable(stmt) => f.write_node(stmt),
+            Statement::ResetVariable(stmt) => f.write_node(stmt),
             Statement::ShowDatabases(stmt) => f.write_node(stmt),
             Statement::ShowSchemas(stmt) => f.write_node(stmt),
             Statement::ShowObjects(stmt) => f.write_node(stmt),
@@ -1308,6 +1310,23 @@ impl AstDisplay for SetVariableStatement {
     }
 }
 impl_display!(SetVariableStatement);
+
+/// `RESET <variable>`
+///
+/// Note: this is not a standard SQL statement, but it is supported by at
+/// least MySQL and PostgreSQL. Not all syntactic forms are supported yet.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ResetVariableStatement {
+    pub variable: Ident,
+}
+
+impl AstDisplay for ResetVariableStatement {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("RESET ");
+        f.write_node(&self.variable);
+    }
+}
+impl_display!(ResetVariableStatement);
 
 /// `SHOW <variable>`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -244,6 +244,7 @@ impl<'a> Parser<'a> {
                 Token::Keyword(ALTER) => Ok(self.parse_alter()?),
                 Token::Keyword(COPY) => Ok(self.parse_copy()?),
                 Token::Keyword(SET) => Ok(self.parse_set()?),
+                Token::Keyword(RESET) => Ok(self.parse_reset()?),
                 Token::Keyword(SHOW) => Ok(self.parse_show()?),
                 Token::Keyword(START) => Ok(self.parse_start_transaction()?),
                 // `BEGIN` is a nonstandard but common alias for the
@@ -4069,6 +4070,13 @@ impl<'a> Parser<'a> {
         } else {
             self.expected(self.peek_pos(), "equals sign or TO", self.peek_token())
         }
+    }
+
+    fn parse_reset(&mut self) -> Result<Statement<Raw>, ParserError> {
+        let variable = self.parse_identifier()?;
+        Ok(Statement::ResetVariable(ResetVariableStatement {
+            variable,
+        }))
     }
 
     fn parse_show(&mut self) -> Result<Statement<Raw>, ParserError> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4044,6 +4044,7 @@ impl<'a> Parser<'a> {
             let token = self.peek_token();
             let value = match (self.parse_value(), token) {
                 (Ok(value), _) => SetVariableValue::Literal(value),
+                (Err(_), Some(Token::Keyword(DEFAULT))) => SetVariableValue::Default,
                 (Err(_), Some(Token::Keyword(kw))) => SetVariableValue::Ident(kw.into_ident()),
                 (Err(_), Some(Token::Ident(id))) => SetVariableValue::Ident(Ident::new(id)),
                 (Err(_), other) => self.expected(self.peek_pos(), "variable value", other)?,

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -338,9 +338,9 @@ SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Li
 parse-statement
 SET a = default
 ----
-SET a = default
+SET a = DEFAULT
 =>
-SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Ident(Ident("default")) })
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Default })
 
 parse-statement
 SET LOCAL a = b

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -343,6 +343,13 @@ SET a = DEFAULT
 SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Default })
 
 parse-statement
+SET a = 'default'
+----
+SET a = 'default'
+=>
+SetVariable(SetVariableStatement { local: false, variable: Ident("a"), value: Literal(String("default")) })
+
+parse-statement
 SET LOCAL a = b
 ----
 SET LOCAL a = b
@@ -404,6 +411,20 @@ SET a =
 error: Expected variable value, found EOF
 SET a =
        ^
+
+parse-statement
+RESET a
+----
+RESET a
+=>
+ResetVariable(ResetVariableStatement { variable: Ident("a") })
+
+parse-statement
+RESET
+----
+error: Expected identifier, found EOF
+RESET
+     ^
 
 parse-statement
 DISCARD ALL

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -41,8 +41,8 @@ use mz_ore::now::{self, NOW_ZERO};
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
-    ExplainOptions, ExplainStage, Expr, FetchDirection, NoticeSeverity, ObjectType, Raw, Statement,
-    TransactionAccessMode,
+    ExplainOptions, ExplainStage, Expr, FetchDirection, NoticeSeverity, ObjectType, Raw,
+    SetVariableValue, Statement, TransactionAccessMode,
 };
 use crate::catalog::{CatalogType, IdReference};
 use crate::names::{
@@ -289,7 +289,7 @@ pub struct ShowVariablePlan {
 #[derive(Debug)]
 pub struct SetVariablePlan {
     pub name: String,
-    pub value: String,
+    pub value: SetVariableValue,
     pub local: bool,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -98,6 +98,7 @@ pub enum Plan {
     ShowAllVariables,
     ShowVariable(ShowVariablePlan),
     SetVariable(SetVariablePlan),
+    ResetVariable(ResetVariablePlan),
     StartTransaction(StartTransactionPlan),
     CommitTransaction,
     AbortTransaction,
@@ -291,6 +292,11 @@ pub struct SetVariablePlan {
     pub name: String,
     pub value: SetVariableValue,
     pub local: bool,
+}
+
+#[derive(Debug)]
+pub struct ResetVariablePlan {
+    pub name: String,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -152,6 +152,7 @@ pub fn describe(
 
         // SCL statements.
         Statement::SetVariable(stmt) => Some(scl::describe_set_variable(&scx, stmt)?),
+        Statement::ResetVariable(stmt) => Some(scl::describe_reset_variable(&scx, stmt)?),
         Statement::ShowVariable(stmt) => Some(scl::describe_show_variable(&scx, stmt)?),
         Statement::Discard(stmt) => Some(scl::describe_discard(&scx, stmt)?),
         Statement::Declare(stmt) => Some(scl::describe_declare(&scx, stmt)?),
@@ -439,6 +440,10 @@ pub fn plan(
         stmt @ Statement::SetVariable(_) => {
             let (stmt, _) = resolve_stmt!(Statement::SetVariable, scx, stmt);
             scl::plan_set_variable(scx, stmt)
+        }
+        stmt @ Statement::ResetVariable(_) => {
+            let (stmt, _) = resolve_stmt!(Statement::ResetVariable, scx, stmt);
+            scl::plan_reset_variable(scx, stmt)
         }
         stmt @ Statement::ShowVariable(_) => {
             let (stmt, _) = resolve_stmt!(Statement::ShowVariable, scx, stmt);

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -20,14 +20,14 @@ use mz_repr::{RelationDesc, ScalarType};
 
 use crate::ast::{
     CloseStatement, DeallocateStatement, DeclareStatement, DiscardStatement, DiscardTarget,
-    ExecuteStatement, FetchStatement, PrepareStatement, Raw, SetVariableStatement,
-    ShowVariableStatement, Value,
+    ExecuteStatement, FetchStatement, PrepareStatement, Raw, ResetVariableStatement,
+    SetVariableStatement, ShowVariableStatement, Value,
 };
 use crate::names::Aug;
 use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::{
     describe, query, ClosePlan, DeallocatePlan, DeclarePlan, ExecutePlan, ExecuteTimeout,
-    FetchPlan, Plan, PreparePlan, SetVariablePlan, ShowVariablePlan,
+    FetchPlan, Plan, PreparePlan, ResetVariablePlan, SetVariablePlan, ShowVariablePlan,
 };
 
 pub fn describe_set_variable(
@@ -49,6 +49,22 @@ pub fn plan_set_variable(
         name: variable.to_string(),
         value,
         local,
+    }))
+}
+
+pub fn describe_reset_variable(
+    _: &StatementContext,
+    _: &ResetVariableStatement,
+) -> Result<StatementDesc, anyhow::Error> {
+    Ok(StatementDesc::new(None))
+}
+
+pub fn plan_reset_variable(
+    _: &StatementContext,
+    ResetVariableStatement { variable }: ResetVariableStatement,
+) -> Result<Plan, anyhow::Error> {
+    Ok(Plan::ResetVariable(ResetVariablePlan {
+        name: variable.to_string(),
     }))
 }
 

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -21,7 +21,7 @@ use mz_repr::{RelationDesc, ScalarType};
 use crate::ast::{
     CloseStatement, DeallocateStatement, DeclareStatement, DiscardStatement, DiscardTarget,
     ExecuteStatement, FetchStatement, PrepareStatement, Raw, SetVariableStatement,
-    SetVariableValue, ShowVariableStatement, Value,
+    ShowVariableStatement, Value,
 };
 use crate::names::Aug;
 use crate::plan::statement::{StatementContext, StatementDesc};
@@ -47,11 +47,7 @@ pub fn plan_set_variable(
 ) -> Result<Plan, anyhow::Error> {
     Ok(Plan::SetVariable(SetVariablePlan {
         name: variable.to_string(),
-        value: match value {
-            SetVariableValue::Literal(Value::String(s)) => s,
-            SetVariableValue::Literal(lit) => lit.to_string(),
-            SetVariableValue::Ident(ident) => ident.into_string(),
-        },
+        value,
         local,
     }))
 }

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -89,7 +89,7 @@ SELECT * FROM test
 # Verify that untargeted introspection queries are disallowd.
 
 statement ok
-SET cluster_replica = ''
+SET cluster_replica = DEFAULT
 
 query error log source reads must target a replica
 SELECT * FROM mz_materializations

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -89,7 +89,7 @@ SELECT * FROM test
 # Verify that untargeted introspection queries are disallowd.
 
 statement ok
-SET cluster_replica = DEFAULT
+RESET cluster_replica
 
 query error log source reads must target a replica
 SELECT * FROM mz_materializations

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -79,6 +79,59 @@ SHOW extra_float_digits
 ----
 1
 
+# Test resetting a variable.
+
+statement ok
+SET extra_float_digits=42
+
+statement ok
+SET extra_float_digits=DEFAULT
+
+query T
+SHOW extra_float_digits
+----
+3
+
+statement ok
+SET extra_float_digits=42
+
+simple
+SET LOCAL extra_float_digits=DEFAULT;
+SHOW extra_float_digits;
+----
+COMPLETE 0
+3
+COMPLETE 1
+
+query T
+SHOW extra_float_digits
+----
+42
+
+statement ok
+RESET extra_float_digits
+
+query T
+SHOW extra_float_digits
+----
+3
+
+# Test that resetting a read-only variable succeeds.
+
+statement ok
+SET server_version=DEFAULT
+
+statement ok
+RESET server_version
+
+# Test that resetting an unknown variable fails.
+
+statement error unrecognized configuration parameter
+SET does_not_exist = DEFAULT
+
+statement error unrecognized configuration parameter
+RESET does_not_exist
+
 # Test that a failed transaction will not commit var changes.
 
 statement ok


### PR DESCRIPTION
This PR adds support for setting SQL variables to their default values via:
  1. `SET <var> = DEFAULT` or 
  2. `RESET <var>`

### Motivation

  * This PR adds a known-desirable feature.

    Closes #12551.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add support for setting variables to their default values via `SET <var> = DEFAULT` and `RESET <var>`.
