### PR TITLE
sql[-parser]: integrate connectors with name resolution

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -411,7 +411,7 @@ impl_display_t!(CreateConnectorStatement);
 pub struct CreateSourceStatement<T: AstInfo> {
     pub name: UnresolvedObjectName,
     pub col_names: Vec<Ident>,
-    pub connector: CreateSourceConnector,
+    pub connector: CreateSourceConnector<T>,
     pub with_options: Vec<WithOption<T>>,
     pub include_metadata: Vec<SourceIncludeMetadata>,
     pub format: CreateSourceFormat<T>,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1728,10 +1728,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_csr_connector_avro(&mut self) -> Result<CsrConnectorAvro<Raw>, ParserError> {
-        let connector = if self.peek_keyword(CONNECTOR) {
-            let _ = self.expect_keyword(CONNECTOR);
+        let connector = if self.parse_keyword(CONNECTOR) {
             CsrConnector::Reference {
-                connector: self.parse_object_name()?,
+                connector: self.parse_raw_name()?,
                 url: None,
                 with_options: None,
             }
@@ -1772,10 +1771,9 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_csr_connector_proto(&mut self) -> Result<CsrConnectorProto<Raw>, ParserError> {
-        let connector = if self.peek_keyword(CONNECTOR) {
-            let _ = self.expect_keyword(CONNECTOR);
+        let connector = if self.parse_keyword(CONNECTOR) {
             CsrConnector::Reference {
-                connector: self.parse_object_name()?,
+                connector: self.parse_raw_name()?,
                 url: None,
                 with_options: None,
             }
@@ -2077,7 +2075,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector, ParserError> {
+    fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector<Raw>, ParserError> {
         match self.expect_one_of_keywords(&[KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
@@ -2119,7 +2117,7 @@ impl<'a> Parser<'a> {
                         broker: self.parse_literal_string()?,
                     },
                     CONNECTOR => KafkaConnector::Reference {
-                        connector: self.parse_object_name()?,
+                        connector: self.parse_raw_name()?,
                         broker: None,
                         with_options: None,
                     },

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1365,7 +1365,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'l
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: UnresolvedObjectName([Ident("conn1")]), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
@@ -1379,7 +1379,7 @@ CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONF
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: UnresolvedObjectName([Ident("conn1")]), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Reference { connector: UnresolvedObjectName([Ident("conn2")]), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain)), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain)), if_not_exists: false, materialized: false, key_constraint: None })
 
 
 parse-statement
@@ -1387,4 +1387,4 @@ CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING 
 ----
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: UnresolvedObjectName([Ident("conn1")]), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connector: CsrConnectorProto { connector: Reference { connector: UnresolvedObjectName([Ident("conn2")]), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain)), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])), broker: None, with_options: None }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connector: CsrConnectorProto { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])), url: None, with_options: None }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain)), if_not_exists: false, materialized: false, key_constraint: None })

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -26,9 +26,9 @@ use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
     AstInfo, CreateConnectorStatement, CreateIndexStatement, CreateSecretStatement,
     CreateSinkStatement, CreateSourceStatement, CreateTableStatement, CreateTypeAs,
