### PR TITLE
persist: stop cloning Vecs for blob::set and consensus::compare_and_set

### DIFF
--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -217,12 +217,12 @@ impl BlobMulti for MaelstromBlobMulti {
         &self,
         _deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         _atomic: Atomicity,
     ) -> Result<(), ExternalError> {
         // lin_kv_write is always atomic, so we're free to ignore the atomic
         // param.
-        let value = serde_json::to_string(&value).expect("failed to serialize value");
+        let value = serde_json::to_string(value.as_ref()).expect("failed to serialize value");
         self.handle
             .lin_kv_write(Value::from(format!("blob/{}", key)), Value::from(value))
             .await
@@ -293,12 +293,12 @@ impl BlobMulti for CachingBlobMulti {
         &self,
         deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         atomic: Atomicity,
     ) -> Result<(), ExternalError> {
         // Intentionally don't put this in the cache on set, so that this blob
         // gets fetched at least once (exercising those code paths).
-        self.blob.set(deadline, key, value.clone(), atomic).await
+        self.blob.set(deadline, key, value, atomic).await
     }
 
     async fn delete(&self, deadline: Instant, key: &str) -> Result<(), ExternalError> {

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -284,8 +284,6 @@ where
             // retry even indeterminate errors. See
             // [Self::apply_unbatched_idempotent_cmd].
             let cas_res = retry_determinate("apply_unbatched_cmd::cas", || async {
-                // If Consensus::compare_and_set took new as a ref, then we
-                // wouldn't have to clone here.
                 self.consensus
                     .compare_and_set(
                         Instant::now() + FOREVER,
@@ -369,8 +367,6 @@ where
                 state
             );
             let cas_res = retry_external("maybe_init_state::cas", || async {
-                // If Consensus::compare_and_set took new as a ref, then we
-                // wouldn't have to clone here.
                 consensus
                     .compare_and_set(Instant::now() + FOREVER, &path, None, new.clone())
                     .await

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use bytes::Bytes;
 use fail::fail_point;
 
 use tokio::fs::{self, File, OpenOptions};
@@ -111,7 +112,7 @@ impl BlobMulti for FileBlobMulti {
         &self,
         _deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         atomic: Atomicity,
     ) -> Result<(), ExternalError> {
         let file_path = self.blob_path(key);

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
 use mz_ore::cast::CastFrom;
 use mz_persist_types::Codec;
 
@@ -157,6 +158,7 @@ impl<B: BlobMulti + Send + Sync + 'static> BlobCache<B> {
 
         let mut val = Vec::new();
         batch.encode(&mut val);
+        let val = Bytes::from(val);
         let val_len = u64::cast_from(val.len());
 
         let write_start = Instant::now();

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -363,7 +363,7 @@ pub trait BlobMulti: std::fmt::Debug {
         &self,
         deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         atomic: Atomicity,
     ) -> Result<(), ExternalError>;
 
@@ -422,14 +422,14 @@ pub mod tests {
 
         // Set a key with AllowNonAtomic and get it back.
         blob0
-            .set(no_timeout, "k0", values[0].clone(), AllowNonAtomic)
+            .set(no_timeout, "k0", values[0].clone().into(), AllowNonAtomic)
             .await?;
         assert_eq!(blob0.get(no_timeout, "k0").await?, Some(values[0].clone()));
         assert_eq!(blob1.get(no_timeout, "k0").await?, Some(values[0].clone()));
 
         // Set a key with RequireAtomic and get it back.
         blob0
-            .set(no_timeout, "k0a", values[0].clone(), RequireAtomic)
+            .set(no_timeout, "k0a", values[0].clone().into(), RequireAtomic)
             .await?;
         assert_eq!(blob0.get(no_timeout, "k0a").await?, Some(values[0].clone()));
         assert_eq!(blob1.get(no_timeout, "k0a").await?, Some(values[0].clone()));
@@ -444,13 +444,13 @@ pub mod tests {
 
         // Can overwrite a key with AllowNonAtomic.
         blob0
-            .set(no_timeout, "k0", values[1].clone(), AllowNonAtomic)
+            .set(no_timeout, "k0", values[1].clone().into(), AllowNonAtomic)
             .await?;
         assert_eq!(blob0.get(no_timeout, "k0").await?, Some(values[1].clone()));
         assert_eq!(blob1.get(no_timeout, "k0").await?, Some(values[1].clone()));
         // Can overwrite a key with RequireAtomic.
         blob0
-            .set(no_timeout, "k0a", values[1].clone(), RequireAtomic)
+            .set(no_timeout, "k0a", values[1].clone().into(), RequireAtomic)
             .await?;
         assert_eq!(blob0.get(no_timeout, "k0a").await?, Some(values[1].clone()));
         assert_eq!(blob1.get(no_timeout, "k0a").await?, Some(values[1].clone()));
@@ -475,7 +475,7 @@ pub mod tests {
         assert_eq!(blob_keys, empty_keys);
         // Can reset a deleted key to some other value.
         blob0
-            .set(no_timeout, "k0", values[1].clone(), AllowNonAtomic)
+            .set(no_timeout, "k0", values[1].clone().into(), AllowNonAtomic)
             .await?;
         assert_eq!(blob1.get(no_timeout, "k0").await?, Some(values[1].clone()));
         assert_eq!(blob0.get(no_timeout, "k0").await?, Some(values[1].clone()));
@@ -486,7 +486,7 @@ pub mod tests {
         for i in 1..=5 {
             let key = format!("k{}", i);
             blob0
-                .set(no_timeout, &key, values[0].clone(), AllowNonAtomic)
+                .set(no_timeout, &key, values[0].clone().into(), AllowNonAtomic)
                 .await?;
             expected_keys.push(key);
         }

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -14,6 +14,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use bytes::{Bytes, BytesMut};
 use mz_persist_types::Codec;
 use serde::{Deserialize, Serialize};
 use tokio_postgres::error::SqlState;
@@ -238,18 +239,18 @@ pub struct VersionedData {
     /// The sequence number of the data.
     pub seqno: SeqNo,
     /// The data itself.
-    pub data: Vec<u8>,
+    pub data: Bytes,
 }
 
 impl<T: Codec> From<(SeqNo, &T)> for VersionedData {
     fn from(x: (SeqNo, &T)) -> Self {
         let (seqno, t) = x;
-        let mut ret = VersionedData {
+        let mut data = BytesMut::new();
+        Codec::encode(t, &mut data);
+        VersionedData {
             seqno,
-            data: Vec::new(),
-        };
-        Codec::encode(t, &mut ret.data);
-        ret
+            data: Bytes::from(data),
+        }
     }
 }
 
@@ -532,7 +533,7 @@ pub mod tests {
 
         let state = VersionedData {
             seqno: SeqNo(5),
-            data: "abc".as_bytes().to_vec(),
+            data: Bytes::from("abc"),
         };
 
         // Incorrectly setting the data with a non-None expected should fail.
@@ -582,7 +583,7 @@ pub mod tests {
 
         let new_state = VersionedData {
             seqno: SeqNo(10),
-            data: "def".as_bytes().to_vec(),
+            data: Bytes::from("def"),
         };
 
         // Trying to update without the correct expected seqno fails, (even if expected > current)
@@ -603,7 +604,7 @@ pub mod tests {
 
         let invalid_constant_seqno = VersionedData {
             seqno: SeqNo(5),
-            data: "invalid".as_bytes().to_vec(),
+            data: Bytes::from("invalid"),
         };
 
         // Trying to set the data to a sequence number == current fails even if
@@ -617,7 +618,7 @@ pub mod tests {
 
         let invalid_regressing_seqno = VersionedData {
             seqno: SeqNo(3),
-            data: "invalid".as_bytes().to_vec(),
+            data: Bytes::from("invalid"),
         };
 
         // Trying to set the data to a sequence number < current fails even if
@@ -686,7 +687,7 @@ pub mod tests {
 
         let state = VersionedData {
             seqno: SeqNo(1),
-            data: "einszweidrei".as_bytes().to_vec(),
+            data: Bytes::from("einszweidrei"),
         };
 
         assert_eq!(
@@ -710,7 +711,7 @@ pub mod tests {
         // Trying to update from a stale version of current doesn't work.
         let invalid_jump_forward = VersionedData {
             seqno: SeqNo(11),
-            data: "invalid".as_bytes().to_vec(),
+            data: Bytes::from("invalid"),
         };
         assert_eq!(
             consensus
@@ -741,7 +742,7 @@ pub mod tests {
                     None,
                     VersionedData {
                         seqno: SeqNo(0),
-                        data: vec![],
+                        data: Bytes::new(),
                     }
                 )
                 .await,
@@ -755,7 +756,7 @@ pub mod tests {
                     None,
                     VersionedData {
                         seqno: SeqNo(i64::MAX.try_into().expect("i64::MAX fits in u64")),
-                        data: vec![],
+                        data: Bytes::new(),
                     }
                 )
                 .await,
@@ -768,7 +769,7 @@ pub mod tests {
                 None,
                 VersionedData {
                     seqno: SeqNo(1 << 63),
-                    data: vec![],
+                    data: Bytes::new(),
                 }
             )
             .await
@@ -780,7 +781,7 @@ pub mod tests {
                 None,
                 VersionedData {
                     seqno: SeqNo(u64::MAX),
-                    data: vec![],
+                    data: Bytes::new(),
                 }
             )
             .await

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use bytes::Bytes;
 
 use crate::error::Error;
 use crate::location::{Atomicity, BlobMulti, Consensus, ExternalError, SeqNo, VersionedData};
@@ -56,15 +57,15 @@ impl MemMultiRegistry {
 
 #[derive(Debug, Default)]
 struct MemBlobMultiCore {
-    dataz: HashMap<String, Vec<u8>>,
+    dataz: HashMap<String, Bytes>,
 }
 
 impl MemBlobMultiCore {
     fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
-        Ok(self.dataz.get(key).cloned())
+        Ok(self.dataz.get(key).map(|x| x.to_vec()))
     }
 
-    fn set(&mut self, key: &str, value: Vec<u8>) -> Result<(), ExternalError> {
+    fn set(&mut self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         self.dataz.insert(key.to_owned(), value);
         Ok(())
     }
@@ -112,7 +113,7 @@ impl BlobMulti for MemBlobMulti {
         &self,
         _deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         _atomic: Atomicity,
     ) -> Result<(), ExternalError> {
         // NB: This is always atomic, so we're free to ignore the atomic param.

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -438,7 +438,7 @@ impl BlobMulti for S3BlobMulti {
         &self,
         _deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         _atomic: Atomicity,
     ) -> Result<(), ExternalError> {
         // NB: S3 is always atomic, so we're free to ignore the atomic param.
@@ -467,7 +467,7 @@ impl BlobMulti for S3BlobMulti {
 }
 
 impl S3BlobMulti {
-    async fn set_single_part(&self, key: &str, value: Vec<u8>) -> Result<(), ExternalError> {
+    async fn set_single_part(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         let start_overall = Instant::now();
         let path = self.get_path(key);
 
@@ -488,7 +488,7 @@ impl S3BlobMulti {
         Ok(())
     }
 
-    async fn set_multi_part(&self, key: &str, value: Vec<u8>) -> Result<(), ExternalError> {
+    async fn set_multi_part(&self, key: &str, value: Bytes) -> Result<(), ExternalError> {
         let start_overall = Instant::now();
         let path = self.get_path(key);
 
@@ -519,7 +519,6 @@ impl S3BlobMulti {
         // TODO: The aws cli throttles how many of these are outstanding at any
         // given point. We'll likely want to do the same at some point.
         let start_parts = Instant::now();
-        let value = Bytes::from(value);
         let mut part_futs = Vec::new();
         for (part_num, part_range) in self.multipart_config.part_iter(value.len()) {
             // NB: Without this spawn, these will execute serially. This is rust

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -15,6 +15,7 @@ use std::time::{Instant, UNIX_EPOCH};
 
 use anyhow::anyhow;
 use async_trait::async_trait;
+use bytes::Bytes;
 use rand::prelude::SmallRng;
 use rand::{Rng, SeedableRng};
 use tracing::trace;
@@ -159,7 +160,7 @@ impl BlobMulti for UnreliableBlobMulti {
         &self,
         deadline: Instant,
         key: &str,
-        value: Vec<u8>,
+        value: Bytes,
         atomic: Atomicity,
     ) -> Result<(), ExternalError> {
         self.handle


### PR DESCRIPTION
The production impls (s3 and postgres) didn't need to take owned data, so the cloning was unnecessary.

See commits for details.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
