### PR TITLE
sql[-parser]: introduce dedicated syntax for debezium txn metadata

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -415,7 +415,7 @@ pub struct CreateSourceStatement<T: AstInfo> {
     pub with_options: Vec<WithOption<T>>,
     pub include_metadata: Vec<SourceIncludeMetadata>,
     pub format: CreateSourceFormat<T>,
-    pub envelope: Option<Envelope>,
+    pub envelope: Option<Envelope<T>>,
     pub if_not_exists: bool,
     pub materialized: bool,
     pub key_constraint: Option<KeyConstraint>,
@@ -480,7 +480,7 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub connector: CreateSinkConnector<T>,
     pub with_options: Vec<WithOption<T>>,
     pub format: Option<Format<T>>,
-    pub envelope: Option<Envelope>,
+    pub envelope: Option<Envelope<T>>,
     pub with_snapshot: bool,
     pub as_of: Option<AsOf<T>>,
     pub if_not_exists: bool,
@@ -1835,7 +1835,7 @@ impl_display_t!(WithOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum WithOptionValue<T: AstInfo> {
     Value(Value),
-    ObjectName(UnresolvedObjectName),
+    Ident(Ident),
     DataType(T::DataType),
     // Temporary variant until we have support for connectors, which will use
     // explicit fields for each secret reference.
@@ -1846,7 +1846,7 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             WithOptionValue::Value(value) => f.write_node(value),
-            WithOptionValue::ObjectName(name) => f.write_node(name),
+            WithOptionValue::Ident(id) => f.write_node(id),
             WithOptionValue::DataType(typ) => f.write_node(typ),
             WithOptionValue::Secret(name) => {
                 f.write_str("SECRET ");

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -60,6 +60,7 @@ Cluster
 Clusters
 Coalesce
 Collate
+Collection
 Columns
 Commit
 Committed
@@ -177,6 +178,7 @@ Matching
 Materialize
 Materialized
 Message
+Metadata
 Minute
 Minutes
 Month

--- a/src/sql-parser/tests/testdata/copy
+++ b/src/sql-parser/tests/testdata/copy
@@ -46,21 +46,21 @@ COPY t TO STDOUT WITH (FORMAT TEXT)
 ----
 COPY t TO STDOUT WITH (format = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
 COPY t FROM STDIN WITH (FORMAT CSV, DELIMETER '|')
 ----
 COPY t FROM STDIN WITH (format = csv, delimeter = '|')
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("csv")]))) }, WithOption { key: Ident("delimeter"), value: Some(Value(String("|"))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: From, target: Stdin, options: [WithOption { key: Ident("format"), value: Some(Ident(Ident("csv"))) }, WithOption { key: Ident("delimeter"), value: Some(Value(String("|"))) }] })
 
 parse-statement
 COPY t TO STDOUT (format = text)
 ----
 COPY t TO STDOUT WITH (format = text)
 =>
-Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(ObjectName(UnresolvedObjectName([Ident("text")]))) }] })
+Copy(CopyStatement { relation: Table { name: Name(UnresolvedObjectName([Ident("t")])), columns: [] }, direction: To, target: Stdout, options: [WithOption { key: Ident("format"), value: Some(Ident(Ident("text"))) }] })
 
 parse-statement
 COPY t TO STDOUT ()

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -491,14 +491,14 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SEKRET)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = sekret)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(ObjectName(UnresolvedObjectName([Ident("sekret")]))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("sekret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = secret)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(ObjectName(UnresolvedObjectName([Ident("secret")]))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("secret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
@@ -655,7 +655,7 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSIS
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = user)) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Inline { url: "http://localhost:8081" }, seed: None, with_options: [WithOption { key: Ident("username"), value: Some(ObjectName(UnresolvedObjectName([Ident("user")]))) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Inline { url: "http://localhost:8081" }, seed: None, with_options: [WithOption { key: Ident("username"), value: Some(Ident(Ident("user"))) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
@@ -1379,7 +1379,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONF
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain)), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, materialized: false, key_constraint: None })
 
 
 parse-statement
