### PR TITLE
storage: resume ingestion on restart

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -163,8 +163,8 @@ pub fn build_compute_dataflow<A: Allocate>(
                 // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
                 let (ok_stream, err_stream, token) = persist_source::persist_source(
                     region,
-                    source.storage_metadata.clone(),
                     Arc::clone(&compute_state.persist_clients),
+                    source.storage_metadata.clone(),
                     dataflow.as_of.clone().unwrap(),
                 );
 

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -59,7 +59,7 @@ where
 
         let persist_clients = Arc::clone(&compute_state.persist_clients);
         let persist_location = self.storage_metadata.persist_location.clone();
-        let shard_id = self.storage_metadata.persist_shard;
+        let shard_id = self.storage_metadata.data_shard;
 
         // Log the shard ID so we know which shard to read for testing.
         // TODO(teskje): Remove once we have a built-in way for reading back sinked data.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -731,7 +731,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     let mut ingestion = IngestionDescription {
                         id: entry.id(),
                         desc: source_description,
-                        since: Antichain::from_elem(Timestamp::minimum()),
                         source_imports: BTreeMap::new(),
                         storage_metadata: (),
                     };
@@ -769,7 +768,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     let mut ingestion = IngestionDescription {
                         id: entry.id(),
                         desc: source_description,
-                        since: Antichain::from_elem(since_ts),
                         source_imports: BTreeMap::new(),
                         storage_metadata: (),
                     };
@@ -788,6 +786,14 @@ impl<S: Append + 'static> Coordinator<S> {
                         }])
                         .await
                         .unwrap();
+
+                    let policy = ReadPolicy::ValidFrom(Antichain::from_elem(since_ts));
+                    self.dataflow_client
+                        .storage_mut()
+                        .set_read_policy(vec![(entry.id(), policy)])
+                        .await
+                        .unwrap();
+
                     self.initialize_storage_read_policies(
                         vec![entry.id()],
                         self.logical_compaction_window_ms,
@@ -818,7 +824,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         let ingestion = IngestionDescription {
                             id: entry.id(),
                             desc,
-                            since: Antichain::from_elem(Timestamp::minimum()),
                             source_imports: BTreeMap::new(),
                             storage_metadata: (),
                         };
@@ -2769,7 +2774,6 @@ impl<S: Append + 'static> Coordinator<S> {
                 let ingestion = IngestionDescription {
                     id: table_id,
                     desc: source_description,
-                    since: Antichain::from_elem(since_ts),
                     source_imports: BTreeMap::new(),
                     storage_metadata: (),
                 };
@@ -2780,6 +2784,13 @@ impl<S: Append + 'static> Coordinator<S> {
                         ingestion,
                         remote_addr: None,
                     }])
+                    .await
+                    .unwrap();
+
+                let policy = ReadPolicy::ValidFrom(Antichain::from_elem(since_ts));
+                self.dataflow_client
+                    .storage_mut()
+                    .set_read_policy(vec![(table_id, policy)])
                     .await
                     .unwrap();
 
@@ -2883,7 +2894,6 @@ impl<S: Append + 'static> Coordinator<S> {
                 let mut ingestion = IngestionDescription {
                     id: source_id,
                     desc: source_description,
-                    since: Antichain::from_elem(Timestamp::minimum()),
                     source_imports: BTreeMap::new(),
                     storage_metadata: (),
                 };
