### PR TITLE
tracing: downgrade tokio_postgres in otel filter

### DIFF
--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -111,7 +111,9 @@ pub struct TracingCliArgs {
         long,
         env = "OPENTELEMETRY_FILTER",
         requires = "opentelemetry-endpoint",
-        default_value = "debug"
+        // tokio_postgres has busy `debug` logging.
+        // TODO(guswynn): switch tokio_postgres logging to `trace` upstream
+        default_value = "tokio_postgres=info,debug"
     )]
     pub opentelemetry_filter: SerializableTargets,
     /// The address on which to listen for Tokio console connections.


### PR DESCRIPTION
@danhhz mentioned in https://github.com/MaterializeInc/materialize/pull/12966 that these are noisy. We can downgrade them by default, and then fix it in upstream later!

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/5404303/172450755-d23a3f73-36de-4b51-b9c8-86f61d305465.png">
