### PR TITLE
dataflow-types: allow dropping the default cluster (again)

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -381,7 +381,6 @@ where
                 .iter_mut()
                 .map(|(id, compute)| (*id, compute.client.as_stream()))
                 .collect();
-            let mut storage_alive = true;
             loop {
                 tokio::select! {
                     Some((instance, response)) = compute_stream.next() => {
@@ -390,13 +389,11 @@ where
                         self.stashed_response = Some(UnderlyingControllerResponse::Compute(instance, response));
                         return Ok(());
                     }
-                    response = self.storage_controller.recv(), if storage_alive => {
+                    response = self.storage_controller.recv() => {
                         if let Some(response) = response? {
                             assert!(self.stashed_response.is_none());
                             self.stashed_response = Some(UnderlyingControllerResponse::Storage(response));
                             return Ok(());
-                        } else {
-                            storage_alive = false;
                         }
                     }
                 }


### PR DESCRIPTION
A recent regression, introduced by the change to start a pod per source,
made it so that dropping the default cluster panicked. Fix that, by
ensuring we don't incorrectly indicate that the storage message stream
is finished when there are no sources.

Fix #12837.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
