### PR TITLE
persist: make info logging less spammy

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -559,6 +559,8 @@ where
             // Keep trying, it'll show up. The deadline will eventually bail
             // us out of this loop if something has gone wrong internally.
             None => {
+                // This is quite unexpected given that our initial blobs _are_
+                // linearizable, so always log at info.
                 info!(
                     "unexpected missing blob, trying again in {:?}: {}",
                     retry.next_sleep(),


### PR DESCRIPTION
A number of these happen often enough that the show up regularly in the
logs. We've received the question of whether they are ignorable a number
of times (plus it's spammy), so downgrade the first few attempts through
each of the retry loops to debug!.

I tried to use `tracing::event` and pass it a tracing::Level instead of
duplicating the log message in both halves of an if branch, but it
complained. Knowing the impl of tracing, this makes sense, but it's a
touch unfortunate. I wonder if there's still some way to accomplish the
same thing without so much duplication.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
