### PR TITLE
test: move expected values of equality checks in the results

### DIFF
--- a/test/debezium/postgres/02-drop-primary-key.td.gh6521
+++ b/test/debezium/postgres/02-drop-primary-key.td.gh6521
@@ -28,8 +28,8 @@ CREATE SEQUENCE pk_sequence;
 ALTER TABLE alter_drop_primary_key DROP CONSTRAINT alter_drop_primary_key_pkey;
 INSERT INTO alter_drop_primary_key VALUES (123);
 
-> SELECT COUNT(*) = 2 FROM alter_drop_primary_key;
-true
+> SELECT COUNT(*) FROM alter_drop_primary_key;
+2
 
 > SELECT DISTINCT f1 FROM alter_drop_primary_key;
 123

--- a/test/debezium/postgres/07-add-column-with-delete.td
+++ b/test/debezium/postgres/07-add-column-with-delete.td
@@ -49,5 +49,5 @@ DELETE FROM alter_add_column_with_delete WHERE new_column = 2;
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DELETE FROM alter_add_column_with_delete WHERE new_column = 1;
 
-> SELECT COUNT(*) = 0 FROM alter_add_column_with_delete;
-true
+> SELECT COUNT(*) FROM alter_add_column_with_delete;
+0

--- a/test/debezium/postgres/33-toasted-values.td
+++ b/test/debezium/postgres/33-toasted-values.td
@@ -35,9 +35,9 @@ $ postgres-execute connection=postgres://postgres:postgres@postgres
 UPDATE toasted_full SET f1 = (REPEAT('c', 32 * 1024) || 'd') WHERE f1 IS NULL;
 UPDATE toasted_full SET f1 = (REPEAT('e', 32 * 1024) || 'f') WHERE f1 = REPEAT('a', 32 * 1024) || 'b';
 
-> SELECT length(f1) = (32 * 1024) + 1, substr(f1, 1, 2), substr(f1, 32 * 1024, 2) FROM toasted_full;
-true cc cd
-true ee ef
+> SELECT length(f1), substr(f1, 1, 2), substr(f1, 32 * 1024, 2) FROM toasted_full;
+32769 cc cd
+32769 ee ef
 
 # The documentation says that we do not support REPLICA IDENTITY DEFAULT, which is the more interesting
 # case, so we are not testing that here.

