### PR TITLE
materialized: remove pid file creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,7 +2781,6 @@ dependencies = [
  "mz-pgrepr",
  "mz-pgtest",
  "mz-pgwire",
- "mz-pid-file",
  "mz-postgres-util",
  "mz-prof",
  "mz-repr",

--- a/src/materialized/Cargo.toml
+++ b/src/materialized/Cargo.toml
@@ -60,7 +60,6 @@ mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pgwire = { path = "../pgwire" }
-mz-pid-file = { path = "../pid-file" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-prof = { path = "../prof" }
 mz-repr = { path = "../repr" }

--- a/src/materialized/tests/server.rs
+++ b/src/materialized/tests/server.rs
@@ -97,38 +97,6 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[test]
-fn test_pid_file() -> Result<(), Box<dyn Error>> {
-    let data_dir = tempfile::tempdir()?;
-    let config = util::Config::default().data_directory(data_dir.path());
-
-    // While `server1` is running, it should not be possible to start another
-    // server against the same data directory.
-    let server1 = util::start_server(config.clone())?;
-    match util::start_server(config.clone()) {
-        Ok(_) => panic!("unexpected success"),
-        Err(e) => {
-            if !e
-                .to_string()
-                .contains("running with the same data directory")
-            {
-                return Err(e.into());
-            }
-        }
-    }
-
-    // But it should be possible to start a server against a *different*
-    // data directory.
-    let _server2 = util::start_server(util::Config::default())?;
-
-    // Stopping `server1` should allow starting another server against the
-    // `server1`'s old data directory.
-    drop(server1);
-    util::start_server(config)?;
-
-    Ok(())
-}
-
 // Test the /sql POST endpoint of the HTTP server.
 #[test]
 fn test_http_sql() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
This was needed for sqlite exclusivity. Now that we require postgres
stash, which does its own epoch checking, we no longer need this.

### Motivation

  * This PR adds a feature that has not yet been specified.

This further removes dependence on the data directory.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a