### PR TITLE
mzcompose: don't require separate postgres for remote clusters

### DIFF
--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -18,6 +18,6 @@ psql -Atc "CREATE SCHEMA IF NOT EXISTS catalog"
 
 exec materialized \
     --listen-addr=0.0.0.0:6875 \
-    --persist-consensus-url=postgresql://materialize@%2Ftmp?options=--search_path=consensus \
-    --catalog-postgres-stash=postgresql://materialize@%2Ftmp?options=--search_path=catalog \
+    "--persist-consensus-url=postgresql://materialize@$(hostname):5432?options=--search_path=consensus" \
+    "--catalog-postgres-stash=postgresql://materialize@$(hostname):5432?options=--search_path=catalog" \
     "$@"

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -15,7 +15,6 @@ from materialize.mzcompose.services import (
     Computed,
     Kafka,
     Materialized,
-    Postgres,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -25,10 +24,7 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Postgres(),
-    Materialized(
-        options="--persist-consensus-url postgres://postgres:postgres@postgres"
-    ),
+    Materialized(),
     Testdrive(),
 ]
 
@@ -201,10 +197,8 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
     print(f"+++ Running disruption scenario {disruption.name}")
 
     c.up("testdrive", persistent=True)
-    c.up("postgres")
-    c.wait_for_postgres()
     c.up("materialized")
-    c.wait_for_materialized(service="materialized")
+    c.wait_for_materialized()
 
     nodes = [
         Computed(
@@ -260,7 +254,6 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         cleanup_list = [
             "materialized",
             "testdrive",
-            "postgres",
             *[n.name for n in nodes],
         ]
         c.kill(*cleanup_list)

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -19,7 +19,6 @@ from materialize.mzcompose.services import (
     Kafka,
     Localstack,
     Materialized,
-    Postgres,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -50,10 +49,7 @@ SERVICES = [
         options="--workers 2 --process 1 computed_3:2102 computed_4:2102 --linger --reconcile",
         ports=[2100, 2102],
     ),
-    Postgres(),
-    Materialized(
-        options="--persist-consensus-url postgres://postgres:postgres@postgres",
-    ),
+    Materialized(),
     Testdrive(
         volumes=[
             "mzdata:/mzdata",
@@ -89,9 +85,8 @@ def workflow_nightly(c: Composition) -> None:
 
 
 def test_cluster(c: Composition, *glob: str) -> None:
-    c.up("materialized", "postgres")
-    c.wait_for_materialized(service="materialized")
-    c.wait_for_postgres()
+    c.up("materialized")
+    c.wait_for_materialized()
 
     # Create a remote cluster and verify that tests pass.
     c.up("computed_1")
@@ -123,7 +118,7 @@ def test_cluster(c: Composition, *glob: str) -> None:
 # This tests that the client does not wait indefinitely on a resource that crashed
 def test_github_12251(c: Composition) -> None:
     c.up("materialized")
-    c.wait_for_materialized(service="materialized")
+    c.wait_for_materialized()
     c.up("computed_1")
     c.sql(
         """

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -19,7 +19,6 @@ from materialize.mzcompose.services import (
     Computed,
     Kafka,
     Materialized,
-    Postgres,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -1034,11 +1033,7 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Postgres(),
-    Materialized(
-        memory="8G",
-        options="--persist-consensus-url postgres://postgres:postgres@postgres",
-    ),
+    Materialized(memory="8G"),
     Testdrive(default_timeout="60s"),
 ]
 
@@ -1065,11 +1060,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "postgres"]
-    )
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
 
-    c.wait_for_postgres()
     c.up("materialized")
     c.wait_for_materialized()
 
@@ -1092,13 +1084,10 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "postgres"]
-    )
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
 
-    c.wait_for_postgres()
     c.up("materialized")
-    c.wait_for_materialized(service="materialized")
+    c.wait_for_materialized()
 
     nodes = [
         Computed(
@@ -1139,9 +1128,7 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
 
 def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Create multiple clusters with multiple nodes and replicas each"""
-    c.start_and_wait_for_tcp(
-        services=["zookeeper", "kafka", "schema-registry", "postgres"]
-    )
+    c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
     c.wait_for_postgres()
 
     parser.add_argument(
@@ -1177,7 +1164,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
 
     c.up("testdrive", persistent=True)
     c.up("materialized")
-    c.wait_for_materialized(service="materialized")
+    c.wait_for_materialized()
 
     # Construct the requied Computed instances and peer them into clusters
     computeds = []

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -17,7 +17,6 @@ from materialize.mzcompose.services import (
     Kafka,
     Localstack,
     Materialized,
-    Postgres,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -27,12 +26,8 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Postgres(),
     Localstack(),
-    Materialized(
-        options="--persist-consensus-url postgres://postgres:postgres@postgres",
-        extra_ports=[2101],
-    ),
+    Materialized(),
     Testdrive(),
 ]
 
@@ -178,8 +173,6 @@ def workflow_default(c: Composition) -> None:
     c.start_and_wait_for_tcp(
         services=["zookeeper", "kafka", "schema-registry", "localstack"]
     )
-    c.up("postgres")
-    c.wait_for_postgres()
     for id, disruption in enumerate(disruptions):
         run_test(c, disruption, id)
 


### PR DESCRIPTION
Rather than requiring a separate Postgres service to use remote clusters
with the Materialized service, just use a Postgres URL that works both
internal and external to the Materialized service.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
