### PR TITLE
mzcompose,feature-benchmark: Fix the FB the Postgres Platform era

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -800,7 +800,7 @@ class Composition:
         _wait_for_pg(
             dbname=dbname,
             host=host,
-            port=port or self.default_port(service),
+            port=self.port(service, port) if port else self.default_port(service),
             timeout_secs=timeout_secs,
             query=query,
             user=user,

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -54,6 +54,8 @@ class Materialized(Service):
         if environment is None:
             environment = [
                 "MZ_SOFT_ASSERTIONS=1",
+                "MZ_UNSAFE=1",
+                "MZ_EXPERIMENTAL=1",
                 # Please think twice before forwarding additional environment
                 # variables from the host, as it's easy to write tests that are
                 # then accidentally dependent on the state of the host machine.
@@ -87,7 +89,6 @@ class Materialized(Service):
         command_list = [
             f"--data-directory={data_directory}",
             f"--listen-addr 0.0.0.0:{guest_port}",
-            "--unsafe-mode",
             f"--timestamp-frequency {timestamp_frequency}",
         ]
 


### PR DESCRIPTION
- as the feature benchmark is creating clusters, a dedicated Postgres
  instance is required.
- the Materialized() class now takes a postgres_consensus_url argument
- _wait_for_pg() with a port number has been fixed to resolve the
  port to the correct local port before attempting to ping it.


### Motivation

  * This PR fixes a previously unreported bug.
The feature benchmark was no longer operational after recent changes in the product

### Tips for reviewer

@benesch if you could review the small changes in mzcompose/*.py that would be much appreciated.