### PR TITLE
test,replica-isolation: Fix the drop-create-replica scenario

### DIFF
--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -79,7 +79,7 @@ def drop_create_replica(c: Composition) -> None:
         dedent(
             """
             > DROP CLUSTER REPLICA cluster1.replica1
-            > CREATE CLUSTER REPLICA cluster1.replica3 REMOTE ('computed_2_1:2100', 'computed_2_2:2100')
+            > CREATE CLUSTER REPLICA cluster1.replica3 REMOTE ('computed_1_1:2100', 'computed_1_2:2100')
             """
         )
     )


### PR DESCRIPTION
The scenario was attempted to use computed instances belonging
to another replica.

Patch courtesy of @lluki 


### Motivation

  * This PR fixes a previously unreported bug.

The test was failing in the gRPC PR