### PR TITLE
Backport window function work

### DIFF
--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -572,6 +572,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::ListConcat { .. }
         | AggregateFunc::StringAgg { .. }
         | AggregateFunc::RowNumber { .. }
-        | AggregateFunc::DenseRank { .. } => ReductionType::Basic,
+        | AggregateFunc::DenseRank { .. }
+        | AggregateFunc::Lag { .. } => ReductionType::Basic,
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -574,6 +574,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::RowNumber { .. }
         | AggregateFunc::DenseRank { .. }
         | AggregateFunc::LagLead { .. }
-        | AggregateFunc::FirstValue { .. } => ReductionType::Basic,
+        | AggregateFunc::FirstValue { .. }
+        | AggregateFunc::LastValue { .. } => ReductionType::Basic,
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -571,6 +571,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::ArrayConcat { .. }
         | AggregateFunc::ListConcat { .. }
         | AggregateFunc::StringAgg { .. }
-        | AggregateFunc::RowNumber { .. } => ReductionType::Basic,
+        | AggregateFunc::RowNumber { .. }
+        | AggregateFunc::DenseRank { .. } => ReductionType::Basic,
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -573,6 +573,6 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::StringAgg { .. }
         | AggregateFunc::RowNumber { .. }
         | AggregateFunc::DenseRank { .. }
-        | AggregateFunc::Lag { .. } => ReductionType::Basic,
+        | AggregateFunc::LagLead { .. } => ReductionType::Basic,
     }
 }

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -573,6 +573,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
         | AggregateFunc::StringAgg { .. }
         | AggregateFunc::RowNumber { .. }
         | AggregateFunc::DenseRank { .. }
-        | AggregateFunc::LagLead { .. } => ReductionType::Basic,
+        | AggregateFunc::LagLead { .. }
+        | AggregateFunc::FirstValue { .. } => ReductionType::Basic,
     }
 }

--- a/src/dataflow/src/compute/render/reduce.rs
+++ b/src/dataflow/src/compute/render/reduce.rs
@@ -1474,7 +1474,8 @@ pub mod monoids {
             | AggregateFunc::RowNumber { .. }
             | AggregateFunc::DenseRank { .. }
             | AggregateFunc::LagLead { .. }
-            | AggregateFunc::FirstValue { .. } => None,
+            | AggregateFunc::FirstValue { .. }
+            | AggregateFunc::LastValue { .. } => None,
         }
     }
 }

--- a/src/dataflow/src/compute/render/reduce.rs
+++ b/src/dataflow/src/compute/render/reduce.rs
@@ -1471,7 +1471,8 @@ pub mod monoids {
             | AggregateFunc::ArrayConcat { .. }
             | AggregateFunc::ListConcat { .. }
             | AggregateFunc::StringAgg { .. }
-            | AggregateFunc::RowNumber { .. } => None,
+            | AggregateFunc::RowNumber { .. }
+            | AggregateFunc::DenseRank { .. } => None,
         }
     }
 }

--- a/src/dataflow/src/compute/render/reduce.rs
+++ b/src/dataflow/src/compute/render/reduce.rs
@@ -1473,7 +1473,8 @@ pub mod monoids {
             | AggregateFunc::StringAgg { .. }
             | AggregateFunc::RowNumber { .. }
             | AggregateFunc::DenseRank { .. }
-            | AggregateFunc::LagLead { .. } => None,
+            | AggregateFunc::LagLead { .. }
+            | AggregateFunc::FirstValue { .. } => None,
         }
     }
 }

--- a/src/dataflow/src/compute/render/reduce.rs
+++ b/src/dataflow/src/compute/render/reduce.rs
@@ -1472,7 +1472,8 @@ pub mod monoids {
             | AggregateFunc::ListConcat { .. }
             | AggregateFunc::StringAgg { .. }
             | AggregateFunc::RowNumber { .. }
-            | AggregateFunc::DenseRank { .. } => None,
+            | AggregateFunc::DenseRank { .. }
+            | AggregateFunc::Lag { .. } => None,
         }
     }
 }

--- a/src/dataflow/src/compute/render/reduce.rs
+++ b/src/dataflow/src/compute/render/reduce.rs
@@ -1473,7 +1473,7 @@ pub mod monoids {
             | AggregateFunc::StringAgg { .. }
             | AggregateFunc::RowNumber { .. }
             | AggregateFunc::DenseRank { .. }
-            | AggregateFunc::Lag { .. } => None,
+            | AggregateFunc::LagLead { .. } => None,
         }
     }
 }

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -36,7 +36,7 @@ pub use linear::{
     util::{join_permutations, permutation_for_arrangement},
     MapFilterProject,
 };
-pub use relation::func::{AggregateFunc, TableFunc};
+pub use relation::func::{AggregateFunc, LagLeadType, TableFunc};
 pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -41,7 +41,8 @@ pub use relation::func::{AnalyzedRegex, CaptureGroupDesc};
 pub use relation::join_input_mapper::JoinInputMapper;
 pub use relation::{
     compare_columns, AggregateExpr, CollectionPlan, ColumnOrder, JoinImplementation,
-    MirRelationExpr, RowSetFinishing, RECURSION_LIMIT,
+    MirRelationExpr, RowSetFinishing, WindowFrame, WindowFrameBound, WindowFrameUnits,
+    RECURSION_LIMIT,
 };
 pub use scalar::func::{self, BinaryFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc};
 pub use scalar::{like_pattern, EvalError, MirScalarExpr};

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -28,7 +28,7 @@ use mz_repr::adt::numeric::{self, NumericMaxScale};
 use mz_repr::adt::regex::Regex as ReprRegex;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, RelationType, Row, RowArena, ScalarType};
 
-use crate::relation::{compare_columns, ColumnOrder, WindowFrame, WindowFrameBound};
+use crate::relation::{compare_columns, ColumnOrder, WindowFrame, WindowFrameBound, WindowFrameUnits};
 use crate::scalar::func::{add_timestamp_months, jsonb_stringify};
 use crate::EvalError;
 
@@ -803,6 +803,129 @@ where
     })
 }
 
