### PR TITLE
ci: always upload mzcompose logs for debugging

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -66,9 +66,4 @@ fi
 
 echo "+++ :docker: Running \`mzcompose run ${run_args[*]}\`" >&2
 
-if ! mzcompose run "${run_args[@]}"; then
-    echo "Command failed! Uploading logs for debugging." >&2
-    mzcompose --mz-quiet logs --no-color > services.log
-    buildkite-agent artifact upload services.log
-    exit 1
-fi
+mzcompose run "${run_args[@]}"

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -17,6 +17,9 @@ run() {
     bin/ci-builder run stable bin/mzcompose --mz-quiet --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
 
+run logs --no-color > services.log
+buildkite-agent artifact upload services.log
+
 run kill
 run rm --force -v
 run down --volumes


### PR DESCRIPTION
This way we can see the logs for commands that timed out. As written we
see logs for successful runs too, but that seems fine!

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
