### PR TITLE
coord: cancel queries on connection terminate

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1546,6 +1546,11 @@ impl<S: Append + 'static> Coordinator<S> {
             .drop_temporary_schema(session.conn_id())
             .expect("unable to drop temporary schema");
         self.active_conns.remove(&session.conn_id());
+        self.internal_cmd_tx
+            .send(Message::Command(Command::RemovePendingPeeks {
+                conn_id: session.conn_id(),
+            }))
+            .expect("sending to internal_cmd_tx cannot fail");
     }
 
     /// Handle removing in-progress transaction state regardless of the end action

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -983,9 +983,9 @@ fn test_github_12546() -> Result<(), Box<dyn Error>> {
         let (client, _conn_task) = server.connect_async(tokio_postgres::NoTls).await?;
         assert_eq!(
             client
-                .query_one("SELECT 1::int4", &[])
+                .query_one("SELECT count(*) FROM test", &[])
                 .await?
-                .get::<_, i32>(0),
+                .get::<_, i64>(0),
             1,
         );
 


### PR DESCRIPTION
When a connection terminates, cancel all its peeks. This allows compute to remove any panic'ing queries from its rehydration log.

### Motivation

  * This PR fixes a recognized bug. #12546

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