+// The expected input is in the format of [((OriginalRow, InputValue), OrderByExprs...)]
+fn last_value<'a, I>(
+    datums: I,
+    temp_storage: &'a RowArena,
+    order_by: &[ColumnOrder],
+    window_frame: &WindowFrame,
+) -> Datum<'a>
+where
+    I: IntoIterator<Item = Datum<'a>>,
+{
+    // Sort the datums according to the ORDER BY expressions and return the ((OriginalRow, InputValue), OrderByRow) record
+    // The OrderByRow is kept around because it is required to compute the peer groups in RANGE mode
+    let datums = order_aggregate_datums_with_rank(datums, order_by);
+
+    // Decode the input (OriginalRow, InputValue) into separate datums, while keeping the OrderByRow
+    let datums = datums
+        .into_iter()
+        .map(|(d, order_by_row)| {
+            let mut iter = d.unwrap_list().iter();
+            let original_row = iter.next().unwrap();
+            let input_value = iter.next().unwrap();
+
+            (input_value, original_row, order_by_row)
+        })
+        .collect_vec();
+
+    let length = datums.len();
+    let mut result: Vec<(Datum, Datum)> = Vec::with_capacity(length);
+    for (idx, (current_datum, original_row, order_by_row)) in datums.iter().enumerate() {
+        let last_value = match &window_frame.end_bound {
+            WindowFrameBound::CurrentRow => match &window_frame.units {
+                // Always return the current value when in ROWS mode
+                WindowFrameUnits::Rows => *current_datum,
+                WindowFrameUnits::Range => {
+                    // When in RANGE mode, return the last value of the peer group
+                    // The peer group is the group of rows with the same ORDER BY value
+                    // Note: Range is only supported for the default window frame (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW),
+                    // which is why it does not appear in the other branches
+                    datums[idx..]
+                        .iter()
+                        .take_while(|(_, _, row)| row == order_by_row)
+                        .last()
+                        .unwrap()
+                        .0
+                }
+                // GROUPS is not supported, and forbidden during planning
+                WindowFrameUnits::Groups => unreachable!(),
+            },
+            WindowFrameBound::UnboundedFollowing => {
+                if let WindowFrameBound::OffsetFollowing(start_offset) = &window_frame.start_bound {
+                    let start_offset = usize::cast_from(*start_offset);
+
+                    // If the frame starts after the last row of the window, return null
+                    if idx + start_offset > length - 1 {
+                        Datum::Null
+                    } else {
+                        datums[length - 1].0
+                    }
+                } else {
+                    datums[length - 1].0
+                }
+            }
+            WindowFrameBound::OffsetFollowing(offset) => {
+                let end_offset = usize::cast_from(*offset);
+                let end_idx = idx.saturating_add(end_offset);
+                if let WindowFrameBound::OffsetFollowing(start_offset) = &window_frame.start_bound {
+                    let start_offset = usize::cast_from(*start_offset);
+                    let start_idx = idx.saturating_add(start_offset);
+
+                    // If the frame is empty or starts after the last row of the window, return null
+                    if end_offset < start_offset || start_idx >= length {
+                        Datum::Null
+                    } else {
+                        // Return the last valid element in the window
+                        datums
+                            .get(end_idx)
+                            .map(|d| d.0)
+                            .unwrap_or(datums[length - 1].0)
+                    }
+                } else {
+                    datums
+                        .get(end_idx)
+                        .map(|d| d.0)
+                        .unwrap_or(datums[length - 1].0)
+                }
+            }
+            WindowFrameBound::OffsetPreceding(offset) => {
+                let end_offset = usize::cast_from(*offset);
+                let end_idx = idx.saturating_sub(end_offset);
+                if idx < end_offset {
+                    // If the frame ends before the first row, return null
+                    Datum::Null
+                } else if let WindowFrameBound::OffsetPreceding(start_offset) =
+                    &window_frame.start_bound
+                {
+                    // If the frame is empty, return null
+                    if offset > start_offset {
+                        Datum::Null
+                    } else {
+                        datums[end_idx].0
+                    }
+                } else {
+                    datums[end_idx].0
+                }
+            }
+            // Forbidden during planning
+            WindowFrameBound::UnboundedPreceding => unreachable!(),
+        };
+
+        result.push((last_value, *original_row));
+    }
+
+    let result = result.into_iter().map(|(lag, original_row)| {
+        temp_storage.make_datum(|packer| {
+            packer.push_list(vec![lag, original_row]);
+        })
+    });
+
+    temp_storage.make_datum(|packer| {
+        packer.push_list(result);
+    })
+}
+
 /// Identify whether the given aggregate function is Lag or Lead, since they share
 /// implementations.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect)]
@@ -889,6 +1012,10 @@ pub enum AggregateFunc {
         order_by: Vec<ColumnOrder>,
         window_frame: WindowFrame,
     },
+    LastValue {
+        order_by: Vec<ColumnOrder>,
+        window_frame: WindowFrame,
+    },
     /// Accumulates any number of `Datum::Dummy`s into `Datum::Dummy`.
     ///
     /// Useful for removing an expensive aggregation while maintaining the shape
@@ -950,6 +1077,10 @@ impl AggregateFunc {
                 order_by,
                 window_frame,
             } => first_value(datums, temp_storage, order_by, window_frame),
+            AggregateFunc::LastValue {
+                order_by,
+                window_frame,
+            } => last_value(datums, temp_storage, order_by, window_frame),
             AggregateFunc::Dummy => Datum::Dummy,
         }
     }
@@ -979,6 +1110,7 @@ impl AggregateFunc {
             AggregateFunc::DenseRank { .. } => Datum::empty_list(),
             AggregateFunc::LagLead { .. } => Datum::empty_list(),
             AggregateFunc::FirstValue { .. } => Datum::empty_list(),
+            AggregateFunc::LastValue { .. } => Datum::empty_list(),
             _ => Datum::Null,
         }
     }
