### PR TITLE
lowertest: simplify the interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,7 +3289,6 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "mz-repr-test-util",
- "once_cell",
  "proc-macro2",
  "serde",
  "serde_json",
@@ -3390,7 +3389,6 @@ dependencies = [
  "datadriven",
  "mz-lowertest-derive",
  "mz-ore",
- "once_cell",
  "proc-macro2",
  "serde",
  "serde_json",
@@ -3777,7 +3775,6 @@ dependencies = [
  "mz-lowertest",
  "mz-ore",
  "mz-repr",
- "once_cell",
  "proc-macro2",
 ]
 

--- a/src/expr-test-util/Cargo.toml
+++ b/src/expr-test-util/Cargo.toml
@@ -7,7 +7,6 @@ rust-version = "1.61.0"
 publish = false
 
 [dependencies]
-once_cell = "1.12.0"
 mz-expr = { path = "../expr" }
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore" }

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -9,7 +9,6 @@
 
 use std::collections::HashMap;
 
-use once_cell::sync::Lazy;
 use proc_macro2::TokenTree;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -24,16 +23,6 @@ use mz_ore::str::separated;
 use mz_repr::{ColumnType, GlobalId, RelationType, Row, ScalarType};
 use mz_repr_test_util::*;
 
-/// Contains the type information required to build a [MirRelationExpr] and
-/// all types it depends on.
-pub static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
-    let mut rti = ReflectedTypeInfo::default();
-    EvalError::add_to_reflected_type_info(&mut rti);
-    MirRelationExpr::add_to_reflected_type_info(&mut rti);
-    TestCatalogCommand::add_to_reflected_type_info(&mut rti);
-    rti
-});
-
 /// Builds a [MirScalarExpr] from a string.
 ///
 /// See [mz_lowertest::to_json] for the syntax.
@@ -41,7 +30,6 @@ pub fn build_scalar(s: &str) -> Result<MirScalarExpr, String> {
     deserialize(
         &mut tokenize(s)?.into_iter(),
         "MirScalarExpr",
-        &RTI,
         &mut MirScalarExprDeserializeContext::default(),
     )
 }
@@ -53,7 +41,6 @@ pub fn build_rel(s: &str, catalog: &TestCatalog) -> Result<MirRelationExpr, Stri
     deserialize(
         &mut tokenize(s)?.into_iter(),
         "MirRelationExpr",
-        &RTI,
         &mut MirRelationExprDeserializeContext::new(catalog),
     )
 }
