### PR TITLE
mzbuild: allow specifying architecture to build for

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -516,6 +516,7 @@ class ResolvedImage:
             *(f"--build-arg={k}={v}" for k, v in build_args.items()),
             "-t",
             self.spec(),
+            f"--platform=linux/{self.image.rd.arch.go_str()}",
             str(self.image.path),
         ]
         spawn.runv(cmd, stdin=f, stdout=sys.stderr.buffer)
@@ -790,6 +791,13 @@ class Repository:
             help="whether to enable code coverage compilation flags",
             action="store_true",
         )
+        parser.add_argument(
+            "--arch",
+            default=Arch.X86_64,
+            help="the CPU architecture to build for",
+            type=Arch,
+            choices=Arch,
+        )
 
     @classmethod
     def from_arguments(cls, root: Path, args: argparse.Namespace) -> "Repository":
@@ -798,7 +806,9 @@ class Repository:
         The provided namespace must contain the options installed by
         `Repository.install_arguments`.
         """
-        return cls(root, release_mode=args.release, coverage=args.coverage)
+        return cls(
+            root, release_mode=args.release, coverage=args.coverage, arch=args.arch
+        )
 
     @property
     def root(self) -> Path:

--- a/misc/python/materialize/xcompile.py
+++ b/misc/python/materialize/xcompile.py
@@ -136,13 +136,16 @@ def tool(arch: Arch, name: str, channel: Optional[str] = None) -> List[str]:
 
 
 def _enter_builder(arch: Arch, channel: Optional[str] = None) -> List[str]:
-    assert (
-        arch == Arch.host()
-    ), f"target architecture {arch} does not match host architecture {Arch.host()}"
     if "MZ_DEV_CI_BUILDER" in os.environ or sys.platform == "darwin":
         return []
     else:
-        return ["bin/ci-builder", "run", channel if channel else "stable"]
+        return [
+            "env",
+            f"MZ_DEV_CI_BUILDER_ARCH={arch}",
+            "bin/ci-builder",
+            "run",
+            channel if channel else "stable",
+        ]
 
 
 def _bootstrap_darwin(arch: Arch) -> None:


### PR DESCRIPTION
Teach the `mzimage` command to accept the `--arch` flag, as in

    $ mzimage acquire --arch=x86_64 materialized

which allows cross-compiling for an architecture other than the host.
This works wonderfully on macOS where we have cross-compiling toolchains
that run on the host. On Linux it is too slow to be useful, though, as
Docker will attempt to compile Rust via QEMU emulation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
