### PR TITLE
storage,coord: remove the concept of builtin logs from storage

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -22,9 +22,11 @@
 //! More information about builtin system tables and types can be found in
 //! <https://materialize.com/docs/sql/system-tables/>.
 
+use std::hash::Hash;
+
 use differential_dataflow::Hashable;
 use once_cell::sync::Lazy;
-use std::hash::Hash;
+use serde::Serialize;
 
 use mz_dataflow_types::logging::{DifferentialLog, LogVariant, MaterializedLog, TimelyLog};
 use mz_repr::{RelationDesc, ScalarType};
@@ -66,7 +68,7 @@ impl<T: TypeReference> Builtin<T> {
     }
 }
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, Serialize)]
 pub struct BuiltinLog {
     pub variant: LogVariant,
     pub name: &'static str,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1641,7 +1641,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 .resolve_full_name(from_entry.name(), from_entry.conn_id()),
                         )
                         .unwrap()
-                        .clone(),
+                        .into_owned(),
                     connector: connector.clone(),
                     envelope: Some(sink.envelope),
                     as_of,
@@ -2391,7 +2391,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                         .resolve_full_name(from_entry.name(), from_entry.conn_id()),
                                 )
                                 .unwrap()
-                                .clone(),
+                                .into_owned(),
                             connector: SinkConnector::Tail(TailSinkConnector {}),
                             envelope: Some(sink.envelope),
                             as_of: SinkAsOf {
@@ -3452,7 +3452,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             .resolve_full_name(from.name(), Some(session.conn_id())),
                     )
                     .unwrap()
-                    .clone();
+                    .into_owned();
                 let sink_id = self.catalog.allocate_user_id().await?;
                 let sink_desc = make_sink_desc(self, from_id, from_desc, &[from_id][..])?;
                 let sink_name = format!("tail-{}", sink_id);
@@ -4164,7 +4164,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         .resolve_full_name(table.name(), Some(session.conn_id())),
                 )
                 .expect("desc called on table")
-                .clone(),
+                .into_owned(),
             None => {
                 tx.send(
                     Err(CoordError::SqlCatalog(CatalogError::UnknownItem(

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -2664,9 +2664,6 @@ pub mod sources {
 
         /// A local "source" is fed by a local input handle.
         Local { timeline: Timeline },
-
-        /// A source for compute logging data.
-        Log,
     }
 
     impl Arbitrary for SourceConnector {
@@ -2703,7 +2700,6 @@ pub mod sources {
                         }
                     ),
                 any::<Timeline>().prop_map(|timeline| SourceConnector::Local { timeline }),
-                Just(SourceConnector::Log)
             ]
             .boxed()
         }
@@ -2732,7 +2728,6 @@ pub mod sources {
                     SourceConnector::Local { timeline } => Kind::Local(ProtoLocal {
                         timeline: Some(timeline.into_proto()),
                     }),
-                    SourceConnector::Log => Kind::Log(()),
                 }),
             }
         }
@@ -2761,7 +2756,6 @@ pub mod sources {
                 Kind::Local(ProtoLocal { timeline }) => SourceConnector::Local {
                     timeline: timeline.into_rust_if_some("ProtoLocal::timeline")?,
                 },
-                Kind::Log(()) => SourceConnector::Log,
             })
         }
     }
@@ -2823,8 +2817,6 @@ pub mod sources {
                 } => false,
                 // Local sources (i.e., tables) also support retractions (deletes)
                 SourceConnector::Local { .. } => false,
-                // Log sources _may_ produce retractions.
-                SourceConnector::Log { .. } => false,
             }
         }
 
@@ -2832,7 +2824,6 @@ pub mod sources {
             match self {
                 SourceConnector::External { connector, .. } => connector.name(),
                 SourceConnector::Local { .. } => "local",
-                SourceConnector::Log => "log",
             }
         }
 
@@ -2840,7 +2831,6 @@ pub mod sources {
             match self {
                 SourceConnector::External { timeline, .. } => timeline.clone(),
                 SourceConnector::Local { timeline, .. } => timeline.clone(),
-                SourceConnector::Log => Timeline::EpochMilliseconds,
             }
         }
 
@@ -2878,7 +2868,6 @@ pub mod sources {
                 }
                 SourceConnector::External { .. } => None,
                 SourceConnector::Local { .. } => None,
