### PR TITLE
zippy: Restore import

### DIFF
--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -18,6 +18,7 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 from materialize.zippy.framework import Test
+from materialize.zippy.scenarios import *  # noqa: F401 F403
 
 SERVICES = [
     Zookeeper(),


### PR DESCRIPTION
flake8 erroneously suggested the removal of an "unused" import

### Motivation
  * This PR fixes a previously unreported bug.
Zippy was failing in Nighly CI