### PR TITLE
mzcompose: use stable hostname for materialized service

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -106,8 +106,7 @@ class Materialized(Service):
             {"image": image} if image else {"mzbuild": "materialized"}
         )
 
-        if hostname:
-            config["hostname"] = hostname
+        config["hostname"] = hostname or name
 
         # Depending on the docker-compose version, this may either work or be ignored with a warning
         # Unfortunately no portable way of setting the memory limit is known


### PR DESCRIPTION
The `materialized` service needs a stable hostname to record in the
PostgreSQL consensus URL. By default Docker uses the container ID, which
is not stable across restarts. Change mzcompose to use the service name
as the hostname, unless another hostname is explicitly configured.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug: upgrade tests in #12840 were timing out because the `materialized` container was restarting with a different hostname.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a