### PR TITLE
sql: reject multiple REMOTE options for the same cluster replica

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2775,6 +2775,9 @@ fn plan_replica_config(options: Vec<ReplicaOption<Aug>>) -> Result<ReplicaConfig
     for option in options {
         match option {
             ReplicaOption::Remote { hosts } => {
+                if !remote_replicas.is_empty() {
+                    bail!("REMOTE specified more than once");
+                }
                 for host in hosts {
                     remote_replicas.insert(with_option_type!(Some(host), String));
                 }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -34,6 +34,9 @@ CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234')))
 statement error cannot create multiple replicas named 'r1' on cluster 'bar'
 CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1234')), r1 (REMOTE ('localhost:1234')))
 
+statement error REMOTE specified more than once
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1234'), REMOTE ('localhost:1234')))
+
 statement ok
 CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1235')), r2 (REMOTE ('localhost:1236')))
 


### PR DESCRIPTION
This makes REMOTE work like the other cluster replica options.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported in Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
