### PR TITLE
tests: Fix tests for the new CREATE CLUSTER ... REPLICAS syntax

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -143,9 +143,9 @@ def start_services(
 
             c.sql("DROP CLUSTER default")
             c.sql(
-                "CREATE CLUSTER default REPLICA replica1 (REMOTE ("
+                "CREATE CLUSTER default REPLICAS (replica1 (REMOTE ("
                 + ",".join([f"'computed_{n}:2100'" for n in range(0, nodes)])
-                + "));"
+                + ")));"
             )
 
     c.up("testdrive", persistent=True)

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1234,7 +1234,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     replica_name = f"replica_{cluster_id}_{replica_id}"
 
                     replica_definitions.append(
-                        f"REPLICA {replica_name} (REMOTE ("
+                        f"{replica_name} (REMOTE ("
                         + ", ".join(f'"{n}:2100"' for n in nodes)
                         + "))"
                     )


### PR DESCRIPTION
PR #12778 changed the syntax for CREATE CLUSTER which caused tests
to break.

### Motivation

  * This PR fixes a previously unreported bug.

The CI was reporting regressions in the "limits" test.

@sploiselle FYI