### PR TITLE
sql: simplify WITH OPTION handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3900,7 +3900,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "datadriven",
- "enum-kinds",
  "itertools",
  "mz-ore",
  "mz-persist-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,6 +3880,7 @@ dependencies = [
  "mz-repr",
  "mz-sql-parser",
  "once_cell",
+ "paste",
  "prost",
  "protobuf-native",
  "rdkafka",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -533,9 +533,9 @@ class Composition:
             replica_name: The replica name to use
         """
         self.sql(
-            f"CREATE CLUSTER {cluster_name} REMOTE {replica_name} ("
+            f"CREATE CLUSTER {cluster_name} REPLICAS ( {replica_name} ( REMOTE ["
             + ", ".join(f'"{p.name}:2100"' for p in cluster)
-            + ")"
+            + "]))"
         )
 
     def start_and_wait_for_tcp(self, services: List[str]) -> None:

--- a/src/materialized/tests/sql.rs
+++ b/src/materialized/tests/sql.rs
@@ -315,7 +315,7 @@ fn test_tail_basic() -> Result<(), Box<dyn Error>> {
     // view derived from the index. This previously selected an invalid
     // `AS OF` timestamp (#5391).
     client_writes
-        .batch_execute("ALTER INDEX t_primary_idx SET (logical_compaction_window = '1ms')")?;
+        .batch_execute("ALTER INDEX t_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms')")?;
     client_writes.batch_execute("CREATE VIEW v AS SELECT * FROM t")?;
     client_reads.batch_execute(
         "COMMIT; BEGIN;

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.57"
-enum-kinds = "0.5.1"
 itertools = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }
 # TODO(aljoscha): persist/storage sinks should have a human-readable

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -24,8 +24,6 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use enum_kinds::EnumKind;
-
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{AstInfo, Expr, Ident, UnresolvedObjectName, WithOption, WithOptionValue};
 
@@ -517,8 +515,7 @@ impl<T: AstInfo> AstDisplay for DbzTxMetadataOption<T> {
 }
 impl_display_t!(DbzTxMetadataOption);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, EnumKind)]
-#[enum_kind(ConnectorType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateConnector<T: AstInfo> {
     Kafka {
         broker: String,
@@ -594,8 +591,7 @@ pub struct KafkaSourceConnector<T: AstInfo> {
     pub key: Option<Vec<Ident>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, EnumKind)]
-#[enum_kind(SourceConnectorType)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSourceConnector<T: AstInfo> {
     Kafka(KafkaSourceConnector<T>),
     Kinesis {
@@ -701,8 +697,7 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
 }
 impl_display_t!(CreateSourceConnector);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, EnumKind)]
-#[enum_kind(CreateSinkConnectorKind)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSinkConnector<T: AstInfo> {
     Kafka {
         broker: String,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -702,7 +702,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     /// Expressions that form part of the index key. If not included, the
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
-    pub with_options: Vec<WithOption<T>>,
+    pub with_options: Vec<IndexOptions<T>>,
     pub if_not_exists: bool,
 }
 
@@ -740,6 +740,37 @@ impl<T: AstInfo> AstDisplay for CreateIndexStatement<T> {
     }
 }
 impl_display_t!(CreateIndexStatement);
+
+/// An option in a `CREATE CLUSTER` statement.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum IndexOptionName {
+    // The `LOGICAL COMPACTION WINDOW` option
+    LogicalCompactionWindow,
+}
+
+impl AstDisplay for IndexOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            IndexOptionName::LogicalCompactionWindow => {
+                f.write_str("LOGICAL COMPACTION WINDOW");
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IndexOptions<T: AstInfo> {
+    pub name: IndexOptionName,
+    pub value: WithOptionValue<T>,
+}
+
+impl<T: AstInfo> AstDisplay for IndexOptions<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        f.write_str(" = ");
+        f.write_node(&self.value);
+    }
+}
 
 /// A `CREATE ROLE` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1022,8 +1053,8 @@ impl_display!(AlterObjectRenameStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterIndexAction<T: AstInfo> {
-    SetOptions(Vec<WithOption<T>>),
-    ResetOptions(Vec<Ident>),
+    SetOptions(Vec<IndexOptions<T>>),
+    ResetOptions(Vec<IndexOptionName>),
 }
 
 /// `ALTER INDEX ... {RESET, SET}`

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -25,7 +25,7 @@ use crate::ast::{
     AstInfo, ColumnDef, CreateConnector, CreateSinkConnector, CreateSourceConnector,
     CreateSourceFormat, Envelope, Expr, Format, Ident, KeyConstraint, Query, SourceIncludeMetadata,
     TableAlias, TableConstraint, TableWithJoins, UnresolvedDatabaseName, UnresolvedObjectName,
-    UnresolvedSchemaName, Value, WithOptionVecString,
+    UnresolvedSchemaName, Value,
 };
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
@@ -702,7 +702,7 @@ pub struct CreateIndexStatement<T: AstInfo> {
     /// Expressions that form part of the index key. If not included, the
     /// key_parts will be inferred from the named object.
     pub key_parts: Option<Vec<Expr<T>>>,
-    pub with_options: Vec<IndexOptions<T>>,
+    pub with_options: Vec<IndexOption<T>>,
     pub if_not_exists: bool,
 }
 
@@ -759,12 +759,12 @@ impl AstDisplay for IndexOptionName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct IndexOptions<T: AstInfo> {
+pub struct IndexOption<T: AstInfo> {
     pub name: IndexOptionName,
     pub value: WithOptionValue<T>,
 }
 
-impl<T: AstInfo> AstDisplay for IndexOptions<T> {
+impl<T: AstInfo> AstDisplay for IndexOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.name);
         f.write_str(" = ");
@@ -1054,7 +1054,7 @@ impl_display!(AlterObjectRenameStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AlterIndexAction<T: AstInfo> {
-    SetOptions(Vec<IndexOptions<T>>),
+    SetOptions(Vec<IndexOption<T>>),
     ResetOptions(Vec<IndexOptionName>),
 }
 
@@ -1882,7 +1882,7 @@ impl<T: AstInfo> TryFrom<WithOptionValue<T>> for bool {
     }
 }
 
-impl<T: AstInfo> TryFrom<WithOptionValue<T>> for WithOptionVecString {
+impl<T: AstInfo> TryFrom<WithOptionValue<T>> for Vec<String> {
     type Error = anyhow::Error;
     fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
         match v {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1860,34 +1860,33 @@ impl<T: AstInfo> AstDisplay for WithOptionValue<T> {
 }
 impl_display_t!(WithOptionValue);
 
-impl<T: AstInfo> TryFrom<WithOptionValue<T>> for String {
-    type Error = anyhow::Error;
+macro_rules! try_from_with_option_value_value {
+    ($t:ty, $ty_name:expr) => {
+        impl<T: AstInfo> TryFrom<WithOptionValue<T>> for $t {
+            type Error = anyhow::Error;
 
-    fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
-        match v {
-            WithOptionValue::Value(v) => v.try_into(),
-            _ => anyhow::bail!("cannot use value as string"),
+            fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
+                match v {
+                    WithOptionValue::Value(v) => v.try_into(),
+                    _ => anyhow::bail!("cannot use value as {}", $ty_name),
+                }
+            }
         }
-    }
+    };
 }
 
-impl<T: AstInfo> TryFrom<WithOptionValue<T>> for bool {
-    type Error = anyhow::Error;
+try_from_with_option_value_value!(String, "string");
+try_from_with_option_value_value!(bool, "boolean");
 
-    fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
-        match v {
-            WithOptionValue::Value(v) => v.try_into(),
-            _ => anyhow::bail!("cannot use value as boolean"),
-        }
-    }
-}
-
-impl<T: AstInfo> TryFrom<WithOptionValue<T>> for Vec<String> {
+impl<T: AstInfo, V: TryFrom<WithOptionValue<T>>> TryFrom<WithOptionValue<T>> for Vec<V>
+where
+    Vec<V>: TryFrom<Value, Error = anyhow::Error>,
+{
     type Error = anyhow::Error;
     fn try_from(v: WithOptionValue<T>) -> Result<Self, Self::Error> {
         match v {
             WithOptionValue::Value(v) => v.try_into(),
-            _ => anyhow::bail!("cannot use value as array of strings"),
+            _ => anyhow::bail!("cannot use value as array"),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -168,18 +168,21 @@ impl TryFrom<Value> for i32 {
     }
 }
 
-impl TryFrom<Value> for Vec<String> {
+impl<X: TryFrom<Value>> TryFrom<Value> for Vec<X> {
     type Error = anyhow::Error;
     fn try_from(v: Value) -> Result<Self, Self::Error> {
         match v {
             Value::Array(a) => {
                 let mut out = Vec::with_capacity(a.len());
                 for i in a {
-                    out.push(i.try_into()?)
+                    out.push(
+                        i.try_into()
+                            .map_err(|_| anyhow::anyhow!("cannot use value in array"))?,
+                    )
                 }
                 Ok(out)
             }
-            _ => anyhow::bail!("cannot use value as number"),
+            _ => anyhow::bail!("cannot use value as array"),
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -168,9 +168,7 @@ impl TryFrom<Value> for i32 {
     }
 }
 
-pub struct WithOptionVecString(pub Vec<String>);
-
-impl TryFrom<Value> for WithOptionVecString {
+impl TryFrom<Value> for Vec<String> {
     type Error = anyhow::Error;
     fn try_from(v: Value) -> Result<Self, Self::Error> {
         match v {
@@ -179,7 +177,7 @@ impl TryFrom<Value> for WithOptionVecString {
                 for i in a {
                     out.push(i.try_into()?)
                 }
-                Ok(WithOptionVecString(out))
+                Ok(out)
             }
             _ => anyhow::bail!("cannot use value as number"),
         }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -168,6 +168,24 @@ impl TryFrom<Value> for i32 {
     }
 }
 
+pub struct WithOptionVecString(pub Vec<String>);
+
+impl TryFrom<Value> for WithOptionVecString {
+    type Error = anyhow::Error;
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        match v {
+            Value::Array(a) => {
+                let mut out = Vec::with_capacity(a.len());
+                for i in a {
+                    out.push(i.try_into()?)
+                }
+                Ok(WithOptionVecString(out))
+            }
+            _ => anyhow::bail!("cannot use value as number"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum DateTimeField {
     Millennium,

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -64,6 +64,7 @@ Collection
 Columns
 Commit
 Committed
+Compaction
 Compiled
 Compression
 Confluent
@@ -173,6 +174,7 @@ Limit
 List
 Local
 Log
+Logical
 Login
 Map
 Matching
@@ -319,6 +321,7 @@ Views
 Warning
 When
 Where
+Window
 With
 Without
 Work

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2588,26 +2588,17 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_replica_option(&mut self) -> Result<ReplicaOption<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[AVAILABILITY, REMOTE, SIZE])? {
+        let name = match self.expect_one_of_keywords(&[AVAILABILITY, REMOTE, SIZE])? {
             AVAILABILITY => {
                 self.expect_keyword(ZONE)?;
-                let _ = self.consume_token(&Token::Eq);
-                Ok(ReplicaOption::AvailabilityZone(
-                    self.parse_with_option_value()?,
-                ))
+                ReplicaOptionName::AvailabilityZone
             }
-            REMOTE => {
-                self.expect_token(&Token::LParen)?;
-                let hosts = self.parse_comma_separated(Self::parse_with_option_value)?;
-                self.expect_token(&Token::RParen)?;
-                Ok(ReplicaOption::Remote { hosts })
-            }
-            SIZE => {
-                let _ = self.consume_token(&Token::Eq);
-                Ok(ReplicaOption::Size(self.parse_with_option_value()?))
-            }
+            REMOTE => ReplicaOptionName::Remote,
+            SIZE => ReplicaOptionName::Size,
             _ => unreachable!(),
-        }
+        };
+        let value = self.parse_with_option_value()?;
+        Ok(ReplicaOption { name, value })
     }
 
     fn parse_cluster_option(&mut self) -> Result<ClusterOption<Raw>, ParserError> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2437,7 +2437,18 @@ impl<'a> Parser<'a> {
             }
         };
 
-        let with_options = self.parse_opt_with_options()?;
+        let with_options = if self.parse_keyword(WITH) {
+            self.expect_token(&Token::LParen)?;
+            let o = if matches!(self.peek_token(), Some(Token::RParen)) {
+                vec![]
+            } else {
+                self.parse_comma_separated(Parser::parse_index_option)?
+            };
+            self.expect_token(&Token::RParen)?;
+            o
+        } else {
+            vec![]
+        };
 
         Ok(Statement::CreateIndex(CreateIndexStatement {
             name,
@@ -2447,6 +2458,18 @@ impl<'a> Parser<'a> {
             with_options,
             if_not_exists,
         }))
+    }
+
+    fn parse_index_option_name(&mut self) -> Result<IndexOptionName, ParserError> {
+        self.expect_keywords(&[LOGICAL, COMPACTION, WINDOW])?;
+        Ok(IndexOptionName::LogicalCompactionWindow)
+    }
+
+    fn parse_index_option(&mut self) -> Result<IndexOptions<Raw>, ParserError> {
+        let name = self.parse_index_option_name()?;
+        let _ = self.consume_token(&Token::Eq);
+        let value = self.parse_with_option_value()?;
+        Ok(IndexOptions { name, value })
     }
 
     fn parse_raw_ident(&mut self) -> Result<RawClusterName, ParserError> {
@@ -2552,7 +2575,6 @@ impl<'a> Parser<'a> {
     fn parse_create_cluster(&mut self) -> Result<Statement<Raw>, ParserError> {
         let name = self.parse_identifier()?;
 
-        let _ = self.parse_keyword(WITH);
         let options = if matches!(self.peek_token(), Some(Token::Semicolon) | None) {
             vec![]
         } else {
@@ -3079,7 +3101,7 @@ impl<'a> Parser<'a> {
         Ok(match self.expect_one_of_keywords(&[RESET, SET, RENAME])? {
             RESET => {
                 self.expect_token(&Token::LParen)?;
-                let reset_options = self.parse_comma_separated(Parser::parse_identifier)?;
+                let reset_options = self.parse_comma_separated(Parser::parse_index_option_name)?;
                 self.expect_token(&Token::RParen)?;
 
                 Statement::AlterIndex(AlterIndexStatement {
@@ -3089,7 +3111,9 @@ impl<'a> Parser<'a> {
                 })
             }
             SET => {
-                let set_options = self.parse_with_options(true)?;
+                self.expect_token(&Token::LParen)?;
+                let set_options = self.parse_comma_separated(Parser::parse_index_option)?;
+                self.expect_token(&Token::RParen)?;
                 Statement::AlterIndex(AlterIndexStatement {
                     index_name: name,
                     if_exists,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2465,11 +2465,11 @@ impl<'a> Parser<'a> {
         Ok(IndexOptionName::LogicalCompactionWindow)
     }
 
-    fn parse_index_option(&mut self) -> Result<IndexOptions<Raw>, ParserError> {
+    fn parse_index_option(&mut self) -> Result<IndexOption<Raw>, ParserError> {
         let name = self.parse_index_option_name()?;
         let _ = self.consume_token(&Token::Eq);
         let value = self.parse_with_option_value()?;
-        Ok(IndexOptions { name, value })
+        Ok(IndexOption { name, value })
     }
 
     fn parse_raw_ident(&mut self) -> Result<RawClusterName, ParserError> {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1185,31 +1185,31 @@ CREATE CLUSTER cluster REPLICAS (), BADOPT
                                     ^
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }] }])] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
 ----
 error: Expected end of statement, found INTROSPECTION
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
                                                                      ^
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1'), SIZE '1'))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1'), SIZE '1'))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
 =>
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }, ReplicaOption { name: Size, value: Value(String("1")) }] }])] })
 
 parse-statement
-CREATE CLUSTER REPLICA replica REMOTE ('host1')
+CREATE CLUSTER REPLICA replica REMOTE ['host1']
 ----
 error: Expected dot, found REMOTE
-CREATE CLUSTER REPLICA replica REMOTE ('host1')
+CREATE CLUSTER REPLICA replica REMOTE ['host1']
                                ^
 
 parse-statement
@@ -1220,10 +1220,10 @@ CREATE CLUSTER REPLICA replica SIZE 'small'
                                ^
 
 parse-statement
-CREATE CLUSTER REPLICA replica SIZE 'small', (REMOTE ('host1'))
+CREATE CLUSTER REPLICA replica SIZE 'small', (REMOTE ['host1'])
 ----
 error: Expected dot, found SIZE
-CREATE CLUSTER REPLICA replica SIZE 'small', (REMOTE ('host1'))
+CREATE CLUSTER REPLICA replica SIZE 'small', (REMOTE ['host1'])
                                ^
 
 parse-statement
@@ -1248,9 +1248,9 @@ CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 
 CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }, ReplicaOption { name: AvailabilityZone, value: Value(String("b")) }] } })
 
 parse-statement
-CREATE CLUSTER REPLICA default.replica REMOTE ('host1'), AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 ----
-CREATE CLUSTER REPLICA default.replica REMOTE ('host1'), AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 =>
 CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }, ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }] } })
 

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -728,11 +728,11 @@ CREATE INDEX foo ON myschema.bar (a, b)
 CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [], if_not_exists: false })
 
 parse-statement
-CREATE INDEX foo ON myschema.bar (a, b) WITH (baz = 'raz')
+CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
 ----
-CREATE INDEX foo ON myschema.bar (a, b) WITH (baz = 'raz')
+CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [WithOption { key: Ident("baz"), value: Some(Value(String("raz"))) }], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: LogicalCompactionWindow, value: Value(Number("0")) }], if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
@@ -1040,51 +1040,51 @@ CREATE TABLE IF NOT EXISTS foo (bar int4)
 parse-statement
 ALTER INDEX name SET (property = true)
 ----
+error: Expected LOGICAL, found identifier "property"
 ALTER INDEX name SET (property = true)
-=>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
+                      ^
 
 parse-statement
 ALTER INDEX name RESET (property)
 ----
+error: Expected LOGICAL, found identifier "property"
 ALTER INDEX name RESET (property)
-=>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: ResetOptions([Ident("property")]) })
+                        ^
 
 parse-statement
 ALTER INDEX IF EXISTS name SET (property = true)
 ----
+error: Expected LOGICAL, found identifier "property"
 ALTER INDEX IF EXISTS name SET (property = true)
-=>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: true, action: SetOptions([WithOption { key: Ident("property"), value: Some(Value(Boolean(true))) }]) })
+                                ^
 
 parse-statement
 ALTER INDEX name SET ()
 ----
-error: Expected identifier, found right parenthesis
+error: Expected LOGICAL, found right parenthesis
 ALTER INDEX name SET ()
                       ^
 
 parse-statement
 ALTER INDEX name RESET ()
 ----
-error: Expected identifier, found right parenthesis
+error: Expected LOGICAL, found right parenthesis
 ALTER INDEX name RESET ()
                         ^
 
 parse-statement
 ALTER INDEX name SET (property)
 ----
+error: Expected LOGICAL, found identifier "property"
 ALTER INDEX name SET (property)
-=>
-AlterIndex(AlterIndexStatement { index_name: UnresolvedObjectName([Ident("name")]), if_exists: false, action: SetOptions([WithOption { key: Ident("property"), value: None }]) })
+                      ^
 
 parse-statement
 ALTER INDEX name RESET (property = true)
 ----
-error: Expected right parenthesis, found equals sign
+error: Expected LOGICAL, found identifier "property"
 ALTER INDEX name RESET (property = true)
-                                 ^
+                        ^
 
 parse-statement
 ALTER SOURCE name SET (property = true)
@@ -1159,9 +1159,9 @@ CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replica
 parse-statement
 CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION GRANULARITY = '1s'
 ----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
-=>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
+error: Expected one of REPLICAS or INTROSPECTION, found WITH
+CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION GRANULARITY = '1s'
+                       ^
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = 0
@@ -1189,7 +1189,7 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1')), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
@@ -1203,7 +1203,7 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1'), SIZE '1'))
 ----
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ('host1'), SIZE '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [Remote { hosts: [Value(String("host1"))] }, Size(Value(String("1")))] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }, ReplicaOption { name: Size, value: Value(String("1")) }] }])] })
 
 parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ('host1')
@@ -1231,28 +1231,28 @@ CREATE CLUSTER REPLICA default.replica SIZE 'small'
 ----
 CREATE CLUSTER REPLICA default.replica SIZE 'small'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [Size(Value(String("small")))] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Value(String("small")) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
 ----
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [Size(Value(String("small"))), AvailabilityZone(Value(String("a")))] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Value(String("small")) }, ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 ----
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [AvailabilityZone(Value(String("a"))), AvailabilityZone(Value(String("b")))] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }, ReplicaOption { name: AvailabilityZone, value: Value(String("b")) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica REMOTE ('host1'), AVAILABILITY ZONE 'a'
 ----
 CREATE CLUSTER REPLICA default.replica REMOTE ('host1'), AVAILABILITY ZONE 'a'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [Remote { hosts: [Value(String("host1"))] }, AvailabilityZone(Value(String("a")))] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }, ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }] } })
 
 parse-statement
 DROP CLUSTER cluster

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -28,6 +28,7 @@ mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
 mz-sql-parser = { path = "../sql-parser" }
+paste = "1.0"
 protobuf-native = "0.2.1"
 prost = "0.10.3"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static"] }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -26,11 +26,10 @@
 // `plan_root_query` and fanning out based on the contents of the `SELECT`
 // statement.
 
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
 use mz_dataflow_types::client::ComputeInstanceId;
@@ -41,8 +40,8 @@ use mz_ore::now::{self, NOW_ZERO};
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
-    ExplainOptions, ExplainStage, Expr, FetchDirection, NoticeSeverity, ObjectType, Raw,
-    SetVariableValue, Statement, TransactionAccessMode,
+    ExplainOptions, ExplainStage, Expr, FetchDirection, IndexOptionName, NoticeSeverity,
+    ObjectType, Raw, SetVariableValue, Statement, TransactionAccessMode,
 };
 use crate::catalog::{CatalogType, IdReference};
 use crate::names::{
@@ -382,7 +381,7 @@ pub struct AlterIndexSetOptionsPlan {
 #[derive(Debug)]
 pub struct AlterIndexResetOptionsPlan {
     pub id: GlobalId,
-    pub options: Vec<IndexOptionName>,
+    pub options: HashSet<IndexOptionName>,
 }
 
 #[derive(Debug)]
@@ -576,8 +575,7 @@ pub enum ExecuteTimeout {
     WaitOnce,
 }
 
-#[derive(Clone, Debug, EnumKind)]
-#[enum_kind(IndexOptionName)]
+#[derive(Clone, Debug)]
 pub enum IndexOption {
     /// Configures the logical compaction window for an index. `None` disables
     /// logical compaction entirely.

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -225,14 +225,14 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.sql(
             """
             DROP CLUSTER IF EXISTS cluster1 CASCADE;
