### PR TITLE
materialized: remove unused --storage-controller-addr

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -174,16 +174,6 @@ pub struct Args {
     #[structopt(long, default_value = "2100")]
     base_service_port: u16,
 
-    // === Timely worker configuration. ===
-    /// Address of a storage process that the controller should connect to.
-    #[clap(
-        long,
-        env = "STORAGE_CONTROLLER_ADDR",
-        value_name = "HOST:ADDR",
-        conflicts_with = "orchestrator"
-    )]
-    storage_controller_addr: Option<String>,
-
     // === Performance tuning parameters. ===
     /// How much historical detail to maintain in arrangements.
     ///


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

    Fixes https://github.com/MaterializeInc/materialize/issues/12567.

### Tips for reviewer

The `--storage-controller-addr` parameter is unused since https://github.com/MaterializeInc/materialize/pull/11690. From looking at the PR it seems like it was left in intentionally, so removing it might not be the right thing to do. @benesch could you weigh in?

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove `materialized`'s defunct `--storage-controller-addr` command line parameter.
