### PR TITLE
storage: convert Arc source tokens back to Rcs

### DIFF
--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -100,7 +100,7 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use timely::communication::Allocate;
 use timely::dataflow::Scope;
@@ -153,7 +153,7 @@ pub fn build_storage_dataflow<A: Allocate>(
                 ingestion.storage_metadata,
                 source_data,
                 storage_state,
-                Arc::clone(&token),
+                Rc::clone(&token),
             );
 
             storage_state.source_tokens.insert(ingestion.id, token);

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -10,7 +10,6 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::channels::pact::Exchange;
@@ -32,7 +31,7 @@ pub fn render<G>(
     storage_metadata: CollectionMetadata,
     source_data: Collection<G, Result<Row, DataflowError>, Diff>,
     storage_state: &mut StorageState,
-    token: Arc<dyn Any + Send + Sync>,
+    token: Rc<dyn Any>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -54,7 +53,7 @@ pub fn render<G>(
 
     let shared_frontier = Rc::clone(&storage_state.source_uppers[&src_id]);
 
-    let weak_token = Arc::downgrade(&token);
+    let weak_token = Rc::downgrade(&token);
 
     persist_op.build_async(
         scope.clone(),

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -10,6 +10,7 @@
 //! A source that reads from an a persist shard.
 
 use std::any::Any;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Instant;
@@ -42,7 +43,7 @@ pub fn persist_source<G>(
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
     Stream<G, (DataflowError, Timestamp, Diff)>,
-    Arc<dyn Any + Send + Sync>,
+    Rc<dyn Any>,
 )
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
@@ -172,7 +173,7 @@ where
         _ => panic!("decoding failed"),
     });
 
-    let token = Arc::new(token);
+    let token = Rc::new(token);
 
     (ok_stream, err_stream, token)
 }

--- a/src/storage/src/source/util.rs
+++ b/src/storage/src/source/util.rs
@@ -7,15 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
+use std::rc::Rc;
 
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{OperatorInfo, OutputHandle};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
+use timely::scheduling::ActivateOnDrop;
 use timely::Data;
 
+use mz_ore::collections::CollectionExt;
 use mz_repr::Timestamp;
 
 use super::{SourceStatus, SourceToken};
@@ -67,30 +69,34 @@ where
     let (mut data_output, data_stream) = builder.new_output();
     builder.set_notify(false);
 
-    builder.build(|mut capabilities| {
-        let mut capabilities = Some(capabilities.pop().unwrap());
+    builder.build(|capabilities| {
+        let mut capability = Some(capabilities.into_element());
 
-        let drop_activator = Arc::new(scope.sync_activator_for(&operator_info.address[..]));
-        let drop_activator_weak = Arc::downgrade(&drop_activator);
+        let drop_activator = Rc::new(ActivateOnDrop::new(
+            (),
+            Rc::new(operator_info.address.clone()),
+            scope.activations(),
+        ));
+        let drop_activator_weak = Rc::downgrade(&drop_activator);
 
         // Export a token to the outside word that will keep this source alive.
         token = Some(SourceToken {
-            activator: drop_activator,
+            _activator: drop_activator,
         });
 
         let mut tick = construct(operator_info);
 
         move |_frontier| {
-            // Drop all capabilities if the thread-safe `SourceToken` is dropped.
+            // Drop all capabilities if `token` is dropped.
             if drop_activator_weak.upgrade().is_none() {
-                capabilities = None;
+                capability = None;
             }
-            if let Some(data_cap) = &mut capabilities {
+            if let Some(cap) = &mut capability {
                 // We still have our capability, so the source is still alive.
                 // Delegate to the inner source.
-                if let SourceStatus::Done = tick(data_cap, &mut data_output.activate()) {
+                if let SourceStatus::Done = tick(cap, &mut data_output.activate()) {
                     // The inner source is finished. Drop our capability.
-                    capabilities = None;
+                    capability = None;
                 }
             }
         }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -9,7 +9,6 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use crossbeam_channel::TryRecvError;
 use timely::communication::Allocate;
@@ -54,7 +53,7 @@ pub struct StorageState {
     /// and we should aim for that but are not there yet.
     pub source_uppers: HashMap<GlobalId, Rc<RefCell<Antichain<mz_repr::Timestamp>>>>,
     /// Handles to created sources, keyed by ID
-    pub source_tokens: HashMap<GlobalId, Arc<dyn Any + Send + Sync>>,
+    pub source_tokens: HashMap<GlobalId, Rc<dyn Any>>,
     /// Decoding metrics reported by all dataflows.
     pub decode_metrics: DecodeMetrics,
     /// Tracks the conditional write frontiers we have reported.


### PR DESCRIPTION
@guswynn @petrosagg I pulled this out of #12798 since that didn't get landed. I addressed [your feedback](https://github.com/MaterializeInc/materialize/pull/12798#issuecomment-1143110140) from that review, Gus! I don't have all the context paged in on why we would/wouldn't want to do this, but given that these are thread local right now I found the `Arc`s confusing. But perhaps y'all know of some reason why they'll need to become thread safe again!

----

PR #12082 converted source tokens to thread-safe `Arc`s to be compatible
with the TCP storage/compute boundary, but since #12216 replaced the TCP
boundary with persist we can go back to Rcs.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
