### PR TITLE
otel: add an mzcompose for running a local collector

### DIFF
--- a/misc/opentelemetry/README.md
+++ b/misc/opentelemetry/README.md
@@ -1,0 +1,15 @@
+# OpenTelemetry development environment
+An [mzcompose] composition for working with OpenTelemetry traces locally.
+Primarily adapted from [the opentelemetry-rust repo].
+
+### Usage
+
+```
+$ ./mzcompose up
+$ MZ_OPENTELEMETRY_ENDPOINT="http://localhost:4317" bin/materialized
+```
+
+Go to <http://localhost:16686> in your browser to browse the traces.
+
+[mzcompose]: ../../doc/developer/mzcompose.md
+[the opentelemetry-rust repo]: https://github.com/open-telemetry/opentelemetry-rust/tree/a767fd3a7f08f4d7312a1c0dbb5ac0580a108eb3/examples/basic-otlp-http

--- a/misc/opentelemetry/mzcompose
+++ b/misc/opentelemetry/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/misc/opentelemetry/mzcompose.py
+++ b/misc/opentelemetry/mzcompose.py
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import Service
+
+SERVICES = [
+    Service(
+        "jaeger-all-in-one",
+        {
+            "image": "jaegertracing/all-in-one:latest",
+            "ports": [16686, 14268, 14250],
+        },
+    ),
+    Service(
+        "otel-collector",
+        {
+            "image": "otel/opentelemetry-collector:latest",
+            "command": "--config=/etc/otel-collector-config.yaml",
+            "ports": [
+                1888,  # pprof
+                13133,  # health_check
+                4317,  # otlp grpc
+                4318,  # otlp http
+                55670,  # zpages
+            ],
+            "volumes": ["./otel-collector-config.yaml:/etc/otel-collector-config.yaml"],
+            "depends_on": ["jaeger-all-in-one"],
+        },
+    ),
+]

--- a/misc/opentelemetry/otel-collector-config.yaml
+++ b/misc/opentelemetry/otel-collector-config.yaml
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Primarily adapted from https://github.com/open-telemetry/opentelemetry-rust/tree/a767fd3a7f08f4d7312a1c0dbb5ac0580a108eb3/examples/basic-otlp-http
+
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+
+exporters:
+  logging:
+    loglevel: debug
+
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [pprof, zpages, health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]


### PR DESCRIPTION
This pr adds an mzcompose composition into `misc/opentelemetry` that sets up a local jaeger and otel collecor, which you can point mz at to have a local (non-honeycomb, and in some cases better ui than honeycomb) way to explore the opentel data mz is exporting!

This pr is pretty much made entirely from: https://github.com/open-telemetry/opentelemetry-rust/tree/a767fd3a7f08f4d7312a1c0dbb5ac0580a108eb3/examples/basic-otlp-http (see https://github.com/open-telemetry/opentelemetry-rust/pull/802 also)

I intend to add more docs for the honeycomb usage of mz with otel in the same readme, in a later pr.

### Motivation
  * This PR adds a feature that has not yet been specified.
see above

### Testing

- [?] This PR has adequate test coverage / QA involvement has been duly considered.
  - Do I need to add ci for this?

### Release notes

None