-            CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')));
+            CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ['computed_1_1:2100', 'computed_1_2:2100']));
             """
         )
 
         c.sql(
             """
             DROP CLUSTER IF EXISTS cluster2 CASCADE;
-            CREATE CLUSTER cluster2 REPLICAS (replica1 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100')));
+            CREATE CLUSTER cluster2 REPLICAS (replica1 (REMOTE ['computed_2_1:2100', 'computed_2_2:2100']));
             """
         )
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -93,7 +93,7 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.up("computed_2")
     c.sql("DROP CLUSTER IF EXISTS cluster1 CASCADE;")
     c.sql(
-        "CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ('computed_1:2100', 'computed_2:2100')));"
+        "CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ['computed_1:2100', 'computed_2:2100']));"
     )
     c.run("testdrive", *glob)
 
@@ -101,7 +101,7 @@ def test_cluster(c: Composition, *glob: str) -> None:
     c.up("computed_3")
     c.up("computed_4")
     c.sql(
-        "CREATE CLUSTER REPLICA cluster1.replica2 REMOTE ('computed_3:2100', 'computed_4:2100')"
+        "CREATE CLUSTER REPLICA cluster1.replica2 REMOTE ['computed_3:2100', 'computed_4:2100']"
     )
     c.run("testdrive", *glob)
 
@@ -123,7 +123,7 @@ def test_github_12251(c: Composition) -> None:
     c.sql(
         """
         DROP CLUSTER IF EXISTS cluster1 CASCADE;
-        CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ('computed_1:2100')));
+        CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ['computed_1:2100']));
         SET cluster = cluster1;
         """
     )

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -144,9 +144,9 @@ def start_services(
             c.up(*[f"computed_{n}" for n in range(0, nodes)])
 
             c.sql(
-                "CREATE CLUSTER REPLICA default.feature_benchmark REMOTE ("
+                "CREATE CLUSTER REPLICA default.feature_benchmark REMOTE ["
                 + ",".join([f"'computed_{n}:2100'" for n in range(0, nodes)])
-                + ");"
+                + "];"
             )
 
             c.sql("DROP CLUSTER REPLICA default.default_replica")

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1117,8 +1117,8 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
         c.sql(
             """
             CREATE CLUSTER cluster1 REPLICAS (
-                replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')),
-                replica2 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'))
+                replica1 (REMOTE ['computed_1_1:2100', 'computed_1_2:2100']),
+                replica2 (REMOTE ['computed_2_1:2100', 'computed_2_2:2100'])
             )
         """
         )
@@ -1220,9 +1220,9 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     replica_name = f"replica_{cluster_id}_{replica_id}"
 
                     replica_definitions.append(
-                        f"{replica_name} (REMOTE ("
+                        f"{replica_name} (REMOTE ["
                         + ", ".join(f"'{n}:2100'" for n in nodes)
-                        + "))"
+                        + "])"
                     )
 
                 c.sql(

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -72,7 +72,7 @@ def drop_create_replica(c: Composition) -> None:
         dedent(
             """
             > DROP CLUSTER REPLICA cluster1.replica1
