### PR TITLE
otel: setup otel for computed and storaged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,6 +2794,7 @@ dependencies = [
  "mz-orchestrator",
  "mz-orchestrator-kubernetes",
  "mz-orchestrator-process",
+ "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist-client",
  "mz-pgrepr",
@@ -3099,7 +3100,6 @@ dependencies = [
  "differential-dataflow",
  "dogsdogsdogs",
  "futures",
- "http",
  "itertools",
  "mz-avro",
  "mz-build-info",
@@ -3107,6 +3107,7 @@ dependencies = [
  "mz-expr",
  "mz-interchange",
  "mz-kafka-util",
+ "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist-client",
  "mz-pid-file",
@@ -3485,6 +3486,20 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "mz-orchestrator-tracing"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "http",
+ "mz-orchestrator",
+ "mz-ore",
+ "mz-repr",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3907,6 +3922,7 @@ dependencies = [
  "materialized",
  "md-5",
  "mz-orchestrator-process",
+ "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist-client",
  "mz-pgrepr",
@@ -5692,9 +5708,9 @@ dependencies = [
  "axum",
  "clap",
  "futures",
- "http",
  "mz-build-info",
  "mz-dataflow-types",
+ "mz-orchestrator-tracing",
  "mz-ore",
  "mz-pid-file",
  "mz-prof",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "src/orchestrator",
     "src/orchestrator-kubernetes",
     "src/orchestrator-process",
+    "src/orchestrator-tracing",
     "src/persist-client",
     "src/persist-types",
     "src/persist",

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -89,7 +89,7 @@ def main() -> int:
             path = ROOT / "target" / "debug" / args.program
         command = [str(path), *args.args]
         if args.tokio_console:
-            command += ["--tokio-console"]
+            command += ["--tokio-console-listen-addr=127.0.0.1:6669"]
         if args.program == "materialized":
             if args.reset:
                 print("Removing mzdata directory...")

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -15,7 +15,6 @@ dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 futures = "0.3.21"
-http = "0.2.7"
 itertools = "0.10.3"
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-build-info = { path = "../build-info" }
@@ -23,6 +22,7 @@ mz-dataflow-types = { path = "../dataflow-types" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
+mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pid-file = { path = "../pid-file" }

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -169,9 +169,15 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
 
     mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
+        service_name: "computed".into(),
+        // Only log the service name when the presence of the
+        // `--pid-file-location` argument indicates that we're running under the
+        // process orchestrator, which intermingles log output from multiple
+        // services. Other orchestrators separate log output from different
+        // services.
+        log_service_name: args.pid_file_location.is_some(),
         log_filter: args.log_filter.clone(),
         opentelemetry_config: None,
-        prefix: args.log_process_name.then(|| "computed".into()),
         #[cfg(feature = "tokio-console")]
         tokio_console: false,
     })

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -20,16 +20,15 @@ use serde::ser::Serialize;
 use tokio::net::TcpListener;
 use tokio::select;
 use tracing::info;
-use tracing_subscriber::filter::Targets;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::{ComputeClient, GenericClient};
 use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
 use mz_dataflow_types::ConnectorContext;
+use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
-use mz_ore::tracing::{StderrLogConfig, TracingConfig};
 
 use mz_compute::server::Server;
 use mz_pid_file::PidFile;
@@ -91,22 +90,8 @@ struct Args {
     #[clap(long, value_name = "PATH")]
     pid_file_location: Option<PathBuf>,
 
-    // === Logging options. ===
-    /// Which log messages to emit. See `materialized`'s help for more
-    /// info.
-    ///
-    /// The default value for this option is "info".
-    #[clap(
-        long,
-        env = "LOG_FILTER",
-        value_name = "FILTER",
-        default_value = "info"
-    )]
-    log_filter: Targets,
-
-    /// Add the process name to the tracing logs
-    #[clap(long, hide = true)]
-    log_process_name: bool,
+    #[clap(flatten)]
+    tracing: TracingCliArgs,
 }
 
 #[tokio::main]
@@ -168,23 +153,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-
-    mz_ore::tracing::configure(TracingConfig {
-        service_name: "computed".into(),
-        stderr_log: StderrLogConfig {
-            // Only log the service name when the presence of the
-            // `--pid-file-location` argument indicates that we're running under
-            // the process orchestrator, which intermingles log output from
-            // multiple services. Other orchestrators separate log output from
-            // different services.
-            include_service_name: args.pid_file_location.is_some(),
-            filter: args.log_filter.clone(),
-        },
-        opentelemetry: None,
-        #[cfg(feature = "tokio-console")]
-        tokio_console: None,
-    })
-    .await?;
+    mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     if args.workers == 0 {
         bail!("--workers must be greater than 0");
@@ -214,7 +183,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         experimental_mode: false,
         metrics_registry: MetricsRegistry::new(),
         now: SYSTEM_TIME.clone(),
-        connector_context: ConnectorContext::from_cli_args(&args.log_filter, args.aws_external_id),
+        connector_context: ConnectorContext::from_cli_args(
+            &args.tracing.log_filter.inner,
+            args.aws_external_id,
+        ),
     };
 
     let serve_config = ServeConfig {

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -224,7 +224,6 @@ where
                                             assigned.listen_host, assigned.ports["http"]
                                         ),
                                         format!("--workers={}", size_config.workers),
-                                        "--log-process-name".to_string(),
                                     ];
                                     compute_opts.extend(assigned.peers.iter().map(
                                         |(host, ports)| format!("{host}:{}", ports["compute"]),

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -56,6 +56,7 @@ mz-http-util = { path = "../http-util" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
+mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pgwire = { path = "../pgwire" }
@@ -138,7 +139,7 @@ default = ["jemalloc"]
 # access to the file system.
 dev-web = []
 jemalloc = ["mz-prof/jemalloc", "tikv-jemallocator"]
-tokio-console = ["mz-ore/tokio-console"]
+tokio-console = ["mz-ore/tokio-console", "mz-orchestrator-tracing/tokio-console"]
 
 [package.metadata.cargo-udeps.ignore]
 # sysctl is only used on macOS.

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -472,6 +472,11 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
     // handled by the custom panic handler.
     let metrics_registry = MetricsRegistry::new();
     runtime.block_on(mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
+        service_name: "materialized".into(),
+        // Only log the service name when using the process orchestrator, which
+        // intermingles log output from multiple services. Other orchestrators
+        // separate log output from different services.
+        log_service_name: matches!(args.orchestrator, Orchestrator::Process),
         log_filter: args.log_filter.clone(),
         opentelemetry_config: args.opentelemetry_endpoint.map(|endpoint| {
             mz_ore::tracing::OpenTelemetryConfig {
@@ -484,7 +489,6 @@ fn run(args: Args) -> Result<(), anyhow::Error> {
                 log_filter: args.opentelemetry_log_filter,
             }
         }),
-        prefix: None,
         #[cfg(feature = "tokio-console")]
         tokio_console: args.tokio_console,
     }))?;

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -39,6 +39,7 @@ use mz_frontegg_auth::FronteggAuthentication;
 use mz_orchestrator::{Orchestrator, ServiceConfig, ServicePort};
 use mz_orchestrator_kubernetes::{KubernetesOrchestrator, KubernetesOrchestratorConfig};
 use mz_orchestrator_process::{ProcessOrchestrator, ProcessOrchestratorConfig};
+use mz_orchestrator_tracing::{TracingCliArgs, TracingOrchestrator};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
@@ -169,6 +170,8 @@ pub struct OrchestratorConfig {
     /// Whether or not COMPUTE and STORAGE processes should die when their connection with the
     /// ADAPTER is lost.
     pub linger: bool,
+    /// A tracing configuration to inject into all created services.
+    pub tracing: TracingCliArgs,
 }
 
 /// The orchestrator itself.
@@ -285,6 +288,10 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
         ),
         OrchestratorBackend::Process(config) => Box::new(ProcessOrchestrator::new(config).await?),
     };
+    let orchestrator = Box::new(TracingOrchestrator::new(
+        orchestrator,
+        config.orchestrator.tracing,
+    ));
     let storage_service = orchestrator
         .namespace("storage")
         .ensure_service(

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -302,7 +302,6 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
                             "--http-console-addr={}:{}",
                             assigned.listen_host, assigned.ports["http"]
                         ),
-                        "--log-process-name".to_string(),
                     ];
                     if config.orchestrator.linger {
                         storage_opts.push(format!("--linger"))

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -27,6 +27,7 @@ use tower_http::cors::AllowOrigin;
 use materialized::{OrchestratorBackend, OrchestratorConfig, TlsMode};
 use mz_frontegg_auth::FronteggAuthentication;
 use mz_orchestrator_process::ProcessOrchestratorConfig;
+use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::id_gen::PortAllocator;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NowFn, SYSTEM_TIME};
@@ -160,6 +161,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             storaged_image: "storaged".into(),
             computed_image: "computed".into(),
             linger: false,
