### PR TITLE
ci: remove soft_fail from replica-isolation

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -173,7 +173,6 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 10
     inputs: [test/replica-isolation]
-    soft_fail: true
     plugins:
       - ./ci/plugins/mzcompose:
           composition: replica-isolation


### PR DESCRIPTION
From conversation in #12549, this test no longer flakes.

Closes #12549

### Motivation

This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
