### PR TITLE
otel: improve misc/opentelemetry's port handling

### DIFF
--- a/misc/opentelemetry/README.md
+++ b/misc/opentelemetry/README.md
@@ -5,11 +5,13 @@ Primarily adapted from [the opentelemetry-rust repo].
 ### Usage
 
 ```
-$ ./mzcompose up
+$ ./mzcompose up -d
 $ MZ_OPENTELEMETRY_ENDPOINT="http://localhost:4317" bin/materialized
 ```
 
-Go to <http://localhost:16686> in your browser to browse the traces.
+
+Use `./mzcompose web jaeger` to browse the traces.
+Alternatively, go to <http://localhost:16686> in your browser.
 
 [mzcompose]: ../../doc/developer/mzcompose.md
 [the opentelemetry-rust repo]: https://github.com/open-telemetry/opentelemetry-rust/tree/a767fd3a7f08f4d7312a1c0dbb5ac0580a108eb3/examples/basic-otlp-http

--- a/misc/opentelemetry/mzcompose.py
+++ b/misc/opentelemetry/mzcompose.py
@@ -15,10 +15,11 @@ from materialize.mzcompose.services import Service
 
 SERVICES = [
     Service(
-        "jaeger-all-in-one",
+        "jaeger",
         {
             "image": "jaegertracing/all-in-one:latest",
-            "ports": [16686, 14268, 14250],
+            "ports": ["16686:16686", 14268, 14250],
+            "allow_host_ports": True,
         },
     ),
     Service(
@@ -29,12 +30,13 @@ SERVICES = [
             "ports": [
                 1888,  # pprof
                 13133,  # health_check
-                4317,  # otlp grpc
-                4318,  # otlp http
+                "4317:4317",  # otlp grpc
+                "4318:4318",  # otlp http
                 55670,  # zpages
             ],
+            "allow_host_ports": True,
             "volumes": ["./otel-collector-config.yaml:/etc/otel-collector-config.yaml"],
-            "depends_on": ["jaeger-all-in-one"],
+            "depends_on": ["jaeger"],
         },
     ),
 ]

--- a/misc/opentelemetry/otel-collector-config.yaml
+++ b/misc/opentelemetry/otel-collector-config.yaml
@@ -20,7 +20,7 @@ exporters:
     loglevel: debug
 
   jaeger:
-    endpoint: jaeger-all-in-one:14250
+    endpoint: jaeger:14250
     insecure: true
 
 processors:


### PR DESCRIPTION
This pr improves the otel jaeger mzcompose's docs, and makes it work with canonical ports!

### Motivation
makes it easier to setup mzcompose's with services that have canonical ports

### Tips for reviewer

@benesch please read this logic carefully, I think I tested the 3 main cases, but its quite subtle code actually; I think I misrote it like 4 times

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
