### PR TITLE
sql: temporarily allow secret references in with option values

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1827,6 +1827,9 @@ pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
     ObjectName(UnresolvedObjectName),
     DataType(T::DataType),
+    // Temporary variant until we have support for connectors, which will use
+    // explicit fields for each secret reference.
+    Secret(T::ObjectName),
 }
 
 impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
@@ -1835,6 +1838,10 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
             WithOptionValue::Value(value) => f.write_node(value),
             WithOptionValue::ObjectName(name) => f.write_node(name),
             WithOptionValue::DataType(typ) => f.write_node(typ),
+            WithOptionValue::Secret(name) => {
+                f.write_str("SECRET ");
+                f.write_node(name)
+            }
         }
     }
 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -487,6 +487,44 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2"), Number("40000000")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SEKRET)
+----
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = sekret)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(ObjectName(UnresolvedObjectName([Ident("sekret")]))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
+----
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = secret)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(ObjectName(UnresolvedObjectName([Ident("secret")]))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+----
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement roundtrip
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
+----
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = secret)
+
+parse-statement roundtrip
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+----
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+
+parse-statement
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a.b.c)
+----
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a.b.c)
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1415,7 +1415,7 @@ fn plan_view_select(
     // don't need to clone the Select.
 
     // Extract hints about group size if there are any
-    let mut options = crate::normalize::options(&s.options);
+    let mut options = crate::normalize::options(&s.options)?;
 
     let option = options.remove("expected_group_size");
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -323,7 +323,7 @@ pub fn plan_create_source(
     let envelope = envelope.clone().unwrap_or(Envelope::None);
 
     let with_options_original = with_options;
-    let mut with_options = normalize::options(with_options_original);
+    let mut with_options = normalize::options(with_options_original)?;
     let mut with_option_objects = normalize::option_objects(with_options_original);
 
     let ts_frequency = match with_options.remove("timestamp_frequency_ms") {
@@ -1246,7 +1246,7 @@ fn get_encoding_inner(
                         },
                 } => {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => (normalize::options(&ccsr_options), url),
+                        CsrConnector::Inline { url } => (normalize::options(&ccsr_options)?, url),
                         CsrConnector::Reference {
                             url, with_options, ..
                         } => {
@@ -1266,7 +1266,7 @@ fn get_encoding_inner(
                     };
                     let ccsr_config = kafka_util::generate_ccsr_client_config(
                         registry_url.parse()?,
-                        &kafka_util::extract_config(&mut normalize::options(with_options))?,
+                        &kafka_util::extract_config(&mut normalize::options(with_options)?)?,
                         &mut ccsr_with_options,
                     )?;
                     normalize::ensure_empty_options(
@@ -1320,7 +1320,7 @@ fn get_encoding_inner(
                     seed
                 {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => (normalize::options(&ccsr_options), url),
+                        CsrConnector::Inline { url } => (normalize::options(&ccsr_options)?, url),
                         CsrConnector::Reference {
                             url, with_options, ..
                         } => {
@@ -1340,7 +1340,7 @@ fn get_encoding_inner(
                     // We validate here instead of in purification, to match the behavior of avro
                     let _ccsr_config = kafka_util::generate_ccsr_client_config(
                         registry_url.parse()?,
-                        &kafka_util::extract_config(&mut normalize::options(with_options))?,
+                        &kafka_util::extract_config(&mut normalize::options(with_options)?)?,
                         &mut ccsr_with_options,
                     )?;
                     normalize::ensure_empty_options(
@@ -1858,7 +1858,7 @@ fn kafka_sink_builder(
             if seed.is_some() {
                 bail!("SEED option does not make sense with sinks");
             }
-            let mut ccsr_with_options = normalize::options(&with_options);
+            let mut ccsr_with_options = normalize::options(&with_options)?;
 
             let schema_registry_url = url.parse::<Url>()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
@@ -2036,7 +2036,7 @@ fn get_kafka_sink_consistency_config(
                     bail!("SEED option does not make sense with sinks");
                 }
                 let schema_registry_url = uri.parse::<Url>()?;
-                let mut ccsr_with_options = normalize::options(&with_options);
+                let mut ccsr_with_options = normalize::options(&with_options)?;
                 let ccsr_config = kafka_util::generate_ccsr_client_config(
                     schema_registry_url.clone(),
                     config_options,
@@ -2187,7 +2187,7 @@ pub fn plan_create_sink(
         scx.catalog.config().nonce
     );
 
-    let mut with_options = normalize::options(&with_options);
+    let mut with_options = normalize::options(&with_options)?;
 
     let desc = from.desc(&scx.catalog.resolve_full_name(from.name()))?;
     let key_indices = match &connector {
@@ -2912,7 +2912,7 @@ pub fn plan_create_connector(
             broker,
             with_options,
         } => {
-            let mut with_options = normalize::options(&with_options);
+            let mut with_options = normalize::options(&with_options)?;
             ConnectorInner::Kafka {
                 broker: broker.parse()?,
                 config_options: kafka_util::extract_config(&mut with_options)?,
@@ -2922,7 +2922,7 @@ pub fn plan_create_connector(
             registry,
             with_options,
         } => {
-            let with_options = normalize::options(&with_options);
+            let with_options = normalize::options(&with_options)?;
             ConnectorInner::CSR {
                 registry,
                 with_options: with_options

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -65,7 +65,7 @@ pub async fn purify_create_source(
         ..
     } = &mut stmt;
 
-    let mut with_options_map = normalize::options(with_options);
+    let mut with_options_map = normalize::options(with_options)?;
     let mut config_options = BTreeMap::new();
 
     match connector {
@@ -352,11 +352,11 @@ async fn purify_csr_connector_proto(
                     .expect("CSR Connector must specify Registry URL"),
             }
             .parse()?;
-            let kafka_options = kafka_util::extract_config(&mut normalize::options(with_options))?;
+            let kafka_options = kafka_util::extract_config(&mut normalize::options(with_options)?)?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
                 &kafka_options,
-                &mut normalize::options(&ccsr_options),
+                &mut normalize::options(&ccsr_options)?,
             )?;
 
             let value =
@@ -414,7 +414,7 @@ async fn purify_csr_connector_avro(
             kafka_util::generate_ccsr_client_config(
                 url,
                 &connector_options,
-                &mut normalize::options(ccsr_options),
+                &mut normalize::options(ccsr_options)?,
             )
         })?;
 


### PR DESCRIPTION
To facilitate the connector/secret work, temporarily allow secret
references in WITH option clauses, as in:

    CREATE SOURCE ... WITH (sasl_password = SECRET a.b.c);

This commit only wires up the parser support for these references. The
planner will reject any references of this form.

The key trick here is that secret references are represented as

    WithOptionValue::Secret(T::ObjectName)

rather than:

    WithOptionValue::ObjectName(UnresolvedObjectName)

That means they will participate in name resolution like normal, so that
a `CreateSourceStatement<Aug>` will contain the global ID for all
embedded secret references.

Once we mandate the use of connectors with explicit fields for secret
references, we can remove this.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR works towards a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
