### PR TITLE
sql: restrict `CREATE SINK` to unsafe mode

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2091,9 +2091,10 @@ fn persist_sink_builder(
 }
 
 pub fn describe_create_sink(
-    _: &StatementContext,
+    scx: &StatementContext,
     _: CreateSinkStatement<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
+    scx.require_unsafe_mode("CREATE SINK")?;
     Ok(StatementDesc::new(None))
 }
 
@@ -2101,6 +2102,7 @@ pub fn plan_create_sink(
     scx: &StatementContext,
     mut stmt: CreateSinkStatement<Aug>,
 ) -> Result<Plan, anyhow::Error> {
+    scx.require_unsafe_mode("CREATE SINK")?;
     let compute_instance = match &stmt.in_cluster {
         None => scx.resolve_compute_instance(None)?.id(),
         Some(in_cluster) => in_cluster.0,

--- a/test/kafka-sasl-plain/mzcompose.yml
+++ b/test/kafka-sasl-plain/mzcompose.yml
@@ -49,6 +49,7 @@ services:
     mzbuild: materialized
     environment:
       - SASL_PASSWORD=sekurity
+      - MZ_UNSAFE_MODE=1
     volumes:
       - secrets:/share/secrets
     depends_on: [test-certs]

--- a/test/upgrade/mzcompose.py
+++ b/test/upgrade/mzcompose.py
@@ -51,7 +51,7 @@ SERVICES = [
     Postgres(),
     Materialized(
         options=" ".join(mz_options.values()),
-        environment=[
+        environment_extra=[
             "SSL_KEY_PASSWORD=mzmzmz",
         ],
         volumes_extra=["secrets:/share/secrets"],
@@ -148,7 +148,7 @@ def test_upgrade_from_version(
                 for start_version, opt in mz_options.items()
                 if from_version[1:] >= start_version
             ),
-            environment=[
+            environment_extra=[
                 "SSL_KEY_PASSWORD=mzmzmz",
             ],
             volumes_extra=["secrets:/share/secrets"],


### PR DESCRIPTION
Sinks have serious defects in Materialize Cloud, so we're disabling them
for now.

Fix #12816.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
