### PR TITLE
dataflow-types: remove async from add_replica codepath

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -194,7 +194,7 @@ where
                 let mut compute_instance = self.compute_mut(instance_id).unwrap();
                 let client = RemoteClient::new(&replicas.into_iter().collect::<Vec<_>>());
                 let client: Box<dyn ComputeClient<T>> = Box::new(client);
-                compute_instance.add_replica(replica_id, client).await;
+                compute_instance.add_replica(replica_id, client);
             }
             ConcreteComputeInstanceReplicaConfig::Managed {
                 size_config,
@@ -272,8 +272,7 @@ where
                 let client: Box<dyn ComputeClient<T>> = Box::new(client);
                 self.compute_mut(instance_id)
                     .unwrap()
-                    .add_replica(replica_id, client)
-                    .await;
+                    .add_replica(replica_id, client);
             }
         }
 

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -222,8 +222,8 @@ where
     }
 
     /// Adds a new instance replica, by name.
-    pub async fn add_replica(&mut self, id: ReplicaId, client: Box<dyn ComputeClient<T>>) {
-        self.compute.client.add_replica(id, client).await;
+    pub fn add_replica(&mut self, id: ReplicaId, client: Box<dyn ComputeClient<T>>) {
+        self.compute.client.add_replica(id, client);
     }
 
     pub fn get_replica_ids(&self) -> impl Iterator<Item = ReplicaId> + '_ {

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -136,7 +136,7 @@ where
     /// Introduce a new replica, and catch it up to the commands of other replicas.
     ///
     /// It is not yet clear under which circumstances a replica can be removed.
-    pub async fn add_replica<C: ComputeClient<T> + 'static>(&mut self, id: ReplicaId, client: C) {
+    pub fn add_replica<C: ComputeClient<T> + 'static>(&mut self, id: ReplicaId, client: C) {
         for (_, frontiers) in self.uppers.values_mut() {
             frontiers.insert(id, {
                 let mut frontier = timely::progress::frontier::MutableAntichain::new();


### PR DESCRIPTION
The code path to add replicas was marked as `async` but didn't execute any async code.

### Motivation

This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
