### PR TITLE
sql: always resolve all names as first step of planning

### DIFF
--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -24,8 +24,8 @@ use std::mem;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
-    Expr, FunctionArgs, Ident, UnresolvedDataType, UnresolvedDatabaseName, UnresolvedObjectName,
-    UnresolvedSchemaName, WithOption,
+    Expr, FunctionArgs, Ident, Statement, UnresolvedDataType, UnresolvedDatabaseName,
+    UnresolvedObjectName, UnresolvedSchemaName, WithOption,
 };
 
 /// This represents the metadata that lives next to an AST, as we take it through
@@ -44,6 +44,8 @@ use crate::ast::{
 /// Currently this process brings an Ast<Raw> to Ast<Aug>, and lives in
 /// sql/src/names.rs:resolve_names.
 pub trait AstInfo: Clone {
+    /// The type used for nested statements.
+    type NestedStatement: AstDisplay + Clone + Hash + Debug + Eq;
     /// The type used for table references.
     type ObjectName: AstDisplay + Clone + Hash + Debug + Eq;
     /// The type used for schema names.
@@ -116,6 +118,7 @@ impl AstDisplay for RawIdent {
 impl_display!(RawIdent);
 
 impl AstInfo for Raw {
+    type NestedStatement = Statement<Raw>;
     type ObjectName = RawObjectName;
     type SchemaName = UnresolvedSchemaName;
     type DatabaseName = UnresolvedDatabaseName;

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -51,7 +51,7 @@ pub enum Statement<T: AstInfo> {
     CreateCluster(CreateClusterStatement<T>),
     CreateClusterReplica(CreateClusterReplicaStatement<T>),
     CreateSecret(CreateSecretStatement<T>),
-    AlterObjectRename(AlterObjectRenameStatement<T>),
+    AlterObjectRename(AlterObjectRenameStatement),
     AlterIndex(AlterIndexStatement<T>),
     AlterSecret(AlterSecretStatement<T>),
     Discard(DiscardStatement),
@@ -1027,14 +1027,14 @@ impl_display_t!(CreateTypeAs);
 
 /// `ALTER <OBJECT> ... RENAME TO`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct AlterObjectRenameStatement<T: AstInfo> {
+pub struct AlterObjectRenameStatement {
     pub object_type: ObjectType,
     pub if_exists: bool,
-    pub name: T::ObjectName,
+    pub name: UnresolvedObjectName,
     pub to_item_name: Ident,
 }
 
-impl<T: AstInfo> AstDisplay for AlterObjectRenameStatement<T> {
+impl AstDisplay for AlterObjectRenameStatement {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER ");
         f.write_node(&self.object_type);
@@ -1047,7 +1047,7 @@ impl<T: AstInfo> AstDisplay for AlterObjectRenameStatement<T> {
         f.write_node(&self.to_item_name);
     }
 }
-impl_display_t!(AlterObjectRenameStatement);
+impl_display!(AlterObjectRenameStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterIndexAction<T: AstInfo> {
@@ -1058,7 +1058,7 @@ pub enum AlterIndexAction<T: AstInfo> {
 /// `ALTER INDEX ... {RESET, SET}`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterIndexStatement<T: AstInfo> {
-    pub index_name: T::ObjectName,
+    pub index_name: UnresolvedObjectName,
     pub if_exists: bool,
     pub action: AlterIndexAction<T>,
 }
@@ -1092,7 +1092,7 @@ impl_display_t!(AlterIndexStatement);
 /// `ALTER SECRET ... AS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlterSecretStatement<T: AstInfo> {
-    pub name: T::ObjectName,
+    pub name: UnresolvedObjectName,
     pub if_exists: bool,
     pub value: Expr<T>,
 }
@@ -2020,7 +2020,7 @@ pub enum IfExistsBehavior {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DeclareStatement<T: AstInfo> {
     pub name: Ident,
-    pub stmt: Box<Statement<T>>,
+    pub stmt: Box<T::NestedStatement>,
 }
 
 impl<T: AstInfo> AstDisplay for DeclareStatement<T> {
@@ -2091,7 +2091,7 @@ impl_display!(FetchDirection);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PrepareStatement<T: AstInfo> {
     pub name: Ident,
-    pub stmt: Box<Statement<T>>,
+    pub stmt: Box<T::NestedStatement>,
 }
 
 impl<T: AstInfo> AstDisplay for PrepareStatement<T> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3053,7 +3053,7 @@ impl<'a> Parser<'a> {
             };
 
         let if_exists = self.parse_if_exists()?;
-        let name = self.parse_raw_name()?;
+        let name = self.parse_object_name()?;
 
         self.expect_keywords(&[RENAME, TO])?;
         let to_item_name = self.parse_identifier()?;
@@ -3068,7 +3068,7 @@ impl<'a> Parser<'a> {
 
     fn parse_alter_index(&mut self) -> Result<Statement<Raw>, ParserError> {
         let if_exists = self.parse_if_exists()?;
-        let name = self.parse_raw_name()?;
+        let name = self.parse_object_name()?;
 
         Ok(match self.expect_one_of_keywords(&[RESET, SET, RENAME])? {
             RESET => {
@@ -3107,7 +3107,7 @@ impl<'a> Parser<'a> {
 
     fn parse_alter_secret(&mut self) -> Result<Statement<Raw>, ParserError> {
         let if_exists = self.parse_if_exists()?;
-        let name = self.parse_raw_name()?;
+        let name = self.parse_object_name()?;
 
         Ok(match self.expect_one_of_keywords(&[AS, RENAME])? {
             AS => {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1049,21 +1049,21 @@ ALTER INDEX name SET (property = true)
 ----
 ALTER INDEX name SET (property = true)
 =>
-AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
+AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
 
 parse-statement
 ALTER INDEX name RESET (property)
 ----
 ALTER INDEX name RESET (property)
 =>
-AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: ResetOptions([Ident("property")]) })
+AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: ResetOptions([Ident("property")]) })
 
 parse-statement
 ALTER INDEX IF EXISTS name SET (property = true)
 ----
 ALTER INDEX IF EXISTS name SET (property = true)
 =>
-AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: true, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
+AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: true, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
 
 parse-statement
 ALTER INDEX name SET ()
@@ -1084,7 +1084,7 @@ ALTER INDEX name SET (property)
 ----
 ALTER INDEX name SET (property)
 =>
-AlterIndex(AlterIndexStatement { index_name: Name(UnresolvedObjectName([Ident("name")])), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: None }]) })
+AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: None }]) })
 
 parse-statement
 ALTER INDEX name RESET (property = true)
@@ -1119,7 +1119,7 @@ ALTER INDEX name RENAME TO name2
 ----
 ALTER INDEX name RENAME TO name2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: Index, if_exists: false, name: Name(UnresolvedObjectName([Ident("name")])), to_item_name: Ident("name2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: Index, if_exists: false, name: UnresolvedObjectName([Ident("name")]), to_item_name: Ident("name2") })
 
 parse-statement
 ALTER INDEX i1 misplaced
@@ -1336,14 +1336,14 @@ ALTER SECRET secret RENAME TO secret2
 ----
 ALTER SECRET secret RENAME TO secret2
 =>
-AlterObjectRename(AlterObjectRenameStatement { object_type: Secret, if_exists: false, name: Name(UnresolvedObjectName([Ident("secret")])), to_item_name: Ident("secret2") })
+AlterObjectRename(AlterObjectRenameStatement { object_type: Secret, if_exists: false, name: UnresolvedObjectName([Ident("secret")]), to_item_name: Ident("secret2") })
 
 parse-statement
 ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 ----
 ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 =>
-AlterSecret(AlterSecretStatement { name: Name(UnresolvedObjectName([Ident("secret")])), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
+AlterSecret(AlterSecretStatement { name: UnresolvedObjectName([Ident("secret")]), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 
 parse-statement

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -588,6 +588,7 @@ impl ResolvedDataType {
 }
 
 impl AstInfo for Aug {
+    type NestedStatement = Statement<Raw>;
     type ObjectName = ResolvedObjectName;
     type SchemaName = ResolvedSchemaName;
     type DatabaseName = ResolvedDatabaseName;
@@ -750,6 +751,13 @@ impl<'a> NameResolver<'a> {
 }
 
 impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
+    fn fold_nested_statement(
+        &mut self,
+        stmt: <Raw as AstInfo>::NestedStatement,
+    ) -> <Aug as AstInfo>::NestedStatement {
+        stmt
+    }
+
     fn fold_query(&mut self, q: Query<Raw>) -> Query<Aug> {
         // Retain the old values of various CTE names so that we can restore them after we're done
         // planning this SELECT.

--- a/src/sql/src/plan/statement/scl.rs
+++ b/src/sql/src/plan/statement/scl.rs
@@ -20,7 +20,7 @@ use mz_repr::{RelationDesc, ScalarType};
 
 use crate::ast::{
     CloseStatement, DeallocateStatement, DeclareStatement, DiscardStatement, DiscardTarget,
-    ExecuteStatement, FetchStatement, PrepareStatement, Raw, ResetVariableStatement,
+    ExecuteStatement, FetchStatement, PrepareStatement, ResetVariableStatement,
     SetVariableStatement, ShowVariableStatement, Value,
 };
 use crate::names::Aug;
@@ -124,7 +124,7 @@ pub fn describe_declare(
 
 pub fn plan_declare(
     _: &StatementContext,
-    DeclareStatement { name, stmt }: DeclareStatement<Raw>,
+    DeclareStatement { name, stmt }: DeclareStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     Ok(Plan::Declare(DeclarePlan {
         name: name.to_string(),
@@ -201,7 +201,7 @@ pub fn describe_prepare(
 
 pub fn plan_prepare(
     scx: &StatementContext,
-    PrepareStatement { name, stmt }: PrepareStatement<Raw>,
+    PrepareStatement { name, stmt }: PrepareStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
     // TODO: PREPARE supports specifying param types.
     let param_types = [];


### PR DESCRIPTION
This does for the plan_* suite of functions what #12830 did for the
describe_* suite of functions. The `sql::plan` function now
unconditionally performs name resolution as the first step of planning.

A few statements need to opt some of their names out of the forced name
resolution. `DROP` and `ALTER` both need to suppress name resolution
errors if the `IF EXISTS` clause is present. `PREPARE` and `DECLARE`
need to defer name resolution on their embedded statements. The approach
taken is to make these names non-generic in the AST; e.g., where you'd
normally use a `T::ObjectName`, you use an `UnresolvedObjectName`
instead; this leaves resolving the names to the relevant plan_ function.
In the future we might want to investigate alternatives, like definining
`Aug::ObjectName` as `Result<ResolvedObjectName, anyhow::Error>`.

This is further work towards #5302.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
