### PR TITLE
sql: harmonize describe_* functions

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -55,9 +55,9 @@ pub enum Statement<T: AstInfo> {
     AlterIndex(AlterIndexStatement<T>),
     AlterSecret(AlterSecretStatement<T>),
     Discard(DiscardStatement),
-    DropDatabase(DropDatabaseStatement<T>),
-    DropSchema(DropSchemaStatement<T>),
-    DropObjects(DropObjectsStatement<T>),
+    DropDatabase(DropDatabaseStatement),
+    DropSchema(DropSchemaStatement),
+    DropObjects(DropObjectsStatement),
     DropRoles(DropRolesStatement),
     DropClusters(DropClustersStatement),
     DropClusterReplicas(DropClusterReplicasStatement),
@@ -1145,13 +1145,13 @@ impl AstDisplay for DiscardTarget {
 impl_display!(DiscardTarget);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct DropDatabaseStatement<T: AstInfo> {
-    pub name: T::DatabaseName,
+pub struct DropDatabaseStatement {
+    pub name: UnresolvedDatabaseName,
     pub if_exists: bool,
     pub restrict: bool,
 }
 
-impl<T: AstInfo> AstDisplay for DropDatabaseStatement<T> {
+impl AstDisplay for DropDatabaseStatement {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DROP DATABASE ");
         if self.if_exists {
@@ -1163,16 +1163,16 @@ impl<T: AstInfo> AstDisplay for DropDatabaseStatement<T> {
         }
     }
 }
-impl_display_t!(DropDatabaseStatement);
+impl_display!(DropDatabaseStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct DropSchemaStatement<T: AstInfo> {
-    pub name: T::SchemaName,
+pub struct DropSchemaStatement {
+    pub name: UnresolvedSchemaName,
     pub if_exists: bool,
     pub cascade: bool,
 }
 
-impl<T: AstInfo> AstDisplay for DropSchemaStatement<T> {
+impl AstDisplay for DropSchemaStatement {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DROP SCHEMA ");
         if self.if_exists {
@@ -1184,11 +1184,11 @@ impl<T: AstInfo> AstDisplay for DropSchemaStatement<T> {
         }
     }
 }
-impl_display_t!(DropSchemaStatement);
+impl_display!(DropSchemaStatement);
 
 /// `DROP`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct DropObjectsStatement<T: AstInfo> {
+pub struct DropObjectsStatement {
     /// If this was constructed as `DROP MATERIALIZED <type>`
     pub materialized: bool,
     /// The type of the object to drop: TABLE, VIEW, etc.
@@ -1196,13 +1196,13 @@ pub struct DropObjectsStatement<T: AstInfo> {
     /// An optional `IF EXISTS` clause. (Non-standard.)
     pub if_exists: bool,
     /// One or more objects to drop. (ANSI SQL requires exactly one.)
-    pub names: Vec<T::ObjectName>,
+    pub names: Vec<UnresolvedObjectName>,
     /// Whether `CASCADE` was specified. This will be `false` when
     /// `RESTRICT` or no drop behavior at all was specified.
     pub cascade: bool,
 }
 
-impl<T: AstInfo> AstDisplay for DropObjectsStatement<T> {
+impl AstDisplay for DropObjectsStatement {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("DROP ");
         f.write_node(&self.object_type);
@@ -1216,7 +1216,7 @@ impl<T: AstInfo> AstDisplay for DropObjectsStatement<T> {
         }
     }
 }
-impl_display_t!(DropObjectsStatement);
+impl_display!(DropObjectsStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DropRolesStatement {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2757,7 +2757,7 @@ impl<'a> Parser<'a> {
         };
 
         let if_exists = self.parse_if_exists()?;
-        let names = self.parse_comma_separated(Parser::parse_raw_name)?;
+        let names = self.parse_comma_separated(Parser::parse_object_name)?;
         let cascade = matches!(
             self.parse_at_most_one_keyword(&[CASCADE, RESTRICT], "DROP")?,
             Some(CASCADE),

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -900,14 +900,14 @@ DROP TABLE foo
 ----
 DROP TABLE foo
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Table, if_exists: false, names: [Name(UnresolvedObjectName([Ident("foo")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Table, if_exists: false, names: [UnresolvedObjectName([Ident("foo")])], cascade: false })
 
 parse-statement
 DROP TABLE IF EXISTS foo, bar CASCADE
 ----
 DROP TABLE IF EXISTS foo, bar CASCADE
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Table, if_exists: true, names: [Name(UnresolvedObjectName([Ident("foo")])), Name(UnresolvedObjectName([Ident("bar")]))], cascade: true })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Table, if_exists: true, names: [UnresolvedObjectName([Ident("foo")]), UnresolvedObjectName([Ident("bar")])], cascade: true })
 
 parse-statement
 DROP TABLE
@@ -928,21 +928,21 @@ DROP VIEW myschema.myview
 ----
 DROP VIEW myschema.myview
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: View, if_exists: false, names: [Name(UnresolvedObjectName([Ident("myschema"), Ident("myview")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: View, if_exists: false, names: [UnresolvedObjectName([Ident("myschema"), Ident("myview")])], cascade: false })
 
 parse-statement
 DROP SOURCE myschema.mydatasource
 ----
 DROP SOURCE myschema.mydatasource
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Source, if_exists: false, names: [Name(UnresolvedObjectName([Ident("myschema"), Ident("mydatasource")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Source, if_exists: false, names: [UnresolvedObjectName([Ident("myschema"), Ident("mydatasource")])], cascade: false })
 
 parse-statement
 DROP INDEX IF EXISTS myschema.myindex
 ----
 DROP INDEX IF EXISTS myschema.myindex
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Index, if_exists: true, names: [Name(UnresolvedObjectName([Ident("myschema"), Ident("myindex")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Index, if_exists: true, names: [UnresolvedObjectName([Ident("myschema"), Ident("myindex")])], cascade: false })
 
 parse-statement
 TAIL foo.bar
@@ -1315,14 +1315,14 @@ DROP SECRET secret
 ----
 DROP SECRET secret
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Secret, if_exists: false, names: [Name(UnresolvedObjectName([Ident("secret")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Secret, if_exists: false, names: [UnresolvedObjectName([Ident("secret")])], cascade: false })
 
 parse-statement
 DROP SECRET IF EXISTS secret
 ----
 DROP SECRET IF EXISTS secret
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Secret, if_exists: true, names: [Name(UnresolvedObjectName([Ident("secret")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Secret, if_exists: true, names: [UnresolvedObjectName([Ident("secret")])], cascade: false })
 
 parse-statement
 SHOW SECRETS
@@ -1358,7 +1358,7 @@ DROP CONNECTOR conn1
 ----
 DROP CONNECTOR conn1
 =>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Connector, if_exists: false, names: [Name(UnresolvedObjectName([Ident("conn1")]))], cascade: false })
+DropObjects(DropObjectsStatement { materialized: false, object_type: Connector, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -78,9 +78,9 @@ use crate::catalog::{CatalogItem, CatalogItemType, CatalogType, CatalogTypeDetai
 use crate::connectors::populate_connectors;
 use crate::kafka_util;
 use crate::names::{
-    resolve_names_data_type, resolve_object_name, Aug, FullSchemaName, QualifiedObjectName,
-    RawDatabaseSpecifier, ResolvedClusterName, ResolvedDataType, ResolvedDatabaseSpecifier,
-    ResolvedObjectName, SchemaSpecifier,
+    resolve_names_data_type, Aug, FullSchemaName, QualifiedObjectName, RawDatabaseSpecifier,
+    ResolvedClusterName, ResolvedDataType, ResolvedDatabaseSpecifier, ResolvedObjectName,
+    SchemaSpecifier,
 };
 use crate::normalize;
 use crate::normalize::ident;
@@ -101,7 +101,7 @@ use crate::pure::Schema;
 
 pub fn describe_create_database(
     _: &StatementContext,
-    _: &CreateDatabaseStatement,
+    _: CreateDatabaseStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -121,7 +121,7 @@ pub fn plan_create_database(
 
 pub fn describe_create_schema(
     _: &StatementContext,
-    _: &CreateSchemaStatement,
+    _: CreateSchemaStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -160,7 +160,7 @@ pub fn plan_create_schema(
 
 pub fn describe_create_table(
     _: &StatementContext,
-    _: &CreateTableStatement<Raw>,
+    _: CreateTableStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -296,7 +296,7 @@ pub fn plan_create_table(
 
 pub fn describe_create_source(
     _: &StatementContext,
-    _: &CreateSourceStatement<Raw>,
+    _: CreateSourceStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -1473,7 +1473,7 @@ fn get_key_envelope(
 
 pub fn describe_create_view(
     _: &StatementContext,
-    _: &CreateViewStatement<Raw>,
+    _: CreateViewStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -1582,7 +1582,7 @@ pub fn plan_create_view(
 
 pub fn describe_create_views(
     _: &StatementContext,
-    _: &CreateViewsStatement<Raw>,
+    _: CreateViewsStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2132,7 +2132,7 @@ fn persist_sink_builder(
 
 pub fn describe_create_sink(
     _: &StatementContext,
-    _: &CreateSinkStatement<Raw>,
+    _: CreateSinkStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2394,7 +2394,7 @@ fn get_root_dependencies<'a>(
 
 pub fn describe_create_index(
     _: &StatementContext,
-    _: &CreateIndexStatement<Raw>,
+    _: CreateIndexStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2516,7 +2516,7 @@ pub fn plan_create_index(
 
 pub fn describe_create_type(
     _: &StatementContext,
-    _: &CreateTypeStatement<Raw>,
+    _: CreateTypeStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2667,7 +2667,7 @@ pub fn plan_create_type(
 
 pub fn describe_create_role(
     _: &StatementContext,
-    _: &CreateRoleStatement,
+    _: CreateRoleStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2712,7 +2712,7 @@ pub fn plan_create_role(
 
 pub fn describe_create_cluster(
     _: &StatementContext,
-    _: &CreateClusterStatement<Raw>,
+    _: CreateClusterStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2836,7 +2836,7 @@ fn plan_replica_config(options: Vec<ReplicaOption<Aug>>) -> Result<ReplicaConfig
 
 pub fn describe_create_cluster_replica(
     _: &StatementContext,
-    _: &CreateClusterReplicaStatement<Raw>,
+    _: CreateClusterReplicaStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2862,7 +2862,7 @@ pub fn plan_create_cluster_replica(
 
 pub fn describe_create_secret(
     _: &StatementContext,
-    _: &CreateSecretStatement<Raw>,
+    _: CreateSecretStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2898,9 +2898,9 @@ pub fn plan_create_secret(
     }))
 }
 
-pub fn describe_create_connector<T: mz_sql_parser::ast::AstInfo>(
+pub fn describe_create_connector(
     _: &StatementContext,
-    _: &CreateConnectorStatement<T>,
+    _: CreateConnectorStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2956,7 +2956,7 @@ pub fn plan_create_connector(
 
 pub fn describe_drop_database(
     _: &StatementContext,
-    _: &DropDatabaseStatement<Raw>,
+    _: DropDatabaseStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -2967,7 +2967,7 @@ pub fn plan_drop_database(
         name,
         restrict,
         if_exists,
-    }: DropDatabaseStatement<Raw>,
+    }: DropDatabaseStatement,
 ) -> Result<Plan, anyhow::Error> {
     let id = match scx.resolve_database(&name) {
         Ok(database) => {
@@ -2988,7 +2988,7 @@ pub fn plan_drop_database(
 
 pub fn describe_drop_objects(
     _: &StatementContext,
-    _: &DropObjectsStatement<Raw>,
+    _: DropObjectsStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3001,7 +3001,7 @@ pub fn plan_drop_objects(
         names,
         cascade,
         if_exists,
-    }: DropObjectsStatement<Raw>,
+    }: DropObjectsStatement,
 ) -> Result<Plan, anyhow::Error> {
     if materialized {
         bail!(
@@ -3010,22 +3010,17 @@ pub fn plan_drop_objects(
         );
     }
 
-    let names: Vec<_> = names
-        .into_iter()
-        .map(|name| resolve_object_name(scx, name))
-        .collect();
-
-    let names = if !if_exists && names.iter().any(|res| res.is_err()) {
-        let error = names
-            .into_iter()
-            .filter_map(|res| res.err())
-            .next()
-            .expect("branch only taken if there are errors");
-        return Err(error.into());
-    } else {
-        // TODO(benesch/jkosh44): generate a notice indicating items do not exist.
-        names.into_iter().filter_map(|res| res.ok()).collect()
-    };
+    let mut items = vec![];
+    for name in names {
+        let name = normalize::unresolved_object_name(name)?;
+        match scx.catalog.resolve_item(&name) {
+            Ok(item) => items.push(item),
+            Err(_) if if_exists => {
+                // TODO(benesch/jkosh44): generate a notice indicating items do not exist.
+            }
+            Err(e) => return Err(e.into()),
+        }
+    }
 
     match object_type {
         ObjectType::Source
@@ -3035,7 +3030,7 @@ pub fn plan_drop_objects(
         | ObjectType::Sink
         | ObjectType::Type
         | ObjectType::Secret
-        | ObjectType::Connector => plan_drop_items(scx, object_type, names, cascade),
+        | ObjectType::Connector => plan_drop_items(scx, object_type, items, cascade),
         ObjectType::Role | ObjectType::Cluster | ObjectType::ClusterReplica => {
             unreachable!("handled through their respective plan_drop functions")
         }
@@ -3045,7 +3040,7 @@ pub fn plan_drop_objects(
 
 pub fn describe_drop_schema(
     _: &StatementContext,
-    _: &DropSchemaStatement<Raw>,
+    _: DropSchemaStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3056,7 +3051,7 @@ pub fn plan_drop_schema(
         name,
         cascade,
         if_exists,
-    }: DropSchemaStatement<Raw>,
+    }: DropSchemaStatement,
 ) -> Result<Plan, anyhow::Error> {
     match scx.resolve_schema(name) {
         Ok(schema) => {
@@ -3106,7 +3101,7 @@ pub fn plan_drop_schema(
 
 pub fn describe_drop_role(
     _: &StatementContext,
-    _: &DropRolesStatement,
+    _: DropRolesStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3139,7 +3134,7 @@ pub fn plan_drop_role(
 
 pub fn describe_drop_cluster(
     _: &StatementContext,
-    _: &DropClustersStatement,
+    _: DropClustersStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3182,7 +3177,7 @@ pub fn plan_drop_cluster(
 
 pub fn describe_drop_cluster_replica(
     _: &StatementContext,
-    _: &DropClusterReplicasStatement,
+    _: DropClusterReplicasStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3225,16 +3220,9 @@ pub fn plan_drop_cluster_replica(
 pub fn plan_drop_items(
     scx: &StatementContext,
     object_type: ObjectType,
-    names: Vec<ResolvedObjectName>,
+    items: Vec<&dyn CatalogItem>,
     cascade: bool,
 ) -> Result<Plan, anyhow::Error> {
-    let items: Vec<_> = names
-        .iter()
-        .map(|name| {
-            scx.get_item_by_resolved_name(name)
-                .expect("can't parse a drop for non-user items")
-        })
-        .collect();
     let mut ids = vec![];
     for item in items {
         ids.extend(plan_drop_item(scx, object_type, item, cascade)?);
@@ -3304,7 +3292,7 @@ with_options! {
 
 pub fn describe_alter_index_options(
     _: &StatementContext,
-    _: &AlterIndexStatement<Raw>,
+    _: AlterIndexStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3381,7 +3369,7 @@ pub fn plan_alter_index_options(
 
 pub fn describe_alter_object_rename(
     _: &StatementContext,
-    _: &AlterObjectRenameStatement<Raw>,
+    _: AlterObjectRenameStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -3431,7 +3419,7 @@ pub fn plan_alter_object_rename(
 
 pub fn describe_alter_secret_options(
     _: &StatementContext,
-    _: &AlterSecretStatement<Raw>,
+    _: AlterSecretStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }

--- a/src/sql/src/plan/statement/raise.rs
+++ b/src/sql/src/plan/statement/raise.rs
@@ -18,7 +18,7 @@ use crate::plan::{Plan, RaisePlan};
 
 pub fn describe_raise(
     _: &StatementContext,
-    _: &RaiseStatement,
+    _: RaiseStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -32,7 +32,7 @@ use crate::plan::{
 
 pub fn describe_set_variable(
     _: &StatementContext,
-    _: &SetVariableStatement,
+    _: SetVariableStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -54,7 +54,7 @@ pub fn plan_set_variable(
 
 pub fn describe_reset_variable(
     _: &StatementContext,
-    _: &ResetVariableStatement,
+    _: ResetVariableStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -70,7 +70,7 @@ pub fn plan_reset_variable(
 
 pub fn describe_show_variable(
     _: &StatementContext,
-    ShowVariableStatement { variable, .. }: &ShowVariableStatement,
+    ShowVariableStatement { variable, .. }: ShowVariableStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     let desc = if variable.as_str() == UncasedStr::new("ALL") {
         RelationDesc::empty()
@@ -98,7 +98,7 @@ pub fn plan_show_variable(
 
 pub fn describe_discard(
     _: &StatementContext,
-    _: &DiscardStatement,
+    _: DiscardStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -117,7 +117,7 @@ pub fn plan_discard(
 
 pub fn describe_declare(
     _: &StatementContext,
-    _: &DeclareStatement<Raw>,
+    _: DeclareStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -140,7 +140,7 @@ with_options! {
 
 pub fn describe_fetch(
     _: &StatementContext,
-    _: &FetchStatement<Raw>,
+    _: FetchStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -178,7 +178,7 @@ pub fn plan_fetch(
 
 pub fn describe_close(
     _: &StatementContext,
-    _: &CloseStatement,
+    _: CloseStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -194,7 +194,7 @@ pub fn plan_close(
 
 pub fn describe_prepare(
     _: &StatementContext,
-    _: &PrepareStatement<Raw>,
+    _: PrepareStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -253,7 +253,7 @@ fn plan_execute_desc<'a>(
 
 pub fn describe_deallocate(
     _: &StatementContext,
-    _: &DeallocateStatement,
+    _: DeallocateStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -22,7 +22,7 @@ use mz_sql_parser::ast::ShowCreateConnectorStatement;
 
 use crate::ast::visit_mut::VisitMut;
 use crate::ast::{
-    ObjectType, Raw, SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
+    ObjectType, SelectStatement, ShowColumnsStatement, ShowCreateIndexStatement,
     ShowCreateSinkStatement, ShowCreateSourceStatement, ShowCreateTableStatement,
     ShowCreateViewStatement, ShowDatabasesStatement, ShowIndexesStatement, ShowObjectsStatement,
     ShowSchemasStatement, ShowStatementFilter, Statement, Value,
@@ -38,7 +38,7 @@ use crate::plan::{Params, Plan, SendRowsPlan};
 
 pub fn describe_show_create_view(
     _: &StatementContext,
-    _: &ShowCreateViewStatement<Raw>,
+    _: ShowCreateViewStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -76,7 +76,7 @@ pub fn plan_show_create_view(
 
 pub fn describe_show_create_table(
     _: &StatementContext,
-    _: &ShowCreateTableStatement<Raw>,
+    _: ShowCreateTableStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -111,7 +111,7 @@ pub fn plan_show_create_table(
 
 pub fn describe_show_create_source(
     _: &StatementContext,
-    _: &ShowCreateSourceStatement<Raw>,
+    _: ShowCreateSourceStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -140,7 +140,7 @@ pub fn plan_show_create_source(
 
 pub fn describe_show_create_sink(
     _: &StatementContext,
-    _: &ShowCreateSinkStatement<Raw>,
+    _: ShowCreateSinkStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -169,7 +169,7 @@ pub fn plan_show_create_sink(
 
 pub fn describe_show_create_index(
     _: &StatementContext,
-    _: &ShowCreateIndexStatement<Raw>,
+    _: ShowCreateIndexStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
@@ -198,7 +198,7 @@ pub fn plan_show_create_index(
 
 pub fn describe_show_create_connector(
     _: &StatementContext,
-    _: &ShowCreateConnectorStatement<Raw>,
+    _: ShowCreateConnectorStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()

--- a/src/sql/src/plan/statement/tcl.rs
+++ b/src/sql/src/plan/statement/tcl.rs
@@ -21,7 +21,7 @@ use crate::plan::{Plan, StartTransactionPlan};
 
 pub fn describe_start_transaction(
     _: &StatementContext,
-    _: &StartTransactionStatement,
+    _: StartTransactionStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -36,7 +36,7 @@ pub fn plan_start_transaction(
 
 pub fn describe_set_transaction(
     _: &StatementContext,
-    _: &SetTransactionStatement,
+    _: SetTransactionStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     bail_unsupported!("SET TRANSACTION")
 }
@@ -67,7 +67,7 @@ fn verify_transaction_modes(
 
 pub fn describe_rollback(
     _: &StatementContext,
-    _: &RollbackStatement,
+    _: RollbackStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }
@@ -82,7 +82,7 @@ pub fn plan_rollback(
 
 pub fn describe_commit(
     _: &StatementContext,
-    _: &CommitStatement,
+    _: CommitStatement,
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(None))
 }


### PR DESCRIPTION
Make all the describe_* functions have the same signature: i.e., taking
an augmented statement by value. This simplifes the top-level describe
function and prepares us to hoist name resolution into a separate pass.

A future commit will apply the same logic to the plan_* functions.

This is further work towards #5302.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
