### PR TITLE
coord,storage: reduce runtime of `Coordinator::advance_local_inputs()`

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -86,7 +86,7 @@ use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch};
-use tracing::warn;
+use tracing::{trace, warn};
 use uuid::Uuid;
 
 use mz_build_info::BuildInfo;
@@ -834,7 +834,13 @@ impl<S: Append + 'static> Coordinator<S> {
             }
 
             if let Some(timestamp) = self.global_timeline.should_advance_to() {
+                let start = Instant::now();
                 self.advance_local_inputs(timestamp).await;
+                trace!(
+                    "advancing table frontiers to {} took: {} ms",
+                    timestamp,
+                    start.elapsed().as_millis()
+                );
             }
         }
     }


### PR DESCRIPTION
**Updated (and less controversial) version of #12777**

### Motivation

That method, which is invoked at least every `timestamp_interval` is blocking the main coordinator task, and therefore should run as quickly as possible.

This two multiple mitigations that work towards reducing the runtime of `advance_local_inputs()`: we parallelize `compare_and_append()` calls in `StorageController::append()` and we parallelize `downgrade_since()` calls in `StorageController::update_read_capabilities()`.

### Tips for reviewer

The first commit adds duration logging, which allows us to look into things. The rest of the individual commits have comments in the code that outline why we do things the way we do them.

I used

```
 bin/mzcompose --find limits run default --scenario Tables
```

to understand the baseline performance and to gauge the impact of the two main changes. I did reduce `COUNT` to `100` in `tests/limits.mzcompose.py`, though, in order to not have to wait too long.

Impact of mitigations (runtime numbers on my linux machine):

1. Without any mitigations, at around 100 tables the runtime of `advance_local_inputs()` is about 300ms.
2. With my two mitigations that parallelize persist calls, runtime goes down to about 300ms. (which is not surprising, because the Postgres persist implementation is serializing calls, even for different shards)
3. With the two mitigations and Dan's postgres threadpool change, runtime goes down to about 50ms.

The threadpool commit is from #12482  and should not be merged along with these changes. It's only in here to get a feel for its impact. We should definitely merge that PR as well, though.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.