### PR TITLE
storage: handling missing keys with ENVELOPE NONE #12275

### DIFF
--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -54,12 +54,17 @@ message ProtoTimeline {
 
 message ProtoSourceEnvelope {
     oneof kind {
-        ProtoKeyEnvelope none = 1;
+        ProtoNoneEnvelope none = 1;
         ProtoDebeziumEnvelope debezium = 2;
         ProtoUpsertEnvelope upsert = 3;
         google.protobuf.Empty cdc_v2 = 4;
         google.protobuf.Empty differential_row = 5;
     }
+}
+
+message ProtoNoneEnvelope {
+    ProtoKeyEnvelope key_envelope = 1;
+    uint64 key_arity = 2;
 }
 
 message ProtoUpsertEnvelope {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -571,6 +571,19 @@ pub fn plan_create_source(
     };
     let (key_desc, value_desc) = encoding.desc()?;
 
+    let key_desc = key_desc.map(|key_desc| {
+        // keys are optional with `Envelope::None`, so we mark each of the key's columns as nullable
+        if let mz_sql_parser::ast::Envelope::None = &envelope {
+            RelationDesc::from_names_and_types(
+                key_desc
+                    .into_iter()
+                    .map(|(name, typ)| (name, typ.nullable(true))),
+            )
+        } else {
+            key_desc
+        }
+    });
+
     let key_envelope = get_key_envelope(include_metadata, &envelope, &encoding)?;
 
     // Not all source envelopes are compatible with all source connectors.

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -615,13 +615,11 @@ fn raise_key_value_errors(
     KV { key, val }: KV,
 ) -> Option<Result<(Option<Row>, Row, Diff), DecodeError>> {
     match (key, val) {
-        (key, Some(value)) => match (key, value) {
-            (Some(Ok(key)), Ok((value, diff))) => Some(Ok((Some(key), value, diff))),
-            (None, Ok((value, diff))) => Some(Ok((None, value, diff))),
-            // always prioritize the value error if either or both have an error
-            (_, Err(e)) => Some(Err(e)),
-            (Some(Err(e)), _) => Some(Err(e)),
-        },
+        (Some(Ok(key)), Some(Ok((value, diff)))) => Some(Ok((Some(key), value, diff))),
+        (None, Some(Ok((value, diff)))) => Some(Ok((None, value, diff))),
+        // always prioritize the value error if either or both have an error
+        (_, Some(Err(e))) => Some(Err(e)),
+        (Some(Err(e)), _) => Some(Err(e)),
         (None, None) => None,
         // TODO(petrosagg): these errors would be better grouped under an EnvelopeError enum
         _ => Some(Err(DecodeError::Text(

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -41,6 +41,8 @@ pub struct IngestAction {
     start_iteration: isize,
     repeat: isize,
     headers: Option<Vec<(String, Option<String>)>>,
+    omit_key: bool,
+    omit_value: bool,
 }
 
 #[derive(Clone)]
@@ -174,6 +176,8 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
     let start_iteration = cmd.args.opt_parse::<isize>("start-iteration")?.unwrap_or(0);
     let repeat = cmd.args.opt_parse::<isize>("repeat")?.unwrap_or(1);
     let publish = cmd.args.opt_bool("publish")?.unwrap_or(false);
+    let omit_key = cmd.args.opt_bool("omit-key")?.unwrap_or(false);
+    let omit_value = cmd.args.opt_bool("omit-value")?.unwrap_or(false);
     let format = match cmd.args.string("format")?.as_str() {
         "avro" => Format::Avro {
             schema: cmd.args.string("schema")?,
@@ -282,6 +286,8 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         start_iteration,
         repeat,
         headers,
+        omit_key,
+        omit_value,
     })
 }
 
@@ -402,13 +408,21 @@ impl Action for IngestAction {
                     false,
                 )?;
                 let mut row = row.as_bytes();
-                let key = match &key_transcoder {
-                    None => None,
-                    Some(kt) => kt.transcode(&mut row)?,
+                let key = if self.omit_key {
+                    None
+                } else {
+                    match &key_transcoder {
+                        None => None,
+                        Some(kt) => kt.transcode(&mut row)?,
+                    }
                 };
-                let value = value_transcoder
-                    .transcode(&mut row)
-                    .with_context(|| format!("parsing row: {}", String::from_utf8_lossy(row)))?;
+                let value = if self.omit_value {
+                    None
+                } else {
+                    value_transcoder
+                        .transcode(&mut row)
+                        .with_context(|| format!("parsing row: {}", String::from_utf8_lossy(row)))?
+                };
                 let producer = &state.kafka_producer;
                 let timeout = cmp::max(state.default_timeout, Duration::from_secs(1));
                 let headers = self.headers.clone();

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -408,13 +408,10 @@ impl Action for IngestAction {
                     false,
                 )?;
                 let mut row = row.as_bytes();
-                let key = if self.omit_key {
-                    None
-                } else {
-                    match &key_transcoder {
-                        None => None,
-                        Some(kt) => kt.transcode(&mut row)?,
-                    }
+                let key = match (self.omit_key, &key_transcoder) {
+                    (true, _) => None,
+                    (false, None) => None,
+                    (false, Some(kt)) => kt.transcode(&mut row)?,
                 };
                 let value = if self.omit_value {
                     None

--- a/test/testdrive/kafka-envelope-none.td
+++ b/test/testdrive/kafka-envelope-none.td
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=missing_keys_or_values partitions=1
+
+> CREATE MATERIALIZED SOURCE missing_keys_or_values
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-missing_keys_or_values-${testdrive.seed}'
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  INCLUDE KEY
+  ENVELOPE NONE
+
+# make sure a record with both key and value goes through
+
+$ kafka-ingest topic=missing_keys_or_values format=bytes key-format=bytes key-terminator=:
+hello:world
+
+> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+key   text mz_offset
+---------------------------------
+hello world 1
+
+
+# send a value without a key. key columns should be null
+
+$ kafka-ingest topic=missing_keys_or_values format=bytes omit-key=true
+foo
+
+> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+key    text  mz_offset
+---------------------------------
+hello  world 1
+<null> foo   2
+
+
+# send an empty record with neither key nor value, should be skipped
+
+$ kafka-ingest topic=missing_keys_or_values format=bytes omit-value=true omit-key=true
+
+> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+key    text  mz_offset
+---------------------------------
+hello  world 1
+<null> foo   2
+
+
+# send a key without a value, should error
+
+$ kafka-ingest topic=missing_keys_or_values key-format=bytes format=bytes omit-value=true
+bar
+
+! SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+contains: Decode error: Text: Value not present for message
+

--- a/test/testdrive/kafka-envelope-none.td
+++ b/test/testdrive/kafka-envelope-none.td
@@ -57,4 +57,3 @@ bar
 
 ! SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
 contains: Decode error: Text: Value not present for message
-

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -144,6 +144,8 @@ $ set noconflictschema={
 $ kafka-create-topic topic=avro-data-record
 $ kafka-ingest format=avro key-format=avro topic=avro-data-record key-schema=${multikeyschema} schema=${noconflictschema} timestamp=1
 {"id": 1, "geo": "nyc"} {"a": 99}
+$ kafka-ingest format=avro topic=avro-data-record schema=${noconflictschema} timestamp=2 omit-key=true
+{"a": 88}
 
 > CREATE MATERIALIZED SOURCE avro_key_record_flattened
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-record-${testdrive.seed}'
@@ -152,10 +154,11 @@ $ kafka-ingest format=avro key-format=avro topic=avro-data-record key-schema=${m
   INCLUDE KEY
   ENVELOPE NONE
 
-> SELECT * FROM avro_key_record_flattened
-id geo a
---------
-1 nyc 99
+> SELECT * FROM avro_key_record_flattened ORDER BY a ASC
+id     geo    a
+----------------
+<null> <null> 88
+1      nyc    99
 
 > CREATE MATERIALIZED SOURCE avro_key_record_renamed
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-record-${testdrive.seed}'
@@ -164,10 +167,11 @@ id geo a
   INCLUDE KEY AS named
   ENVELOPE NONE
 
-> SELECT (named).id as named_id, (named).geo as named_geo, a FROM avro_key_record_renamed
+> SELECT (named).id as named_id, (named).geo as named_geo, a FROM avro_key_record_renamed ORDER BY a ASC
 named_id named_geo a
---------------------
-1 nyc 99
+---------------------
+<null>   <null>    88
+1        nyc       99
 
 ! CREATE MATERIALIZED SOURCE avro_debezium
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-dbz-${testdrive.seed}'
@@ -183,6 +187,7 @@ $ kafka-create-topic topic=textsrc partitions=1
 $ kafka-ingest topic=textsrc format=bytes key-format=bytes key-terminator=:
 one,1:horse,apple
 two,2:bee,honey
+:cow,grass
 
 > CREATE MATERIALIZED SOURCE textsrc
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -190,12 +195,12 @@ two,2:bee,honey
   VALUE FORMAT TEXT
   INCLUDE KEY
 
-> SELECT * FROM textsrc
-key   text        mz_offset
+> SELECT * FROM textsrc ORDER BY mz_offset ASC
+key    text        mz_offset
 ---------------------------
-one,1 horse,apple 1
-two,2 bee,honey   2
-
+one,1  horse,apple 1
+two,2  bee,honey   2
+<null> cow,grass   3
 
 > CREATE MATERIALIZED SOURCE regexvalue
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -204,10 +209,11 @@ two,2 bee,honey   2
   INCLUDE KEY
 
 > SELECT * FROM regexvalue
-key   animal food  mz_offset
+key   animal  food  mz_offset
 ----------------------------
-one,1 horse  apple 1
-two,2 bee    honey 2
+one,1  horse  apple 1
+two,2  bee    honey 2
+<null> cow    grass 3
 
 > CREATE MATERIALIZED SOURCE regexboth
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -215,11 +221,12 @@ two,2 bee    honey 2
   VALUE FORMAT REGEX '(?P<animal>[^,]+),(?P<food>\w+)'
   INCLUDE KEY
 
-> SELECT * FROM regexboth
-id_name id animal food  mz_offset
+> SELECT * FROM regexboth ORDER BY mz_offset ASC
+id_name id     animal food  mz_offset
 ---------------------------------
-one     1  horse  apple 1
-two     2  bee    honey 2
+one     1      horse  apple 1
+two     2      bee    honey 2
+<null>  <null> cow    grass 3
 
 
 > CREATE MATERIALIZED SOURCE regexbothnest
@@ -229,10 +236,11 @@ two     2  bee    honey 2
   INCLUDE KEY AS nest
 
 > SELECT (nest).id_name, (nest).id, animal FROM regexbothnest
-id_name id animal
------------------
-one     1  horse
-two     2  bee
+id_name id     animal
+--------------------
+<null>  <null> cow
+one     1      horse
+two     2      bee
 
 $ file-append path=test.proto
 syntax = "proto3";
@@ -259,16 +267,20 @@ $ kafka-ingest topic=proto
   format=protobuf descriptor-file=test.proto message=Value
 {"id": "a"} {"measurement": 10}
 
+$ kafka-ingest topic=proto format=protobuf descriptor-file=test.proto message=Value omit-key=true
+{"measurement": 11}
+
 > CREATE MATERIALIZED SOURCE input_proto
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-proto-${testdrive.seed}'
   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
   INCLUDE KEY
 
-> SELECT * FROM input_proto
-id  measurement  mz_offset
+> SELECT * FROM input_proto ORDER BY measurement ASC
+id     measurement  mz_offset
 --------------------------
-a   10           1
+a      10           1
+<null> 11           2
 
 $ kafka-create-topic topic=proto-structured partitions=1
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR updates Kafka sources with `ENVELOPE NONE` to produce null key column values when the Kafka message's key is missing, rather than erroring out like it currently does. This follows the [thought noted here](https://github.com/MaterializeInc/materialize/issues/12275#issuecomment-1146726156) that it should apply equally to each message format, which is an opinion I'd be happy to revisit if there's concern.

The approach is simple -- if we see an incoming record without a key, we create a `Row` with as many `NULL` values as there are key-derived columns to fill in the blanks.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

See #12275

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

* Added explicit tests for various permutations of Kafka messages with and without keys and values when using `ENVELOPE NONE`. This required a small tweak to `testdrive` to send messages without keys or values.
* Added tests that demonstrate successful null value handling across various formats, like Regex, Avro, Protobuf and Bytes, and when multiple key columns are flattened.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - When `INCLUDE KEY` is used with an `ENVELOPE NONE` Kafka source, records with missing keys now produce `NULL` column values, rather than raising an error.