-    CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior,
-    KafkaConnector, KafkaSourceConnector, Op, Query, Statement, TableFactor, TableFunction,
-    UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition, WithOption, WithOptionValue,
+    CreateTypeStatement, CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op,
+    Query, Statement, TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName,
+    Value, ViewDefinition, WithOption, WithOptionValue,
 };
 
 use crate::names::{
@@ -320,9 +320,9 @@ pub fn create_statement(
         Statement::CreateSource(CreateSourceStatement {
             name,
             col_names: _,
-            connector,
+            connector: _,
             with_options,
-            format,
+            format: _,
             include_metadata: _,
             envelope: _,
             if_not_exists,
@@ -341,15 +341,6 @@ pub fn create_statement(
                     }
                 }
             }
-            if let mz_sql_parser::ast::CreateSourceConnector::Kafka(KafkaSourceConnector {
-                connector: KafkaConnector::Reference { connector, .. },
-                ..
-            }) = connector
-            {
-                *connector = allocate_name(connector)?;
-            };
-
-            crate::connectors::qualify_csr_connector_names(format, scx)?;
         }
 
         Statement::CreateTable(CreateTableStatement {

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -291,8 +291,8 @@ pub fn plan(
             ddl::plan_create_table(scx, stmt, depends_on)
         }
         stmt @ Statement::CreateSource(_) => {
-            let (stmt, _) = resolve_stmt!(Statement::CreateSource, scx, stmt);
-            ddl::plan_create_source(scx, stmt)
+            let (stmt, depends_on) = resolve_stmt!(Statement::CreateSource, scx, stmt);
+            ddl::plan_create_source(scx, stmt, depends_on)
         }
         stmt @ Statement::CreateView(_) => {
             let (stmt, depends_on) = resolve_stmt!(Statement::CreateView, scx, stmt);

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -75,7 +75,6 @@ use crate::ast::{
     Value, ViewDefinition, WithOption,
 };
 use crate::catalog::{CatalogItem, CatalogItemType, CatalogType, CatalogTypeDetails};
-use crate::connectors::populate_connectors;
 use crate::kafka_util;
 use crate::names::{
     resolve_names_data_type, resolve_object_name, Aug, FullSchemaName, QualifiedObjectName,
@@ -304,9 +303,8 @@ pub fn describe_create_source(
 pub fn plan_create_source(
     scx: &StatementContext,
     stmt: CreateSourceStatement<Aug>,
+    mut depends_on: HashSet<GlobalId>,
 ) -> Result<Plan, anyhow::Error> {
-    let mut depends_on = vec![];
-    let stmt = populate_connectors(stmt, scx.catalog, &mut depends_on)?;
     let CreateSourceStatement {
         name,
         col_names,
@@ -353,21 +351,10 @@ pub fn plan_create_source(
         CreateSourceConnector::Kafka(kafka) => {
             let (broker, options) = match &kafka.connector {
                 mz_sql_parser::ast::KafkaConnector::Inline { broker } => (broker.to_owned(), None),
-                mz_sql_parser::ast::KafkaConnector::Reference {
-                    broker,
-                    with_options,
-                    connector,
-                } => {
-                    let broker_addr = broker.to_owned().expect("connector should be populated");
-                    let options = with_options
-                        .to_owned()
-                        .expect("connector should be populated");
-                    depends_on.push(
-                        scx.catalog
-                            .resolve_item(&normalize::unresolved_object_name(connector.clone())?)?
-                            .id(),
-                    );
-                    (broker_addr, Some(options))
+                mz_sql_parser::ast::KafkaConnector::Reference { connector, .. } => {
+                    let item = scx.get_item_by_resolved_name(&connector)?;
+                    let connector = item.catalog_connector()?;
+                    (connector.uri(), Some(connector.options()))
                 }
             };
 
@@ -410,7 +397,7 @@ pub fn plan_create_source(
                 Some(v) => bail!("invalid start_offset value: {}", v),
             }
 
-            let encoding = get_encoding(format, &envelope, with_options_original)?;
+            let encoding = get_encoding(scx, format, &envelope, with_options_original)?;
 
             let mut connector = KafkaSourceConnector {
                 addrs: broker.parse()?,
@@ -506,7 +493,7 @@ pub fn plan_create_source(
             let aws = normalize::aws_config(&mut with_options, Some(region.into()))?;
             let connector =
                 ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, aws });
-            let encoding = get_encoding(format, &envelope, with_options_original)?;
+            let encoding = get_encoding(scx, format, &envelope, with_options_original)?;
             (connector, encoding)
         }
         CreateSourceConnector::S3 {
@@ -548,7 +535,7 @@ pub fn plan_create_source(
                     Compression::None => mz_dataflow_types::sources::Compression::None,
                 },
             });
-            let encoding = get_encoding(format, &envelope, with_options_original)?;
+            let encoding = get_encoding(scx, format, &envelope, with_options_original)?;
             if matches!(encoding, SourceDataEncoding::KeyValue { .. }) {
                 bail!("S3 sources do not support key decoding");
             }
@@ -649,7 +636,7 @@ pub fn plan_create_source(
                                 .desc(&full_name)
                                 .context("tx_metadata must refer to a source")?;
 
-                            depends_on.push(item.id());
+                            depends_on.insert(item.id());
                             depends_on.extend(item.uses());
 
                             Some(typecheck_debezium_transaction_metadata(
@@ -906,7 +893,7 @@ pub fn plan_create_source(
             timeline,
         },
         desc,
-        depends_on,
+        depends_on: depends_on.into_iter().collect(),
     };
 
     normalize::ensure_empty_options(&with_options, "CREATE SOURCE")?;
@@ -1164,19 +1151,20 @@ fn typecheck_debezium_transaction_metadata(
 }
 
 fn get_encoding(
+    scx: &StatementContext,
     format: &CreateSourceFormat<Aug>,
     envelope: &Envelope,
     with_options: &Vec<WithOption<Aug>>,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     let encoding = match format {
         CreateSourceFormat::None => bail!("Source format must be specified"),
-        CreateSourceFormat::Bare(format) => get_encoding_inner(format, with_options)?,
+        CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format, with_options)?,
         CreateSourceFormat::KeyValue { key, value } => {
-            let key = match get_encoding_inner(key, with_options)? {
+            let key = match get_encoding_inner(scx, key, with_options)? {
                 SourceDataEncoding::Single(key) => key,
                 SourceDataEncoding::KeyValue { key, .. } => key,
             };
-            let value = match get_encoding_inner(value, with_options)? {
+            let value = match get_encoding_inner(scx, value, with_options)? {
                 SourceDataEncoding::Single(value) => value,
                 SourceDataEncoding::KeyValue { value, .. } => value,
             };
@@ -1197,6 +1185,7 @@ fn get_encoding(
 }
 
 fn get_encoding_inner(
+    scx: &StatementContext,
     format: &Format<Aug>,
     with_options: &Vec<WithOption<Aug>>,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
@@ -1246,22 +1235,18 @@ fn get_encoding_inner(
                         },
                 } => {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => (normalize::options(&ccsr_options)?, url),
-                        CsrConnector::Reference {
-                            url, with_options, ..
-                        } => {
-                            let registry_url = match url {
-                                Some(url) => url,
-                                None => unreachable!("connector must already be populated"),
-                            };
-                            let client_options = match with_options {
-                                Some(opts) => BTreeMap::from_iter(
-                                    opts.iter()
-                                        .map(|(k, v)| (k.to_owned(), Value::String(v.to_string()))),
-                                ),
-                                None => BTreeMap::new(),
-                            };
-                            (client_options, registry_url)
+                        CsrConnector::Inline { url } => {
+                            (normalize::options(&ccsr_options)?, url.into())
+                        }
+                        CsrConnector::Reference { connector, .. } => {
+                            let item = scx.get_item_by_resolved_name(&connector)?;
+                            let connector = item.catalog_connector()?;
+                            let options = connector
+                                .options()
+                                .into_iter()
+                                .map(|(k, v)| (k, Value::String(v)))
+                                .collect();
+                            (options, connector.uri())
                         }
                     };
                     let ccsr_config = kafka_util::generate_ccsr_client_config(
@@ -1320,21 +1305,18 @@ fn get_encoding_inner(
                     seed
                 {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => (normalize::options(&ccsr_options)?, url),
-                        CsrConnector::Reference {
-                            url, with_options, ..
-                        } => {
-                            let registry_url = match url {
-                                Some(url) => url,
-                                None => unreachable!("connector must already be populated"),
-                            };
-                            let client_options = match with_options {
-                                Some(opts) => BTreeMap::from_iter(opts.iter().map(|(k, v)| {
-                                    (k.to_owned(), crate::ast::Value::String(v.to_owned()))
-                                })),
-                                None => BTreeMap::new(),
-                            };
-                            (client_options, registry_url)
+                        CsrConnector::Inline { url } => {
+                            (normalize::options(&ccsr_options)?, url.to_string())
+                        }
+                        CsrConnector::Reference { connector, .. } => {
+                            let item = scx.get_item_by_resolved_name(&connector)?;
+                            let connector = item.catalog_connector()?;
+                            let options = connector
+                                .options()
+                                .into_iter()
+                                .map(|(k, v)| (k, Value::String(v)))
+                                .collect();
+                            (options, connector.uri())
                         }
                     };
                     // We validate here instead of in purification, to match the behavior of avro

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -195,7 +195,7 @@ pub async fn purify_create_source(
 
 async fn purify_source_format(
     format: &mut CreateSourceFormat<Raw>,
-    connector: &mut CreateSourceConnector,
+    connector: &mut CreateSourceConnector<Raw>,
     envelope: &Option<Envelope>,
     connector_options: &BTreeMap<String, String>,
     with_options: &Vec<WithOption<Raw>>,
@@ -251,7 +251,7 @@ async fn purify_source_format(
 
 async fn purify_source_format_single(
     format: &mut Format<Raw>,
-    connector: &mut CreateSourceConnector,
+    connector: &mut CreateSourceConnector<Raw>,
     envelope: &Option<Envelope>,
     connector_options: &BTreeMap<String, String>,
     with_options: &Vec<WithOption<Raw>>,
@@ -326,7 +326,7 @@ async fn purify_source_format_single(
 }
 
 async fn purify_csr_connector_proto(
-    connector: &mut CreateSourceConnector,
+    connector: &mut CreateSourceConnector<Raw>,
     csr_connector: &mut CsrConnectorProto<Raw>,
     envelope: &Option<Envelope>,
     with_options: &Vec<WithOption<Raw>>,
@@ -384,7 +384,7 @@ async fn purify_csr_connector_proto(
 }
 
 async fn purify_csr_connector_avro(
-    connector: &mut CreateSourceConnector,
+    connector: &mut CreateSourceConnector<Raw>,
     csr_connector: &mut CsrConnectorAvro<Raw>,
     envelope: &Option<Envelope>,
     connector_options: &BTreeMap<String, String>,


### PR DESCRIPTION
Connector references in `CREATE SOURCE` statements, as in

    CREATE SOURCE ... FROM KAFKA CONNECTOR db.schema.connector

were currently handled with custom name resolution and dependency
tracking code. But they work just like table references in a `SELECT`
statement.

This commit pivots connectors to use the standard name resolution
infrastructure, which eliminates a heap of complexity.

Part of the connector epic (#11504).

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
