### PR TITLE
all: convert `Into` impls to `From` impls

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -165,6 +165,11 @@ extra_lints=(
     # See `clippy.toml` for more info
     # TODO(guswynn): renamed this to `disallowed_methods` when we upgrade
     clippy::disallowed_methods
+
+    # Implementing `From`
+    # gets you `Into` for free.
+    # See <https://doc.rust-lang.org/std/convert/trait.Into.html>.
+    clippy::from_over_into
 )
 
 # NOTE(benesch): we ignore some ShellCheck complaints about sloppy word

--- a/src/ccsr/src/tls.rs
+++ b/src/ccsr/src/tls.rs
@@ -63,10 +63,9 @@ impl Identity {
     }
 }
 
-impl Into<reqwest::Identity> for Identity {
-    fn into(self) -> reqwest::Identity {
-        reqwest::Identity::from_pkcs12_der(&self.der, &self.pass)
-            .expect("known to be a valid identity")
+impl From<Identity> for reqwest::Identity {
+    fn from(id: Identity) -> Self {
+        reqwest::Identity::from_pkcs12_der(&id.der, &id.pass).expect("known to be a valid identity")
     }
 }
 
@@ -109,9 +108,9 @@ impl Certificate {
     }
 }
 
-impl Into<reqwest::Certificate> for Certificate {
-    fn into(self) -> reqwest::Certificate {
-        reqwest::Certificate::from_der(&self.der).expect("known to be a valid cert")
+impl From<Certificate> for reqwest::Certificate {
+    fn from(cert: Certificate) -> Self {
+        reqwest::Certificate::from_der(&cert.der).expect("known to be a valid cert")
     }
 }
 

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -1600,10 +1600,10 @@ pub mod sources {
 
     /// Convert from MzOffset to Kafka::Offset as long as
     /// the offset is not negative
-    impl Into<KafkaOffset> for MzOffset {
-        fn into(self) -> KafkaOffset {
+    impl From<MzOffset> for KafkaOffset {
+        fn from(offset: MzOffset) -> Self {
             KafkaOffset {
-                offset: self.offset - 1,
+                offset: offset.offset - 1,
             }
         }
     }

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -2221,10 +2221,10 @@ fn arb_numeric() -> BoxedStrategy<Numeric> {
         .boxed()
 }
 
-impl<'a> Into<Datum<'a>> for &'a PropDatum {
-    fn into(self) -> Datum<'a> {
+impl<'a> From<&'a PropDatum> for Datum<'a> {
+    fn from(pd: &'a PropDatum) -> Self {
         use PropDatum::*;
-        match self {
+        match pd {
             Null => Datum::Null,
             Bool(b) => Datum::from(*b),
             Int16(i) => Datum::from(*i),


### PR DESCRIPTION
`std` is setup such that if you implement `From`, you get the reverse `Into` for free. The opposite is not true, as the two blanket impls would conflict.

I changed all the `Into` impls into `From` impls. You can see that the blanket impl works, as I had to change no other code. I also added a clippy lint to prevent this mistake in the future.

### Motivation

   * This PR refactors existing code.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
