### PR TITLE
tracing: add identifying information to log prefixes in the process orchestrator

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -404,7 +404,11 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     // Configure tracing to log the service name when using the process
     // orchestrator, which intermingles log output from multiple services. Other
     // orchestrators separate log output from different services.
-    args.tracing.log_include_service_name = matches!(args.orchestrator, Orchestrator::Process);
+    args.tracing.log_prefix = if matches!(args.orchestrator, Orchestrator::Process) {
+        Some("materialized".to_string())
+    } else {
+        None
+    };
     runtime.block_on(mz_ore::tracing::configure("materialized", &args.tracing))?;
 
     // Initialize fail crate for failpoint support

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -67,7 +67,8 @@ pub struct TracingConfig {
 #[derive(Debug, Clone)]
 pub struct StderrLogConfig {
     /// Whether to prefix each log line with the service name.
-    pub include_service_name: bool,
+    /// An optional prefix for each stderr log line.
+    pub prefix: Option<String>,
     /// A filter which determines which events are emitted to the log.
     pub filter: Targets,
 }
@@ -135,10 +136,7 @@ where
     let stderr_log_layer = fmt::layer()
         .event_format(PrefixFormat {
             inner: format(),
-            prefix: config
-                .stderr_log
-                .include_service_name
-                .then(|| service_name.to_string()),
+            prefix: config.stderr_log.prefix,
         })
         .with_writer(io::stderr)
         .with_ansi(atty::is(atty::Stream::Stderr))


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/12785, @benesch and I realized that stuff can be cleaned up if we just make the log-prefix much more clear!

### Motivation

  * This PR adds a feature that has not yet been specified.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