@@ -3013,7 +3023,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     let ingestion = IngestionDescription {
                         id,
                         desc,
-                        since: Antichain::from_elem(Timestamp::minimum()),
                         source_imports: BTreeMap::new(),
                         storage_metadata: (),
                     };

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -358,7 +358,7 @@ impl<T> ComputeCommand<T> {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// Create the enumerated sources, each associated with its identifier.
-    CreateSources(Vec<IngestionDescription<CollectionMetadata, T>>),
+    CreateSources(Vec<IngestionDescription<CollectionMetadata>>),
     /// Enable compaction in storage-managed collections.
     ///
     /// Each entry in the vector names a collection and provides a frontier after which
@@ -411,11 +411,8 @@ impl Arbitrary for StorageCommand<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         prop_oneof![
-            proptest::collection::vec(
-                any::<IngestionDescription<CollectionMetadata, mz_repr::Timestamp>>(),
-                1..4
-            )
-            .prop_map(StorageCommand::CreateSources),
+            proptest::collection::vec(any::<IngestionDescription<CollectionMetadata>>(), 1..4)
+                .prop_map(StorageCommand::CreateSources),
             proptest::collection::vec(
                 (
                     any::<GlobalId>(),

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -345,7 +345,11 @@ where
         for d in dataflows {
             let mut source_imports = BTreeMap::new();
             for (id, si) in d.source_imports {
-                let metadata = self.storage_controller.collection_metadata(id)?;
+                let metadata = self
+                    .storage_controller
+                    .collection(id)?
+                    .collection_metadata
+                    .clone();
                 let desc = SourceInstanceDesc {
                     description: si.description,
                     storage_metadata: metadata,
@@ -358,7 +362,11 @@ where
             for (id, se) in d.sink_exports {
                 let connection = match se.connection {
                     SinkConnection::Persist(conn) => {
-                        let metadata = self.storage_controller.collection_metadata(id)?;
+                        let metadata = self
+                            .storage_controller
+                            .collection(id)?
+                            .collection_metadata
+                            .clone();
                         let conn = PersistSinkConnection {
                             value_desc: conn.value_desc,
                             storage_metadata: metadata,

--- a/src/dataflow-types/src/client/controller/storage.proto
+++ b/src/dataflow-types/src/client/controller/storage.proto
@@ -16,6 +16,6 @@ package mz_dataflow_types.client.controller.storage;
 message ProtoCollectionMetadata {
     string blob_uri = 1;
     string consensus_uri = 2;
-    string shard_id = 3;
-    string timestamp_shard_id = 4;
+    string data_shard = 3;
+    string remap_shard = 4;
 }

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -27,12 +27,13 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use bytes::BufMut;
 use differential_dataflow::lattice::Lattice;
 use futures::future;
 use futures::stream::TryStreamExt as _;
 use futures::stream::{FuturesUnordered, StreamExt};
-use mz_persist_client::cache::PersistClientCache;
 use proptest_derive::Arbitrary;
+use prost::Message;
 use serde::{Deserialize, Serialize};
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::frontier::MutableAntichain;
@@ -43,11 +44,12 @@ use uuid::Uuid;
 
 use mz_orchestrator::{NamespacedOrchestrator, ServiceConfig, ServicePort};
 use mz_ore::collections::CollectionExt;
+use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{
     read::ReadHandle, write::WriteHandle, PersistClient, PersistLocation, ShardId,
 };
-use mz_persist_types::Codec64;
-use mz_repr::proto::{RustType, TryFromProtoError};
+use mz_persist_types::{Codec, Codec64};
+use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId};
 use mz_stash::{self, StashError, TypedCollection};
 
@@ -56,7 +58,9 @@ use crate::client::{
     GenericClient, ProtoStorageCommand, ProtoStorageResponse, StorageClient, StorageCommand,
     StorageResponse, StoragedRemoteClient,
 };
-use crate::sources::{IngestionDescription, SourceConnection, SourceData, SourceDesc};
+use crate::sources::{
+    ExternalSourceConnection, IngestionDescription, SourceConnection, SourceData, SourceDesc,
+};
 use crate::Update;
 
 include!(concat!(
@@ -64,11 +68,14 @@ include!(concat!(
     "/mz_dataflow_types.client.controller.storage.rs"
 ));
 
+static METADATA_COLLECTION: TypedCollection<GlobalId, CollectionMetadata> =
+    TypedCollection::new("storage-collection-metadata");
+
 /// Describes a request to create a source.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CreateSourceRequest<T> {
+pub struct CreateSourceRequest {
     /// The description of the source to ingest.
-    pub ingestion: IngestionDescription<(), T>,
+    pub ingestion: IngestionDescription<()>,
     /// The address of a `storaged` process on which to install the source.
     ///
     /// If `None`, the controller manages the lifetime of the `storaged`
@@ -89,13 +96,10 @@ pub trait StorageController: Debug + Send {
         id: GlobalId,
     ) -> Result<&mut CollectionState<Self::Timestamp>, StorageError>;
 
-    /// Returns the necessary metadata to read a collection
-    fn collection_metadata(&self, id: GlobalId) -> Result<CollectionMetadata, StorageError>;
-
     /// Create the sources described in the individual CreateSourceCommand commands.
     ///
-    /// Each command carries the source id, the  source description, an initial `since` read
-    /// validity frontier, and initial timestamp bindings.
+    /// Each command carries the source id, the source description, and any associated metadata
+    /// needed to ingest the particular source.
     ///
     /// This command installs collection state for the indicated sources, and the are
     /// now valid to use in queries at times beyond the initial `since` frontiers. Each
@@ -103,7 +107,7 @@ pub trait StorageController: Debug + Send {
     /// be repeatedly downgraded with `allow_compaction()` to permit compaction.
     async fn create_sources(
         &mut self,
-        sources: Vec<CreateSourceRequest<Self::Timestamp>>,
+        sources: Vec<CreateSourceRequest>,
     ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
@@ -152,11 +156,14 @@ pub trait StorageController: Debug + Send {
 }
 
 /// Metadata required by a storage instance to read a storage collection
-#[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Serialize, Deserialize)]
 pub struct CollectionMetadata {
+    /// The persist location where the shards are located
     pub persist_location: PersistLocation,
-    pub timestamp_shard_id: ShardId,
-    pub persist_shard: ShardId,
+    /// The persist shard id of the remap collection used to reclock this collection
+    pub remap_shard: ShardId,
+    /// The persist shard containing the contents of this storage collection
+    pub data_shard: ShardId,
 }
 
 impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
@@ -164,8 +171,8 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
         ProtoCollectionMetadata {
             blob_uri: self.persist_location.blob_uri.clone(),
             consensus_uri: self.persist_location.consensus_uri.clone(),
-            shard_id: self.persist_shard.to_string(),
-            timestamp_shard_id: self.timestamp_shard_id.to_string(),
+            data_shard: self.data_shard.to_string(),
+            remap_shard: self.remap_shard.to_string(),
         }
     }
 
@@ -175,15 +182,32 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
                 blob_uri: value.blob_uri,
                 consensus_uri: value.consensus_uri,
             },
-            timestamp_shard_id: value
-                .timestamp_shard_id
+            remap_shard: value
+                .remap_shard
                 .parse()
                 .map_err(TryFromProtoError::InvalidShardId)?,
-            persist_shard: value
-                .shard_id
+            data_shard: value
+                .data_shard
                 .parse()
                 .map_err(TryFromProtoError::InvalidShardId)?,
         })
+    }
+}
+
+impl Codec for CollectionMetadata {
+    fn codec_name() -> String {
+        "protobuf[CollectionMetadata]".into()
+    }
+
+    fn encode<B: BufMut>(&self, buf: &mut B) {
+        self.into_proto()
+            .encode(buf)
+            .expect("no required fields means no initialization errors");
+    }
+
+    fn decode(buf: &[u8]) -> Result<Self, String> {
+        let proto = ProtoCollectionMetadata::decode(buf).map_err(|err| err.to_string())?;
+        proto.into_rust().map_err(|err| err.to_string())
     }
 }
 
@@ -333,18 +357,9 @@ where
             .ok_or(StorageError::IdentifierMissing(id))
     }
 
-    fn collection_metadata(&self, id: GlobalId) -> Result<CollectionMetadata, StorageError> {
-        let collection = self.collection(id)?;
-        Ok(CollectionMetadata {
-            persist_location: self.persist_location.clone(),
-            timestamp_shard_id: collection.timestamp_shard_id,
-            persist_shard: collection.persist_shard,
-        })
-    }
-
     async fn create_sources(
         &mut self,
-        mut sources: Vec<CreateSourceRequest<T>>,
+        mut sources: Vec<CreateSourceRequest>,
     ) -> Result<(), StorageError> {
         // Validate first, to avoid corrupting state.
         // 1. create a dropped source identifier, or
@@ -359,8 +374,7 @@ where
         }
         for source in sources.iter() {
             if let Ok(collection) = self.collection(source.ingestion.id) {
-                let (desc, since) = &collection.description;
-                if (desc, since) != (&source.ingestion.desc, &source.ingestion.since) {
+                if collection.description != source.ingestion.desc {
                     return Err(StorageError::SourceIdReused(source.ingestion.id));
                 }
             }
@@ -370,31 +384,45 @@ where
 
         // Install collection state for each bound source.
         for source in sources {
-            // TODO(petrosagg): durably record the persist shard we mint here
-            let persist_shard = ShardId::new();
+            let id = source.ingestion.id;
+
+            let metadata = CollectionMetadata {
+                persist_location: self.persist_location.clone(),
+                data_shard: ShardId::new(),
+                remap_shard: ShardId::new(),
+            };
+            // We can't persist the shards for tables until we figure out what ADAPTERs wants to do
+            // with system tables that are assumed to be empty on creation
+            // We also can't persist the shards for postgres sources until we wire up correct start
+            // offsets to the SourceReaders
+            let metadata = match source.ingestion.desc.connection {
+                SourceConnection::Local { .. }
+                | SourceConnection::External {
+                    connection: ExternalSourceConnection::Postgres(_),
+                    ..
+                } => metadata,
+                _ => {
+                    METADATA_COLLECTION
+                        .insert_without_overwrite(&mut self.state.stash, &id, metadata)
+                        .await?
+                }
+            };
+
             let (write, read) = self
                 .persist_client
-                .open(persist_shard)
+                .open(metadata.data_shard)
                 .await
                 .expect("invalid persist usage");
-            self.state
-                .persist_handles
-                .insert(source.ingestion.id, PersistHandles { read, write });
-
-            let timestamp_shard_id = TypedCollection::new("timestamp-shard-id")
-                .insert_without_overwrite(
-                    &mut self.state.stash,
-                    &source.ingestion.id,
-                    ShardId::new(),
-                )
-                .await?;
 
             let collection_state = CollectionState::new(
                 source.ingestion.desc.clone(),
-                source.ingestion.since.clone(),
-                persist_shard,
-                timestamp_shard_id,
+                read.since().clone(),
+                metadata,
             );
+
+            self.state
+                .persist_handles
+                .insert(source.ingestion.id, PersistHandles { read, write });
 
             self.state
                 .collections
@@ -415,7 +443,7 @@ where
         for source in external_sources {
             let mut source_imports = BTreeMap::new();
             for (id, _) in source.ingestion.source_imports {
-                let metadata = self.collection_metadata(id)?;
+                let metadata = self.collection(id)?.collection_metadata.clone();
                 source_imports.insert(id, metadata);
             }
 
@@ -423,11 +451,13 @@ where
 
             let augmented_ingestion = IngestionDescription {
                 source_imports,
+                storage_metadata: self
+                    .collection(source.ingestion.id)?
+                    .collection_metadata
+                    .clone(),
                 // The rest of the fields are identical
                 id: source.ingestion.id,
                 desc: source.ingestion.desc,
-                since: source.ingestion.since,
-                storage_metadata: self.collection_metadata(source.ingestion.id)?,
             };
 
             let addr = if let Some(remote_addr) = remote_addr {
@@ -536,7 +566,7 @@ where
 
         let mut appends_by_id = HashMap::new();
         for (id, (updates, upper)) in updates_by_id {
-            let current_upper = self.collection(id)?.write_frontier.frontier().to_owned();
+            let current_upper = self.state.persist_handles[&id].write.upper().clone();
             appends_by_id.insert(id, (updates.into_iter().flatten(), current_upper, upper));
         }
 
@@ -810,8 +840,8 @@ where
 /// State maintained about individual collections.
 #[derive(Debug)]
 pub struct CollectionState<T> {
-    /// Description with which the source was created, and its initial `since`.
-    pub(super) description: (crate::sources::SourceDesc, Antichain<T>),
+    /// Description with which the source was created
+    pub(super) description: SourceDesc,
 
     /// Accumulation of read capabilities for the collection.
     ///
@@ -830,12 +860,7 @@ pub struct CollectionState<T> {
     /// equal to `write_frontier.frontier()`.
     pub write_frontier: MutableAntichain<T>,
 
-    // TODO: only makes sense for collections that are ingested so maybe should live elsewhere?
-    /// The persist shard id of the remap collection used to reclock this collection
-    pub timestamp_shard_id: ShardId,
-
-    /// The persist shard containing the contents of this storage collection
-    pub persist_shard: ShardId,
+    pub collection_metadata: CollectionMetadata,
 }
 
 #[derive(Debug)]
@@ -848,22 +873,16 @@ pub(super) struct PersistHandles<T: Timestamp + Lattice + Codec64> {
 
 impl<T: Timestamp> CollectionState<T> {
     /// Creates a new collection state, with an initial read policy valid from `since`.
-    pub fn new(
-        description: SourceDesc,
-        since: Antichain<T>,
-        persist_shard: ShardId,
-        timestamp_shard_id: ShardId,
-    ) -> Self {
+    pub fn new(description: SourceDesc, since: Antichain<T>, metadata: CollectionMetadata) -> Self {
         let mut read_capabilities = MutableAntichain::new();
         read_capabilities.update_iter(since.iter().map(|time| (time.clone(), 1)));
         Self {
-            description: (description, since.clone()),
+            description,
             read_capabilities,
             implied_capability: since.clone(),
             read_policy: ReadPolicy::ValidFrom(since),
             write_frontier: MutableAntichain::new_bottom(Timestamp::minimum()),
-            timestamp_shard_id,
-            persist_shard,
+            collection_metadata: metadata,
         }
     }
 }

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -246,12 +246,12 @@ where
 {
     fn observe_command(&mut self, command: &StorageCommand<T>) {
         match command {
-            StorageCommand::CreateSources(sources) => {
-                for source in sources {
+            StorageCommand::CreateSources(ingestions) => {
+                for ingestion in ingestions {
                     let mut frontier = MutableAntichain::new();
                     frontier.update_iter(iter::once((T::minimum(), self.parts as i64)));
-                    let previous = self.uppers.insert(source.id, frontier);
-                    assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", source.id, command);
+                    let previous = self.uppers.insert(ingestion.id, frontier);
+                    assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", ingestion.id, command);
                 }
             }
             _ => {

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -267,6 +267,5 @@ message ProtoIngestionDescription {
     repeated ProtoSourceMetadataImport source_imports = 1;
     mz_repr.global_id.ProtoGlobalId id = 2;
     ProtoSourceDesc desc = 3;
-    mz_persist.gen.persist.ProtoU64Antichain since = 4;
-    mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 5;
+    mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 4;
 }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -61,7 +61,7 @@ pub use crate::r#impl::metrics::Metrics;
 ///
 /// This structure can be durably written down or transmitted for use by other
 /// processes. This location can contain any number of persist shards.
-#[derive(Arbitrary, Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Arbitrary, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 pub struct PersistLocation {
     /// Uri string that identifies the blob store.
     pub blob_uri: String,

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3.21"
 futures-executor = "0.3.21"
 futures-util = "0.3.19"
 globset = { version = "0.4.9", optional = true }
+itertools = { version = "0.10.3", optional = true }
 mz-avro = { path = "../avro", features = ["snappy"], optional = true }
 mz-ccsr = { path = "../ccsr", optional = true }
 mz-dataflow-types = { path = "../dataflow-types" }
@@ -49,7 +50,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = { version = "1.0.81", optional = true }
 tempfile = { version = "3.2.0", optional = true }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
-tokio = { version = "1.19.2", features = ["fs", "rt", "sync"] }
+tokio = { version = "1.19.2", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", optional = true }
 tokio-util = { version = "0.7.3", features = ["io"] }
 tracing = "0.1.35"
@@ -68,6 +69,7 @@ server = [
     "csv-core",
     "globset",
     "once_cell",
+    "itertools",
     "mz-avro",
     "mz-ccsr",
     "mz-interchange",

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -104,6 +104,7 @@ use std::rc::Rc;
 
 use timely::communication::Allocate;
 use timely::dataflow::Scope;
+use timely::progress::Antichain;
 use timely::worker::Worker as TimelyWorker;
 
 use mz_dataflow_types::client::controller::storage::CollectionMetadata;
@@ -124,7 +125,8 @@ pub fn build_storage_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     storage_state: &mut StorageState,
     debug_name: &str,
-    ingestion: IngestionDescription<CollectionMetadata, mz_repr::Timestamp>,
+    ingestion: IngestionDescription<CollectionMetadata>,
+    as_of: Antichain<mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let name = format!("Source dataflow: {debug_name}");
@@ -140,6 +142,7 @@ pub fn build_storage_dataflow<A: Allocate>(
                 region,
                 &debug_name,
                 ingestion.clone(),
+                as_of,
                 // NOTE: For now sources never have LinearOperators but might have in the future
                 None,
                 storage_state,

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -31,14 +31,14 @@ use crate::storage_state::StorageState;
 pub fn render<G>(
     scope: &mut G,
     src_id: GlobalId,
-    storage_metadata: CollectionMetadata,
+    metadata: CollectionMetadata,
     source_data: Collection<G, Result<Row, DataflowError>, Diff>,
     storage_state: &mut StorageState,
     token: Rc<dyn Any>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    let operator_name = format!("persist_sink({})", storage_metadata.persist_shard);
+    let operator_name = format!("persist_sink({})", metadata.data_shard);
     let mut persist_op = OperatorBuilder::new(operator_name, scope.clone());
 
     // We want exactly one worker (in the cluster) to send all the data to persist. It's fine
@@ -54,7 +54,7 @@ pub fn render<G>(
 
     let mut input = persist_op.new_input(&source_data.inner, Exchange::new(move |_| hashed_id));
 
-    let shared_frontier = Rc::clone(&storage_state.source_uppers[&src_id]);
+    let current_upper = Rc::clone(&storage_state.source_uppers[&src_id]);
 
     let weak_token = Rc::downgrade(&token);
 
@@ -69,19 +69,25 @@ pub fn render<G>(
             let mut write = persist_clients
                 .lock()
                 .await
-                .open(storage_metadata.persist_location)
+                .open(metadata.persist_location)
                 .await
                 .expect("could not open persist client")
-                .open_writer::<SourceData, (), Timestamp, Diff>(storage_metadata.persist_shard)
+                .open_writer::<SourceData, (), Timestamp, Diff>(metadata.data_shard)
                 .await
                 .expect("could not open persist shard");
 
+            // Initialize this sink's `upper` to the `upper` of the persist shard we are writing
+            // to. Data from the source not beyond this time will be dropped, as it has already
+            // been persisted.
+            // In the future, sources will avoid passing through data not beyond this upper
+            *current_upper.borrow_mut() = write.upper().clone();
+
             while scheduler.notified().await {
-                let input_frontier = frontiers.borrow()[0].clone();
+                let input_upper = frontiers.borrow()[0].clone();
 
                 if !active_write_worker
                     || weak_token.upgrade().is_none()
-                    || shared_frontier.borrow().is_empty()
+                    || current_upper.borrow().is_empty()
                 {
                     return;
                 }
@@ -93,17 +99,19 @@ pub fn render<G>(
                     // (100 was chosen arbitrarily), and avoid having to make a batch
                     // per-timestamp.
                     for (row, ts, diff) in buffer.drain(..) {
-                        stashed_batches
-                            .entry(ts)
-                            .or_insert_with(|| {
-                                // TODO: the lower has to be the min because we don't know
-                                // what the minimum ts of data we will see is. In the future,
-                                // this lower should be declared in `finish` instead.
-                                write.builder(100, Antichain::from_elem(Timestamp::minimum()))
-                            })
-                            .add(&SourceData(row), &(), &ts, &diff)
-                            .await
-                            .expect("invalid usage");
+                        if write.upper().less_equal(&ts) {
+                            stashed_batches
+                                .entry(ts)
+                                .or_insert_with(|| {
+                                    // TODO: the lower has to be the min because we don't know
+                                    // what the minimum ts of data we will see is. In the future,
+                                    // this lower should be declared in `finish` instead.
+                                    write.builder(100, Antichain::from_elem(Timestamp::minimum()))
+                                })
+                                .add(&SourceData(row), &(), &ts, &diff)
+                                .await
+                                .expect("invalid usage");
+                        }
                     }
                 }
 
@@ -111,22 +119,22 @@ pub fn render<G>(
                 // TODO(guswynn/petrosagg): remove this additional allocation
                 let mut finalized_timestamps: Vec<_> = stashed_batches
                     .keys()
-                    .filter(|ts| !input_frontier.less_equal(ts))
+                    .filter(|ts| !input_upper.less_equal(ts))
                     .copied()
                     .collect();
                 finalized_timestamps.sort_unstable();
 
                 // If the frontier has advanced, we need to finalize data being written to persist
-                if PartialOrder::less_than(&*shared_frontier.borrow(), &input_frontier) {
+                if PartialOrder::less_than(&*current_upper.borrow(), &input_upper) {
                     // We always append, even in case we don't have any updates, because appending
                     // also advances the frontier.
                     if finalized_timestamps.is_empty() {
-                        let expected_upper = shared_frontier.borrow().clone();
+                        let expected_upper = current_upper.borrow().clone();
                         write
                             .compare_and_append(
                                 Vec::<((SourceData, ()), Timestamp, Diff)>::new(),
                                 expected_upper,
-                                input_frontier.clone(),
+                                input_upper.clone(),
                             )
                             .await
                             .expect("cannot append updates")
@@ -134,13 +142,13 @@ pub fn render<G>(
                             .expect("invalid/outdated upper");
 
                         // advance our stashed frontier
-                        *shared_frontier.borrow_mut() = input_frontier.clone();
+                        *current_upper.borrow_mut() = input_upper.clone();
                         // wait for more data or a new input frontier
                         continue;
                     }
 
-                    // `shared_frontier` tracks the last known upper
-                    let mut expected_upper = shared_frontier.borrow().clone();
+                    // `current_upper` tracks the last known upper
+                    let mut expected_upper = current_upper.borrow().clone();
                     let finalized_batch_count = finalized_timestamps.len();
 
                     for (i, ts) in finalized_timestamps.into_iter().enumerate() {
@@ -149,7 +157,7 @@ pub fn render<G>(
                         // Set the upper to the upper of the batch (which is 1 past the ts it
                         // manages) OR the new frontier if we are appending the final batch
                         let new_upper = if i == finalized_batch_count - 1 {
-                            input_frontier.clone()
+                            input_upper.clone()
                         } else {
                             Antichain::from_elem(ts + 1)
                         };
@@ -172,7 +180,7 @@ pub fn render<G>(
                         expected_upper = new_upper;
                     }
                     // advance our stashed frontier
-                    *shared_frontier.borrow_mut() = input_frontier.clone();
+                    *current_upper.borrow_mut() = input_upper.clone();
                 } else {
                     // We cannot have updates without the frontier advancing
                     assert!(finalized_timestamps.is_empty());

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -22,6 +22,7 @@ use futures::executor::block_on;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::operators::{Exchange, Map, OkErr};
 use timely::dataflow::Scope;
+use timely::progress::Antichain;
 
 use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::sources::{encoding::*, *};
@@ -72,7 +73,8 @@ enum SourceType<Delimited, ByteStream, RowSource, AppendRowSource> {
 pub fn render_source<G>(
     scope: &mut G,
     dataflow_debug_name: &String,
-    ingestion: IngestionDescription<CollectionMetadata, Timestamp>,
+    ingestion: IngestionDescription<CollectionMetadata>,
+    as_of: Antichain<G::Timestamp>,
     mut linear_operators: Option<LinearOperator>,
     storage_state: &mut crate::storage_state::StorageState,
 ) -> (
@@ -155,7 +157,7 @@ where
                 encoding: encoding.clone(),
                 now: storage_state.now.clone(),
                 base_metrics: &storage_state.source_metrics,
-                as_of: ingestion.since.clone(),
+                as_of: as_of.clone(),
                 storage_metadata: ingestion.storage_metadata,
                 persist_clients: Arc::clone(&storage_state.persist_clients),
             };
@@ -334,9 +336,9 @@ where
                                     let (tx_source_ok_stream, tx_source_err_stream, tx_token) =
                                         persist_source::persist_source(
                                             scope,
-                                            tx_storage_metadata,
                                             persist_clients,
-                                            ingestion.since.clone(),
+                                            tx_storage_metadata,
+                                            as_of.clone(),
                                         );
                                     let (tx_source_ok, tx_source_err) = (
                                         tx_source_ok_stream.as_collection(),
@@ -370,7 +372,7 @@ where
 
                             let (upsert_ok, upsert_err) = super::upsert::upsert(
                                 &transformed_results,
-                                ingestion.since.clone(),
+                                as_of.clone(),
                                 &mut linear_operators,
                                 source_arity,
                                 upsert_envelope.clone(),
@@ -473,16 +475,15 @@ where
             match &envelope {
                 SourceEnvelope::Upsert(_) => {}
                 _ => {
-                    let as_of_frontier1 = ingestion.since.clone();
+                    let as_of_frontier1 = as_of.clone();
                     collection = collection
                         .inner
                         .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier1.borrow()))
                         .as_collection();
 
-                    let as_of_frontier2 = ingestion.since;
                     err_collection = err_collection
                         .inner
-                        .map_in_place(move |(_, time, _)| time.advance_by(as_of_frontier2.borrow()))
+                        .map_in_place(move |(_, time, _)| time.advance_by(as_of.borrow()))
                         .as_collection();
                 }
             }

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -45,8 +45,8 @@ use crate::source::{SourceStatus, YIELD_INTERVAL};
 // upper frontier from all shards.
 pub fn persist_source<G>(
     scope: &G,
-    storage_metadata: CollectionMetadata,
     persist_clients: Arc<Mutex<PersistClientCache>>,
+    metadata: CollectionMetadata,
     as_of: Antichain<Timestamp>,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
@@ -79,12 +79,10 @@ where
         let mut read = persist_clients
             .lock()
             .await
-            .open(storage_metadata.persist_location)
+            .open(metadata.persist_location)
             .await
             .expect("could not open persist client")
-            .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(
-                storage_metadata.persist_shard,
-            )
+            .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(metadata.data_shard)
             .await
             .expect("could not open persist shard");
 

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -79,7 +79,7 @@ impl ReclockOperator {
         drop(persist_clients);
 
         let (write_handle, read_handle) = persist_client
-            .open(metadata.timestamp_shard_id)
+            .open(metadata.remap_shard)
             .await
             .context("error opening persist shard")?;
 
@@ -493,8 +493,8 @@ mod tests {
                 blob_uri: "mem://".to_owned(),
                 consensus_uri: "mem://".to_owned(),
             },
-            timestamp_shard_id: shard,
-            persist_shard: ShardId::new(),
+            remap_shard: shard,
+            data_shard: ShardId::new(),
         };
 
         ReclockOperator::new(


### PR DESCRIPTION
This is the first part of making source ingestion fault tolerant. With
this PR the storage controller durably records the persist shard ids of
all sources and the `storaged` process is changed in such a way that it
can resume appending data to the definite collection.

Tables are an exception to the above and maintain the previous behaviour
where new shards are minted every time the storage controller restarts
and are never durably persisted.

Postgres sources are also an exception to the above because unlike
sources like Kafka we lose the ability to generate a full snapshot at
the LSN of a replication slot once the initial transaction that created
it has ended. This means that a `storaged` instance that just restarted
has no way of reproducing the previous stream. This won't be an issue
when we wire up start offsets correctly in which case the postgres
source reader will completely skip the snapshot phase and just read from
the replication slot.

Lastly, while this PR makes source ingestion fault tolerant in the sense
that after restarts we can resume correctly it does not yet do the
optimization that we skip ahead in the upstream system. For example for
Kafka we will re-read everything from the beginning and just drop all
data that is not beyond the current upper frontier on the floor. This is
wasteful but has the sideeffect of fully re-hydrating the in-memory
state of the ingestion pipeline.

After this gets merged I'll work on a follow up PR that implements the
optimization described above for simple cases like NONE envelope
sources.