### PR TITLE
dataflow-types: add Protobuf support to SinkDesc

### DIFF
--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -34,6 +34,7 @@ fn main() {
                 "dataflow-types/src/logging.proto",
                 "dataflow-types/src/postgres_source.proto",
                 "dataflow-types/src/types/aws.proto",
+                "dataflow-types/src/types/sinks.proto",
                 "dataflow-types/src/types/sources.proto",
                 "dataflow-types/src/types/sources/encoding.proto",
                 "dataflow-types/src/plan.proto",

--- a/src/dataflow-types/src/types.proto
+++ b/src/dataflow-types/src/types.proto
@@ -13,6 +13,7 @@ syntax = "proto3";
 
 import "dataflow-types/src/client/controller/storage.proto";
 import "dataflow-types/src/plan.proto";
+import "dataflow-types/src/types/sinks.proto";
 import "expr/src/scalar.proto";
 import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
@@ -38,7 +39,7 @@ message ProtoDataflowDescription {
 
     message ProtoSinkExport {
         mz_repr.global_id.ProtoGlobalId id = 1;
-        string sink_desc = 2;
+        mz_dataflow_types.types.sinks.ProtoSinkDesc sink_desc = 2;
     }
 
     repeated ProtoSourceImport source_imports = 1;

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -3442,10 +3442,28 @@ pub mod sinks {
         Persist(PersistSinkConnector),
     }
 
-    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
     pub struct KafkaSinkConsistencyConnector {
         pub topic: String,
         pub schema_id: i32,
+    }
+
+    impl RustType<ProtoKafkaSinkConsistencyConnector> for KafkaSinkConsistencyConnector {
+        fn into_proto(self: &Self) -> ProtoKafkaSinkConsistencyConnector {
+            ProtoKafkaSinkConsistencyConnector {
+                topic: self.topic.clone(),
+                schema_id: self.schema_id,
+            }
+        }
+
+        fn from_proto(
+            proto: ProtoKafkaSinkConsistencyConnector,
+        ) -> Result<Self, TryFromProtoError> {
+            Ok(KafkaSinkConsistencyConnector {
+                topic: proto.topic,
+                schema_id: proto.schema_id,
+            })
+        }
     }
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -3887,6 +3887,24 @@ pub mod sinks {
         },
         Json,
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use mz_repr::proto::protobuf_roundtrip;
+        use proptest::prelude::*;
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(32))]
+
+            #[test]
+            fn sink_desc_protobuf_roundtrip(expect in any::<SinkDesc<mz_repr::Timestamp>>()) {
+                let actual = protobuf_roundtrip::<_, ProtoSinkDesc>(&expect);
+                assert!(actual.is_ok());
+                assert_eq!(actual.unwrap(), expect);
+            }
+        }
+    }
 }
 
 /// An index storing processed updates so they can be queried

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -3468,10 +3468,26 @@ pub mod sinks {
     }
 
     /// TODO(JLDLaughlin): Documentation.
-    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
     pub struct PublishedSchemaInfo {
         pub key_schema_id: Option<i32>,
         pub value_schema_id: i32,
+    }
+
+    impl RustType<ProtoPublishedSchemaInfo> for PublishedSchemaInfo {
+        fn into_proto(self: &Self) -> ProtoPublishedSchemaInfo {
+            ProtoPublishedSchemaInfo {
+                key_schema_id: self.key_schema_id.clone(),
+                value_schema_id: self.value_schema_id,
+            }
+        }
+
+        fn from_proto(proto: ProtoPublishedSchemaInfo) -> Result<Self, TryFromProtoError> {
+            Ok(PublishedSchemaInfo {
+                key_schema_id: proto.key_schema_id,
+                value_schema_id: proto.value_schema_id,
+            })
+        }
     }
 
     #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -22,7 +22,7 @@ message ProtoSinkDesc {
     mz_repr.global_id.ProtoGlobalId from = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
     ProtoSinkConnector connector = 3;
-    ProtoSinkEnvelope envelope = 4;
+    optional ProtoSinkEnvelope envelope = 4;
     ProtoSinkAsOf as_of = 5;
 }
 
