### PR TITLE
Show a readable name in mz_cluster_replicas.size

### DIFF
--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -125,12 +125,10 @@ impl CatalogState {
 
         let (size, az) = match &replica.config {
             ConcreteComputeInstanceReplicaConfig::Managed {
-                size_config,
+                size_config: _,
+                size_name,
                 availability_zone,
-            } => (
-                Some(format!("{}-{}", size_config.scale, size_config.workers)),
-                availability_zone.as_deref(),
-            ),
+            } => (Some(&**size_name), availability_zone.as_deref()),
             ConcreteComputeInstanceReplicaConfig::Remote { .. } => (None, None),
         };
 
@@ -140,7 +138,7 @@ impl CatalogState {
                 Datum::Int64(compute_instance_id),
                 Datum::Int64(id),
                 Datum::String(&name),
-                Datum::from(size.as_deref()),
+                Datum::from(size),
                 Datum::from(az),
             ]),
             diff,

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -150,19 +150,25 @@ async fn migrate<S: Append>(stash: &mut S, version: u64) -> Result<(), StashErro
                 )],
                     )
                     .await?;
-                COLLECTION_COMPUTE_INSTANCE_REPLICAS.upsert(
-                    stash,
-                    vec![
-                        (
-                            ComputeInstanceReplicaKey { id: 1},
+                COLLECTION_COMPUTE_INSTANCE_REPLICAS
+                    .upsert(
+                        stash,
+                        vec![(
+                            ComputeInstanceReplicaKey { id: 1 },
                             ComputeInstanceReplicaValue {
                                 compute_instance_id: 1,
                                 name: "default_replica".into(),
-                                config: "{\"Managed\":{\"size_config\":{\"memory_limit\": null, \"cpu_limit\": null, \"scale\": 1, \"workers\": 1}}}".into(),
-                            }
-                        )
-                    ]
-                ).await?;
+                                config: "{ \
+                                    \"Managed\": { \
+                                        \"size_config\": {\"scale\": 1, \"workers\": 1}, \
+                                        \"size_name\": \"default\" \
+                                    } \
+                                }"
+                                .into(),
+                            },
+                        )],
+                    )
+                    .await?;
                 Ok(())
             })
         },

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -313,7 +313,10 @@ fn concretize_replica_config(
                     )| (*scale, *cpu_limit),
                 );
                 let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