-                SourceConnector::Log => None,
             };
 
             Ok(result)

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -180,7 +180,6 @@ message ProtoSourceConnector {
     oneof kind {
         ProtoExternal external = 1;
         ProtoLocal local = 2;
-        google.protobuf.Empty log = 3;
     }
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -11,6 +11,7 @@
 
 //! Catalog abstraction layer.
 
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::error::Error;
 use std::fmt;
@@ -292,7 +293,7 @@ pub trait CatalogItem {
     ///
     /// If the catalog item is not of a type that produces data (i.e., a sink or
     /// an index), it returns an error.
-    fn desc(&self, name: &FullObjectName) -> Result<&RelationDesc, CatalogError>;
+    fn desc(&self, name: &FullObjectName) -> Result<Cow<RelationDesc>, CatalogError>;
 
     /// Returns the resolved function.
     ///

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -324,7 +324,7 @@ pub fn plan_copy_from(
     }
     let mut desc = table
         .desc(&scx.catalog.resolve_full_name(table.name()))?
-        .clone();
+        .into_owned();
     let _ = table
         .table_details()
         .expect("attempted to insert into non-table");

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -286,7 +286,7 @@ pub fn describe_tail(
         TailRelation::Name(name) => {
             let item = scx.get_item_by_resolved_name(&name)?;
             item.desc(&scx.catalog.resolve_full_name(item.name()))?
-                .clone()
+                .into_owned()
         }
         TailRelation::Query(query) => {
             let query::PlannedQuery { desc, .. } =

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -7,6 +7,22 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use chrono::MIN_DATETIME;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use mz_build_info::DUMMY_BUILD_INFO;
+use mz_dataflow_types::sources::SourceConnector;
+use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
+use mz_lowertest::*;
+use mz_ore::now::{EpochMillis, NOW_ZERO};
+use mz_repr::{GlobalId, RelationDesc, ScalarType};
+
 use crate::ast::Expr;
 use crate::catalog::{
     CatalogComputeInstance, CatalogConfig, CatalogConnector, CatalogDatabase, CatalogError,
@@ -20,18 +36,6 @@ use crate::names::{
 };
 use crate::plan::StatementDesc;
 use crate::DEFAULT_SCHEMA;
-use chrono::MIN_DATETIME;
-use mz_build_info::DUMMY_BUILD_INFO;
-use mz_dataflow_types::sources::SourceConnector;
-use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
-use mz_lowertest::*;
-use mz_ore::now::{EpochMillis, NOW_ZERO};
-use mz_repr::{GlobalId, RelationDesc, ScalarType};
-use once_cell::sync::Lazy;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
-use uuid::Uuid;
 
 static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     start_time: MIN_DATETIME,
@@ -79,9 +83,9 @@ impl CatalogItem for TestCatalogItem {
         unimplemented!()
     }
 
-    fn desc(&self, _: &FullObjectName) -> Result<&RelationDesc, CatalogError> {
+    fn desc(&self, _: &FullObjectName) -> Result<Cow<RelationDesc>, CatalogError> {
         match &self {
-            TestCatalogItem::BaseTable { desc, .. } => Ok(desc),
+            TestCatalogItem::BaseTable { desc, .. } => Ok(Cow::Borrowed(desc)),
             _ => Err(CatalogError::UnknownItem(format!(
                 "{:?} does not have a desc() method",
                 self

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -102,7 +102,7 @@ where
     match source_desc.connector.clone() {
         // Create a new local input (exposed as TABLEs to users). Data is inserted
         // via Command::Insert commands. Defers entirely to `render_table`
-        SourceConnector::Local { .. } | SourceConnector::Log => unreachable!(),
+        SourceConnector::Local { .. } => unreachable!(),
 
         SourceConnector::External {
             connector,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -110,7 +110,7 @@ impl<'a, A: Allocate> ActiveStorageState<'a, A> {
             StorageCommand::CreateSources(sources) => {
                 for source in sources {
                     match &source.desc.connector {
-                        SourceConnector::Local { .. } | SourceConnector::Log => {
+                        SourceConnector::Local { .. } => {
                             self.storage_state.table_state.insert(
                                 source.id,
                                 TableState {


### PR DESCRIPTION
Materialize presents timely/differential logging relations as built-in
sources. They are completely unlike sources managed by the storage
layer, though, as they only exist within the context of a compute
replica that has introspection enabled.

This removes all knowledge of these logging relations from the storage
layer. Instead, these relations are represented explicitly in the
adapter layer as a new `BuiltinLog` catalog item type. This makes the
special cases for these logs far more explicit; previously those special
cases were largely the result of emergent behavior, leading to bugs like
 #12644.

When exposed to the user, we continue to call these logging relations
"sources", to avoid introducing yet another noun. For example, logging
relations continue to appear in the output of `SHOW SOURCES` and are
listed as an object of type `source` in `SHOW OBJECTS`. But we're now
well positioned to revisit this decision in the future, if we like.

Fix #12644.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
