### PR TITLE
storage: remove manual persist source

### DIFF
--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -190,7 +190,6 @@ message ProtoExternalSourceConnector {
         ProtoS3SourceConnector s3 = 3;
         ProtoPostgresSourceConnector postgres = 4;
         ProtoPubNubSourceConnector pubnub = 5;
-        ProtoPersistSourceConnector persist = 6;
     }
 }
 
@@ -216,12 +215,6 @@ message ProtoPostgresSourceConnector {
 message ProtoPubNubSourceConnector {
     string subscribe_key = 1;
     string channel = 2;
-}
-
-message ProtoPersistSourceConnector {
-    string consensus_uri = 1;
-    string blob_uri = 2;
-    string shard_id = 3;
 }
 
 message ProtoS3SourceConnector {

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -567,7 +567,7 @@ pub struct KafkaSourceConnector {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EnumKind)]
 #[enum_kind(SourceConnectorType)]
-pub enum CreateSourceConnector<T: AstInfo> {
+pub enum CreateSourceConnector {
     Kafka(KafkaSourceConnector),
     Kinesis {
         arn: String,
@@ -595,15 +595,9 @@ pub enum CreateSourceConnector<T: AstInfo> {
         /// The PubNub channel to subscribe to
         channel: String,
     },
-    Persist {
-        consensus_uri: String,
-        blob_uri: String,
-        collection_id: String,
-        columns: Vec<ColumnDef<T>>,
-    },
 }
 
-impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
+impl AstDisplay for CreateSourceConnector {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             CreateSourceConnector::Kafka(KafkaSourceConnector {
@@ -683,28 +677,10 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
                 f.write_str(&display::escape_single_quote_string(channel));
                 f.write_str("'");
             }
-            CreateSourceConnector::Persist {
-                consensus_uri,
-                blob_uri,
-                collection_id,
-                columns,
-            } => {
-                f.write_str("PERSIST CONSENSUS '");
-                f.write_node(&display::escape_single_quote_string(consensus_uri));
-                f.write_str("' BLOB '");
-                f.write_node(&display::escape_single_quote_string(blob_uri));
-                f.write_str("' SHARD '");
-                f.write_node(&display::escape_single_quote_string(collection_id));
-                f.write_str("'");
-
-                f.write_str(" (");
-                f.write_node(&display::comma_separated(columns));
-                f.write_str(")");
-            }
         }
     }
 }
-impl_display_t!(CreateSourceConnector);
+impl_display!(CreateSourceConnector);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EnumKind)]
 #[enum_kind(CreateSinkConnectorKind)]

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -411,7 +411,7 @@ impl_display_t!(CreateConnectorStatement);
 pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
-    pub connector: CreateSourceConnector<T>,
+    pub connector: CreateSourceConnector,
     pub with_options: Vec<WithOption<T>>,
     pub include_metadata: Vec<SourceIncludeMetadata>,
     pub format: CreateSourceFormat<T>,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2077,8 +2077,8 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[KAFKA, KINESIS, AVRO, S3, PERSIST, POSTGRES, PUBNUB])? {
+    fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector, ParserError> {
+        match self.expect_one_of_keywords(&[KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
                 let subscribe_key = self.parse_literal_string()?;
@@ -2111,25 +2111,6 @@ impl<'a> Parser<'a> {
                     publication,
                     slot,
                     details,
-                })
-            }
-            PERSIST => {
-                self.expect_keyword(CONSENSUS)?;
-                let consensus_uri = self.parse_literal_string()?;
-
-                self.expect_keyword(BLOB)?;
-                let blob_uri = self.parse_literal_string()?;
-
-                self.expect_keyword(SHARD)?;
-                let shard_id = self.parse_literal_string()?;
-
-                // TODO: fail if/when we have constraints
-                let (columns, _constraints) = self.parse_columns(Mandatory)?;
-                Ok(CreateSourceConnector::Persist {
-                    consensus_uri,
-                    blob_uri,
-                    collection_id: shard_id,
-                    columns,
                 })
             }
             KAFKA => {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -186,7 +186,6 @@ pub async fn purify_create_source(
             *details = Some(hex::encode(details_proto.encode_to_vec()));
         }
         CreateSourceConnector::PubNub { .. } => (),
-        CreateSourceConnector::Persist { .. } => (),
     }
 
     purify_source_format(format, connector, &envelope, &config_options, with_options).await?;
@@ -196,7 +195,7 @@ pub async fn purify_create_source(
 
 async fn purify_source_format(
     format: &mut CreateSourceFormat<Raw>,
-    connector: &mut CreateSourceConnector<Raw>,
+    connector: &mut CreateSourceConnector,
     envelope: &Option<Envelope>,
     connector_options: &BTreeMap<String, String>,
     with_options: &Vec<WithOption<Raw>>,
@@ -252,7 +251,7 @@ async fn purify_source_format(
 
 async fn purify_source_format_single(
     format: &mut Format<Raw>,
-    connector: &mut CreateSourceConnector<Raw>,
+    connector: &mut CreateSourceConnector,
     envelope: &Option<Envelope>,
     connector_options: &BTreeMap<String, String>,
     with_options: &Vec<WithOption<Raw>>,
@@ -327,7 +326,7 @@ async fn purify_source_format_single(
 }
 
 async fn purify_csr_connector_proto(
-    connector: &mut CreateSourceConnector<Raw>,
+    connector: &mut CreateSourceConnector,
     csr_connector: &mut CsrConnectorProto<Raw>,
     envelope: &Option<Envelope>,
     with_options: &Vec<WithOption<Raw>>,
@@ -385,7 +384,7 @@ async fn purify_csr_connector_proto(
 }
 
 async fn purify_csr_connector_avro(
-    connector: &mut CreateSourceConnector<Raw>,
+    connector: &mut CreateSourceConnector,
     csr_connector: &mut CsrConnectorAvro<Raw>,
     envelope: &Option<Envelope>,
     connector_options: &BTreeMap<String, String>,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -200,9 +200,6 @@ where
                     );
                     ((SourceType::Row(ok), err), cap)
                 }
-                ExternalSourceConnector::Persist(_) => {
-                    unreachable!("persist/STORAGE sources cannot be rendered in a storage instance")
-                }
             };
 
             // Include any source errors.

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -98,7 +98,6 @@ pub fn serve(config: Config) -> Result<(Server, LocalStorageClient), anyhow::Err
             command_rx,
             storage_state: StorageState {
                 source_uppers: HashMap::new(),
-                persist_handles: HashMap::new(),
                 source_tokens: HashMap::new(),
                 decode_metrics,
                 reported_frontiers: HashMap::new(),


### PR DESCRIPTION
The manually specified persist sources were being handled specially in various places in the code. In the future we want to provide a way for users to sink any view back into STORAGE but that would probably be implemented with a special syntax that creates a storage collection that is used simultaneously as a source and a sink 