### PR TITLE
Empty clusters

### DIFF
--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -88,7 +88,10 @@ Adding replicas to clusters | See [Cluster replica scaling](/sql/create-cluster#
 ## Example
 
 ```sql
-CREATE CLUSTER c1 REPLICA r1 (SIZE = 'medium'), REPLICA r2 (SIZE = 'medium');
+CREATE CLUSTER c1 REPLICAS (r1 (SIZE = 'medium'), r2 (SIZE = 'medium'));
+
+-- Create an empty cluster
+CREATE CLUSTER c1 REPLICAS ();
 ```
 
 [AWS availability zone ID]: https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -907,8 +907,8 @@ pub enum ClusterOption<T: AstInfo> {
     IntrospectionGranularity(WithOptionValue<T>),
     /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
     IntrospectionDebugging(WithOptionValue<T>),
-    /// The `REPLICA` option.
-    Replica(ReplicaDefinition<T>),
+    /// The `REPLICAS` option.
+    Replicas(Vec<ReplicaDefinition<T>>),
 }
 
 impl<T: AstInfo> AstDisplay for ClusterOption<T> {
@@ -922,11 +922,9 @@ impl<T: AstInfo> AstDisplay for ClusterOption<T> {
                 f.write_str("INTROSPECTION DEBUGGING ");
                 f.write_node(debugging);
             }
-            ClusterOption::Replica(replica) => {
-                f.write_str("REPLICA ");
-                f.write_node(&replica.name);
-                f.write_str(" (");
-                f.write_node(&display::comma_separated(&replica.options));
+            ClusterOption::Replicas(replicas) => {
+                f.write_str("REPLICAS (");
+                f.write_node(&display::comma_separated(&replicas));
                 f.write_str(")");
             }
         }
@@ -940,6 +938,18 @@ pub struct ReplicaDefinition<T: AstInfo> {
     /// The comma-separated options.
     pub options: Vec<ReplicaOption<T>>,
 }
+
+// Note that this display is meant for replicas defined inline when creating
+// clusters.
+impl<T: AstInfo> AstDisplay for ReplicaDefinition<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        f.write_str(" (");
+        f.write_node(&display::comma_separated(&self.options));
+        f.write_str(")");
+    }
+}
+impl_display_t!(ReplicaDefinition);
 
 /// `CREATE CLUSTER REPLICA ..`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2571,6 +2571,7 @@ impl<'a> Parser<'a> {
         } else {
             self.parse_comma_separated(Parser::parse_cluster_option)?
         };
+
         Ok(Statement::CreateCluster(CreateClusterStatement {
             name,
             options,
@@ -2601,13 +2602,24 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_cluster_option(&mut self) -> Result<ClusterOption<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[REPLICA, INTROSPECTION])? {
-            REPLICA => {
-                let name = self.parse_identifier()?;
+        match self.expect_one_of_keywords(&[REPLICAS, INTROSPECTION])? {
+            REPLICAS => {
                 self.expect_token(&Token::LParen)?;
-                let options = self.parse_comma_separated(Parser::parse_replica_option)?;
+
+                let replicas = if self.peek_token() == Some(Token::RParen) {
+                    vec![]
+                } else {
+                    self.parse_comma_separated(|parser| {
+                        let name = parser.parse_identifier()?;
+                        parser.expect_token(&Token::LParen)?;
+                        let options = parser.parse_comma_separated(Parser::parse_replica_option)?;
+                        parser.expect_token(&Token::RParen)?;
+                        Ok(ReplicaDefinition { name, options })
+                    })?
+                };
+
                 self.expect_token(&Token::RParen)?;
-                Ok(ClusterOption::Replica(ReplicaDefinition { name, options }))
+                Ok(ClusterOption::Replicas(replicas))
             }
             INTROSPECTION => match self.expect_one_of_keywords(&[DEBUGGING, GRANULARITY])? {
                 DEBUGGING => {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1098,56 +1098,67 @@ ALTER INDEX i1
               ^
 
 parse-statement
-CREATE CLUSTER cluster
+CREATE CLUSTER cluster REPLICAS ()
 ----
-CREATE CLUSTER cluster
+CREATE CLUSTER cluster REPLICAS ()
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([])] })
 
 parse-statement
-CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
 ----
-CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionGranularity(Value(String("1s")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster INTROSPECTION GRANULARITY = '1s'
+CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s', REPLICAS ()
 ----
-CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s', REPLICAS ()
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionGranularity(Value(String("1s")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionGranularity(Value(String("1s"))), Replicas([])] })
 
 parse-statement
-CREATE CLUSTER cluster WITH INTROSPECTION GRANULARITY = '1s'
-
-parse-statement
-CREATE CLUSTER cluster BADOPT
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = '1s'
 ----
-error: Expected end of statement, found identifier "parse"
-parse-statement
-^
-
-parse-statement
-CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'))
-----
-CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'))
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica(ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] })] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICA a (REMOTE ('host1')), INTROSPECTION GRANULARITY '1s', REPLICA b (SIZE '1')
+CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION GRANULARITY = '1s'
 ----
-CREATE CLUSTER cluster REPLICA a (REMOTE ('host1')), INTROSPECTION GRANULARITY '1s', REPLICA b (SIZE '1')
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica(ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] }), IntrospectionGranularity(Value(String("1s"))), Replica(ReplicaDefinition { name: Ident("b"), options: [Size(Value(String("1")))] })] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'), SIZE '1')
+CREATE CLUSTER cluster REPLICAS (), BADOPT
 ----
