### PR TITLE
clean up non-advisory warnings in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -10,18 +10,11 @@ skip = [
     # Waiting for csv, http, and aws_smithy_types to upgrade to v1.0.
     { name = "itoa", version = "0.4.1" },
 
-    # Waiting for pprof and prometheus to upgrade.
-    { name = "parking_lot_core", version = "0.8.3" },
-    { name = "parking_lot", version = "0.11.1" },
-
     # Waiting for vte to upgrade to v0.7.0.
     { name = "arrayvec", version = "0.5.2" },
 
     # https://github.com/tokio-rs/tokio/pull/4521
     { name = "tokio-util", version = "0.6.9" },
-
-    # https://github.com/awslabs/smithy-rs/pull/1301
-    { name = "urlencoding", version = "1.3.0" },
 
     # WASI dependencies from multiple sources.
     { name = "wasi", version = "0.10.0+wasi-snapshot-preview1" },
@@ -66,11 +59,6 @@ wrappers = [
     "globset",
     "jsonpath_lib",
     "mio",
-    # TODO(guswynn): switch to `tracing:enabled!` when its released
-    "mz-coord",
-    "mz-compute",
-    "mz-dataflow",
-    "mz-storage",
     "native-tls",
     "opentls",
     "os_info",
@@ -187,7 +175,6 @@ allow-git = [
 
     # Dependencies that we control upstream whose official releases we don't
     # care about.
-    "https://github.com/MaterializeInc/cloud-sdks.git",
     "https://github.com/frankmcsherry/columnation",
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",


### PR DESCRIPTION
Working on https://github.com/MaterializeInc/materialize/pull/12652, I noticed some warnings, and remembered we don't use `log::enabled!` anymore!
I did not ignore the advisory warnings, as those scare me more.

### Motivation


   * This PR refactors existing code.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