@@ -85,10 +72,9 @@ pub fn generate_explanation(
 ///    the test catalog.
 pub fn json_to_spec(rel_json: &str, catalog: &TestCatalog) -> (String, Vec<String>) {
     let mut ctx = MirRelationExprDeserializeContext::new(&catalog);
-    let spec = from_json(
+    let spec = serialize::<MirRelationExpr, _>(
         &serde_json::from_str(rel_json).unwrap(),
         "MirRelationExpr",
-        &RTI,
         &mut ctx,
     );
     let mut source_defs = ctx
@@ -97,10 +83,9 @@ pub fn json_to_spec(rel_json: &str, catalog: &TestCatalog) -> (String, Vec<Strin
             format!(
                 "(defsource {} {})",
                 name,
-                from_json(
+                serialize::<RelationType, _>(
                     &serde_json::to_value(typ).unwrap(),
                     "RelationType",
-                    &RTI,
                     &mut GenericTestDeserializeContext::default()
                 )
             )
@@ -176,7 +161,6 @@ impl<'a> TestCatalog {
         while let Some(command) = deserialize_optional::<TestCatalogCommand, _, _>(
             &mut stream_iter,
             "TestCatalogCommand",
-            &RTI,
             &mut GenericTestDeserializeContext::default(),
         )? {
             match command {
@@ -246,7 +230,6 @@ impl MirScalarExprDeserializeContext {
         &mut self,
         first_arg: TokenTree,
         rest_of_stream: &mut I,
-        rti: &ReflectedTypeInfo,
     ) -> Result<Option<MirScalarExpr>, String>
     where
         I: Iterator<Item = TokenTree>,
@@ -268,13 +251,11 @@ impl MirScalarExprDeserializeContext {
                 let error = deserialize(
                     rest_of_stream,
                     "EvalError",
-                    rti,
                     &mut GenericTestDeserializeContext::default(),
                 )?;
                 let typ: Option<ScalarType> = deserialize_optional(
                     rest_of_stream,
                     "ScalarType",
-                    rti,
                     &mut GenericTestDeserializeContext::default(),
                 )?;
                 Ok(Some(MirScalarExpr::literal(
@@ -313,7 +294,6 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
         first_arg: TokenTree,
         rest_of_stream: &mut I,
         type_name: &str,
-        rti: &ReflectedTypeInfo,
     ) -> Result<Option<String>, String>
     where
         I: Iterator<Item = TokenTree>,
@@ -324,7 +304,7 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
                     Some(self.build_column(rest_of_stream.next())?)
                 }
                 TokenTree::Group(_) => None,
-                symbol => self.build_literal_if_able(symbol, rest_of_stream, rti)?,
+                symbol => self.build_literal_if_able(symbol, rest_of_stream)?,
             }
         } else {
             None
@@ -335,12 +315,7 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
         }
     }
 
-    fn reverse_syntax_override(
-        &mut self,
-        json: &Value,
-        type_name: &str,
-        rti: &ReflectedTypeInfo,
-    ) -> Option<String> {
+    fn reverse_syntax_override(&mut self, json: &Value, type_name: &str) -> Option<String> {
         if type_name == "MirScalarExpr" {
             let map = json.as_object().unwrap();
             // Each enum instance only belows to one variant.
@@ -357,10 +332,9 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
                             let result = format!(
                                 "({} {})",
                                 datum_to_test_spec(row.unpack_first()),
-                                from_json(
+                                serialize::<ScalarType, _>(
                                     &serde_json::to_value(&column_type.scalar_type).unwrap(),
                                     "ScalarType",
-                                    rti,
                                     self
                                 )
                             );
@@ -368,11 +342,10 @@ impl TestDeserializeContext for MirScalarExprDeserializeContext {
                         } else if let Some(inner_data) = obj.get("Err") {
                             let result = format!(
                                 "(err {} {})",
-                                from_json(&inner_data, "EvalError", rti, self),
-                                from_json(
+                                serialize::<EvalError, _>(&inner_data, "EvalError", self),
+                                serialize::<ScalarType, _>(
                                     &serde_json::to_value(&column_type.scalar_type).unwrap(),
                                     "ScalarType",
-                                    rti,
                                     self
                                 ),
                             );
@@ -448,7 +421,7 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
         // Deserialize the types of each column first
         // in order to refer to column types when constructing the `Datum`
         // objects in each row.
-        let typ: RelationType = deserialize(stream_iter, "RelationType", &RTI, self)?;
+        let typ: RelationType = deserialize(stream_iter, "RelationType", self)?;
 
         let mut rows = Vec::new();
         match raw_rows {
@@ -479,10 +452,9 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
         let error: EvalError = deserialize(
             stream_iter,
             "EvalError",
-            &RTI,
             &mut GenericTestDeserializeContext::default(),
         )?;
-        let typ: RelationType = deserialize(stream_iter, "RelationType", &RTI, self)?;
+        let typ: RelationType = deserialize(stream_iter, "RelationType", self)?;
 
         Ok(MirRelationExpr::Constant {
             rows: Err(error),
@@ -518,11 +490,11 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
             invalid_token => Err(format!("Invalid let specification {:?}", invalid_token)),
         }?;
 
-        let value: MirRelationExpr = deserialize(stream_iter, "MirRelationExpr", &RTI, self)?;
+        let value: MirRelationExpr = deserialize(stream_iter, "MirRelationExpr", self)?;
 
         let (id, prev) = self.scope.insert(&name, value.typ());
 
-        let body: MirRelationExpr = deserialize(stream_iter, "MirRelationExpr", &RTI, self)?;
+        let body: MirRelationExpr = deserialize(stream_iter, "MirRelationExpr", self)?;
 
         if let Some((old_id, old_val)) = prev {
             self.scope.set(&name, old_id, old_val);
@@ -542,7 +514,7 @@ impl<'a> MirRelationExprDeserializeContext<'a> {
         I: Iterator<Item = TokenTree>,
     {
         let mut inputs: Vec<MirRelationExpr> =
-            deserialize(stream_iter, "Vec<MirRelationExpr>", &RTI, self)?;
+            deserialize(stream_iter, "Vec<MirRelationExpr>", self)?;
         Ok(MirRelationExpr::Union {
             base: Box::new(inputs.remove(0)),
             inputs,
@@ -577,14 +549,13 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
         first_arg: TokenTree,
         rest_of_stream: &mut I,
         type_name: &str,
-        rti: &ReflectedTypeInfo,
     ) -> Result<Option<String>, String>
     where
         I: Iterator<Item = TokenTree>,
     {
         match self
             .inner_ctx
-            .override_syntax(first_arg.clone(), rest_of_stream, type_name, rti)?
+            .override_syntax(first_arg.clone(), rest_of_stream, type_name)?
         {
             Some(result) => Ok(Some(result)),
             None => {
@@ -613,13 +584,8 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
         }
     }
 
-    fn reverse_syntax_override(
-        &mut self,
-        json: &Value,
-        type_name: &str,
-        rti: &ReflectedTypeInfo,
-    ) -> Option<String> {
-        match self.inner_ctx.reverse_syntax_override(json, type_name, rti) {
+    fn reverse_syntax_override(&mut self, json: &Value, type_name: &str) -> Option<String> {
+        match self.inner_ctx.reverse_syntax_override(json, type_name) {
             Some(result) => Some(result),
             None => {
                 if type_name == "MirRelationExpr" {
@@ -640,8 +606,16 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                                 return Some(format!(
                                     "(let {} {} {})",
                                     id,
-                                    from_json(&inner_map["value"], "MirRelationExpr", rti, self),
-                                    from_json(&inner_map["body"], "MirRelationExpr", rti, self),
+                                    serialize::<MirRelationExpr, _>(
+                                        &inner_map["value"],
+                                        "MirRelationExpr",
+                                        self
+                                    ),
+                                    serialize::<MirRelationExpr, _>(
+                                        &inner_map["body"],
+                                        "MirRelationExpr",
+                                        self
+                                    ),
                                 ));
                             }
                             "Get" => {
@@ -686,13 +660,21 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                                     return Some(format!(
                                         "(constant [{}] {})",
                                         separated(" ", rows),
-                                        from_json(&inner_map["typ"], "RelationType", rti, self)
+                                        serialize::<RelationType, _>(
+                                            &inner_map["typ"],
+                                            "RelationType",
+                                            self
+                                        )
                                     ));
                                 } else if let Some(inner_data) = inner_map["rows"].get("Err") {
                                     return Some(format!(
                                         "(constant_err {} {})",
-                                        from_json(&inner_data, "EvalError", rti, self),
-                                        from_json(&inner_map["typ"], "RelationType", rti, self)
+                                        serialize::<EvalError, _>(&inner_data, "EvalError", self),
+                                        serialize::<RelationType, _>(
+                                            &inner_map["typ"],
+                                            "RelationType",
+                                            self
+                                        )
                                     ));
                                 } else {
                                     unreachable!("unexpected JSON data: {:?}", inner_map);
@@ -703,10 +685,9 @@ impl<'a> TestDeserializeContext for MirRelationExprDeserializeContext<'a> {
                                 inputs.insert(0, inner_map["base"].clone());
                                 return Some(format!(
                                     "(union {})",
-                                    from_json(
+                                    serialize::<Vec<MirRelationExpr>, _>(
                                         &Value::Array(inputs),
                                         "Vec<MirRelationExpr>",
-                                        rti,
                                         self
                                     )
                                 ));

--- a/src/expr-test-util/tests/test_runner.rs
+++ b/src/expr-test-util/tests/test_runner.rs
@@ -9,7 +9,7 @@
 
 mod test {
     use mz_expr_test_util::*;
-    use mz_lowertest::{from_json, TestDeserializeContext};
+    use mz_lowertest::{serialize, MzReflect, TestDeserializeContext};
     use mz_ore::result::ResultExt;
     use serde::de::DeserializeOwned;
     use serde::Serialize;
@@ -24,14 +24,14 @@ mod test {
         ctx_gen: G,
     ) -> Result<T, String>
     where
-        T: DeserializeOwned + Serialize + Eq + Clone,
+        T: DeserializeOwned + MzReflect + Serialize + Eq + Clone,
         F: Fn(&str) -> Result<T, String>,
         C: TestDeserializeContext,
         G: Fn() -> C,
     {
         let result: T = build_obj(s)?;
         let json = serde_json::to_value(result.clone()).map_err_to_string()?;
-        let new_s = from_json(&json, type_name, &RTI, &mut ctx_gen());
+        let new_s = serialize::<T, _>(&json, type_name, &mut ctx_gen());
         let new_result = build_obj(&new_s)?;
         if new_result.eq(&result) {
             Ok(result)

--- a/src/lowertest/Cargo.toml
+++ b/src/lowertest/Cargo.toml
@@ -16,4 +16,3 @@ serde_json = "1.0.81"
 [dev-dependencies]
 anyhow = "1.0.57"
 datadriven = "0.6.0"
-once_cell = "1.12.0"

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -92,12 +92,11 @@ The main object creation method is
 pub fn deserialize<D, I, C>(
     stream_iter: &mut I,
     type_name: &'static str,
-    rti: &ReflectedTypeInfo,
     ctx: &mut C,
 ) -> Result<D, String>
 where
     C: TestDeserializeContext,
-    D: DeserializeOwned,
+    D: DeserializeOwned + MzReflect,
     I: Iterator<Item = proc_macro2::TokenTree>
 ```
 
@@ -130,6 +129,13 @@ Default values are supported as long as the default fields are last. Put
 `#[serde(default)]` over any fields you want to be default and make sure those
 fields have default values.
 
+You can add the attribute `#[mzreflect(ignore)]` to a field to avoid having to
+derive `MzReflect` as long as at least one of the following conditions apply:
+* you have [overridden the syntax](#extending-the-syntax) such that you can
+construct an instance of the field without using the DSL
+* you have marked the field with the attribute `#[serde(default)]` and always
+  want the field to be initialized with the default value.
+
 [serde_json]: https://docs.serde.rs/serde_json/
 
 ### 1. Parsing the test syntax
@@ -151,39 +157,7 @@ You have to pass in a string containing the name of your type.
 Rust does not have type objects that you can manipulate. Thus, information about
 enums and structs are keyed by string.
 
-### 3. Feeding in type information
-
-Enum/struct information must be passed into the converter via
-the struct `ReflectedTypeInfo`.
-
-To populate the `ReflectedTypeInfo` struct, add these two lines to your code:
-```
-let mut rti = ReflectedTypeInfo::default();
-<Object_type>::add_to_reflected_type_info(&mut rti);
-```
-
-Provided your object type is a [supported type](#supported-types), the
-`add_to_reflected_type_info` function will recursively add types your object
-type depends on to `ReflectedTypoInfo`.
-
-Notably, the type `Result<<ok_type>, <error_type>>` is not yet
-supported, so you may find that you need to separately add information about the
-error type to `ReflectedTypoInfo`.
-```
-<error_type>::add_to_reflected_type_info(&mut rti)
-```
-
-If it is unnecessary to add the type of a field to `ReflectedTypeInfo` because:
-* you have [overridden the syntax](#extending-the-syntax) such that you can
-construct an instance of the field without using the DSL
-* you have marked the field with the attribute `#[serde(default)]` and always
-  want the field to be initialized with the default value.
-You can add the attribute `#[mzreflect(ignore)]` to the field. If you do so,
-`add_to_reflected_type_info` will not add the type of the field to
-`ReflectedTypeInfo`, but it will add the types of other fields of the enum
-variant or struct without the attribute.
-
-### 4. Feeding in syntax extensions
+### 3. Feeding in syntax extensions
 
 If you don't need to extend or override the syntax, give a
 `&mut GenericTestDeserializationContext::default()`.
@@ -197,9 +171,6 @@ Create an object that implements the trait `TestDeserializationContext`.
 The trait has a method `override_syntax`.
 * Its first argument is `&mut self` this way the `TestDeserializationContext`
   can store state across multiple objects being created.
-* The return value should always be `Ok(None)` except in the specific cases when
-  you are overriding or extending the syntax, in which case the return value
-  will be either `Ok(Some(JSON_string))` or `Err(err_string)`.
 * The second and third arguments of the method is the first element in the
   stream and a pointer to the rest of the stream respectively. The contract of
   `override_syntax` is that you promise not to iterate through the stream more
@@ -211,13 +182,16 @@ The trait has a method `override_syntax`.
   variant (resp. struct) you are trying to create has a field that is not a
   supported type, you should use `override_syntax` to specify how to create the
   enum variant (resp. struct).
+* The return value should always be `Ok(None)` except in the specific cases when
+  you are overriding or extending the syntax, in which case the return value
+  will be either `Ok(Some(JSON_string))` or `Err(err_string)`.
 
 Refer to the [proc_macro2] docs for information how to parse the stream.
 
 [proc_macro2]: https://docs.rs/proc-macro2/1.0.27/proc_macro2/enum.TokenTree.html
 
-If an object being created is registered as an enum or struct in
-`ReflectedTypeInfo`, what is passed to `override_syntax` changes:
+If an object being created is an enum or struct that derives `MzReflect`, what
+is passed to `override_syntax` changes:
 * If the spec is a parentheses group (<arg1> .. <argn>), `first_arg` will be
   `<arg1>` and `rest_of_stream` will be `<arg2> .. <argn>`. This saves you the
   effort of unpacking the parentheses group.
@@ -239,8 +213,8 @@ an alternate syntax and you believe:
 2. it is unnecessary for the default syntax to be supported.
 
 you can add the attribute `#[mzreflect(ignore)]` to one or more fields of the
-enum variant or struct so that their types do not have to be added to
-`ReflectedTypeInfo`. This has the side effect of disabling the ability to
+enum variant or struct so that their fields and any subtypes do not need to
+derive `MzReflect`. This has the side effect of disabling the ability to
 construct the enum variant or the struct using the default syntax.
 
 ### Supported types
@@ -264,12 +238,15 @@ types with values that `serde_json` cannot distinguish from `None` because
 * `Option<NoArgumentStruct>`. `serde_json` cannot distinguish
   `Some(NoArgumentStruct)` from `None`.
 
+The type `Result<<ok_type>, <error_type>>` is not yet supported.
+
 ## Roundtrip
 
 To convert a Rust object back into the readable syntax:
 1) Serialize the Rust object to a [serde_json::Value] object by calling
    `let json = serde_json::to_value(obj)?;`.
-2) Feed the json into the method `from_json`.
+2) Feed the json into the method `serialize::<T, _>`. `T` is the type of the
+   object that the json represents.
 
 [serde_json::Value]: https://docs.serde.rs/serde_json/enum.Value.html
 
@@ -288,9 +265,6 @@ struct FuncXParams {
     argn: ...
 }
 ```
-Also, calling `FuncXParams::add_to_reflected_type_info` would allow
-automatically and recursively populating `ReflectedTypeInfo` with all the
-information required to construct all of the arguments.
 
 Likewise, if you want to run arbitrary sequences of functions selected from a
 finite set `{Func1, ..., Funcj}`, you can define a enum where each variant

--- a/src/lowertest/README.md
+++ b/src/lowertest/README.md
@@ -159,8 +159,8 @@ enums and structs are keyed by string.
 
 ### 3. Feeding in syntax extensions
 
-If you don't need to extend or override the syntax, give a
-`&mut GenericTestDeserializationContext::default()`.
+If you don't need to extend or override the syntax, call either
+`deserialize_generic` or `deserialize_optional_generic`.
 
 Otherwise, see ["Extending the syntax"](#extending-the-syntax).
 

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -72,6 +72,22 @@ pub fn unquote(s: &str) -> String {
 
 /* #endregion */
 
+/// Simpler interface for [deserialize_optional] when no syntax overrides or extensions are needed.
+pub fn deserialize_optional_generic<D, I>(
+    stream_iter: &mut I,
+    type_name: &'static str,
+) -> Result<Option<D>, String>
+where
+    D: DeserializeOwned + MzReflect,
+    I: Iterator<Item = TokenTree>,
+{
+    deserialize_optional(
+        stream_iter,
+        type_name,
+        &mut GenericTestDeserializeContext::default(),
+    )
+}
+
 /// If the `stream_iter` is not empty, deserialize the next `TokenTree` into a `D`.
 ///
 /// See [`to_json`] for the object spec syntax.
@@ -97,6 +113,19 @@ where
         })?)),
         None => Ok(None),
     }
+}
+
+/// Simpler interface for [deserialize] when no syntax overrides or extensions are needed.
+pub fn deserialize_generic<D, I>(stream_iter: &mut I, type_name: &'static str) -> Result<D, String>
+where
+    D: DeserializeOwned + MzReflect,
+    I: Iterator<Item = TokenTree>,
+{
+    deserialize(
+        stream_iter,
+        type_name,
+        &mut GenericTestDeserializeContext::default(),
+    )
 }
 
 /// Deserialize the next `TokenTree` into a `D` object.
@@ -310,7 +339,7 @@ pub trait TestDeserializeContext {
 ///
 /// Does not override or extend any of the default syntax.
 #[derive(Default)]
-pub struct GenericTestDeserializeContext;
+struct GenericTestDeserializeContext;
 
 impl TestDeserializeContext for GenericTestDeserializeContext {
     fn override_syntax<I>(
@@ -602,6 +631,21 @@ where
 }
 
 /* #endregion */
+
+/// Simpler interface for [serialize] when no syntax overrides or extensions are needed.
+pub fn serialize_generic<M>(json: &Value, type_name: &str) -> String
+where
+    M: MzReflect,
+{
+    let mut rti = ReflectedTypeInfo::default();
+    M::add_to_reflected_type_info(&mut rti);
+    from_json(
+        json,
+        type_name,
+        &rti,
+        &mut GenericTestDeserializeContext::default(),
+    )
+}
 
 pub fn serialize<M, C>(json: &Value, type_name: &str, ctx: &mut C) -> String
 where

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -35,6 +35,12 @@ pub trait MzReflect {
     fn add_to_reflected_type_info(rti: &mut ReflectedTypeInfo);
 }
 
+impl<T: MzReflect> MzReflect for Vec<T> {
+    fn add_to_reflected_type_info(rti: &mut ReflectedTypeInfo) {
+        T::add_to_reflected_type_info(rti);
+    }
+}
+
 /// Info that must be combined with a spec to form deserializable JSON.
 ///
 /// To add information required to construct a struct or enum,
@@ -76,15 +82,16 @@ pub fn unquote(s: &str) -> String {
 pub fn deserialize_optional<D, I, C>(
     stream_iter: &mut I,
     type_name: &'static str,
-    rti: &ReflectedTypeInfo,
     ctx: &mut C,
 ) -> Result<Option<D>, String>
 where
     C: TestDeserializeContext,
-    D: DeserializeOwned,
+    D: DeserializeOwned + MzReflect,
     I: Iterator<Item = TokenTree>,
 {
-    match to_json(stream_iter, type_name, rti, ctx)? {
+    let mut rti = ReflectedTypeInfo::default();
+    D::add_to_reflected_type_info(&mut rti);
+    match to_json(stream_iter, type_name, &rti, ctx)? {
         Some(j) => Ok(Some(serde_json::from_str::<D>(&j).map_err(|e| {
             format!("String while serializing: {}\nOriginal JSON: {}", e, j)
         })?)),
@@ -102,15 +109,14 @@ where
 pub fn deserialize<D, I, C>(
     stream_iter: &mut I,
     type_name: &'static str,
-    rti: &ReflectedTypeInfo,
     ctx: &mut C,
 ) -> Result<D, String>
 where
     C: TestDeserializeContext,
-    D: DeserializeOwned,
+    D: DeserializeOwned + MzReflect,
     I: Iterator<Item = TokenTree>,
 {
-    deserialize_optional(stream_iter, type_name, rti, ctx)?
+    deserialize_optional(stream_iter, type_name, ctx)?
         .ok_or_else(|| format!("Empty spec for type {}", type_name))
 }
 
@@ -182,9 +188,7 @@ where
             return Ok(Some(result));
         }
         // Resolving types that are not enums or structs defined by us.
-        if let Some(result) =
-            ctx.override_syntax(first_arg.clone(), stream_iter, &type_name, rti)?
-        {
+        if let Some(result) = ctx.override_syntax(first_arg.clone(), stream_iter, &type_name)? {
             return Ok(Some(result));
         }
         match first_arg {
@@ -290,7 +294,6 @@ pub trait TestDeserializeContext {
         first_arg: TokenTree,
         rest_of_stream: &mut I,
         type_name: &str,
-        rti: &ReflectedTypeInfo,
     ) -> Result<Option<String>, String>
     where
         I: Iterator<Item = TokenTree>;
@@ -300,12 +303,7 @@ pub trait TestDeserializeContext {
     ///
     /// Returns `Some(value)` if `json` has been resolved.
     /// Returns `None` is `json` should be resolved in the default manner.
-    fn reverse_syntax_override(
-        &mut self,
-        json: &Value,
-        type_name: &str,
-        rti: &ReflectedTypeInfo,
-    ) -> Option<String>;
+    fn reverse_syntax_override(&mut self, json: &Value, type_name: &str) -> Option<String>;
 }
 
 /// Default `TestDeserializeContext`.
@@ -320,7 +318,6 @@ impl TestDeserializeContext for GenericTestDeserializeContext {
         _first_arg: TokenTree,
         _rest_of_stream: &mut I,
         _type_name: &str,
-        _rti: &ReflectedTypeInfo,
     ) -> Result<Option<String>, String>
     where
         I: Iterator<Item = TokenTree>,
@@ -328,12 +325,7 @@ impl TestDeserializeContext for GenericTestDeserializeContext {
         Ok(None)
     }
 
-    fn reverse_syntax_override(
-        &mut self,
-        _: &Value,
-        _: &str,
-        _: &ReflectedTypeInfo,
-    ) -> Option<String> {
+    fn reverse_syntax_override(&mut self, _: &Value, _: &str) -> Option<String> {
         None
     }
 }
@@ -474,7 +466,7 @@ where
     C: TestDeserializeContext,
     I: Iterator<Item = TokenTree>,
 {
-    if let Some(result) = ctx.override_syntax(first_arg.clone(), rest_of_stream, type_name, rti)? {
+    if let Some(result) = ctx.override_syntax(first_arg.clone(), rest_of_stream, type_name)? {
         Ok(Some(result))
     } else if let Some((f_names, f_types)) = rti.struct_dict.get(type_name).map(|r| r.clone()) {
         Ok(Some(to_json_fields(
@@ -611,6 +603,16 @@ where
 
 /* #endregion */
 
+pub fn serialize<M, C>(json: &Value, type_name: &str, ctx: &mut C) -> String
+where
+    C: TestDeserializeContext,
+    M: MzReflect,
+{
+    let mut rti = ReflectedTypeInfo::default();
+    M::add_to_reflected_type_info(&mut rti);
+    from_json(json, type_name, &rti, ctx)
+}
+
 /// Converts serialized JSON to the syntax that [to_json] handles.
 ///
 /// `json` is assumed to have been produced by serializing an object of type
@@ -622,7 +624,7 @@ where
     C: TestDeserializeContext,
 {
     let (type_name, option_found) = normalize_type_name(type_name);
-    if let Some(result) = ctx.reverse_syntax_override(json, &type_name, rti) {
+    if let Some(result) = ctx.reverse_syntax_override(json, &type_name) {
         return result;
     }
     // If type is `Option<T>`, convert the value to "null" if it is null,

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -177,11 +177,7 @@ mod tests {
                 &mut TestOverrideDeserializeContext::default(),
             )
         } else {
-            deserialize_optional(
-                &mut stream.into_iter(),
-                "TestEnum",
-                &mut GenericTestDeserializeContext::default(),
-            )
+            deserialize_optional_generic(&mut stream.into_iter(), "TestEnum")
         }
     }
 
@@ -198,11 +194,7 @@ mod tests {
                     &mut TestOverrideDeserializeContext::default(),
                 )
             } else {
-                serialize::<TestEnum, _>(
-                    &json,
-                    "TestEnum",
-                    &mut GenericTestDeserializeContext::default(),
-                )
+                serialize_generic::<TestEnum>(&json, "TestEnum")
             };
             (json, new_s)
         } else {

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -14,7 +14,6 @@ mod tests {
     use std::collections::HashMap;
 
     use mz_ore::result::ResultExt;
-    use once_cell::sync::Lazy;
     use proc_macro2::TokenTree;
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
@@ -79,12 +78,6 @@ mod tests {
         OptionStructNesting(SecondLayerOfOption),
     }
 
-    static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
-        let mut rti = ReflectedTypeInfo::default();
-        TestEnum::add_to_reflected_type_info(&mut rti);
-        rti
-    });
-
     #[derive(Default)]
     struct TestOverrideDeserializeContext;
 
@@ -103,7 +96,6 @@ mod tests {
             first_arg: TokenTree,
             rest_of_stream: &mut I,
             type_name: &str,
-            rti: &ReflectedTypeInfo,
         ) -> Result<Option<String>, String>
         where
             I: Iterator<Item = TokenTree>,
@@ -143,7 +135,11 @@ mod tests {
             } else if type_name == "f64" {
                 if let TokenTree::Punct(punct) = first_arg.clone() {
                     if punct.as_char() == '+' {
-                        return to_json(rest_of_stream, type_name, rti, self);
+                        if let Some(token) = rest_of_stream.next() {
+                            return Ok(Some(token.to_string()));
+                        } else {
+                            return Err("+ is not an f64".to_string());
+                        }
                     }
                 }
             } else if type_name == "usize" {
@@ -156,12 +152,7 @@ mod tests {
         }
 
         /// This decrements all numbers of type "usize" by one.
-        fn reverse_syntax_override(
-            &mut self,
-            json: &Value,
-            type_name: &str,
-            _rti: &ReflectedTypeInfo,
-        ) -> Option<String> {
+        fn reverse_syntax_override(&mut self, json: &Value, type_name: &str) -> Option<String> {
             if type_name == "usize" {
                 let result: usize = json.as_u64().unwrap() as usize;
                 if result == 0 {
@@ -183,14 +174,12 @@ mod tests {
             deserialize_optional(
                 &mut stream.into_iter(),
                 "TestEnum",
-                &RTI,
                 &mut TestOverrideDeserializeContext::default(),
             )
         } else {
             deserialize_optional(
                 &mut stream.into_iter(),
                 "TestEnum",
-                &RTI,
                 &mut GenericTestDeserializeContext::default(),
             )
         }
@@ -203,17 +192,15 @@ mod tests {
         let (json, new_s) = if let Some(result) = &result {
             let json = serde_json::to_value(result).map_err_to_string()?;
             let new_s = if args.get("override").is_some() {
-                from_json(
+                serialize::<TestEnum, _>(
                     &json,
                     "TestEnum",
-                    &RTI,
                     &mut TestOverrideDeserializeContext::default(),
                 )
             } else {
-                from_json(
+                serialize::<TestEnum, _>(
                     &json,
                     "TestEnum",
-                    &RTI,
                     &mut GenericTestDeserializeContext::default(),
                 )
             };

--- a/src/repr-test-util/Cargo.toml
+++ b/src/repr-test-util/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
-once_cell = "1.12.0"
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -14,7 +14,7 @@
 use chrono::NaiveDateTime;
 use proc_macro2::TokenTree;
 
-use mz_lowertest::{deserialize_optional, GenericTestDeserializeContext};
+use mz_lowertest::deserialize_optional_generic;
 use mz_ore::str::StrExt;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{Datum, Row, RowArena, ScalarType};
@@ -114,11 +114,7 @@ pub fn get_scalar_type_or_default<I>(
 where
     I: Iterator<Item = TokenTree>,
 {
-    let typ: Option<ScalarType> = deserialize_optional(
-        scalar_type_stream,
-        "ScalarType",
-        &mut GenericTestDeserializeContext::default(),
-    )?;
+    let typ: Option<ScalarType> = deserialize_optional_generic(scalar_type_stream, "ScalarType")?;
     match typ {
         Some(typ) => Ok(typ),
         None => {

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -12,21 +12,12 @@
 //! These test utilities are relied by crates other than `repr`.
 
 use chrono::NaiveDateTime;
-use once_cell::sync::Lazy;
 use proc_macro2::TokenTree;
 
-use mz_lowertest::{
-    deserialize_optional, GenericTestDeserializeContext, MzReflect, ReflectedTypeInfo,
-};
+use mz_lowertest::{deserialize_optional, GenericTestDeserializeContext};
 use mz_ore::str::StrExt;
 use mz_repr::adt::numeric::Numeric;
-use mz_repr::{ColumnType, Datum, Row, RowArena, ScalarType};
-
-pub static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
-    let mut rti = ReflectedTypeInfo::default();
-    ColumnType::add_to_reflected_type_info(&mut rti);
-    rti
-});
+use mz_repr::{Datum, Row, RowArena, ScalarType};
 
 /* #endregion */
 
@@ -126,7 +117,6 @@ where
     let typ: Option<ScalarType> = deserialize_optional(
         scalar_type_stream,
         "ScalarType",
-        &RTI,
         &mut GenericTestDeserializeContext::default(),
     )?;
     match typ {

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -9,7 +9,7 @@
 
 #[cfg(test)]
 mod tests {
-    use mz_lowertest::{deserialize_optional, tokenize, GenericTestDeserializeContext};
+    use mz_lowertest::{deserialize_optional_generic, tokenize};
     use mz_ore::str::separated;
     use mz_repr::ScalarType;
     use mz_repr_test_util::*;
@@ -43,11 +43,8 @@ mod tests {
                 .next()
                 .ok_or_else(|| "Empty row spec".to_string())?,
         )?;
-        let scalar_types: Option<Vec<ScalarType>> = deserialize_optional(
-            &mut stream_iter,
-            "Vec<ScalarType>",
-            &mut GenericTestDeserializeContext::default(),
-        )?;
+        let scalar_types: Option<Vec<ScalarType>> =
+            deserialize_optional_generic(&mut stream_iter, "Vec<ScalarType>")?;
         let scalar_types = if let Some(scalar_types) = scalar_types {
             scalar_types
         } else {

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -46,7 +46,6 @@ mod tests {
         let scalar_types: Option<Vec<ScalarType>> = deserialize_optional(
             &mut stream_iter,
             "Vec<ScalarType>",
-            &RTI,
             &mut GenericTestDeserializeContext::default(),
         )?;
         let scalar_types = if let Some(scalar_types) = scalar_types {

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -44,11 +44,6 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     timestamp_frequency: Duration::from_secs(1),
     now: NOW_ZERO.clone(),
 });
-static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
-    let mut rti = ReflectedTypeInfo::default();
-    TestCatalogCommand::add_to_reflected_type_info(&mut rti);
-    rti
-});
 
 /// A dummy [`CatalogItem`] implementation.
 ///
@@ -324,7 +319,6 @@ impl TestCatalog {
         while let Some(command) = deserialize_optional::<TestCatalogCommand, _, _>(
             &mut stream_iter,
             "TestCatalogCommand",
-            &RTI,
             &mut GenericTestDeserializeContext::default(),
         )? {
             match command {

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -316,10 +316,9 @@ pub enum TestCatalogCommand {
 impl TestCatalog {
     pub(crate) fn execute_commands(&mut self, spec: &str) -> Result<String, String> {
         let mut stream_iter = tokenize(spec)?.into_iter();
-        while let Some(command) = deserialize_optional::<TestCatalogCommand, _, _>(
+        while let Some(command) = deserialize_optional_generic::<TestCatalogCommand, _>(
             &mut stream_iter,
             "TestCatalogCommand",
-            &mut GenericTestDeserializeContext::default(),
         )? {
             match command {
                 TestCatalogCommand::Defsource { source_name, desc } => {

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -91,11 +91,8 @@ fn run_command(
     catalog: &TestCatalog,
 ) -> Result<String, String> {
     let mut model = convert_input_to_model(input, catalog)?;
-    let directive: Directive = deserialize(
-        &mut tokenize(command)?.into_iter(),
-        "Directive",
-        &mut GenericTestDeserializeContext::default(),
-    )?;
+    let directive: Directive =
+        deserialize_generic(&mut tokenize(command)?.into_iter(), "Directive")?;
 
     if matches!(directive, Directive::Opt | Directive::EndToEnd) {
         model.optimize();

--- a/src/sql/src/query_model/test/mod.rs
+++ b/src/sql/src/query_model/test/mod.rs
@@ -19,7 +19,6 @@ use crate::query_model::Model;
 use catalog::TestCatalog;
 
 use crate::names::resolve_names_stmt;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -38,12 +37,6 @@ enum Directive {
     /// Ensure that the HIR ⇒ QGM ⇒ HIR round trip reaches a fixpoint after one iteration.
     RoundTrip,
 }
-
-pub static RTI: Lazy<ReflectedTypeInfo> = Lazy::new(|| {
-    let mut rti = ReflectedTypeInfo::default();
-    Directive::add_to_reflected_type_info(&mut rti);
-    rti
-});
 
 /// Convert the input string to a Query Graph Model.
 fn convert_input_to_model(input: &str, catalog: &TestCatalog) -> Result<Model, String> {
@@ -101,7 +94,6 @@ fn run_command(
     let directive: Directive = deserialize(
         &mut tokenize(command)?.into_iter(),
         "Directive",
-        &RTI,
         &mut GenericTestDeserializeContext::default(),
     )?;
 

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -23,7 +23,7 @@ mod tests {
     use mz_expr::{Id, MirRelationExpr};
     use mz_expr_test_util::{
         build_rel, generate_explanation, json_to_spec, MirRelationExprDeserializeContext,
-        TestCatalog, RTI,
+        TestCatalog,
     };
     use mz_lowertest::{deserialize, tokenize};
     use mz_ore::str::separated;
@@ -296,7 +296,6 @@ mod tests {
                     let rel: MirRelationExpr = deserialize(
                         &mut inner_iter,
                         "MirRelationExpr",
-                        &RTI,
                         &mut MirRelationExprDeserializeContext::new(cat),
                     )?;
                     let id = cat.insert(&name, rel.typ(), true)?;


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

Previously, to construct an object using `lowertest`, you had to construct a `ReflectedTypeInfo` object and pass it into the `deserialize` or `deserialize_optional` method. Now, `deserialize_optional` and `deserialize` automatically construct the correct `ReflectedTypeInfo` object required to deserialize your object, and a user of `lowertest` no longer needs to be aware of the existence of a `ReflectedTypeInfo`.

Previously, you had to import `GenericTestDeserializeContext` to construct an object using `lowertest` where you have not added any syntax extensions or overrides. Now there is a `deserialize_generic` method that automatically creates the `GenericTestDeserializeContext` for you.

### Tips for reviewer

The interesting changes are in `src/lowertest/src/lib.rs` and `src/lowertest/README.md`. The other files just mostly contain mechanical removal of unnecessary references to `ReflectedTypeInfo` or interface changes.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

No user facing changes.
