### PR TITLE
feature-benchmark: Make it more fair to Platform

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -57,15 +57,19 @@ steps:
 
   - id: feature-benchmark
     label: "Feature benchmark against latest release"
-    timeout_in_minutes: 180
+    timeout_in_minutes: 360
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
           args:
+            - --this-nodes
+            - 4
             - --other-tag
             - latest
+            - --other-options
+            - --workers 4
 
   - id: coverage
     label: Code coverage


### PR DESCRIPTION
Make the feature-benchmark slightly more fair to Platform by
starting a 4-node compute cluster on Platform while running
the single-process Mz instance with --workers 4

### Motivation

  * This PR fixes a previously unreported bug.
The feature benchmark in Nightly was giving false positives because Platform was essentially running with --workers 1