### PR TITLE
platform-upgrade: Minimum viable subset of the framework

### DIFF
--- a/misc/python/materialize/platform_upgrade_test/actions.py
+++ b/misc/python/materialize/platform_upgrade_test/actions.py
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import TYPE_CHECKING, List, Type
+
+from materialize.mzcompose import Composition
+
+if TYPE_CHECKING:
+    from materialize.platform_upgrade_test.checks import Check
+
+
+class Action:
+    def execute(self, c: Composition) -> None:
+        assert False
+
+
+class StartInstance(Action):
+    def execute(self, c: Composition) -> None:
+        c.up("materialized")
+        c.wait_for_materialized()
+
+
+class Populate(Action):
+    def __init__(self, checks: List[Type["Check"]]) -> None:
+        self.checks = [check_class() for check_class in checks]
+
+    def execute(self, c: Composition) -> None:
+        for check in self.checks:
+            check.run_populate(c)
+
+
+class Validate(Action):
+    def __init__(self, checks: List[Type["Check"]]) -> None:
+        self.checks = [check_class() for check_class in checks]
+
+    def execute(self, c: Composition) -> None:
+        for check in self.checks:
+            check.run_validate(c)
+
+
+class Testdrive(Action):
+    def __init__(self, td_str: str) -> None:
+        self.td_str = td_str
+
+    def execute(self, c: Composition) -> None:
+        c.testdrive(input=self.td_str)

--- a/misc/python/materialize/platform_upgrade_test/checks.py
+++ b/misc/python/materialize/platform_upgrade_test/checks.py
@@ -1,0 +1,52 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+from typing import List
+
+from materialize.mzcompose import Composition
+from materialize.platform_upgrade_test.actions import Testdrive
+
+
+class Check:
+    def populate(self) -> List[Testdrive]:
+        assert False
+
+    def validate(self) -> Testdrive:
+        assert False
+
+    def run_populate(self, c: Composition) -> None:
+        for action in self.populate():
+            action.execute(c)
+
+    def run_validate(self, c: Composition) -> None:
+        self.validate().execute(c)
+
+
+class DataTypes(Check):
+    def populate(self) -> List[Testdrive]:
+        return [
+            Testdrive(s)
+            for s in [
+                "> CREATE TABLE types_table (int_col INTEGER, dec_col DECIMAL, double_col DOUBLE)",
+                "> INSERT INTO types_table VALUES (123, 123.234, 123.234)",
+                "> INSERT INTO types_table VALUES (234, 234.345, 234.345)",
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM types_table;
+                123 123.234 123.234
+                234 234.345 234.345
+                """
+            )
+        )

--- a/misc/python/materialize/platform_upgrade_test/upgrade_scenarios.py
+++ b/misc/python/materialize/platform_upgrade_test/upgrade_scenarios.py
@@ -1,0 +1,36 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import List, Type
+
+from materialize.mzcompose import Composition
+from materialize.platform_upgrade_test.actions import (
+    Action,
+    Populate,
+    StartInstance,
+    Validate,
+)
+from materialize.platform_upgrade_test.checks import Check
+
+
+class Scenario:
+    def __init__(self, checks: List[Type[Check]]) -> None:
+        self.checks = checks
+
+    def actions(self) -> List[Action]:
+        assert False
+
+    def run(self, c: Composition) -> None:
+        for action in self.actions():
+            action.execute(c)
+
+
+class NoRestartNoUpgrade(Scenario):
+    def actions(self) -> List[Action]:
+        return [StartInstance(), Populate(self.checks), Validate(self.checks)]

--- a/test/platform-upgrade/mzcompose
+++ b/test/platform-upgrade/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/platform-upgrade/mzcompose.py
+++ b/test/platform-upgrade/mzcompose.py
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import (
+    Kafka,
+    Materialized,
+    Postgres,
+    SchemaRegistry,
+    Testdrive,
+    Zookeeper,
+)
+from materialize.platform_upgrade_test.checks import Check
+from materialize.platform_upgrade_test.upgrade_scenarios import *  # noqa: F401 F403
+from materialize.platform_upgrade_test.upgrade_scenarios import Scenario
+
+SERVICES = [
+    Zookeeper(),
+    Kafka(),
+    SchemaRegistry(),
+    Postgres(),
+    Materialized(),
+    Testdrive(default_timeout="5s", no_reset=True, seed=1),
+]
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    c.silent = True
+
+    parser.add_argument(
+        "--scenario", metavar="SCENARIO", type=str, help="Scenario to run."
+    )
+
+    parser.add_argument("--check", metavar="CHECK", type=str, help="Check to run.")
+
+    args = parser.parse_args()
+
+    c.up("testdrive", persistent=True)
+
+    #    c.start_and_wait_for_tcp(
+    #        services=["zookeeper", "kafka", "schema-registry", "postgres"]
+    #    )
+
+    scenarios = (
+        [globals()[args.scenario]] if args.scenario else Scenario.__subclasses__()
+    )
+
+    checks = [globals()[args.check]] if args.check else Check.__subclasses__()
+
+    for scenario_class in scenarios:
+        print(f"Testing upgrade scenario {scenario_class}")
+        scenario = scenario_class(checks=checks)
+        scenario.run(c)


### PR DESCRIPTION
The new platform upgrade framework separates the individual features
to be checked on an upgrade into self-contained Check classes that
contain both the population and the validation logic for each feature.

The Checks will then be run at the appropriate times during an
upgrade Scenario. This commit provides a dummy Scenario, where we
are not upgrading or restarting anything but still perform the
population and validation steps.

### Motivation

  * This PR adds a feature that has not yet been specified.

This PR implements the minimal subset of #12089 . This is needed so that creation of tests for #12758 (gRPC/Protobuf) can begin in earnest.

Even if Materialize's upgrade story has not been completely specified, it is already known that all possible Protobuf/gRPC messages of all kinds that can fly through the system need to be exercised.

### Tips for reviewer

@benesch if you can give this a 30-second glance-over to confirm that you are OK with the placement and naming of files and the general structure, that would be much appreciated.

I will add docstrings in a follow-up commit once the dust settles.