+            tracing: TracingCliArgs::default(),
         },
         secrets_controller: None,
         listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -275,7 +275,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 containers: vec![Container {
                     name: "default".into(),
                     image: Some(image),
-                    args: Some(args(ServiceAssignments {
+                    args: Some(args(&ServiceAssignments {
                         listen_host: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
                         ports: &ports,
                         index: None,

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -214,7 +214,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             .collect::<Vec<_>>();
         for i in 0..(scale_in.get()) {
             if !processes_exist[i] {
-                let mut args = args(ServiceAssignments {
+                let mut args = args(&ServiceAssignments {
                     listen_host: IpAddr::V4(Ipv4Addr::LOCALHOST),
                     ports: &peers[i].1,
                     index: Some(i),

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -58,6 +58,10 @@ pub struct ProcessOrchestratorConfig {
 /// **This orchestrator is for development only.** Due to limitations in the
 /// Unix process API, it does not exactly conform to the documented semantics
 /// of `Orchestrator`.
+///
+/// Processes launched by this orchestrator must support a `--pid-file-location`
+/// command line flag which causes a PID file to be emitted at the specified
+/// path.
 #[derive(Debug)]
 pub struct ProcessOrchestrator {
     image_dir: PathBuf,

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mz-orchestrator-tracing"
+description = "Service orchestration for tracing-aware services."
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.61.0"
+publish = false
+
+[dependencies]
+anyhow = "1.0.57"
+async-trait = "0.1.53"
+clap = { version = "3.1.18", features = ["env", "derive"] }
+http = "0.2.7"
+mz-orchestrator = { path = "../orchestrator" }
+mz-ore = { path = "../ore" }
+mz-repr = { path = "../repr" }
+tracing-subscriber = { version = "0.3.11", default-features = false }
+
+[features]
+tokio-console = ["mz-ore/tokio-console"]

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -1,0 +1,331 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Service orchestration for tracing-aware services.
+
+use std::ffi::OsString;
+use std::fmt;
+#[cfg(feature = "tokio-console")]
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+#[cfg(feature = "tokio-console")]
+use std::time::Duration;
+
+use async_trait::async_trait;
+use clap::{FromArgMatches, IntoApp};
+use http::header::{HeaderName, HeaderValue};
+use tracing_subscriber::filter::Targets;
+
+#[cfg(feature = "tokio-console")]
+use mz_orchestrator::ServicePort;
+use mz_orchestrator::{
+    NamespacedOrchestrator, Orchestrator, Service, ServiceAssignments, ServiceConfig,
+};
+use mz_ore::cli::KeyValueArg;
+#[cfg(feature = "tokio-console")]
+use mz_ore::tracing::TokioConsoleConfig;
+use mz_ore::tracing::{OpenTelemetryConfig, StderrLogConfig, TracingConfig};
+
+/// Command line arguments for application tracing.
+///
+/// These arguments correspond directly to parameters in [`TracingConfig`], and
+/// this type can be directly converted into a `TracingConfig` via the supplied
+/// `From<TracingCliArgs>` implementation.
+///
+/// This logic is separated from `mz_ore::tracing` because the details of how
+/// these command-line arguments are parsed and unparsed is specific to
+/// orchestrators and does not belong in a foundational crate like `mz_ore`.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct TracingCliArgs {
+    /// Which tracing events to log to stderr.
+    ///
+    /// This value is a comma-separated list of filter directives. Each filter
+    /// directive has the following format:
+    ///
+    /// ```text
+    /// [module::path=]level
+    /// ```
+    ///
+    /// A directive indicates that log messages from the specified module that
+    /// are at least as severe as the specified level should be emitted. If a
+    /// directive omits the module, then it implicitly applies to all modules.
+    /// When directives conflict, the last directive wins. If a log message does
+    /// not match any directive, it is not emitted.
+    ///
+    /// The module path of a log message reflects its location in Materialize's
+    /// source code. Choosing module paths for filter directives requires
+    /// familiarity with Materialize's codebase and is intended for advanced
+    /// users. Note that module paths change frequency from release to release.
+    ///
+    /// The valid levels for a log message are, in increasing order of severity:
+    /// trace, debug, info, warn, and error. The special level "off" may be used
+    /// in a directive to suppress all log messages, even errors.
+    ///
+    /// The default value for this option is "info".
+    #[clap(
+        long,
+        env = "LOG_FILTER",
+        value_name = "FILTER",
+        default_value = "info"
+    )]
+    pub log_filter: SerializableTargets,
+    /// Whether to prefix each stderr log line with name of the service that
+    /// emitted the event.
+    #[clap(long, env = "LOG_INCLUDE_SERVICE_NAME")]
+    pub log_include_service_name: bool,
+    /// Export tracing events to the provided observability backend.
+    ///
+    /// The specified endpoint should speak the OTLP/HTTP protocol. If the
+    /// backend requires authentication, you can pass authentication metadata
+    /// via the `--opentelemetry-header` option.
+    #[clap(long, env = "OPENTELEMETRY_ENDPOINT")]
+    pub opentelemetry_endpoint: Option<String>,
+    /// A header to pass with every request to the OpenTelemetry endpoint
+    /// specified by `--opentelemetry-endpoint` in the form `NAME=VALUE`.
+    ///
+    /// Requires that the `--opentelemetry-endpoint` option is specified.
+    /// To specify multiple headers, either specify this option multiple times,
+    /// or specify it once with multiple `NAME=VALUE` pairs separated by commas.
+    #[clap(
+        long,
+        env = "OPENTELEMETRY_HEADER",
+        requires = "opentelemetry-endpoint",
+        value_name = "NAME=VALUE",
+        use_value_delimiter = true
+    )]
+    pub opentelemetry_header: Vec<KeyValueArg<HeaderName, HeaderValue>>,
+    /// Which tracing events to export to the OpenTelemetry endpoint specified
+    /// by `--opentelemetry-endpoint`.
+    ///
+    /// The syntax of this option is the same as the syntax of the
+    /// `--log-filter` option.
+    ///
+    /// Requires that the `--opentelemetry-endpoint` option is specified.
+    #[clap(
+        long,
+        env = "OPENTELEMETRY_FILTER",
+        requires = "opentelemetry-endpoint",
+        default_value = "debug"
+    )]
+    pub opentelemetry_filter: SerializableTargets,
+    /// The address on which to listen for Tokio console connections.
+    ///
+    /// For details about Tokio console, see: <https://github.com/tokio-rs/console>
+    ///
+    /// Requires that the `--tokio-console` option is specified.
+    #[cfg(feature = "tokio-console")]
+    #[clap(long, env = "TOKIO_CONSOLE_LISTEN_ADDR")]
+    pub tokio_console_listen_addr: Option<SocketAddr>,
+    /// How frequently to publish updates to Tokio console clients.
+    ///
+    /// Requires that the `--tokio-console` option is specified.
+    #[cfg(feature = "tokio-console")]
+    #[clap(
+        long,
+        env = "TOKIO_CONSOLE_PUBLISH_INTERVAL",
+        requires = "tokio-console-listen-addr",
+        parse(try_from_str = mz_repr::util::parse_duration),
+        default_value = "1s",
+    )]
+    pub tokio_console_publish_interval: Duration,
+    /// How long Tokio console data is retained for completed tasks.
+    ///
+    /// Requires that the `--tokio-console` option is specified.
+    #[cfg(feature = "tokio-console")]
+    #[clap(
+        long,
+        env = "TOKIO_CONSOLE_RETENTION",
+        requires = "tokio-console-listen-addr",
+        parse(try_from_str = mz_repr::util::parse_duration),
+        default_value = "1h",
+    )]
+    pub tokio_console_retention: Duration,
+}
+
+impl Default for TracingCliArgs {
+    fn default() -> TracingCliArgs {
+        let matches = TracingCliArgs::command().get_matches_from::<_, OsString>([]);
+        TracingCliArgs::from_arg_matches(&matches)
+            .expect("no arguments produce valid TracingCliArgs")
+    }
+}
+
+impl From<&TracingCliArgs> for TracingConfig {
+    fn from(args: &TracingCliArgs) -> TracingConfig {
+        TracingConfig {
+            stderr_log: StderrLogConfig {
+                include_service_name: args.log_include_service_name,
+                filter: args.log_filter.inner.clone(),
+            },
+            opentelemetry: args.opentelemetry_endpoint.clone().map(|endpoint| {
+                OpenTelemetryConfig {
+                    endpoint,
+                    headers: args
+                        .opentelemetry_header
+                        .iter()
+                        .map(|header| (header.key.clone(), header.value.clone()))
+                        .collect(),
+                    filter: args.opentelemetry_filter.inner.clone(),
+                }
+            }),
+            #[cfg(feature = "tokio-console")]
+            tokio_console: args
+                .tokio_console_listen_addr
+                .map(|listen_addr| TokioConsoleConfig {
+                    listen_addr,
+                    publish_interval: args.tokio_console_publish_interval,
+                    retention: args.tokio_console_retention,
+                }),
+        }
+    }
+}
+
+/// Wraps an [`Orchestrator`] to inject tracing into all created services.
+#[derive(Debug)]
+pub struct TracingOrchestrator {
+    inner: Box<dyn Orchestrator>,
+    tracing_args: TracingCliArgs,
+}
+
+impl TracingOrchestrator {
+    /// Constructs a new tracing orchestrator.
+    ///
+    /// The orchestrator wraps the provided `inner` orchestrator. It mutates
+    /// [`ServiceConfig`]s to inject the tracing configuration specified by
+    /// `tracing_args`.
+    ///
+    /// All services created by the orchestrator **must** embed the
+    /// [`TracingCliArgs`] in their command-line argument parser.
+    pub fn new(inner: Box<dyn Orchestrator>, tracing_args: TracingCliArgs) -> TracingOrchestrator {
+        TracingOrchestrator {
+            inner,
+            tracing_args,
+        }
+    }
+}
+
+impl Orchestrator for TracingOrchestrator {
+    fn namespace(&self, namespace: &str) -> Arc<dyn NamespacedOrchestrator> {
+        Arc::new(NamespacedTracingOrchestrator {
+            inner: self.inner.namespace(namespace),
+            tracing_args: self.tracing_args.clone(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct NamespacedTracingOrchestrator {
+    inner: Arc<dyn NamespacedOrchestrator>,
+    tracing_args: TracingCliArgs,
+}
+
+#[async_trait]
+impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
+    async fn ensure_service(
+        &self,
+        id: &str,
+        mut service_config: ServiceConfig<'_>,
+    ) -> Result<Box<dyn Service>, anyhow::Error> {
+        let args_fn = |assigned: &ServiceAssignments| {
+            #[cfg(feature = "tokio-console")]
+            let tokio_console_port = assigned.ports.get("tokio-console");
+            let mut args = (service_config.args)(assigned);
+            let TracingCliArgs {
+                log_filter,
+                log_include_service_name,
+                opentelemetry_endpoint,
+                opentelemetry_header,
+                opentelemetry_filter,
+                #[cfg(feature = "tokio-console")]
+                    tokio_console_listen_addr: _,
+                #[cfg(feature = "tokio-console")]
+                tokio_console_publish_interval,
+                #[cfg(feature = "tokio-console")]
+                tokio_console_retention,
+            } = &self.tracing_args;
+            args.push(format!("--log-filter={log_filter}"));
+            if *log_include_service_name {
+                args.push("--log-include-service-name".into());
+            }
+            if let Some(endpoint) = opentelemetry_endpoint {
+                args.push(format!("--opentelemetry-endpoint={endpoint}"));
+                for kv in opentelemetry_header {
+                    args.push(format!(
+                        "--opentelemetry-header={}={}",
+                        kv.key,
+                        kv.value
+                            .to_str()
+                            .expect("opentelemetry-header had non-ascii value"),
+                    ));
+                }
+                args.push(format!("--opentelemetry-filter={opentelemetry_filter}",));
+            }
+            #[cfg(feature = "tokio-console")]
+            if let Some(port) = tokio_console_port {
+                args.push(format!(
+                    "--tokio-console-listen-addr={}:{}",
+                    assigned.listen_host, port,
+                ));
+                args.push(format!(
+                    "--tokio-console-publish-interval={} microseconds",
+                    tokio_console_publish_interval.as_micros(),
+                ));
+                args.push(format!(
+                    "--tokio-console-retention={} microseconds",
+                    tokio_console_retention.as_micros(),
+                ));
+            }
+            args
+        };
+        service_config.args = &args_fn;
+        #[cfg(feature = "tokio-console")]
+        if self.tracing_args.tokio_console_listen_addr.is_some() {
+            service_config.ports.push(ServicePort {
+                name: "tokio-console".into(),
+                port_hint: 6669,
+            });
+        }
+        self.inner.ensure_service(id, service_config).await
+    }
+
+    async fn drop_service(&self, id: &str) -> Result<(), anyhow::Error> {
+        self.inner.drop_service(id).await
+    }
+
+    async fn list_services(&self) -> Result<Vec<String>, anyhow::Error> {
+        self.inner.list_services().await
+    }
+}
+
+/// Wraps [`Targets`] to provide a [`Display`](fmt::Display) implementation.
+#[derive(Debug, Clone)]
+pub struct SerializableTargets {
+    /// The parsed targets.
+    pub inner: Targets,
+    /// A string representation of `inner`.
+    pub raw: String,
+}
+
+impl FromStr for SerializableTargets {
+    type Err = tracing_subscriber::filter::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(SerializableTargets {
+            inner: s.parse()?,
+            raw: s.into(),
+        })
+    }
+}
+
+impl fmt::Display for SerializableTargets {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -79,7 +79,7 @@ pub struct ServiceConfig<'a> {
     /// A function that generates the arguments for each process of the service
     /// given the assignments that the orchestrator has made.
     #[derivative(Debug = "ignore")]
-    pub args: &'a (dyn Fn(ServiceAssignments) -> Vec<String> + Send + Sync),
+    pub args: &'a (dyn Fn(&ServiceAssignments) -> Vec<String> + Send + Sync),
     /// Ports to expose.
     pub ports: Vec<ServicePort>,
     /// An optional limit on the memory that the service can use.

--- a/src/ore/src/cli.rs
+++ b/src/ore/src/cli.rs
@@ -82,7 +82,7 @@ where
 }
 
 /// A command-line argument of the form `KEY=VALUE`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KeyValueArg<K, V> {
     /// The key of the command-line argument.
     pub key: K,

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -19,6 +19,7 @@ materialized = { path = "../materialized", default-features = false }
 md-5 = "0.10.1"
 mz-ore = { path = "../ore", features = ["task"] }
 mz-orchestrator-process = { path = "../orchestrator-process" }
+mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -58,6 +58,7 @@ use uuid::Uuid;
 
 use materialized::{OrchestratorBackend, OrchestratorConfig};
 use mz_orchestrator_process::ProcessOrchestratorConfig;
+use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::id_gen::PortAllocator;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
@@ -576,6 +577,7 @@ impl Runner {
                 storaged_image: "storaged".into(),
                 computed_image: "computed".into(),
                 linger: false,
+                tracing: TracingCliArgs::default(),
             },
             secrets_controller: None,
             listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),

--- a/src/storaged/Cargo.toml
+++ b/src/storaged/Cargo.toml
@@ -11,9 +11,9 @@ anyhow = "1.0.57"
 axum = "0.5.6"
 clap = { version = "3.1.18", features = ["derive", "env"] }
 futures = "0.3.21"
-http = { version = "0.2.7" }
 mz-build-info = { path = "../build-info" }
 mz-dataflow-types = { path = "../dataflow-types" }
+mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-pid-file = { path = "../pid-file" }
 mz-prof = { path = "../prof" }

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -99,10 +99,6 @@ struct Args {
         default_value = "info"
     )]
     log_filter: Targets,
-
-    /// Add the process name to the tracing logs
-    #[clap(long, hide = true)]
-    log_process_name: bool,
 }
 
 #[tokio::main]
@@ -137,9 +133,15 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
 
     mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
+        service_name: "storaged".into(),
+        // Only log the service name when the presence of the
+        // `--pid-file-location` argument indicates that we're running under the
+        // process orchestrator, which intermingles log output from multiple
+        // services. Other orchestrators separate log output from different
+        // services.
+        log_service_name: args.pid_file_location.is_some(),
         log_filter: args.log_filter.clone(),
         opentelemetry_config: None,
-        prefix: args.log_process_name.then(|| "storaged".into()),
         #[cfg(feature = "tokio-console")]
         tokio_console: false,
     })

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -29,6 +29,7 @@ use mz_dataflow_types::ConnectorContext;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
+use mz_ore::tracing::{StderrLogConfig, TracingConfig};
 use mz_pid_file::PidFile;
 use mz_storage::Server;
 
@@ -132,18 +133,20 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
 
-    mz_ore::tracing::configure(mz_ore::tracing::TracingConfig {
+    mz_ore::tracing::configure(TracingConfig {
         service_name: "storaged".into(),
-        // Only log the service name when the presence of the
-        // `--pid-file-location` argument indicates that we're running under the
-        // process orchestrator, which intermingles log output from multiple
-        // services. Other orchestrators separate log output from different
-        // services.
-        log_service_name: args.pid_file_location.is_some(),
-        log_filter: args.log_filter.clone(),
-        opentelemetry_config: None,
+        stderr_log: StderrLogConfig {
+            // Only log the service name when the presence of the
+            // `--pid-file-location` argument indicates that we're running under
+            // the process orchestrator, which intermingles log output from
+            // multiple services. Other orchestrators separate log output from
+            // different services.
+            include_service_name: args.pid_file_location.is_some(),
+            filter: args.log_filter.clone(),
+        },
+        opentelemetry: None,
         #[cfg(feature = "tokio-console")]
-        tokio_console: false,
+        tokio_console: None,
     })
     .await?;
 


### PR DESCRIPTION
This pr allows computed and storaged to be setup to send traces to an otel-collector. They use the exact same env vars, so that all services can be configured with a single endpoint env var, easily! Other than that, this is mostly code-movement and some copying.

### Motivation

  * This PR adds a known-desirable feature.

opentel support for all our services.

### Tips for reviewer

This will conflict with #12483 and Ill have to make sure they compose well

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
<img width="318" alt="image" src="https://user-images.githubusercontent.com/5404303/170128642-f287622f-2ca0-4163-9ad1-c7fd9c5a9d5c.png">

(I also tested a fake testing span for computed and it showed up, but normal traffic doesn't show up right now

### Release notes

None
