### PR TITLE
testdrive: Do not print the output header unless explicitly requested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4103,6 +4103,7 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tokio-util 0.7.2",
+ "tracing",
  "tracing-subscriber",
  "url",
  "uuid 1.1.0",

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -61,6 +61,7 @@ tempfile = "3.2.0"
 termcolor = "1.1.3"
 tiberius = { version = "0.9.0", default-features = false }
 time = "0.3.9"
+tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 tokio = { version = "1.18.2", features = ["process"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["with-chrono-0_4", "with-serde_json-1"] }

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -25,6 +25,7 @@ use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 use time::Instant;
+use tracing::info;
 use tracing_subscriber::filter::EnvFilter;
 use url::Url;
 use walkdir::WalkDir;
@@ -232,7 +233,7 @@ async fn main() {
         }
     };
 
-    eprintln!(
+    info!(
         "Configuration parameters:
     Kafka address: {}
     Schema registry URL: {}


### PR DESCRIPTION
testdrive prints a "Configuration parameters" header on every execution.
Now that testdrive is used extensively and repeateadly in mzcompose
workflows, this output clutters the log needlessly.

Convert the eprintln! to a info! so that it is not produced by default.

### Motivation

  * This PR fixes a previously unreported bug.
CI output is cluttered with instances of the testdrive output header