### PR TITLE
persist: add tracing integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3599,6 +3599,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "mz-http-util",
+ "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist",
  "mz-persist-types",
@@ -3612,7 +3613,6 @@ dependencies = [
  "timely",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uuid 1.1.1",
 ]
 

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -227,6 +227,11 @@ where
     Ok(())
 }
 
+/// Shutdown any tracing infra, if any.
+pub fn shutdown() {
+    opentelemetry::global::shutdown_tracer_provider();
+}
+
 /// Returns the level of a specific target from a [`Targets`].
 pub fn target_level(targets: &Targets, target: &str) -> Level {
     if targets.would_enable(target, &Level::TRACE) {

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -35,8 +35,8 @@ differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-
 futures = "0.3.21"
 futures-util = "0.3"
 mz-ore = { path = "../ore" }
-mz-persist-types = { path = "../persist-types" }
 mz-persist = { path = "../persist" }
+mz-persist-types = { path = "../persist-types" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
 serde = { version = "1.0.137", features = ["derive"] }
@@ -45,6 +45,9 @@ tokio = { version = "1.18.2", default-features = false, features = ["macros", "s
 tracing = "0.1.34"
 uuid = { version = "1.1.1", features = ["v4"] }
 
+[features]
+tokio-console = ["mz-ore/tokio-console"]
+
 [dev-dependencies]
 async-trait = "0.1.56"
 axum = "0.5.6"
@@ -52,8 +55,9 @@ clap = { version = "3.1.18", features = ["derive", "env"] }
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["html_reports"] }
 futures-task = "0.3.21"
 mz-http-util = { path = "../http-util" }
+mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
+mz-ore = { path = "../ore", features = ["tracing_"] }
 num_cpus = "1.13.1"
 num_enum = "0.5.7"
 serde_json = "1.0.81"
 tempfile = "3.2.0"
-tracing-subscriber = { version = "0.3.11", default-features = false, features = ["env-filter", "fmt"] }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -30,7 +30,7 @@ use mz_persist_types::{Codec, Codec64};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp;
-use tracing::{debug, trace};
+use tracing::{debug, instrument, trace};
 use uuid::Uuid;
 
 use crate::cache::PersistClientCache;
@@ -211,6 +211,7 @@ impl PersistClient {
     /// If `shard_id` has never been used before, initializes a new shard and
     /// returns handles with `since` and `upper` frontiers set to initial values
     /// of `Antichain::from_elem(T::minimum())`.
+    #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
     pub async fn open<K, V, T, D>(
         &self,
         shard_id: ShardId,
@@ -245,6 +246,7 @@ impl PersistClient {
     ///
     /// Use this to save latency and a bit of persist traffic if you're just
     /// going to immediately drop or expire the [WriteHandle].
+    #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
     pub async fn open_reader<K, V, T, D>(
         &self,
         shard_id: ShardId,
@@ -267,6 +269,7 @@ impl PersistClient {
     ///
     /// Use this to save latency and a bit of persist traffic if you're just
     /// going to immediately drop or expire the [ReadHandle].
+    #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
     pub async fn open_writer<K, V, T, D>(
         &self,
         shard_id: ShardId,


### PR DESCRIPTION
Persist offers introspection into performance and behavior through integration
with the [tracing] crate.

[tracing]: https://docs.rs/tracing

There are many policies we could adopt for what is instrumented and at what
level. At the same time, it's early enough that there are lots of unknowns
around what will be most useful for debugging real problems and what knobs are
wanted to opt into additional detail. As a result, we adopt a common idiom of
tracing at the persist API boundary with the rest of mz (as well as persist's
API boundary with external systems such as s3 and aurora, which we wouldn't do
if they themselves offered tracing integration). Concretely:

- All persist spans have a `target` of `persist`, regardless of which crate or
  module they are in. In the future, we'll use `persist::foo` to allow fine
  grained opt-in of supplementary info for targeted problems (e.g. unexpected
  retries, slow throughput).
- All persist spans have a `shard` field.
- Every method in the persist public API is traced at info level. However, this
  excludes "sugar" methods (e.g. WriteHandle::append and
  WriteHandle::append_batch) that are implemented entirely in terms of other
  public persist API methods.
- All writes to external systems are traced at info level. Reads are traced at
  debug level.
- Additional information is traced at debug level.

We'll tune this policy over time as we gain experience debugging persist in
production.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Ignore the first two commits, they are other PRs.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
