### PR TITLE
python: fix bin/materialized args parsing

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -73,7 +73,7 @@ def main() -> int:
         help="Activate the Tokio console",
         action="store_true",
     )
-    args = parser.parse_args()
+    args = parser.parse_intermixed_args()
 
     # Handle `+toolchain` like rustup.
     args.channel = None


### PR DESCRIPTION
This PR fixes argument parsing for `bin/materialized`. Seems like `argparse` by default gets confused when one mixes options and positional arguments like we do.

### Motivation

  * This PR fixes a previously unreported bug.

    The following invocation fails with "run: error: unrecognized arguments: -- --experimental":

    ```
    $ bin/materialized --release -- --experimental
    ```

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).