### PR TITLE
bin: add script to build/push Docker images to personal account

### DIFF
--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# stage-cloud – build cloud Docker images and push to personal Docker Hub.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+. misc/shlib/shlib.bash
+
+if [[ $# -ne 1 ]]; then
+    die "usage: stage-cloud DOCKER-HUB-USERNAME"
+fi
+username=$1
+
+for image in materialized-slim storaged computed; do
+    bin/mzimage acquire --arch=x86_64 "$image"
+    docker tag "$(bin/mzimage spec "$image")" "$username/$image"
+    docker push "$username/$image"
+done
+
+echo "Launch environment with materialized image ref \`$username/$image:latest\`"


### PR DESCRIPTION
Add a new bin/cloud-push script to push `materialized-slim`, `storaged`,
and `computed` to a personal Docker Hub account.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
