### PR TITLE
tracing: factor ComputeCommand and ComputeResponse into structs and add otel context

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -18,7 +18,9 @@ use tokio::select;
 use tracing::info;
 
 use mz_build_info::{build_info, BuildInfo};
-use mz_dataflow_types::client::{ComputeClient, ComputeCommand, ComputeResponse, GenericClient};
+use mz_dataflow_types::client::{
+    ComputeClient, GenericClient, TelemetriedComputeCommand, TelemetriedComputeResponse,
+};
 use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
 use mz_dataflow_types::ConnectorContext;
 use mz_orchestrator_tracing::TracingCliArgs;
@@ -189,7 +191,7 @@ struct ServeConfig {
 
 async fn serve<G>(config: ServeConfig, mut client: G) -> Result<(), anyhow::Error>
 where
-    G: GenericClient<ComputeCommand, ComputeResponse>,
+    G: GenericClient<TelemetriedComputeCommand, TelemetriedComputeResponse>,
 {
     let mut grpc_serve = mz_dataflow_types::client::tcp::grpc_computed_server(config.listen_addr);
 

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -39,7 +39,6 @@ message ProtoPeek {
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
     optional int64 target_replica = 7;
-    map<string, string> otel_ctx = 8;
 }
 
 message ProtoComputeCommand {
@@ -60,6 +59,10 @@ message ProtoComputeCommand {
         repeated mz_repr.proto.ProtoU128 uuids = 1;
     }
 
+    message ProtoOpenTelemetryContext {
+        map<string, string> ctx = 1;
+    }
+
     oneof kind {
         ProtoInstanceConfig create_instance = 1;
         google.protobuf.Empty drop_instance = 2;
@@ -68,6 +71,8 @@ message ProtoComputeCommand {
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
     }
+
+    ProtoOpenTelemetryContext otel_ctx = 50;
 }
 
 message ProtoComputeResponse {
@@ -88,7 +93,6 @@ message ProtoComputeResponse {
     message ProtoPeekResponseKind {
         mz_repr.proto.ProtoU128 id = 1;
         mz_dataflow_types.types.ProtoPeekResponse resp = 2;
-    map<string, string> otel_ctx = 3;
     }
 
     message ProtoTailResponseKind {
@@ -96,9 +100,16 @@ message ProtoComputeResponse {
         mz_dataflow_types.types.ProtoTailResponse resp = 2;
     }
 
+    message ProtoOpenTelemetryContext {
+        map<string, string> ctx = 1;
+    }
+
+
     oneof kind {
         ProtoFrontierUppersKind frontier_uppers = 1;
         ProtoPeekResponseKind peek_response = 2;
         ProtoTailResponseKind tail_response = 3;
     }
+
+    ProtoOpenTelemetryContext otel_ctx = 50;
 }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -80,6 +80,7 @@ tracing_ = [
   "opentelemetry",
   "opentelemetry-otlp",
   "tonic",
+  "serde",
 ]
 tokio-console = ["console-subscriber", "tokio", "tokio/tracing"]
 cli = ["clap"]


### PR DESCRIPTION
As part of distributed tracing, we need commands and responses to pass opentelemetry context back and forth between services. This pr elevates `ComputeCommand` and `ComputeResponse` into structs, with sub-fields for the `enum variants`. Some details:
- The `otel_ctx` in `CommandResponse` may end up being unused, but I want to leave it for now, to keep it parallel with `ComputeCommand` for now
- @danhhz has horror stories about using maps with proto, but I looked at the `Message` impl for them and it seems reasonable, and these maps will always be only a few elements.
- I chose to go with this route now, instead of just adding the context to the `Peek` variant, so its easier to trace other commands in the future. And it gets some bad rebases in people's futures out of the waey
- Note that the `otel_ctx` stuff is currently unused, but shows the motivation to be used in later pr's

### Motivation

   * This PR refactors existing code.
  
### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes
None
