### PR TITLE
materialized: switch storage to postgres stash

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -107,13 +107,14 @@ def main() -> int:
             if args.reset:
                 print("Removing mzdata directory...")
                 shutil.rmtree("mzdata", ignore_errors=True)
-            for schema in ["consensus", "catalog"]:
+            for schema in ["consensus", "catalog", "storage"]:
                 if args.reset:
                     _run_sql(args.postgres, f"DROP SCHEMA IF EXISTS {schema} CASCADE")
                 _run_sql(args.postgres, f"CREATE SCHEMA IF NOT EXISTS {schema}")
             command += [
                 f"--persist-consensus-url={args.postgres}?options=--search_path=consensus",
                 f"--catalog-postgres-stash={args.postgres}?options=--search_path=catalog",
+                f"--storage-postgres-stash={args.postgres}?options=--search_path=storage",
             ]
         elif args.program == "sqllogictest":
             command += [f"--postgres-url={args.postgres}"]

--- a/src/materialized/ci/entrypoint.sh
+++ b/src/materialized/ci/entrypoint.sh
@@ -15,10 +15,12 @@ pg_ctlcluster 14 materialize start
 
 psql -Atc "CREATE SCHEMA IF NOT EXISTS consensus"
 psql -Atc "CREATE SCHEMA IF NOT EXISTS catalog"
+psql -Atc "CREATE SCHEMA IF NOT EXISTS storage"
 
 exec materialized \
     --sql-listen-addr=0.0.0.0:6875 \
     --http-listen-addr=0.0.0.0:6876 \
     "--persist-consensus-url=postgresql://materialize@$(hostname):5432?options=--search_path=consensus" \
     "--catalog-postgres-stash=postgresql://materialize@$(hostname):5432?options=--search_path=catalog" \
+    "--storage-postgres-stash=postgresql://materialize@$(hostname):5432?options=--search_path=storage" \
     "$@"

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -348,6 +348,9 @@ pub struct Args {
     /// Postgres catalog stash connection string.
     #[clap(long, env = "CATALOG_POSTGRES_STASH", value_name = "POSTGRES_URL")]
     catalog_postgres_stash: String,
+    /// Postgres storage stash connection string.
+    #[clap(long, env = "STORAGE_POSTGRES_STASH", value_name = "POSTGRES_URL")]
+    storage_postgres_stash: String,
 
     // === AWS options. ===
     /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
@@ -582,6 +585,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         consensus_uri: args.persist_consensus_url.to_string(),
     };
     let catalog_postgres_stash = Some(args.catalog_postgres_stash);
+    let storage_postgres_stash = args.storage_postgres_stash;
 
     // When inside a cgroup with a cpu limit,
     // the logical cpus can be lower than the physical cpus.
@@ -684,6 +688,7 @@ max log level: {max_log_level}",
         data_directory,
         persist_location,
         catalog_postgres_stash,
+        storage_postgres_stash,
         orchestrator,
         secrets_controller: Some(secrets_controller),
         unsafe_mode: args.unsafe_mode,

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -100,6 +100,8 @@ pub struct Config {
     /// Optional Postgres connection string which will use Postgres as the metadata
     /// stash instead of sqlite from the `data_directory`.
     pub catalog_postgres_stash: Option<String>,
+    /// Postgres connection string for storage's stash.
+    pub storage_postgres_stash: String,
 
     // === Connector options. ===
     /// Configuration for source and sink connectors created by the storage
@@ -349,7 +351,7 @@ async fn serve_stash<S: mz_stash::Append + 'static>(
 
     // Initialize dataflow controller.
     let storage_controller = mz_dataflow_types::client::controller::storage::Controller::new(
-        config.data_directory,
+        config.storage_postgres_stash,
         config.persist_location,
         orchestrator.orchestrator.namespace("storage"),
         config.orchestrator.storaged_image,


### PR DESCRIPTION
Storage is the last remaining use of sqlite stash in non-tests. Change it to use postgres like the others.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
