### PR TITLE
doc/user: hide s3 and Kinesis source pages + remove mentions

### DIFF
--- a/doc/user/content/_index.md
+++ b/doc/user/content/_index.md
@@ -8,8 +8,7 @@ weight: 1
 ---
 
 Materialize is a streaming database for real-time applications. Materialize
-accepts input data from a variety of streaming sources (like Kafka), data stores and databases (like S3 and Postgres), and files
-(like CSV and JSON), and lets you query them using SQL.
+accepts input data from streaming sources (like Kafka), and databases (like PostgreSQL), and lets you query them using SQL.
 
 {{< callout primary_url="/docs/get-started/" primary_text="Get Started">}}
   # Get started with Materialize

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -56,11 +56,9 @@ Being Kafka API-compatible, Redpanda is supported as a [**source**](/overview/ke
 
 ### Kinesis Data Streams
 
-Kinesis Data Streams is supported as a [**source**](/overview/key-concepts/#sources), but not as a sink {{% gh 2372 %}}.
-
 | Service | Support level | Notes |  |
 | --- | --- | --- | --- |
-| AWS Kinesis Data Streams | {{< supportLevel beta >}} | See the [source documentation](/sql/create-source/kinesis/) for more details. | [](#notify) |
+| AWS Kinesis Data Streams | {{< supportLevel in-progress >}} | Subscribe via “Notify Me” to register interest. | [](#notify) |
 
 ### Other message brokers
 
@@ -121,11 +119,9 @@ Debezium has an extensive ecosystem of connectors, but each database has its own
 
 ### S3
 
-S3 is supported as a [**source**](/overview/key-concepts/#sources), but not as a sink {{% gh 7256 %}}.
-
 | Service | Support level | Notes |  |
 | --- | --- | --- | --- |
-| Amazon S3 | {{< supportLevel beta >}} | See the [source documentation](/sql/create-source/s3/) for more details. | [](#notify) |
+| Amazon S3 | {{< supportLevel in-progress >}} | Subscribe via “Notify Me” to register interest. | [](#notify) |
 | MinIO Object Storage | {{< supportLevel researching >}} | Not supported yet {{% gh 6568 %}}. <br> MinIO provides a [S3-compatible API](https://min.io/product/s3-compatibility) that may enable interoperability with Materialize, but this hasn't been officially tested. | [](#notify) |
 
 ### Other object storage services

--- a/doc/user/content/integrations/node-js.md
+++ b/doc/user/content/integrations/node-js.md
@@ -147,17 +147,15 @@ For more details, see the  [`node-postgres` query](https://node-postgres.com/fea
 
 ## Push data to a source
 
-Materialize processes live streams of data and maintains views in memory, relying on other systems (traditional databases, S3, or Kafka) to serve as "systems of record" for the data. Instead of updating Materialize directly, **Node.js should send data to an intermediary system.** Materialize connects to the intermediary system as a "source" and reads streaming updates from that.
+Materialize processes live streams of data and maintains views in memory, relying on other systems (traditional databases, or Kafka) to serve as "systems of record" for the data. Instead of updating Materialize directly, **Node.js should send data to an intermediary system**. Materialize connects to the intermediary system as a "source" and reads streaming updates from that.
 
 The table below lists the intermediary systems a Node.js application can use to stream data for Materialize:
 
 Intermediary System | Notes
 -------------|-------------
 **Kafka** | Produce messages from [Node.js to Kafka](https://kafka.js.org/docs/getting-started), and create a [Materialize Kafka Source](/sql/create-source/json-kafka/) to consume them. Kafka is recommended for scenarios where low-latency and high-throughput are important.
-**Kinesis** | Send data from [Node.js to a Kinesis stream](https://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-implementation-app-nodejs.html) and consume them with a [Materialize Kinesis source](/sql/create-source/json-kinesis/). Kinesis is easier to configure and maintain than Kafka but less fully-featured and configurable. For example, Kinesis is a [volatile source](/overview/volatility/) because it cannot do infinite retention.
 **PostgreSQL** | Node.js sends data to PostgreSQL, and the [Materialize PostgreSQL source](/sql/create-source/postgres/) receives events from the change feed (the write-ahead log) of the database. Ideal for Node.js apps that already use PostgreSQL and fast-changing relational data.
 **PubNub** | Streams as a service provider PubNub provides a [Node.js SDK](https://www.pubnub.com/docs/sdks/javascript/nodejs) to send data into a stream, [Materialize PubNub source](/sql/create-source/json-pubnub/) subscribes to the stream and consumes data.
-**S3** | [Write data from Node.js to S3](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/getting-started-nodejs.html) in an append-only fashion, use the Materialize [S3 Source](/sql/create-source/json-s3), to scan the S3 bucket for data and [listen for new data via SQS notifications](/sql/create-source/s3/#listening-to-sqs-notifications). If data is already sent to S3 and minute latency is not an issue, this is an economical and low-maintenance option.
 
 ## Insert data into tables
 

--- a/doc/user/content/overview/_index.md
+++ b/doc/user/content/overview/_index.md
@@ -101,7 +101,7 @@ Ultimately, this lets you refresh answers to your queries very quickly because M
 
 While we've covered the high-level details above, this section gives some of the more specific details about Materialize itself.
 
-Materialize ingests streams of data from Kafka, Kinesis, PostgreSQL, S3, or local files that you
+Materialize ingests streams of data from external systems like Kafka and PostgreSQL that you
 declare as "sources". These sources monitor changes in the upstream data and
 automatically pull new records into your Materialize instance. You can interact
 with this data in Materialize as if it were in a SQL table.

--- a/doc/user/content/overview/volatility.md
+++ b/doc/user/content/overview/volatility.md
@@ -15,16 +15,13 @@ repeatedly. In other words, if Materialize restarts, it must be able to replay
 the source from the beginning of time and receive exactly the same data.
 
 We call a source that cannot uphold this guarantee a *volatile* source. Many
-common sources of streaming data are volatile. For example, [Amazon
-Kinesis](https://aws.amazon.com/kinesis/) streams are volatile, because (by
-default) data is only retained for 24 hours. If Materialize restarts after
-reading a Kinesis stream for 25 hours, it will be unable to recover the first
-hour of data.
+common sources of streaming data are volatile. For example, [Kafka](/sql/create-source/kafka) streams not configured with infinite retention are volatile, because (by
+default) data is only retained for 7 days. If Materialize restarts after
+reading a Kafka stream for longer than this retention period, it might be unable to recover part of the data.
 
 While it is possible to connect to volatile sources in Materialize, the system
-internally tracks the volatility. Forthcoming features that rely on
-deterministic replay, like [exactly-once
-sinks](https://github.com/MaterializeInc/materialize/issues/2915), will not
+internally tracks the volatility. Features that rely on
+deterministic replay, like [exactly-once sinks](/sql/create-sink/#exactly-once-sinks-with-topic-reuse-after-restart), will not
 support construction atop volatile sources.
 
 ## Rules
@@ -40,19 +37,15 @@ These rules will evolve in future versions of Materialize.
 
 At present, the following source types are always considered volatile:
 
-  * [Kinesis sources](/sql/create-source/text-kinesis/)
   * [PubNub sources](/sql/create-source/text-pubnub/)
 
 The following source types are always considered to be of unknown volatility:
 
   * [Kafka sources](/sql/create-source/avro-kafka/)
-  * [S3 sources](/sql/create-source/text-s3/)
 
-In the future, Materialize will let you configure whether a given Kafka, S3, or
-file source is considered volatile or nonvolatile, as their volatility depends
-on their configuration. Common ways to introduce volatility include configuring
-a retention policy on a Kafka topic used in a Kafka source, deleting an object
-from an S3 bucket used in an S3 source, or editing a file used in a file source.
+In the future, Materialize will let you configure whether a given source is considered volatile or nonvolatile, as their volatility depends
+on their configuration. A common way to introduce volatility is, for example, to configure
+a retention policy on a Kafka topic used in a Kafka source.
 
 ### Views, indexes, and sinks
 

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -22,10 +22,8 @@ Materialize bundles **native connectors** for the following external systems:
 {{< linkbox title="Message Brokers" >}}
 - [Kafka](/sql/create-source/kafka)
 - [Redpanda](/sql/create-source/kafka)
-- [Kinesis Data Streams](/sql/create-source/kinesis)
 {{</ linkbox >}}
-{{< linkbox title="Object Storage" >}}
-- [S3](/sql/create-source/s3)
+{{< linkbox title="" >}}
 {{</ linkbox >}}
 {{< linkbox title="Databases (CDC)" >}}
 - [PostgreSQL](/sql/create-source/postgres)

--- a/doc/user/content/sql/create-source/kinesis.md
+++ b/doc/user/content/sql/create-source/kinesis.md
@@ -15,7 +15,7 @@ aliases:
     - /sql/create-source/csv-kinesis
 ---
 
-[//]: # "NOTE(morsapaes) Once we're ready to bring the KDS source back, check # to restore the previous docs state."
+[//]: # "NOTE(morsapaes) Once we're ready to bring the KDS source back, check #12991 to restore the previous docs state."
 
 {{< beta />}}
 

--- a/doc/user/content/sql/create-source/kinesis.md
+++ b/doc/user/content/sql/create-source/kinesis.md
@@ -1,11 +1,12 @@
 ---
 title: "CREATE SOURCE: Kinesis Data Streams"
 description: "Connecting Materialize to a Kinesis data stream"
-menu:
-  main:
-    parent: 'create-source'
-    name: Kinesis Data Streams
-    weight: 40
+draft: true
+#menu:
+#  main:
+#    parent: 'create-source'
+#    name: Kinesis Data Streams
+#    weight: 40
 aliases:
     - /sql/create-source/kinesis-source
     - /sql/create-source/json-kinesis
@@ -13,6 +14,8 @@ aliases:
     - /sql/create-source/text-kinesis
     - /sql/create-source/csv-kinesis
 ---
+
+[//]: # "NOTE(morsapaes) Once we're ready to bring the KDS source back, check # to restore the previous docs state."
 
 {{< beta />}}
 

--- a/doc/user/content/sql/create-source/s3.md
+++ b/doc/user/content/sql/create-source/s3.md
@@ -14,7 +14,7 @@ aliases:
     - /sql/create-source/csv-s3
 ---
 
-[//]: # "NOTE(morsapaes) ."
+[//]: # "NOTE(morsapaes) Once we're ready to bring the KDS source back, check #12991 to restore the previous docs state."
 
 {{< beta />}}
 

--- a/doc/user/content/sql/create-source/s3.md
+++ b/doc/user/content/sql/create-source/s3.md
@@ -1,17 +1,20 @@
 ---
 title: "CREATE SOURCE: S3"
 description: "Connecting Materialize to an S3 bucket"
-menu:
-  main:
-    parent: 'create-source'
-    name: S3
-    weight: 30
+draft: true
+#menu:
+#  main:
+#    parent: 'create-source'
+#    name: S3
+#    weight: 30
 aliases:
     - /sql/create-source/s3-source
     - /sql/create-source/json-s3
     - /sql/create-source/text-s3
     - /sql/create-source/csv-s3
 ---
+
+[//]: # "NOTE(morsapaes) ."
 
 {{< beta />}}
 

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -37,7 +37,7 @@ Field | Meaning
 **type** | Whether the source was created by the `user` or the `system`.
 **materialized** | Does the source have an in-memory index? For more details, see [`CREATE INDEX`](../create-index).
 **volatility** | Whether the source is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
-**connector_type** | The type of the source: `file`, `kafka`, `kinesis`, `s3`, `postgres`, or `pubnub`.
+**connector_type** | The type of the source:  `kafka`, `postgres`, or `pubnub`.
 
 ### Internal statistic sources
 

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -474,7 +474,7 @@ Field            | Type       | Meaning
 `oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the source.
 `schema_id`      | [`bigint`] | The ID of the schema to which the source belongs.
 `name`           | [`text`]   | The name of the source.
-`connector_type` | [`text`]   | The type of the source: `file`, `kafka`, `kinesis`, `s3`, `postgres`, or `pubnub`.
+`connector_type` | [`text`]   | The type of the source: `kafka`, `postgres`, or `pubnub`.
 `volatility`     | [`text`]   | Whether the source is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
 
 ### `mz_tables`


### PR DESCRIPTION
After #12932, S3 and Kinesis sources are hidden behind the `--unsafe-mode` flag. This PR removes the respective source pages and any references to these sources from the user-facing docs.

It sounds like we plan to rework the implementation for these sources at some point (#12930), so I've downgraded them to `in-progress` under "Tools & Integrations".