@@ -1095,6 +1227,28 @@ impl AggregateFunc {
                     element_type: Box::new(ScalarType::Record {
                         fields: vec![
                             (ColumnName::from("?first_value?"), value_type),
+                            (ColumnName::from("?record?"), original_row_type),
+                        ],
+                        custom_oid: None,
+                        custom_name: None,
+                    }),
+                    custom_oid: None,
+                }
+            }
+            AggregateFunc::LastValue { .. } => {
+                // The input type for LastValue is ((OriginalRow, EncodedArgs), OrderByExprs...)
+                let fields = input_type.scalar_type.unwrap_record_element_type();
+                let original_row_type = fields[0].unwrap_record_element_type()[0]
+                    .clone()
+                    .nullable(false);
+                let value_type = fields[0].unwrap_record_element_type()[1]
+                    .clone()
+                    .nullable(true);
+
+                ScalarType::List {
+                    element_type: Box::new(ScalarType::Record {
+                        fields: vec![
+                            (ColumnName::from("?last_value?"), value_type),
                             (ColumnName::from("?record?"), original_row_type),
                         ],
                         custom_oid: None,
@@ -1400,6 +1554,7 @@ impl fmt::Display for AggregateFunc {
                 ..
             } => f.write_str("lead"),
             AggregateFunc::FirstValue { .. } => f.write_str("first_value"),
+            AggregateFunc::LastValue { .. } => f.write_str("last_value"),
             AggregateFunc::Dummy => f.write_str("dummy"),
         }
     }

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -759,8 +759,7 @@ where
                 let start_offset = usize::cast_from(*offset);
                 let start_idx = idx.saturating_sub(start_offset);
                 if let WindowFrameBound::OffsetPreceding(end_offset) = &window_frame.end_bound {
-                    let end_offset = usize::try_from(*end_offset)
-                        .expect("Window frame offset does not fit in usize");
+                    let end_offset = usize::cast_from(*end_offset);
 
                     // If the frame is empty or ends before the first row, return null
                     if start_offset < end_offset || idx < end_offset {
@@ -773,8 +772,7 @@ where
                 }
             }
             WindowFrameBound::OffsetFollowing(offset) => {
-                let start_offset =
-                    usize::try_from(*offset).expect("Window frame offset does not fit in usize");
+                let start_offset = usize::cast_from(*offset);
                 let start_idx = idx.saturating_add(start_offset);
                 if let WindowFrameBound::OffsetFollowing(end_offset) = &window_frame.end_bound {
                     // If the frame is empty or starts after the last row, return null

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -28,7 +28,9 @@ use mz_repr::adt::numeric::{self, NumericMaxScale};
 use mz_repr::adt::regex::Regex as ReprRegex;
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, RelationType, Row, RowArena, ScalarType};
 
-use crate::relation::{compare_columns, ColumnOrder, WindowFrame, WindowFrameBound, WindowFrameUnits};
+use crate::relation::{
+    compare_columns, ColumnOrder, WindowFrame, WindowFrameBound, WindowFrameUnits,
+};
 use crate::scalar::func::{add_timestamp_months, jsonb_stringify};
 use crate::EvalError;
 

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2093,7 +2093,7 @@ impl AggregateExpr {
                 }
             }
 
-            // The input type for LagLead is a ((OriginalRow, InputValue), OrderByExprs...)
+            // The input type for FirstValue is a ((OriginalRow, InputValue), OrderByExprs...)
             AggregateFunc::FirstValue { window_frame, .. } => {
                 let tuple = self
                     .expr

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2037,10 +2037,7 @@ impl AggregateExpr {
 
             // The input type for LagLead is a ((OriginalRow, (InputValue, Offset, Default)), OrderByExprs...)
             AggregateFunc::LagLead { lag_lead, .. } => {
-                let tuple = self
-                    .expr
-                    .clone()
-                    .call_unary(UnaryFunc::RecordGet(0));
+                let tuple = self.expr.clone().call_unary(UnaryFunc::RecordGet(0));
 
                 // Get the overall return type
                 let return_type = self
@@ -2095,10 +2092,7 @@ impl AggregateExpr {
 
             // The input type for FirstValue is a ((OriginalRow, InputValue), OrderByExprs...)
             AggregateFunc::FirstValue { window_frame, .. } => {
-                let tuple = self
-                    .expr
-                    .clone()
-                    .call_unary(UnaryFunc::RecordGet(0));
+                let tuple = self.expr.clone().call_unary(UnaryFunc::RecordGet(0));
 
                 // Get the overall return type
                 let return_type = self
@@ -2109,9 +2103,7 @@ impl AggregateExpr {
                 let first_value_return_type = return_type.unwrap_record_element_type()[0].clone();
 
                 // Extract the original row
-                let original_row = tuple
-                    .clone()
-                    .call_unary(UnaryFunc::RecordGet(0));
+                let original_row = tuple.clone().call_unary(UnaryFunc::RecordGet(0));
 
                 // Extract the input value
                 let expr = tuple.call_unary(UnaryFunc::RecordGet(1));
@@ -2141,10 +2133,7 @@ impl AggregateExpr {
 
             // The input type for LastValue is a ((OriginalRow, InputValue), OrderByExprs...)
             AggregateFunc::LastValue { window_frame, .. } => {
-                let tuple = self
-                    .expr
-                    .clone()
-                    .call_unary(UnaryFunc::RecordGet(0));
+                let tuple = self.expr.clone().call_unary(UnaryFunc::RecordGet(0));
 
                 // Get the overall return type
                 let return_type = self
@@ -2155,9 +2144,7 @@ impl AggregateExpr {
                 let last_value_return_type = return_type.unwrap_record_element_type()[0].clone();
 
                 // Extract the original row
-                let original_row = tuple
-                    .clone()
-                    .call_unary(UnaryFunc::RecordGet(0));
+                let original_row = tuple.clone().call_unary(UnaryFunc::RecordGet(0));
 
                 // Extract the input value
                 let expr = tuple.call_unary(UnaryFunc::RecordGet(1));

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2139,6 +2139,52 @@ impl AggregateExpr {
                 }
             }
 
+            // The input type for LastValue is a ((OriginalRow, InputValue), OrderByExprs...)
+            AggregateFunc::LastValue { window_frame, .. } => {
+                let tuple = self
+                    .expr
+                    .clone()
+                    .call_unary(UnaryFunc::RecordGet(0));
+
+                // Get the overall return type
+                let return_type = self
+                    .typ(input_type)
+                    .scalar_type
+                    .unwrap_list_element_type()
+                    .clone();
+                let last_value_return_type = return_type.unwrap_record_element_type()[0].clone();
+
+                // Extract the original row
+                let original_row = tuple
+                    .clone()
+                    .call_unary(UnaryFunc::RecordGet(0));
+
+                // Extract the input value
+                let expr = tuple.call_unary(UnaryFunc::RecordGet(1));
+
+                // If the window frame includes the current (single) row, return its value, null otherwise
+                let value = if window_frame.includes_current_row() {
+                    expr
+                } else {
+                    MirScalarExpr::literal_null(last_value_return_type)
+                };
+
+                MirScalarExpr::CallVariadic {
+                    func: VariadicFunc::ListCreate {
+                        elem_type: return_type,
+                    },
+                    exprs: vec![MirScalarExpr::CallVariadic {
+                        func: VariadicFunc::RecordCreate {
+                            field_names: vec![
+                                ColumnName::from("?last_value?"),
+                                ColumnName::from("?record?"),
+                            ],
+                        },
+                        exprs: vec![value, original_row],
+                    }],
+                }
+            }
+
             // All other variants should return the argument to the aggregation.
             AggregateFunc::MaxNumeric
             | AggregateFunc::MaxInt16

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2503,6 +2503,38 @@ lazy_static! {
                     Ok((e, ValueWindowFunc::Lag))
                 }) => AnyCompatible, 3108;
             },
+            "lead" => ValueWindow {
+                // All args are encoded into a single record to be handled later
+                params!(Any) => Operation::unary(|ecx, e| {
+                    let typ = ecx.scalar_type(&e);
+                    let e = HirScalarExpr::CallVariadic {
+                        func: VariadicFunc::RecordCreate {
+                            field_names: vec![ColumnName::from("expr"), ColumnName::from("offset"), ColumnName::from("default")]
+                        },
+                        exprs: vec![e, HirScalarExpr::literal(Datum::Int32(1), ScalarType::Int32), HirScalarExpr::literal_null(typ)],
+                    };
+                    Ok((e, ValueWindowFunc::Lead))
+                }) => Any, 3109;
+                params!(Any, Int32) => Operation::binary(|ecx, e, offset| {
+                    let typ = ecx.scalar_type(&e);
+                    let e = HirScalarExpr::CallVariadic {
+                        func: VariadicFunc::RecordCreate {
+                            field_names: vec![ColumnName::from("expr"), ColumnName::from("offset"), ColumnName::from("default")]
+                        },
+                        exprs: vec![e, offset, HirScalarExpr::literal_null(typ)],
+                    };
+                    Ok((e, ValueWindowFunc::Lead))
+                }) => Any, 3110;
+                params!(AnyCompatible, Int32, AnyCompatible) => Operation::variadic(|_ecx, exprs| {
+                    let e = HirScalarExpr::CallVariadic {
+                        func: VariadicFunc::RecordCreate {
+                            field_names: vec![ColumnName::from("expr"), ColumnName::from("offset"), ColumnName::from("default")]
+                        },
+                        exprs,
+                    };
+                    Ok((e, ValueWindowFunc::Lead))
+                }) => AnyCompatible, 3111;
+            },
 
             // Table functions.
             "generate_series" => Table {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -492,6 +492,12 @@ impl From<ScalarWindowFunc> for Operation<ScalarWindowFunc> {
     }
 }
 
+impl From<ValueWindowFunc> for Operation<(HirScalarExpr, ValueWindowFunc)> {
+    fn from(a: ValueWindowFunc) -> Operation<(HirScalarExpr, ValueWindowFunc)> {
+        Operation::unary(move |_ecx, e| Ok((e, a.clone())))
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 /// Describes possible types of function parameters.
 ///
@@ -2534,6 +2540,9 @@ lazy_static! {
                     };
                     Ok((e, ValueWindowFunc::Lead))
                 }) => AnyCompatible, 3111;
+            },
+            "first_value" => ValueWindow {
+                params!(Any) => ValueWindowFunc::FirstValue => Any, 3112;
             },
 
             // Table functions.

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2544,6 +2544,9 @@ lazy_static! {
             "first_value" => ValueWindow {
                 params!(Any) => ValueWindowFunc::FirstValue => Any, 3112;
             },
+            "last_value" => ValueWindow {
+                params!(Any) => ValueWindowFunc::LastValue => Any, 3113;
+            },
 
             // Table functions.
             "generate_series" => Table {

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2458,6 +2458,9 @@ lazy_static! {
             "row_number" => ScalarWindow {
                 params!() => ScalarWindowFunc::RowNumber, 3100;
             },
+            "dense_rank" => ScalarWindow {
+                params!() => ScalarWindowFunc::DenseRank, 3102;
+            },
 
             // Table functions.
             "generate_series" => Table {

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -509,6 +509,11 @@ impl<'a> Explanation<'a> {
                     WindowExprType::Scalar(scalar) => {
                         write!(f, "{}()", scalar.clone().into_expr())?
                     }
+                    WindowExprType::Value(scalar) => {
+                        write!(f, "{}(", scalar.clone().into_expr())?;
+                        self.fmt_scalar_expr(f, &scalar.expr)?;
+                        write!(f, ")")?
+                    }
                 }
                 write!(f, " over (")?;
                 for (i, e) in expr.partition.iter().enumerate() {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -207,15 +207,21 @@ impl WindowExpr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// A window function with its parameters.
 ///
-/// There are two types of window functions: scalar window functions, that
-/// return a different scalar value for each row within a partition, and
-/// aggregate window functions, that return the same value for all the tuples
-/// within the same partition. Aggregate window functions can be computed
-/// by joinining the input relation with a reduction over the same relation
-/// that computes the aggregation using the partition key as its grouping
-/// key.
+/// There are three types of window functions:
+/// - scalar window functions, that return a different scalar value for each
+/// row within a partition that depends exclusively on the position of the row
+/// within the partition;
+/// - value window functions, that return a scalar value for each row within a
+/// partition that might be computed based on a single previous, current or
+/// following row;
+/// - aggregate window functions, that return a computed value for the row that
+/// depends on multiple other rows within the same partition. Aggregate window
+/// functions can be in some cases be computed by joining the input relation
+/// with a reduction over the same relation that computes the aggregation using
+/// the partition key as its grouping key.
 pub enum WindowExprType {
     Scalar(ScalarWindowExpr),
+    Value(ValueWindowExpr),
 }
 
 impl WindowExprType {
@@ -225,6 +231,7 @@ impl WindowExprType {
     {
         match self {
             Self::Scalar(expr) => expr.visit_expressions(f),
+            Self::Value(expr) => expr.visit_expressions(f),
         }
     }
 
@@ -234,6 +241,7 @@ impl WindowExprType {
     {
         match self {
             Self::Scalar(expr) => expr.visit_expressions_mut(f),
+            Self::Value(expr) => expr.visit_expressions_mut(f),
         }
     }
 
@@ -245,6 +253,7 @@ impl WindowExprType {
     ) -> ColumnType {
         match self {
             Self::Scalar(expr) => expr.typ(outers, inner, params),
+            Self::Value(expr) => expr.typ(outers, inner, params),
         }
     }
 }
@@ -311,6 +320,65 @@ impl ScalarWindowFunc {
         match self {
             ScalarWindowFunc::RowNumber => ScalarType::Int64.nullable(false),
             ScalarWindowFunc::DenseRank => ScalarType::Int64.nullable(false),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ValueWindowExpr {
+    pub func: ValueWindowFunc,
+    pub expr: Box<HirScalarExpr>,
+    pub order_by: Vec<ColumnOrder>,
+}
+
+impl ValueWindowExpr {
+    pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
+    {
+        f(&self.expr)
+    }
+
+    pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
+    {
+        f(&mut self.expr)
+    }
+
+    fn typ(
+        &self,
+        outers: &[RelationType],
+        inner: &RelationType,
+        params: &BTreeMap<usize, ScalarType>,
+    ) -> ColumnType {
+        self.func.output_type(self.expr.typ(outers, inner, params))
+    }
+
+    pub fn into_expr(self) -> mz_expr::AggregateFunc {
+        match self.func {
+            ValueWindowFunc::Lag => mz_expr::AggregateFunc::Lag {
+                order_by: self.order_by,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+/// Value Window functions
+pub enum ValueWindowFunc {
+    Lag,
+}
+
+impl ValueWindowFunc {
+    pub fn output_type(&self, input_type: ColumnType) -> ColumnType {
+        match self {
+            ValueWindowFunc::Lag => {
+                // The input is a (value, offset, default) record, so extract the type of the first arg
+                input_type.scalar_type.unwrap_record_element_type()[0]
+                    .clone()
+                    .nullable(true)
+            }
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -368,6 +368,10 @@ impl ValueWindowExpr {
                 order_by: self.order_by,
                 lag_lead: mz_expr::LagLeadType::Lead,
             },
+            ValueWindowFunc::FirstValue => mz_expr::AggregateFunc::FirstValue {
+                order_by: self.order_by,
+                window_frame: self.window_frame,
+            },
         }
     }
 }
@@ -377,6 +381,7 @@ impl ValueWindowExpr {
 pub enum ValueWindowFunc {
     Lag,
     Lead,
+    FirstValue,
 }
 
 impl ValueWindowFunc {
@@ -388,6 +393,7 @@ impl ValueWindowFunc {
                     .clone()
                     .nullable(true)
             }
+            ValueWindowFunc::FirstValue => input_type.scalar_type.nullable(true),
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -372,6 +372,10 @@ impl ValueWindowExpr {
                 order_by: self.order_by,
                 window_frame: self.window_frame,
             },
+            ValueWindowFunc::LastValue => mz_expr::AggregateFunc::LastValue {
+                order_by: self.order_by,
+                window_frame: self.window_frame,
+            },
         }
     }
 }
@@ -382,6 +386,7 @@ pub enum ValueWindowFunc {
     Lag,
     Lead,
     FirstValue,
+    LastValue,
 }
 
 impl ValueWindowFunc {
@@ -393,7 +398,9 @@ impl ValueWindowFunc {
                     .clone()
                     .nullable(true)
             }
-            ValueWindowFunc::FirstValue => input_type.scalar_type.nullable(true),
+            ValueWindowFunc::FirstValue | ValueWindowFunc::LastValue => {
+                input_type.scalar_type.nullable(true)
+            }
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -35,7 +35,8 @@ use crate::plan::Params;
 
 // these happen to be unchanged at the moment, but there might be additions later
 pub use mz_expr::{
-    BinaryFunc, ColumnOrder, TableFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc,
+    BinaryFunc, ColumnOrder, TableFunc, UnaryFunc, UnmaterializableFunc, VariadicFunc, WindowFrame,
+    WindowFrameBound, WindowFrameUnits,
 };
 
 use super::Explanation;
@@ -329,6 +330,7 @@ pub struct ValueWindowExpr {
     pub func: ValueWindowFunc,
     pub expr: Box<HirScalarExpr>,
     pub order_by: Vec<ColumnOrder>,
+    pub window_frame: WindowFrame,
 }
 
 impl ValueWindowExpr {

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -262,6 +262,7 @@ impl ScalarWindowExpr {
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
+            ScalarWindowFunc::DenseRank => {}
         }
         Ok(())
     }
@@ -272,6 +273,7 @@ impl ScalarWindowExpr {
     {
         match self.func {
             ScalarWindowFunc::RowNumber => {}
+            ScalarWindowFunc::DenseRank => {}
         }
         Ok(())
     }
@@ -290,6 +292,9 @@ impl ScalarWindowExpr {
             ScalarWindowFunc::RowNumber => mz_expr::AggregateFunc::RowNumber {
                 order_by: self.order_by,
             },
+            ScalarWindowFunc::DenseRank => mz_expr::AggregateFunc::DenseRank {
+                order_by: self.order_by,
+            },
         }
     }
 }
@@ -298,12 +303,14 @@ impl ScalarWindowExpr {
 /// Scalar Window functions
 pub enum ScalarWindowFunc {
     RowNumber,
+    DenseRank,
 }
 
 impl ScalarWindowFunc {
     pub fn output_type(&self) -> ColumnType {
         match self {
             ScalarWindowFunc::RowNumber => ScalarType::Int64.nullable(false),
+            ScalarWindowFunc::DenseRank => ScalarType::Int64.nullable(false),
         }
     }
 }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -1040,6 +1040,224 @@ impl HirScalarExpr {
                                     });
                             SS::Column(inner.arity() - 1)
                         }
+                        WindowExprType::Value(func) => {
+                            let hir_scalar_input = func.expr.clone();
+                            *inner =
+                                inner
+                                    .take_dangerous()
+                                    .let_in(id_gen, |id_gen, mut get_inner| {
+                                        let order_by = order_by
+                                            .into_iter()
+                                            .map(|o| {
+                                                o.applied_to(
+                                                    id_gen,
+                                                    col_map,
+                                                    cte_map,
+                                                    &mut get_inner,
+                                                    subquery_map,
+                                                )
+                                            })
+                                            .collect_vec();
+
+                                        // Compute the encoded args for all rows
+                                        let mir_encoded_args = hir_scalar_input.applied_to(
+                                            id_gen,
+                                            col_map,
+                                            cte_map,
+                                            &mut get_inner,
+                                            subquery_map,
+                                        );
+                                        let mir_encoded_args_type =
+                                            mir_encoded_args.typ(&get_inner.typ()).scalar_type;
+
+                                        // Record input arity here so that any group_keys that need to mutate get_inner
+                                        // don't add those columns to the aggregate input.
+                                        let input_arity = get_inner.typ().arity();
+                                        // The reduction that computes the window function must be keyed on the columns
+                                        // from the outer context, plus the expressions in the partition key. The current
+                                        // subquery will be 'executed' for every distinct row from the outer context so
+                                        // by putting the outer columns in the grouping key we isolate each re-execution.
+                                        let mut group_key = col_map
+                                            .inner
+                                            .iter()
+                                            .map(|(_, outer_col)| *outer_col)
+                                            .sorted()
+                                            .collect_vec();
+                                        for p in partition {
+                                            let key = p.applied_to(
+                                                id_gen,
+                                                col_map,
+                                                cte_map,
+                                                &mut get_inner,
+                                                subquery_map,
+                                            );
+                                            if let mz_expr::MirScalarExpr::Column(c) = key {
+                                                group_key.push(c);
+                                            } else {
+                                                get_inner = get_inner.map_one(key);
+                                                group_key.push(get_inner.arity() - 1);
+                                            }
+                                        }
+
+                                        get_inner.let_in(id_gen, |_id_gen, get_inner| {
+                                            let to_reduce = get_inner;
+                                            let input_type = to_reduce.typ();
+
+                                            // Original columns of the relation
+                                            let fields = input_type
+                                                .column_types
+                                                .iter()
+                                                .take(input_arity)
+                                                .map(|t| (ColumnName::from("?column?"), t.clone()))
+                                                .collect_vec();
+
+                                            // Original row made into a record
+                                            let original_row_record =
+                                                mz_expr::MirScalarExpr::CallVariadic {
+                                                    func: mz_expr::VariadicFunc::RecordCreate {
+                                                        field_names: fields
+                                                            .iter()
+                                                            .map(|(name, _)| name.clone())
+                                                            .collect_vec(),
+                                                    },
+                                                    exprs: (0..input_arity)
+                                                        .map(|column| {
+                                                            mz_expr::MirScalarExpr::Column(column)
+                                                        })
+                                                        .collect_vec(),
+                                                };
+                                            let original_row_record_type = ScalarType::Record {
+                                                fields,
+                                                custom_oid: None,
+                                                custom_name: None,
+                                            };
+
+                                            // Build a new record with the original row in a record in a list + the encoded args in a record
+                                            let fn_input_record_fields =
+                                                [original_row_record_type, mir_encoded_args_type]
+                                                    .iter()
+                                                    .map(|t| {
+                                                        (
+                                                            ColumnName::from("?column?"),
+                                                            t.clone().nullable(false),
+                                                        )
+                                                    })
+                                                    .collect_vec();
+                                            let fn_input_record =
+                                                mz_expr::MirScalarExpr::CallVariadic {
+                                                    func: mz_expr::VariadicFunc::RecordCreate {
+                                                        field_names: fn_input_record_fields
+                                                            .iter()
+                                                            .map(|(n, _)| n.clone())
+                                                            .collect_vec(),
+                                                    },
+                                                    exprs: vec![
+                                                        original_row_record,
+                                                        mir_encoded_args,
+                                                    ],
+                                                };
+                                            let fn_input_record_type = ScalarType::Record {
+                                                fields: fn_input_record_fields,
+                                                custom_oid: None,
+                                                custom_name: None,
+                                            }
+                                            .nullable(false);
+
+                                            // Build a new record with the record above + the ORDER BY exprs
+                                            // This follows the standard encoding of ORDER BY exprs used by aggregate functions
+                                            let mut agg_input = vec![fn_input_record];
+                                            agg_input.extend(order_by.clone());
+                                            let agg_input = mz_expr::MirScalarExpr::CallVariadic {
+                                                func: mz_expr::VariadicFunc::RecordCreate {
+                                                    field_names: (0..2)
+                                                        .map(|_| ColumnName::from("?column?"))
+                                                        .collect_vec(),
+                                                },
+                                                exprs: agg_input,
+                                            };
+
+                                            let agg_input_type = ScalarType::Record {
+                                                fields: vec![(
+                                                    ColumnName::from("?column?"),
+                                                    fn_input_record_type.nullable(false),
+                                                )],
+                                                custom_oid: None,
+                                                custom_name: None,
+                                            }
+                                            .nullable(false);
+
+                                            let func = func.into_expr();
+                                            let aggregate = mz_expr::AggregateExpr {
+                                                func,
+                                                expr: agg_input,
+                                                distinct: false,
+                                            };
+
+                                            // Actually call reduce with the window function
+                                            // The input is [((OriginalRow, EncodedArgs), OrderByExprs...)]
+                                            // The output of the aggregation function should be a list of tuples that has
+                                            // the result in the first position, and the original row in the second position
+                                            let mut reduce = to_reduce
+                                                .reduce(
+                                                    group_key.clone(),
+                                                    vec![aggregate.clone()],
+                                                    None,
+                                                )
+                                                .flat_map(
+                                                    mz_expr::TableFunc::UnnestList {
+                                                        el_typ: aggregate
+                                                            .func
+                                                            .output_type(agg_input_type)
+                                                            .scalar_type
+                                                            .unwrap_list_element_type()
+                                                            .clone(),
+                                                    },
+                                                    vec![mz_expr::MirScalarExpr::Column(
+                                                        group_key.len(),
+                                                    )],
+                                                );
+                                            let record_col = reduce.arity() - 1;
+
+                                            // Unpack the record output by the window function
+                                            for c in 0..input_arity {
+                                                reduce =
+                                                    reduce
+                                                        .take_dangerous()
+                                                        .map_one(mz_expr::MirScalarExpr::CallUnary {
+                                                        func: mz_expr::UnaryFunc::RecordGet(c),
+                                                        expr: Box::new(
+                                                            mz_expr::MirScalarExpr::CallUnary {
+                                                                func: mz_expr::UnaryFunc::RecordGet(
+                                                                    1,
+                                                                ),
+                                                                expr: Box::new(
+                                                                    mz_expr::MirScalarExpr::Column(
+                                                                        record_col,
+                                                                    ),
+                                                                ),
+                                                            },
+                                                        ),
+                                                    });
+                                            }
+
+                                            // Append the column with the result of the window function.
+                                            reduce = reduce.take_dangerous().map_one(
+                                                mz_expr::MirScalarExpr::CallUnary {
+                                                    func: mz_expr::UnaryFunc::RecordGet(0),
+                                                    expr: Box::new(mz_expr::MirScalarExpr::Column(
+                                                        record_col,
+                                                    )),
+                                                },
+                                            );
+
+                                            let agg_col = record_col + 1 + input_arity;
+                                            reduce.project(
+                                                (record_col + 1..agg_col + 1).collect_vec(),
+                                            )
+                                        })
+                                    });
+                            SS::Column(inner.arity() - 1)
+                        }
                     }
                 }
             }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -629,3 +629,709 @@ ORDER BY y, z DESC, x
 1  1  c  NaN
 1  2  c  NaN
 2  3  c    1
+
+## lag
+
+# Simple cases
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lag(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+a     b
+b     b
+b     c
+c     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+b     b
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lag(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+b     a
+b     b
+c     b
+c     c
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+NULL  b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+a     a
+NULL  a
+NULL  a
+a     b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY x, lag
+----
+c     a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(x) OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY x, lag
+----
+NULL  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lag(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+NULL  a
+c     c
+c     c
+b     c
+b     b
+b     b
+a     b
+a     a
+a     a
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+
+# With default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  -1
+1  c  NaN  -1
+2  c  NaN  1
+3  c  1  2
+4  b  1  -1
+4  b  0  4
+1  a  1  -1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# Complex expressions
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  -9
+3  c  1  -8
+4  b  1  NULL
+4  b  0  5
+1  a  1  NULL
+2  a  1  2
+2  a  1  3
+3  a  1  3
+
+# Nulls in the first argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# Nulls in the first argument with a default value in the third argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+
+# Zero offset
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  7
+1  c  NaN  1
+2  c  NaN  2
+3  c  1  3
+4  b  1  4
+4  b  0  4
+1  a  1  1
+2  a  1  2
+2  a  1  2
+3  a  1  3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  2
+1  c  NaN  NaN
+2  c  NaN  NaN
+3  c  1  4
+4  b  1  5
+4  b  0  4
+1  a  1  2
+2  a  1  3
+2  a  1  3
+3  a  1  4
+
+# Positive offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  1
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  2
+2  a  1  NULL
+3  a  1  3
+
+# Out of range positive offsets
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1  NULL
+4  b  1  4
+4  b  0  NULL
+1  a  1  2
+2  a  1  2
+2  a  1  3
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NaN
+2  c  NaN  4
+3  c  1  NULL
+4  b  1  4
+4  b  0  NULL
+1  a  1  3
+2  a  1  3
+2  a  1  4
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  4
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  3
+2  a  1  4
+2  a  1  NULL
+3  a  1  NULL
+
+# Out of range negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Variable per row offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  1
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  1
+2  c  NaN  1
+3  c  1  1
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+
+# Null offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  1
+2  a  1  NULL
+3  a  1  1
+
+# Null offset with default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+# Variable per row default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lag(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lag
+----
+7  d  -5  -5
+1  c  NaN  NaN
+2  c  NaN  1
+3  c  1  2
+4  b  1  1
+4  b  0  4
+1  a  1  1
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+# reduce_elision code path
+# Default offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+# Zero offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+# Negative offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, -1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  NULL
+3  NULL
+
+# Default value with offset 1
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  10
+3  10
+
+# Default value with offset 0
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+# Complex expression
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  3
+3  13
+
+# Complex offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+3  NULL
+1  2
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  4
+
+# Complex default value
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  1
+3  3
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lag(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+----
+1  2
+3  12

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -469,3 +469,163 @@ ORDER BY row_number() OVER ()
 a
 b
 c
+
+# dense_rank
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank
+----
+1  a
+2  b
+2  b
+3  c
+3  c
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+3  a
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+2  b
+2  b
+3  a
+
+query IT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT dense_rank() OVER (ORDER BY x DESC), x FROM t
+ORDER BY dense_rank
+----
+1  c
+1  c
+2  b
+2  b
+3  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  a
+1  a
+2  b
+2  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY dense_rank, x
+----
+1  b
+1  c
+2  a
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY dense_rank, x
+----
+1  a
+1  b
+1  c
+
+query IT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT dense_rank() OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+1  c
+1  c
+1  c
+1  b
+1  b
+1  b
+1  a
+1  a
+1  a
+
+# Make sure a non-column expression following the window function is correctly
+# handled.
+query ITT
+WITH t (x) AS (VALUES ('a'))
+SELECT dense_rank() OVER (PARTITION BY NULL) AS q, x, 'b'
+FROM t
+----
+1 a b
+
+
+query IITT
+WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY x DESC, z), x, y, z
+FROM t
+ORDER BY y, x DESC, z
+----
+1  3  a    1
+2  2  a    1
+2  2  a    1
+3  1  a    1
+1  4  b    0
+2  4  b    1
+1  3  c    1
+2  2  c  NaN
+3  1  c  NaN
+
+
+# NaNs have the same rank
+query IITT
+WITH t (x, y, z) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0))
+SELECT dense_rank() OVER (PARTITION BY y ORDER BY z DESC), x, y, z
+FROM t
+ORDER BY y, z DESC, x
+----
+1  1  a    1
+1  2  a    1
+1  2  a    1
+1  3  a    1
+1  4  b    1
+2  4  b    0
+1  1  c  NaN
+1  2  c  NaN
+2  3  c    1

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -1335,3 +1335,18 @@ FROM (SELECT DISTINCT f1, f2 FROM t) q
 ----
 1  2
 3  12
+
+# Null value in input relation
+# This was caused by a bug in the reduce elision logic
+statement ok
+CREATE TABLE t3 (f1 INTEGER)
+----
+
+statement ok
+INSERT INTO t3 VALUES (NULL)
+----
+
+query II
+SELECT f1, lag(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t3 GROUP BY f1 ORDER BY 1
+----
+NULL NULL

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -3573,3 +3573,1372 @@ FROM t5
 GROUP BY f1
 ----
 1 NULL
+
+## last_value
+
+# Default frame (RANGE BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW)
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# Default frame with large peer group
+# Warning: there are multiple valid results of this query
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f3) OVER (PARTITION BY f2 ORDER BY f1)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  3
+2  a  3  3
+3  a  4  4
+4  b  5  6
+4  b  6  6
+1  c  7  7
+2  c  8  8
+3  c  9  9
+7  d  10  10
+
+# ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN y FOLLOWING AND x FOLLOWING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y FOLLOWING AND x FOLLOWING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  2
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN CURRENT ROW AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN CURRENT ROW AND x FOLLOWING for last_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN CURRENT ROW AND x FOLLOWING for last_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND 0 PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN 0 PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y PRECEDING AND x PRECEDING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y PRECEDING AND x PRECEDING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN y PRECEDING AND x PRECEDING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551615 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551614 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# u64::MAX PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, last_value(f1) OVER (PARTITION BY f2 ORDER BY f1 DESC, f3 DESC ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, last_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# reduce_elision code path
+# Using the same table as first_value
+
+# Default frame, includes current row
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame ending at UNBOUNDED FOLLOWING
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame ending at 1 FOLLOWING
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame ending at 0 FOLLOWING
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame ending at CURRENT ROW
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame ending at 0 PRECEDING
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame ending at 1 PRECEDING
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, last_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -2084,3 +2084,1492 @@ query II
 SELECT f1, lead(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t4 GROUP BY f1 ORDER BY 1
 ----
 NULL NULL
+
+## window frames
+
+# Invalid frame start
+query error frame start cannot be UNBOUNDED FOLLOWING
+SELECT row_number() OVER (ROWS UNBOUNDED FOLLOWING)
+
+# Invalid frame end
+query error frame end cannot be UNBOUNDED PRECEDING
+SELECT row_number() OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED PRECEDING)
+
+# End frame can't be of a type that comes before the start bound
+query error frame starting from current row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN CURRENT ROW AND 1 PRECEDING)
+
+query error frame starting from following row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN 1 FOLLOWING AND 1 PRECEDING)
+
+query error frame starting from following row cannot have preceding rows
+SELECT row_number() OVER (ROWS BETWEEN 1 FOLLOWING AND CURRENT ROW)
+
+# But end offsets can come before start offsets
+query I
+SELECT row_number() OVER (ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+----
+1
+
+query I
+SELECT row_number() OVER (ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+----
+1
+
+# Negative offsets are not allowed
+# Our error message is different from Postgres, so it's not checked here
+query error
+SELECT row_number() OVER (ROWS -1 PRECEDING)
+
+query error
+SELECT row_number() OVER (ROWS -1 FOLLOWING)
+
+# Current implementation restrictions
+# RANGE is not supported outside of the default frame
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND 1 PRECEDING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+query error RANGE in non-default window frames not yet supported
+SELECT row_number() OVER (RANGE BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+
+# Default window frame works fine
+query I
+SELECT row_number() OVER ()
+----
+1
+
+query I
+SELECT row_number() OVER (RANGE UNBOUNDED PRECEDING)
+----
+1
+
+query I
+SELECT row_number() OVER (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+----
+1
+
+# GROUPS is not supported at all
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND CURRENT ROW)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+
+query error GROUPS in window frames not yet supported
+SELECT row_number() OVER (GROUPS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+
+## first_value
+
+# Default frame (RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  1
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN 0 PRECEDING AND x PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND 0 PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  1
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND y PRECEDING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  NULL
+4  b  6  4
+1  c  7  NULL
+2  c  8  1
+3  c  9  2
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  1
+3  a  4  2
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  1
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 10 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x PRECEDING AND CURRENT ROW
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND x FOLLOWING
+# Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN x PRECEDING AND UNBOUNDED FOLLOWING
+# Equivalent to ROWS BETWEEN x PRECEDING AND CURRENT ROW for first_value
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  2
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  2
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  2
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  1
+2  a  3  1
+3  a  4  1
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  1
+3  c  9  1
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND CURRENT ROW
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND x FOLLOWING
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING
+# Always returns current row
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN 0 FOLLOWING AND x FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+# ROWS BETWEEN x FOLLOWING AND 0 FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x < y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x > y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND y FOLLOWING, where x == y
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND 2 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND 10 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# ROWS BETWEEN x FOLLOWING AND UNBOUNDED FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  1
+2  a  2  2
+2  a  3  2
+3  a  4  3
+4  b  5  4
+4  b  6  4
+1  c  7  1
+2  c  8  2
+3  c  9  3
+7  d  10  7
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  2
+2  a  3  3
+3  a  4  NULL
+4  b  5  4
+4  b  6  NULL
+1  c  7  2
+2  c  8  3
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  2
+2  a  2  3
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  3
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 10 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# Test near-overflow behavior on offsets
+# u64::MAX FOLLOWING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551614 FOLLOWING AND 18446744073709551615 FOLLOWING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# u64::MAX PRECEDING
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551615 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+query ITII
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1), (2, 'a', 2), (2, 'a', 3), (3, 'a', 4), (4, 'b', 5), (4, 'b', 6), (1, 'c', 7), (2, 'c', 8), (3, 'c', 9), (7, 'd', 10))
+SELECT f1, f2, f3, first_value(f1) OVER (PARTITION BY f2 ORDER BY f1, f3 ROWS BETWEEN 18446744073709551615 PRECEDING AND 18446744073709551614 PRECEDING)
+FROM t
+ORDER BY f2, f3, f1, first_value
+----
+1  a  1  NULL
+2  a  2  NULL
+2  a  3  NULL
+3  a  4  NULL
+4  b  5  NULL
+4  b  6  NULL
+1  c  7  NULL
+2  c  8  NULL
+3  c  9  NULL
+7  d  10  NULL
+
+# reduce_elision code path
+statement ok
+CREATE TABLE t5 (f1 INTEGER)
+----
+
+statement ok
+INSERT INTO t5 VALUES (1)
+----
+
+# Default frame, includes current row
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at UNBOUNDED PRECEDING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 1 PRECEDING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 0 PRECEDING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 1 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 0 PRECEDING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 PRECEDING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at CURRENT ROW
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND CURRENT ROW)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 0 FOLLOWING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 0 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 1
+
+# Frame starting at 1 FOLLOWING
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND 0 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND 1 FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL
+
+query II
+SELECT f1, first_value(f1) OVER (PARTITION BY f1 ROWS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING)
+FROM t5
+GROUP BY f1
+----
+1 NULL

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -1350,3 +1350,737 @@ query II
 SELECT f1, lag(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t3 GROUP BY f1 ORDER BY 1
 ----
 NULL NULL
+
+## lead
+
+# Simple cases
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+b     a
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+b     a
+b     b
+c     b
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lead(x) OVER (ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+b     a
+b     b
+c     b
+c     c
+NULL  c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+a     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'))
+SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+a     b
+b     b
+b     c
+
+query TT
+WITH t (x) AS (VALUES ('a'), ('b'), ('b'), ('c'), ('c'))
+SELECT lead(x) OVER (ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+a     b
+b     b
+b     c
+c     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98))
+SELECT lead(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+c     a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 98), ('b', 99), ('c', 98), ('a', 98), ('a', 99))
+SELECT lead(x) OVER (PARTITION BY y ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+a  a
+b  a
+c  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lead(x) OVER (PARTITION BY y ORDER BY x DESC), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+NULL  b
+a     c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lead(x) OVER (PARTITION BY x ORDER BY x), x FROM t
+ORDER BY x, lead
+----
+NULL  a
+NULL  b
+NULL  c
+
+query TT
+WITH t (x, y) AS (VALUES ('a', 1), ('b', 2), ('c', 1))
+SELECT lead(a1.x) OVER (PARTITION BY NULL ORDER BY 10000) AS q, a1.x
+FROM t AS a1, t AS a2
+ORDER BY q DESC, a1.x DESC
+----
+NULL  c
+c     c
+c     c
+c     b
+b     b
+b     b
+b     a
+a     a
+a     a
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    4
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    4
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    4
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+
+# With default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  -1
+1  c  NaN  2
+2  c  NaN  3
+3  c  1   -1
+4  b  1    4
+4  b  0   -1
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1   -1
+
+# Complex expressions
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + coalesce(nullif(f3, 'NaN'), -10)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5    NULL
+1  c  NaN  -8
+2  c  NaN   4
+3  c  1     NULL
+4  b  1     4
+4  b  0     NULL
+1  a  1     3
+2  a  1     3
+2  a  1     4
+3  a  1     NULL
+
+# Nulls in the first argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(NULL::int) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(nullif(f1, 4)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5    NULL
+1  c  NaN  2
+2  c  NaN  3
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    2
+2  a  1    2
+2  a  1    3
+3  a  1    NULL
+
+# Nulls in the first argument with a default value in the third argument
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(NULL::int, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+
+# Zero offset
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   7
+1  c  NaN  1
+2  c  NaN  2
+3  c  1    3
+4  b  1    4
+4  b  0    4
+1  a  1    1
+2  a  1    2
+2  a  1    2
+3  a  1    3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   2
+1  c  NaN  NaN
+2  c  NaN  NaN
+3  c  1    4
+4  b  1    5
+4  b  0    4
+1  a  1    2
+2  a  1    3
+2  a  1    3
+3  a  1    4
+
+# Positive offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  3
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    2
+2  a  1    3
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  4
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    3
+2  a  1    4
+2  a  1    NULL
+3  a  1    NULL
+
+# Out of range positive offsets
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1    NULL
+4  b  1    NULL
+4  b  0    NULL
+1  a  1    NULL
+2  a  1    NULL
+2  a  1    NULL
+3  a  1    NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, 10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5   0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1    0
+4  b  1    0
+4  b  0    0
+1  a  1    0
+2  a  1    0
+2  a  1    0
+3  a  1    0
+
+# Negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  1
+3  c  1  2
+4  b  1  NULL
+4  b  0  4
+1  a  1  NULL
+2  a  1  1
+2  a  1  2
+3  a  1  2
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, -1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NaN
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  5
+1  a  1  NULL
+2  a  1  2
+2  a  1  3
+3  a  1  3
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, -2) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NaN
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  2
+2  a  1  NULL
+3  a  1  3
+
+# Out of range negative offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1 + f3, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, -10, 0) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  0
+1  c  NaN  0
+2  c  NaN  0
+3  c  1  0
+4  b  1  0
+4  b  0  0
+1  a  1  0
+2  a  1  0
+2  a  1  0
+3  a  1  0
+
+# Variable per row offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, f1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  2
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  2
+2  a  1  3
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, f1 - 1) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  1
+2  c  NaN  3
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  1
+2  a  1  2
+2  a  1  3
+3  a  1  NULL
+
+
+# Null offsets
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, NULL) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, nullif(f1, 1)) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  3
+2  a  1  NULL
+3  a  1  NULL
+
+# Null offset with default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, NULL, -10) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  NULL
+1  c  NaN  NULL
+2  c  NaN  NULL
+3  c  1  NULL
+4  b  1  NULL
+4  b  0  NULL
+1  a  1  NULL
+2  a  1  NULL
+2  a  1  NULL
+3  a  1  NULL
+
+# Variable per row default value
+query ITTT
+WITH t (f1, f2, f3) AS (VALUES (1, 'a', 1.0), (2, 'a', 1.0), (2, 'a', 1.0), (3, 'a', 1.0), (4, 'b', 0), (4, 'b', 1), (1, 'c', 'NaN'), (2, 'c', 'NaN'), (3, 'c', 1.0), (7, 'd', -5.0))
+SELECT f1, f2, f3, lead(f1, 1, f3) OVER (PARTITION BY f2 ORDER BY f3 DESC, f1)
+FROM t
+ORDER BY f2 DESC, f3 DESC, f1, lead
+----
+7  d  -5  -5
+1  c  NaN  2
+2  c  NaN  3
+3  c  1  1
+4  b  1  4
+4  b  0  0
+1  a  1  2
+2  a  1  2
+2  a  1  3
+3  a  1  1
+
+# reduce_elision code path
+# Default offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  NULL
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  NULL
+3  NULL
+
+# Zero offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 0) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  1
+3  3
+
+# Negative offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, -1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  NULL
+3  NULL
+
+# Default value with offset 1
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 1, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  10
+3  10
+
+# Default value with offset 0
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  1
+3  3
+
+# Complex expression
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, 0, 10) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, 1, f1 * f2 + 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  3
+3  13
+
+# Complex offset
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, f1 - f1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  12
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, f1 - 1) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  NULL
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1 * f2, f2 - 2 * f1, f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  4
+
+# Complex default value
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 0, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  1
+3  3
+
+query II
+WITH t (f1, f2) AS (VALUES (1, 2), (1, 2), (3, 4))
+SELECT f1, lead(f1, 1, f1 * f2) OVER (PARTITION BY f1, f2)
+FROM (SELECT DISTINCT f1, f2 FROM t) q
+ORDER BY 1, 2
+----
+1  2
+3  12
+
+# Null value in input relation
+# This was caused by a bug in the reduce elision logic
+statement ok
+CREATE TABLE t4 (f1 INTEGER)
+----
+
+statement ok
+INSERT INTO t4 VALUES (NULL)
+----
+
+query II
+SELECT f1, lead(0, f1 , 0) OVER (PARTITION BY f1 ORDER BY f1) FROM t4 GROUP BY f1 ORDER BY 1
+----
+NULL NULL


### PR DESCRIPTION
This PR backports to the v0.26 branch the recently added window functions, namely:
- `dense_rank` (#11377)
- `lag` (#11785)
- `lead` (#11891)
- `first_value` (#12073)
- `last_value` (#12195)

### Motivation

  * This PR adds a known-desirable feature: window functions in the LTS release.

### Tips for reviewer

- There's basically nothing new here, only cherry-picked commits with minimal changes to deal with features that don't exist in v0.26 (e.g. removing Protobuf-related code).

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Add `dense_rank`, `lag`, `lead`, `first_value` and `last_value` as new SQL window functions.
