### PR TITLE
dataflow-types: link SourceDesc and SourceInstanceDesc

### DIFF
--- a/src/dataflow-types/src/types.proto
+++ b/src/dataflow-types/src/types.proto
@@ -14,6 +14,7 @@ syntax = "proto3";
 import "dataflow-types/src/client/controller/storage.proto";
 import "dataflow-types/src/plan.proto";
 import "dataflow-types/src/types/sinks.proto";
+import "dataflow-types/src/types/sources.proto";
 import "expr/src/scalar.proto";
 import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
@@ -63,7 +64,7 @@ message ProtoBuildDesc {
 }
 
 message ProtoSourceInstanceDesc {
-    string description = 1;
+    mz_dataflow_types.types.sources.ProtoSourceDesc description = 1;
     ProtoSourceInstanceArguments arguments = 2;
     mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 3;
 }


### PR DESCRIPTION
Remove `any_source_desc_stub` and ensure `SourceInstanceDesc` uses proper Protobuf serialization for `SourceDesc` instead of treating it as an opaque JSON string.

### Motivation

   * This PR refactors existing code: half of #12678

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
