### PR TITLE
coord,storage: reduce runtime of `Coordinator::advance_local_inputs()`

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -86,7 +86,7 @@ use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch};
-use tracing::warn;
+use tracing::{trace, warn};
 use uuid::Uuid;
 
 use mz_build_info::BuildInfo;
@@ -799,7 +799,13 @@ impl<S: Append + 'static> Coordinator<S> {
             }
 
             if let Some(timestamp) = self.global_timeline.should_advance_to() {
+                let start = Instant::now();
                 self.advance_local_inputs(timestamp).await;
+                trace!(
+                    "advancing table frontiers to {} took: {} ms",
+                    timestamp,
+                    start.elapsed().as_millis()
+                );
             }
         }
     }

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -18,7 +18,7 @@
 //! Eventually, the source is dropped with either `drop_sources()` or by allowing compaction to the
 //! empty frontier.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::error::Error;
 use std::fmt;
 use std::fmt::Debug;
@@ -33,6 +33,10 @@ use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, ChangeBatch, Timestamp};
+use tokio::runtime::Handle;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::task::JoinHandle;
+use tracing::{error, trace, warn};
 use uuid::Uuid;
 
 use mz_persist_client::{
@@ -195,6 +199,7 @@ pub struct StorageControllerState<T: Timestamp + Lattice + Codec64, S = mz_stash
     pub(super) collections: BTreeMap<GlobalId, CollectionState<T>>,
     pub(super) stash: S,
     pub(super) persist_handles: BTreeMap<GlobalId, PersistHandles<T>>,
+    persist_downgrade: PersistWorker<T>,
 }
 
 /// A storage controller for a storage instance.
@@ -280,11 +285,13 @@ impl<T: Timestamp + Lattice + Codec64> StorageControllerState<T> {
     pub(super) fn new(client: Box<dyn StorageClient<T>>, state_dir: PathBuf) -> Self {
         let stash = mz_stash::Sqlite::open(&state_dir.join("storage"))
             .expect("unable to create storage stash");
+        let persist_downgrade = PersistWorker::new();
         Self {
             client,
             collections: BTreeMap::default(),
             stash,
             persist_handles: BTreeMap::default(),
+            persist_downgrade,
         }
     }
 }
@@ -357,7 +364,8 @@ where
                 .expect("invalid persist usage");
             self.state
                 .persist_handles
-                .insert(id, PersistHandles { read, write });
+                .insert(id, PersistHandles { write });
+            self.state.persist_downgrade.register(persist_shard, read);
 
             let timestamp_shard_id = TypedCollection::new("timestamp-shard-id")
                 .insert_without_overwrite(&mut self.state.stash, &id, ShardId::new())
@@ -527,18 +535,14 @@ where
         let mut compaction_commands = Vec::new();
         for (id, change) in storage_net.iter_mut() {
             if !change.is_empty() {
-                let frontier = self
-                    .collection(*id)
-                    .unwrap()
-                    .read_capabilities
-                    .frontier()
-                    .to_owned();
+                let collection = self.collection(*id).unwrap();
+                let frontier = collection.read_capabilities.frontier().to_owned();
 
                 compaction_commands.push((*id, frontier.clone()));
 
-                let handles = self.state.persist_handles.get_mut(id).unwrap();
-
-                handles.read.downgrade_since(frontier).await;
+                self.state
+                    .persist_downgrade
+                    .downgrade(collection.persist_shard, frontier);
             }
         }
 
