### PR TITLE
bin/run: add some convenience features

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -45,7 +45,7 @@ def main() -> int:
     parser.add_argument(
         "--postgres",
         help="PostgreSQL connection string",
-        default=DEFAULT_POSTGRES,
+        default=os.getenv("MZDEV_POSTGRES", DEFAULT_POSTGRES),
     )
     parser.add_argument(
         "--release",


### PR DESCRIPTION
**bin/run: allow configuring postgres conn string via env var**

This allows developers who consistently want to use a different
PostgreSQL database to do so by configuring the `MZDEV_POSTGRES`
environment variable.

**bin/run: add --reset argument to delete prior state**

Add a --reset argument to bin/run that deletes state from prior runs of
materialized before starting the new incarnation. This is a good bit
more convenient than having to clear out the PostgreSQL database and
mzdata directory by hand.

### Motivation

  * This PR adds two features that have not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
