### PR TITLE
limits test: Do not call wait_for_postgres()

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1129,7 +1129,6 @@ def workflow_cluster(c: Composition, parser: WorkflowArgumentParser) -> None:
 def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Create multiple clusters with multiple nodes and replicas each"""
     c.start_and_wait_for_tcp(services=["zookeeper", "kafka", "schema-registry"])
-    c.wait_for_postgres()
 
     parser.add_argument(
         "--workers",
@@ -1222,7 +1221,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
 
                     replica_definitions.append(
                         f"{replica_name} (REMOTE ("
-                        + ", ".join(f'"{n}:2100"' for n in nodes)
+                        + ", ".join(f"'{n}:2100'" for n in nodes)
                         + "))"
                     )
 


### PR DESCRIPTION
Now that the composition no longer uses Postgres, do not call
wait_for_postgres()

### Motivation

  * This PR fixes a previously unreported bug.
The "instance size" Nightly CI job started failing on startup.

@benesch FYI