### PR TITLE
storage: implement Semigroup and Codec64 for MzOffset

### DIFF
--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -81,6 +81,31 @@ pub struct MzOffset {
     pub offset: u64,
 }
 
+impl differential_dataflow::difference::Semigroup for MzOffset {
+    fn plus_equals(&mut self, rhs: &Self) {
+        self.offset.plus_equals(&rhs.offset)
+    }
+    fn is_zero(&self) -> bool {
+        self.offset.is_zero()
+    }
+}
+
+impl mz_persist_types::Codec64 for MzOffset {
+    fn codec_name() -> String {
+        "MzOffset".to_string()
+    }
+
+    fn encode(&self) -> [u8; 8] {
+        mz_persist_types::Codec64::encode(&self.offset)
+    }
+
+    fn decode(buf: [u8; 8]) -> Self {
+        Self {
+            offset: mz_persist_types::Codec64::decode(buf),
+        }
+    }
+}
+
 impl RustType<ProtoMzOffset> for MzOffset {
     fn into_proto(&self) -> ProtoMzOffset {
         ProtoMzOffset {


### PR DESCRIPTION
Closes https://github.com/MaterializeInc/materialize/issues/11954

@petrosagg mentioned on that pr that we could clean the reclock operator up by just making `MzOffset` implement `Semigroup`, so this is that implementation! The main issue is that we now are locked into the fact that offsets are `Codec64`, but we had the requirement implicitly before

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
CI

### Release notes
None
