### PR TITLE
doc/user: add release notes for v0.26.2

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -7,7 +7,8 @@ pygmentsUseClasses = true
 # Keep the releases in reverse order of their release date. The first release
 # in the list is assumed to be the most recent.
 versions = [
-  { name = "v0.26.1", date = "05 May 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
+  { name = "v0.26.2", date = "23 May 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
+  { name = "v0.26.1", date = "05 May 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.26.0", date = "13 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.25.0", date = "31 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
   { name = "v0.24.0", date = "24 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },

--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -27,6 +27,10 @@ the v0.26.x series through at least August 31 2022, issuing **patch releases** a
 necessary to address severe bugs and security vulnerabilities.
 {{</ note >}}
 
+{{% version-header v0.26.2 %}}
+
+- Restore CPU and memory Prometheus metrics in the [monitoring dashboard](/ops/monitoring/#quick-monitoring-dashboard).
+
 {{% version-header v0.26.1 %}}
 
 - Support configuring the


### PR DESCRIPTION
There are no real user-facing changes, but mentioning the Prometheus metrics fix since it's the main motivation for this release.