### PR TITLE
tracing: use compute and storage idents in otel traces

### DIFF
--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -431,6 +431,7 @@ where
                                     "--http-console-addr={}:{}",
                                     assigned.listen_host, assigned.ports["http"]
                                 ),
+                                format!("--opentelemetry-resource=storage_id={}", ingestion.id),
                             ]
                         },
                         ports: vec![


### PR DESCRIPTION
This pr adds additional context key-values to the traces that computed and storaged produce. Note that we just pass strings, whereas ints may be more efficient in the future, and that these are overrideable on the `environmentd` cmd-line, as it applies its resources after the arg closure in `ensure_service`.

This is what it looks like:
![image](https://user-images.githubusercontent.com/5404303/172496257-cb74fa8e-e188-4476-81da-b844554fe370.png)


### Motivation

  * This PR fixes a recognized bug.
https://github.com/MaterializeInc/materialize/issues/12878

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
