### PR TITLE
compute: remove storage_addr configuration parameter

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -128,7 +128,6 @@ class Computed(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        storage_addr: Optional[str] = "materialized:2101",
         workers: Optional[int] = None,
     ) -> None:
         if environment is None:
@@ -158,9 +157,6 @@ class Computed(Service):
                 command_list.append(options)
             else:
                 command_list.extend(options)
-
-        if storage_addr:
-            command_list.append(f"--storage-addr {storage_addr}")
 
         if workers:
             command_list.append(f"--workers {workers}")

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -86,14 +86,6 @@ struct Args {
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
     #[clap(long, value_name = "ID")]
     aws_external_id: Option<String>,
-    /// The address of the storage server to bind or connect to.
-    #[clap(
-        long,
-        env = "COMPUTED_STORAGE_ADDR",
-        value_name = "HOST:PORT",
-        default_value = "127.0.0.1:2101"
-    )]
-    storage_addr: String,
     /// Whether or not process should die when connection with ADAPTER is lost.
     #[clap(long)]
     linger: bool,

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -56,8 +56,6 @@ pub struct OrchestratorConfig {
     pub orchestrator: Box<dyn Orchestrator>,
     /// The computed image to use when starting new compute instances.
     pub computed_image: String,
-    /// The storage address that compute instances should connect to.
-    pub storage_addr: String,
     /// Whether or not process should die when connection with ADAPTER is lost.
     pub linger: bool,
 }
@@ -203,7 +201,6 @@ where
                 let OrchestratorConfig {
                     orchestrator,
                     computed_image,
-                    storage_addr,
                     linger,
                 } = &self.orchestrator;
 
@@ -219,7 +216,6 @@ where
                                 image: computed_image.clone(),
                                 args: &|hosts_ports, my_ports, my_index| {
                                     let mut compute_opts = vec![
-                                        format!("--storage-addr={storage_addr}"),
                                         format!(
                                             "--listen-addr={}:{}",
                                             default_listen_host, my_ports["controller"]

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -296,10 +296,6 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
                     let mut storage_opts = vec![
                         format!("--workers=1"),
                         format!(
-                            "--storage-addr={}:{}",
-                            default_listen_host, my_ports["compute"]
-                        ),
-                        format!(
                             "--listen-addr={}:{}",
                             default_listen_host, my_ports["controller"]
                         ),
@@ -320,10 +316,6 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
                         port_hint: 2100,
                     },
                     ServicePort {
-                        name: "compute".into(),
-                        port_hint: 2101,
-                    },
-                    ServicePort {
                         name: "http".into(),
                         port_hint: 6875,
                     },
@@ -340,7 +332,6 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
     let orchestrator = mz_dataflow_types::client::controller::OrchestratorConfig {
         orchestrator,
         computed_image: config.orchestrator.computed_image,
-        storage_addr: storage_service.addresses("compute").into_element(),
         linger: config.orchestrator.linger,
     };
 

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -73,14 +73,6 @@ struct Args {
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
     #[clap(long, value_name = "ID")]
     aws_external_id: Option<String>,
-    /// The address of the storage server to bind or connect to.
-    #[clap(
-        long,
-        env = "STORAGED_STORAGE_ADDR",
-        value_name = "HOST:PORT",
-        default_value = "127.0.0.1:2101"
-    )]
-    storage_addr: String,
     /// Whether or not process should die when connection with ADAPTER is lost.
     #[clap(long)]
     linger: bool,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -32,28 +32,27 @@ SERVICES = [
     Localstack(),
     Computed(
         name="computed_1",
-        options="--workers 2 --processes 2 --process 0 computed_1:2102 computed_2:2102 --storage-addr materialized:2101",
+        options="--workers 2 --processes 2 --process 0 computed_1:2102 computed_2:2102",
         ports=[2100, 2102],
     ),
     Computed(
         name="computed_2",
-        options="--workers 2 --processes 2 --process 1 computed_1:2102 computed_2:2102 --storage-addr materialized:2101",
+        options="--workers 2 --processes 2 --process 1 computed_1:2102 computed_2:2102",
         ports=[2100, 2102],
     ),
     Computed(
         name="computed_3",
-        options="--workers 2 --processes 2 --process 0 computed_3:2102 computed_4:2102 --storage-addr materialized:2101 --linger --reconcile",
+        options="--workers 2 --processes 2 --process 0 computed_3:2102 computed_4:2102 --linger --reconcile",
         ports=[2100, 2102],
     ),
     Computed(
         name="computed_4",
-        options="--workers 2 --processes 2 --process 1 computed_3:2102 computed_4:2102 --storage-addr materialized:2101 --linger --reconcile",
+        options="--workers 2 --processes 2 --process 1 computed_3:2102 computed_4:2102 --linger --reconcile",
         ports=[2100, 2102],
     ),
     Postgres(),
     Materialized(
         options="--persist-consensus-url postgres://postgres:postgres@postgres",
-        extra_ports=[2101],
     ),
     Testdrive(
         volumes=[


### PR DESCRIPTION
Since #12216 separated storage and compute by transiting all data via
the persist library, the compute layer no longer needs to communicate
directly with the storage layer. So remove the configuration parameters
that pertained to the old storage-compute network protocol.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes obsolete code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
