### PR TITLE
Rename liveness endpoint explicitly

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -141,8 +141,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             axum::Server::bind(&addr.parse()?).serve(
                 mz_prof::http::router(&BUILD_INFO)
                     .route(
-                        "/api/health",
-                        routing::get(mz_http_util::handle_health_check),
+                        "/api/livez",
+                        routing::get(mz_http_util::handle_liveness_check),
                     )
                     .into_make_service(),
             ),

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -85,8 +85,8 @@ macro_rules! make_handle_static {
     };
 }
 
-/// Serves a basic health check response
+/// Serves a basic liveness check response
 #[allow(clippy::unused_async)]
-pub async fn handle_health_check() -> impl IntoResponse {
-    return (StatusCode::OK, "Health check successful!");
+pub async fn handle_liveness_check() -> impl IntoResponse {
+    return (StatusCode::OK, "Liveness check successful!");
 }

--- a/src/materialized/src/http.rs
+++ b/src/materialized/src/http.rs
@@ -362,8 +362,8 @@ impl MetricsServer {
                 ),
             )
             .route(
-                "/api/health",
-                routing::get(mz_http_util::handle_health_check),
+                "/api/livez",
+                routing::get(mz_http_util::handle_liveness_check),
             );
         let server = axum::Server::bind(&addr).serve(router.into_make_service());
         if let Err(err) = server.await {

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -150,8 +150,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             axum::Server::bind(&addr.parse()?).serve(
                 mz_prof::http::router(&BUILD_INFO)
                     .route(
-                        "/api/health",
-                        routing::get(mz_http_util::handle_health_check),
+                        "/api/livez",
+                        routing::get(mz_http_util::handle_liveness_check),
                     )
                     .into_make_service(),
             ),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.
   
Rename health check endpoint to call out the explicit use for liveness checking using the kubernetes de facto standard name.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- Add a liveness endpoint for the components