### PR TITLE
Not for merging; example of spawning tasks for `GenericClient`, and why I think we should split the trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +851,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cast"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1011,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -1683,6 +1709,12 @@ name = "error-iter"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e09bfe3000e5aaf2904d2c90e8f38de83dff06731c666d588d382f19da6606a9"
+
+[[package]]
+name = "event-listener"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fail"
@@ -2906,6 +2938,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "moro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8472c674b8319e7529bfdb3c51216810e36727be2056136d07130a0b1c132df6"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "futures",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3233,7 @@ dependencies = [
  "http-serde",
  "itertools",
  "maplit",
+ "moro",
  "mz-ccsr",
  "mz-expr",
  "mz-interchange",

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -54,6 +54,7 @@ url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1.1.1", features = ["serde", "v4"] }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git"}
+moro = "0.4.0"
 
 [build-dependencies]
 tonic-build = "0.7"


### PR DESCRIPTION
(Please read the commits separately)

Goal + Background: its clear that using `select!` is too difficult to scale the number of engineers that need to write correct `async` rust code. https://github.com/MaterializeInc/materialize/pull/12796 shows that creating a foolproof api (albeit, and ugly one) is possible for common cases, but almost all outstanding (as in, all but 1 or 2) `select!`s not fixed in that pr involve `GenericClient::recv`

There are 2 main proposals to improve the api of using `GenericClient` in ways that will making writing `select!`'s correctly easier:
1. Split the `GenericClient` into 2 traits: 1 for `send` and 1 for `recv`
2. spawn each `GenericClient` in a task and communicate with that task with channels

The first commit in this pr implements 2. Note that, unless im missing something, it still requires an incorrect `select` against a generic `GenericClient::recv`

The second commit shows one way to fix this problem in a general way, using https://docs.rs/moro/latest/moro/macro.async_scope.html. This is a path I consider quite promising: instead of one `select!` loop, each individual future you want to run concurrently is "spawned" onto a thread-local future that are all polled concurrently.

Note that, because `send` and `recv` both take `&mut self`, this second commit ascertains that there needs to be some kind of coordination between them; this is not extraneous, the presence of the cancel-safety bug in the first commit is proof that there is some kind of coordination

To resolve this, we use a coarse-grained lock around the entire client. This is better than doing locking at the higher-up callsites (like I do here: https://github.com/MaterializeInc/materialize/pull/12928), but still prevents processing of `send`'s while the `recv` side holds the lock.

Therefore, I think it is prudent to implement 1. This allows `GenericClient` impls that don't share state between `send` and `recv` to experience no overhead, while also allowing more complex ones that do (like `ActiveReplication`, etc) to do _fine-grained locking_ on their _shared state_. In my experience, using std mutexes around shared _data_ is far preferable to doing locking at the level we are doing concurrency (the send-recv loop in the second commit). A cursory glance of our `GenericClient` impls shows me that we are primarily sharing simple data, and not async resources.


We can also implement 2 to make using `GenericClient`'s easier than needing to use `moro`, and we only have to carefully maintain `spawn_client`
