### PR TITLE
persist: flush out update batches to s3 to bound memory use

### DIFF
--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -22,7 +22,7 @@ use mz_persist::postgres::{PostgresConsensus, PostgresConsensusConfig};
 use mz_persist::s3::{S3BlobConfig, S3BlobMulti};
 use mz_persist::workload::DataGenerator;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::PersistClient;
+use mz_persist_client::{PersistClient, PersistConfig};
 use mz_persist_types::Codec64;
 
 // The "plumbing" and "porcelain" names are from git [1]. Our "plumbing"
@@ -96,7 +96,7 @@ pub fn bench_persist(c: &mut Criterion) {
 async fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
     let blob = Arc::new(MemBlobMulti::open(MemBlobMultiConfig::default()));
     let consensus = Arc::new(MemConsensus::default());
-    PersistClient::new(blob, consensus).await
+    PersistClient::new(PersistConfig::default(), blob, consensus).await
 }
 
 async fn create_file_pg_client() -> Result<Option<(PersistClient, TempDir)>, ExternalError> {
@@ -110,7 +110,7 @@ async fn create_file_pg_client() -> Result<Option<(PersistClient, TempDir)>, Ext
     let blob = Arc::new(FileBlobMulti::open(file).await?) as Arc<dyn BlobMulti + Send + Sync>;
     let consensus =
         Arc::new(PostgresConsensus::open(pg).await?) as Arc<dyn Consensus + Send + Sync>;
-    let client = PersistClient::new(blob, consensus).await?;
+    let client = PersistClient::new(PersistConfig::default(), blob, consensus).await?;
     Ok(Some((client, dir)))
 }
 
@@ -127,7 +127,7 @@ async fn create_s3_pg_client() -> Result<Option<PersistClient>, ExternalError> {
     let blob = Arc::new(S3BlobMulti::open(s3).await?) as Arc<dyn BlobMulti + Send + Sync>;
     let consensus =
         Arc::new(PostgresConsensus::open(pg).await?) as Arc<dyn Consensus + Send + Sync>;
-    let client = PersistClient::new(blob, consensus).await?;
+    let client = PersistClient::new(PersistConfig::default(), blob, consensus).await?;
     Ok(Some(client))
 }
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -27,7 +27,7 @@ use mz_persist::location::{BlobMulti, Consensus, ExternalError};
 use mz_persist::unreliable::{UnreliableBlobMulti, UnreliableConsensus, UnreliableHandle};
 use mz_persist_client::read::{Listen, ListenEvent, ReadHandle};
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{PersistClient, ShardId};
+use mz_persist_client::{PersistClient, PersistConfig, ShardId};
 
 use crate::maelstrom::api::{Body, ErrorCode, MaelstromError, NodeId, ReqTxnOp, ResTxnOp};
 use crate::maelstrom::node::{Handle, Service};
