### PR TITLE
Improve error msg when computed or storaged can't connect to Postgres for consensus

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -456,14 +456,14 @@ where
             Err(err) => {
                 if retry.attempt() >= INFO_MIN_ATTEMPTS {
                     info!(
-                        "external operation {} failed, retrying in {:?}: {}",
+                        "external operation {} failed, retrying in {:?}: {:#}",
                         name,
                         retry.next_sleep(),
                         err
                     );
                 } else {
                     debug!(
-                        "external operation {} failed, retrying in {:?}: {}",
+                        "external operation {} failed, retrying in {:?}: {:#}",
                         name,
                         retry.next_sleep(),
                         err
@@ -498,14 +498,14 @@ where
             Err(ExternalError::Determinate(err)) => {
                 if retry.attempt() >= INFO_MIN_ATTEMPTS {
                     info!(
-                        "external operation {} failed, retrying in {:?}: {}",
+                        "external operation {} failed, retrying in {:?}: {:#}",
                         name,
                         retry.next_sleep(),
                         err
                     );
                 } else {
                     debug!(
-                        "external operation {} failed, retrying in {:?}: {}",
+                        "external operation {} failed, retrying in {:?}: {:#}",
                         name,
                         retry.next_sleep(),
                         err

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -70,7 +70,8 @@ pub struct Determinate {
 
 impl std::fmt::Display for Determinate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "determinate: {}", self.inner)
+        write!(f, "determinate: ")?;
+        self.inner.fmt(f)
     }
 }
 
@@ -94,7 +95,8 @@ pub struct Indeterminate {
 
 impl std::fmt::Display for Indeterminate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "indeterminate: {}", self.inner)
+        write!(f, "indeterminate: ")?;
+        self.inner.fmt(f)
     }
 }
 

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::anyhow;
+use anyhow::Context;
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
@@ -138,7 +139,9 @@ impl PostgresConsensus {
         // TODO: reconsider opening with NoTLS. Perhaps we actually want to,
         // especially given the fact that its not entirely known what data
         // will actually be stored in Consensus.
-        let (mut client, conn) = tokio_postgres::connect(&config.url, NoTls).await?;
+        let (mut client, conn) = tokio_postgres::connect(&config.url, NoTls)
+            .await
+            .with_context(|| format!("error connecting to postgres"))?;
         let handle = task::spawn(|| "pg_consensus_client", async move {
             if let Err(e) = conn.await {
                 tracing::error!("connection error: {}", e);


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug: #12762 

### Tips for reviewer

The main part of the PR is simply adding the `.with_context` in `postgres.rs`. However, this necessitated some other minor changes.

`with_context` creates a nested `anyhow` error, which created a problem because the original error printing code in `machine.rs` uses `{}`, which means that `anyhow` would print only the outer error. I changed it to `{:#}`, because `anyhow`’s documentation says that we can use `{:#}` to make `anyhow` print also the inner errors (see https://github.com/dtolnay/anyhow/blob/master/src/lib.rs#L293).

But then one more change was needed in `fmt::Display` for `Indeterminate`, because `fmt` was not passing on the `alternate` flag that is in the `Formatter`. (How the `{:#}` works is that it calls `Display::fmt`, which would be the same as `{}`, except that the `alternate` flag is set on the `Formatter`. The original code in `fmt::Display` for `Indeterminate` overrode the format by using `{}`, i.e., created a new `Formatter` that didn’t have the `alternate` flag set. Now it uses the same formatter for printing `self.inner` that it got as an argument.)

### Testing

- I tested by modifying the consensus uri that materialized passes to computed and storaged, and observing the error msgs. Before the change, the msg looked like this:
`compute-cluster-1-replica-1: 2022-06-03T09:25:01.688725Z  INFO mz_persist_client::r#impl::machine: external operation consensus::open failed, retrying in 16s: indeterminate: error connecting to server: No such file or directory (os error 2)`
After the change:
`compute-cluster-1-replica-1: 2022-06-03T14:54:18.385938Z  INFO mz_persist_client::r#impl::machine: external operation consensus::open failed, retrying in 16s: indeterminate: error connecting to postgres at 'postgres://gabor@%2Fvar%2Frun%2Fpostgresqlxxxxxxxx?options=--search_path=consensus': error connecting to server: No such file or directory (os error 2): No such file or directory (os error 2)` (The `xxxx` is to make the URL wrong to trigger the error.)
- Maybe it would be good to also test in the original scenario described in the issue, where materialized and computed are on different hosts but the consensus uri tries to point to a local postgres, thus failing on computed's machine. @philip-stoev, do you think we should do this? If yes, could you please help with this? Note that even the above before-the-change error msg is not exactly the same as it was in the issue. I'm guessing that this is just because the code changed in the meantime, but I'm not 100% sure that it is not because I didn't exactly recreate the scenario described in the issue.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
