### PR TITLE
coord: don't consider indexes from other clusters

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -340,13 +340,21 @@ impl CatalogState {
         self.entry_by_id.get(id)
     }
 
-    /// Returns all indexes on this object known in the catalog.
-    pub fn get_indexes_on(&self, id: GlobalId) -> impl Iterator<Item = (GlobalId, &Index)> {
+    /// Returns all indexes on the given object and compute instance known in
+    /// the catalog.
+    pub fn get_indexes_on(
+        &self,
+        id: GlobalId,
+        compute_instance: ComputeInstanceId,
+    ) -> impl Iterator<Item = (GlobalId, &Index)> {
+        let index_matches =
+            move |idx: &Index| idx.on == id && idx.compute_instance == compute_instance;
+
         self.get_entry(&id)
             .used_by()
             .iter()
             .filter_map(move |uses_id| match self.get_entry(uses_id).item() {
-                CatalogItem::Index(index) if index.on == id => Some((*uses_id, index)),
+                CatalogItem::Index(index) if index_matches(index) => Some((*uses_id, index)),
                 _ => None,
             })
     }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -3017,6 +3017,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // See: #11048.
         fn check_no_unmaterialized_sources<S: Append>(
             catalog: &Catalog<S>,
+            compute_instance: ComputeInstanceId,
             id_bundle: &CollectionIdBundle,
             session: &Session,
         ) -> Result<(), CoordError> {
@@ -3026,8 +3027,11 @@ impl<S: Append + 'static> Coordinator<S> {
                 if entry.is_table() {
                     continue;
                 }
-                let mut indexes = catalog.state().get_indexes_on(*id).peekable();
-                if indexes.peek().is_none() {
+                let has_indexes = catalog
+                    .state()
+                    .get_indexes_on(*id, compute_instance)
+                    .any(|_| true);
+                if !has_indexes {
                     unmaterialized.push(
                         catalog
                             .resolve_full_name(entry.name(), Some(session.conn_id()))
@@ -3182,7 +3186,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let id_bundle = self
                 .index_oracle(compute_instance)
                 .sufficient_collections(&source_ids);
-            check_no_unmaterialized_sources(&self.catalog, &id_bundle, session)?;
+            check_no_unmaterialized_sources(&self.catalog, compute_instance, &id_bundle, session)?;
             let allowed_id_bundle = &self.txn_reads.get(&conn_id).unwrap().read_holds.id_bundle;
             // Find the first reference or index (if any) that is not in the transaction. A
             // reference could be caused by a user specifying an object in a different
@@ -3227,7 +3231,12 @@ impl<S: Append + 'static> Coordinator<S> {
                 .index_oracle(compute_instance)
                 .sufficient_collections(&source_ids);
             if when == QueryWhen::Immediately {
-                check_no_unmaterialized_sources(&self.catalog, &id_bundle, session)?;
+                check_no_unmaterialized_sources(
+                    &self.catalog,
+                    compute_instance,
+                    &id_bundle,
+                    session,
+                )?;
             }
             self.determine_timestamp(session, &id_bundle, when, compute_instance)?
         };

--- a/src/coord/src/coord/indexes.rs
+++ b/src/coord/src/coord/indexes.rs
@@ -94,7 +94,7 @@ impl<T: CoordTimestamp> ComputeInstanceIndexOracle<'_, T> {
 
     pub fn indexes_on(&self, id: GlobalId) -> impl Iterator<Item = (GlobalId, &Index)> {
         self.catalog
-            .get_indexes_on(id)
+            .get_indexes_on(id, self.compute.instance_id())
             .filter(|(idx_id, _idx)| self.compute.collection(*idx_id).is_ok())
     }
 }

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -347,7 +347,7 @@ impl<T> Controller<T> {
     pub fn compute(&self, instance: ComputeInstanceId) -> Option<ComputeController<T>> {
         let compute = self.compute.get(&instance)?;
         Some(ComputeController {
-            _instance: instance,
+            instance,
             compute,
             storage_controller: self.storage(),
         })

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -56,7 +56,7 @@ pub(super) struct ComputeControllerState<T> {
 /// An immutable controller for a compute instance.
 #[derive(Debug, Copy, Clone)]
 pub struct ComputeController<'a, T> {
-    pub(super) _instance: ComputeInstanceId, // likely to be needed soon
+    pub(super) instance: ComputeInstanceId,
     pub(super) compute: &'a ComputeControllerState<T>,
     pub(super) storage_controller: &'a dyn StorageController<Timestamp = T>,
 }
@@ -180,6 +180,11 @@ impl<'a, T> ComputeController<'a, T>
 where
     T: Timestamp + Lattice,
 {
+    /// Returns this controller's compute instance ID.
+    pub fn instance_id(&self) -> ComputeInstanceId {
+        self.instance
+    }
+
     /// Acquires an immutable handle to a controller for the storage instance.
     #[inline]
     pub fn storage(&self) -> &dyn crate::client::controller::StorageController<Timestamp = T> {
@@ -202,7 +207,7 @@ where
     /// Constructs an immutable handle from this mutable handle.
     pub fn as_ref<'b>(&'b self) -> ComputeController<'b, T> {
         ComputeController {
-            _instance: self.instance,
+            instance: self.instance,
             storage_controller: self.storage_controller,
             compute: &self.compute,
         }

--- a/test/sqllogictest/github-12674.slt
+++ b/test/sqllogictest/github-12674.slt
@@ -1,0 +1,33 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/12674
+
+statement ok
+CREATE SOURCE test_source FROM PUBNUB
+  SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+  CHANNEL 'pubnub-market-orders'
+
+statement ok
+CREATE CLUSTER with_index REPLICA r (SIZE '1')
+
+statement ok
+CREATE CLUSTER without_index REPLICA r (SIZE '1')
+
+statement ok
+SET CLUSTER = with_index
+
+statement ok
+CREATE DEFAULT INDEX ON test_source
+
+statement ok
+SET cluster = without_index
+
+query error unable to automatically determine a query timestamp
+SELECT * FROM test_source


### PR DESCRIPTION
Prior to this PR, the code for detecting peeks on unmaterialized sources would take into account all indexes found in the catalog. This is wrong, since indexes are cluster-specific and only indexes on the current cluster can be used to fulfill peeks.

### Motivation

  * This PR fixes a recognized bug.

    Fixes #12674.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).