### PR TITLE
gate S3 and Kinesis sources with unsafe mode

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -465,6 +465,7 @@ pub fn plan_create_source(
             (connector, encoding)
         }
         CreateSourceConnector::Kinesis { arn, .. } => {
+            scx.require_unsafe_mode("CREATE SOURCE ... FROM KINESIS")?;
             let arn: ARN = arn
                 .parse()
                 .map_err(|e| anyhow!("Unable to parse provided ARN: {:#?}", e))?;
@@ -491,6 +492,7 @@ pub fn plan_create_source(
             pattern,
             compression,
         } => {
+            scx.require_unsafe_mode("CREATE SOURCE ... FROM S3")?;
             let aws = normalize::aws_config(&mut with_options, None)?;
             let mut converted_sources = Vec::new();
             for ks in key_sources {

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -17,7 +17,10 @@ from materialize.mzcompose.services import (
 
 SERVICES = [
     Localstack(),
-    Materialized(environment=["MZ_LOG_FILTER=dataflow::source::s3=trace,info"], options=["--unsafe-mode"]),
+    Materialized(
+        environment=["MZ_LOG_FILTER=dataflow::source::s3=trace,info"],
+        options=["--unsafe-mode"],
+    ),
     Toxiproxy(),
     Testdrive(default_timeout="600s"),
 ]

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -18,8 +18,7 @@ from materialize.mzcompose.services import (
 SERVICES = [
     Localstack(),
     Materialized(
-        environment=["MZ_LOG_FILTER=dataflow::source::s3=trace,info"],
-        options=["--unsafe-mode"],
+        environment_extra=["MZ_LOG_FILTER=dataflow::source::s3=trace,info"],
     ),
     Toxiproxy(),
     Testdrive(default_timeout="600s"),

--- a/test/s3-resumption/mzcompose.py
+++ b/test/s3-resumption/mzcompose.py
@@ -17,7 +17,7 @@ from materialize.mzcompose.services import (
 
 SERVICES = [
     Localstack(),
-    Materialized(environment=["MZ_LOG_FILTER=dataflow::source::s3=trace,info"]),
+    Materialized(environment=["MZ_LOG_FILTER=dataflow::source::s3=trace,info"], options=["--unsafe-mode"]),
     Toxiproxy(),
     Testdrive(default_timeout="600s"),
 ]


### PR DESCRIPTION
Gates S3 and Kinesis with unsafe mode

Fixes https://github.com/MaterializeInc/materialize/issues/12930

### Motivation

  * This PR fixes a recognized bug.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A