### PR TITLE
repr: implement `RustType` for `prost` scalar types and update developer guide

### DIFF
--- a/src/repr/src/proto.rs
+++ b/src/repr/src/proto.rs
@@ -196,6 +196,27 @@ where
     }
 }
 
+macro_rules! rust_type_id(
+    ($($t:ty),*) => (
+        $(
+            /// Identity type for $t.
+            impl RustType<$t> for $t {
+                #[inline]
+                fn into_proto(&self) -> $t {
+                    self.clone()
+                }
+
+                #[inline]
+                fn from_proto(proto: $t) -> Result<Self, TryFromProtoError> {
+                    Ok(proto)
+                }
+            }
+        )+
+    );
+);
+
+rust_type_id![bool, f32, f64, i32, i64, String, u32, u64, Vec<u8>];
+
 /// Blanket implementation for `BTreeMap<K, V>` where there exists `T` such
 /// that `T` implements `ProtoMapEntry<K, V>`.
 impl<K, V, T> RustType<Vec<T>> for BTreeMap<K, V>


### PR DESCRIPTION
Add trivial `RustType` implementations for Rust types that are used to represent Protobuf scalar types[^1] and update the developer guide to reflect the API changes proposed in #12579.

[^1]: https://github.com/tokio-rs/prost#scalar-values

Closes #12579.

### Motivation

   * This PR refactors existing code.

Updates the docs and adds missing trivial `RustType` implementations for scalar types.

### Tips for reviewer

I am adding two commits -- the first adds missing trivial `RustType` implementations for scalar types, the second updates the developer guide. @wangandi feel free to fix directly in this PR before you merge.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A
