### PR TITLE
persist: repurpose open loop benchmark for platform

### DIFF
--- a/test/kafka-ingest-open-loop/setup.td
+++ b/test/kafka-ingest-open-loop/setup.td
@@ -13,24 +13,11 @@
 
 $ kafka-create-topic topic=load-test partitions=4
 
-# Mirror mz_source_info and use to keep track of how much data has been ingested
-# at all times.
-> CREATE MATERIALIZED VIEW records_ingested AS
-  SELECT SUM("offset") FROM mz_source_info WHERE
-  source_name = 'testdrive-load-test-${testdrive.seed}';
-
-# Alter the underlying index to keep track of historical data.
-> ALTER INDEX records_ingested_primary_idx SET(logical_compaction_window="off");
-
-# Sleep enough so that no one asks for times not already present in the index.
-> SELECT mz_internal.mz_sleep(2)
-<null>
-
 > CREATE SOURCE load_test
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-load-test-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE PARTITION AS kafka_partition, OFFSET AS mz_offset
-  ENVELOPE ${arg.envelope}
+  ENVELOPE NONE
 
 # Create an intermediate view that applies meaningless filters (in the sense that
 # no data can get filtered out) which defeat the demand optimization that gets
@@ -47,15 +34,9 @@ $ kafka-create-topic topic=load-test partitions=4
 # Render a dataflow that uses the source, but does a minimal amount of
 # work and keeps a minimal amount of data in memory.
 #
-# This view can be also be used to track how many records have been ingested when
-# the data is append only (ie no duplicate keys).
+# This view can be used to track how many records have been ingested when
+# the data is append only. Note that this approach will not accurately count
+# the number of rows that have been ingested when something suppresses duplicate
+# keys such as the upsert envelope.
 > CREATE MATERIALIZED VIEW load_test_count AS SELECT
   COUNT(*) FROM intermediate;
-
-# Create a view so we can easily query the time that has fully been
-# closed in the load test.
-> CREATE MATERIALIZED VIEW load_test_materialization_frontier AS
-  SELECT frontiers.time FROM
-  mz_materialization_frontiers frontiers, mz_indexes indexes WHERE
-  frontiers.global_id = indexes.id AND
-  indexes.name = 'load_test_count_primary_idx';


### PR DESCRIPTION
This commit brings back the open loop benchmark with some limitations for use
with new versions of materialized/computed intended for platform.

The open loop benchmark:
- no longer supports the upsert envelope.
- currently only supports a single computed process with a single worker.
- currently only supports a single storaged process.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