@@ -1387,4 +1387,18 @@ CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING 
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connector: CsrConnectorProto { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain)), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connector: CsrConnectorProto { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement
+CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
+----
+CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")]))), Collection(Value(String("foo")))] })), if_not_exists: false, materialized: false, key_constraint: None })
+
+parse-statement
+CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+----
+CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, materialized: false, key_constraint: None })

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -196,7 +196,7 @@ pub async fn purify_create_source(
 async fn purify_source_format(
     format: &mut CreateSourceFormat<Raw>,
     connector: &mut CreateSourceConnector<Raw>,
-    envelope: &Option<Envelope>,
+    envelope: &Option<Envelope<Raw>>,
     connector_options: &BTreeMap<String, String>,
     with_options: &Vec<WithOption<Raw>>,
 ) -> Result<(), anyhow::Error> {
@@ -252,7 +252,7 @@ async fn purify_source_format(
 async fn purify_source_format_single(
     format: &mut Format<Raw>,
     connector: &mut CreateSourceConnector<Raw>,
-    envelope: &Option<Envelope>,
+    envelope: &Option<Envelope<Raw>>,
     connector_options: &BTreeMap<String, String>,
     with_options: &Vec<WithOption<Raw>>,
 ) -> Result<(), anyhow::Error> {
@@ -328,7 +328,7 @@ async fn purify_source_format_single(
 async fn purify_csr_connector_proto(
     connector: &mut CreateSourceConnector<Raw>,
     csr_connector: &mut CsrConnectorProto<Raw>,
-    envelope: &Option<Envelope>,
+    envelope: &Option<Envelope<Raw>>,
     with_options: &Vec<WithOption<Raw>>,
 ) -> Result<(), anyhow::Error> {
     let topic = if let CreateSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) = connector
@@ -386,7 +386,7 @@ async fn purify_csr_connector_proto(
 async fn purify_csr_connector_avro(
     connector: &mut CreateSourceConnector<Raw>,
     csr_connector: &mut CsrConnectorAvro<Raw>,
-    envelope: &Option<Envelope>,
+    envelope: &Option<Envelope<Raw>>,
     connector_options: &BTreeMap<String, String>,
 ) -> Result<(), anyhow::Error> {
     let topic = if let CreateSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) = connector

--- a/test/debezium/mysql/40-check-smoke.td
+++ b/test/debezium/mysql/40-check-smoke.td
@@ -25,9 +25,10 @@ $ schema-registry-wait-schema schema=mysql.transaction-value
 
 > CREATE MATERIALIZED SOURCE t1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'mysql.test.t1'
-  WITH (tx_metadata = mysql_tx_metadata, tx_metadata_collection_name='test.t1')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE DEBEZIUM;
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE mysql_tx_metadata, COLLECTION 'test.t1')
+  );
 
 > SELECT * FROM t1;
 123 123

--- a/test/debezium/postgres/50-large-transaction.td
+++ b/test/debezium/postgres/50-large-transaction.td
@@ -34,15 +34,18 @@ $ schema-registry-wait-schema schema=postgres.public.large_same_rows-value
 
 > CREATE MATERIALIZED SOURCE large_distinct_rows
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.large_distinct_rows'
-  WITH (tx_metadata = postgres_tx_metadata, tx_metadata_collection_name='public.large_distinct_rows')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE DEBEZIUM;
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE postgres_tx_metadata, COLLECTION 'public.large_distinct_rows')
+  );
 
 > CREATE MATERIALIZED SOURCE large_same_rows
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.large_same_rows'
-  WITH (tx_metadata = postgres_tx_metadata, tx_metadata_collection_name='public.large_same_rows')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE DEBEZIUM;
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE postgres_tx_metadata, COLLECTION 'public.large_same_rows')
+  );
+
 
 > SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM large_distinct_rows
 10000 10000 1 10000

--- a/test/testdrive/kafka-avro-debezium-transaction.td
+++ b/test/testdrive/kafka-avro-debezium-transaction.td
@@ -182,20 +182,22 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 #
 > CREATE MATERIALIZED SOURCE data_schema_inline
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH(tx_metadata = data_txdata, tx_metadata_collection_name = 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE data_txdata, COLLECTION 'testdrive-data-${testdrive.seed}')
+  )
 
 > CREATE MATERIALIZED SOURCE data2_schema_inline
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data2-${testdrive.seed}'
-  WITH(tx_metadata = data_txdata, tx_metadata_collection_name = 'testdrive-data2-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE data_txdata, COLLECTION 'testdrive-data2-${testdrive.seed}')
+  )
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 4, "b": 5}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
 
-# Note that this should still work even if data2 (which shares the tx_metadata topic) isn't able to progress!
+# Note that this should still work even if data2 (which shares the transaction metadata source) isn't able to progress!
 > SELECT a, b FROM data_schema_inline
 a  b
 -----
@@ -248,9 +250,10 @@ $ file-append path=data-schema.json
 
 > CREATE MATERIALIZED SOURCE data_schema_file
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH(tx_metadata = data_txdata, tx_metadata_collection_name = 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA FILE '${testdrive.temp-dir}/data-schema.json'
-  ENVELOPE DEBEZIUM
+    ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE data_txdata, COLLECTION 'testdrive-data-${testdrive.seed}')
+  )
 
 > SELECT a, b FROM data_schema_file
 a  b
@@ -382,14 +385,19 @@ $ kafka-ingest format=avro topic=data-txdata-bad-schema schema=${txschema-bad-sc
 
 ! CREATE MATERIALIZED SOURCE data_schema_inline_with_bad_schema_tx_metadata
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-bad-schema-${testdrive.seed}'
-  WITH(tx_metadata = data_txdata_bad_schema, tx_metadata_collection_name = 'testdrive-data-bad-schema-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (
+          SOURCE data_txdata_bad_schema,
+          COLLECTION 'testdrive-data-bad-schema-${testdrive.seed}'
+      )
+  )
 contains:'id' column must be of type non-nullable string
 
 ! CREATE MATERIALIZED SOURCE data_schema_inline_with_sink
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH(tx_metadata = data_sink, tx_metadata_collection_name = 'testdrive-data-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
-contains:tx_metadata must refer to a source
+  ENVELOPE DEBEZIUM (
+      TRANSACTION METADATA (SOURCE data_sink, COLLECTION 'testdrive-data-${testdrive.seed}')
+  )
+contains:provided TRANSACTION METADATA SOURCE materialize.public.data_sink is not a source


### PR DESCRIPTION
Promote the tx_metadata WITH option for Debezium-enveloped sources to
full-fledged syntax. For example:

    ... ENVELOPE DEBEZIUM (
        TRANSACTION METADATA (SOURCE db.schema.item, COLLECTION 'coll')
    )

This avoids a gnarly special case in `WithOptionValue` and clears the
way for some of the forthcoming connector/secret work.

Fix #11668.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
