### PR TITLE
process orchestrator: Introduce command wrapper

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -399,6 +399,10 @@ pub struct Args {
     /// Turn on the console-subscriber to use materialize with `tokio-console`
     #[clap(long, hide = true)]
     tokio_console: bool,
+
+    /// Prefix commands issued by the process orchestrator with the supplied value.
+    #[clap(long, env = "MZ_PROCESS_ORCHESTRATOR_WRAPPER")]
+    process_orchestrator_wrapper: Option<String>,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -588,6 +592,9 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                     suppress_output: false,
                     process_listen_host: args.process_listen_host,
                     data_dir: args.data_directory.clone(),
+                    command_wrapper: args
+                        .process_orchestrator_wrapper
+                        .map_or(Ok(vec![]), |s| shell_words::split(&s))?,
                 })
             }
         },

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -155,6 +155,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
                 suppress_output: true,
                 process_listen_host: None,
                 data_dir: data_directory,
+                command_wrapper: vec![],
             }),
             storaged_image: "storaged".into(),
             computed_image: "computed".into(),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -572,6 +572,7 @@ impl Runner {
                     suppress_output: false,
                     process_listen_host: None,
                     data_dir: temp_dir.path().to_path_buf(),
+                    command_wrapper: vec![],
                 }),
                 storaged_image: "storaged".into(),
                 computed_image: "computed".into(),


### PR DESCRIPTION
This PR adds a feature that has not yet been specified: Allow to specify a wrapper for commands issued by the process orchestrator.

Configure the command wrapper using the environment symbol `MZ_PROCESS_ORCHESTRATOR_WRAPPER`.

Its contents are separated into a command and arguments using shell quoting semantics. The string %N is substituted with the replica name, and the string %P:{port} is substituted with the port number of the named endpoint.

For example, the following command records a perf trace for each child process:

`MZ_PROCESS_ORCHESTRATOR_WRAPPER="perf record -o perf.data.%N" bin/materialized`

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
