### PR TITLE
compute: Ignore invalid protocol prefixes

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -21,6 +21,7 @@ use timely::execute::execute_from;
 use timely::worker::Worker as TimelyWorker;
 use timely::WorkerConfig;
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, LocalClient, LocalComputeClient};
 use mz_dataflow_types::ConnectorContext;
@@ -227,8 +228,19 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     _ => (),
                 }
 
-                self.activate_compute().unwrap().handle_compute_command(cmd);
-
+                if self.compute_state.is_none() {
+                    // STOP-GAP for #12233 FIXME
+                    // We should never reach this branch, but due to a bug in the controller,
+                    // we don't start the protocol correctly and might send messages in the window
+                    // between establishing the connection and hydrating this instance. We need to
+                    // ignore these messages until the controller produces a correct instance of
+                    // the communication protocol. It seems that this is the case when we see a
+                    // `CreateInstance` command floating by, from which point on we're confident we
+                    // won't drop messages anymore.
+                    warn!("Received command without initialization (stop-gap for #12233): {cmd:?}");
+                } else {
+                    self.activate_compute().unwrap().handle_compute_command(cmd);
+                }
                 if should_drop_compute {
                     self.compute_state = None;
                 }


### PR DESCRIPTION
Implement a stop-gap to protect the computed against malformed prefixes
of the compute command protocol. This ignores all messages until the first
CreateInstance command. This should be correct because the invalid prefix
of messages should also be folded into the command history, which drives
the hydration of each replica. Ignoring the prefix is fine because the
intention of the messages will be picked up later.

Related: #12233

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
