### PR TITLE
dataflow-types: support multiple materializations for Postgres sources

### DIFF
--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -3098,10 +3098,10 @@ pub mod sources {
         pub fn requires_single_materialization(&self) -> bool {
             match self {
                 ExternalSourceConnector::S3(c) => c.requires_single_materialization(),
-                ExternalSourceConnector::Postgres(_) => true,
 
                 ExternalSourceConnector::Kafka(_)
                 | ExternalSourceConnector::Kinesis(_)
+                | ExternalSourceConnector::Postgres(_)
                 | ExternalSourceConnector::PubNub(_)
                 | ExternalSourceConnector::Persist(_) => false,
             }

--- a/test/pg-cdc/support-multiple-materializations.td
+++ b/test/pg-cdc/support-multiple-materializations.td
@@ -44,12 +44,10 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
 1 true
 2 false
 
-! CREATE MATERIALIZED VIEW t1_mat_dupe AS
+> CREATE MATERIALIZED VIEW t1_mat_dupe AS
   SELECT * FROM t1
-contains:Cannot re-materialize source mz_source
 
-! CREATE MATERIALIZED VIEWS FROM SOURCE mz_source (t1 as t1_not_a_dupe, t2 as t2_not_a_dupe)
-contains:Cannot re-materialize source mz_source
+> CREATE MATERIALIZED VIEWS FROM SOURCE mz_source (t1 as t1_not_a_dupe, t2 as t2_not_a_dupe)
 
 > DROP VIEW t1_mat;
 


### PR DESCRIPTION
Allow users to create multiple indexes/materialized views based on Postgres sources. Since now with `persist`/`storage` we ingest all the data from Postgres eagerly at source creation instead of when indexes are created, it is possible to create multiple materializations of the source.

### Motivation
  * This PR adds a feature that has not yet been specified: allow users to create multiple materialized views from Postgres sources.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Allow multiple materialized views and indexes to be created from Postgres sources.