-            > CREATE CLUSTER REPLICA cluster1.replica3 REMOTE ('computed_1_1:2100', 'computed_1_2:2100')
+            > CREATE CLUSTER REPLICA cluster1.replica3 REMOTE ['computed_1_1:2100', 'computed_1_2:2100']
             """
         )
     )
@@ -82,7 +82,7 @@ def create_invalid_replica(c: Composition) -> None:
     c.testdrive(
         dedent(
             """
-            > CREATE CLUSTER REPLICA cluster1.replica3 REMOTE ('no_such_host:2100')
+            > CREATE CLUSTER REPLICA cluster1.replica3 REMOTE ['no_such_host:2100']
             """
         )
     )
@@ -208,8 +208,8 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.sql(
             """
             CREATE CLUSTER cluster1 REPLICAS (
-                replica1 (REMOTE ('computed_1_1:2100', 'computed_1_2:2100')),
-                replica2 (REMOTE ('computed_2_1:2100', 'computed_2_2:2100'))
+                replica1 (REMOTE ['computed_1_1:2100', 'computed_1_2:2100']),
+                replica2 (REMOTE ['computed_2_1:2100', 'computed_2_2:2100'])
             )
             """
         )

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -26,19 +26,19 @@ CREATE CLUSTER foo REPLICAS (), REPLICAS()
 # Creating cluster w/ remote replica works.
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234')))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 statement error cluster 'foo' already exists
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234')))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 statement error cannot create multiple replicas named 'r1' on cluster 'bar'
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1234')), r1 (REMOTE ('localhost:1234')))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234']), r1 (REMOTE ['localhost:1234']))
 
 statement error REMOTE specified more than once
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1234'), REMOTE ('localhost:1234')))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234'], REMOTE ['localhost:1234']))
 
 statement ok
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ('localhost:1235')), r2 (REMOTE ('localhost:1236')))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235']), r2 (REMOTE ['localhost:1236']))
 
 query TT rowsort
 SELECT * FROM mz_clusters
@@ -62,7 +62,7 @@ default
 # Test invalid option combinations.
 
 statement error only one of REMOTE or SIZE may be specified
-CREATE CLUSTER baz REPLICAS (r1 (REMOTE ('localhost:1234'), SIZE 'small'))
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], SIZE 'small'))
 
 # Test `cluster` session variable.
 
@@ -178,7 +178,7 @@ statement ok
 DROP CLUSTER foo
 
 statement ok
-CREATE CLUSTER baz REPLICAS (r1 (REMOTE ('localhost:1234')))
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
@@ -195,13 +195,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234'))), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION GRANULARITY '1s'
 
 statement ok
 DROP CLUSTER foo
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ('localhost:1234'))), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION GRANULARITY '1s'
 
 statement ok
 DROP CLUSTER foo
@@ -379,10 +379,10 @@ statement error AVAILABILITY ZONE specified more than once
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ('host1'), AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ('host1'), AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ('host1')
+CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1']

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -12,7 +12,7 @@
 mode cockroach
 
 statement ok
-create cluster c replicas (r1 (remote ('1.0:1234')))
+create cluster c replicas (r1 (remote ['1.0:1234']))
 
 statement ok
 set cluster = c

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -98,7 +98,7 @@ $ kafka-create-topic topic=nums
 
 # Disable logical compaction, to ensure we can view historical detail.
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (logical_compaction_window = 'off')
+  SET (LOGICAL COMPACTION WINDOW = 0)
 
 # Create a sink before we ingest any data, to ensure the sink starts AS OF 0
 > CREATE SINK nums_sink FROM nums
@@ -173,7 +173,7 @@ mz_timestamp  mz_diff  num
 # 4.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (logical_compaction_window = '1ms')
+  SET (LOGICAL COMPACTION WINDOW = '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":5},"time":4,"diff":-1}]}
@@ -193,11 +193,11 @@ contains:Timestamp (3) is not valid for all inputs
 # Set the compaction window back to off and advance the number in transactions 5 and 6.
 
 > ALTER INDEX materialize.public.nums_primary_idx
-  SET (logical_compaction_window = 'off')
+  SET (LOGICAL COMPACTION WINDOW = 0)
 
 # But also create an index that compacts frequently.
 > CREATE VIEW nums_compacted AS SELECT * FROM nums
-> CREATE DEFAULT INDEX ON nums_compacted WITH (logical_compaction_window = '1ms')
+> CREATE DEFAULT INDEX ON nums_compacted WITH (LOGICAL COMPACTION WINDOW = '1ms')
 
 $ kafka-ingest format=avro topic=nums schema=${nums-schema}
 {"array":[{"data":{"num":6},"time":5,"diff":-1}]}

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -226,7 +226,7 @@ contains:unknown catalog item 'nonexistent'
 ! SHOW INDEX FROM foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
 
-> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ('localhost:1234')))
+> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234']))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
 > SHOW INDEXES IN CLUSTER clstr WHERE on_name = 'foo'
 clstr foo  foo_primary_idx1   1  a       <null>                     false

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -232,7 +232,7 @@ cluster    name        type  volatility
   WITH (partition_count=-1, replication_factor=-1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ('localhost:1234')))
+> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 > CREATE SINK clstr_sink
   IN CLUSTER clstr FROM src


### PR DESCRIPTION
As part of  and the design of `CREATE CONNECTOR`, we aim to move `WITH` option handling into a form that accepts keywords rather than idents as options' keys. This PR proposes a general design to do that, as well as a macro to simplify extracting concrete data from those options.

Note that this does change the syntax for defining `REMOTE` replicas, by using the existing array option parsing, rather than the _ad hoc_ comma separated string parsing we previously supported.

If this design passes review, I'll then move the remaining `WITH` options over.

### Motivation

This PR refactors existing code + adds a known-desirable feature #5390.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
