### PR TITLE
computed,storaged: Allocate pid file first

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -148,6 +148,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
     mz_ore::tracing::configure("computed", &args.tracing).await?;
 
+    let mut _pid_file = None;
+    if let Some(pid_file_location) = &args.pid_file_location {
+        _pid_file = Some(PidFile::open(&pid_file_location).unwrap());
+    }
+
     if args.workers == 0 {
         bail!("--workers must be greater than 0");
     }
@@ -191,11 +196,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     let mut client: Box<dyn ComputeClient> = Box::new(client);
     if args.reconcile {
         client = Box::new(ComputeCommandReconcile::new(client))
-    }
-
-    let mut _pid_file = None;
-    if let Some(pid_file_location) = &args.pid_file_location {
-        _pid_file = Some(PidFile::open(&pid_file_location).unwrap());
     }
 
     serve(serve_config, client).await

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -125,6 +125,11 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
     mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
+    let mut _pid_file = None;
+    if let Some(pid_file_location) = &args.pid_file_location {
+        _pid_file = Some(PidFile::open(&pid_file_location).unwrap());
+    }
+
     if args.workers == 0 {
         bail!("--workers must be greater than 0");
     }
@@ -176,11 +181,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     );
     let (server, client) = mz_storage::serve(config)?;
     let client: Box<dyn StorageClient> = Box::new(client);
-
-    let mut _pid_file = None;
-    if let Some(pid_file_location) = &args.pid_file_location {
-        _pid_file = Some(PidFile::open(&pid_file_location).unwrap());
-    }
 
     serve(serve_config, server, client).await
 }


### PR DESCRIPTION
The purpose of the pid file is to prevent duplicate process creation. To do so, the PID
file should be created before anything else, especially before network connections are
made or listening sockets are openend.

### Motivation


  * This PR fixes a previously unreported bug.

  This is hypothetical scenario, I did not actually observe it: The coordinator starts 
  computed, computed initializes logging to one of our logging services. The logging service
  is down and is blocked. The coordinator dies and restarts and restarts computed. 
  In this case the PID file does not block the second process. With this PR the pid file
  would have blocked the second process.


### Tips for reviewer

Should be a fairly minor change.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Existing tests cover this enough.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

None

