### PR TITLE
storage: fix missing commas in the storaged Docker entrypoint

### DIFF
--- a/src/storage/ci/Dockerfile
+++ b/src/storage/ci/Dockerfile
@@ -18,4 +18,4 @@ COPY storaged /usr/local/bin/
 
 USER materialize
 
-ENTRYPOINT ["tini" "--" "storaged", "--listen-addr=0.0.0.0:2100", "--internal-http-listen-addr=0.0.0.0:6877"]
+ENTRYPOINT ["tini", "--", "storaged", "--listen-addr=0.0.0.0:2100", "--internal-http-listen-addr=0.0.0.0:6877"]


### PR DESCRIPTION
We need to get CI coverage of these Docker images in the main
repository, but for now this will do.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a