-                CoordError::InvalidClusterReplicaSize { size, expected }
+                CoordError::InvalidClusterReplicaSize {
+                    size: size.clone(),
+                    expected,
+                }
             })?;
 
             if let Some(az) = &availability_zone {
@@ -326,6 +329,7 @@ fn concretize_replica_config(
             }
             ConcreteComputeInstanceReplicaConfig::Managed {
                 size_config: *size_config,
+                size_name: size,
                 availability_zone,
             }
         }

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -75,8 +75,10 @@ pub enum ConcreteComputeInstanceReplicaConfig {
     },
     /// A remote but managed replica
     Managed {
-        /// The size of the replica
+        /// The size configuration of the replica.
         size_config: ClusterReplicaSizeConfig,
+        /// A readable name for the replica size.
+        size_name: String,
         /// The replica's availability zone, if `Some`.
         availability_zone: Option<String>,
     },

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -235,6 +235,7 @@ where
             }
             ConcreteComputeInstanceReplicaConfig::Managed {
                 size_config,
+                size_name: _,
                 availability_zone,
             } => {
                 let OrchestratorConfig {
@@ -328,8 +329,9 @@ where
         config: ConcreteComputeInstanceReplicaConfig,
     ) -> Result<(), anyhow::Error> {
         if let ConcreteComputeInstanceReplicaConfig::Managed {
-            size_config: _size_config,
-            availability_zone: _az,
+            size_config: _,
+            size_name: _,
+            availability_zone: _,
         } = config
         {
             let OrchestratorConfig { orchestrator, .. } = &self.orchestrator;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3151,7 +3151,7 @@ pub fn plan_drop_cluster_replica(
             Err(_) if if_exists => continue,
             Err(e) => return Err(e.into()),
         };
-        let replica_name = replica.to_string();
+        let replica_name = replica.into_string();
         // Check to see if name exists
         if instance.replica_names().contains(&replica_name) {
             names_out.push((instance.name().to_string(), replica_name))
@@ -3164,7 +3164,7 @@ pub fn plan_drop_cluster_replica(
                 bail!(
                     "CLUSTER {} has no CLUSTER REPLICA named {}",
                     instance.name(),
-                    replica.to_string()
+                    replica_name.quoted(),
                 )
             }
         }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -299,16 +299,25 @@ statement ok
 CREATE CLUSTER REPLICA default.foo_bar SIZE '1'
 
 statement ok
+DROP CLUSTER REPLICA default.foo_bar
+
+statement ok
 CREATE CLUSTER REPLICA default."foo-bar" SIZE '1'
 
 statement ok
-DROP CLUSTER REPLICA default.foo_bar
+DROP CLUSTER REPLICA default."foo-bar"
 
 statement ok
 CREATE CLUSTER REPLICA default."好-好" SIZE '1'
 
 statement ok
+DROP CLUSTER REPLICA default."好-好"
+
+statement ok
 CREATE CLUSTER REPLICA default."好_好" SIZE '1'
+
+statement ok
+DROP CLUSTER REPLICA default."好_好"
 
 # clusters wo replicas cannot service selects
 
@@ -368,6 +377,12 @@ SELECT * FROM t1;
 statement error unknown cluster
 DROP CLUSTER REPLICA no_such_cluster.bar
 
+statement ok
+RESET cluster
+
+statement ok
+DROP CLUSTER foo CASCADE
+
 # Availability zones
 # Note that we don't support availability zones configured with slt, so they
 # can't be meaningfully specified
@@ -386,3 +401,19 @@ CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1']
+
+# Test that the contents of mz_cluster_replicas look sensible
+
+statement ok
+CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_32 (SIZE '32'), size_2_2 (SIZE '2-2'))
+
+query TTT
+SELECT name, size, status FROM mz_cluster_replicas ORDER BY name
+----
+default_replica  default  unknown
+size_1           1        unknown
+size_2_2         2-2      unknown
+size_32          32       unknown
+
+statement ok
+DROP CLUSTER foo CASCADE


### PR DESCRIPTION
Before:

```sql
materialize=> select * from mz_cluster_replicas;
 cluster_id | id |      name       | size | availability_zone | status
------------+----+-----------------+------+-------------------+---------
          2 |  2 | r1              | 2-1  |                   | healthy
          1 |  1 | default_replica | 1-1  |                   | healthy
```

After:

```sql
materialize=> select * from mz_cluster_replicas;
 cluster_id | id |      name       |  size   | availability_zone | status
------------+----+-----------------+---------+-------------------+---------
          2 |  2 | r1              | small   |                   | healthy
          1 |  1 | default_replica | default |                   | healthy
```

### Motivation

  * This PR fixes a previously unreported bug.

    `mz_cluster_replicas.size` contains the string `"{size_config.scale}-{size_config.workers}"`, not the size name the user specifies when creating a replica. Without any further explanation for what the string means, users will find this confusing. Plus, we might want to hide these sizing details from users anyway.

    While trying to write a test, I discovered a second bug that is also fixed here:

    ```sql
    materialize=> CREATE CLUSTER REPLICA default."test-123" SIZE '1';
    CREATE CLUSTER REPLICA
    materialize=> DROP CLUSTER REPLICA default."test-123";
    ERROR:  CLUSTER default has no CLUSTER REPLICA named "test-123"
    ```

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Change the `size` field of the `mz_cluster_replicas` table to contain a readable size name.
