### PR TITLE
Use persist/catalog URLs that are already set in entrypoint.sh

### DIFF
--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -16,8 +16,9 @@ pg_ctlcluster 14 materialize start
 psql -Atc "CREATE SCHEMA IF NOT EXISTS consensus"
 psql -Atc "CREATE SCHEMA IF NOT EXISTS catalog"
 
+export MZ_PERSIST_CONSENSUS_URL="${MZ_PERSIST_CONSENSUS_URL:-postgresql://materialize@%2Ftmp?options=--search_path=consensus}"
+export MZ_CATALOG_POSTGRES_STASH="${MZ_CATALOG_POSTGRES_STASH:-postgresql://materialize@%2Ftmp?options=--search_path=catalog}"
+
 exec materialized \
     --listen-addr=0.0.0.0:6875 \
-    --persist-consensus-url=postgresql://materialize@%2Ftmp?options=--search_path=consensus \
-    --catalog-postgres-stash=postgresql://materialize@%2Ftmp?options=--search_path=catalog \
     "$@"


### PR DESCRIPTION
Haven't tested yet, but this should fix the issue where `materialized` (as opposed to `materialized-slim`) images couldn't be spun up in cloud.