-CREATE CLUSTER cluster REPLICA a (REMOTE ('host1'), SIZE '1')
+error: Expected one of REPLICAS or INTROSPECTION, found identifier "badopt"
+CREATE CLUSTER cluster REPLICAS (), BADOPT
+                                    ^
+
+parse-statement
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')))
+----
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica(ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }, Size(Value(String("1")))] })] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] }])] })
+
+parse-statement
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
+----
+error: Expected end of statement, found INTROSPECTION
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
+                                                                     ^
+
+parse-statement
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1'), SIZE '1'))
+----
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1'), SIZE '1'))
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }, Size(Value(String("1")))] }])] })
 
 parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ('host1')

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2804,7 +2804,7 @@ pub fn plan_create_cluster(
     _: &StatementContext,
     CreateClusterStatement { name, options }: CreateClusterStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
-    let mut replicas = vec![];
+    let mut replicas_definitions = None;
     let mut introspection_debugging = None;
     let mut introspection_granularity = None;
 
@@ -2823,14 +2823,24 @@ pub fn plan_create_cluster(
                 introspection_granularity =
                     Some(with_option_type!(Some(interval), OptionalInterval));
             }
-            ClusterOption::Replica(replica) => {
-                replicas.push((
-                    normalize::ident(replica.name),
-                    plan_replica_config(replica.options)?,
-                ));
+            ClusterOption::Replicas(replicas) => {
+                if replicas_definitions.is_some() {
+                    bail!("REPLICAS specified more than once");
+                }
+
+                let mut defs = Vec::with_capacity(replicas.len());
+                for ReplicaDefinition { name, options } in replicas {
+                    defs.push((normalize::ident(name), plan_replica_config(options)?));
+                }
+                replicas_definitions = Some(defs);
             }
         }
     }
+
+    let replicas = match replicas_definitions {
+        Some(r) => r,
+        None => bail_unsupported!("CLUSTER without REPLICAS option"),
+    };
 
     let introspection_granularity =
         introspection_granularity.unwrap_or(Some(DEFAULT_INTROSPECTION_GRANULARITY));

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -233,14 +233,14 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.sql(
             """
             DROP CLUSTER IF EXISTS cluster1 CASCADE;
-            CREATE CLUSTER cluster1 REPLICA replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100'));
+            CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')));
             """
         )
 
         c.sql(
             """
             DROP CLUSTER IF EXISTS cluster2 CASCADE;
-            CREATE CLUSTER cluster2 REPLICA replica1 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'));
+            CREATE CLUSTER cluster2 REPLICAS (replica1 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100')));
             """
         )
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -98,7 +98,7 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.up("computed_2")
     c.sql("DROP CLUSTER IF EXISTS cluster1 CASCADE;")
     c.sql(
-        "CREATE CLUSTER cluster1 REPLICA replica1 (REMOTE ('computed_1:2100', 'computed_2:2100'));"
+        "CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ('computed_1:2100', 'computed_2:2100')));"
     )
     c.run("testdrive", *glob)
 
@@ -128,7 +128,7 @@ def test_github_12251(c: Composition) -> None:
     c.sql(
         """
         DROP CLUSTER IF EXISTS cluster1 CASCADE;
-        CREATE CLUSTER cluster1 REPLICA replica1 (REMOTE ('computed_1:2100'));
+        CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ('computed_1:2100')));
         SET cluster = cluster1;
         """
     )

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1121,9 +1121,10 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.sql(
             """
-            CREATE CLUSTER cluster1
-            REPLICA replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')),
-            REPLICA replica2 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'))
+            CREATE CLUSTER cluster1 REPLICAS (
+                replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')),
+                replica2 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'))
+            )
         """
         )
 
