### PR TITLE
Don't crash when gRPC channel is closed

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -1104,8 +1104,11 @@ pub mod tcp {
             } else {
                 return Err(anyhow::anyhow!("Sent into disconnected channel"));
             };
-            sender.send(cmd.into_proto()).expect("Ok");
-            Ok(())
+            if sender.send(cmd.into_proto()).is_err() {
+                Err(anyhow::anyhow!("Sent into disconnected channel"))
+            } else {
+                Ok(())
+            }
         }
 
         async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -1105,6 +1105,7 @@ pub mod tcp {
                 return Err(anyhow::anyhow!("Sent into disconnected channel"));
             };
             if sender.send(cmd.into_proto()).is_err() {
+                self.state = GrpcComputedTcpConn::Disconnected;
                 Err(anyhow::anyhow!("Sent into disconnected channel"))
             } else {
                 Ok(())


### PR DESCRIPTION
I'm not sure about this, because I'm not an expert on the new gRPC stuff, but we'll see what Lukas thinks.

I recently observed a crash here, and when I looked at the code -- it didn't seem to make sense. The `tx.send` will fail when the corresponding `rx` has been dropped. I haven't traced tonic internals enough to be sure, but I think that's a legit thing to happen if the connection has gone away? If so, we should behave the same way here as we do for other times the state is disconnected.