@@ -639,9 +643,6 @@ pub struct CollectionState<T> {
 
 #[derive(Debug)]
 pub(super) struct PersistHandles<T: Timestamp + Lattice + Codec64> {
-    /// A `ReadHandle` for the backing persist shard/collection. This internally holds back the
-    /// since frontier and we need to downgrade that when the read capabilities change.
-    read: ReadHandle<SourceData, (), T, Diff>,
     write: WriteHandle<SourceData, (), T, Diff>,
 }
 
@@ -663,6 +664,112 @@ impl<T: Timestamp> CollectionState<T> {
             write_frontier: MutableAntichain::new_bottom(Timestamp::minimum()),
             timestamp_shard_id,
             persist_shard,
+        }
+    }
+}
+
+/// A wrapper that holds on to backing persist shards/collections that the
+/// storage controller is aware of. The handles hold back the since frontier and
+/// we need to downgrade them when the read capabilities change.
+///
+/// Internally, this has an async task and the methods for registering a handle
+/// and downgrading sinces add commands to a queue that this task is working
+/// off. This makes the methods non-blocking and moves the work outside the main
+/// coordinator task, meaning the coordinator is spending less time waiting on
+/// persist calls.
+#[derive(Debug)]
+struct PersistWorker<T: Timestamp + Lattice + Codec64> {
+    tx: UnboundedSender<PersistWorkerCmd<T>>,
+    handle: Option<JoinHandle<Result<(), anyhow::Error>>>,
+}
+
+impl<T> Drop for PersistWorker<T>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    fn drop(&mut self) {
+        self.send(PersistWorkerCmd::Shutdown);
+
+        let handle = match Handle::try_current() {
+            Ok(x) => x,
+            Err(_) => {
+                warn!("PersistDowngrade dropped without a tokio Runtime present, cannot join on handle");
+                return;
+            }
+        };
+
+        let res = handle
+            .block_on(self.handle.take().expect("missing join handle"))
+            .expect("join error");
+
+        match res {
+            Ok(()) => (), // All good!
+            Err(e) => {
+                error!("error while shutting down PersistDowngrade: {}", e)
+            }
+        }
+    }
+}
+
+/// Commands for [PersistWorker].
+#[derive(Debug)]
+enum PersistWorkerCmd<T: Timestamp + Lattice + Codec64> {
+    Register(ShardId, ReadHandle<SourceData, (), T, Diff>),
+    Downgrade(ShardId, Antichain<T>),
+    Shutdown,
+}
+
+impl<T: Timestamp + Lattice + Codec64> PersistWorker<T> {
+    fn new() -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let handle = mz_ore::task::spawn(|| "PersistDowngrade", async move {
+            let mut read_handles: HashMap<ShardId, ReadHandle<SourceData, (), T, Diff>> =
+                HashMap::new();
+
+            while let Some(cmd) = rx.recv().await {
+                match cmd {
+                    PersistWorkerCmd::Register(shard_id, read_handle) => {
+                        let previous = read_handles.insert(shard_id, read_handle);
+                        if previous.is_some() {
+                            panic!("already registered a ReadHandle for shard {:?}", shard_id);
+                        }
+                    }
+                    PersistWorkerCmd::Downgrade(shard_id, since) => {
+                        let read_handle =
+                            read_handles.get_mut(&shard_id).expect("missing ReadHandle");
+                        read_handle.downgrade_since(since).await;
+                    }
+                    PersistWorkerCmd::Shutdown => {
+                        trace!("shutting down persist since downgrade task");
+                        break;
+                    }
+                }
+            }
+
+            Ok(())
+        });
+
+        Self {
+            tx,
+            handle: Some(handle),
+        }
+    }
+
+    fn register(&self, shard_id: ShardId, read_handle: ReadHandle<SourceData, (), T, Diff>) {
+        self.send(PersistWorkerCmd::Register(shard_id, read_handle))
+    }
+
+    fn downgrade(&self, shard_id: ShardId, since: Antichain<T>) {
+        self.send(PersistWorkerCmd::Downgrade(shard_id, since))
+    }
+
+    fn send(&self, cmd: PersistWorkerCmd<T>) {
+        match self.tx.send(cmd) {
+            Ok(()) => (), // All good!
+            Err(e) => {
+                error!("could not forward command: {:?}", e);
+            }
         }
     }
 }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -48,7 +48,7 @@ use crate::ShardId;
 /// tokio::time::timeout(timeout, write.fetch_recent_upper()).await
 /// # };
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WriteHandle<K, V, T, D>
 where
     T: Timestamp + Lattice + Codec64,


### PR DESCRIPTION
### Motivation

That method, which is invoked at least every `timestamp_interval` is blocking the main coordinator task, and therefore should run as quickly as possible.

This adds multiple mitigations that work towards reducing the runtime of `advance_local_inputs()`.

### Tips for reviewer

The first commit adds duration logging, which allows us to look into things. The rest of the individual commits have meaningful commit messages.

I used

```
 bin/mzcompose --find limits run default --scenario Tables
```

to understand the baseline performance and to gauge the impact of the two main changes. I did reduce `COUNT` to `100` in `tests/limits.mzcompose.py`, though, in order to not have to wait too long.

Impact of mitigations (runtime numbers on my linux machine):

1. Without any mitigations, at around 100 tables the runtime of `advance_local_inputs()` is about 320ms.
2. With "moving downgrades to separate task" and "parallelize appending", runtime goes down to about 150ms.
3. With Petros' experimental `PersistConsensus` rework, runtime goes down to about 100ms.

The last commit is from #12699 and should not be merged along with these changes. It's only in here to get a feel for its impact.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.