@@ -1233,8 +1234,9 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     )
 
                 c.sql(
-                    f"CREATE CLUSTER cluster_{cluster_id} "
+                    f"CREATE CLUSTER cluster_{cluster_id} REPLICAS ("
                     + ",".join(replica_definitions)
+                    + ")"
                 )
 
             # Construct some dataflows in each cluster

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -216,9 +216,10 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
 
         c.sql(
             """
-            CREATE CLUSTER cluster1
-            REPLICA replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')),
-            REPLICA replica2 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'))
+            CREATE CLUSTER cluster1 REPLICAS (
+                replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')),
+                replica2 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'))
+            )
             """
         )
 

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -11,25 +11,31 @@
 
 mode cockroach
 
-statement ok
+statement error CLUSTER without REPLICAS option not yet supported
 CREATE CLUSTER foo
+
+statement ok
+CREATE CLUSTER foo REPLICAS ()
 
 statement ok
 DROP CLUSTER foo
 
+statement error REPLICAS specified more than once
+CREATE CLUSTER foo REPLICAS (), REPLICAS()
+
 # Creating cluster w/ remote replica works.
 
 statement ok
-CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234'))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234')))
 
 statement error cluster 'foo' already exists
-CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234'))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234')))
 
 statement error cannot create multiple replicas named 'r1' on cluster 'bar'
-CREATE CLUSTER bar REPLICA r1 (REMOTE ('localhost:1234')), REPLICA r1 (REMOTE ('localhost:1234'))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1234')), r1 (REMOTE ('localhost:1234')))
 
 statement ok
-CREATE CLUSTER bar REPLICA r1 (REMOTE ('localhost:1235')), REPLICA r2 (REMOTE ('localhost:1236'))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1235')), r2 (REMOTE ('localhost:1236')))
 
 query TT rowsort
 SELECT * FROM mz_clusters
@@ -52,11 +58,8 @@ default
 
 # Test invalid option combinations.
 
-statement error Expected one of REPLICA or INTROSPECTION, found SIZE
-CREATE CLUSTER baz SIZE 'small'
-
 statement error only one of REMOTE or SIZE may be specified
-CREATE CLUSTER baz REPLICA r1 (REMOTE ('localhost:1234'), SIZE 'small')
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ('localhost:1234'), SIZE 'small'))
 
 # Test `cluster` session variable.
 
@@ -172,7 +175,7 @@ statement ok
 DROP CLUSTER foo
 
 statement ok
-CREATE CLUSTER baz REPLICA r1 (REMOTE ('localhost:1234'))
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ('localhost:1234')))
 
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
@@ -189,13 +192,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234')), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234'))), INTROSPECTION GRANULARITY '1s'
 
 statement ok
 DROP CLUSTER foo
 
 statement ok
-CREATE CLUSTER foo REPLICA r1 (REMOTE ('localhost:1234')), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234'))), INTROSPECTION GRANULARITY '1s'
 
 statement ok
 DROP CLUSTER foo
@@ -203,16 +206,16 @@ DROP CLUSTER foo
 # Test that bad cluster sizes don't cause a crash
 
 statement error unknown cluster replica size
-CREATE CLUSTER foo REPLICA a (SIZE 'lol')
+CREATE CLUSTER foo REPLICAS (a (SIZE 'lol'))
 
 statement ok
-CREATE CLUSTER foo REPLICA a (SIZE '1')
+CREATE CLUSTER foo REPLICAS (a (SIZE '1'))
 
 statement ok
-CREATE CLUSTER foo2 REPLICA a (SIZE '32')
+CREATE CLUSTER foo2 REPLICAS (a (SIZE '32'))
 
 statement ok
-CREATE CLUSTER foo3 REPLICA a (SIZE '2-2')
+CREATE CLUSTER foo3 REPLICAS (a (SIZE '2-2'))
 
 statement ok
 DROP CLUSTER foo, foo2, foo3 CASCADE
@@ -231,7 +234,7 @@ SELECT COUNT(name) FROM mz_indexes WHERE cluster_id <> 1;
 0
 
 statement ok
-CREATE CLUSTER test REPLICA foo (SIZE '1');
+CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 
 query I
 SELECT COUNT(name) FROM mz_indexes;
@@ -256,7 +259,7 @@ default default_replica
 default size_1
 
 statement ok
-CREATE CLUSTER foo REPLICA size_1 (SIZE '1'), REPLICA size_2 (SIZE '2')
+CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 
 query TT
 SHOW CLUSTER REPLICAS
