### PR TITLE
get rid of unnecessary `mut` annotation

### DIFF
--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -165,9 +165,7 @@ impl ConsensusConfig {
                 PostgresConsensusConfig::new(value).await?,
             )),
             #[cfg(any(test, debug_assertions))]
-            "mem" => {
-                Ok(ConsensusConfig::Mem)
-            }
+            "mem" => Ok(ConsensusConfig::Mem),
             p => Err(anyhow!(
                 "unknown persist consensus scheme {}: {}",
                 p,

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -144,7 +144,7 @@ impl ConsensusConfig {
                 err
             )
         })?;
-        let mut query_params = url.query_pairs().collect::<HashMap<_, _>>();
+        let query_params = url.query_pairs().collect::<HashMap<_, _>>();
 
         let config = match url.scheme() {
             "sqlite" => {
@@ -166,7 +166,6 @@ impl ConsensusConfig {
             )),
             #[cfg(any(test, debug_assertions))]
             "mem" => {
-                query_params.clear();
                 Ok(ConsensusConfig::Mem)
             }
             p => Err(anyhow!(


### PR DESCRIPTION
### Motivation

Fix a warning in builds without --all-targets set. (Which was firing because the object is never mutated in those)

### Tips for reviewer

This could be done in a slightly more complicated way if we wanted to retain the `HashMap::clear` call in that code path that's only hit in tests/debug builds.

But, since it seems to be a dead store, we can just get rid of it.
