### PR TITLE
coord: prevent log reads if introspection is disabled

### DIFF
--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -381,6 +381,7 @@ impl ErrorResponse {
             CoordError::FixedValueParameter(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::IdExhaustionError => SqlState::INTERNAL_ERROR,
             CoordError::Internal(_) => SqlState::INTERNAL_ERROR,
+            CoordError::IntrospectionDisabled { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidRematerialization { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             CoordError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             CoordError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -100,7 +100,8 @@ CREATE MATERIALIZED VIEW introspection_view AS SELECT * FROM mz_materializations
 query error log source reads must target a replica
 SELECT * FROM introspection_view
 
-# Verify that introspection queries on unreplicated clusters are allowed.
+# Verify that untargeted introspection queries on unreplicated clusters are
+# allowed.
 
 statement ok
 DROP CLUSTER REPLICA test.replica_b;
@@ -111,10 +112,21 @@ SELECT * FROM mz_materializations
 statement ok
 SELECT * FROM introspection_view
 
-# Clean up.
+# Verify that querying introspection data is disallowed on clusters with
+# introspection disabled.
 
 statement ok
-DROP VIEW introspection_view
+DROP CLUSTER test CASCADE
+
+statement ok
+CREATE CLUSTER test
+  REPLICA replica_a (SIZE '1')
+  WITH INTROSPECTION GRANULARITY 'off'
+
+query error cannot read log sources on cluster with disabled introspection
+SELECT * FROM mz_materializations
+
+# Clean up.
 
 statement ok
 DROP CLUSTER test


### PR DESCRIPTION
If introspection is disabled for a cluster, queries to log sources will fail (currently they hang forever, in the future they might return a cryptic error instead). By checking for this scenario in the coordinator, we can improve UX by returning a nice error message.

### Motivation

  * This PR fixes a recognized bug.

    Fixes #12662.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Makes queries to introspection sources, on clusters with introspection disabled, return a useful error instead of hanging indefinitely.
