### PR TITLE
materialized: Extend the range of the PortAllocator to 1000

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -518,7 +518,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                     port_allocator: Arc::new(PortAllocator::new(
                         args.base_service_port,
                         args.base_service_port
-                            .checked_add(100)
+                            .checked_add(1000)
                             .expect("Port number overflow, base-service-port too large."),
                     )),
                     suppress_output: false,


### PR DESCRIPTION
In the one-storaged-per-source world, 100 TCP ports are not
sufficient to do anything meaningful and a 'port exhaustion'
panic occurs easily.

### Motivation

  * This PR fixes a previously unreported bug.
The "limits" test started failing due to insufficient ports.
