### PR TITLE
test: Fix mzbuild CargoTest

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -339,6 +339,8 @@ class CargoTest(CargoPreImage):
         output = spawn.capture(args + ["--message-format=json"], cwd=self.rd.root)
 
         tests = []
+        target_dir = str(self.rd.cargo_target_dir().absolute())
+        ci_builder_target_dir = "/mnt/build/" + xcompile.target(self.rd.arch)
         for line in output.split("\n"):
             if line.strip() == "":
                 continue
@@ -359,7 +361,10 @@ class CargoTest(CargoPreImage):
                 crate_path = Path(crate_path_match.group(1)).relative_to(
                     self.rd.root.resolve()
                 )
-                tests.append((message["executable"], slug, crate_path))
+                executable = message["executable"]
+                if executable.startswith(ci_builder_target_dir):
+                    executable = target_dir + executable[len(ci_builder_target_dir) :]
+                tests.append((executable, slug, crate_path))
 
         os.makedirs(self.path / "tests" / "examples")
         with open(self.path / "tests" / "manifest", "w") as manifest:


### PR DESCRIPTION
The CargoTest class in mzbuild is responsible for building test
binaries for mzcompose. When trying to build tests locally, many people
were running into an issue about a missing file. For example:
`FileNotFoundError: [Errno 2] No such file or directory: '/mnt/build/x86_64-unknown-linux-gnu/debug/deps/mz_persist_types-11278be3f5b6c9ee'`

The issue was that cargo test was being run inside the docker
container, so the executable paths being printed were paths inside the
container. mzbuild would then look for the executables using the
printed on the host machine and fail to find the executables.

This commit translates any paths from the container path to the host
machine path so mzbuild can correctly find test executables.

### Motivation
This PR fixes a previously unreported bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes.
