### PR TITLE
coord: add initial audit log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,9 @@ name = "bytesize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -2981,6 +2984,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mz-audit-log"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "serde",
+ "serde_json",
+ "uuid 1.1.1",
+]
+
+[[package]]
 name = "mz-avro"
 version = "0.6.5"
 dependencies = [
@@ -3124,6 +3138,7 @@ dependencies = [
  "fail",
  "futures",
  "itertools",
+ "mz-audit-log",
  "mz-build-info",
  "mz-ccsr",
  "mz-dataflow-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "src/audit-log",
     "src/avro-derive",
     "src/avro",
     "src/billing-demo",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -513,6 +513,12 @@ class Composition:
                 print(f"> {statement}")
                 cursor.execute(statement)
 
+    def sql_query(self, sql: str) -> Any:
+        """Execute and return results of a SQL query."""
+        with self.sql_cursor() as cursor:
+            cursor.execute(sql)
+            return cursor.fetchall()
+
     def create_cluster(
         self,
         cluster: List,

--- a/src/audit-log/Cargo.toml
+++ b/src/audit-log/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mz-audit-log"
+description = "Audit log data structures."
+version = "0.0.0"
+edition = "2021"
+rust-version = "1.61.0"
+publish = false
+
+[dependencies]
+anyhow = "1.0.57"
+bytesize = { version = "1.1.0", features = ["serde"] }
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
+uuid = { version = "1.0.0", features = ["serde", "v4"] }

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -1,0 +1,219 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Audit log data structures.
+//!
+//! The audit log is logging that is produced by user actions and consumed
+//! by users in the form of the `mz_catalog.mz_audit_events` SQL table and
+//! by the cloud management layer for billing and introspection. This crate
+//! is designed to make the production and consumption of the logs type
+//! safe. Events and their metadata are versioned and the data structures
+//! replicated here so that if the data change in some other crate, a
+//! new version here can be made. This avoids needing to poke at the data
+//! when reading it to determine what it means and should have full backward
+//! compatibility. This is its own crate so that production and consumption can
+//! be in different processes and production is not allowed to specify private
+//! data structures unknown to the reader.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// New version variants should be added if fields need to be added, changed, or removed.
+#[derive(Serialize, Deserialize)]
+pub enum VersionedEvent {
+    V1(EventV1),
+}
+
+impl VersionedEvent {
+    /// Create a new event, with a generated UUID. This function must always
+    /// require and produce the most recent variant of VersionedEvent.
+    pub fn new(
+        event_type: EventType,
+        object_type: ObjectType,
+        event_details: EventDetails,
+        user: String,
+        occurred_at_unix_epoch_nanos: u64,
+    ) -> Self {
+        Self::new_uuid(
+            Uuid::new_v4(),
+            event_type,
+            object_type,
+            event_details,
+            user,
+            occurred_at_unix_epoch_nanos,
+        )
+    }
+
+    /// Create a new event. This function must always require and produce the most
+    /// recent variant of VersionedEvent.
+    pub fn new_uuid(
+        uuid: Uuid,
+        event_type: EventType,
+        object_type: ObjectType,
+        event_details: EventDetails,
+        user: String,
+        occurred_at_unix_epoch_nanos: u64,
+    ) -> Self {
+        Self::V1(EventV1::new(
+            uuid,
+            event_type,
+            object_type,
+            event_details,
+            user,
+            occurred_at_unix_epoch_nanos,
+        ))
+    }
+
+    // Implement deserialize and serialize so writers and readers don't have to
+    // coordinate about which Serializer to use.
+    pub fn deserialize(data: &[u8]) -> Result<Self, anyhow::Error> {
+        Ok(serde_json::from_slice(data)?)
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("must serialize")
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum EventType {
+    Create,
+    Drop,
+    Alter,
+    Rename,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ObjectType {
+    Cluster,
+    ClusterReplica,
+    Index,
+    Sink,
+    Source,
+    View,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum EventDetails {
+    CreateComputeInstanceReplicaV1(CreateComputeInstanceReplicaV1),
+    DropComputeInstanceReplicaV1(DropComputeInstanceReplicaV1),
+    FullNameV1(FullNameV1),
+    NameV1(NameV1),
+    RenameItemV1(RenameItemV1),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FullNameV1 {
+    pub database: String,
+    pub schema: String,
+    pub item: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NameV1 {
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RenameItemV1 {
+    pub previous_name: FullNameV1,
+    pub new_name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DropComputeInstanceReplicaV1 {
+    pub cluster_name: String,
+    pub replica_name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CreateComputeInstanceReplicaV1 {
+    pub cluster_name: String,
+    pub replica_name: String,
+    pub logical_size: String,
+}
+
+impl EventDetails {
+    pub fn as_json(&self) -> serde_json::Value {
+        match self {
+            EventDetails::CreateComputeInstanceReplicaV1(v) => {
+                serde_json::to_value(v).expect("must serialize")
+            }
+            EventDetails::DropComputeInstanceReplicaV1(v) => {
+                serde_json::to_value(v).expect("must serialize")
+            }
+            EventDetails::RenameItemV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::NameV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::FullNameV1(v) => serde_json::to_value(v).expect("must serialize"),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct EventV1 {
+    pub uuid: Uuid,
+    pub event_type: EventType,
+    pub object_type: ObjectType,
+    pub event_details: EventDetails,
+    pub user: String,
+    pub occurred_at: u64,
+}
+
+impl EventV1 {
+    fn new(
+        uuid: Uuid,
+        event_type: EventType,
+        object_type: ObjectType,
+        event_details: EventDetails,
+        user: String,
+        occurred_at: u64,
+    ) -> EventV1 {
+        EventV1 {
+            uuid,
+            event_type,
+            object_type,
+            event_details,
+            user,
+            occurred_at,
+        }
+    }
+}
+
+// Test all versions of events. This test hard codes bytes so that
+// programmers are not able to change data structures here without this test
+// failing. Instead of changing data structures, add new variants.
+#[test]
+fn test_audit_log() -> Result<(), anyhow::Error> {
+    let cases: Vec<(VersionedEvent, &'static str)> = vec![(
+        VersionedEvent::V1(EventV1::new(
+            Uuid::from_u128(1),
+            EventType::Create,
+            ObjectType::View,
+            EventDetails::NameV1(NameV1 {
+                name: "name".into(),
+            }),
+            "user".into(),
+            1,
+        )),
+        r#"{"V1":{"uuid":"00000000-0000-0000-0000-000000000001","event_type":"Create","object_type":"View","event_details":{"NameV1":{"name":"name"}},"user":"user","occurred_at":1}}"#,
+    )];
+
+    for (event, expected_bytes) in cases {
+        let event_bytes = serde_json::to_vec(&event).unwrap();
+        assert_eq!(
+            event_bytes,
+            expected_bytes.as_bytes(),
+            "expected bytes {}, got {}",
+            expected_bytes,
+            std::str::from_utf8(&event_bytes).unwrap(),
+        );
+    }
+
+    Ok(())
+}

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -18,6 +18,7 @@ fail = { version = "0.5.0", features = ["failpoints"] }
 futures = "0.3.21"
 itertools = "0.10.3"
 once_cell = "1.12.0"
+mz-audit-log = { path = "../audit-log" }
 mz-build-info = { path = "../build-info" }
 mz-ccsr = { path = "../ccsr" }
 mz-dataflow-types = { path = "../dataflow-types" }

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1148,6 +1148,18 @@ pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("status", ScalarType::String.nullable(false)),
 });
 
+pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_audit_events",
+    schema: MZ_CATALOG_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("uuid", ScalarType::Uuid.nullable(false))
+        .with_column("event_type", ScalarType::String.nullable(false))
+        .with_column("object_type", ScalarType::String.nullable(false))
+        .with_column("event_details", ScalarType::Jsonb.nullable(false))
+        .with_column("user", ScalarType::String.nullable(false))
+        .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
+});
+
 pub const MZ_RELATIONS: BuiltinView = BuiltinView {
     name: "mz_relations",
     schema: MZ_CATALOG_SCHEMA,
@@ -2049,6 +2061,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_SECRETS),
         Builtin::Table(&MZ_CONNECTORS),
         Builtin::Table(&MZ_CLUSTER_REPLICAS),
+        Builtin::Table(&MZ_AUDIT_EVENTS),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_CATALOG_NAMES),

--- a/src/coord/tests/sql.rs
+++ b/src/coord/tests/sql.rs
@@ -76,6 +76,7 @@ async fn datadriven() {
                             .clone();
                         catalog
                             .transact(
+                                None,
                                 vec![Op::CreateItem {
                                     id,
                                     oid,

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -40,5 +40,33 @@ def workflow_github_8021(c: Composition) -> None:
     c.kill("materialized")
 
 
+def workflow_audit_log(c: Composition) -> None:
+    c.up("materialized")
+    c.wait_for_materialized(service="materialized")
+
+    # Create some audit log entries.
+    c.sql("CREATE TABLE t (i INT)")
+    c.sql("CREATE DEFAULT INDEX ON t")
+
+    # occurred_at is a timestamp with microsecond precesion, so order by something
+    # else also to avoid flakes in case two events share a timestamp.
+    log = c.sql_query("SELECT * FROM mz_audit_events ORDER BY occurred_at, uuid")
+
+    # Restart mz.
+    c.kill("materialized")
+    c.up("materialized")
+    c.wait_for_materialized()
+
+    # Verify the audit log entries are still present and have not changed.
+    restart_log = c.sql_query(
+        "SELECT * FROM mz_audit_events ORDER BY occurred_at, uuid"
+    )
+    if log != restart_log:
+        print("initial audit log:", log)
+        print("audit log after restart:", restart_log)
+        raise Exception("audit logs not equal after restart")
+
+
 def workflow_default(c: Composition) -> None:
     workflow_github_8021(c)
+    workflow_audit_log(c)

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -1,0 +1,62 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test expected population of mz_audit_events after some DDL statements.
+
+mode cockroach
+
+statement ok
+CREATE CLUSTER foo REPLICAS (r (SIZE '1'));
+
+statement ok
+CREATE MATERIALIZED VIEW v2 AS SELECT 1
+
+statement ok
+CREATE VIEW unmat AS SELECT 1
+
+statement ok
+CREATE TABLE t ()
+
+statement ok
+CREATE DEFAULT INDEX ON t
+
+statement ok
+ALTER VIEW unmat RENAME TO renamed
+
+statement ok
+CREATE OR REPLACE VIEW v2 AS SELECT 2
+
+statement ok
+CREATE DEFAULT INDEX ON renamed
+
+statement ok
+DROP VIEW renamed
+
+statement ok
+CREATE SOURCE s FROM PUBNUB
+SUBSCRIBE KEY 'sub-c-4377ab04-f100-11e3-bffd-02ee2ddab7fe'
+CHANNEL 'pubnub-market-orders';
+
+query TTTT
+SELECT event_type, object_type, event_details, user FROM mz_audit_events ORDER BY occurred_at
+----
+Create  Cluster  {"name":"foo"}  materialize
+Create  ClusterReplica  {"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+Create  View  {"database":"materialize","item":"v2","schema":"public"}  materialize
+Create  Index  {"database":"materialize","item":"v2_primary_idx","schema":"public"}  materialize
+Create  View  {"database":"materialize","item":"unmat","schema":"public"}  materialize
+Create  Index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
+Rename  View  {"new_name":"renamed","previous_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
+Drop  Index  {"database":"materialize","item":"v2_primary_idx","schema":"public"}  materialize
+Drop  View  {"database":"materialize","item":"v2","schema":"public"}  materialize
+Create  View  {"database":"materialize","item":"v2","schema":"public"}  materialize
+Create  Index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
+Drop  Index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
+Drop  View  {"database":"materialize","item":"renamed","schema":"public"}  materialize
+Create  Source  {"database":"materialize","item":"s","schema":"public"}  materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -393,6 +393,7 @@ mz_worker_materialization_frontiers           system true          volatile    l
 
 > SHOW TABLES FROM mz_catalog
 mz_array_types
+mz_audit_events
 mz_base_types
 mz_clusters
 mz_cluster_replicas
@@ -421,6 +422,7 @@ mz_views
 name                  type
 ----------------------------
 mz_array_types        system
+mz_audit_events       system
 mz_base_types         system
 mz_clusters           system
 mz_cluster_replicas   system
@@ -451,6 +453,7 @@ mz_views              system
 
 > SHOW EXTENDED tables FROM tester
 mz_array_types
+mz_audit_events
 mz_base_types
 mz_clusters
 mz_cluster_replicas
@@ -482,6 +485,7 @@ test_table
 
 > SHOW EXTENDED tables FROM tester
 mz_array_types
+mz_audit_events
 mz_base_types
 mz_clusters
 mz_cluster_replicas
@@ -509,7 +513,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-24
+25
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
Add a versioned audit log crate that is populated in the same transaction as catalog changes. The crate can be used for reading the log in a type safe way.

### Motivation

  * This PR adds a known-desirable feature.

    Fixes https://github.com/MaterializeInc/cloud/issues/3112
    See https://github.com/MaterializeInc/cloud/issues/2714

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a