### PR TITLE
storage: read debezium transactional metadata from persist

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5113,7 +5113,7 @@ pub mod fast_path_peek {
 
     #[derive(Debug)]
     pub struct PeekDataflowPlan<T> {
-        desc: mz_dataflow_types::DataflowDescription<mz_dataflow_types::Plan<T>, (), T>,
+        desc: mz_dataflow_types::DataflowDescription<mz_dataflow_types::Plan<T>, GlobalId, T>,
         id: GlobalId,
         key: Vec<MirScalarExpr>,
         permutation: HashMap<usize, usize>,

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -309,7 +309,7 @@ pub struct CreateSourceCommand<T> {
     /// The source identifier
     pub id: GlobalId,
     /// The source description
-    pub desc: SourceDesc,
+    pub desc: SourceDesc<CollectionMetadata>,
     /// The initial `since` frontier
     pub since: Antichain<T>,
     /// Additional storage controller metadata needed to ingest this source

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -37,7 +37,7 @@ use crate::client::replicated::ActiveReplication;
 use crate::client::{ComputeClient, ComputeCommand, ComputeInstanceId, InstanceConfig, ReplicaId};
 use crate::client::{GenericClient, Peek};
 use crate::logging::LoggingConfig;
-use crate::{DataflowDescription, SourceInstanceDesc};
+use crate::DataflowDescription;
 use mz_expr::RowSetFinishing;
 use mz_repr::{GlobalId, Row};
 
@@ -244,7 +244,7 @@ where
     /// always able to return to a state that can serve the output read capabilities.
     pub async fn create_dataflows(
         &mut self,
-        dataflows: Vec<DataflowDescription<crate::plan::Plan<T>, (), T>>,
+        dataflows: Vec<DataflowDescription<crate::plan::Plan<T>, GlobalId, T>>,
     ) -> Result<(), ComputeError> {
         // Validate dataflows as having inputs whose `since` is less or equal to the dataflow's `as_of`.
         // Start tracking frontiers for each dataflow, using its `as_of` for each index and sink.
@@ -341,28 +341,9 @@ where
         // the compute instance to read them
         let mut augmented_dataflows = Vec::with_capacity(dataflows.len());
         for d in dataflows {
-            let mut source_imports = BTreeMap::new();
-            for (id, si) in d.source_imports {
-                let metadata = self.storage_controller.collection_metadata(id)?;
-                let desc = SourceInstanceDesc {
-                    description: si.description,
-                    storage_metadata: metadata,
-                    arguments: si.arguments,
-                };
-                source_imports.insert(id, desc);
-            }
-
-            augmented_dataflows.push(DataflowDescription {
-                source_imports,
-                // The rest of the fields are identical
-                index_imports: d.index_imports,
-                objects_to_build: d.objects_to_build,
-                index_exports: d.index_exports,
-                sink_exports: d.sink_exports,
-                as_of: d.as_of,
-                debug_name: d.debug_name,
-                id: d.id,
-            });
+            let augmented_dataflow =
+                d.map_storage_metadata(&mut |id| self.storage_controller.collection_metadata(id))?;
+            augmented_dataflows.push(augmented_dataflow);
         }
 
         self.compute

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -375,7 +375,7 @@ where
             if matches!(desc.connector, SourceConnector::External { .. }) {
                 dataflow_commands.push(CreateSourceCommand {
                     id,
-                    desc,
+                    desc: desc.map_storage_metadata(&mut |id| self.collection_metadata(id))?,
                     since,
                     storage_metadata: self.collection_metadata(id)?,
                 });

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -16,6 +16,7 @@ import "repr/src/global_id.proto";
 import "repr/src/proto.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
+import "dataflow-types/src/client/controller/storage.proto";
 import "dataflow-types/src/errors.proto";
 import "dataflow-types/src/postgres_source.proto";
 import "dataflow-types/src/types/aws.proto";
@@ -90,7 +91,7 @@ message ProtoDebeziumEnvelope {
 }
 
 message ProtoDebeziumTransactionMetadata {
-    mz_repr.global_id.ProtoGlobalId tx_metadata_global_id = 1;
+    mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata tx_metadata_storage_metadata = 1;
     uint64 tx_status_idx = 2;
     uint64 tx_transaction_id_idx = 3;
     uint64 tx_data_collections_idx = 4;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1235,7 +1235,7 @@ fn typecheck_debezium_transaction_metadata(
     };
 
     Ok(DebeziumTransactionMetadata {
-        tx_metadata_global_id,
+        tx_metadata_storage_metadata: tx_metadata_global_id,
         tx_status_idx,
         tx_transaction_id_idx,
         tx_data_collections_idx,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -100,7 +100,7 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use timely::communication::Allocate;
 use timely::dataflow::Scope;
@@ -155,7 +155,7 @@ pub fn build_storage_dataflow<A: Allocate>(
                 source.storage_metadata,
                 source_data,
                 storage_state,
-                Arc::clone(&token),
+                Rc::clone(&token),
             );
 
             storage_state.source_tokens.insert(source.id, token);

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -10,7 +10,6 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::channels::pact::Exchange;
@@ -32,7 +31,7 @@ pub fn render<G>(
     storage_metadata: CollectionMetadata,
     source_data: Collection<G, Result<Row, DataflowError>, Diff>,
     storage_state: &mut StorageState,
-    token: Arc<dyn Any + Send + Sync>,
+    token: Rc<dyn Any>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -54,7 +53,7 @@ pub fn render<G>(
 
     let shared_frontier = Rc::clone(&storage_state.source_uppers[&src_id]);
 
-    let weak_token = Arc::downgrade(&token);
+    let weak_token = Rc::downgrade(&token);
 
     persist_op.build_async(
         scope.clone(),

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -11,7 +11,8 @@
 //!
 //! See [`render_source`] for more details.
 
-use std::sync::Arc;
+use std::any::Any;
+use std::rc::Rc;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::consolidate::ConsolidateStream;
@@ -77,7 +78,7 @@ pub fn render_source<G>(
     storage_state: &mut crate::storage_state::StorageState,
 ) -> (
     (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>),
-    Arc<dyn std::any::Any + Send + Sync>,
+    Rc<dyn Any>,
 )
 where
     G: Scope<Timestamp = Timestamp>,
@@ -90,7 +91,7 @@ where
     }
 
     // Tokens that we should return from the method.
-    let mut needed_tokens: Vec<Arc<dyn std::any::Any + Send + Sync>> = Vec::new();
+    let mut needed_tokens: Vec<Rc<dyn Any>> = Vec::new();
 
     // Before proceeding, we may need to remediate sources with non-trivial relational
     // expressions that post-process the bare source. If the expression is trivial, a
@@ -248,7 +249,7 @@ where
                         schema_registry_config,
                         confluent_wire_format,
                     );
-                    needed_tokens.push(Arc::new(token));
+                    needed_tokens.push(Rc::new(token));
                     (oks, None)
                 } else {
                     // Depending on the type of _raw_ source produced for the given source
@@ -309,7 +310,7 @@ where
                         ),
                     };
                     if let Some(tok) = extra_token {
-                        needed_tokens.push(Arc::new(tok));
+                        needed_tokens.push(Rc::new(tok));
                     }
 
                     // render envelopes
@@ -493,12 +494,12 @@ where
             // Consolidate the results, as there may now be cancellations.
             collection = collection.consolidate_stream();
 
-            let source_token = Arc::new(capability);
+            let source_token = Rc::new(capability);
 
             needed_tokens.push(source_token);
 
             // Return the collections and any needed tokens.
-            ((collection, err_collection), Arc::new(needed_tokens))
+            ((collection, err_collection), Rc::new(needed_tokens))
         }
     }
 }

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -22,9 +22,11 @@
 // https://github.com/tokio-rs/prost/issues/237
 #![allow(missing_docs)]
 
+use std::cell::RefCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
+use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
@@ -43,6 +45,7 @@ use timely::dataflow::operators::{Capability, Event};
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
 use timely::scheduling::activate::SyncActivator;
+use timely::scheduling::Activator;
 use timely::Data;
 use tokio::time::MissedTickBehavior;
 use tracing::error;
@@ -310,21 +313,18 @@ where
     }
 }
 
-// TODO(guswynn): consider moving back to non-thread-safe `RC`'s if
-// we end up with a boundary-per-worker
-// TODO(guswynn): consider just using `SyncActivateOnDrop` if merged into timely
-/// A `SourceToken` manages interest in a source, and is thread-safe.
+/// A `SourceToken` manages interest in a source.
 ///
 /// When the `SourceToken` is dropped the associated source will be stopped.
 pub struct SourceToken {
-    pub activator: Arc<SyncActivator>,
+    capability: Rc<RefCell<Option<Capability<Timestamp>>>>,
+    activator: Activator,
 }
 
 impl Drop for SourceToken {
     fn drop(&mut self) {
-        // Best effort: sync activation
-        // failures are ignored
-        let _ = self.activator.activate();
+        *self.capability.borrow_mut() = None;
+        self.activator.activate();
     }
 }
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -9,7 +9,6 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crossbeam_channel::TryRecvError;
@@ -72,7 +71,7 @@ pub struct StorageState {
     /// Persist shard ids for the reclocking collection of a source.
     pub collection_metadata: HashMap<GlobalId, CollectionMetadata>,
     /// Handles to created sources, keyed by ID
-    pub source_tokens: HashMap<GlobalId, Arc<dyn Any + Send + Sync>>,
+    pub source_tokens: HashMap<GlobalId, Rc<dyn Any>>,
     /// Decoding metrics reported by all dataflows.
     pub decode_metrics: DecodeMetrics,
     /// Tracks the conditional write frontiers we have reported.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -57,7 +57,7 @@ pub struct StorageState {
     /// dropped, as this is used to check for rebinding of previous identifiers.
     /// Once we have a better mechanism to avoid that, for example that identifiers
     /// must strictly increase, we can clean up descriptions when sources are dropped.
-    pub source_descriptions: HashMap<GlobalId, SourceDesc>,
+    pub source_descriptions: HashMap<GlobalId, SourceDesc<CollectionMetadata>>,
     /// The highest observed upper frontier for collection.
     ///
     /// This is shared among all source instances, so that they can jointly advance the


### PR DESCRIPTION
Resolve a TODO to read the Debezium transactional metadata source out of
persist, rather than re-rendering the source.

This PR will unblock creating a pod per source (#12770), but it is
blocked on reverting (#12082), which is no longer necessary now that TCP
boundary has been removed.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Tips for reviewer

  * Go commit by commit.
  * @guswynn @frankmcsherry the first commit is for you two, since it essentially reverts #12082 because Petros's PR has made #12082 unnecessary.
  * @petrosagg @cjubb39 the second commit is for you two. It is a lot scarier than it looks. The tl;dr is that I parameterized the `DebeziumTransactionMetadata` struct so that it _either_ stores the global ID of the transaction metadata source _or_ the persist shard ID, depending on where in the codebase we are. This matches the approach taken for `DataflowDesc`. The reason the diff is so large is because converting from `SourceDesc<GlobalId>` to `SourceDesc<CollectionMetadata>` involves a massive amount of boilerplate since the `DebeziumTransactionMetadata` struct is nested so deeply. I factored the boilerplate into `map_storage_metadata` methods on each type, so it should be very mechanical to review.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
