### PR TITLE
persist: also return Determinate errors from unreliable

### DIFF
--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -21,6 +21,7 @@ use std::sync::Once;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
 use mz_ore::cli::{self, CliConfig};
+use mz_ore::task::RuntimeExt;
 
 pub mod maelstrom;
 pub mod open_loop;
@@ -56,7 +57,15 @@ fn main() {
         .expect("Failed building the Runtime");
 
     let res = match args.command {
-        Command::Maelstrom(args) => crate::maelstrom::txn::run(args),
+        Command::Maelstrom(args) => runtime.block_on(async {
+            // Run the maelstrom stuff in a spawn_blocking because it internally
+            // spawns tasks, so the runtime need to be in the TLC.
+            runtime
+                .handle()
+                .spawn_blocking_named(|| "maelstrom::run", || crate::maelstrom::txn::run(args))
+                .await
+                .expect("task failed")
+        }),
         Command::OpenLoop(args) => runtime.block_on(crate::open_loop::run(args)),
         Command::SourceExample(args) => runtime.block_on(crate::source_example::run(args)),
     };

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -65,7 +65,7 @@ impl SeqNo {
 /// that the operation _definitely did NOT succeed_ (e.g. permission denied).
 #[derive(Debug)]
 pub struct Determinate {
-    pub(crate) inner: anyhow::Error,
+    inner: anyhow::Error,
 }
 
 impl std::fmt::Display for Determinate {
@@ -75,6 +75,15 @@ impl std::fmt::Display for Determinate {
 }
 
 impl std::error::Error for Determinate {}
+
+impl Determinate {
+    /// Return a new Determinate wrapping the given error.
+    ///
+    /// Exposed for testing via [crate::unreliable].
+    pub(crate) fn new(inner: anyhow::Error) -> Self {
+        Determinate { inner }
+    }
+}
 
 /// An error coming from an underlying durability system (e.g. s3) indicating
 /// that the operation _might have succeeded_ (e.g. timeout).


### PR DESCRIPTION
The investigation of why maelstrom ops errored more than my mental model
said they should revealed two sources of mismatch. The first was that
unreliable always returned (indeterminate) timeout errors, which was a
bug that this commit fixes. (The other was that my mental model didn't
account for CaS failures when the state was out of date.)

Also included is some debugging changes that were helpful in tracing
this down. Finally, there are also a couple small fixes for ways this
has rotted given that I haven't gotten a chance to hook it up to CI yet.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
