### PR TITLE
Customize Timely communication setup logic to avoid phantom connections causing crashes

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -102,9 +102,7 @@ async fn main() {
 
 fn create_communication_config(args: &Args) -> Result<CommunicationConfig, anyhow::Error> {
     let process = match args.process {
-        None => {
-            bail!("--process argument must be specified when more than one address is specified");
-        }
+        None => 0,
         Some(process) if process >= args.addresses.len() => {
             bail!(
                 "process index {process} out of range [0, {})",

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -12,6 +12,7 @@ use std::process;
 
 use anyhow::bail;
 use axum::routing;
+use mz_compute::server::CommunicationConfig;
 use once_cell::sync::Lazy;
 use tokio::select;
 use tracing::info;
@@ -99,48 +100,23 @@ async fn main() {
     }
 }
 
-fn create_communication_config(args: &Args) -> Result<timely::CommunicationConfig, anyhow::Error> {
-    if args.addresses.len() > 1 {
-        let process = match args.process {
-            None => {
-                bail!(
-                    "--process argument must be specified when more than one address is specified"
-                );
-            }
-            Some(process) if process >= args.addresses.len() => {
-                bail!(
-                    "process index {process} out of range [0, {})",
-                    args.addresses.len()
-                );
-            }
-            Some(process) => process,
-        };
-        Ok(timely::CommunicationConfig::Cluster {
-            threads: args.workers,
-            process,
-            addresses: args.addresses.clone(),
-            report: true,
-            log_fn: Box::new(|_| None),
-        })
-    } else {
-        match args.process {
-            Some(process) if process > 1 => {
-                bail!("process index {process} out of range [0, 1)");
-            }
-            _ => (),
+fn create_communication_config(args: &Args) -> Result<CommunicationConfig, anyhow::Error> {
+    let process = match args.process {
+        None => {
+            bail!("--process argument must be specified when more than one address is specified");
         }
-        if args.workers > 1 {
-            Ok(timely::CommunicationConfig::Process(args.workers))
-        } else {
-            Ok(timely::CommunicationConfig::Thread)
+        Some(process) if process >= args.addresses.len() => {
+            bail!(
+                "process index {process} out of range [0, {})",
+                args.addresses.len()
+            );
         }
-    }
-}
-
-fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
-    Ok(timely::Config {
-        worker: timely::WorkerConfig::default(),
-        communication: create_communication_config(args)?,
+        Some(process) => process,
+    };
+    Ok(CommunicationConfig {
+        threads: args.workers,
+        process,
+        addresses: args.addresses.clone(),
     })
 }
 
@@ -156,7 +132,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     if args.workers == 0 {
         bail!("--workers must be greater than 0");
     }
-    let timely_config = create_timely_config(&args)?;
+    let comm_config = create_communication_config(&args)?;
 
     info!("about to bind to {:?}", args.listen_addr);
 
@@ -177,7 +153,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let config = mz_compute::server::Config {
         workers: args.workers,
-        timely_config,
+        comm_config,
         experimental_mode: false,
         metrics_registry: MetricsRegistry::new(),
         now: SYSTEM_TIME.clone(),

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -101,12 +101,15 @@ fn start_connections(
                     stream.write_all(my_index.to_ne_bytes().as_slice()).expect("failed to send worker index");
                     let mut buffer = [0u8; 8];
                     let _ = stream.read_exact(&mut buffer);
+                    // TODO [btv] - We can remove this once we have more reliable
+                    // network connections (possibly after linkerd is torn out)
                     let peer_ack = u64::from_ne_bytes(buffer);
                     if peer_ack != ACK_MAGIC {
                         println!("worker {my_index} failed computed handshake with worker {index}; retrying");
                         sleep(Duration::from_secs(1));
                         continue;
                     };
+                    // TODO [btv] - end of the region that can be removed (see above comment)
                     if noisy { println!("worker {}:\tconnection to worker {}", my_index, index); }
                     break Some(stream);
                 },
@@ -144,10 +147,13 @@ pub fn await_connections(
                 "received incorrect timely handshake",
             ));
         }
+        // TODO [btv] - We can remove this once we have more reliable
+        // network connections (possibly after linkerd is torn out)
         let identifier = u64::from_ne_bytes((&buffer[8..16]).try_into().unwrap());
         stream
             .write_all(ACK_MAGIC.to_ne_bytes().as_slice())
             .expect("failed to send ack magic");
+        // TODO [btv] - end of the region that can be removed (see above comment)
         results[identifier as usize - my_index - 1] = Some(stream);
         if noisy {
             println!(

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -90,7 +90,7 @@ where
                     Ok((stuff, guard)) => Ok((
                         stuff
                             .into_iter()
-                            .map(|x| GenericBuilder::ZeroCopy(x))
+                            .map(GenericBuilder::ZeroCopy)
                             .collect(),
                         Box::new(guard),
                     )),
@@ -141,7 +141,7 @@ fn create_sockets(
     noisy: bool,
 ) -> IoResult<Vec<Option<TcpStream>>> {
     let hosts1 = Arc::new(addresses);
-    let hosts2 = hosts1.clone();
+    let hosts2 = Arc::clone(&hosts1);
 
     let start_task = thread::spawn(move || start_connections(hosts1, my_index, noisy));
     let await_task = thread::spawn(move || await_connections(hosts2, my_index, noisy));

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -1,0 +1,233 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Code to spin up communication mesh for a compute replica.
+//! Most of this logic was taken from Timely's communication::networking
+//! module, with the crucial difference that we
+//! actually verify that we can receive data on a connection before considering it
+//! established, and retry otherwise. This allows us to cope with the phenomenon
+//! of spuriously accepted connections that has been observed in Kubernetes with linkerd.
+
+use std::any::Any;
+use std::io::{self, Write};
+use std::io::{Read, Result as IoResult};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::thread::sleep;
+use std::time::Duration;
+
+use timely::communication::allocator::zero_copy::initialize::initialize_networking_from_sockets;
+use timely::communication::allocator::GenericBuilder;
+use timely::communication::{initialize_from, WorkerGuards};
+use timely::worker::Worker;
+use timely::{CommunicationConfig, Config};
+
+// This constant is sent along immediately after establishing a TCP stream, so
+// that it is easy to sniff out Timely traffic when it is multiplexed with
+// other traffic on the same port.
+const HANDSHAKE_MAGIC: u64 = 0xc2f1fb770118add9;
+
+// This constant is sent upon receiving a connection. The process establishing
+// the connection must receive it in order to consider the connection to be
+// successfully established.
+const ACK_MAGIC: u64 = 0x68656c6f77726c64;
+
+/// Fork of timely::execute::execute that calls into our fork of create_sockets
+pub fn execute_acking_connections<T, F>(
+    mut config: Config,
+    func: F,
+) -> Result<WorkerGuards<T>, String>
+where
+    T: Send + 'static,
+    F: Fn(&mut Worker<timely::communication::Allocator>) -> T + Send + Sync + 'static,
+{
+    if let CommunicationConfig::Cluster { ref mut log_fn, .. } = config.communication {
+        *log_fn = Box::new(|events_setup| {
+            let mut result = None;
+            if let Ok(addr) = ::std::env::var("TIMELY_COMM_LOG_ADDR") {
+                use timely::dataflow::operators::capture::EventWriterCore;
+                use timely::logging::BatchLogger;
+
+                eprintln!("enabled COMM logging to {}", addr);
+
+                if let Ok(stream) = TcpStream::connect(&addr) {
+                    let writer = EventWriterCore::new(stream);
+                    let mut logger = BatchLogger::new(writer);
+                    result = Some(timely::logging_core::Logger::new(
+                        ::std::time::Instant::now(),
+                        ::std::time::Duration::default(),
+                        events_setup,
+                        move |time, data| logger.publish_batch(time, data),
+                    ));
+                } else {
+                    panic!("Could not connect to communication log address: {:?}", addr);
+                }
+            }
+            result
+        });
+    }
+
+    let (allocators, other) = match config.communication {
+        timely::CommunicationConfig::Cluster {
+            threads,
+            process,
+            addresses,
+            report,
+            log_fn,
+        } => {
+            let sockets_result = create_sockets(addresses, process, report);
+            let result: Result<(Vec<GenericBuilder>, Box<dyn Any + Send>), String> =
+                match sockets_result.and_then(|sockets| {
+                    initialize_networking_from_sockets(sockets, process, threads, log_fn)
+                }) {
+                    Ok((stuff, guard)) => Ok((
+                        stuff
+                            .into_iter()
+                            .map(|x| GenericBuilder::ZeroCopy(x))
+                            .collect(),
+                        Box::new(guard),
+                    )),
+                    Err(err) => Err(format!("failed to initialize networking: {}", err)),
+                };
+            result
+        }
+        _ => config.communication.try_build(),
+    }?;
+
+    let worker_config = config.worker;
+    initialize_from(allocators, other, move |allocator| {
+        let mut worker = Worker::new(worker_config.clone(), allocator);
+
+        // If an environment variable is set, use it as the default timely logging.
+        if let Ok(addr) = ::std::env::var("TIMELY_WORKER_LOG_ADDR") {
+            use timely::dataflow::operators::capture::EventWriterCore;
+            use timely::logging::{BatchLogger, TimelyEvent};
+
+            if let Ok(stream) = TcpStream::connect(&addr) {
+                let writer = EventWriterCore::new(stream);
+                let mut logger = BatchLogger::new(writer);
+                worker
+                    .log_register()
+                    .insert::<TimelyEvent, _>("timely", move |time, data| {
+                        logger.publish_batch(time, data)
+                    });
+            } else {
+                panic!("Could not connect logging stream to: {:?}", addr);
+            }
+        }
+
+        let result = func(&mut worker);
+        while worker.has_dataflows() {
+            worker.step_or_park(None);
+        }
+        result
+    })
+}
+
+/// Creates socket connections from a list of host addresses.
+///
+/// The item at index i in the resulting vec, is a Some(TcpSocket) to process i, except
+/// for item `my_index` which is None (no socket to self).
+fn create_sockets(
+    addresses: Vec<String>,
+    my_index: usize,
+    noisy: bool,
+) -> IoResult<Vec<Option<TcpStream>>> {
+    let hosts1 = Arc::new(addresses);
+    let hosts2 = hosts1.clone();
+
+    let start_task = thread::spawn(move || start_connections(hosts1, my_index, noisy));
+    let await_task = thread::spawn(move || await_connections(hosts2, my_index, noisy));
+
+    let mut results = start_task.join().unwrap()?;
+    results.push(None);
+    let to_extend = await_task.join().unwrap()?;
+    results.extend(to_extend.into_iter());
+
+    if noisy {
+        println!("worker {}:\tinitialization complete", my_index)
+    }
+
+    Ok(results)
+}
+
+/// Result contains connections [0, my_index - 1].
+fn start_connections(
+    addresses: Arc<Vec<String>>,
+    my_index: usize,
+    noisy: bool,
+) -> IoResult<Vec<Option<TcpStream>>> {
+    let results = addresses.iter().take(my_index).enumerate().map(|(index, address)| {
+        loop {
+            match TcpStream::connect(address) {
+                Ok(mut stream) => {
+                    stream.set_nodelay(true).expect("set_nodelay call failed");
+                    stream.write_all(HANDSHAKE_MAGIC.to_ne_bytes().as_slice()).expect("failed to send handshake magic");
+                    stream.write_all(my_index.to_ne_bytes().as_slice()).expect("failed to send worker index");
+                    let mut buffer = [0u8; 8];
+                    let _ = stream.read_exact(&mut buffer);
+                    let peer_ack = u64::from_ne_bytes(buffer);
+                    if peer_ack != ACK_MAGIC {
+                        println!("worker {my_index} failed computed handshake with worker {index}; retrying");
+                        sleep(Duration::from_secs(1));
+                        continue;
+                    };
+                    if noisy { println!("worker {}:\tconnection to worker {}", my_index, index); }
+                    break Some(stream);
+                },
+                Err(error) => {
+                    println!("worker {my_index}:\terror connecting to worker {index}: {error}; retrying");
+                    sleep(Duration::from_secs(1));
+                },
+            }
+        }
+    }).collect();
+
+    Ok(results)
+}
+
+/// Result contains connections [my_index + 1, addresses.len() - 1].
+pub fn await_connections(
+    addresses: Arc<Vec<String>>,
+    my_index: usize,
+    noisy: bool,
+) -> IoResult<Vec<Option<TcpStream>>> {
+    let mut results: Vec<_> = (0..(addresses.len() - my_index - 1))
+        .map(|_| None)
+        .collect();
+    let listener = TcpListener::bind(&addresses[my_index][..])?;
+
+    for _ in (my_index + 1)..addresses.len() {
+        let mut stream = listener.accept()?.0;
+        stream.set_nodelay(true).expect("set_nodelay call failed");
+        let mut buffer = [0u8; 16];
+        stream.read_exact(&mut buffer)?;
+        let magic = u64::from_ne_bytes((&buffer[0..8]).try_into().unwrap());
+        if magic != HANDSHAKE_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "received incorrect timely handshake",
+            ));
+        }
+        let identifier = u64::from_ne_bytes((&buffer[8..16]).try_into().unwrap());
+        stream
+            .write_all(ACK_MAGIC.to_ne_bytes().as_slice())
+            .expect("failed to send ack magic");
+        results[identifier as usize - my_index - 1] = Some(stream);
+        if noisy {
+            println!(
+                "worker {}:\tconnection from worker {}",
+                my_index, identifier
+            );
+        }
+    }
+
+    Ok(results)
+}

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -88,10 +88,7 @@ where
                     initialize_networking_from_sockets(sockets, process, threads, log_fn)
                 }) {
                     Ok((stuff, guard)) => Ok((
-                        stuff
-                            .into_iter()
-                            .map(GenericBuilder::ZeroCopy)
-                            .collect(),
+                        stuff.into_iter().map(GenericBuilder::ZeroCopy).collect(),
                         Box::new(guard),
                     )),
                     Err(err) => Err(format!("failed to initialize networking: {}", err)),

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -20,3 +20,5 @@ pub(crate) mod sink;
 
 pub use arrangement::manager::{TraceManager, TraceMetrics};
 pub use sink::SinkBaseMetrics;
+
+pub mod communication;

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -12,6 +12,7 @@
 //! Driver for timely/differential dataflow.
 
 pub(crate) mod arrangement;
+pub mod communication;
 pub mod compute_state;
 pub(crate) mod logging;
 pub(crate) mod render;
@@ -20,4 +21,3 @@ pub(crate) mod sink;
 
 pub use arrangement::manager::{TraceManager, TraceMetrics};
 pub use sink::SinkBaseMetrics;
-pub mod communication;

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -20,5 +20,4 @@ pub(crate) mod sink;
 
 pub use arrangement::manager::{TraceManager, TraceMetrics};
 pub use sink::SinkBaseMetrics;
-
 pub mod communication;

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -16,7 +16,9 @@ use anyhow::anyhow;
 use crossbeam_channel::TryRecvError;
 use timely::communication::initialize::WorkerGuards;
 use timely::communication::Allocate;
+use timely::execute::execute_from;
 use timely::worker::Worker as TimelyWorker;
+use timely::WorkerConfig;
 use tokio::sync::mpsc;
 
 use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, LocalClient, LocalComputeClient};
@@ -24,18 +26,28 @@ use mz_dataflow_types::ConnectorContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 
-use crate::communication::execute_acking_connections;
+use crate::communication::initialize_networking;
 use crate::compute_state::ActiveComputeState;
 use crate::compute_state::ComputeState;
 use crate::SinkBaseMetrics;
 use crate::{TraceManager, TraceMetrics};
 
+/// Configuration of the cluster we will spin up
+pub struct CommunicationConfig {
+    /// Number of per-process worker threads
+    pub threads: usize,
+    /// Identity of this process
+    pub process: usize,
+    /// Addresses of all processes
+    pub addresses: Vec<String>,
+}
+
 /// Configures a dataflow server.
 pub struct Config {
     /// The number of worker threads to spawn.
     pub workers: usize,
-    /// The Timely configuration
-    pub timely_config: timely::Config,
+    /// Configuration for the communication mesh
+    pub comm_config: CommunicationConfig,
     /// Whether the server is running in experimental mode.
     pub experimental_mode: bool,
     /// Function to get wall time now.
@@ -83,28 +95,36 @@ pub fn serve(config: Config) -> Result<(Server, LocalComputeClient), anyhow::Err
 
     let tokio_executor = tokio::runtime::Handle::current();
 
-    let worker_guards = execute_acking_connections(config.timely_config, move |timely_worker| {
-        let timely_worker_index = timely_worker.index();
-        let _tokio_guard = tokio_executor.enter();
-        let command_rx = command_channels.lock().unwrap()[timely_worker_index % config.workers]
-            .take()
-            .unwrap();
-        let compute_response_tx = compute_response_channels.lock().unwrap()
-            [timely_worker_index % config.workers]
-            .take()
-            .unwrap();
-        let (_sink_metrics, _trace_metrics) = metrics_bundle.clone();
-        Worker {
-            timely_worker,
-            command_rx,
-            compute_state: None,
-            compute_response_tx,
-            metrics_bundle: metrics_bundle.clone(),
-            connector_context: config.connector_context.clone(),
-        }
-        .run()
-    })
-    .map_err(|e| anyhow!("{}", e))?;
+    let (builders, other) =
+        initialize_networking(config.comm_config).map_err(|e| anyhow!("{e}"))?;
+
+    let worker_guards = execute_from(
+        builders,
+        other,
+        WorkerConfig::default(),
+        move |timely_worker| {
+            let timely_worker_index = timely_worker.index();
+            let _tokio_guard = tokio_executor.enter();
+            let command_rx = command_channels.lock().unwrap()[timely_worker_index % config.workers]
+                .take()
+                .unwrap();
+            let compute_response_tx = compute_response_channels.lock().unwrap()
+                [timely_worker_index % config.workers]
+                .take()
+                .unwrap();
+            let (_sink_metrics, _trace_metrics) = metrics_bundle.clone();
+            Worker {
+                timely_worker,
+                command_rx,
+                compute_state: None,
+                compute_response_tx,
+                metrics_bundle: metrics_bundle.clone(),
+                connector_context: config.connector_context.clone(),
+            }
+            .run()
+        },
+    )
+    .map_err(|e| anyhow!("{e}"))?;
     let worker_threads = worker_guards
         .guards()
         .iter()

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -24,6 +24,7 @@ use mz_dataflow_types::ConnectorContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 
+use crate::communication::execute_acking_connections;
 use crate::compute_state::ActiveComputeState;
 use crate::compute_state::ComputeState;
 use crate::SinkBaseMetrics;
@@ -82,7 +83,7 @@ pub fn serve(config: Config) -> Result<(Server, LocalComputeClient), anyhow::Err
 
     let tokio_executor = tokio::runtime::Handle::current();
 
-    let worker_guards = timely::execute::execute(config.timely_config, move |timely_worker| {
+    let worker_guards = execute_acking_connections(config.timely_config, move |timely_worker| {
         let timely_worker_index = timely_worker.index();
         let _tokio_guard = tokio_executor.enter();
         let command_rx = command_channels.lock().unwrap()[timely_worker_index % config.workers]


### PR DESCRIPTION
### Motivation

Mitigates an issue I was seeing where replicas would commonly go into crash loops after one process died, taking several reboot cycles to recover, and in some cases never recovering all. On my personal stack I was observing this roughly one out of every 2 or 3 times a process was killed.

We are not certain what causes the issue, but my current theory is that when two process crash and attempt to reconnect, the `linkerd` proxy sidecar somehow reactivates the connection that previously belonged to the old, crashed process. Thus the connecting process is able to establish a "phantom" TCP connection that it will never be able to read from.

We mitigate this issue by requiring the receiving process to send a magic string back to the connecting process. If the connecting process does not receive this string, it will not consider the connection to have been successfully established, and will continue in the connection establishment retry loop.

### Tips for reviewer

Virtually all of this code was copied and pasted from Timely -- we could make this change in Timely itself, but there was concerns about adding custom logic there just to hack around weird Materialize Cloud networking issues.

I have no strong opinions, and would be happy to make the change in Timely itself instead, if people think the grossness of copy-pasting all this code outweighs those concerns. Just let me know what you all think!

The only actual changes are (1) sending the ack string as described above, and (2) using the stdlib conversion functions between buffers and integral types, rather than taking a dependency on `abomonation`.

#### Appendix

This is the diff that would be made to Timely, for ease of review here:

```
1 file changed, 15 insertions(+), 1 deletion(-)
communication/src/networking.rs | 16 +++++++++++++++-

modified   communication/src/networking.rs
@@ -1,6 +1,6 @@
 //! Networking code for sending and receiving fixed size `Vec<u8>` between machines.
 
-use std::io;
+use std::io::{self, Write};
 use std::io::{Read, Result};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -15,6 +15,11 @@ use abomonation::{encode, decode};
 // other traffic on the same port.
 const HANDSHAKE_MAGIC: u64 = 0xc2f1fb770118add9;
 
+// This constant is sent upon receiving a connection. The process establishing
+// the connection must receive it in order to consider the connection to be
+// successfully established.
+const ACK_MAGIC: u64 = 0x68656c6f77726c64;
+
 /// Framing data for each `Vec<u8>` transmission, indicating a typed channel, the source and
 /// destination workers, and the length in bytes.
 #[derive(Abomonation, Debug, PartialEq, Eq, Hash, Clone, Copy)]
@@ -91,6 +96,14 @@ pub fn start_connections(addresses: Arc<Vec<String>>, my_index: usize, noisy: bo
                     stream.set_nodelay(true).expect("set_nodelay call failed");
                     unsafe { encode(&HANDSHAKE_MAGIC, &mut stream) }.expect("failed to encode/send handshake magic");
                     unsafe { encode(&(my_index as u64), &mut stream) }.expect("failed to encode/send worker index");
+                    let mut buffer = [0u8; 8];
+                    let _ = stream.read_exact(&mut buffer);
+                    let peer_ack = u64::from_ne_bytes(buffer);
+                    if peer_ack != ACK_MAGIC {
+                        println!("worker {my_index} failed computed handshake with worker {index}; retrying");
+                        sleep(Duration::from_secs(1));
+                        continue;
+                    }
                     if noisy { println!("worker {}:\tconnection to worker {}", my_index, index); }
                     break Some(stream);
                 },
@@ -121,6 +134,7 @@ pub fn await_connections(addresses: Arc<Vec<String>>, my_index: usize, noisy: bo
                 "received incorrect timely handshake"));
         }
         let identifier = unsafe { decode::<u64>(&mut buffer) }.expect("failed to decode worker index").0.clone() as usize;
+        stream.write_all(ACK_MAGIC.to_ne_bytes().as_slice()).expect("failed to send ack magic");
         results[identifier - my_index - 1] = Some(stream);
         if noisy { println!("worker {}:\tconnection from worker {}", my_index, identifier); }
     }
 ```

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

I don't have an automated test, but... something that was completely broken now seems, anecdotally, to be working reliably, so I think that's good enough!