### PR TITLE
sql: rely on TryFrom for WithOption handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,6 +3751,7 @@ dependencies = [
  "mz-ore",
  "mz-persist-client",
  "mz-persist-types",
+ "mz-sql-parser",
  "num-traits",
  "num_enum",
  "once_cell",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,6 +31,7 @@ mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore", features = ["bytes", "smallvec"] }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
+mz-sql-parser = { path = "../sql-parser" }
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 ordered-float = { version = "3.0.0", features = ["serde"] }

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -69,6 +69,66 @@ impl RustType<ProtoInterval> for Interval {
     }
 }
 
+use mz_sql_parser::ast::{AstInfo, IntervalValue, Value, WithOptionValue};
+
+impl TryFrom<Value> for Interval {
+    type Error = anyhow::Error;
+
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        Ok(match v {
+            Value::Interval(IntervalValue { value, .. })
+            | Value::Number(value)
+            | Value::String(value) => crate::strconv::parse_interval(&value)?,
+            _ => bail!("cannot use value as interval"),
+        })
+    }
+}
+
+impl<T: AstInfo> TryFrom<WithOptionValue<T>> for Interval {
+    type Error = anyhow::Error;
+
+    fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
+        match v {
+            WithOptionValue::Value(v) => v.try_into(),
+            _ => anyhow::bail!("cannot use value as interval"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
+pub struct OptionalInterval(pub Option<Interval>);
+
+impl TryFrom<Value> for OptionalInterval {
+    type Error = anyhow::Error;
+
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        let inner = match v {
+            Value::Null => None,
+            v => {
+                let d: Interval = v.try_into()?;
+                // An interval of 0 disables the setting.
+                if d == Interval::default() {
+                    None
+                } else {
+                    Some(d)
+                }
+            }
+        };
+        Ok(OptionalInterval(inner))
+    }
+}
+
+impl<T: AstInfo> TryFrom<WithOptionValue<T>> for OptionalInterval {
+    type Error = anyhow::Error;
+
+    fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
+        match v {
+            WithOptionValue::Value(v) => v.try_into(),
+            _ => anyhow::bail!("cannot use value as interval"),
+        }
+    }
+}
+
 impl num_traits::ops::checked::CheckedNeg for Interval {
     fn checked_neg(&self) -> Option<Self> {
         if let (Some(months), Some(days), Some(micros)) = (

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.61.0"
 publish = false
 
 [dependencies]
+anyhow = "1.0.57"
 enum-kinds = "0.5.1"
 itertools = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1828,6 +1828,28 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
 }
 impl_display_t!(WithOptionValue);
 
+impl<T: AstInfo> TryFrom<WithOptionValue<T>> for String {
+    type Error = anyhow::Error;
+
+    fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
+        match v {
+            WithOptionValue::Value(v) => v.try_into(),
+            _ => anyhow::bail!("cannot use value as string"),
+        }
+    }
+}
+
+impl<T: AstInfo> TryFrom<WithOptionValue<T>> for bool {
+    type Error = anyhow::Error;
+
+    fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
+        match v {
+            WithOptionValue::Value(v) => v.try_into(),
+            _ => anyhow::bail!("cannot use value as boolean"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TransactionMode {
     AccessMode(TransactionAccessMode),

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -134,6 +134,40 @@ impl AstDisplay for Value {
 }
 impl_display!(Value);
 
+impl TryFrom<Value> for String {
+    type Error = anyhow::Error;
+
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        match v {
+            Value::String(v) => Ok(v),
+            _ => anyhow::bail!("cannot use value as string"),
+        }
+    }
+}
+
+impl TryFrom<Value> for bool {
+    type Error = anyhow::Error;
+
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        match v {
+            Value::Boolean(v) => Ok(v),
+            _ => anyhow::bail!("cannot use value as boolean"),
+        }
+    }
+}
+
+impl TryFrom<Value> for i32 {
+    type Error = anyhow::Error;
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        match v {
+            Value::Number(v) => v
+                .parse::<i32>()
+                .map_err(|_| anyhow::anyhow!("invalid numeric value")),
+            _ => anyhow::bail!("cannot use value as number"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum DateTimeField {
     Millennium,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1164,6 +1164,20 @@ CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
 
 parse-statement
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = 0
+----
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY 0
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(Number("0")))] })
+
+parse-statement
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = NULL
+----
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY NULL
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(Null))] })
+
+parse-statement
 CREATE CLUSTER cluster REPLICAS (), BADOPT
 ----
 error: Expected one of REPLICAS or INTROSPECTION, found identifier "badopt"

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -495,21 +495,6 @@ macro_rules! with_option_type {
             _ => ::anyhow::bail!("expected Interval"),
         }
     };
-    ($name:expr, OptionalInterval) => {
-        match $name {
-            Some(crate::ast::WithOptionValue::Value(Value::String(value))) => {
-                if value.as_str() == "off" {
-                    None
-                } else {
-                    Some(mz_repr::strconv::parse_interval(&value)?)
-                }
-            }
-            Some(crate::ast::WithOptionValue::Value(Value::Interval(interval))) => {
-                Some(mz_repr::strconv::parse_interval(&interval.value)?)
-            }
-            _ => ::anyhow::bail!("expected Interval or 'off'"),
-        }
-    };
 }
 
 /// Ensures that the given set of options are empty, useful for validating that

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -330,7 +330,7 @@ CREATE CLUSTER REPLICA default."" SIZE '1';
 statement error unknown cluster
 CREATE CLUSTER REPLICA no_such_cluster.size_1 SIZE '1';
 
-statement error expected String or bare identifier
+statement error invalid SIZE
 CREATE CLUSTER foo REPLICAS (size_2 (SIZE NULL));
 
 statement error unknown cluster replica size
@@ -339,10 +339,10 @@ CREATE CLUSTER foo REPLICAS (size_2 (SIZE ''));
 statement error unknown cluster replica size
 CREATE CLUSTER foo REPLICAS (size_2 (SIZE 'no_such_size'));
 
-statement error expected String or bare identifier
+statement error invalid SIZE
 CREATE CLUSTER foo REPLICAS (size_2 (SIZE 1));
 
-statement error unknown cluster replica size
+statement error invalid SIZE
 CREATE CLUSTER foo REPLICAS (size_2 (SIZE a));
 
 statement ok

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -123,7 +123,7 @@ DROP CLUSTER test CASCADE
 statement ok
 CREATE CLUSTER test
   REPLICAS (replica_a (SIZE '1')),
-  INTROSPECTION GRANULARITY 'off'
+  INTROSPECTION GRANULARITY 0
 
 query error cannot read log sources on cluster with disabled introspection
 SELECT * FROM mz_materializations


### PR DESCRIPTION
As part of #5390, I want to simplify handling `WithOptionValue` + `Value` handling by using std lib features as much as possible.

The one large/controversial change I've made is to change the means by which users disable interval-based settings; rather than using `'off'`, let users either use `0` or `NULL`. This approximates [how PG handles e.g. disabling timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html).

### Motivation

This PR refactors existing code as part of #5390

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Change the value to disable `CLUSTER...INTROSPECTION GRANULARITY` from the value `'off'` to either `0` or `NULL`, e.g. `CREATE CLUSTER test REPLICAS (), INTROSPECTION GRANULARITY 0`