@@ -307,7 +310,7 @@ CREATE CLUSTER REPLICA default."好_好" SIZE '1'
 # clusters wo replicas cannot service selects
 
 statement ok
-CREATE CLUSTER empty
+CREATE CLUSTER empty REPLICAS ()
 
 statement ok
 SET cluster = empty
@@ -325,25 +328,25 @@ statement error unknown cluster
 CREATE CLUSTER REPLICA no_such_cluster.size_1 SIZE '1';
 
 statement error expected String or bare identifier
-CREATE CLUSTER foo REPLICA size_2 (SIZE NULL);
+CREATE CLUSTER foo REPLICAS (size_2 (SIZE NULL));
 
 statement error unknown cluster replica size
-CREATE CLUSTER foo REPLICA size_2 (SIZE '');
+CREATE CLUSTER foo REPLICAS (size_2 (SIZE ''));
 
 statement error unknown cluster replica size
-CREATE CLUSTER foo REPLICA size_2 (SIZE 'no_such_size');
+CREATE CLUSTER foo REPLICAS (size_2 (SIZE 'no_such_size'));
 
 statement error expected String or bare identifier
-CREATE CLUSTER foo REPLICA size_2 (SIZE 1);
+CREATE CLUSTER foo REPLICAS (size_2 (SIZE 1));
 
 statement error unknown cluster replica size
-CREATE CLUSTER foo REPLICA size_2 (SIZE a);
+CREATE CLUSTER foo REPLICAS (size_2 (SIZE a));
 
 statement ok
 DROP CLUSTER foo CASCADE;
 
 statement ok
-CREATE CLUSTER foo REPLICA size_2 (SIZE '1');
+CREATE CLUSTER foo REPLICAS (size_2 (SIZE '1'));
 
 statement ok
 SET cluster=foo

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -12,7 +12,7 @@
 mode cockroach
 
 statement ok
-create cluster c replica r1 (remote ('1.0:1234'))
+create cluster c replicas (r1 (remote ('1.0:1234')))
 
 statement ok
 set cluster = c

--- a/test/sqllogictest/github-12674.slt
+++ b/test/sqllogictest/github-12674.slt
@@ -15,10 +15,10 @@ CREATE SOURCE test_source FROM PUBNUB
   CHANNEL 'pubnub-market-orders'
 
 statement ok
-CREATE CLUSTER with_index REPLICA r (SIZE '1')
+CREATE CLUSTER with_index REPLICAS (r (SIZE '1'))
 
 statement ok
-CREATE CLUSTER without_index REPLICA r (SIZE '1')
+CREATE CLUSTER without_index REPLICAS (r (SIZE '1'))
 
 statement ok
 SET CLUSTER = with_index

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -17,8 +17,10 @@ INSERT INTO test VALUES('a', 'b')
 
 statement ok
 CREATE CLUSTER test
-  REPLICA replica_a (SIZE '1'),
-  REPLICA replica_b (SIZE '2'),
+  REPLICAS (
+    replica_a (SIZE '1'),
+    replica_b (SIZE '2')
+  ),
   INTROSPECTION GRANULARITY '50 milliseconds'
 
 statement ok
@@ -120,7 +122,7 @@ DROP CLUSTER test CASCADE
 
 statement ok
 CREATE CLUSTER test
-  REPLICA replica_a (SIZE '1'),
+  REPLICAS (replica_a (SIZE '1')),
   INTROSPECTION GRANULARITY 'off'
 
 query error cannot read log sources on cluster with disabled introspection

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -226,7 +226,7 @@ contains:unknown catalog item 'nonexistent'
 ! SHOW INDEX FROM foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
 
-> CREATE CLUSTER clstr REPLICA r1 (REMOTE ('localhost:1234'))
+> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ('localhost:1234')))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
 > SHOW INDEXES IN CLUSTER clstr WHERE on_name = 'foo'
 clstr foo  foo_primary_idx1   1  a       <null>                     false

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -232,7 +232,7 @@ cluster    name        type  volatility
   WITH (partition_count=-1, replication_factor=-1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE CLUSTER clstr REPLICA r1 (REMOTE ('localhost:1234'))
+> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ('localhost:1234')))
 
 > CREATE SINK clstr_sink
   IN CLUSTER clstr FROM src


### PR DESCRIPTION
@JLDLaughlin identified an issue with some ergonomics around `CREATE CLUSTER` in #12736; @benesch proposed a fix in ##12769, which I've implemented here.

Note that I have not updated the docs to reflect this in case we pivot. Once this merges will amend docs as a fast-follow.

### Motivation

This PR adds a known-desirable feature. #12769

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
