### PR TITLE
storage: fix upsert operator for unordered keys

### DIFF
--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -234,6 +234,19 @@ where
             let mut row_packer = mz_repr::Row::default();
             let mut dv = DatumVec::new();
 
+            // Prepare sorted and structured `key_indices` required
+            // by the upsert operator, and a `DatumVec` used to avoid
+            // an allocation.
+            let mut key_indices_sorted = upsert_envelope.key_indices.clone();
+            key_indices_sorted.sort_unstable();
+            let key_indices_map = upsert_envelope
+                .key_indices
+                .iter()
+                .enumerate()
+                .map(|(idx, value_idx)| (*value_idx, idx))
+                .collect();
+            let mut kdv = DatumVec::new();
+
             move |input, output| {
                 // Digest each input, reduce by presented timestamp.
                 input.for_each(|cap, data| {
@@ -263,6 +276,9 @@ where
                         &mut row_packer,
                         &mut dv,
                         &upsert_envelope,
+                        &key_indices_sorted,
+                        &key_indices_map,
+                        &mut kdv,
                         &predicates,
                         &position_or,
                         &mut removed_times,
@@ -364,8 +380,15 @@ fn process_pending_values_batch(
     row_packer: &mut Row,
     // A shared row used to build a Vec<Datum<'_>> for evaluation
     dv: &mut DatumVec,
-    // Additional source properties used to correctly inter
+    // Additional source properties used to correctly manage key-value pairs
     upsert_envelope: &UpsertEnvelope,
+    // `key_indices` in `upsert_envelope`, but sorted
+    key_indices_sorted: &[usize],
+    // `key_indices` in `upsert_envelope`, but turned into a value index to
+    // key index map
+    key_indices_map: &BTreeMap<usize, usize>,
+    // A shared row used to build a Vec<Datum<'_>> for key thinning
+    kdv: &mut DatumVec,
     // Additional information used to pre-evaluate predicates that reduces the output
     // stream size
     predicates: &[MirScalarExpr],
@@ -433,19 +456,20 @@ fn process_pending_values_batch(
                 // key columns, cloning when need-be
                 let thinned_value = new_value
                     .as_ref()
-                    .map(|full_row| thin(&upsert_envelope.key_indices, &full_row, row_packer))
+                    .map(|full_row| thin(key_indices_sorted, &full_row, row_packer))
                     .map_err(|e| e.clone());
                 current_values
                     .insert(decoded_key.clone(), thinned_value)
                     .map(|res| {
                         res.map(|v| {
                             rehydrate(
-                                &upsert_envelope.key_indices,
+                                &key_indices_map,
                                 // The value is never `Ok`
                                 // unless the key is also
                                 decoded_key.as_ref().unwrap(),
                                 &v,
                                 row_packer,
+                                kdv,
                             )
                         })
                     })
@@ -453,12 +477,13 @@ fn process_pending_values_batch(
                 current_values.remove(&decoded_key).map(|res| {
                     res.map(|v| {
                         rehydrate(
-                            &upsert_envelope.key_indices,
+                            key_indices_map,
                             // The value is never `Ok`
                             // unless the key is also
                             decoded_key.as_ref().unwrap(),
                             &v,
                             row_packer,
+                            kdv,
                         )
                     })
                 })
@@ -509,13 +534,13 @@ fn build_datum_vec_for_evaluation<'row>(
     }
 }
 
-/// `thin` uses information from the source description to find which indexes in the row
-/// are keys and skip them.
-fn thin(key_indices: &[usize], value: &Row, row_buf: &mut Row) -> Row {
+/// `thin` uses information from the source description to find which indices in the row
+/// are keys and skip them. It requires that `key_indices` is sorted.
+fn thin(key_indices_sorted: &[usize], value: &Row, row_buf: &mut Row) -> Row {
     let mut row_packer = row_buf.packer();
     let values = &mut value.iter();
     let mut next_idx = 0;
-    for &key_idx in key_indices {
+    for &key_idx in key_indices_sorted {
         // First, push the datums that are before `key_idx`
         row_packer.extend(values.take(key_idx - next_idx));
         // Then, skip this key datum
@@ -528,22 +553,38 @@ fn thin(key_indices: &[usize], value: &Row, row_buf: &mut Row) -> Row {
     row_buf.clone()
 }
 
-/// `rehydrate` uses information from the source description to find which indexes in the row
-/// are keys and add them back in in the right places.
-fn rehydrate(key_indices: &[usize], key: &Row, thinned_value: &Row, row_buf: &mut Row) -> Row {
+/// `rehydrate` uses information from the source description to find which indices in the row
+/// are keys and add them back in in the right places. `key_indices` is a map
+/// from the each key-part's index in the value to its index in the key.
+fn rehydrate(
+    key_indices_map: &BTreeMap<usize, usize>,
+    key: &Row,
+    thinned_value: &Row,
+    row_buf: &mut Row,
+    kdv: &mut DatumVec,
+) -> Row {
     let mut row_packer = row_buf.packer();
     let values = &mut thinned_value.iter();
+
+    let mut key_datums = kdv.borrow();
+    key_datums.extend(key.iter());
+
     let mut next_idx = 0;
-    for (&key_idx, key_datum) in key_indices.iter().zip(key.iter()) {
+    let mut key_indices_iter = key_indices_map.iter().peekable();
+
+    while let Some((value_idx, key_idx)) = key_indices_iter.peek() {
+        // Make borrowck happy
+        let value_idx = **value_idx;
+        let key_idx = **key_idx;
         // First, push the datums that are before `key_idx`
-        row_packer.extend(values.take(key_idx - next_idx));
+        row_packer.extend(values.take(value_idx - next_idx));
         // Then, push this key datum
-        row_packer.push(key_datum);
-        next_idx = key_idx + 1;
+        row_packer.push(key_datums[key_idx]);
+        key_indices_iter.next().unwrap();
+        next_idx = value_idx + 1;
     }
     // Finally, push any columns after the last key index
     row_packer.extend(values);
-
     row_buf.clone()
 }
 
@@ -554,27 +595,43 @@ mod tests {
     #[test]
     fn test_rehydrate_thin_first() {
         let mut packer = Row::default();
+        let mut kdv = DatumVec::new();
 
         let key_indices = vec![0];
+        let mut key_indices_sorted = key_indices.clone();
+        key_indices_sorted.sort_unstable();
+        let key_indices_map = key_indices
+            .iter()
+            .enumerate()
+            .map(|(idx, value_idx)| (*value_idx, idx))
+            .collect();
         let key = Row::pack([Datum::String("key")]);
 
         let thinned = Row::pack([Datum::String("two")]);
 
-        let rehydrated = rehydrate(&key_indices, &key, &thinned, &mut packer);
+        let rehydrated = rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv);
 
         assert_eq!(
             rehydrated,
             Row::pack([Datum::String("key"), Datum::String("two"),])
         );
 
-        assert_eq!(thin(&key_indices, &rehydrated, &mut packer), thinned);
+        assert_eq!(thin(&key_indices_sorted, &rehydrated, &mut packer), thinned);
     }
 
     #[test]
     fn test_rehydrate_thin_middle() {
         let mut packer = Row::default();
+        let mut kdv = DatumVec::new();
 
         let key_indices = vec![2];
+        let mut key_indices_sorted = key_indices.clone();
+        key_indices_sorted.sort_unstable();
+        let key_indices_map = key_indices
+            .iter()
+            .enumerate()
+            .map(|(idx, value_idx)| (*value_idx, idx))
+            .collect();
         let key = Row::pack([Datum::String("key")]);
 
         let thinned = Row::pack([
@@ -583,7 +640,7 @@ mod tests {
             Datum::String("four"),
         ]);
 
-        let rehydrated = rehydrate(&key_indices, &key, &thinned, &mut packer);
+        let rehydrated = rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv);
 
         assert_eq!(
             rehydrated,
@@ -595,14 +652,22 @@ mod tests {
             ])
         );
 
-        assert_eq!(thin(&key_indices, &rehydrated, &mut packer), thinned);
+        assert_eq!(thin(&key_indices_sorted, &rehydrated, &mut packer), thinned);
     }
 
     #[test]
     fn test_rehydrate_thin_multiple() {
         let mut packer = Row::default();
+        let mut kdv = DatumVec::new();
 
         let key_indices = vec![2, 4];
+        let mut key_indices_sorted = key_indices.clone();
+        key_indices_sorted.sort_unstable();
+        let key_indices_map = key_indices
+            .iter()
+            .enumerate()
+            .map(|(idx, value_idx)| (*value_idx, idx))
+            .collect();
         let key = Row::pack([Datum::String("key1"), Datum::String("key2")]);
 
         let thinned = Row::pack([
@@ -612,7 +677,7 @@ mod tests {
             Datum::String("six"),
         ]);
 
-        let rehydrated = rehydrate(&key_indices, &key, &thinned, &mut packer);
+        let rehydrated = rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv);
 
         assert_eq!(
             rehydrated,
@@ -626,7 +691,47 @@ mod tests {
             ])
         );
 
-        assert_eq!(thin(&key_indices, &rehydrated, &mut packer), thinned);
+        assert_eq!(thin(&key_indices_sorted, &rehydrated, &mut packer), thinned);
+    }
+
+    #[test]
+    fn test_rehydrate_thin_unordered() {
+        let mut packer = Row::default();
+        let mut kdv = DatumVec::new();
+
+        // Note these are unordered
+        let key_indices = vec![4, 2];
+        let mut key_indices_sorted = key_indices.clone();
+        key_indices_sorted.sort_unstable();
+        let key_indices_map = key_indices
+            .iter()
+            .enumerate()
+            .map(|(idx, value_idx)| (*value_idx, idx))
+            .collect();
+
+        let key = Row::pack([Datum::String("key2"), Datum::String("key1")]);
+
+        let thinned = Row::pack([
+            Datum::String("one"),
+            Datum::String("two"),
+            Datum::String("four"),
+            Datum::String("six"),
+        ]);
+        let full = Row::pack([
+            Datum::String("one"),
+            Datum::String("two"),
+            Datum::String("key1"),
+            Datum::String("four"),
+            Datum::String("key2"),
+            Datum::String("six"),
+        ]);
+
+        assert_eq!(thin(&key_indices_sorted, &full, &mut packer), thinned);
+
+        assert_eq!(
+            rehydrate(&key_indices_map, &key, &thinned, &mut packer, &mut kdv),
+            full
+        );
     }
 
     #[test]

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -572,16 +572,12 @@ fn rehydrate(
     let mut next_idx = 0;
     let mut key_indices_iter = key_indices_map.iter().peekable();
 
-    while let Some((value_idx, key_idx)) = key_indices_iter.peek() {
-        // Make borrowck happy
-        let value_idx = **value_idx;
-        let key_idx = **key_idx;
+    while let Some((value_idx, key_idx)) = key_indices_iter.next() {
         // First, push the datums that are before `key_idx`
-        row_packer.extend(values.take(value_idx - next_idx));
+        row_packer.extend(values.take(*value_idx - next_idx));
         // Then, push this key datum
-        row_packer.push(key_datums[key_idx]);
-        key_indices_iter.next().unwrap();
-        next_idx = value_idx + 1;
+        row_packer.push(key_datums[*key_idx]);
+        next_idx = *value_idx + 1;
     }
     // Finally, push any columns after the last key index
     row_packer.extend(values);

--- a/test/testdrive/upsert-unordered-key.td
+++ b/test/testdrive/upsert-unordered-key.td
@@ -1,0 +1,76 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Must be a subset of the keys in the rows AND
+# in a different order than the value.
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "b", "type": "string"},
+        {"name": "a", "type": "long"}
+    ]
+  }
+
+$ set schema={
+    "type" : "record",
+    "name" : "envelope",
+    "fields" : [
+      {
+        "name": "before",
+        "type": [
+          {
+            "name": "row",
+            "type": "record",
+            "fields": [
+              {
+                  "name": "a",
+                  "type": "long"
+              },
+              {
+                "name": "data",
+                "type": "string"
+              },
+              {
+                  "name": "b",
+                  "type": "string"
+              }]
+           },
+           "null"
+         ]
+      },
+      {
+        "name": "after",
+        "type": ["row", "null"]
+      }
+    ]
+  }
+
+$ kafka-create-topic topic=dbzupsert partitions=1
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish2", "b": "bdata"}}}
+
+> CREATE MATERIALIZED SOURCE doin_upsert
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE DEBEZIUM UPSERT
+
+> SELECT * FROM doin_upsert
+a data b
+-----------
+1 fish2 bdata
+
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+{"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish2", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish3", "b": "bdata"}}}
+
+> SELECT * FROM doin_upsert
+a data b
+-----------
+1 fish3 bdata


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/product/issues/159
Supercedes https://github.com/MaterializeInc/materialize/pull/12687

This allows `thin` and `rehydrate` to work on unordered keys. I chose to create the sorted list and map required to implement these functions correctly in the upsert operator, as I feel it makes the code more clear, as opposed to making `UpsertEnvelope` pre-calculate these.

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
I have a unit test that should cover it, and a td test using `DEBEZIUM UPSERT`

### Release notes

Fixes the above, bug, and this will need to be backported
