### PR TITLE
add tracing::instrument on advance_local_inputs

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -860,6 +860,7 @@ impl<S: Append + 'static> Coordinator<S> {
     // a time greater than any previous table read (if wall clock has gone
     // backward). This downgrades the capabilities of all tables, which means that
     // all tables can no longer produce new data before this timestamp.
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn advance_local_inputs(&mut self, advance_to: mz_repr::Timestamp) {
         let start = Instant::now();
         let appends = self


### PR DESCRIPTION
we are turning on otel collection in cloud shortly, so this trace will be more clear:
<img width="1479" alt="image" src="https://user-images.githubusercontent.com/5404303/172440632-5d405d71-7113-42f2-be5a-1b8832b9e418.png">

Note that I changed the log line to be `debug!` so it shows up with the default otel filter (`"debug"`)

### Motivation

  * This PR adds a feature that has not yet been specified.


### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
local testing

### Release notes

None
