### PR TITLE
fix(expr): fix `coalesce` display problem 

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -57,9 +57,15 @@ fn return_true() -> bool {
 impl ColumnType {
     pub fn union(&self, other: &Self) -> Result<Self, anyhow::Error> {
         match (self.scalar_type.clone(), other.scalar_type.clone()) {
-            (scalar_type, other_scalar_type) if scalar_type.base_eq(&other_scalar_type) => {
+            (scalar_type, other_scalar_type) if scalar_type == other_scalar_type => {
                 Ok(ColumnType {
                     scalar_type,
+                    nullable: self.nullable || other.nullable,
+                })
+            }
+            (scalar_type, other_scalar_type) if scalar_type.base_eq(&other_scalar_type) => {
+                Ok(ColumnType {
+                    scalar_type: scalar_type.without_modifiers(),
                     nullable: self.nullable || other.nullable,
                 })
             }

--- a/test/README.md
+++ b/test/README.md
@@ -3,4 +3,4 @@
 This directory contains system test files for Materialize. Its contents are
 explained in detail in [Developer guide: testing].
 
-[Developer guide: testing]: /doc/developer/guide-testing.md
+[Developer guide: testing]: ../doc/developer/guide-testing.md

--- a/test/sqllogictest/boolean.slt
+++ b/test/sqllogictest/boolean.slt
@@ -380,3 +380,8 @@ NULL  NULL
 NULL  2
 1  NULL
 1  2
+
+query T
+SELECT CASE WHEN FALSE THEN 'short_string'::char(20) ELSE 'long_string_long_string'::char(30) END
+----
+long_string_long_string

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -445,6 +445,26 @@ SELECT coalesce(row(4, 3), row(2, 1))
 ----
 (4,3)
 
+query T
+select coalesce(null::char(1), 'abc');
+----
+abc
+
+query T
+SELECT coalesce('abc', null::char(1));
+----
+abc
+
+query T
+SELECT coalesce(null::char(1),'abcde','abc');
+----
+abcde
+
+query T
+SELECT coalesce('abcde',null::char(1),'abc');
+----
+abcde
+
 # TODO(#11469)
 query error coalesce could not convert type record
 SELECT coalesce(row(1, 2), row(3), row(4, 5));
@@ -463,6 +483,26 @@ query T
 SELECT coalesce(1, 1 / 0, a) FROM v
 ----
 1
+
+query T
+select coalesce(null::char(1), 'abc');
+----
+abc
+
+query T
+SELECT coalesce('abc', null::char(1));
+----
+abc
+
+query T
+SELECT coalesce(null::char(1),'abcde','abc');
+----
+abcde
+
+query T
+SELECT coalesce('abcde',null::char(1),'abc');
+----
+abcde
 
 # Test greatest.
 query I

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -203,10 +203,10 @@ Query:
 | | types = (integer?, integer)
 | | keys = ()
 | Map greatest(#1), greatest(#1, #1), greatest(#1, #0), greatest(#0, #0)
-| | types = (integer?, integer, integer, integer, integer, integer?)
+| | types = (integer?, integer, integer, integer, integer?, integer?)
 | | keys = ()
 | Project (#2..=#5)
-| | types = (integer, integer, integer, integer?)
+| | types = (integer, integer, integer?, integer?)
 | | keys = ()
 
 EOF
@@ -223,10 +223,10 @@ Query:
 | | types = (integer?, integer)
 | | keys = ()
 | Map least(#1), least(#1, #1), least(#1, #0), least(#0, #0)
-| | types = (integer?, integer, integer, integer, integer, integer?)
+| | types = (integer?, integer, integer, integer, integer?, integer?)
 | | keys = ()
 | Project (#2..=#5)
-| | types = (integer, integer, integer, integer?)
+| | types = (integer, integer, integer?, integer?)
 | | keys = ()
 
 EOF

--- a/test/sqllogictest/qgm/qgm-type-inference.slt
+++ b/test/sqllogictest/qgm/qgm-type-inference.slt
@@ -332,7 +332,7 @@ digraph G {
     node [ shape = box ]
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (integer)| 1: Q1.C3 (integer)| 2: Q1.C4 (integer)| 3: Q1.C5 (integer?) }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (integer)| 1: Q1.C3 (integer)| 2: Q1.C4 (integer?)| 3: Q1.C5 (integer?) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -341,7 +341,7 @@ digraph G {
     }
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer)| 2: greatest(Q0.C1) (integer)| 3: greatest(Q0.C1, Q0.C1) (integer)| 4: greatest(Q0.C1, Q0.C0) (integer)| 5: greatest(Q0.C0, Q0.C0) (integer?) }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer)| 2: greatest(Q0.C1) (integer)| 3: greatest(Q0.C1, Q0.C1) (integer)| 4: greatest(Q0.C1, Q0.C0) (integer?)| 5: greatest(Q0.C0, Q0.C0) (integer?) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -372,7 +372,7 @@ digraph G {
     node [ shape = box ]
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (integer)| 1: Q1.C3 (integer)| 2: Q1.C4 (integer)| 3: Q1.C5 (integer?) }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (integer)| 1: Q1.C3 (integer)| 2: Q1.C4 (integer?)| 3: Q1.C5 (integer?) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -381,7 +381,7 @@ digraph G {
     }
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer)| 2: least(Q0.C1) (integer)| 3: least(Q0.C1, Q0.C1) (integer)| 4: least(Q0.C1, Q0.C0) (integer)| 5: least(Q0.C0, Q0.C0) (integer?) }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer)| 2: least(Q0.C1) (integer)| 3: least(Q0.C1, Q0.C1) (integer)| 4: least(Q0.C1, Q0.C0) (integer?)| 5: least(Q0.C0, Q0.C0) (integer?) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -412,7 +412,7 @@ digraph G {
     node [ shape = box ]
     subgraph cluster2 {
         label = "Box2:Select"
-        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (integer)| 1: Q1.C3 (integer)| 2: Q1.C4 (integer)| 3: Q1.C5 (integer?) }" ]
+        boxhead2 [ shape = record, label = "{ Distinct: Preserve| 0: Q1.C2 (integer)| 1: Q1.C3 (integer)| 2: Q1.C4 (integer?)| 3: Q1.C5 (integer?) }" ]
         {
             rank = same
             node [ shape = circle ]
@@ -421,7 +421,7 @@ digraph G {
     }
     subgraph cluster1 {
         label = "Box1:Select"
-        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer)| 2: coalesce(Q0.C1) (integer)| 3: coalesce(Q0.C1, Q0.C1) (integer)| 4: coalesce(Q0.C1, Q0.C0) (integer)| 5: coalesce(Q0.C0, Q0.C0) (integer?) }" ]
+        boxhead1 [ shape = record, label = "{ Distinct: Preserve| 0: Q0.C0 (integer?)| 1: Q0.C1 (integer)| 2: coalesce(Q0.C1) (integer)| 3: coalesce(Q0.C1, Q0.C1) (integer)| 4: coalesce(Q0.C1, Q0.C0) (integer?)| 5: coalesce(Q0.C0, Q0.C0) (integer?) }" ]
         {
             rank = same
             node [ shape = circle ]

--- a/test/testdrive/char-varchar-distinct.td
+++ b/test/testdrive/char-varchar-distinct.td
@@ -17,11 +17,16 @@
 > SELECT 'a '::char(5) UNION DISTINCT SELECT 'a  '::char(5);
 "a    "
 
+# NOTE(benesch): this does not match PostgreSQL, which will choose to preserve
+# the trailing spaces of *one* of the datums arbitrarily. We can't allow such
+# nondeterminism in our dataflow layer, so we choose to strip all trailing
+# spaces.
 > SELECT 'a '::char(5) UNION DISTINCT SELECT 'a  '::char(10);
-"a    "
+"a"
 
+# Ditto.
 > SELECT 'a '::char(10) UNION DISTINCT SELECT 'a  '::char(5);
-"a         "
+"a"
 
 > SELECT 'a '::varchar(5) UNION DISTINCT SELECT 'a  '::varchar(5);
 "a "
@@ -34,8 +39,9 @@ a
 > SELECT 'a '::varchar(5) UNION DISTINCT SELECT 'a '::text;
 "a "
 
+# This again does not match PostgreSQL for the reason described above.
 > SELECT 'a '::char(5) UNION DISTINCT SELECT 'a '::text;
-"a    "
+"a"
 
 > CREATE TABLE char_table (f1 CHAR(20));
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
The old logic will select first `ColumnType` in `Vec` as output, but in below case the first `ColumnType`'s `scalar type` is `Char` and its length is 1 so it can not display correctly. I fix it with adding `filter` to avoid this problem(We only select the first `Not Null Expr`). Relate issue: #11166
```
materialize=> select coalesce(null::char(1), 'abc');
 coalesce 
----------
 a
(1 row)
```

And I fix a doc link problem by the way when i searched the way to test :)
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
