### PR TITLE
tracing: pass otel context between materialized and computed for peeks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "paste",
  "pin-project",
  "prometheus",
+ "serde",
  "smallvec",
  "stacker",
  "tokio",

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -39,6 +39,7 @@ message ProtoPeek {
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
     optional int64 target_replica = 7;
+    map<string, string> otel_ctx = 8;
 }
 
 message ProtoComputeCommand {
@@ -87,6 +88,7 @@ message ProtoComputeResponse {
     message ProtoPeekResponseKind {
         mz_repr.proto.ProtoU128 id = 1;
         mz_dataflow_types.types.ProtoPeekResponse resp = 2;
+    map<string, string> otel_ctx = 3;
     }
 
     message ProtoTailResponseKind {

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -437,12 +437,16 @@ where
                             .await?;
                         Ok(None)
                     }
-                    ComputeResponse::PeekResponse(uuid, response) => {
+                    ComputeResponse::PeekResponse(uuid, peek_response, otel_ctx) => {
                         self.compute_mut(instance)
                             .expect("Reference to absent instance")
                             .remove_peeks(std::iter::once(uuid))
                             .await?;
-                        Ok(Some(ControllerResponse::PeekResponse(uuid, response)))
+                        Ok(Some(ControllerResponse::PeekResponse(
+                            uuid,
+                            peek_response,
+                            otel_ctx,
+                        )))
                     }
                     ComputeResponse::TailResponse(global_id, response) => {
                         let mut changes = timely::progress::ChangeBatch::new();

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -479,7 +479,7 @@ where
                     Some(Ok(ComputeResponse::FrontierUppers(list)))
                 }
             }
-            ComputeResponse::PeekResponse(uuid, response) => {
+            ComputeResponse::PeekResponse(uuid, response, otel_ctx) => {
                 // Incorporate new peek responses; awaiting all responses.
                 let entry = self
                     .peek_responses
@@ -503,7 +503,8 @@ where
                         };
                     }
                     self.peek_responses.remove(&uuid);
-                    Some(Ok(ComputeResponse::PeekResponse(uuid, response)))
+                    // We take the otel_ctx from the last peek, but they should all be the same
+                    Some(Ok(ComputeResponse::PeekResponse(uuid, response, otel_ctx)))
                 } else {
                     None
                 }

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -148,10 +148,10 @@ where
                 self.responses
                     .push_back(ComputeResponse::FrontierUppers(list));
             }
-            ComputeResponse::PeekResponse(uuid, response) => {
+            ComputeResponse::PeekResponse(uuid, response, otel_ctx) => {
                 if self.peeks.remove(&uuid) {
                     self.responses
-                        .push_back(ComputeResponse::PeekResponse(uuid, response));
+                        .push_back(ComputeResponse::PeekResponse(uuid, response, otel_ctx));
                 }
             }
             ComputeResponse::TailResponse(id, response) => {

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -31,6 +31,7 @@ pin-project = "1.0.0"
 prometheus = { version = "0.13.1", default-features = false, optional = true }
 smallvec = { version = "1.8.0", optional = true }
 stacker = { version = "0.1.14", optional = true }
+serde = { version = "1.0.137", features = ["derive"], optional = true }
 tokio = { version = "1.18.2", features = ["io-util", "net", "rt-multi-thread", "time"], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
@@ -71,6 +72,7 @@ tracing_ = [
   "tracing-subscriber/ansi",
   "tracing-opentelemetry",
   "tokio-native-tls",
+  "serde",
   "native-tls",
   "http",
   "hyper",


### PR DESCRIPTION
(Depends on https://github.com/MaterializeInc/materialize/pull/12828 merging first)


Builds this tree:
<img width="1331" alt="Screen Shot 2022-06-02 at 11 16 40 AM" src="https://user-images.githubusercontent.com/5404303/171720293-d220bf06-88f3-41f9-9e6e-501928dff73e.png">

This is a first draft, and I am looking for feedback on how we think we should organize this going forward in later prs. Note that the end time of spans is often before the start of the span on the other side of the channel/transport. Definitely some stuff to think about!

Also, i couldn't figure out how to force a peek to end up needing to go into compute's `pending_peek` list, so I forced it to happen and got this, note the `process_peek` span!
<img width="404" alt="Screen Shot 2022-06-02 at 11 13 25 AM" src="https://user-images.githubusercontent.com/5404303/171720303-8d1505f8-0d00-4a60-a958-e6540e792179.png">

### Motivation

  * This PR adds a feature that has not yet been specified.
I will be writing a thorough issue today about how we go forward

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - see above

### Release notes

None