### PR TITLE
sql: model REPLICA clause in CREATE CLUSTER as an option

### DIFF
--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1102,49 +1102,52 @@ CREATE CLUSTER cluster
 ----
 CREATE CLUSTER cluster
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [], replicas: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [] })
 
 parse-statement
-CREATE CLUSTER cluster VIRTUAL
+CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s'
 ----
-error: Expected INTROSPECTION, found identifier "virtual"
-CREATE CLUSTER cluster VIRTUAL
-                       ^
+CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s'
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionGranularity(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster SIZE 'small'
+CREATE CLUSTER cluster INTROSPECTION GRANULARITY = '1s'
 ----
-error: Expected INTROSPECTION, found SIZE
-CREATE CLUSTER cluster SIZE 'small'
-                       ^
+CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s'
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionGranularity(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster SIZE = 'small'
+CREATE CLUSTER cluster WITH INTROSPECTION GRANULARITY = '1s'
+
+parse-statement
+CREATE CLUSTER cluster BADOPT
 ----
-error: Expected INTROSPECTION, found SIZE
-CREATE CLUSTER cluster SIZE = 'small'
-                       ^
+error: Expected end of statement, found identifier "parse"
+parse-statement
+^
 
 parse-statement
 CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'))
 ----
 CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [], replicas: [ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] }] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica(ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] })] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICA a SIZE '1'
+CREATE CLUSTER cluster REPLICA a (REMOTE ('host1')), INTROSPECTION GRANULARITY '1s', REPLICA b (SIZE '1')
 ----
-error: Expected left parenthesis, found SIZE
-CREATE CLUSTER cluster REPLICA a SIZE '1'
-                                 ^
+CREATE CLUSTER cluster REPLICA a (REMOTE ('host1')), INTROSPECTION GRANULARITY '1s', REPLICA b (SIZE '1')
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica(ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] }), IntrospectionGranularity(Value(String("1s"))), Replica(ReplicaDefinition { name: Ident("b"), options: [Size(Value(String("1")))] })] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'), SIZE '1')
 ----
 CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'), SIZE '1')
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [], replicas: [ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }, Size(Value(String("1")))] }] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica(ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }, Size(Value(String("1")))] })] })
 
 parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ('host1')

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -52,7 +52,7 @@ default
 
 # Test invalid option combinations.
 
-statement error Expected INTROSPECTION, found SIZE
+statement error Expected one of REPLICA or INTROSPECTION, found SIZE
 CREATE CLUSTER baz SIZE 'small'
 
 statement error only one of REMOTE or SIZE may be specified
@@ -189,13 +189,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234')) INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234')), INTROSPECTION GRANULARITY '1s'
 
 statement ok
 DROP CLUSTER foo
 
 statement ok
-CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234')) INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234')), INTROSPECTION GRANULARITY '1s'
 
 statement ok
 DROP CLUSTER foo

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -18,8 +18,8 @@ INSERT INTO test VALUES('a', 'b')
 statement ok
 CREATE CLUSTER test
   REPLICA replica_a (SIZE '1'),
-  REPLICA replica_b (SIZE '2')
-  WITH INTROSPECTION GRANULARITY '50 milliseconds'
+  REPLICA replica_b (SIZE '2'),
+  INTROSPECTION GRANULARITY '50 milliseconds'
 
 statement ok
 SET cluster = test
@@ -120,8 +120,8 @@ DROP CLUSTER test CASCADE
 
 statement ok
 CREATE CLUSTER test
-  REPLICA replica_a (SIZE '1')
-  WITH INTROSPECTION GRANULARITY 'off'
+  REPLICA replica_a (SIZE '1'),
+  INTROSPECTION GRANULARITY 'off'
 
 query error cannot read log sources on cluster with disabled introspection
 SELECT * FROM mz_materializations


### PR DESCRIPTION
Previously the `REPLICA` clause to `CREATE CLUSTER` had to appear first
and could not be followed by a comma. This was valid syntax:

    CREATE CLUSTER c
    REPLICA a (SIZE 'small'),
    REPLICA b (SIZE 'small')  -- note missing comma
    INTROSPECTION GRANULARITY '1s'

But this was not:

    CREATE CLUSTER c
    REPLICA a (SIZE 'small'),
    REPLICA b (SIZE 'small'), -- note comma
    INTROSPECTION GRANULARITY '1s'

This commit adjusts the syntax so that the latter is valid but the
former is not. This makes it more natural to intersperse replica
specifications with other options.

Touches #12660.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes part of a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
