### PR TITLE
storage: don't render sources for tables

### DIFF
--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -102,7 +102,6 @@ pub fn serve(config: Config) -> Result<(Server, LocalStorageClient), anyhow::Err
             timely_worker,
             command_rx,
             storage_state: StorageState {
-                table_state: HashMap::new(),
                 source_descriptions: HashMap::new(),
                 source_uppers: HashMap::new(),
                 persist_handles: HashMap::new(),


### PR DESCRIPTION
Since #12216, tables are now entirely handled by the controller. There
is no longer a need to send a `CreateSourceCommand` to the `storaged`
process for table sources.

We should eventually adjust the types here to enforce this statically,
but this quick fix will unblock #12770.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
