### PR TITLE
storage: create a separate service for each source

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -204,6 +204,7 @@ where
                     orchestrator,
                     computed_image,
                     linger,
+                    ..
                 } = &self.orchestrator;
 
                 let service_name = generate_replica_service_name(instance_id, replica_id);

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -60,7 +60,7 @@ pub trait NamespacedOrchestrator: fmt::Debug + Send + Sync {
 }
 
 /// Describes a running service managed by an `Orchestrator`.
-pub trait Service: fmt::Debug {
+pub trait Service: fmt::Debug + Send + Sync {
     /// Given the name of a port, returns the addresses for each of the
     /// service's processes, in order.
     ///


### PR DESCRIPTION
Create a separate orchestrator service for each source. This means a
process per source when running locally and a pod per source when
running in Kubernetes. This is our storage scalability story for
Materialize Platform.

This will cause some fallout. As written, this creates a process for
every system table, which is hefty.

Fix MaterializeInc/cloud#2708.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Review just the last commit! The first two commits are from #12798 and will be rebased away after that PR merges.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
