### PR TITLE
tracing: bump tracing-opentelemetry to 0.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6389,10 +6389,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9378e96a9361190ae297e7f3a8ff644aacd2897f244b1ff81f381669196fa6"
+checksum = "93600c803bb15e2a32bd376001b8625587f268fe887669b5ac86af524637c242"
 dependencies = [
+ "once_cell",
  "opentelemetry",
  "tracing",
  "tracing-core",


### PR DESCRIPTION
https://github.com/tokio-rs/tracing/releases/tag/tracing-opentelemetry-0.17.3

Fixes a bug in how span locations are collected, and adds some more features

I opted to just bump the lock file and not the `tracing-opentelemetry = 0.17` in our cargo.toml's