### PR TITLE
ci: Perform full pycheck against the /test directory

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -17,9 +17,10 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-py_folders=(ci misc/python)
+mypy_folders=(ci misc/python)
+flake8_folders=(ci misc/python test)
 
-try bin/pyactivate -m mypy "${py_folders[@]}"
+try bin/pyactivate -m mypy "${mypy_folders[@]}"
 if ! try_last_failed; then
     # mzcompose.py files need to be passed to mypy individually to avoid
     # duplicate module warnings. We don't check these if the previous `mypy`
@@ -27,7 +28,14 @@ if ! try_last_failed; then
     for file in $(git_files "**/mzcompose.py"); do
         try bin/pyactivate -m mypy "$file"
     done
+
+    for file in $(git_files "test/**.py"); do
+        if [[ $file == *"mzcompose"* ]]; then
+            continue
+        fi
+        try bin/pyactivate -m mypy "$file"
+    done
 fi
-try bin/pyactivate -m flake8 --select F --ignore F541 --extend-exclude venv "${py_folders[@]}"
+try bin/pyactivate -m flake8 --select F --ignore F541 --extend-exclude venv "${flake8_folders[@]}"
 try bin/pyactivate -m pytest -qq --doctest-modules misc/python
 try_finish

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -8,10 +8,8 @@
 # by the Apache License, Version 2.0.
 
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable
 
-from materialize import spawn
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Computed,

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -11,7 +11,7 @@ import argparse
 import os
 import sys
 import time
-from typing import List, Optional, Type
+from typing import List, Type
 
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -13,7 +13,7 @@ from typing import List
 
 from parameterized import parameterized_class  # type: ignore
 
-from materialize.feature_benchmark.action import Action, Kgen, LambdaAction, TdAction
+from materialize.feature_benchmark.action import Action, Kgen, TdAction
 from materialize.feature_benchmark.measurement_source import (
     Lambda,
     MeasurementSource,

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -8,8 +8,6 @@
 # by the Apache License, Version 2.0.
 
 import random
-from os import environ
-from unittest.mock import patch
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -9,16 +9,16 @@
 
 import unittest
 
-import psycopg2
-import psycopg3
-import sqlalchemy
-from psycopg3.oids import builtins
+import psycopg2  # type: ignore
+import psycopg3  # type: ignore
+import sqlalchemy  # type: ignore
+from psycopg3.oids import builtins  # type: ignore
 
 MATERIALIZED_URL = "postgresql://materialize@materialized:6875/materialize"
 
 
 class SmokeTest(unittest.TestCase):
-    def test_custom_types(self):
+    def test_custom_types(self) -> None:
         with psycopg3.connect(MATERIALIZED_URL, autocommit=True) as conn:
             # Text encoding of lists and maps is supported...
             with conn.cursor() as cur:
@@ -44,12 +44,12 @@ class SmokeTest(unittest.TestCase):
                 ):
                     cur.execute("SELECT '{a => 1, b => 2}'::map[text => int]")
 
-    def test_sqlalchemy(self):
+    def test_sqlalchemy(self) -> None:
         engine = sqlalchemy.engine.create_engine(MATERIALIZED_URL)
         results = [[c1, c2] for c1, c2 in engine.execute("VALUES (1, 2), (3, 4)")]
         self.assertEqual(results, [[1, 2], [3, 4]])
 
-    def test_psycopg2_tail(self):
+    def test_psycopg2_tail(self) -> None:
         """Test TAIL with psycopg2 via server cursors."""
         with psycopg2.connect(MATERIALIZED_URL) as conn:
             conn.set_session(autocommit=True)
@@ -85,7 +85,7 @@ class SmokeTest(unittest.TestCase):
                 self.assertEqual(b, "b")
                 self.assertEqual(cur.fetchone(), None)
 
-    def test_psycopg3_tail_copy(self):
+    def test_psycopg3_tail_copy(self) -> None:
         """Test tail with psycopg3 via its new binary COPY decoding support."""
         with psycopg3.connect(MATERIALIZED_URL) as conn:
             conn.autocommit = True
@@ -141,7 +141,7 @@ class SmokeTest(unittest.TestCase):
     # There might be problem with stream and the cancellation message. Skip until
     # resolved.
     @unittest.skip("https://github.com/psycopg/psycopg3/issues/30")
-    def test_psycopg3_tail_stream(self):
+    def test_psycopg3_tail_stream(self) -> None:
         """Test tail with psycopg3 via its new streaming query support."""
         with psycopg3.connect(MATERIALIZED_URL) as conn:
             conn.autocommit = True

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -9,7 +9,6 @@
 
 import argparse
 import contextlib
-import inspect
 import os
 import sys
 import tempfile
@@ -605,9 +604,9 @@ class NestedCTEsIndependent(Generator):
         )
         table_list = ", ".join(f"a{i}" for i in cls.all())
         print(
-            f"> WITH a{1} AS (SELECT * FROM t1 WHERE f1 <= 1), {cte_list} SELECT * FROM a{cls.COUNT};"
+            f"> WITH a{1} AS (SELECT * FROM t1 WHERE f1 <= 1), {cte_list} SELECT * FROM {table_list};"
         )
-        print(f"{cls.COUNT}")
+        print(" ".join(f"{a}" for a in cls.all()))
 
 
 class NestedCTEsChained(Generator):
@@ -623,7 +622,6 @@ class NestedCTEsChained(Generator):
             f"a{i} AS (SELECT a{i-1}.f1 + 0 AS f1 FROM a{i-1}, t1 WHERE a{i-1}.f1 = t1.f1)"
             for i in cls.no_first()
         )
-        table_list = ", ".join(f"a{i}" for i in cls.all())
         print(
             f"> WITH a{1} AS (SELECT * FROM t1), {cte_list} SELECT * FROM a{cls.COUNT};"
         )

--- a/test/persistence/mzcompose.py
+++ b/test/persistence/mzcompose.py
@@ -10,7 +10,7 @@
 import os
 import time
 from argparse import Namespace
-from typing import List, Union
+from typing import Union
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -8,11 +8,9 @@
 # by the Apache License, Version 2.0.
 
 from dataclasses import dataclass
-from pathlib import Path
 from textwrap import dedent
-from typing import Callable, Optional
+from typing import Callable
 
-from materialize import spawn
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Computed,

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from os import environ
-from unittest.mock import patch
-
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import (
     Localstack,

--- a/test/stash/mzcompose.py
+++ b/test/stash/mzcompose.py
@@ -7,8 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import time
-
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import Materialized, Postgres, Testdrive
 

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -9,7 +9,7 @@
 
 from pathlib import Path
 
-from materialize import ci_util, spawn, ui
+from materialize import ci_util, ui
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
     Kafka,

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -7,10 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import json
-import os
-import sys
-from typing import Dict
+import random
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
@@ -21,12 +18,6 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 from materialize.zippy.framework import Test
-from materialize.zippy.kafka_actions import *
-from materialize.zippy.mz_actions import *
-from materialize.zippy.scenarios import *
-from materialize.zippy.source_actions import *
-from materialize.zippy.table_actions import *
-from materialize.zippy.view_actions import *
 
 SERVICES = [
     Zookeeper(),


### PR DESCRIPTION
Pass all .py files in /test through mypy and flake8. Previosly,
only the mzcompose.py files were processed, and only by mypy.

### Motivation

  * This PR fixes a previously unreported bug.
flake8 checks were not happening against test/ which was hiding bugs
mypy checks were not happening against non-mzcompose.py files in test/