### PR TITLE
storage: s3: remove `select!` macros

### DIFF
--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -146,28 +146,9 @@ async fn download_objects_task(
     }
     let mut seen_buckets: HashMap<String, BucketInfo> = HashMap::new();
 
-    loop {
-        let msg = tokio::select! {
-            msg = rx.recv() => {
-                if let Some(msg) = msg {
-                    msg
-                } else {
-                    break;
-                }
-            }
-            status = shutdown_rx.changed() => {
-                if status.is_ok() {
-                    if let DataflowStatus::Stopped = *shutdown_rx.borrow() {
-                        debug!("source_id={} download_objects received dataflow shutdown message", source_id);
-                        break;
-                    }
-                }
-                continue;
-            }
-        };
-
-        match msg {
-            Ok(msg) => {
+    while *shutdown_rx.borrow_and_update() == DataflowStatus::Running {
+        match rx.recv().await {
+            Some(Ok(msg)) => {
                 if let Some(bi) = seen_buckets.get_mut(&msg.bucket) {
                     if bi.keys.contains(&msg.key) {
                         bi.metrics.objects_duplicate.inc();
@@ -229,14 +210,19 @@ async fn download_objects_task(
                     }
                 };
             }
-            Err(e) => {
+            Some(Err(e)) => {
                 if tx.send(Err(e)).await.is_err() {
                     rx.close();
                     break;
                 }
             }
+            None => break,
         }
     }
+    debug!(
+        "source_id={} download_objects received dataflow shutdown message",
+        source_id
+    );
     debug!("source_id={} exiting download objects task", source_id);
 }
 
@@ -400,28 +386,16 @@ async fn read_sqs_task(
     let mut metrics: HashMap<String, ScanBucketMetrics> = HashMap::new();
 
     let mut allowed_errors = 10;
-    'outer: loop {
-        let sqs_fut = client
+    'outer: while *shutdown_rx.borrow_and_update() == DataflowStatus::Running {
+        let response = client
             .receive_message()
             .max_number_of_messages(10)
             .queue_url(&queue_url)
             .visibility_timeout(500)
             // the maximum possible time for a long poll
             .wait_time_seconds(20)
-            .send();
-        let response = tokio::select! {
-            response = sqs_fut => response,
-            status = shutdown_rx.changed() => {
-                if status.is_ok() {
-                    if let DataflowStatus::Stopped = *shutdown_rx.borrow() {
-                        debug!("source_id={} scan_sqs received dataflow shutdown message", source_id);
-                        break;
-                    }
-                }
-                continue;
-            }
-        };
-
+            .send()
+            .await;
         match response {
             Ok(response) => {
                 let messages = if let Some(m) = response.messages {
@@ -491,6 +465,10 @@ async fn read_sqs_task(
             }
         }
     }
+    debug!(
+        "source_id={} scan_sqs received dataflow shutdown message",
+        source_id
+    );
     debug!("source_id={} exiting sqs reader queue={}", source_id, queue);
 }
 


### PR DESCRIPTION
Following the saga of eliminating `select!` calls from the codebase,
these two particular cases don't even need a `select!` because there is
just one branch that does work in a loop and another branch that
receives a shutdown notification, cancelling the other branch.

In order to avoid cancelling the futuring doing the work at some random
point we must explicitly put a point where we deem is appropriate to
exit and cleanup. However, if we do so we can directly use the shutdown
watch receiver without concurrent polling.

This has the effect that a shutdown notification won't apply immediately
and it will wait for one more message to arrive to the source reader but
that's unavoidable if we want to not cancel the future.