@@ -65,10 +65,10 @@ message ProtoKafkaSinkConnector {
     mz_kafka_util.addr.ProtoKafkaAddrs addrs = 1;
     string topic = 2;
     string topic_prefix = 3;
-    ProtoKeyDescAndIndices key_desc_and_indices = 4;
-    ProtoRelationKeyIndicesVec relation_key_indices = 5;
+    optional ProtoKeyDescAndIndices key_desc_and_indices = 4;
+    optional ProtoRelationKeyIndicesVec relation_key_indices = 5;
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
-    ProtoPublishedSchemaInfo published_schema_info = 7;
+    optional ProtoPublishedSchemaInfo published_schema_info = 7;
     ProtoKafkaSinkConsistencyConnector consistency = 8;
     bool exactly_once = 9;
     repeated mz_repr.global_id.ProtoGlobalId transitive_source_dependencies = 10;

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -12,6 +12,7 @@ syntax = "proto3";
 import "google/protobuf/empty.proto";
 
 import "kafka-util/src/addr.proto";
+import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
 
@@ -36,6 +37,11 @@ message ProtoSinkConnector {
 message ProtoKafkaSinkConsistencyConnector {
     string topic = 1;
     int32 schema_id = 2;
+}
+
+message ProtoSinkAsOf {
+    mz_persist.gen.persist.ProtoU64Antichain frontier = 1;
+    bool strict = 2;
 }
 
 message ProtoKafkaSinkConnector {

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -9,6 +9,10 @@
 
 syntax = "proto3";
 
+import "google/protobuf/empty.proto";
+
+import "kafka-util/src/addr.proto";
+import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
 
 package mz_dataflow_types.types.sinks;
@@ -16,6 +20,30 @@ package mz_dataflow_types.types.sinks;
 message ProtoKafkaSinkConsistencyConnector {
     string topic = 1;
     int32 schema_id = 2;
+}
+
+message ProtoKafkaSinkConnector {
+    message ProtoKeyDescAndIndices {
+        mz_repr.relation_and_scalar.ProtoRelationDesc desc = 1;
+        repeated uint64 indices = 2;
+    }
+
+    message ProtoRelationKeyIndicesVec {
+        repeated uint64 relation_key_indices = 1;
+    }
+
+    mz_kafka_util.addr.ProtoKafkaAddrs addrs = 1;
+    string topic = 2;
+    string topic_prefix = 3;
+    ProtoKeyDescAndIndices key_desc_and_indices = 4;
+    ProtoRelationKeyIndicesVec relation_key_indices = 5;
+    mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
+    ProtoPublishedSchemaInfo published_schema_info = 7;
+    ProtoKafkaSinkConsistencyConnector consistency = 8;
+    bool exactly_once = 9;
+    repeated mz_repr.global_id.ProtoGlobalId transitive_source_dependencies = 10;
+    uint64 fuel = 11;
+    map<string, string> config_options = 12;
 }
 
 message ProtoPublishedSchemaInfo {

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -18,6 +18,14 @@ import "repr/src/relation_and_scalar.proto";
 
 package mz_dataflow_types.types.sinks;
 
+message ProtoSinkDesc {
+    mz_repr.global_id.ProtoGlobalId from = 1;
+    mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
+    ProtoSinkConnector connector = 3;
+    ProtoSinkEnvelope envelope = 4;
+    ProtoSinkAsOf as_of = 5;
+}
+
 message ProtoSinkEnvelope {
     oneof kind {
         google.protobuf.Empty debezium = 1;

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -17,6 +17,14 @@ import "repr/src/relation_and_scalar.proto";
 
 package mz_dataflow_types.types.sinks;
 
+message ProtoSinkEnvelope {
+    oneof kind {
+        google.protobuf.Empty debezium = 1;
+        google.protobuf.Empty upsert = 2;
+        google.protobuf.Empty differential_row = 3;
+    }
+}
+
 message ProtoSinkConnector {
     oneof kind {
         ProtoKafkaSinkConnector kafka = 1;

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -13,6 +13,11 @@ import "repr/src/relation_and_scalar.proto";
 
 package mz_dataflow_types.types.sinks;
 
+message ProtoKafkaSinkConsistencyConnector {
+    string topic = 1;
+    int32 schema_id = 2;
+}
+
 message ProtoPublishedSchemaInfo {
     optional int32 key_schema_id = 1;
     int32 value_schema_id = 2;

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -13,6 +13,11 @@ import "repr/src/relation_and_scalar.proto";
 
 package mz_dataflow_types.types.sinks;
 
+message ProtoPublishedSchemaInfo {
+    optional int32 key_schema_id = 1;
+    int32 value_schema_id = 2;
+}
+
 message ProtoPersistSinkConnector {
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
     string shard_id = 2;

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -1,0 +1,21 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "repr/src/relation_and_scalar.proto";
+
+package mz_dataflow_types.types.sinks;
+
+message ProtoPersistSinkConnector {
+    mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
+    string shard_id = 2;
+    string consensus_uri = 3;
+    string blob_uri = 4;
+}

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -17,6 +17,14 @@ import "repr/src/relation_and_scalar.proto";
 
 package mz_dataflow_types.types.sinks;
 
+message ProtoSinkConnector {
+    oneof kind {
+        ProtoKafkaSinkConnector kafka = 1;
+        google.protobuf.Empty tail = 2;
+        ProtoPersistSinkConnector persist = 3;
+    }
+}
+
 message ProtoKafkaSinkConsistencyConnector {
     string topic = 1;
     int32 schema_id = 2;


### PR DESCRIPTION
Add Protobuf serialization/deserialization support to `SinkDesc` and all types involved.

The PR is structured in independent commits, with Protobuf support being added to each type in its own commit in a bottom-up strategy, ending finally with the implementation for `SinkDesc` and its generative tests. Commits should ideally be read in order, since latter commits use types from previous commits, but otherwise all commits are buildable and correct.

Each type involved includes also an implementation for `Arbitrary` for testing.

This is the continuation of #12573, and finishes support for `SinkDesc`, but intentionally excludes integrating it in the `DataflowDescriptions` tests, as I'll do it in a separate future PR. After this PR, #12358 should be done wrt. Protobuf support, with full end-to-end generative testing for `DataflowCommand` being the last piece (all commands are tested right now, but in separate tests).

There is an open issue still: I can't make the generator for `KafkaSinkConnector` to not stack overflow: help is much desired and appreciated here, as I'm running out of ideas.

### Motivation

  * This PR is part of #12358.

### Tips for reviewer

    * I'd recommend reviewing it per commit, since most changes for the same type are quite small.
    * Each commit includes all necessary changes to implement Protobuf conversion + `Arbitrary` for the given type.
    * Replacing `any_sink_desc_stub` with the `Arbitrary` implementation of `SinkDesc` is left for a future PR.
    * Please help with the generator for `KafkaSinkConnector`! (`any_kafka_sink_connector`)

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
