### PR TITLE
ore/tests: don't assign local ZooKeeper port in PortAllocator

### DIFF
--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -37,8 +37,9 @@ pub static KAFKA_ADDRS: Lazy<mz_kafka_util::KafkaAddrs> =
         Ok(addr) => addr.parse().expect("unable to parse KAFKA_ADDRS"),
         _ => "localhost:9092".parse().unwrap(),
     });
+// Port 2181 is used by ZooKeeper.
 static PORT_ALLOCATOR: Lazy<Arc<PortAllocator>> =
-    Lazy::new(|| Arc::new(PortAllocator::new(2100, 2200)));
+    Lazy::new(|| Arc::new(PortAllocator::new_with_filter(2100, 2200, vec![2181])));
 
 #[derive(Clone)]
 pub struct Config {

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -39,7 +39,7 @@ pub static KAFKA_ADDRS: Lazy<mz_kafka_util::KafkaAddrs> =
     });
 // Port 2181 is used by ZooKeeper.
 static PORT_ALLOCATOR: Lazy<Arc<PortAllocator>> =
-    Lazy::new(|| Arc::new(PortAllocator::new_with_filter(2100, 2200, vec![2181])));
+    Lazy::new(|| Arc::new(PortAllocator::new_with_filter(2100, 2200, &[2181])));
 
 #[derive(Clone)]
 pub struct Config {

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -115,7 +115,7 @@ impl PortAllocator {
     /// `max`, both inclusive.
     ///
     /// The ports listed in `banned` will not be assigned.
-    pub fn new_with_filter(min: u16, max: u16, banned: Vec<u16>) -> PortAllocator {
+    pub fn new_with_filter(min: u16, max: u16, banned: &[u16]) -> PortAllocator {
         PortAllocator(Mutex::new(
             (min..=max).filter(|p| !banned.contains(p)).collect(),
         ))

--- a/src/ore/src/id_gen.rs
+++ b/src/ore/src/id_gen.rs
@@ -111,6 +111,16 @@ impl PortAllocator {
         PortAllocator(Mutex::new((min..=max).collect()))
     }
 
+    /// Creates a new `PortAllocator` that will assign ports between `min` and
+    /// `max`, both inclusive.
+    ///
+    /// The ports listed in `banned` will not be assigned.
+    pub fn new_with_filter(min: u16, max: u16, banned: Vec<u16>) -> PortAllocator {
+        PortAllocator(Mutex::new(
+            (min..=max).filter(|p| !banned.contains(p)).collect(),
+        ))
+    }
+
     /// Allocates a new port.
     ///
     /// Returns `None` if the allocator is exhausted.


### PR DESCRIPTION
### Motivation

Before, tests would be flaky when run locally, if a `computed` or
`storaged` process tried to bind to the ZooKeeper port. In such as case,
the test would just hang indefinitely because the expected process never
becomes ready.