### PR TITLE
Trace key compile-time stages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,6 +4183,7 @@ dependencies = [
  "mz-repr",
  "proc-macro2",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/misc/opentelemetry/mzcompose.py
+++ b/misc/opentelemetry/mzcompose.py
@@ -7,10 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from dataclasses import dataclass
-from typing import Dict, List, Optional
-
-from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import Service
 
 SERVICES = [

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -880,7 +880,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
     /// An empty list of arrangement keys indicates that only a `Collection` stream can
     /// be assumed to exist.
     #[tracing::instrument(
-        level = "debug",
+        level = "trace",
         name = "mir_to_lir",
         skip_all,
         fields(

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -880,6 +880,7 @@ impl<T: timely::progress::Timestamp> Plan<T> {
     /// An empty list of arrangement keys indicates that only a `Collection` stream can
     /// be assumed to exist.
     #[tracing::instrument(
+        target = "optimizer"
         level = "trace",
         name = "mir_to_lir",
         skip_all,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -51,7 +51,7 @@ macro_rules! parser_err {
 }
 
 /// Parses a SQL string containing zero or more SQL statements.
-#[tracing::instrument(level = "debug", name = "sql_to_ast")]
+#[tracing::instrument(level = "trace", name = "sql_to_ast")]
 pub fn parse_statements(sql: &str) -> Result<Vec<Statement<Raw>>, ParserError> {
     let tokens = lexer::lex(sql)?;
     Parser::new(sql, tokens).parse_statements()

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -51,7 +51,7 @@ macro_rules! parser_err {
 }
 
 /// Parses a SQL string containing zero or more SQL statements.
-#[tracing::instrument(level = "trace", name = "sql_to_ast")]
+#[tracing::instrument(target = "compiler", level = "trace", name = "sql_to_ast")]
 pub fn parse_statements(sql: &str) -> Result<Vec<Statement<Raw>>, ParserError> {
     let tokens = lexer::lex(sql)?;
     Parser::new(sql, tokens).parse_statements()

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -51,6 +51,7 @@ macro_rules! parser_err {
 }
 
 /// Parses a SQL string containing zero or more SQL statements.
+#[tracing::instrument(level = "debug", name = "sql_to_ast")]
 pub fn parse_statements(sql: &str) -> Result<Vec<Statement<Raw>>, ParserError> {
     let tokens = lexer::lex(sql)?;
     Parser::new(sql, tokens).parse_statements()

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1035,6 +1035,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
 }
 
 /// Resolves names in an AST node using the provided catalog.
+#[tracing::instrument(level = "debug", name = "ast_resolve_names", skip_all)]
 pub fn resolve<N>(
     catalog: &dyn SessionCatalog,
     node: N,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1035,7 +1035,12 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
 }
 
 /// Resolves names in an AST node using the provided catalog.
-#[tracing::instrument(level = "trace", name = "ast_resolve_names", skip_all)]
+#[tracing::instrument(
+    target = "compiler",
+    level = "trace",
+    name = "ast_resolve_names",
+    skip_all
+)]
 pub fn resolve<N>(
     catalog: &dyn SessionCatalog,
     node: N,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1035,7 +1035,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
 }
 
 /// Resolves names in an AST node using the provided catalog.
-#[tracing::instrument(level = "debug", name = "ast_resolve_names", skip_all)]
+#[tracing::instrument(level = "trace", name = "ast_resolve_names", skip_all)]
 pub fn resolve<N>(
     catalog: &dyn SessionCatalog,
     node: N,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -130,7 +130,7 @@ struct CteDesc {
 impl HirRelationExpr {
     /// Rewrite `self` into a `mz_expr::MirRelationExpr`.
     /// This requires rewriting all correlated subqueries (nested `HirRelationExpr`s) into flat queries
-    #[tracing::instrument(level = "trace", name = "hir_to_mir", skip_all)]
+    #[tracing::instrument(target = "optimizer", level = "trace", name = "hir_to_mir", skip_all)]
     pub fn lower(self) -> mz_expr::MirRelationExpr {
         match self {
             // We directly rewrite a Constant into the corresponding `MirRelationExpr::Constant`

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -130,7 +130,7 @@ struct CteDesc {
 impl HirRelationExpr {
     /// Rewrite `self` into a `mz_expr::MirRelationExpr`.
     /// This requires rewriting all correlated subqueries (nested `HirRelationExpr`s) into flat queries
-    #[tracing::instrument(level = "debug", name = "hir_to_mir", skip_all)]
+    #[tracing::instrument(level = "trace", name = "hir_to_mir", skip_all)]
     pub fn lower(self) -> mz_expr::MirRelationExpr {
         match self {
             // We directly rewrite a Constant into the corresponding `MirRelationExpr::Constant`

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -130,6 +130,7 @@ struct CteDesc {
 impl HirRelationExpr {
     /// Rewrite `self` into a `mz_expr::MirRelationExpr`.
     /// This requires rewriting all correlated subqueries (nested `HirRelationExpr`s) into flat queries
+    #[tracing::instrument(level = "debug", name = "hir_to_mir", skip_all)]
     pub fn lower(self) -> mz_expr::MirRelationExpr {
         match self {
             // We directly rewrite a Constant into the corresponding `MirRelationExpr::Constant`

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -95,6 +95,7 @@ pub struct PlannedQuery<E> {
 ///
 /// Note that the returned `RelationDesc` describes the expression after
 /// applying the returned `RowSetFinishing`.
+#[tracing::instrument(level = "debug", name = "ast_to_hir", skip_all)]
 pub fn plan_root_query(
     scx: &StatementContext,
     mut query: Query<Aug>,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -95,7 +95,7 @@ pub struct PlannedQuery<E> {
 ///
 /// Note that the returned `RelationDesc` describes the expression after
 /// applying the returned `RowSetFinishing`.
-#[tracing::instrument(level = "debug", name = "ast_to_hir", skip_all)]
+#[tracing::instrument(level = "trace", name = "ast_to_hir", skip_all)]
 pub fn plan_root_query(
     scx: &StatementContext,
     mut query: Query<Aug>,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -95,7 +95,7 @@ pub struct PlannedQuery<E> {
 ///
 /// Note that the returned `RelationDesc` describes the expression after
 /// applying the returned `RowSetFinishing`.
-#[tracing::instrument(level = "trace", name = "ast_to_hir", skip_all)]
+#[tracing::instrument(target = "compiler", level = "trace", name = "ast_to_hir", skip_all)]
 pub fn plan_root_query(
     scx: &StatementContext,
     mut query: Query<Aug>,

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -13,6 +13,7 @@ mz-dataflow-types = { path = "../dataflow-types" }
 mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
+tracing = "0.1.34"
 
 [dev-dependencies]
 anyhow = "1.0.58"

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -28,6 +28,7 @@ use crate::{monotonic::MonotonicFlag, IndexOracle, Optimizer, TransformError};
 /// Inlines views, performs a full optimization pass including physical
 /// planning using the supplied indexes, propagates filtering and projection
 /// information to dataflow sources and lifts monotonicity information.
+#[tracing::instrument(level = "debug", skip_all)]
 pub fn optimize_dataflow(
     dataflow: &mut DataflowDesc,
     indexes: &dyn IndexOracle,

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -28,7 +28,7 @@ use crate::{monotonic::MonotonicFlag, IndexOracle, Optimizer, TransformError};
 /// Inlines views, performs a full optimization pass including physical
 /// planning using the supplied indexes, propagates filtering and projection
 /// information to dataflow sources and lifts monotonicity information.
-#[tracing::instrument(level = "trace", skip_all)]
+#[tracing::instrument(target = "optimizer", level = "trace", skip_all)]
 pub fn optimize_dataflow(
     dataflow: &mut DataflowDesc,
     indexes: &dyn IndexOracle,

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -28,7 +28,7 @@ use crate::{monotonic::MonotonicFlag, IndexOracle, Optimizer, TransformError};
 /// Inlines views, performs a full optimization pass including physical
 /// planning using the supplied indexes, propagates filtering and projection
 /// information to dataflow sources and lifts monotonicity information.
-#[tracing::instrument(level = "debug", skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn optimize_dataflow(
     dataflow: &mut DataflowDesc,
     indexes: &dyn IndexOracle,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -420,7 +420,7 @@ impl Optimizer {
     ///
     /// This method should only be called with non-empty `indexes` when optimizing a dataflow,
     /// as the optimizations may lock in the use of arrangements that may cease to exist.
-    #[tracing::instrument(level = "debug", name="mir_optimize", skip_all, fields(optimize.pipeline = %self.name))]
+    #[tracing::instrument(level = "trace", name="mir_optimize", skip_all, fields(optimize.pipeline = %self.name))]
     fn transform(
         &self,
         relation: &mut MirRelationExpr,

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -420,7 +420,13 @@ impl Optimizer {
     ///
     /// This method should only be called with non-empty `indexes` when optimizing a dataflow,
     /// as the optimizations may lock in the use of arrangements that may cease to exist.
-    #[tracing::instrument(level = "trace", name="mir_optimize", skip_all, fields(optimize.pipeline = %self.name))]
+    #[tracing::instrument(
+        target = "optimizer",
+        level = "trace",
+        name = "mir_optimize",
+        skip_all,
+        fields(optimize.pipeline = %self.name)
+    )]
     fn transform(
         &self,
         relation: &mut MirRelationExpr,


### PR DESCRIPTION
Annotate key stages of the lifecycle of SQL statements with `tracing::instrument` calls.

### Motivation

This is a first step towards adding observability to the optimizer.

### Tips for reviewer

Most of the annotations give the spans more meaningful names that allow to identify the corresponding stage globally (e.g. `hir_to_mir` is less ambiguous than the actual function name `lower`).

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Tested manually based on the local developer guide in `misc/opentelemetry/README.md`:

```bash
# start Jaeger and otel-collector sidecar containers
(cd misc/opentelemetry && ./mzcompose up -d)

# start materialized with telemetry enabled
MZ_OPENTELEMETRY_ENDPOINT="http://localhost:4317" \
MZ_OPENTELEMETRY_FILTER="tokio_postgres=info,debug compiler=info,debug,trace optimizer=info,debug,trace" \
bin/environmentd --reset

# run a workload
psql -U materialize -h localhost -p 6875 materialize --file /tmp/compiler-tracing-test.sql

# look at the generated traces in the Jaeger UI
(cd misc/opentelemetry && ./mzcompose web jaeger)
```

The contents of `/tmp/compiler-tracing-test.sql` are show below.

```sql
-- schema
CREATE TABLE L(x INT NOT NULL, y INT NOT NULL);
CREATE TABLE R(y INT NOT NULL, z INT NOT NULL);
CREATE TABLE T(a INT NOT NULL);
-- data
INSERT INTO L VALUES (1, 2), (2, 3);
INSERT INTO R VALUES (1, 2), (2, 3);
INSERT INTO T VALUES (2);

-- materialized view definition (V1)
CREATE MATERIALIZED VIEW V1 AS SELECT
    L.x, L.y, R.z
FROM
    L FULL OUTER JOIN R ON L.y = R.y AND EXISTS(SELECT * FROM T where T.a < R.z);

-- logical view definition (V2, depends on V1)
CREATE VIEW V2 AS SELECT * FROM V1 where y > 0 AND z = 5;

-- query (depends on V2)
SELECT * FROM V2 WHERE y > 0 AND z < 5;
```

Here is the outcome for the materialized view definition.

![Screenshot from 2022-06-10 17-09-05](https://user-images.githubusercontent.com/1071946/173084043-4b95c06d-0455-40da-a053-85f65418d37d.png)

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

- Key stages of the lifecycle of SQL statements are now reporting their own spans as part of `debug`-level telemetry.