@@ -449,7 +449,7 @@ impl Service for TransactorService {
             as Arc<dyn Consensus + Send + Sync>;
 
         // Wire up the TransactorService.
-        let client = PersistClient::new(blob, consensus).await?;
+        let client = PersistClient::new(PersistConfig::default(), blob, consensus).await?;
         let transactor = Transactor::new(&client, shard_id).await?;
         let service = TransactorService(Arc::new(Mutex::new(transactor)));
         Ok(service)

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -33,7 +33,7 @@ use tracing::{error, trace};
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist::location::{BlobMulti, Consensus, ExternalError};
 use mz_persist::unreliable::{UnreliableBlobMulti, UnreliableConsensus, UnreliableHandle};
-use mz_persist_client::{PersistClient, PersistLocation};
+use mz_persist_client::{PersistClient, PersistConfig, PersistLocation};
 
 use self::impls::ConsensusTimestamper;
 use self::impls::PersistConsensus;
@@ -193,7 +193,7 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         as Arc<dyn BlobMulti + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
-    PersistClient::new(blob, consensus).await
+    PersistClient::new(PersistConfig::default(), blob, consensus).await
 }
 
 mod api {

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -1,0 +1,318 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A handle to a batch of updates
+
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
+use mz_persist::indexed::columnar::ColumnarRecordsVecBuilder;
+use mz_persist::indexed::encoding::BlobTraceBatchPart;
+use mz_persist::location::{Atomicity, BlobMulti};
+use mz_persist_types::{Codec, Codec64};
+use timely::progress::{Antichain, Timestamp};
+use tracing::{debug_span, instrument, warn, Instrument};
+use uuid::Uuid;
+
+use crate::error::InvalidUsage;
+use crate::r#impl::machine::{retry_external, FOREVER};
+use crate::ShardId;
+
+/// A handle to a batch of updates that has been written to blob storage but
+/// which has not yet been appended to a shard.
+///
+/// A [Batch] needs to be marked as consumed or it needs to be deleted via [Self::delete].
+/// Otherwise, a dangling batch will leak and backing blobs will remain in blob storage.
+#[derive(Debug)]
+pub struct Batch<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    /// [Description] of updates contained in this batch.
+    desc: Description<T>,
+
+    shard_id: ShardId,
+
+    /// Keys to blobs that make up this batch of updates.
+    pub(crate) blob_keys: Vec<String>,
+
+    /// Handle to the [BlobMulti] that the blobs of this batch were uploaded to.
+    _blob: Arc<dyn BlobMulti + Send + Sync>,
+
+    // These provide a bit more safety against appending a batch with the wrong
+    // type to a shard.
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+impl<K, V, T, D> Drop for Batch<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    fn drop(&mut self) {
+        if self.blob_keys.len() > 0 {
+            warn!(
+                "un-consumed Batch, with {} dangling blob keys: {:?}",
+                self.blob_keys.len(),
+                self.blob_keys
+            );
+        }
+    }
+}
+
+impl<K, V, T, D> Batch<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    pub(crate) fn new(
+        blob: Arc<dyn BlobMulti + Send + Sync>,
+        shard_id: ShardId,
+        desc: Description<T>,
+        blob_keys: Vec<String>,
+    ) -> Self {
+        Self {
+            desc,
+            blob_keys,
+            shard_id,
+            _blob: blob,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// The `shard_id` of this [Batch].
+    pub fn shard_id(&self) -> ShardId {
+        self.shard_id
+    }
+
+    /// The `upper` of this [Batch].
+    pub fn upper(&self) -> &Antichain<T> {
+        self.desc.upper()
+    }
+
+    /// The `lower` of this [Batch].
+    pub fn lower(&self) -> &Antichain<T> {
+        self.desc.lower()
+    }
+
+    /// Marks the blobs that this batch handle points to as consumed, likely
+    /// because they were appended to a shard.
+    ///
+    /// Consumers of a blob need to make this explicit, so that we can log
+    /// warnings in case a batch is not used.
+    pub(crate) fn mark_consumed(&mut self) {
+        self.blob_keys.clear();
+    }
+
+    /// Deletes the blobs that make up this batch from the given blob store and
+    /// marks them as deleted.
+    #[instrument(level = "debug", skip_all, fields(shard = %self.shard_id))]
+    pub async fn delete(mut self) {
+        // TODO: This is temporarily disabled because nemesis seems to have
+        // caught that we sometimes delete batches that are later needed.
+        // Temporarily removing the deletions while we figure out the bug in
+        // case it has anything to do with CI timeouts.
+        //
+        // let deadline = Instant::now() + FOREVER;
+        // for key in self.blob_keys.iter() {
+        //     retry_external("batch::delete", || async {
+        //         self.blob.delete(deadline, key).await
+        //     })
+        //     .await;
+        // }
+        self.blob_keys.clear();
+    }
+}
+
+/// A builder for [Batches](Batch) that allows adding updates piece by piece and
+/// then finishing it.
+#[derive(Debug)]
+pub struct BatchBuilder<K, V, T, D>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    size_hint: usize,
+    lower: Antichain<T>,
+    max_ts: T,
+
+    shard_id: ShardId,
+    records: ColumnarRecordsVecBuilder,
+    blob: Arc<dyn BlobMulti + Send + Sync>,
+
+    key_buf: Vec<u8>,
+    val_buf: Vec<u8>,
+
+    // These provide a bit more safety against appending a batch with the wrong
+    // type to a shard.
+    _phantom: PhantomData<(K, V, T, D)>,
+}
+
+impl<K, V, T, D> BatchBuilder<K, V, T, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Semigroup + Codec64,
+{
+    pub(crate) fn new(
+        size_hint: usize,
+        lower: Antichain<T>,
+        blob: Arc<dyn BlobMulti + Send + Sync>,
+        shard_id: ShardId,
+    ) -> Self {
+        Self {
+            size_hint,
+            lower,
+            max_ts: T::minimum(),
+            records: ColumnarRecordsVecBuilder::default(),
+            blob,
+            shard_id,
+            key_buf: Vec::new(),
+            val_buf: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Finish writing this batch and return a handle to the written batch.
+    ///
+    /// This fails if any of the updates in this batch are beyond the given
+    /// `upper`.
+    #[instrument(level = "debug", name = "batch::finish", skip_all, fields(shard = %self.shard_id))]
+    pub async fn finish(self, upper: Antichain<T>) -> Result<Batch<K, V, T, D>, InvalidUsage<T>> {
+        if upper.less_equal(&self.max_ts) {
+            return Err(InvalidUsage::UpdateBeyondUpper {
+                max_ts: self.max_ts,
+                expected_upper: upper.clone(),
+            });
+        }
+
+        let since = Antichain::from_elem(T::minimum());
+        let desc = Description::new(self.lower, upper, since);
+
+        let updates = self.records.finish();
+
+        if updates.len() == 0 {
+            return Ok(Batch::new(
+                Arc::clone(&self.blob),
+                self.shard_id,
+                desc,
+                vec![],
+            ));
+        }
+
+        // TODO: Get rid of the from_le_bytes.
+        let encoded_desc = Description::new(
+            Antichain::from(
+                desc.lower()
+                    .elements()
+                    .iter()
+                    .map(|x| u64::from_le_bytes(T::encode(x)))
+                    .collect::<Vec<_>>(),
+            ),
+            Antichain::from(
+                desc.upper()
+                    .elements()
+                    .iter()
+                    .map(|x| u64::from_le_bytes(T::encode(x)))
+                    .collect::<Vec<_>>(),
+            ),
+            Antichain::from(
+                desc.since()
+                    .elements()
+                    .iter()
+                    .map(|x| u64::from_le_bytes(T::encode(x)))
+                    .collect::<Vec<_>>(),
+            ),
+        );
+
+        let batch = BlobTraceBatchPart {
+            desc: encoded_desc.clone(),
+            updates,
+            index: 0,
+        };
+
+        let mut buf = Vec::new();
+        debug_span!("make_batch::encode").in_scope(|| {
+            batch.encode(&mut buf);
+        });
+        let buf = Bytes::from(buf);
+
+        let key = Uuid::new_v4().to_string();
+        let () = retry_external("make_batch::set", || async {
+            self.blob
+                .set(
+                    Instant::now() + FOREVER,
+                    &key,
+                    Bytes::clone(&buf),
+                    Atomicity::RequireAtomic,
+                )
+                .await
+        })
+        .instrument(debug_span!("make_batch::set", payload_len = buf.len()))
+        .await;
+
+        let batch = Batch::new(
+            Arc::clone(&self.blob),
+            self.shard_id.clone(),
+            desc,
+            vec![key],
+        );
+
+        Ok(batch)
+    }
+
+    /// Adds the given update to the batch.
+    ///
+    /// The update timestamp must be greater or equal to `lower` that was given
+    /// when creating this [BatchBuilder].
+    //
+    // NOTE: This function is async right now, even though it doesn't need it.
+    // We're keeping the option open in case we might need it in the future.
+    pub async fn add(&mut self, key: &K, val: &V, ts: &T, diff: &D) -> Result<(), InvalidUsage<T>> {
+        if !self.lower.less_equal(ts) {
+            return Err(InvalidUsage::UpdateNotBeyondLower {
+                ts: ts.clone(),
+                lower: self.lower.clone(),
+            });
+        }
+
+        self.max_ts.join_assign(ts);
+
+        self.key_buf.clear();
+        self.val_buf.clear();
+        K::encode(key, &mut self.key_buf);
+        V::encode(val, &mut self.val_buf);
+        let t = T::encode(ts);
+        let d = D::encode(diff);
+
+        if self.records.len() == 0 {
+            // Use the first record to attempt to pre-size the builder
+            // allocations.
+            let additional = usize::saturating_add(self.size_hint, 1);
+            self.records
+                .reserve(additional, self.key_buf.len(), self.val_buf.len());
+        }
+        self.records.push(((&self.key_buf, &self.val_buf), t, d));
+
+        // TODO(aljoscha): As of now, this batch builder doesn't have constant
+        // memory usage but scales with the number of added records. Instead of
+        // keeping one records builder around, we should periodically finish and
+        // flush the updates to a blob, store the blob key in the builder, and
+        // reset the records builder.
+
+        Ok(())
+    }
+}

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -67,7 +67,7 @@ pub enum InvalidUsage<T> {
         /// Set of keys containing updates.
         keys: Vec<String>,
     },
-    /// Bounds of a [crate::write::Batch] are not valid for the attempted append call
+    /// Bounds of a [crate::batch::Batch] are not valid for the attempted append call
     InvalidBatchBounds {
         /// The lower of the batch
         batch_lower: Antichain<T>,
@@ -100,7 +100,7 @@ pub enum InvalidUsage<T> {
         /// The shard of the handle
         handle_shard: ShardId,
     },
-    /// A [crate::write::Batch] was given to a [crate::write::WriteHandle] from
+    /// A [crate::batch::Batch] was given to a [crate::write::WriteHandle] from
     /// a different shard
     BatchNotFromThisShard {
         /// The shard of the batch

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -39,6 +39,7 @@ use crate::r#impl::machine::{retry_external, Machine};
 use crate::read::{ReadHandle, ReaderId};
 use crate::write::WriteHandle;
 
+pub mod batch;
 pub mod cache;
 pub mod error;
 pub mod read;

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -598,6 +598,10 @@ where
             // if the durable data was corrupted, or if operations messes up
             // deployment. In any case, fail loudly.
             .expect("internal error: invalid encoded state");
+
+        // Drop the encoded representation as soon as we can to reclaim memory.
+        drop(value);
+
         let mut ret = Vec::new();
         for chunk in batch.updates {
             for ((k, v), t, d) in chunk.iter() {

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -11,28 +11,23 @@
 
 use std::borrow::Borrow;
 use std::fmt::Debug;
-use std::marker::PhantomData;
 use std::sync::Arc;
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
-use bytes::Bytes;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use mz_persist::indexed::columnar::ColumnarRecordsVecBuilder;
-use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::{Atomicity, BlobMulti, ExternalError, Indeterminate};
+use mz_persist::location::{BlobMulti, ExternalError, Indeterminate};
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
-use tracing::{debug, debug_span, info, instrument, trace, warn, Instrument};
-use uuid::Uuid;
+use tracing::{debug, info, instrument, trace};
 
+use crate::batch::{Batch, BatchBuilder};
 use crate::error::InvalidUsage;
-use crate::r#impl::machine::{retry_external, Machine, FOREVER, INFO_MIN_ATTEMPTS};
+use crate::r#impl::machine::{Machine, INFO_MIN_ATTEMPTS};
 use crate::r#impl::state::Upper;
-use crate::ShardId;
 
 /// A "capability" granting the ability to apply updates to some shard at times
 /// greater or equal to `self.upper()`.
@@ -378,9 +373,9 @@ where
             new_upper
         );
 
-        if self.machine.shard_id() != batch.shard_id {
+        if self.machine.shard_id() != batch.shard_id() {
             return Ok(Err(InvalidUsage::BatchNotFromThisShard {
-                batch_shard: batch.shard_id,
+                batch_shard: batch.shard_id(),
                 handle_shard: self.machine.shard_id(),
             }));
         }
@@ -390,12 +385,12 @@ where
         let since = Antichain::from_elem(T::minimum());
         let desc = Description::new(lower, upper, since);
 
-        if !PartialOrder::less_equal(batch.desc.lower(), desc.lower())
-            || PartialOrder::less_than(batch.desc.upper(), desc.upper())
+        if !PartialOrder::less_equal(batch.lower(), desc.lower())
+            || PartialOrder::less_than(batch.upper(), desc.upper())
         {
             return Ok(Err(InvalidUsage::InvalidBatchBounds {
-                batch_lower: batch.desc.lower().clone(),
-                batch_upper: batch.desc.upper().clone(),
+                batch_lower: batch.lower().clone(),
+                batch_upper: batch.upper().clone(),
                 append_lower: desc.lower().clone(),
                 append_upper: desc.upper().clone(),
             }));
@@ -520,290 +515,11 @@ where
     }
 }
 
-/// A handle to a batch of updates that has been written to blob storage but
-/// which has not yet been appended to a shard.
-///
-/// A [Batch] needs to be marked as consumed or it needs to be deleted via [Self::delete].
-/// Otherwise, a dangling batch will leak and backing blobs will remain in blob storage.
-#[derive(Debug)]
-pub struct Batch<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    /// [Description] of updates contained in this batch.
-    desc: Description<T>,
-
-    shard_id: ShardId,
-
-    /// Keys to blobs that make up this batch of updates.
-    blob_keys: Vec<String>,
-
-    /// Handle to the [BlobMulti] that the blobs of this batch were uploaded to.
-    _blob: Arc<dyn BlobMulti + Send + Sync>,
-
-    // These provide a bit more safety against appending a batch with the wrong
-    // type to a shard.
-    _phantom: PhantomData<(K, V, T, D)>,
-}
-
-impl<K, V, T, D> Drop for Batch<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    fn drop(&mut self) {
-        if self.blob_keys.len() > 0 {
-            warn!(
-                "un-consumed Batch, with {} dangling blob keys: {:?}",
-                self.blob_keys.len(),
-                self.blob_keys
-            );
-        }
-    }
-}
-
-impl<K, V, T, D> Batch<K, V, T, D>
-where
-    K: Debug + Codec,
-    V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64,
-{
-    pub(crate) fn new(
-        blob: Arc<dyn BlobMulti + Send + Sync>,
-        shard_id: ShardId,
-        desc: Description<T>,
-        blob_keys: Vec<String>,
-    ) -> Self {
-        Self {
-            desc,
-            blob_keys,
-            shard_id,
-            _blob: blob,
-            _phantom: PhantomData,
-        }
-    }
-
-    /// The `upper` of this [Batch].
-    pub fn upper(&self) -> &Antichain<T> {
-        self.desc.upper()
-    }
-
-    /// The `lower` of this [Batch].
-    pub fn lower(&self) -> &Antichain<T> {
-        self.desc.lower()
-    }
-
-    /// Marks the blobs that this batch handle points to as consumed, likely
-    /// because they were appended to a shard.
-    ///
-    /// Consumers of a blob need to make this explicit, so that we can log
-    /// warnings in case a batch is not used.
-    pub(crate) fn mark_consumed(&mut self) {
-        self.blob_keys.clear();
-    }
-
-    /// Deletes the blobs that make up this batch from the given blob store and
-    /// marks them as deleted.
-    #[instrument(level = "debug", skip_all, fields(shard = %self.shard_id))]
-    pub async fn delete(mut self) {
-        // TODO: This is temporarily disabled because nemesis seems to have
-        // caught that we sometimes delete batches that are later needed.
-        // Temporarily removing the deletions while we figure out the bug in
-        // case it has anything to do with CI timeouts.
-        //
-        // let deadline = Instant::now() + FOREVER;
-        // for key in self.blob_keys.iter() {
-        //     retry_external("batch::delete", || async {
-        //         self.blob.delete(deadline, key).await
-        //     })
-        //     .await;
-        // }
-        self.blob_keys.clear();
-    }
-}
-
-/// A builder for [Batches](Batch) that allows adding updates piece by piece and
-/// then finishing it.
-#[derive(Debug)]
-pub struct BatchBuilder<K, V, T, D>
-where
-    T: Timestamp + Lattice + Codec64,
-{
-    size_hint: usize,
-    lower: Antichain<T>,
-    max_ts: T,
-
-    shard_id: ShardId,
-    records: ColumnarRecordsVecBuilder,
-    blob: Arc<dyn BlobMulti + Send + Sync>,
-
-    key_buf: Vec<u8>,
-    val_buf: Vec<u8>,
-
-    // These provide a bit more safety against appending a batch with the wrong
-    // type to a shard.
-    _phantom: PhantomData<(K, V, T, D)>,
-}
-
-impl<K, V, T, D> BatchBuilder<K, V, T, D>
-where
-    K: Debug + Codec,
-    V: Debug + Codec,
-    T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64,
-{
-    pub(crate) fn new(
-        size_hint: usize,
-        lower: Antichain<T>,
-        blob: Arc<dyn BlobMulti + Send + Sync>,
-        shard_id: ShardId,
-    ) -> Self {
-        Self {
-            size_hint,
-            lower,
-            max_ts: T::minimum(),
-            records: ColumnarRecordsVecBuilder::default(),
-            blob,
-            shard_id,
-            key_buf: Vec::new(),
-            val_buf: Vec::new(),
-            _phantom: PhantomData,
-        }
-    }
-
-    /// Finish writing this batch and return a handle to the written batch.
-    ///
-    /// This fails if any of the updates in this batch are beyond the given
-    /// `upper`.
-    #[instrument(level = "debug", name = "batch::finish", skip_all, fields(shard = %self.shard_id))]
-    pub async fn finish(self, upper: Antichain<T>) -> Result<Batch<K, V, T, D>, InvalidUsage<T>> {
-        if upper.less_equal(&self.max_ts) {
-            return Err(InvalidUsage::UpdateBeyondUpper {
-                max_ts: self.max_ts,
-                expected_upper: upper.clone(),
-            });
-        }
-
-        let since = Antichain::from_elem(T::minimum());
-        let desc = Description::new(self.lower, upper, since);
-
-        let updates = self.records.finish();
-
-        if updates.len() == 0 {
-            return Ok(Batch::new(
-                Arc::clone(&self.blob),
-                self.shard_id,
-                desc,
-                vec![],
-            ));
-        }
-
-        // TODO: Get rid of the from_le_bytes.
-        let encoded_desc = Description::new(
-            Antichain::from(
-                desc.lower()
-                    .elements()
-                    .iter()
-                    .map(|x| u64::from_le_bytes(T::encode(x)))
-                    .collect::<Vec<_>>(),
-            ),
-            Antichain::from(
-                desc.upper()
-                    .elements()
-                    .iter()
-                    .map(|x| u64::from_le_bytes(T::encode(x)))
-                    .collect::<Vec<_>>(),
-            ),
-            Antichain::from(
-                desc.since()
-                    .elements()
-                    .iter()
-                    .map(|x| u64::from_le_bytes(T::encode(x)))
-                    .collect::<Vec<_>>(),
-            ),
-        );
-
-        let batch = BlobTraceBatchPart {
-            desc: encoded_desc.clone(),
-            updates,
-            index: 0,
-        };
-
-        let mut buf = Vec::new();
-        debug_span!("make_batch::encode").in_scope(|| {
-            batch.encode(&mut buf);
-        });
-        let buf = Bytes::from(buf);
-
-        let key = Uuid::new_v4().to_string();
-        let () = retry_external("make_batch::set", || async {
-            self.blob
-                .set(
-                    Instant::now() + FOREVER,
-                    &key,
-                    Bytes::clone(&buf),
-                    Atomicity::RequireAtomic,
-                )
-                .await
-        })
-        .instrument(debug_span!("make_batch::set", payload_len = buf.len()))
-        .await;
-
-        let batch = Batch::new(
-            Arc::clone(&self.blob),
-            self.shard_id.clone(),
-            desc,
-            vec![key],
-        );
-
-        Ok(batch)
-    }
-
-    /// Adds the given update to the batch.
-    ///
-    /// The update timestamp must be greater or equal to `lower` that was given
-    /// when creating this [BatchBuilder].
-    //
-    // NOTE: This function is async right now, even though it doesn't need it.
-    // We're keeping the option open in case we might need it in the future.
-    pub async fn add(&mut self, key: &K, val: &V, ts: &T, diff: &D) -> Result<(), InvalidUsage<T>> {
-        if !self.lower.less_equal(ts) {
-            return Err(InvalidUsage::UpdateNotBeyondLower {
-                ts: ts.clone(),
-                lower: self.lower.clone(),
-            });
-        }
-
-        self.max_ts.join_assign(ts);
-
-        self.key_buf.clear();
-        self.val_buf.clear();
-        K::encode(key, &mut self.key_buf);
-        V::encode(val, &mut self.val_buf);
-        let t = T::encode(ts);
-        let d = D::encode(diff);
-
-        if self.records.len() == 0 {
-            // Use the first record to attempt to pre-size the builder
-            // allocations.
-            let additional = usize::saturating_add(self.size_hint, 1);
-            self.records
-                .reserve(additional, self.key_buf.len(), self.val_buf.len());
-        }
-        self.records.push(((&self.key_buf, &self.val_buf), t, d));
-
-        // TODO(aljoscha): As of now, this batch builder doesn't have constant
-        // memory usage but scales with the number of added records. Instead of
-        // keeping one records builder around, we should periodically finish and
-        // flush the updates to a blob, store the blob key in the builder, and
-        // reset the records builder.
-
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::time::Instant;
+
+    use crate::r#impl::machine::FOREVER;
     use crate::tests::new_test_client;
     use crate::ShardId;
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -28,6 +28,7 @@ use crate::batch::{Batch, BatchBuilder};
 use crate::error::InvalidUsage;
 use crate::r#impl::machine::{Machine, INFO_MIN_ATTEMPTS};
 use crate::r#impl::state::Upper;
+use crate::PersistConfig;
 
 /// A "capability" granting the ability to apply updates to some shard at times
 /// greater or equal to `self.upper()`.
@@ -49,6 +50,7 @@ pub struct WriteHandle<K, V, T, D>
 where
     T: Timestamp + Lattice + Codec64,
 {
+    pub(crate) cfg: PersistConfig,
     pub(crate) machine: Machine<K, V, T, D>,
     pub(crate) blob: Arc<dyn BlobMulti + Send + Sync>,
 
@@ -433,6 +435,7 @@ where
         trace!("WriteHandle::builder lower={:?}", lower,);
 
         BatchBuilder::new(
+            self.cfg.clone(),
             size_hint,
             lower,
             Arc::clone(&self.blob),

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -527,10 +527,7 @@ impl Default for ColumnarRecordsVecBuilder {
 
 impl ColumnarRecordsVecBuilder {
     /// Create a new ColumnarRecordsVecBuilder with a specified max size.
-    ///
-    /// Only used for testing.
-    #[allow(dead_code)]
-    pub(crate) fn new_with_len(key_val_data_max_len: usize) -> Self {
+    pub fn new_with_len(key_val_data_max_len: usize) -> Self {
         assert!(key_val_data_max_len <= KEY_VAL_DATA_MAX_LEN);
         ColumnarRecordsVecBuilder {
             current: ColumnarRecordsBuilder::default(),


### PR DESCRIPTION
Previously, a BatchBuilder would buffer all updates in memory and flush
them all out as a single BlobTraceBatchPart when the persist user called
BatchBuilder::finish. Now, whenever a BatchBuilder::add call causes
ColumnarRecordsVecBuilder to finish a chunk of updates, they are sent
off in a task to be encoded and uploaded to blob storage. If too many of
these are outstanding (perhaps s3 is down or slow), BatchBuilder::add is
backpressured until the number that are outstanding is back under the
threshold.

Touches #12893

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
