### PR TITLE
mzcompose: pin to working Debezium version

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -14,7 +14,14 @@ from typing import Dict, List, Optional, Tuple, Union
 from materialize.mzcompose import Service, ServiceConfig
 
 DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.3"
-DEFAULT_DEBEZIUM_VERSION = "1.9"
+
+# Be sure to use a `X.Y.Z.Final` tag here; `X.Y` tags refer to the latest
+# minor version in the release series, and minor versions have been known to
+# introduce breakage.
+#
+# Do not upgrade past v1.9.2.Final until debezium/debezium#3570 is resolved.
+DEFAULT_DEBEZIUM_VERSION = "1.9.2.Final"
+
 LINT_DEBEZIUM_VERSIONS = ["1.4", "1.5", "1.6"]
 
 DEFAULT_MZ_VOLUMES = [


### PR DESCRIPTION
We were incorrectly depending on a floating version of Debezium in the
v1.9 series. v1.9.3 introduced a bug that suddenly started cuasing CI to
fail (debezium/debezium#3570), so pin to v1.9.2 for now.

Fix #12882.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR works around a recognized bug in Debezium.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
