### PR TITLE
bin/cluster-dev: store state in in-cluster postgres

### DIFF
--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -26,6 +26,56 @@ bin/mzimage acquire --dev computed
 bin/mzimage acquire --dev materialized-slim
 
 kubectl apply --context=minikube  -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    app: postgres
+spec:
+  type: NodePort
+  ports:
+  - port: 5432
+    name: sql
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:14.3
+        env:
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
+        ports:
+        - containerPort: 5432
+          name: sql
+        volumeMounts:
+        - name: data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -85,6 +135,8 @@ spec:
             - --orchestrator=kubernetes
             - --orchestrator-service-label=materialize.cloud/example1=label1
             - --orchestrator-service-label=materialize.cloud/example2=label2
+            - --persist-consensus-url=postgres://postgres@postgres.default
+            - --catalog-postgres-stash=postgres://postgres@postgres.default
             - --kubernetes-image-pull-policy=never
             - --user-defined-secret=user-managed-secrets
             - --user-defined-secret-mount-path=/secrets


### PR DESCRIPTION
Materialize recently learned to store catalog and persist state in
Postgres rather than SQLite. Adjust bin/cluster-dev accordingly, by
starting a Postgres server inside the Kubernetes cluster and configuring
Materialize to connect to it.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