--- a/test/persistence/kafka-sources/envelope-none-after.td
+++ b/test/persistence/kafka-sources/envelope-none-after.td
@@ -18,8 +18,8 @@ $ set schema={
 > SELECT COUNT(*) FROM envelope_none;
 10000
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
 $ kafka-ingest format=avro topic=envelope-none schema=${schema} publish=true repeat=5000
 {"f1": ${kafka-ingest.iteration}}

--- a/test/persistence/kafka-sources/envelope-none-before.td
+++ b/test/persistence/kafka-sources/envelope-none-before.td
@@ -31,7 +31,7 @@ $ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${sche
   INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
   ENVELOPE NONE
 
-> SELECT COUNT(*) = 10000 FROM envelope_none
-true
+> SELECT COUNT(*) FROM envelope_none
+10000
 
 $ kafka-add-partitions topic=envelope-none total-partitions=4

--- a/test/persistence/kafka-sources/envelope-none-bytes-after.td
+++ b/test/persistence/kafka-sources/envelope-none-bytes-after.td
@@ -13,11 +13,11 @@
 > SELECT COUNT(*) FROM envelope_none_bytes;
 10000
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-bytes-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-bytes-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-text-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-envelope-none-text-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
 $ kafka-ingest topic=envelope-none-bytes format=bytes repeat=5000
 ABC

--- a/test/persistence/kafka-sources/envelope-none-bytes-before.td
+++ b/test/persistence/kafka-sources/envelope-none-bytes-before.td
@@ -19,8 +19,8 @@ XYZ
   INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
   ENVELOPE NONE
 
-> SELECT COUNT(*) = 10000 FROM envelope_none_bytes
-true
+> SELECT COUNT(*) FROM envelope_none_bytes
+10000
 
 $ kafka-create-topic topic=envelope-none-text
 
@@ -34,5 +34,5 @@ XYZ
   INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
   ENVELOPE NONE
 
-> SELECT COUNT(*) = 10000 FROM envelope_none_text
-true
+> SELECT COUNT(*) FROM envelope_none_text
+10000

--- a/test/persistence/kafka-sources/exactly-once-sink-after.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-after.td
@@ -27,8 +27,8 @@ $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keysc
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 
-> SELECT COUNT(*) = 10 FROM exactly_once;
-true
+> SELECT COUNT(*) FROM exactly_once;
+10
 
 # We expect just the 6 new messages, having consumed the older ones in xactly-once-sink-before.td
 $ set-regex match=\d{13} replacement=<TIMESTAMP>

--- a/test/persistence/kafka-sources/kafka-counters-after.td
+++ b/test/persistence/kafka-sources/kafka-counters-after.td
@@ -27,10 +27,10 @@ $ kafka-ingest format=avro topic=kafka-counters key-format=avro key-schema=${key
 {"f1": "-1"} {"f2": "-1"}
 
 
-> SELECT COUNT(*) = 10001 FROM kafka_counters;
-true
+> SELECT COUNT(*) FROM kafka_counters;
+10001
 
 # We expect the counter to be at 1, that is no data was re-ingested
 # from the Kafka topic post-restart.
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-counters-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 1 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-kafka-counters-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+1

--- a/test/persistence/kafka-sources/multipart-key-before.td
+++ b/test/persistence/kafka-sources/multipart-key-before.td
@@ -41,5 +41,5 @@ $ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keys
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT;
 
-> SELECT COUNT(*) = 20000 FROM multipart_key;
-true
+> SELECT COUNT(*) FROM multipart_key;
+20000

--- a/test/persistence/kafka-sources/repeated-source-rendering-after.td
+++ b/test/persistence/kafka-sources/repeated-source-rendering-after.td
@@ -9,11 +9,11 @@
 
 # Run parts of repeated-source-rendering-before.td post-restart
 
-> SELECT COUNT(*) = 10 FROM a_view;
-true
+> SELECT COUNT(*) FROM a_view;
+10
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
 # Verify that we cannot create multiple materializations of a persisted source, even after restart.
 ! CREATE MATERIALIZED VIEW a_view_second_materialization AS SELECT * FROM re_created;
@@ -23,12 +23,12 @@ contains:Cannot re-materialize source re_created
 
 > CREATE MATERIALIZED VIEW a_view AS SELECT * FROM re_created;
 
-> SELECT COUNT(*) = 10 FROM a_view;
-true
+> SELECT COUNT(*) FROM a_view;
+10
 
 # Re-creating the source should result in no messages being read from Kafka, because we still have the persisted data and offsets.
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
 # Same with DROP INDEX
 
@@ -36,8 +36,8 @@ true
 
 > CREATE DEFAULT INDEX ON a_view;
 
-> SELECT COUNT(*) = 10 FROM a_view;
-true
+> SELECT COUNT(*) FROM a_view;
+10
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-re-created-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0

--- a/test/persistence/kafka-sources/start-offset-after.td
+++ b/test/persistence/kafka-sources/start-offset-after.td
@@ -30,8 +30,8 @@ $ set schema={
         ]
     }
 
-> SELECT SUM(CAST(statistics->'topics'->'testdrive-offset-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) = 0 FROM mz_kafka_source_statistics;
-true
+> SELECT SUM(CAST(statistics->'topics'->'testdrive-offset-${testdrive.seed}'->'partitions'->'0'->'msgs' AS INT)) FROM mz_kafka_source_statistics;
+0
 
 $ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count} timestamp=4
 {"f1": "d${kafka-ingest.iteration}"} {"f2": "d${kafka-ingest.iteration}"}

--- a/test/persistence/kafka-sources/topic-compression-after.td
+++ b/test/persistence/kafka-sources/topic-compression-after.td
@@ -26,5 +26,5 @@ $ set schema={
 $ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
 {"f1": ${kafka-ingest.iteration}} {"f2": "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"}
 
-> SELECT COUNT(*) = 1000, COUNT(DISTINCT f2) = 1, MIN(LENGTH(f2)) = 100, MAX(LENGTH(f2)) = 100 FROM topic_compression;
-true true true true
+> SELECT COUNT(*), COUNT(DISTINCT f2), MIN(LENGTH(f2)), MAX(LENGTH(f2)) FROM topic_compression;
+1000 1 100 100

--- a/test/persistence/kafka-sources/topic-compression-before.td
+++ b/test/persistence/kafka-sources/topic-compression-before.td
@@ -33,5 +33,5 @@ $ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT;
 
-> SELECT COUNT(*) = 1000 FROM topic_compression;
-true
+> SELECT COUNT(*) FROM topic_compression;
+1000

--- a/test/persistence/kafka-sources/upsert-deletion-before.td
+++ b/test/persistence/kafka-sources/upsert-deletion-before.td
@@ -37,5 +37,5 @@ $ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${ke
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
-> SELECT COUNT(*) = 10000 FROM upsert_deletion;
-true
+> SELECT COUNT(*) FROM upsert_deletion;
+10000

--- a/test/persistence/kafka-sources/upsert-include-key-before.td
+++ b/test/persistence/kafka-sources/upsert-include-key-before.td
@@ -40,5 +40,5 @@ $ kafka-ingest format=avro topic=include-key key-format=avro key-schema=${keysch
   INCLUDE KEY AS named
   ENVELOPE UPSERT
 
-> SELECT COUNT(*) = 10000 FROM include_key;
-true
+> SELECT COUNT(*) FROM include_key;
+10000

--- a/test/persistence/kafka-sources/upsert-modification-after.td
+++ b/test/persistence/kafka-sources/upsert-modification-after.td
@@ -28,8 +28,8 @@ $ set schema={
 $ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} publish=true start-iteration=2500 repeat=5000
 {"f1": ${kafka-ingest.iteration}} {"f2": "a${kafka-ingest.iteration}"}
 
-> SELECT COUNT(*) = 10000, MIN(f1) = 0, MAX(f1) = 9999 FROM upsert_modification;
-true true true
+> SELECT COUNT(*), MIN(f1), MAX(f1) FROM upsert_modification;
+10000 0 9999
 
 > SELECT MIN(f1), MAX(f1), COUNT(*) FROM upsert_modification WHERE f2 LIKE 'a%';
 2500 7499 5000

--- a/test/persistence/kafka-sources/upsert-modification-before.td
+++ b/test/persistence/kafka-sources/upsert-modification-before.td
@@ -37,8 +37,8 @@ $ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
-> SELECT COUNT(*) = 10000 FROM upsert_modification;
-true
+> SELECT COUNT(*) FROM upsert_modification;
+10000
 
 $ kafka-create-topic topic=textbytes
 

--- a/test/persistence/kafka-sources/wide-data-after.td
+++ b/test/persistence/kafka-sources/wide-data-after.td
@@ -29,5 +29,5 @@ $ set schema={
 $ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10 start-iteration=10
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
-> SELECT COUNT(*) = 20, MIN(LENGTH(value)) = 512 * 1024, MAX(LENGTH(value)) = 512 * 1024 FROM wide_data_source;
-true true true
+> SELECT COUNT(*) = 20, MIN(LENGTH(value)), MAX(LENGTH(value)) FROM wide_data_source;
+20 524288 524288

--- a/test/persistence/kafka-sources/wide-data-before.td
+++ b/test/persistence/kafka-sources/wide-data-before.td
@@ -59,5 +59,5 @@ $ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keys
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT;
 
-> SELECT COUNT(*) = 10 FROM wide_data_source;
-true
+> SELECT COUNT(*) FROM wide_data_source;
+10

--- a/test/persistence/user-tables/table-persistence-after-dml.td
+++ b/test/persistence/user-tables/table-persistence-after-dml.td
@@ -32,8 +32,8 @@
 9
 10
 
-> SELECT COUNT(*) = 0 FROM insert_rollback;
-true
+> SELECT COUNT(*) FROM insert_rollback;
+0
 
 > SELECT * FROM insert_select;
 1

--- a/test/persistence/user-tables/table-persistence-after-large-transaction.td
+++ b/test/persistence/user-tables/table-persistence-after-large-transaction.td
@@ -7,8 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT LENGTH(f1) = 100 * 1024 * 1024 FROM wide_transaction;
-true
+> SELECT LENGTH(f1) FROM wide_transaction;
+104857600
 
-> SELECT COUNT(*) = 1000000, COUNT(DISTINCT f1) = 1000000 FROM long_transaction;
-true true
+> SELECT COUNT(*), COUNT(DISTINCT f1) FROM long_transaction;
+1000000 1000000

--- a/test/pg-cdc-resumption/verify-data.td
+++ b/test/pg-cdc-resumption/verify-data.td
@@ -7,10 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT COUNT(*) = 500000 FROM t1;
-true
-> SELECT COUNT(*) = 500000 FROM t2;
-true
+> SELECT COUNT(*) FROM t1;
+500000
+> SELECT COUNT(*) FROM t2;
+500000
 
 ! SELECT * FROM to_be_altered;
 contains:altered

--- a/test/pg-cdc-resumption/wait-for-snapshot.td
+++ b/test/pg-cdc-resumption/wait-for-snapshot.td
@@ -13,5 +13,5 @@
 # during the replication and not during the initial snapshot
 #
 
-> SELECT COUNT(*) = 0 FROM t0;
-true
+> SELECT COUNT(*) FROM t0;
+0

--- a/test/pg-cdc/create-table-after-source.td
+++ b/test/pg-cdc/create-table-after-source.td
@@ -22,8 +22,8 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
-> SELECT COUNT(*) = 0 FROM mz_source;
-true
+> SELECT COUNT(*) FROM mz_source;
+0
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE t1 (f1 INTEGER);

--- a/test/pg-cdc/create-views-after-alter.td
+++ b/test/pg-cdc/create-views-after-alter.td
@@ -64,23 +64,23 @@ CREATE PUBLICATION mz_source FOR ALL TABLES;
   FROM POSTGRES CONNECTION 'host=postgres port=5432 user=postgres password=postgres sslmode=require dbname=postgres'
   PUBLICATION 'mz_source';
 
-> SELECT COUNT(*) = 1 FROM mz_source;
-true
+> SELECT COUNT(*) FROM mz_source;
+1
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE t2 (f1 INTEGER);
 ALTER TABLE t2 REPLICA IDENTITY FULL;
 INSERT INTO t2 VALUES (2);
 
-> SELECT COUNT(*) = 1 FROM mz_source;
-true
+> SELECT COUNT(*) FROM mz_source;
+1
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 ALTER TABLE t2 ADD COLUMN f2 varchar(1);
 INSERT INTO t2 VALUES (3, 'c');
 
-> SELECT COUNT(*) = 1 FROM mz_source;
-true
+> SELECT COUNT(*) FROM mz_source;
+1
 
 > CREATE VIEWS FROM SOURCE mz_source;
 

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -379,38 +379,38 @@ DELETE FROM conflict_schema.conflict_table;
 # Check that all data sources empty out on the Materialize side
 #
 
-> SELECT COUNT(*) = 0 FROM pk_table;
-true
+> SELECT COUNT(*) FROM pk_table;
+0
 
-> SELECT COUNT(*) = 0 FROM nonpk_table;
-true
+> SELECT COUNT(*) FROM nonpk_table;
+0
 
-> SELECT COUNT(*) = 0 FROM large_text;
-true
+> SELECT COUNT(*) FROM large_text;
+0
 
-> SELECT COUNT(*) = 0 FROM trailing_space_nopk;
-true
+> SELECT COUNT(*) FROM trailing_space_nopk;
+0
 
-> SELECT COUNT(*) = 0 FROM trailing_space_pk;
-true
+> SELECT COUNT(*) FROM trailing_space_pk;
+0
 
-> SELECT COUNT(*) = 0 FROM multipart_pk;
-true
+> SELECT COUNT(*) FROM multipart_pk;
+0
 
-> SELECT COUNT(*) = 0 FROM nulls_table;
-true
+> SELECT COUNT(*) FROM nulls_table;
+0
 
-> SELECT COUNT(*) = 0 FROM utf8_table;
-true
+> SELECT COUNT(*) FROM utf8_table;
+0
 
-> SELECT COUNT(*) = 0 FROM join_view;
-true
+> SELECT COUNT(*) FROM join_view;
+0
 
-> SELECT COUNT(*) = 0 FROM "таблица";
-true
+> SELECT COUNT(*) FROM "таблица";
+0
 
-> SELECT COUNT(*) = 0 FROM conflict_table;
-true
+> SELECT COUNT(*) FROM conflict_table;
+0
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP PUBLICATION mz_source;

--- a/test/testdrive/delete-using.td
+++ b/test/testdrive/delete-using.td
@@ -30,8 +30,8 @@ contains:column reference "f1" is ambiguous
 
 > DELETE FROM t1 AS a1 USING t1 AS a2;
 
-> SELECT COUNT(*) = 0 from t1;
-true
+> SELECT COUNT(*) from t1;
+0
 
 # Impossible join condition
 
@@ -41,8 +41,8 @@ true
 
 > DELETE FROM t1 USING t2 WHERE FALSE;
 
-> SELECT COUNT(*) = 3  FROM t1;
-true
+> SELECT COUNT(*)  FROM t1;
+3
 
 > DELETE FROM t1;
 
@@ -128,8 +128,8 @@ true
 
 > DELETE FROM t1 USING t2 WHERE t1.f1 = t2.f1 OR t1.f1 = 10;
 
-> SELECT COUNT(*) = 3 FROM t1;
-true
+> SELECT COUNT(*) FROM t1;
+3
 
 > DELETE FROM t1;
 
@@ -161,8 +161,8 @@ true
 
 > DELETE FROM t1 USING t2;
 
-> SELECT COUNT(*) = 0 FROM t1;
-true
+> SELECT COUNT(*) FROM t1;
+0
 
 > DELETE FROM t1;
 

--- a/test/testdrive/fetch-concurrent-same-source.td
+++ b/test/testdrive/fetch-concurrent-same-source.td
@@ -28,8 +28,8 @@ $ kafka-ingest format=avro topic=fetch-concurrent-same-source schema=${int} time
 {"f1": 234}
 {"f1": 345}
 
-> SELECT COUNT(*) = 3 FROM fetch_concurrent_same_source;
-true
+> SELECT COUNT(*) FROM fetch_concurrent_same_source;
+3
 
 > BEGIN
 

--- a/test/testdrive/fetch-concurrent-two-sources.td
+++ b/test/testdrive/fetch-concurrent-two-sources.td
@@ -43,11 +43,11 @@ $ kafka-ingest format=avro topic=fetch-concurrent-two-sources schema=${int} time
 $ kafka-ingest format=avro topic=fetch-concurrent-two-sources schema=${int} timestamp=3
 {"f1": 34}
 
-> SELECT COUNT(*) = 3 FROM fetch_concurrent_two_sources1_view;
-true
+> SELECT COUNT(*) FROM fetch_concurrent_two_sources1_view;
+3
 
-> SELECT COUNT(*) = 3 FROM fetch_concurrent_two_sources2_view;
-true
+> SELECT COUNT(*) FROM fetch_concurrent_two_sources2_view;
+3
 
 > BEGIN
 

--- a/test/testdrive/fetch-tail-large-diff.td
+++ b/test/testdrive/fetch-tail-large-diff.td
@@ -19,13 +19,13 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > CREATE MATERIALIZED VIEW v1 AS SELECT NULL FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7
 
-> SELECT COUNT(*) = 10000000 FROM v1;
-true
+> SELECT COUNT(*) FROM v1;
+10000000
 
 > CREATE MATERIALIZED VIEW v2 AS SELECT a1.f1 FROM ten AS a1, ten AS a2, ten AS a3, ten AS a4, ten AS a5, ten AS a6, ten AS a7
 
-> SELECT COUNT(*) = 10000000 FROM v2;
-true
+> SELECT COUNT(*) FROM v2;
+10000000
 
 > BEGIN
 

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -150,5 +150,5 @@ $ kafka-ingest format=avro topic=data partition=15 schema=${schema}
 
 # Make sure that none of the 'EXCEPT ALL' views above has ever produced any records.
 
-> SELECT COUNT(*) = 0 FROM mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
-true
+> SELECT COUNT(*) FROM mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
+0

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -163,8 +163,8 @@ $ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-s
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE NONE
 
-> SELECT COUNT(*) = 8 FROM kafka_ingest_no_partition;
-true
+> SELECT COUNT(*) FROM kafka_ingest_no_partition;
+8
 
 # kafka-verify with regexp (the set-regexp from above is used)
 
@@ -189,12 +189,12 @@ BEGIN;
 INSERT INTO postgres_connect VALUES (1);
 
 # Table is still empty, the transaction we just started is not committed yet
-> SELECT COUNT(*) = 0 FROM postgres_connect;
-true
+> SELECT COUNT(*) FROM postgres_connect;
+0
 
 $ postgres-execute connection=conn1
 INSERT INTO postgres_connect VALUES (2);
 COMMIT;
 
-> SELECT COUNT(*) = 2 FROM postgres_connect;
-true
+> SELECT COUNT(*) FROM postgres_connect;
+2

--- a/test/upgrade/create-in-current_source-kafka-source.td
+++ b/test/upgrade/create-in-current_source-kafka-source.td
@@ -27,5 +27,5 @@ $ kafka-ingest format=avro topic=upgrade-kafka-source-${arg.upgrade-from-version
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE NONE
 
-> SELECT COUNT(*) = 2 FROM kafka_source
-true
+> SELECT COUNT(*) FROM kafka_source
+2


### PR DESCRIPTION
Our testdrive suite has a large number of equality checks that are
evaluated in the SQL context and the testdrive framework only verifies
that the equality was true.

When a test like this fails it's often useful to also know the value
that didn't match the equality check.

By moving the expected values in the results when a test fails the
developer will be informed of both the expected and the actual value of
the equality.
