### PR TITLE
materialized: require catalog postgres stash url

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -584,7 +584,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         },
         consensus_uri: args.persist_consensus_url.to_string(),
     };
-    let catalog_postgres_stash = Some(args.catalog_postgres_stash);
+    let catalog_postgres_stash = args.catalog_postgres_stash;
     let storage_postgres_stash = args.storage_postgres_stash;
 
     // When inside a cgroup with a cpu limit,

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -161,7 +161,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             consensus_uri,
         },
         data_directory: data_directory.clone(),
-        catalog_postgres_stash: Some(catalog_postgres_stash),
+        catalog_postgres_stash,
         storage_postgres_stash,
         orchestrator: OrchestratorConfig {
             backend: OrchestratorBackend::Process(ProcessOrchestratorConfig {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -595,7 +595,7 @@ impl Runner {
                 blob_uri: format!("file://{}/persist/blob", temp_dir.path().display()),
                 consensus_uri,
             },
-            catalog_postgres_stash: Some(catalog_postgres_stash),
+            catalog_postgres_stash,
             storage_postgres_stash,
             orchestrator: OrchestratorConfig {
                 backend: OrchestratorBackend::Process(ProcessOrchestratorConfig {


### PR DESCRIPTION
The postgres catalog is now always used everywhere. Require its use and remove the sqlite Coord branch.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
