### PR TITLE
tracing: log chosen tokio-console port in orchestrator-tracing

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -191,7 +191,7 @@ where
     };
 
     #[cfg(feature = "tokio-console")]
-    let tokio_console_layer = if let Some(console_config) = config.tokio_console {
+    let tokio_console_layer = if let Some(console_config) = config.tokio_console.clone() {
         let layer = ConsoleLayer::builder()
             .server_addr(console_config.listen_addr)
             .publish_interval(console_config.publish_interval)
@@ -208,6 +208,14 @@ where
     #[cfg(feature = "tokio-console")]
     let stack = stack.with(tokio_console_layer);
     stack.init();
+
+    #[cfg(feature = "tokio-console")]
+    if let Some(console_config) = config.tokio_console {
+        tracing::info!(
+            "starting tokio console on http://{}",
+            console_config.listen_addr
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
- I chose to do this in both the orchestrator AND the process itself, as it makes it more clear what is going on.
- I changed the name of the storaged service from `runtime` to `storaged`, when @benesch's pr https://github.com/MaterializeInc/materialize/pull/12770 rebases with this, the id will have to change

### Motivation


   * This PR refactors existing code.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None