### PR TITLE
[secrets] Allow Secrets in Create Source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,7 @@ dependencies = [
  "mz-pgrepr",
  "mz-postgres-util",
  "mz-repr",
+ "mz-secrets",
  "mz-sql-parser",
  "once_cell",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,6 +3215,7 @@ dependencies = [
  "mz-persist-types",
  "mz-postgres-util",
  "mz-repr",
+ "mz-secrets",
  "mz-stash",
  "proptest",
  "proptest-derive",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -34,7 +34,7 @@ use mz_dataflow_types::client::{
 use mz_dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_dataflow_types::sinks::{SinkConnector, SinkConnectorBuilder, SinkEnvelope};
 use mz_dataflow_types::sources::{
-    ConnectorInner, ExternalSourceConnector, MaybeStringId, SourceConnector, Timeline,
+    ConnectorInner, ExternalSourceConnector, SourceConnector, StringOrSecret, Timeline,
 };
 use mz_expr::{ExprHumanizer, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
@@ -3777,7 +3777,7 @@ impl mz_sql::catalog::CatalogConnector for Connector {
         self.connector.uri()
     }
 
-    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId> {
+    fn options(&self) -> std::collections::BTreeMap<String, StringOrSecret> {
         self.connector.options()
     }
 }

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use mz_build_info::BuildInfo;
 use mz_ore::metrics::MetricsRegistry;
+use mz_secrets::SecretsReader;
 
 use crate::catalog::storage;
 
@@ -31,4 +32,5 @@ pub struct Config<'a, S> {
     pub skip_migrations: bool,
     /// The registry that catalog uses to report metrics.
     pub metrics_registry: &'a MetricsRegistry,
+    pub secrets_reader: SecretsReader,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -391,9 +391,6 @@ pub struct Coordinator<S> {
     /// Handle to secret manager that can create and delete secrets from
     /// an arbitrary secret storage engine.
     secrets_controller: Box<dyn SecretsController>,
-    /// Handle to secrets reader that gives us access to user secrets
-    #[allow(dead_code)]
-    secrets_reader: SecretsReader,
     /// Map of strings to corresponding compute replica sizes.
     replica_sizes: ClusterReplicaSizeMap,
     /// Valid availability zones for replicas.
@@ -5237,6 +5234,7 @@ pub async fn serve<S: Append + 'static>(
         now: now.clone(),
         skip_migrations: false,
         metrics_registry: &metrics_registry,
+        secrets_reader,
     })
     .await?;
     let cluster_id = catalog.config().cluster_id;
@@ -5271,7 +5269,6 @@ pub async fn serve<S: Append + 'static>(
                 write_lock_wait_group: VecDeque::new(),
                 pending_writes: Vec::new(),
                 secrets_controller,
-                secrets_reader,
                 replica_sizes,
                 availability_zones,
                 connector_context,

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -36,6 +36,7 @@ mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
+mz-secrets = { path = "../secrets" }
 mz-stash = { path = "../stash" }
 tonic = "0.7.2"
 prost = "0.10.3"

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -19,6 +19,7 @@ use bytes::BufMut;
 use chrono::NaiveDateTime;
 
 use globset::{Glob, GlobBuilder};
+use mz_secrets::SecretsReader;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy};
 use proptest::prop_oneof;
 use proptest_derive::Arbitrary;
@@ -1144,20 +1145,29 @@ pub fn provide_default_metadata(
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum MaybeStringId {
+pub enum StringOrSecret {
     String(String),
     Secret(GlobalId),
+}
+
+impl StringOrSecret {
+    pub fn get_string(&self, secrets_reader: &SecretsReader) -> anyhow::Result<String> {
+        match self {
+            StringOrSecret::String(s) => Ok(s.clone()),
+            StringOrSecret::Secret(id) => secrets_reader.read_string(*id),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ConnectorInner {
     Kafka {
         broker: KafkaAddrs,
-        config_options: BTreeMap<String, MaybeStringId>,
+        config_options: BTreeMap<String, StringOrSecret>,
     },
     CSR {
         registry: String,
-        with_options: BTreeMap<String, MaybeStringId>,
+        with_options: BTreeMap<String, StringOrSecret>,
     },
 }
 
@@ -1169,7 +1179,7 @@ impl ConnectorInner {
         }
     }
 
-    pub fn options(&self) -> BTreeMap<String, MaybeStringId> {
+    pub fn options(&self) -> BTreeMap<String, StringOrSecret> {
         match self {
             ConnectorInner::Kafka { config_options, .. } => config_options.clone(),
             ConnectorInner::CSR { with_options, .. } => with_options.clone(),

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -1144,14 +1144,20 @@ pub fn provide_default_metadata(
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum MaybeStringId {
+    String(String),
+    Secret(GlobalId),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ConnectorInner {
     Kafka {
         broker: KafkaAddrs,
-        config_options: BTreeMap<String, String>,
+        config_options: BTreeMap<String, MaybeStringId>,
     },
     CSR {
         registry: String,
-        with_options: BTreeMap<String, String>,
+        with_options: BTreeMap<String, MaybeStringId>,
     },
 }
 
@@ -1163,7 +1169,7 @@ impl ConnectorInner {
         }
     }
 
-    pub fn options(&self) -> BTreeMap<String, String> {
+    pub fn options(&self) -> BTreeMap<String, MaybeStringId> {
         match self {
             ConnectorInner::Kafka { config_options, .. } => config_options.clone(),
             ConnectorInner::CSR { with_options, .. } => with_options.clone(),

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -7,9 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fs;
+use std::borrow::Borrow;
+use std::fs::File;
+use std::io::Read;
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use anyhow::Context;
 use async_trait::async_trait;
 
 use mz_repr::GlobalId;
@@ -50,6 +54,7 @@ pub enum SecretOp {
 }
 
 /// Configures a [`SecretsReader`].
+#[derive(Debug)]
 pub struct SecretsReaderConfig {
     /// The directory at which secrets are mounted.
     pub mount_path: PathBuf,
@@ -58,25 +63,48 @@ pub struct SecretsReaderConfig {
 /// Securely reads secrets that are managed by a [`SecretsController`].
 ///
 /// Does not provide access to create, update, or delete the secrets within.
+#[derive(Debug, Clone)]
 pub struct SecretsReader {
-    config: SecretsReaderConfig,
+    config: Arc<SecretsReaderConfig>,
 }
 
 impl SecretsReader {
     pub fn new(config: SecretsReaderConfig) -> Self {
-        Self { config }
+        Self {
+            config: Arc::new(config),
+        }
     }
 
     /// Returns the contents of a secret identified by GlobalId
-    pub fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
-        let file_path = self.config.mount_path.join(id.to_string());
-        Ok(fs::read(file_path)?)
+    ///
+    /// This `read` will return a complete version of the secret even though `SecretsReader` is `Clone` and we could
+    /// have concurrent reads.  It will not return, e.g., one block from v1 and another from v2.
+    ///
+    /// - On Linux / OSX filesystems, `File::open` will hold a handle open so that even if the file is deleted, we still
+    ///   continue to read from it.  This means a SecretOp::Delete followed by a SecretOp::Ensure can never "swap out"
+    ///   data mid-`read_to_end`.
+    /// - We do not allow editing secrets which _would_ expose us to this issue.
+    ///
+    /// (N.B. Were we ever to run with Windows / NTFS, this would also work properly _and_ mid-read edits would be
+    /// disallowed)
+    pub fn read<T: Borrow<GlobalId>>(&self, id: T) -> Result<Vec<u8>, anyhow::Error> {
+        let file_path = self.config.mount_path.join(id.borrow().to_string());
+
+        // Inlined the std::fs::read impl because correctness requires and impl that holds the same `File` handle open
+        let mut file = File::open(file_path)?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+        Ok(buf)
+    }
+
+    pub fn read_string<T: Borrow<GlobalId>>(&self, id: T) -> anyhow::Result<String> {
+        String::from_utf8(self.read(id)?).context("converting secret value to string")
     }
 
     /// Returns the path of the secret consisting of a configured base path
     /// and the GlobalId
-    pub fn canonical_path(&self, id: GlobalId) -> Result<PathBuf, anyhow::Error> {
-        let path = self.config.mount_path.join(id.to_string());
+    pub fn canonical_path<T: Borrow<GlobalId>>(&self, id: T) -> Result<PathBuf, anyhow::Error> {
+        let path = self.config.mount_path.join(id.borrow().to_string());
         Ok(path)
     }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::borrow::Borrow;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
@@ -77,8 +76,8 @@ impl SecretsReader {
 
     /// Returns the contents of a secret identified by GlobalId
     ///
-    /// This `read` will return a complete version of the secret even though `SecretsReader` is `Clone` and we could
-    /// have concurrent reads.  It will not return, e.g., one block from v1 and another from v2.
+    /// This `read` will return a complete version of the secret. It will not return, e.g., one block from v1 and
+    /// another from v2.
     ///
     /// - On Linux / OSX filesystems, `File::open` will hold a handle open so that even if the file is deleted, we still
     ///   continue to read from it.  This means a SecretOp::Delete followed by a SecretOp::Ensure can never "swap out"
@@ -88,7 +87,7 @@ impl SecretsReader {
     /// (N.B. Were we ever to run with Windows / NTFS, this would also work properly _and_ mid-read edits would be
     /// disallowed)
     pub fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
-        let file_path = self.config.mount_path.join(id.borrow().to_string());
+        let file_path = self.config.mount_path.join(id.to_string());
 
         // Inlined the std::fs::read impl because correctness requires and impl that holds the same `File` handle open
         let mut file = File::open(file_path)?;
@@ -104,7 +103,7 @@ impl SecretsReader {
     /// Returns the path of the secret consisting of a configured base path
     /// and the GlobalId
     pub fn canonical_path(&self, id: GlobalId) -> Result<PathBuf, anyhow::Error> {
-        let path = self.config.mount_path.join(id.borrow().to_string());
+        let path = self.config.mount_path.join(id.to_string());
         Ok(path)
     }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -87,7 +87,7 @@ impl SecretsReader {
     ///
     /// (N.B. Were we ever to run with Windows / NTFS, this would also work properly _and_ mid-read edits would be
     /// disallowed)
-    pub fn read<T: Borrow<GlobalId>>(&self, id: T) -> Result<Vec<u8>, anyhow::Error> {
+    pub fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
         let file_path = self.config.mount_path.join(id.borrow().to_string());
 
         // Inlined the std::fs::read impl because correctness requires and impl that holds the same `File` handle open
@@ -97,13 +97,13 @@ impl SecretsReader {
         Ok(buf)
     }
 
-    pub fn read_string<T: Borrow<GlobalId>>(&self, id: T) -> anyhow::Result<String> {
+    pub fn read_string(&self, id: GlobalId) -> anyhow::Result<String> {
         String::from_utf8(self.read(id)?).context("converting secret value to string")
     }
 
     /// Returns the path of the secret consisting of a configured base path
     /// and the GlobalId
-    pub fn canonical_path<T: Borrow<GlobalId>>(&self, id: T) -> Result<PathBuf, anyhow::Error> {
+    pub fn canonical_path(&self, id: GlobalId) -> Result<PathBuf, anyhow::Error> {
         let path = self.config.mount_path.join(id.borrow().to_string());
         Ok(path)
     }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -27,6 +27,7 @@ mz-ore = { path = "../ore", features = ["task"] }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
+mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }
 paste = "1.0"
 protobuf-native = "0.2.1"

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,7 +23,7 @@ use once_cell::sync::Lazy;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_dataflow_types::client::ComputeInstanceId;
-use mz_dataflow_types::sources::{MaybeStringId, SourceConnector};
+use mz_dataflow_types::sources::{SourceConnector, StringOrSecret};
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
@@ -276,7 +276,7 @@ pub trait CatalogConnector {
     fn uri(&self) -> String;
 
     /// Returns the options associated with this connector as a Vec, if the type does not support options or none were specified this will be empty
-    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId>;
+    fn options(&self) -> std::collections::BTreeMap<String, StringOrSecret>;
 }
 
 /// An item in a [`SessionCatalog`].

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -188,7 +188,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// at 0.
     fn now(&self) -> EpochMillis;
 
-    /// Returns SecretsReader for catalog
+    /// Returns a secrets reader associated with the catalog.
     fn secrets_reader(&self) -> &SecretsReader;
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,10 +23,11 @@ use once_cell::sync::Lazy;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_dataflow_types::client::ComputeInstanceId;
-use mz_dataflow_types::sources::SourceConnector;
+use mz_dataflow_types::sources::{MaybeStringId, SourceConnector};
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
+use mz_secrets::SecretsReader;
 use mz_sql_parser::ast::Expr;
 use uuid::Uuid;
 
@@ -186,6 +187,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// this means the Unix epoch. This can safely be mocked in tests and start
     /// at 0.
     fn now(&self) -> EpochMillis;
+
+    /// Returns SecretsReader for catalog
+    fn secrets_reader(&self) -> &SecretsReader;
 }
 
 /// Configuration associated with a catalog.
@@ -272,7 +276,7 @@ pub trait CatalogConnector {
     fn uri(&self) -> String;
 
     /// Returns the options associated with this connector as a Vec, if the type does not support options or none were specified this will be empty
-    fn options(&self) -> std::collections::BTreeMap<String, String>;
+    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId>;
 }
 
 /// An item in a [`SessionCatalog`].
@@ -694,6 +698,10 @@ impl SessionCatalog for DummyCatalog {
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
         name
+    }
+
+    fn secrets_reader(&self) -> &SecretsReader {
+        unimplemented!()
     }
 }
 

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -432,7 +432,7 @@ pub fn generate_ccsr_client_config(
 
     // If provided, prefer SSL options from the schema registry configuration
     if let Some(ca_path) = ccsr_options
-        .remove("ssl_ca_location")
+        .remove("ssl.ca.location")
         .map(|v| v.get_string(secrets_reader))
         .transpose()?
     {
@@ -443,11 +443,11 @@ pub fn generate_ccsr_client_config(
     }
 
     let key_path = ccsr_options
-        .remove("ssl_key_location")
+        .remove("ssl.key.location")
         .map(|v| v.get_string(secrets_reader))
         .transpose()?;
     let cert_path = ccsr_options
-        .remove("ssl_certificate_location")
+        .remove("ssl.certificate.location")
         .map(|v| v.get_string(secrets_reader))
         .transpose()?;
     match (key_path, cert_path) {

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -131,7 +131,7 @@ fn extract(
                 .val_type
                 .process_val(&Value::String(secrets_reader.read_string(id)?))
                 .map(|_| StringOrSecret::Secret(id))
-                .map_err(|e| anyhow!("Invalid WITH option {}={}: {}", config.name, id, e))?,
+                .map_err(|e| anyhow!("Invalid WITH option {}={:?}: {}", config.name, id, e))?,
             // Check for default values
             None => match &config.default {
                 Some(v) => StringOrSecret::String(config.do_transform(v.to_string())),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -66,7 +66,7 @@ use mz_sql_parser::ast::{
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
 use crate::names::{Aug, PartialObjectName, ResolvedDataType, ResolvedObjectName};
-use crate::normalize::{self, SqlMaybeValueId};
+use crate::normalize::{self, SqlValueOrSecret};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, AggregateFunc, BinaryFunc,
@@ -1420,7 +1420,7 @@ fn plan_view_select(
     let option = options.remove("expected_group_size");
 
     let expected_group_size = match option {
-        Some(SqlMaybeValueId::Value(Value::Number(n))) => Some(n.parse::<usize>()?),
+        Some(SqlValueOrSecret::Value(Value::Number(n))) => Some(n.parse::<usize>()?),
         Some(_) => sql_bail!("expected_group_size must be a number"),
         None => None,
     };

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -66,7 +66,7 @@ use mz_sql_parser::ast::{
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
 use crate::names::{Aug, PartialObjectName, ResolvedDataType, ResolvedObjectName};
-use crate::normalize;
+use crate::normalize::{self, SqlMaybeValueId};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, AggregateFunc, BinaryFunc,
@@ -1420,7 +1420,7 @@ fn plan_view_select(
     let option = options.remove("expected_group_size");
 
     let expected_group_size = match option {
-        Some(Value::Number(n)) => Some(n.parse::<usize>()?),
+        Some(SqlMaybeValueId::Value(Value::Number(n))) => Some(n.parse::<usize>()?),
         Some(_) => sql_bail!("expected_group_size must be a number"),
         None => None,
     };

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -220,8 +220,10 @@ pub fn plan(
         Statement::CreateRole(stmt) => ddl::plan_create_role(scx, stmt),
         Statement::CreateSchema(stmt) => ddl::plan_create_schema(scx, stmt),
         Statement::CreateSecret(stmt) => ddl::plan_create_secret(scx, stmt),
-        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt),
-        Statement::CreateSource(stmt) => ddl::plan_create_source(scx, stmt),
+        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt, catalog.secrets_reader()),
+        Statement::CreateSource(stmt) => {
+            ddl::plan_create_source(scx, stmt, catalog.secrets_reader())
+        }
         Statement::CreateTable(stmt) => ddl::plan_create_table(scx, stmt),
         Statement::CreateType(stmt) => ddl::plan_create_type(scx, stmt),
         Statement::CreateView(stmt) => ddl::plan_create_view(scx, stmt, params),

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -220,10 +220,8 @@ pub fn plan(
         Statement::CreateRole(stmt) => ddl::plan_create_role(scx, stmt),
         Statement::CreateSchema(stmt) => ddl::plan_create_schema(scx, stmt),
         Statement::CreateSecret(stmt) => ddl::plan_create_secret(scx, stmt),
-        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt, catalog.secrets_reader()),
-        Statement::CreateSource(stmt) => {
-            ddl::plan_create_source(scx, stmt, catalog.secrets_reader())
-        }
+        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt),
+        Statement::CreateSource(stmt) => ddl::plan_create_source(scx, stmt),
         Statement::CreateTable(stmt) => ddl::plan_create_table(scx, stmt),
         Statement::CreateType(stmt) => ddl::plan_create_type(scx, stmt),
         Statement::CreateView(stmt) => ddl::plan_create_view(scx, stmt, params),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -297,7 +297,6 @@ pub fn describe_create_source(
 pub fn plan_create_source(
     scx: &StatementContext,
     stmt: CreateSourceStatement<Aug>,
-    secrets_reader: &SecretsReader,
 ) -> Result<Plan, anyhow::Error> {
     let CreateSourceStatement {
         name,
@@ -355,7 +354,7 @@ pub fn plan_create_source(
             let config_options = if let Some(opts) = options {
                 opts
             } else {
-                kafka_util::extract_config(&mut with_options)?
+                kafka_util::extract_config(&mut with_options, scx.catalog.secrets_reader())?
             };
 
             let group_id_prefix = match with_options.remove("group_id_prefix") {
@@ -396,10 +395,11 @@ pub fn plan_create_source(
                 Some(v) => bail!("invalid start_offset value: {}", v),
             }
 
-            let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
+            let encoding = get_encoding(scx, format, &envelope)?;
 
             // TODO(13017): don't inline secrets at this stage.  Push that into storaged.
-            let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
+            let config_options =
+                kafka_util::inline_secrets(config_options, scx.catalog.secrets_reader())?;
 
             let mut connector = KafkaSourceConnector {
                 addrs: broker.parse()?,
@@ -496,7 +496,7 @@ pub fn plan_create_source(
             let aws = normalize::aws_config(&mut with_options, Some(region.into()))?;
             let connector =
                 ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, aws });
-            let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
+            let encoding = get_encoding(scx, format, &envelope)?;
             (connector, encoding)
         }
         CreateSourceConnector::S3 {
@@ -539,7 +539,7 @@ pub fn plan_create_source(
                     Compression::None => mz_dataflow_types::sources::Compression::None,
                 },
             });
-            let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
+            let encoding = get_encoding(scx, format, &envelope)?;
             if matches!(encoding, SourceDataEncoding::KeyValue { .. }) {
                 bail!("S3 sources do not support key decoding");
             }
@@ -1184,17 +1184,16 @@ fn get_encoding(
     scx: &StatementContext,
     format: &CreateSourceFormat<Aug>,
     envelope: &Envelope<Aug>,
-    secrets_reader: &SecretsReader,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     let encoding = match format {
         CreateSourceFormat::None => bail!("Source format must be specified"),
-        CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format, secrets_reader)?,
+        CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format)?,
         CreateSourceFormat::KeyValue { key, value } => {
-            let key = match get_encoding_inner(scx, key, secrets_reader)? {
+            let key = match get_encoding_inner(scx, key)? {
                 SourceDataEncoding::Single(key) => key,
                 SourceDataEncoding::KeyValue { key, .. } => key,
             };
-            let value = match get_encoding_inner(scx, value, secrets_reader)? {
+            let value = match get_encoding_inner(scx, value)? {
                 SourceDataEncoding::Single(value) => value,
                 SourceDataEncoding::KeyValue { value, .. } => value,
             };
@@ -1217,7 +1216,6 @@ fn get_encoding(
 fn get_encoding_inner(
     scx: &StatementContext,
     format: &Format<Aug>,
-    secrets_reader: &SecretsReader,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     // Avro/CSR can return a `SourceDataEncoding::KeyValue`
     Ok(SourceDataEncoding::Single(match format {
@@ -1267,7 +1265,10 @@ fn get_encoding_inner(
                     let (mut ccsr_with_options, registry_url) = match connector {
                         CsrConnector::Inline { url } => {
                             let mut normalized_options = normalize::options(&ccsr_options)?;
-                            let options = kafka_util::extract_config_ccsr(&mut normalized_options)?;
+                            let options = kafka_util::extract_config_ccsr(
+                                &mut normalized_options,
+                                scx.catalog.secrets_reader(),
+                            )?;
                             normalize::ensure_empty_options(
                                 &normalized_options,
                                 "CONFLUENT SCHEMA REGISTRY",
@@ -1283,7 +1284,7 @@ fn get_encoding_inner(
                     let ccsr_config = kafka_util::generate_ccsr_client_config(
                         registry_url.parse()?,
                         &mut ccsr_with_options,
-                        secrets_reader,
+                        scx.catalog.secrets_reader(),
                     )?;
                     normalize::ensure_empty_options(
                         &ccsr_with_options,
@@ -1338,7 +1339,10 @@ fn get_encoding_inner(
                     let (mut ccsr_with_options, registry_url) = match connector {
                         CsrConnector::Inline { url } => {
                             let mut normalized_options = normalize::options(&ccsr_options)?;
-                            let options = kafka_util::extract_config_ccsr(&mut normalized_options)?;
+                            let options = kafka_util::extract_config_ccsr(
+                                &mut normalized_options,
+                                scx.catalog.secrets_reader(),
+                            )?;
                             normalize::ensure_empty_options(
                                 &normalized_options,
                                 "CONFLUENT SCHEMA REGISTRY",
@@ -1355,7 +1359,7 @@ fn get_encoding_inner(
                     let _ccsr_config = kafka_util::generate_ccsr_client_config(
                         registry_url.parse()?,
                         &mut ccsr_with_options,
-                        secrets_reader,
+                        scx.catalog.secrets_reader(),
                     )?;
                     normalize::ensure_empty_options(
                         &ccsr_with_options,
@@ -1774,7 +1778,6 @@ fn kafka_sink_builder(
     envelope: SinkEnvelope,
     topic_suffix_nonce: String,
     root_dependencies: &[&dyn CatalogItem],
-    secrets_reader: &SecretsReader,
 ) -> Result<SinkConnectorBuilder, anyhow::Error> {
     let consistency_topic = match with_options.remove("consistency_topic") {
         None => None,
@@ -1791,7 +1794,7 @@ fn kafka_sink_builder(
         None => false,
         Some(_) => bail!("reuse_topic must be a boolean"),
     };
-    let config_options = kafka_util::extract_config(with_options)?;
+    let config_options = kafka_util::extract_config(with_options, scx.catalog.secrets_reader())?;
 
     let avro_key_fullname = match with_options.remove("avro_key_fullname") {
         Some(SqlValueOrSecret::Value(Value::String(s))) => Some(s),
@@ -1828,15 +1831,17 @@ fn kafka_sink_builder(
                 bail!("SEED option does not make sense with sinks");
             }
             let mut normalized_with_options = normalize::options(&with_options)?;
-            let mut ccsr_with_options =
-                kafka_util::extract_config_ccsr(&mut normalized_with_options)?;
+            let mut ccsr_with_options = kafka_util::extract_config_ccsr(
+                &mut normalized_with_options,
+                scx.catalog.secrets_reader(),
+            )?;
             normalize::ensure_empty_options(&normalized_with_options, "CONFLUENT SCHEMA REGISTRY")?;
 
             let schema_registry_url = url.parse::<Url>()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 schema_registry_url.clone(),
                 &mut ccsr_with_options,
-                secrets_reader,
+                scx.catalog.secrets_reader(),
             )?;
 
             normalize::ensure_empty_options(&ccsr_with_options, "CONFLUENT SCHEMA REGISTRY")?;
@@ -1876,7 +1881,7 @@ fn kafka_sink_builder(
         reuse_topic,
         consistency,
         consistency_topic,
-        secrets_reader,
+        scx.catalog.secrets_reader(),
     )?;
 
     let broker_addrs = broker.parse()?;
@@ -1957,7 +1962,7 @@ fn kafka_sink_builder(
     let consistency_format = consistency_config.map(|config| config.1);
 
     // TODO(13017): don't inline secrets at this stage.  Push that into storaged.
-    let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
+    let config_options = kafka_util::inline_secrets(config_options, scx.catalog.secrets_reader())?;
     Ok(SinkConnectorBuilder::Kafka(KafkaSinkConnectorBuilder {
         broker_addrs,
         format,
@@ -2010,8 +2015,10 @@ fn get_kafka_sink_consistency_config(
                     bail!("SEED option does not make sense with sinks");
                 }
                 let schema_registry_url = uri.parse::<Url>()?;
-                let mut ccsr_with_options =
-                    kafka_util::extract_config_ccsr(&mut normalize::options(&with_options)?)?;
+                let mut ccsr_with_options = kafka_util::extract_config_ccsr(
+                    &mut normalize::options(&with_options)?,
+                    secrets_reader,
+                )?;
                 let ccsr_config = kafka_util::generate_ccsr_client_config(
                     schema_registry_url.clone(),
                     &mut ccsr_with_options,
@@ -2115,7 +2122,6 @@ pub fn describe_create_sink(
 pub fn plan_create_sink(
     scx: &StatementContext,
     mut stmt: CreateSinkStatement<Aug>,
-    secrets_reader: &SecretsReader,
 ) -> Result<Plan, anyhow::Error> {
     let compute_instance = match &stmt.in_cluster {
         None => scx.resolve_compute_instance(None)?.id(),
@@ -2261,7 +2267,6 @@ pub fn plan_create_sink(
             envelope,
             suffix_nonce,
             &root_user_dependencies,
-            secrets_reader,
         )?,
         CreateSinkConnector::Persist {
             consensus_uri,
@@ -2900,7 +2905,10 @@ pub fn plan_create_connector(
             let mut with_options = normalize::options(&with_options)?;
             ConnectorInner::Kafka {
                 broker: broker.parse()?,
-                config_options: kafka_util::extract_config(&mut with_options)?,
+                config_options: kafka_util::extract_config(
+                    &mut with_options,
+                    scx.catalog.secrets_reader(),
+                )?,
             }
         }
         CreateConnector::CSR {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -40,9 +40,9 @@ use mz_dataflow_types::sources::encoding::{
 use mz_dataflow_types::sources::{
     provide_default_metadata, ConnectorInner, DebeziumDedupProjection, DebeziumEnvelope,
     DebeziumMode, DebeziumSourceProjection, DebeziumTransactionMetadata, ExternalSourceConnector,
-    IncludedColumnPos, KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, MaybeStringId,
-    MzOffset, PostgresSourceConnector, PubNubSourceConnector, S3SourceConnector, SourceConnector,
-    SourceEnvelope, Timeline, UnplannedSourceEnvelope, UpsertStyle,
+    IncludedColumnPos, KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, MzOffset,
+    PostgresSourceConnector, PubNubSourceConnector, S3SourceConnector, SourceConnector,
+    SourceEnvelope, StringOrSecret, Timeline, UnplannedSourceEnvelope, UpsertStyle,
 };
 use mz_expr::CollectionPlan;
 use mz_interchange::avro::{self, AvroSchemaGenerator};
@@ -1301,10 +1301,10 @@ fn get_encoding_inner(
                                     (
                                         k,
                                         match v {
-                                            MaybeStringId::String(s) => {
+                                            StringOrSecret::String(s) => {
                                                 SqlMaybeValueId::Value(Value::String(s))
                                             }
-                                            MaybeStringId::Secret(id) => {
+                                            StringOrSecret::Secret(id) => {
                                                 SqlMaybeValueId::Secret(id)
                                             }
                                         },
@@ -1316,7 +1316,6 @@ fn get_encoding_inner(
                     };
                     let ccsr_config = kafka_util::generate_ccsr_client_config(
                         registry_url.parse()?,
-                        &kafka_util::extract_config(&mut normalize::options(with_options)?)?,
                         &mut ccsr_with_options,
                         secrets_reader,
                     )?;
@@ -1385,10 +1384,10 @@ fn get_encoding_inner(
                                     (
                                         k,
                                         match v {
-                                            MaybeStringId::String(s) => {
+                                            StringOrSecret::String(s) => {
                                                 SqlMaybeValueId::Value(Value::String(s))
                                             }
-                                            MaybeStringId::Secret(id) => {
+                                            StringOrSecret::Secret(id) => {
                                                 SqlMaybeValueId::Secret(id)
                                             }
                                         },
@@ -1401,7 +1400,6 @@ fn get_encoding_inner(
                     // We validate here instead of in purification, to match the behavior of avro
                     let _ccsr_config = kafka_util::generate_ccsr_client_config(
                         registry_url.parse()?,
-                        &kafka_util::extract_config(&mut normalize::options(with_options)?)?,
                         &mut ccsr_with_options,
                         secrets_reader,
                     )?;
@@ -1880,7 +1878,6 @@ fn kafka_sink_builder(
             let schema_registry_url = url.parse::<Url>()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 schema_registry_url.clone(),
-                &config_options,
                 &mut ccsr_with_options,
                 secrets_reader,
             )?;
@@ -2035,7 +2032,7 @@ fn kafka_sink_builder(
 fn get_kafka_sink_consistency_config(
     topic_prefix: &str,
     sink_format: &KafkaSinkFormat,
-    config_options: &BTreeMap<String, MaybeStringId>,
+    config_options: &BTreeMap<String, StringOrSecret>,
     reuse_topic: bool,
     consistency: Option<KafkaConsistency<Aug>>,
     consistency_topic: Option<String>,
@@ -2061,7 +2058,6 @@ fn get_kafka_sink_consistency_config(
                 let mut ccsr_with_options = normalize::options(&with_options)?;
                 let ccsr_config = kafka_util::generate_ccsr_client_config(
                     schema_registry_url.clone(),
-                    config_options,
                     &mut ccsr_with_options,
                     secrets_reader,
                 )?;
@@ -2964,8 +2960,8 @@ pub fn plan_create_connector(
                         (
                             k.to_owned(),
                             match v {
-                                SqlMaybeValueId::Value(v) => MaybeStringId::String(v.to_string()),
-                                SqlMaybeValueId::Secret(id) => MaybeStringId::Secret(id.clone()),
+                                SqlMaybeValueId::Value(v) => StringOrSecret::String(v.to_string()),
+                                SqlMaybeValueId::Secret(id) => StringOrSecret::Secret(id.clone()),
                             },
                         )
                     })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -79,7 +79,7 @@ use crate::names::{
     ResolvedDataType, ResolvedDatabaseSpecifier, ResolvedObjectName, SchemaSpecifier,
 };
 use crate::normalize::ident;
-use crate::normalize::{self, SqlMaybeValueId};
+use crate::normalize::{self, SqlValueOrSecret};
 use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
 use crate::plan::statement::{StatementContext, StatementDesc};
@@ -318,7 +318,7 @@ pub fn plan_create_source(
     let mut with_options = normalize::options(with_options_original)?;
 
     let ts_frequency = match with_options.remove("timestamp_frequency_ms") {
-        Some(val) => match val.try_into_value() {
+        Some(val) => match val.into() {
             Some(Value::Number(n)) => match n.parse::<u64>() {
                 Ok(n) => Duration::from_millis(n),
                 Err(_) => bail!("timestamp_frequency_ms must be an u64"),
@@ -360,7 +360,7 @@ pub fn plan_create_source(
 
             let group_id_prefix = match with_options.remove("group_id_prefix") {
                 None => None,
-                Some(SqlMaybeValueId::Value(Value::String(s))) => Some(s),
+                Some(SqlValueOrSecret::Value(Value::String(s))) => Some(s),
                 Some(_) => bail!("group_id_prefix must be a string"),
             };
 
@@ -380,10 +380,10 @@ pub fn plan_create_source(
                 None => {
                     start_offsets.insert(0, MzOffset::from(0));
                 }
-                Some(SqlMaybeValueId::Value(Value::Number(n))) => {
+                Some(SqlValueOrSecret::Value(Value::Number(n))) => {
                     start_offsets.insert(0, parse_offset(&n)?);
                 }
-                Some(SqlMaybeValueId::Value(Value::Array(vs))) => {
+                Some(SqlValueOrSecret::Value(Value::Array(vs))) => {
                     for (i, v) in vs.iter().enumerate() {
                         match v {
                             Value::Number(n) => {
@@ -685,7 +685,7 @@ pub fn plan_create_source(
                             Ok(_) => Cow::from("ordered"),
                             Err(_) => Cow::from("none"),
                         },
-                        Some(SqlMaybeValueId::Value(Value::String(s))) => Cow::from(s),
+                        Some(SqlValueOrSecret::Value(Value::String(s))) => Cow::from(s),
                         _ => bail!("deduplication option must be a string"),
                     };
 
@@ -727,13 +727,13 @@ pub fn plan_create_source(
 
                             let dedup_start = match with_options.remove("deduplication_start") {
                                 None => None,
-                                Some(SqlMaybeValueId::Value(Value::String(start))) => Some(parse_datetime(&start)?),
+                                Some(SqlValueOrSecret::Value(Value::String(start))) => Some(parse_datetime(&start)?),
                                 _ => bail!("deduplication_start option must be a string"),
                             };
 
                             let dedup_end = match with_options.remove("deduplication_end") {
                                 None => None,
-                                Some(SqlMaybeValueId::Value(Value::String(end))) => Some(parse_datetime(&end)?),
+                                Some(SqlValueOrSecret::Value(Value::String(end))) => Some(parse_datetime(&end)?),
                                 _ => bail!("deduplication_end option must be a string"),
                             };
 
@@ -750,7 +750,7 @@ pub fn plan_create_source(
                                     let pad_start =
                                         match with_options.remove("deduplication_pad_start") {
                                             None => None,
-                                            Some(SqlMaybeValueId::Value(Value::String(pad_start))) => {
+                                            Some(SqlValueOrSecret::Value(Value::String(pad_start))) => {
                                                 Some(parse_datetime(&pad_start)?)
                                             }
                                             _ => bail!(
@@ -838,7 +838,7 @@ pub fn plan_create_source(
 
     let ignore_source_keys = match with_options.remove("ignore_source_keys") {
         None => false,
-        Some(SqlMaybeValueId::Value(Value::Boolean(b))) => b,
+        Some(SqlValueOrSecret::Value(Value::Boolean(b))) => b,
         Some(_) => bail!("ignore_source_keys must be a boolean"),
     };
 
@@ -895,7 +895,7 @@ pub fn plan_create_source(
 
     // Allow users to specify a timeline. If they do not, determine a default timeline for the source.
     let timeline = if let Some(timeline) = with_options.remove("timeline") {
-        match timeline.try_into_value() {
+        match timeline.into() {
             Some(Value::String(timeline)) => Timeline::User(timeline),
             Some(v) => bail!("unsupported timeline value {}", v.to_ast_string()),
             None => bail!("unsupported timeline value: secret"),
@@ -904,7 +904,7 @@ pub fn plan_create_source(
         match envelope {
             SourceEnvelope::CdcV2 => match with_options.remove("epoch_ms_timeline") {
                 None => Timeline::External(name.to_string()),
-                Some(SqlMaybeValueId::Value(Value::Boolean(true))) => Timeline::EpochMilliseconds,
+                Some(SqlValueOrSecret::Value(Value::Boolean(true))) => Timeline::EpochMilliseconds,
                 Some(v) => bail!("unsupported epoch_ms_timeline value {}", v),
             },
             _ => Timeline::EpochMilliseconds,
@@ -1759,7 +1759,7 @@ fn kafka_sink_builder(
     scx: &StatementContext,
     format: Option<Format<Aug>>,
     consistency: Option<KafkaConsistency<Aug>>,
-    with_options: &mut BTreeMap<String, SqlMaybeValueId>,
+    with_options: &mut BTreeMap<String, SqlValueOrSecret>,
     broker: String,
     topic_prefix: String,
     relation_key_indices: Option<Vec<usize>>,
@@ -1772,7 +1772,7 @@ fn kafka_sink_builder(
 ) -> Result<SinkConnectorBuilder, anyhow::Error> {
     let consistency_topic = match with_options.remove("consistency_topic") {
         None => None,
-        Some(SqlMaybeValueId::Value(Value::String(topic))) => Some(topic),
+        Some(SqlValueOrSecret::Value(Value::String(topic))) => Some(topic),
         Some(_) => bail!("consistency_topic must be a string"),
     };
     if consistency_topic.is_some() && consistency.is_some() {
@@ -1781,14 +1781,14 @@ fn kafka_sink_builder(
         bail!("Cannot specify consistency_topic and CONSISTENCY options simultaneously");
     }
     let reuse_topic = match with_options.remove("reuse_topic") {
-        Some(SqlMaybeValueId::Value(Value::Boolean(b))) => b,
+        Some(SqlValueOrSecret::Value(Value::Boolean(b))) => b,
         None => false,
         Some(_) => bail!("reuse_topic must be a boolean"),
     };
     let config_options = kafka_util::extract_config(with_options)?;
 
     let avro_key_fullname = match with_options.remove("avro_key_fullname") {
-        Some(SqlMaybeValueId::Value(Value::String(s))) => Some(s),
+        Some(SqlValueOrSecret::Value(Value::String(s))) => Some(s),
         None => None,
         Some(_) => bail!("avro_key_fullname must be a string"),
     };
@@ -1798,7 +1798,7 @@ fn kafka_sink_builder(
     }
 
     let avro_value_fullname = match with_options.remove("avro_value_fullname") {
-        Some(SqlMaybeValueId::Value(Value::String(s))) => Some(s),
+        Some(SqlValueOrSecret::Value(Value::String(s))) => Some(s),
         None => None,
         Some(_) => bail!("avro_value_fullname must be a string"),
     };
@@ -1898,7 +1898,7 @@ fn kafka_sink_builder(
     // Use the user supplied value for partition count, or default to -1 (broker default)
     let partition_count = match with_options.remove("partition_count") {
         None => -1,
-        Some(SqlMaybeValueId::Value(Value::Number(n))) => n.parse::<i32>()?,
+        Some(SqlValueOrSecret::Value(Value::Number(n))) => n.parse::<i32>()?,
         Some(_) => bail!("partition count for sink topics must be an integer"),
     };
 
@@ -1911,7 +1911,7 @@ fn kafka_sink_builder(
     // Use the user supplied value for replication factor, or default to -1 (broker default)
     let replication_factor = match with_options.remove("replication_factor") {
         None => -1,
-        Some(SqlMaybeValueId::Value(Value::Number(n))) => n.parse::<i32>()?,
+        Some(SqlValueOrSecret::Value(Value::Number(n))) => n.parse::<i32>()?,
         Some(_) => bail!("replication factor for sink topics must be an integer"),
     };
 
@@ -1923,7 +1923,7 @@ fn kafka_sink_builder(
 
     let retention_duration = match with_options.remove("retention_ms") {
         None => None,
-        Some(SqlMaybeValueId::Value(Value::Number(n))) => match n.parse::<i64>()? {
+        Some(SqlValueOrSecret::Value(Value::Number(n))) => match n.parse::<i64>()? {
             -1 => Some(None),
             millis @ 0.. => Some(Some(Duration::from_millis(millis as u64))),
             _ => bail!("retention ms for sink topics must be greater than or equal to -1"),
@@ -1933,7 +1933,7 @@ fn kafka_sink_builder(
 
     let retention_bytes = match with_options.remove("retention_bytes") {
         None => None,
-        Some(SqlMaybeValueId::Value(Value::Number(n))) => Some(n.parse::<i64>()?),
+        Some(SqlValueOrSecret::Value(Value::Number(n))) => Some(n.parse::<i64>()?),
         Some(_) => bail!("retention bytes for sink topics must be an integer"),
     };
 
@@ -2908,8 +2908,8 @@ pub fn plan_create_connector(
                         (
                             k.to_owned(),
                             match v {
-                                SqlMaybeValueId::Value(v) => StringOrSecret::String(v.to_string()),
-                                SqlMaybeValueId::Secret(id) => StringOrSecret::Secret(id.clone()),
+                                SqlValueOrSecret::Value(v) => StringOrSecret::String(v.to_string()),
+                                SqlValueOrSecret::Secret(id) => StringOrSecret::Secret(id.clone()),
                             },
                         )
                     })

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -398,7 +398,7 @@ pub fn plan_create_source(
 
             let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
 
-            // XXX(chae): is this the place to inline? Or should it get delayed until we actually connect to kafka?
+            // TODO(13017): don't inline secrets at this stage.  Push that into storaged.
             let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
 
             let mut connector = KafkaSourceConnector {
@@ -1956,7 +1956,7 @@ fn kafka_sink_builder(
     let consistency_topic = consistency_config.clone().map(|config| config.0);
     let consistency_format = consistency_config.map(|config| config.1);
 
-    // XXX(chae): is this where secrets should be inlined for kafka sinks??  "End of planning"?
+    // TODO(13017): don't inline secrets at this stage.  Push that into storaged.
     let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
     Ok(SinkConnectorBuilder::Kafka(KafkaSinkConnectorBuilder {
         broker_addrs,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -70,7 +70,7 @@ use crate::ast::{
     ReplicaOption, ReplicaOptionName, Select, SelectItem, SetExpr, SourceIncludeMetadata,
     SourceIncludeMetadataType, Statement, SubscriptPosition, TableConstraint, TableFactor,
     TableWithJoins, UnresolvedDatabaseName, UnresolvedObjectName, Value, ViewDefinition,
-    WithOption, WithOptionValue,
+    WithOptionValue,
 };
 use crate::catalog::{CatalogItem, CatalogItemType, CatalogType, CatalogTypeDetails};
 use crate::kafka_util;
@@ -1265,12 +1265,15 @@ fn get_encoding_inner(
                         },
                 } => {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => (
-                            kafka_util::extract_config_ccsr(&mut normalize::options(
-                                &ccsr_options,
-                            )?)?,
-                            url.into(),
-                        ),
+                        CsrConnector::Inline { url } => {
+                            let mut normalized_options = normalize::options(&ccsr_options)?;
+                            let options = kafka_util::extract_config_ccsr(&mut normalized_options)?;
+                            normalize::ensure_empty_options(
+                                &normalized_options,
+                                "CONFLUENT SCHEMA REGISTRY",
+                            )?;
+                            (options, url.into())
+                        }
                         CsrConnector::Reference { connector } => {
                             let item = scx.get_item_by_resolved_name(&connector)?;
                             let connector = item.catalog_connector()?;
@@ -1333,12 +1336,15 @@ fn get_encoding_inner(
                     seed
                 {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => (
-                            kafka_util::extract_config_ccsr(&mut normalize::options(
-                                &ccsr_options,
-                            )?)?,
-                            url.to_string(),
-                        ),
+                        CsrConnector::Inline { url } => {
+                            let mut normalized_options = normalize::options(&ccsr_options)?;
+                            let options = kafka_util::extract_config_ccsr(&mut normalized_options)?;
+                            normalize::ensure_empty_options(
+                                &normalized_options,
+                                "CONFLUENT SCHEMA REGISTRY",
+                            )?;
+                            (options, url.into())
+                        }
                         CsrConnector::Reference { connector } => {
                             let item = scx.get_item_by_resolved_name(&connector)?;
                             let connector = item.catalog_connector()?;
@@ -1821,8 +1827,10 @@ fn kafka_sink_builder(
             if seed.is_some() {
                 bail!("SEED option does not make sense with sinks");
             }
+            let mut normalized_with_options = normalize::options(&with_options)?;
             let mut ccsr_with_options =
-                kafka_util::extract_config_ccsr(&mut normalize::options(&with_options)?)?;
+                kafka_util::extract_config_ccsr(&mut normalized_with_options)?;
+            normalize::ensure_empty_options(&normalized_with_options, "CONFLUENT SCHEMA REGISTRY")?;
 
             let schema_registry_url = url.parse::<Url>()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
@@ -1830,6 +1838,8 @@ fn kafka_sink_builder(
                 &mut ccsr_with_options,
                 secrets_reader,
             )?;
+
+            normalize::ensure_empty_options(&ccsr_with_options, "CONFLUENT SCHEMA REGISTRY")?;
 
             let include_transaction =
                 reuse_topic || consistency_topic.is_some() || consistency.is_some();
@@ -1847,8 +1857,6 @@ fn kafka_sink_builder(
             let key_schema = schema_generator
                 .key_writer_schema()
                 .map(|key_schema| key_schema.to_string());
-
-            normalize::ensure_empty_options(&ccsr_with_options, "CONFLUENT SCHEMA REGISTRY")?;
 
             KafkaSinkFormat::Avro {
                 schema_registry_url,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -328,7 +328,7 @@ async fn purify_csr_connector_proto(
             .parse()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
-                &mut normalize::options(&ccsr_options)?,
+                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
                 catalog.secrets_reader(),
             )?;
 
@@ -389,7 +389,7 @@ async fn purify_csr_connector_avro(
         let ccsr_config = task::block_in_place(|| {
             kafka_util::generate_ccsr_client_config(
                 url,
-                &mut normalize::options(ccsr_options)?,
+                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
                 catalog.secrets_reader(),
             )
         })?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context};
 use aws_arn::ARN;
-use mz_dataflow_types::sources::MaybeStringId;
+use mz_dataflow_types::sources::StringOrSecret;
 use mz_sql_parser::ast::{CsrConnector, KafkaConnector, KafkaSourceConnector};
 use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
@@ -199,7 +199,7 @@ async fn purify_source_format(
     format: &mut CreateSourceFormat<Aug>,
     connector: &mut CreateSourceConnector<Aug>,
     envelope: &Option<Envelope<Aug>>,
-    connector_options: &BTreeMap<String, MaybeStringId>,
+    connector_options: &BTreeMap<String, StringOrSecret>,
     with_options: &Vec<WithOption<Aug>>,
 ) -> Result<(), anyhow::Error> {
     if matches!(format, CreateSourceFormat::KeyValue { .. })
@@ -271,7 +271,7 @@ async fn purify_source_format_single(
     format: &mut Format<Aug>,
     connector: &mut CreateSourceConnector<Aug>,
     envelope: &Option<Envelope<Aug>>,
-    connector_options: &BTreeMap<String, MaybeStringId>,
+    connector_options: &BTreeMap<String, StringOrSecret>,
     with_options: &Vec<WithOption<Aug>>,
 ) -> Result<(), anyhow::Error> {
     match format {
@@ -389,7 +389,6 @@ async fn purify_csr_connector_proto(
             let kafka_options = kafka_util::extract_config(&mut normalize::options(with_options)?)?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
-                &kafka_options,
                 &mut normalize::options(&ccsr_options)?,
                 catalog.secrets_reader(),
             )?;
@@ -423,7 +422,7 @@ async fn purify_csr_connector_avro(
     connector: &mut CreateSourceConnector<Aug>,
     csr_connector: &mut CsrConnectorAvro<Aug>,
     envelope: &Option<Envelope<Aug>>,
-    connector_options: &BTreeMap<String, MaybeStringId>,
+    connector_options: &BTreeMap<String, StringOrSecret>,
 ) -> Result<(), anyhow::Error> {
     let topic = if let CreateSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) = connector
     {
@@ -452,7 +451,6 @@ async fn purify_csr_connector_avro(
         let ccsr_config = task::block_in_place(|| {
             kafka_util::generate_ccsr_client_config(
                 url,
-                &connector_options,
                 &mut normalize::options(ccsr_options)?,
                 catalog.secrets_reader(),
             )

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -83,7 +83,7 @@ pub async fn purify_create_source(
                 }
                 KafkaConnector::Inline { broker } => (
                     broker.to_string(),
-                    kafka_util::extract_config(&mut with_options_map)?,
+                    kafka_util::extract_config(&mut with_options_map, catalog.secrets_reader())?,
                 ),
             };
             let consumer = kafka_util::create_consumer(
@@ -328,7 +328,10 @@ async fn purify_csr_connector_proto(
             .parse()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
-                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
+                &mut kafka_util::extract_config_ccsr(
+                    &mut normalize::options(&ccsr_options)?,
+                    catalog.secrets_reader(),
+                )?,
                 catalog.secrets_reader(),
             )?;
 
@@ -389,7 +392,10 @@ async fn purify_csr_connector_avro(
         let ccsr_config = task::block_in_place(|| {
             kafka_util::generate_ccsr_client_config(
                 url,
-                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
+                &mut kafka_util::extract_config_ccsr(
+                    &mut normalize::options(&ccsr_options)?,
+                    catalog.secrets_reader(),
+                )?,
                 catalog.secrets_reader(),
             )
         })?;

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -22,6 +22,7 @@ use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
+use mz_secrets::SecretsReader;
 
 use crate::ast::Expr;
 use crate::catalog::{
@@ -292,6 +293,10 @@ impl SessionCatalog for TestCatalog {
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
         name
+    }
+
+    fn secrets_reader(&self) -> &SecretsReader {
+        unimplemented!()
     }
 }
 

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -66,6 +66,47 @@ a
 1
 2
 
+> CREATE SECRET ssl_key_location_kafka AS '/share/secrets/materialized-kafka.key'
+
+> CREATE SECRET ssl_certificate_location_kafka AS '/share/secrets/materialized-kafka.crt'
+
+> CREATE SECRET ssl_key_password_kafka AS 'mzmzmz'
+
+> CREATE SECRET ssl_key_location_csr AS '/share/secrets/materialized-schema-registry.key'
+
+> CREATE SECRET ssl_certificate_location_csr  AS '/share/secrets/materialized-schema-registry.crt'
+
+> CREATE SECRET username_csr AS 'materialize'
+
+> CREATE SECRET password_csr AS 'sekurity'
+
+> CREATE SECRET ssl_ca_location AS '/share/secrets/ca.crt'
+
+> CREATE MATERIALIZED SOURCE data_secret
+  FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+      security_protocol = 'SSL',
+      ssl_key_location = SECRET ssl_key_location_kafka,
+      ssl_certificate_location = SECRET ssl_certificate_location_kafka,
+      ssl_ca_location = SECRET ssl_ca_location,
+      ssl_key_password = SECRET ssl_key_password_kafka
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      ssl_key_location = SECRET ssl_key_location_csr,
+      ssl_certificate_location = SECRET ssl_certificate_location_csr,
+      ssl_ca_location = SECRET ssl_ca_location,
+      username = SECRET username_csr,
+      password = SECRET password_csr
+  )
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM data_secret
+a
+---
+1
+2
+
 # Ensure that our test infra correctly sets up certs by failing when CSR is not
 # specifically configured
 ! CREATE MATERIALIZED SOURCE data

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -165,6 +165,15 @@ contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport 
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:Invalid WITH option ssl_certificate_location='foo': file does not exist
 
+> CREATE SECRET invalid_ssl_certificate_location_secret AS 'foo'
+
+! CREATE SINK invalid_ssl_certificate_location FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (security_protocol = SSL , ssl_certificate_location = SECRET invalid_ssl_certificate_location_secret)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+regex:Invalid WITH option ssl_certificate_location=.*: file does not exist
+
 ! CREATE SINK invalid_ssl_key_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
@@ -172,12 +181,30 @@ contains:Invalid WITH option ssl_certificate_location='foo': file does not exist
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:Invalid WITH option ssl_key_location='foo': file does not exist
 
+> CREATE SECRET invalid_ssl_key_location_secret AS 'foo'
+
+! CREATE SINK invalid_ssl_key_location FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (security_protocol = SSL , ssl_key_location = SECRET invalid_ssl_key_location_secret)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+regex:Invalid WITH option ssl_key_location=.*: file does not exist
+
 ! CREATE SINK invalid_ssl_ca_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = SSL , ssl_ca_location = 'foo')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:Invalid WITH option ssl_ca_location='foo': file does not exist
+
+> CREATE SECRET invalid_ssl_ca_location_secret AS 'foo'
+
+! CREATE SINK invalid_ssl_ca_location FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (security_protocol = SSL , ssl_ca_location = SECRET invalid_ssl_ca_location_secret)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+regex:Invalid WITH option ssl_ca_location=.*: file does not exist
 
 #
 # Kerberos options


### PR DESCRIPTION
Introduce two new types:
- In sql-land: `SqlValueOrSecret`, an enum which can hold either a `Value` or a `GlobalId`
- In dataflow-land: `StringOrSecret`, an enum which can hold either a `String` or a `GlobalId`

We put a `SecretsReader` in the catalog so that it's accessible as we get to planning sources and sinks.  Currently we inline during planning -- however, there's a follow-up task (#13017) to pass a `SecretsReader` to storaged so it can inline at the last minute.

### Motivation
#12983 
Part of #11504 

### Tips for reviewer

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Can use `SECRET`s for Kafka and CSR with options
