### PR TITLE
amended version of #12974

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,6 +3934,7 @@ dependencies = [
  "mz-pgrepr",
  "mz-postgres-util",
  "mz-repr",
+ "mz-secrets",
  "mz-sql-parser",
  "once_cell",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "mz-persist-types",
  "mz-postgres-util",
  "mz-repr",
+ "mz-secrets",
  "mz-stash",
  "once_cell",
  "proptest",

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Component, Path};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -32,7 +33,7 @@ use mz_dataflow_types::client::{
 use mz_dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_dataflow_types::sinks::{SinkConnector, SinkConnectorBuilder, SinkEnvelope};
 use mz_dataflow_types::sources::{
-    ConnectorInner, ExternalSourceConnector, SourceConnector, Timeline,
+    ConnectorInner, ExternalSourceConnector, MaybeStringId, SourceConnector, Timeline,
 };
 use mz_expr::{ExprHumanizer, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
@@ -40,6 +41,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{to_datetime, EpochMillis, NowFn};
 use mz_pgrepr::oid::FIRST_USER_OID;
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
+use mz_secrets::{SecretsReader, SecretsReaderConfig};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Expr;
 use mz_sql::catalog::{
@@ -140,6 +142,7 @@ pub struct CatalogState {
     roles: HashMap<String, Role>,
     config: mz_sql::catalog::CatalogConfig,
     oid_counter: u32,
+    secrets_reader: SecretsReader,
 }
 
 impl CatalogState {
@@ -1433,7 +1436,10 @@ impl Catalog<Sqlite> {
     /// See [`Catalog::open_debug`].
     pub async fn open_debug_sqlite(now: NowFn) -> Result<Catalog<Sqlite>, anyhow::Error> {
         let stash = mz_stash::Sqlite::open(None)?;
-        Catalog::open_debug(stash, now).await
+        // N.B. sqlite stash is on its way out and none of the tests that actually use this deal with secrets anyway.
+        // If new tests are added that do, we'll quickly fail
+        let secrets_dir = Component::RootDir;
+        Catalog::open_debug(stash, secrets_dir.as_ref(), now).await
     }
 }
 
@@ -1446,11 +1452,12 @@ impl Catalog<Postgres> {
     pub async fn open_debug_postgres(
         url: String,
         schema: Option<String>,
+        secrets_path: &Path,
         now: NowFn,
     ) -> Result<Catalog<Postgres>, anyhow::Error> {
         let tls = mz_postgres_util::make_tls(&tokio_postgres::Config::new()).unwrap();
         let stash = mz_stash::Postgres::new(url, schema, tls).await?;
-        Catalog::open_debug(stash, now).await
+        Catalog::open_debug(stash, secrets_path, now).await
     }
 }
 
@@ -1485,6 +1492,7 @@ impl<S: Append> Catalog<S> {
                     now: config.now.clone(),
                 },
                 oid_counter: FIRST_USER_OID,
+                secrets_reader: config.secrets_reader,
             },
             transient_revision: 0,
             storage: Arc::new(Mutex::new(config.storage)),
@@ -2004,9 +2012,16 @@ impl<S: Append> Catalog<S> {
     /// This function should not be called in production contexts. Use
     /// [`Catalog::open`] with appropriately set configuration parameters
     /// instead.
-    pub async fn open_debug(stash: S, now: NowFn) -> Result<Catalog<S>, anyhow::Error> {
+    pub async fn open_debug(
+        stash: S,
+        secrets_path: &Path,
+        now: NowFn,
+    ) -> Result<Catalog<S>, anyhow::Error> {
         let metrics_registry = &MetricsRegistry::new();
         let storage = storage::Connection::open(stash).await?;
+        let secrets_reader = SecretsReader::new(SecretsReaderConfig {
+            mount_path: secrets_path.to_path_buf(),
+        });
         let (catalog, _) = Catalog::open(Config {
             storage,
             unsafe_mode: true,
@@ -2015,6 +2030,7 @@ impl<S: Append> Catalog<S> {
             now,
             skip_migrations: true,
             metrics_registry,
+            secrets_reader,
         })
         .await?;
         Ok(catalog)
@@ -3798,6 +3814,10 @@ impl SessionCatalog for ConnCatalog<'_> {
     fn now(&self) -> EpochMillis {
         (self.state.config().now)()
     }
+
+    fn secrets_reader(&self) -> &SecretsReader {
+        &self.state.secrets_reader
+    }
 }
 
 impl mz_sql::catalog::CatalogDatabase for Database {
@@ -3865,7 +3885,7 @@ impl mz_sql::catalog::CatalogConnector for Connector {
         self.connector.uri()
     }
 
-    fn options(&self) -> std::collections::BTreeMap<String, String> {
+    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId> {
         self.connector.options()
     }
 }

--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -33,7 +33,7 @@ use mz_dataflow_types::client::{
 use mz_dataflow_types::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_dataflow_types::sinks::{SinkConnector, SinkConnectorBuilder, SinkEnvelope};
 use mz_dataflow_types::sources::{
-    ConnectorInner, ExternalSourceConnector, MaybeStringId, SourceConnector, Timeline,
+    ConnectorInner, ExternalSourceConnector, SourceConnector, StringOrSecret, Timeline,
 };
 use mz_expr::{ExprHumanizer, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
@@ -3885,7 +3885,7 @@ impl mz_sql::catalog::CatalogConnector for Connector {
         self.connector.uri()
     }
 
-    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId> {
+    fn options(&self) -> std::collections::BTreeMap<String, StringOrSecret> {
         self.connector.options()
     }
 }

--- a/src/coord/src/catalog/config.rs
+++ b/src/coord/src/catalog/config.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use mz_build_info::BuildInfo;
 use mz_ore::metrics::MetricsRegistry;
+use mz_secrets::SecretsReader;
 
 use crate::catalog::storage;
 
@@ -31,4 +32,5 @@ pub struct Config<'a, S> {
     pub skip_migrations: bool,
     /// The registry that catalog uses to report metrics.
     pub metrics_registry: &'a MetricsRegistry,
+    pub secrets_reader: SecretsReader,
 }

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -397,9 +397,6 @@ pub struct Coordinator<S> {
     /// Handle to secret manager that can create and delete secrets from
     /// an arbitrary secret storage engine.
     secrets_controller: Box<dyn SecretsController>,
-    /// Handle to secrets reader that gives us access to user secrets
-    #[allow(dead_code)]
-    secrets_reader: SecretsReader,
     /// Map of strings to corresponding compute replica sizes.
     replica_sizes: ClusterReplicaSizeMap,
     /// Valid availability zones for replicas.
@@ -5273,6 +5270,7 @@ pub async fn serve<S: Append + 'static>(
         now: now.clone(),
         skip_migrations: false,
         metrics_registry: &metrics_registry,
+        secrets_reader,
     })
     .await?;
     let cluster_id = catalog.config().cluster_id;
@@ -5307,7 +5305,6 @@ pub async fn serve<S: Append + 'static>(
                 write_lock_wait_group: VecDeque::new(),
                 pending_writes: Vec::new(),
                 secrets_controller,
-                secrets_reader,
                 replica_sizes,
                 availability_zones,
                 connector_context,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1086,9 +1086,6 @@ impl<S: Append + 'static> Coordinator<S> {
             depends_on,
         }: CreateSourceStatementReady,
     ) {
-        // TODO: verify that the dependent objects are still present. They may
-        // have been dropped while we were purifying the statement.
-
         let stmt = match result {
             Ok(stmt) => stmt,
             Err(e) => return tx.send(Err(e), session),
@@ -1102,6 +1099,15 @@ impl<S: Append + 'static> Coordinator<S> {
             Ok(_) => unreachable!("planning CREATE SOURCE must result in a Plan::CreateSource"),
             Err(e) => return tx.send(Err(e), session),
         };
+
+        // Check just before sequence_create_source.  This mirrors the handling of other sequence_* that are not
+        // handled specially.
+        if !depends_on
+            .iter()
+            .all(|id| self.catalog.try_get_entry(id).is_some())
+        {
+            return tx.send(Err(CoordError::ChangedPlan), session);
+        }
 
         let result = self
             .sequence_create_source(&mut session, plan, depends_on)
@@ -1689,6 +1695,12 @@ impl<S: Append + 'static> Coordinator<S> {
         };
         let depends_on = depends_on.into_iter().collect();
         let params = portal.parameters.clone();
+        // N.B. The catalog can change during purification so we must validate that the dependencies still exist after
+        // purification.  This should be done back on the main thread.  We do the validation in two places:
+        //   1. At the top of sequence_plan, where all plans _except_ Plan::CreateSource are sequenced.
+        //   2. In the handler for `Message::CreateSourceStatementReady`, before we sequence the create source
+        // If we add special handling for more types of `Statement`s, we'll need to ensure similar verficiation
+        // continues to be completed.
         match stmt {
             // `CREATE SOURCE` statements must be purified off the main
             // coordinator thread of control.
@@ -1906,6 +1918,12 @@ impl<S: Append + 'static> Coordinator<S> {
         plan: Plan,
         depends_on: Vec<GlobalId>,
     ) {
+        if !depends_on
+            .iter()
+            .all(|id| self.catalog.try_get_entry(id).is_some())
+        {
+            return tx.send(Err(CoordError::ChangedPlan), session);
+        }
         match plan {
             Plan::CreateConnector(plan) => {
                 tx.send(

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1091,6 +1091,14 @@ impl<S: Append + 'static> Coordinator<S> {
             Err(e) => return tx.send(Err(e), session),
         };
 
+        // Ensure that all dependencies still exist after purification.
+        if !depends_on
+            .iter()
+            .all(|id| self.catalog.try_get_entry(id).is_some())
+        {
+            return tx.send(Err(CoordError::ChangedPlan), session);
+        }
+
         let plan = match self
             .handle_statement(&mut session, Statement::CreateSource(stmt), &params)
             .await
@@ -1099,15 +1107,6 @@ impl<S: Append + 'static> Coordinator<S> {
             Ok(_) => unreachable!("planning CREATE SOURCE must result in a Plan::CreateSource"),
             Err(e) => return tx.send(Err(e), session),
         };
-
-        // Check just before sequence_create_source.  This mirrors the handling of other sequence_* that are not
-        // handled specially.
-        if !depends_on
-            .iter()
-            .all(|id| self.catalog.try_get_entry(id).is_some())
-        {
-            return tx.send(Err(CoordError::ChangedPlan), session);
-        }
 
         let result = self
             .sequence_create_source(&mut session, plan, depends_on)
@@ -1696,11 +1695,11 @@ impl<S: Append + 'static> Coordinator<S> {
         let depends_on = depends_on.into_iter().collect();
         let params = portal.parameters.clone();
         // N.B. The catalog can change during purification so we must validate that the dependencies still exist after
-        // purification.  This should be done back on the main thread.  We do the validation in two places:
-        //   1. At the top of sequence_plan, where all plans _except_ Plan::CreateSource are sequenced.
-        //   2. In the handler for `Message::CreateSourceStatementReady`, before we sequence the create source
-        // If we add special handling for more types of `Statement`s, we'll need to ensure similar verficiation
-        // continues to be completed.
+        // purification.  This should be done back on the main thread.
+        // We do the validation:
+        //   - In the handler for `Message::CreateSourceStatementReady`, before we handle the purified statement.
+        // If we add special handling for more types of `Statement`s, we'll need to ensure similar verification
+        // occurs.
         match stmt {
             // `CREATE SOURCE` statements must be purified off the main
             // coordinator thread of control.
@@ -1918,12 +1917,6 @@ impl<S: Append + 'static> Coordinator<S> {
         plan: Plan,
         depends_on: Vec<GlobalId>,
     ) {
-        if !depends_on
-            .iter()
-            .all(|id| self.catalog.try_get_entry(id).is_some())
-        {
-            return tx.send(Err(CoordError::ChangedPlan), session);
-        }
         match plan {
             Plan::CreateConnector(plan) => {
                 tx.send(

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -36,6 +36,7 @@ mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
+mz-secrets = { path = "../secrets" }
 mz-stash = { path = "../stash" }
 tonic = "0.7.2"
 once_cell = "1.12.0"

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -19,6 +19,7 @@ use bytes::BufMut;
 use chrono::NaiveDateTime;
 
 use globset::{Glob, GlobBuilder};
+use mz_secrets::SecretsReader;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy};
 use proptest::prop_oneof;
 use proptest_derive::Arbitrary;
@@ -1144,20 +1145,29 @@ pub fn provide_default_metadata(
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum MaybeStringId {
+pub enum StringOrSecret {
     String(String),
     Secret(GlobalId),
+}
+
+impl StringOrSecret {
+    pub fn get_string(&self, secrets_reader: &SecretsReader) -> anyhow::Result<String> {
+        match self {
+            StringOrSecret::String(s) => Ok(s.clone()),
+            StringOrSecret::Secret(id) => secrets_reader.read_string(*id),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ConnectorInner {
     Kafka {
         broker: KafkaAddrs,
-        config_options: BTreeMap<String, MaybeStringId>,
+        config_options: BTreeMap<String, StringOrSecret>,
     },
     CSR {
         registry: String,
-        with_options: BTreeMap<String, MaybeStringId>,
+        with_options: BTreeMap<String, StringOrSecret>,
     },
 }
 
@@ -1169,7 +1179,7 @@ impl ConnectorInner {
         }
     }
 
-    pub fn options(&self) -> BTreeMap<String, MaybeStringId> {
+    pub fn options(&self) -> BTreeMap<String, StringOrSecret> {
         match self {
             ConnectorInner::Kafka { config_options, .. } => config_options.clone(),
             ConnectorInner::CSR { with_options, .. } => with_options.clone(),

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -1144,14 +1144,20 @@ pub fn provide_default_metadata(
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum MaybeStringId {
+    String(String),
+    Secret(GlobalId),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ConnectorInner {
     Kafka {
         broker: KafkaAddrs,
-        config_options: BTreeMap<String, String>,
+        config_options: BTreeMap<String, MaybeStringId>,
     },
     CSR {
         registry: String,
-        with_options: BTreeMap<String, String>,
+        with_options: BTreeMap<String, MaybeStringId>,
     },
 }
 
@@ -1163,7 +1169,7 @@ impl ConnectorInner {
         }
     }
 
-    pub fn options(&self) -> BTreeMap<String, String> {
+    pub fn options(&self) -> BTreeMap<String, MaybeStringId> {
         match self {
             ConnectorInner::Kafka { config_options, .. } => config_options.clone(),
             ConnectorInner::CSR { with_options, .. } => with_options.clone(),

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -7,9 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fs;
+use std::borrow::Borrow;
+use std::fs::File;
+use std::io::Read;
 use std::path::PathBuf;
+use std::sync::Arc;
 
+use anyhow::Context;
 use async_trait::async_trait;
 
 use mz_repr::GlobalId;
@@ -50,6 +54,7 @@ pub enum SecretOp {
 }
 
 /// Configures a [`SecretsReader`].
+#[derive(Debug)]
 pub struct SecretsReaderConfig {
     /// The directory at which secrets are mounted.
     pub mount_path: PathBuf,
@@ -58,25 +63,48 @@ pub struct SecretsReaderConfig {
 /// Securely reads secrets that are managed by a [`SecretsController`].
 ///
 /// Does not provide access to create, update, or delete the secrets within.
+#[derive(Debug, Clone)]
 pub struct SecretsReader {
-    config: SecretsReaderConfig,
+    config: Arc<SecretsReaderConfig>,
 }
 
 impl SecretsReader {
     pub fn new(config: SecretsReaderConfig) -> Self {
-        Self { config }
+        Self {
+            config: Arc::new(config),
+        }
     }
 
     /// Returns the contents of a secret identified by GlobalId
-    pub fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
-        let file_path = self.config.mount_path.join(id.to_string());
-        Ok(fs::read(file_path)?)
+    ///
+    /// This `read` will return a complete version of the secret even though `SecretsReader` is `Clone` and we could
+    /// have concurrent reads.  It will not return, e.g., one block from v1 and another from v2.
+    ///
+    /// - On Linux / OSX filesystems, `File::open` will hold a handle open so that even if the file is deleted, we still
+    ///   continue to read from it.  This means a SecretOp::Delete followed by a SecretOp::Ensure can never "swap out"
+    ///   data mid-`read_to_end`.
+    /// - We do not allow editing secrets which _would_ expose us to this issue.
+    ///
+    /// (N.B. Were we ever to run with Windows / NTFS, this would also work properly _and_ mid-read edits would be
+    /// disallowed)
+    pub fn read<T: Borrow<GlobalId>>(&self, id: T) -> Result<Vec<u8>, anyhow::Error> {
+        let file_path = self.config.mount_path.join(id.borrow().to_string());
+
+        // Inlined the std::fs::read impl because correctness requires and impl that holds the same `File` handle open
+        let mut file = File::open(file_path)?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)?;
+        Ok(buf)
+    }
+
+    pub fn read_string<T: Borrow<GlobalId>>(&self, id: T) -> anyhow::Result<String> {
+        String::from_utf8(self.read(id)?).context("converting secret value to string")
     }
 
     /// Returns the path of the secret consisting of a configured base path
     /// and the GlobalId
-    pub fn canonical_path(&self, id: GlobalId) -> Result<PathBuf, anyhow::Error> {
-        let path = self.config.mount_path.join(id.to_string());
+    pub fn canonical_path<T: Borrow<GlobalId>>(&self, id: T) -> Result<PathBuf, anyhow::Error> {
+        let path = self.config.mount_path.join(id.borrow().to_string());
         Ok(path)
     }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::borrow::Borrow;
 use std::fs::File;
 use std::io::Read;
 use std::path::PathBuf;
@@ -77,8 +76,8 @@ impl SecretsReader {
 
     /// Returns the contents of a secret identified by GlobalId
     ///
-    /// This `read` will return a complete version of the secret even though `SecretsReader` is `Clone` and we could
-    /// have concurrent reads.  It will not return, e.g., one block from v1 and another from v2.
+    /// This `read` will return a complete version of the secret. It will not return, e.g., one block from v1 and
+    /// another from v2.
     ///
     /// - On Linux / OSX filesystems, `File::open` will hold a handle open so that even if the file is deleted, we still
     ///   continue to read from it.  This means a SecretOp::Delete followed by a SecretOp::Ensure can never "swap out"
@@ -88,7 +87,7 @@ impl SecretsReader {
     /// (N.B. Were we ever to run with Windows / NTFS, this would also work properly _and_ mid-read edits would be
     /// disallowed)
     pub fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
-        let file_path = self.config.mount_path.join(id.borrow().to_string());
+        let file_path = self.config.mount_path.join(id.to_string());
 
         // Inlined the std::fs::read impl because correctness requires and impl that holds the same `File` handle open
         let mut file = File::open(file_path)?;
@@ -104,7 +103,7 @@ impl SecretsReader {
     /// Returns the path of the secret consisting of a configured base path
     /// and the GlobalId
     pub fn canonical_path(&self, id: GlobalId) -> Result<PathBuf, anyhow::Error> {
-        let path = self.config.mount_path.join(id.borrow().to_string());
+        let path = self.config.mount_path.join(id.to_string());
         Ok(path)
     }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -87,7 +87,7 @@ impl SecretsReader {
     ///
     /// (N.B. Were we ever to run with Windows / NTFS, this would also work properly _and_ mid-read edits would be
     /// disallowed)
-    pub fn read<T: Borrow<GlobalId>>(&self, id: T) -> Result<Vec<u8>, anyhow::Error> {
+    pub fn read(&self, id: GlobalId) -> Result<Vec<u8>, anyhow::Error> {
         let file_path = self.config.mount_path.join(id.borrow().to_string());
 
         // Inlined the std::fs::read impl because correctness requires and impl that holds the same `File` handle open
@@ -97,13 +97,13 @@ impl SecretsReader {
         Ok(buf)
     }
 
-    pub fn read_string<T: Borrow<GlobalId>>(&self, id: T) -> anyhow::Result<String> {
+    pub fn read_string(&self, id: GlobalId) -> anyhow::Result<String> {
         String::from_utf8(self.read(id)?).context("converting secret value to string")
     }
 
     /// Returns the path of the secret consisting of a configured base path
     /// and the GlobalId
-    pub fn canonical_path<T: Borrow<GlobalId>>(&self, id: T) -> Result<PathBuf, anyhow::Error> {
+    pub fn canonical_path(&self, id: GlobalId) -> Result<PathBuf, anyhow::Error> {
         let path = self.config.mount_path.join(id.borrow().to_string());
         Ok(path)
     }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -27,6 +27,7 @@ mz-ore = { path = "../ore", features = ["task"] }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
+mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }
 paste = "1.0"
 protobuf-native = "0.2.1"

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,7 +23,7 @@ use once_cell::sync::Lazy;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_dataflow_types::client::ComputeInstanceId;
-use mz_dataflow_types::sources::{MaybeStringId, SourceConnector};
+use mz_dataflow_types::sources::{SourceConnector, StringOrSecret};
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
@@ -276,7 +276,7 @@ pub trait CatalogConnector {
     fn uri(&self) -> String;
 
     /// Returns the options associated with this connector as a Vec, if the type does not support options or none were specified this will be empty
-    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId>;
+    fn options(&self) -> std::collections::BTreeMap<String, StringOrSecret>;
 }
 
 /// An item in a [`SessionCatalog`].

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -188,7 +188,7 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// at 0.
     fn now(&self) -> EpochMillis;
 
-    /// Returns SecretsReader for catalog
+    /// Returns a secrets reader associated with the catalog.
     fn secrets_reader(&self) -> &SecretsReader;
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,10 +23,11 @@ use once_cell::sync::Lazy;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_dataflow_types::client::ComputeInstanceId;
-use mz_dataflow_types::sources::SourceConnector;
+use mz_dataflow_types::sources::{MaybeStringId, SourceConnector};
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
+use mz_secrets::SecretsReader;
 use mz_sql_parser::ast::Expr;
 use uuid::Uuid;
 
@@ -186,6 +187,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// this means the Unix epoch. This can safely be mocked in tests and start
     /// at 0.
     fn now(&self) -> EpochMillis;
+
+    /// Returns SecretsReader for catalog
+    fn secrets_reader(&self) -> &SecretsReader;
 }
 
 /// Configuration associated with a catalog.
@@ -272,7 +276,7 @@ pub trait CatalogConnector {
     fn uri(&self) -> String;
 
     /// Returns the options associated with this connector as a Vec, if the type does not support options or none were specified this will be empty
-    fn options(&self) -> std::collections::BTreeMap<String, String>;
+    fn options(&self) -> std::collections::BTreeMap<String, MaybeStringId>;
 }
 
 /// An item in a [`SessionCatalog`].
@@ -694,6 +698,10 @@ impl SessionCatalog for DummyCatalog {
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
         name
+    }
+
+    fn secrets_reader(&self) -> &SecretsReader {
+        unimplemented!()
     }
 }
 

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -432,7 +432,7 @@ pub fn generate_ccsr_client_config(
 
     // If provided, prefer SSL options from the schema registry configuration
     if let Some(ca_path) = ccsr_options
-        .remove("ssl_ca_location")
+        .remove("ssl.ca.location")
         .map(|v| v.get_string(secrets_reader))
         .transpose()?
     {
@@ -443,11 +443,11 @@ pub fn generate_ccsr_client_config(
     }
 
     let key_path = ccsr_options
-        .remove("ssl_key_location")
+        .remove("ssl.key.location")
         .map(|v| v.get_string(secrets_reader))
         .transpose()?;
     let cert_path = ccsr_options
-        .remove("ssl_certificate_location")
+        .remove("ssl.certificate.location")
         .map(|v| v.get_string(secrets_reader))
         .transpose()?;
     match (key_path, cert_path) {

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -131,7 +131,7 @@ fn extract(
                 .val_type
                 .process_val(&Value::String(secrets_reader.read_string(id)?))
                 .map(|_| StringOrSecret::Secret(id))
-                .map_err(|e| anyhow!("Invalid WITH option {}={}: {}", config.name, id, e))?,
+                .map_err(|e| anyhow!("Invalid WITH option {}={:?}: {}", config.name, id, e))?,
             // Check for default values
             None => match &config.default {
                 Some(v) => StringOrSecret::String(config.do_transform(v.to_string())),

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -156,7 +156,7 @@ pub fn options(
                 SqlValueOrSecret::Secret(id.clone())
             }
             Some(WithOptionValue::Secret(_)) => {
-                bail!("SECRET option {} must be Object", option.key)
+                panic!("SECRET option {} must be Object", option.key)
             }
             None => {
                 bail!("option {} requires a value", option.key);

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -66,7 +66,7 @@ use mz_sql_parser::ast::{
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
 use crate::names::{Aug, PartialObjectName, ResolvedDataType, ResolvedObjectName};
-use crate::normalize::{self, SqlMaybeValueId};
+use crate::normalize::{self, SqlValueOrSecret};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, AggregateFunc, BinaryFunc,
@@ -1420,7 +1420,7 @@ fn plan_view_select(
     let option = options.remove("expected_group_size");
 
     let expected_group_size = match option {
-        Some(SqlMaybeValueId::Value(Value::Number(n))) => Some(n.parse::<usize>()?),
+        Some(SqlValueOrSecret::Value(Value::Number(n))) => Some(n.parse::<usize>()?),
         Some(_) => sql_bail!("expected_group_size must be a number"),
         None => None,
     };

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -66,7 +66,7 @@ use mz_sql_parser::ast::{
 use crate::catalog::{CatalogItemType, CatalogType, SessionCatalog};
 use crate::func::{self, Func, FuncSpec};
 use crate::names::{Aug, PartialObjectName, ResolvedDataType, ResolvedObjectName};
-use crate::normalize;
+use crate::normalize::{self, SqlMaybeValueId};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, AggregateFunc, BinaryFunc,
@@ -1420,7 +1420,7 @@ fn plan_view_select(
     let option = options.remove("expected_group_size");
 
     let expected_group_size = match option {
-        Some(Value::Number(n)) => Some(n.parse::<usize>()?),
+        Some(SqlMaybeValueId::Value(Value::Number(n))) => Some(n.parse::<usize>()?),
         Some(_) => sql_bail!("expected_group_size must be a number"),
         None => None,
     };

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -220,8 +220,10 @@ pub fn plan(
         Statement::CreateRole(stmt) => ddl::plan_create_role(scx, stmt),
         Statement::CreateSchema(stmt) => ddl::plan_create_schema(scx, stmt),
         Statement::CreateSecret(stmt) => ddl::plan_create_secret(scx, stmt),
-        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt),
-        Statement::CreateSource(stmt) => ddl::plan_create_source(scx, stmt),
+        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt, catalog.secrets_reader()),
+        Statement::CreateSource(stmt) => {
+            ddl::plan_create_source(scx, stmt, catalog.secrets_reader())
+        }
         Statement::CreateTable(stmt) => ddl::plan_create_table(scx, stmt),
         Statement::CreateType(stmt) => ddl::plan_create_type(scx, stmt),
         Statement::CreateView(stmt) => ddl::plan_create_view(scx, stmt, params),

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -220,10 +220,8 @@ pub fn plan(
         Statement::CreateRole(stmt) => ddl::plan_create_role(scx, stmt),
         Statement::CreateSchema(stmt) => ddl::plan_create_schema(scx, stmt),
         Statement::CreateSecret(stmt) => ddl::plan_create_secret(scx, stmt),
-        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt, catalog.secrets_reader()),
-        Statement::CreateSource(stmt) => {
-            ddl::plan_create_source(scx, stmt, catalog.secrets_reader())
-        }
+        Statement::CreateSink(stmt) => ddl::plan_create_sink(scx, stmt),
+        Statement::CreateSource(stmt) => ddl::plan_create_source(scx, stmt),
         Statement::CreateTable(stmt) => ddl::plan_create_table(scx, stmt),
         Statement::CreateType(stmt) => ddl::plan_create_type(scx, stmt),
         Statement::CreateView(stmt) => ddl::plan_create_view(scx, stmt, params),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -399,7 +399,7 @@ pub fn plan_create_source(
 
             let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
 
-            // XXX(chae): is this the place to inline? Or should it get delayed until we actually connect to kafka?
+            // TODO(13017): don't inline secrets at this stage.  Push that into storaged.
             let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
 
             let mut connector = KafkaSourceConnector {
@@ -1957,7 +1957,7 @@ fn kafka_sink_builder(
     let consistency_topic = consistency_config.clone().map(|config| config.0);
     let consistency_format = consistency_config.map(|config| config.1);
 
-    // XXX(chae): is this where secrets should be inlined for kafka sinks??  "End of planning"?
+    // TODO(13017): don't inline secrets at this stage.  Push that into storaged.
     let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
     Ok(SinkConnectorBuilder::Kafka(KafkaSinkConnectorBuilder {
         broker_addrs,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -397,13 +397,7 @@ pub fn plan_create_source(
                 Some(v) => bail!("invalid start_offset value: {}", v),
             }
 
-            let encoding = get_encoding(
-                scx,
-                format,
-                &envelope,
-                with_options_original,
-                secrets_reader,
-            )?;
+            let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
 
             // XXX(chae): is this the place to inline? Or should it get delayed until we actually connect to kafka?
             let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
@@ -503,13 +497,7 @@ pub fn plan_create_source(
             let aws = normalize::aws_config(&mut with_options, Some(region.into()))?;
             let connector =
                 ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, aws });
-            let encoding = get_encoding(
-                scx,
-                format,
-                &envelope,
-                with_options_original,
-                secrets_reader,
-            )?;
+            let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
             (connector, encoding)
         }
         CreateSourceConnector::S3 {
@@ -552,13 +540,7 @@ pub fn plan_create_source(
                     Compression::None => mz_dataflow_types::sources::Compression::None,
                 },
             });
-            let encoding = get_encoding(
-                scx,
-                format,
-                &envelope,
-                with_options_original,
-                secrets_reader,
-            )?;
+            let encoding = get_encoding(scx, format, &envelope, secrets_reader)?;
             if matches!(encoding, SourceDataEncoding::KeyValue { .. }) {
                 bail!("S3 sources do not support key decoding");
             }
@@ -1203,20 +1185,17 @@ fn get_encoding(
     scx: &StatementContext,
     format: &CreateSourceFormat<Aug>,
     envelope: &Envelope<Aug>,
-    with_options: &Vec<WithOption<Aug>>,
     secrets_reader: &SecretsReader,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     let encoding = match format {
         CreateSourceFormat::None => bail!("Source format must be specified"),
-        CreateSourceFormat::Bare(format) => {
-            get_encoding_inner(scx, format, with_options, secrets_reader)?
-        }
+        CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format, secrets_reader)?,
         CreateSourceFormat::KeyValue { key, value } => {
-            let key = match get_encoding_inner(scx, key, with_options, secrets_reader)? {
+            let key = match get_encoding_inner(scx, key, secrets_reader)? {
                 SourceDataEncoding::Single(key) => key,
                 SourceDataEncoding::KeyValue { key, .. } => key,
             };
-            let value = match get_encoding_inner(scx, value, with_options, secrets_reader)? {
+            let value = match get_encoding_inner(scx, value, secrets_reader)? {
                 SourceDataEncoding::Single(value) => value,
                 SourceDataEncoding::KeyValue { value, .. } => value,
             };
@@ -1239,7 +1218,6 @@ fn get_encoding(
 fn get_encoding_inner(
     scx: &StatementContext,
     format: &Format<Aug>,
-    with_options: &Vec<WithOption<Aug>>,
     secrets_reader: &SecretsReader,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     // Avro/CSR can return a `SourceDataEncoding::KeyValue`
@@ -1291,7 +1269,7 @@ fn get_encoding_inner(
                         CsrConnector::Inline { url } => {
                             (normalize::options(&ccsr_options)?, url.into())
                         }
-                        CsrConnector::Reference { connector, .. } => {
+                        CsrConnector::Reference { connector } => {
                             let item = scx.get_item_by_resolved_name(&connector)?;
                             let connector = item.catalog_connector()?;
                             let options = connector
@@ -1917,7 +1895,6 @@ fn kafka_sink_builder(
     let consistency_config = get_kafka_sink_consistency_config(
         &topic_prefix,
         &format,
-        &config_options,
         reuse_topic,
         consistency,
         consistency_topic,
@@ -2033,7 +2010,6 @@ fn kafka_sink_builder(
 fn get_kafka_sink_consistency_config(
     topic_prefix: &str,
     sink_format: &KafkaSinkFormat,
-    config_options: &BTreeMap<String, StringOrSecret>,
     reuse_topic: bool,
     consistency: Option<KafkaConsistency<Aug>>,
     consistency_topic: Option<String>,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1266,31 +1266,16 @@ fn get_encoding_inner(
                         },
                 } => {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => {
-                            (normalize::options(&ccsr_options)?, url.into())
-                        }
+                        CsrConnector::Inline { url } => (
+                            kafka_util::extract_config_ccsr(&mut normalize::options(
+                                &ccsr_options,
+                            )?)?,
+                            url.into(),
+                        ),
                         CsrConnector::Reference { connector } => {
                             let item = scx.get_item_by_resolved_name(&connector)?;
                             let connector = item.catalog_connector()?;
-                            let options = connector
-                                .options()
-                                .into_iter()
-                                // XXX(chae): prob not right to go backwards? maybe generate_ccsr_client_config should take MaybeStringId
-                                .map(|(k, v)| {
-                                    (
-                                        k,
-                                        match v {
-                                            StringOrSecret::String(s) => {
-                                                SqlMaybeValueId::Value(Value::String(s))
-                                            }
-                                            StringOrSecret::Secret(id) => {
-                                                SqlMaybeValueId::Secret(id)
-                                            }
-                                        },
-                                    )
-                                })
-                                .collect();
-                            (options, connector.uri())
+                            (connector.options(), connector.uri())
                         }
                     };
                     let ccsr_config = kafka_util::generate_ccsr_client_config(
@@ -1349,31 +1334,16 @@ fn get_encoding_inner(
                     seed
                 {
                     let (mut ccsr_with_options, registry_url) = match connector {
-                        CsrConnector::Inline { url } => {
-                            (normalize::options(&ccsr_options)?, url.to_string())
-                        }
-                        CsrConnector::Reference { connector, .. } => {
+                        CsrConnector::Inline { url } => (
+                            kafka_util::extract_config_ccsr(&mut normalize::options(
+                                &ccsr_options,
+                            )?)?,
+                            url.to_string(),
+                        ),
+                        CsrConnector::Reference { connector } => {
                             let item = scx.get_item_by_resolved_name(&connector)?;
                             let connector = item.catalog_connector()?;
-                            let options = connector
-                                .options()
-                                .into_iter()
-                                // XXX(chae): prob not right to go backwards? maybe generate_ccsr_client_config should take MaybeStringId
-                                .map(|(k, v)| {
-                                    (
-                                        k,
-                                        match v {
-                                            StringOrSecret::String(s) => {
-                                                SqlMaybeValueId::Value(Value::String(s))
-                                            }
-                                            StringOrSecret::Secret(id) => {
-                                                SqlMaybeValueId::Secret(id)
-                                            }
-                                        },
-                                    )
-                                })
-                                .collect();
-                            (options, connector.uri())
+                            (connector.options(), connector.uri())
                         }
                     };
                     // We validate here instead of in purification, to match the behavior of avro
@@ -1852,7 +1822,8 @@ fn kafka_sink_builder(
             if seed.is_some() {
                 bail!("SEED option does not make sense with sinks");
             }
-            let mut ccsr_with_options = normalize::options(&with_options)?;
+            let mut ccsr_with_options =
+                kafka_util::extract_config_ccsr(&mut normalize::options(&with_options)?)?;
 
             let schema_registry_url = url.parse::<Url>()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
@@ -2032,7 +2003,8 @@ fn get_kafka_sink_consistency_config(
                     bail!("SEED option does not make sense with sinks");
                 }
                 let schema_registry_url = uri.parse::<Url>()?;
-                let mut ccsr_with_options = normalize::options(&with_options)?;
+                let mut ccsr_with_options =
+                    kafka_util::extract_config_ccsr(&mut normalize::options(&with_options)?)?;
                 let ccsr_config = kafka_util::generate_ccsr_client_config(
                     schema_registry_url.clone(),
                     &mut ccsr_with_options,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -22,6 +22,7 @@ use bytes::Bytes;
 use chrono::{NaiveDate, NaiveDateTime};
 use globset::GlobBuilder;
 use itertools::Itertools;
+use mz_secrets::SecretsReader;
 use prost::Message;
 use regex::Regex;
 use reqwest::Url;
@@ -39,8 +40,8 @@ use mz_dataflow_types::sources::encoding::{
 use mz_dataflow_types::sources::{
     provide_default_metadata, ConnectorInner, DebeziumDedupProjection, DebeziumEnvelope,
     DebeziumMode, DebeziumSourceProjection, DebeziumTransactionMetadata, ExternalSourceConnector,
-    IncludedColumnPos, KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, MzOffset,
-    PostgresSourceConnector, PubNubSourceConnector, S3SourceConnector, SourceConnector,
+    IncludedColumnPos, KafkaSourceConnector, KeyEnvelope, KinesisSourceConnector, MaybeStringId,
+    MzOffset, PostgresSourceConnector, PubNubSourceConnector, S3SourceConnector, SourceConnector,
     SourceEnvelope, Timeline, UnplannedSourceEnvelope, UpsertStyle,
 };
 use mz_expr::CollectionPlan;
@@ -77,8 +78,8 @@ use crate::names::{
     self, Aug, FullSchemaName, QualifiedObjectName, RawDatabaseSpecifier, ResolvedClusterName,
     ResolvedDataType, ResolvedDatabaseSpecifier, ResolvedObjectName, SchemaSpecifier,
 };
-use crate::normalize;
 use crate::normalize::ident;
+use crate::normalize::{self, SqlMaybeValueId};
 use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
 use crate::plan::statement::{StatementContext, StatementDesc};
@@ -297,6 +298,7 @@ pub fn describe_create_source(
 pub fn plan_create_source(
     scx: &StatementContext,
     stmt: CreateSourceStatement<Aug>,
+    secrets_reader: &SecretsReader,
 ) -> Result<Plan, anyhow::Error> {
     let CreateSourceStatement {
         name,
@@ -317,8 +319,8 @@ pub fn plan_create_source(
     let mut with_options = normalize::options(with_options_original)?;
 
     let ts_frequency = match with_options.remove("timestamp_frequency_ms") {
-        Some(val) => match val {
-            Value::Number(n) => match n.parse::<u64>() {
+        Some(val) => match val.try_into_value() {
+            Some(Value::Number(n)) => match n.parse::<u64>() {
                 Ok(n) => Duration::from_millis(n),
                 Err(_) => bail!("timestamp_frequency_ms must be an u64"),
             },
@@ -359,7 +361,7 @@ pub fn plan_create_source(
 
             let group_id_prefix = match with_options.remove("group_id_prefix") {
                 None => None,
-                Some(Value::String(s)) => Some(s),
+                Some(SqlMaybeValueId::Value(Value::String(s))) => Some(s),
                 Some(_) => bail!("group_id_prefix must be a string"),
             };
 
@@ -379,10 +381,10 @@ pub fn plan_create_source(
                 None => {
                     start_offsets.insert(0, MzOffset::from(0));
                 }
-                Some(Value::Number(n)) => {
+                Some(SqlMaybeValueId::Value(Value::Number(n))) => {
                     start_offsets.insert(0, parse_offset(&n)?);
                 }
-                Some(Value::Array(vs)) => {
+                Some(SqlMaybeValueId::Value(Value::Array(vs))) => {
                     for (i, v) in vs.iter().enumerate() {
                         match v {
                             Value::Number(n) => {
@@ -395,7 +397,16 @@ pub fn plan_create_source(
                 Some(v) => bail!("invalid start_offset value: {}", v),
             }
 
-            let encoding = get_encoding(scx, format, &envelope, with_options_original)?;
+            let encoding = get_encoding(
+                scx,
+                format,
+                &envelope,
+                with_options_original,
+                secrets_reader,
+            )?;
+
+            // XXX(chae): is this the place to inline? Or should it get delayed until we actually connect to kafka?
+            let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
 
             let mut connector = KafkaSourceConnector {
                 addrs: broker.parse()?,
@@ -492,7 +503,13 @@ pub fn plan_create_source(
             let aws = normalize::aws_config(&mut with_options, Some(region.into()))?;
             let connector =
                 ExternalSourceConnector::Kinesis(KinesisSourceConnector { stream_name, aws });
-            let encoding = get_encoding(scx, format, &envelope, with_options_original)?;
+            let encoding = get_encoding(
+                scx,
+                format,
+                &envelope,
+                with_options_original,
+                secrets_reader,
+            )?;
             (connector, encoding)
         }
         CreateSourceConnector::S3 {
@@ -535,7 +552,13 @@ pub fn plan_create_source(
                     Compression::None => mz_dataflow_types::sources::Compression::None,
                 },
             });
-            let encoding = get_encoding(scx, format, &envelope, with_options_original)?;
+            let encoding = get_encoding(
+                scx,
+                format,
+                &envelope,
+                with_options_original,
+                secrets_reader,
+            )?;
             if matches!(encoding, SourceDataEncoding::KeyValue { .. }) {
                 bail!("S3 sources do not support key decoding");
             }
@@ -681,7 +704,7 @@ pub fn plan_create_source(
                             Ok(_) => Cow::from("ordered"),
                             Err(_) => Cow::from("none"),
                         },
-                        Some(Value::String(s)) => Cow::from(s),
+                        Some(SqlMaybeValueId::Value(Value::String(s))) => Cow::from(s),
                         _ => bail!("deduplication option must be a string"),
                     };
 
@@ -723,13 +746,13 @@ pub fn plan_create_source(
 
                             let dedup_start = match with_options.remove("deduplication_start") {
                                 None => None,
-                                Some(Value::String(start)) => Some(parse_datetime(&start)?),
+                                Some(SqlMaybeValueId::Value(Value::String(start))) => Some(parse_datetime(&start)?),
                                 _ => bail!("deduplication_start option must be a string"),
                             };
 
                             let dedup_end = match with_options.remove("deduplication_end") {
                                 None => None,
-                                Some(Value::String(end)) => Some(parse_datetime(&end)?),
+                                Some(SqlMaybeValueId::Value(Value::String(end))) => Some(parse_datetime(&end)?),
                                 _ => bail!("deduplication_end option must be a string"),
                             };
 
@@ -746,7 +769,7 @@ pub fn plan_create_source(
                                     let pad_start =
                                         match with_options.remove("deduplication_pad_start") {
                                             None => None,
-                                            Some(Value::String(pad_start)) => {
+                                            Some(SqlMaybeValueId::Value(Value::String(pad_start))) => {
                                                 Some(parse_datetime(&pad_start)?)
                                             }
                                             _ => bail!(
@@ -834,7 +857,7 @@ pub fn plan_create_source(
 
     let ignore_source_keys = match with_options.remove("ignore_source_keys") {
         None => false,
-        Some(Value::Boolean(b)) => b,
+        Some(SqlMaybeValueId::Value(Value::Boolean(b))) => b,
         Some(_) => bail!("ignore_source_keys must be a boolean"),
     };
 
@@ -891,15 +914,16 @@ pub fn plan_create_source(
 
     // Allow users to specify a timeline. If they do not, determine a default timeline for the source.
     let timeline = if let Some(timeline) = with_options.remove("timeline") {
-        match timeline {
-            Value::String(timeline) => Timeline::User(timeline),
-            v => bail!("unsupported timeline value {}", v.to_ast_string()),
+        match timeline.try_into_value() {
+            Some(Value::String(timeline)) => Timeline::User(timeline),
+            Some(v) => bail!("unsupported timeline value {}", v.to_ast_string()),
+            None => bail!("unsupported timeline value: secret"),
         }
     } else {
         match envelope {
             SourceEnvelope::CdcV2 => match with_options.remove("epoch_ms_timeline") {
                 None => Timeline::External(name.to_string()),
-                Some(Value::Boolean(true)) => Timeline::EpochMilliseconds,
+                Some(SqlMaybeValueId::Value(Value::Boolean(true))) => Timeline::EpochMilliseconds,
                 Some(v) => bail!("unsupported epoch_ms_timeline value {}", v),
             },
             _ => Timeline::EpochMilliseconds,
@@ -1180,16 +1204,19 @@ fn get_encoding(
     format: &CreateSourceFormat<Aug>,
     envelope: &Envelope<Aug>,
     with_options: &Vec<WithOption<Aug>>,
+    secrets_reader: &SecretsReader,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     let encoding = match format {
         CreateSourceFormat::None => bail!("Source format must be specified"),
-        CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format, with_options)?,
+        CreateSourceFormat::Bare(format) => {
+            get_encoding_inner(scx, format, with_options, secrets_reader)?
+        }
         CreateSourceFormat::KeyValue { key, value } => {
-            let key = match get_encoding_inner(scx, key, with_options)? {
+            let key = match get_encoding_inner(scx, key, with_options, secrets_reader)? {
                 SourceDataEncoding::Single(key) => key,
                 SourceDataEncoding::KeyValue { key, .. } => key,
             };
-            let value = match get_encoding_inner(scx, value, with_options)? {
+            let value = match get_encoding_inner(scx, value, with_options, secrets_reader)? {
                 SourceDataEncoding::Single(value) => value,
                 SourceDataEncoding::KeyValue { value, .. } => value,
             };
@@ -1213,6 +1240,7 @@ fn get_encoding_inner(
     scx: &StatementContext,
     format: &Format<Aug>,
     with_options: &Vec<WithOption<Aug>>,
+    secrets_reader: &SecretsReader,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
     // Avro/CSR can return a `SourceDataEncoding::KeyValue`
     Ok(SourceDataEncoding::Single(match format {
@@ -1269,7 +1297,20 @@ fn get_encoding_inner(
                             let options = connector
                                 .options()
                                 .into_iter()
-                                .map(|(k, v)| (k, Value::String(v)))
+                                // XXX(chae): prob not right to go backwards? maybe generate_ccsr_client_config should take MaybeStringId
+                                .map(|(k, v)| {
+                                    (
+                                        k,
+                                        match v {
+                                            MaybeStringId::String(s) => {
+                                                SqlMaybeValueId::Value(Value::String(s))
+                                            }
+                                            MaybeStringId::Secret(id) => {
+                                                SqlMaybeValueId::Secret(id)
+                                            }
+                                        },
+                                    )
+                                })
                                 .collect();
                             (options, connector.uri())
                         }
@@ -1278,6 +1319,7 @@ fn get_encoding_inner(
                         registry_url.parse()?,
                         &kafka_util::extract_config(&mut normalize::options(with_options)?)?,
                         &mut ccsr_with_options,
+                        secrets_reader,
                     )?;
                     normalize::ensure_empty_options(
                         &ccsr_with_options,
@@ -1339,7 +1381,20 @@ fn get_encoding_inner(
                             let options = connector
                                 .options()
                                 .into_iter()
-                                .map(|(k, v)| (k, Value::String(v)))
+                                // XXX(chae): prob not right to go backwards? maybe generate_ccsr_client_config should take MaybeStringId
+                                .map(|(k, v)| {
+                                    (
+                                        k,
+                                        match v {
+                                            MaybeStringId::String(s) => {
+                                                SqlMaybeValueId::Value(Value::String(s))
+                                            }
+                                            MaybeStringId::Secret(id) => {
+                                                SqlMaybeValueId::Secret(id)
+                                            }
+                                        },
+                                    )
+                                })
                                 .collect();
                             (options, connector.uri())
                         }
@@ -1349,6 +1404,7 @@ fn get_encoding_inner(
                         registry_url.parse()?,
                         &kafka_util::extract_config(&mut normalize::options(with_options)?)?,
                         &mut ccsr_with_options,
+                        secrets_reader,
                     )?;
                     normalize::ensure_empty_options(
                         &ccsr_with_options,
@@ -1758,7 +1814,7 @@ fn kafka_sink_builder(
     scx: &StatementContext,
     format: Option<Format<Aug>>,
     consistency: Option<KafkaConsistency<Aug>>,
-    with_options: &mut BTreeMap<String, Value>,
+    with_options: &mut BTreeMap<String, SqlMaybeValueId>,
     broker: String,
     topic_prefix: String,
     relation_key_indices: Option<Vec<usize>>,
@@ -1767,10 +1823,11 @@ fn kafka_sink_builder(
     envelope: SinkEnvelope,
     topic_suffix_nonce: String,
     root_dependencies: &[&dyn CatalogItem],
+    secrets_reader: &SecretsReader,
 ) -> Result<SinkConnectorBuilder, anyhow::Error> {
     let consistency_topic = match with_options.remove("consistency_topic") {
         None => None,
-        Some(Value::String(topic)) => Some(topic),
+        Some(SqlMaybeValueId::Value(Value::String(topic))) => Some(topic),
         Some(_) => bail!("consistency_topic must be a string"),
     };
     if consistency_topic.is_some() && consistency.is_some() {
@@ -1779,14 +1836,14 @@ fn kafka_sink_builder(
         bail!("Cannot specify consistency_topic and CONSISTENCY options simultaneously");
     }
     let reuse_topic = match with_options.remove("reuse_topic") {
-        Some(Value::Boolean(b)) => b,
+        Some(SqlMaybeValueId::Value(Value::Boolean(b))) => b,
         None => false,
         Some(_) => bail!("reuse_topic must be a boolean"),
     };
     let config_options = kafka_util::extract_config(with_options)?;
 
     let avro_key_fullname = match with_options.remove("avro_key_fullname") {
-        Some(Value::String(s)) => Some(s),
+        Some(SqlMaybeValueId::Value(Value::String(s))) => Some(s),
         None => None,
         Some(_) => bail!("avro_key_fullname must be a string"),
     };
@@ -1796,7 +1853,7 @@ fn kafka_sink_builder(
     }
 
     let avro_value_fullname = match with_options.remove("avro_value_fullname") {
-        Some(Value::String(s)) => Some(s),
+        Some(SqlMaybeValueId::Value(Value::String(s))) => Some(s),
         None => None,
         Some(_) => bail!("avro_value_fullname must be a string"),
     };
@@ -1826,6 +1883,7 @@ fn kafka_sink_builder(
                 schema_registry_url.clone(),
                 &config_options,
                 &mut ccsr_with_options,
+                secrets_reader,
             )?;
 
             let include_transaction =
@@ -1866,6 +1924,7 @@ fn kafka_sink_builder(
         reuse_topic,
         consistency,
         consistency_topic,
+        secrets_reader,
     )?;
 
     let broker_addrs = broker.parse()?;
@@ -1895,7 +1954,7 @@ fn kafka_sink_builder(
     // Use the user supplied value for partition count, or default to -1 (broker default)
     let partition_count = match with_options.remove("partition_count") {
         None => -1,
-        Some(Value::Number(n)) => n.parse::<i32>()?,
+        Some(SqlMaybeValueId::Value(Value::Number(n))) => n.parse::<i32>()?,
         Some(_) => bail!("partition count for sink topics must be an integer"),
     };
 
@@ -1908,7 +1967,7 @@ fn kafka_sink_builder(
     // Use the user supplied value for replication factor, or default to -1 (broker default)
     let replication_factor = match with_options.remove("replication_factor") {
         None => -1,
-        Some(Value::Number(n)) => n.parse::<i32>()?,
+        Some(SqlMaybeValueId::Value(Value::Number(n))) => n.parse::<i32>()?,
         Some(_) => bail!("replication factor for sink topics must be an integer"),
     };
 
@@ -1920,7 +1979,7 @@ fn kafka_sink_builder(
 
     let retention_duration = match with_options.remove("retention_ms") {
         None => None,
-        Some(Value::Number(n)) => match n.parse::<i64>()? {
+        Some(SqlMaybeValueId::Value(Value::Number(n))) => match n.parse::<i64>()? {
             -1 => Some(None),
             millis @ 0.. => Some(Some(Duration::from_millis(millis as u64))),
             _ => bail!("retention ms for sink topics must be greater than or equal to -1"),
@@ -1930,7 +1989,7 @@ fn kafka_sink_builder(
 
     let retention_bytes = match with_options.remove("retention_bytes") {
         None => None,
-        Some(Value::Number(n)) => Some(n.parse::<i64>()?),
+        Some(SqlMaybeValueId::Value(Value::Number(n))) => Some(n.parse::<i64>()?),
         Some(_) => bail!("retention bytes for sink topics must be an integer"),
     };
 
@@ -1945,6 +2004,8 @@ fn kafka_sink_builder(
     let consistency_topic = consistency_config.clone().map(|config| config.0);
     let consistency_format = consistency_config.map(|config| config.1);
 
+    // XXX(chae): is this where secrets should be inlined for kafka sinks??  "End of planning"?
+    let config_options = kafka_util::inline_secrets(config_options, secrets_reader)?;
     Ok(SinkConnectorBuilder::Kafka(KafkaSinkConnectorBuilder {
         broker_addrs,
         format,
@@ -1975,10 +2036,11 @@ fn kafka_sink_builder(
 fn get_kafka_sink_consistency_config(
     topic_prefix: &str,
     sink_format: &KafkaSinkFormat,
-    config_options: &BTreeMap<String, String>,
+    config_options: &BTreeMap<String, MaybeStringId>,
     reuse_topic: bool,
     consistency: Option<KafkaConsistency<Aug>>,
     consistency_topic: Option<String>,
+    secrets_reader: &SecretsReader,
 ) -> Result<Option<(String, KafkaSinkFormat)>, anyhow::Error> {
     let result = match consistency {
         Some(KafkaConsistency {
@@ -2002,6 +2064,7 @@ fn get_kafka_sink_consistency_config(
                     schema_registry_url.clone(),
                     config_options,
                     &mut ccsr_with_options,
+                    secrets_reader,
                 )?;
 
                 Some((
@@ -2102,6 +2165,7 @@ pub fn describe_create_sink(
 pub fn plan_create_sink(
     scx: &StatementContext,
     mut stmt: CreateSinkStatement<Aug>,
+    secrets_reader: &SecretsReader,
 ) -> Result<Plan, anyhow::Error> {
     scx.require_unsafe_mode("CREATE SINK")?;
     let compute_instance = match &stmt.in_cluster {
@@ -2248,6 +2312,7 @@ pub fn plan_create_sink(
             envelope,
             suffix_nonce,
             &root_user_dependencies,
+            secrets_reader,
         )?,
         CreateSinkConnector::Persist {
             consensus_uri,
@@ -2897,8 +2962,16 @@ pub fn plan_create_connector(
                 registry,
                 with_options: with_options
                     .iter()
-                    .map(|(k, v)| (k.to_owned(), v.to_string()))
-                    .collect::<BTreeMap<String, String>>(),
+                    .map(|(k, v)| {
+                        (
+                            k.to_owned(),
+                            match v {
+                                SqlMaybeValueId::Value(v) => MaybeStringId::String(v.to_string()),
+                                SqlMaybeValueId::Secret(id) => MaybeStringId::Secret(id.clone()),
+                            },
+                        )
+                    })
+                    .collect::<BTreeMap<_, _>>(),
             }
         }
     };

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -328,7 +328,7 @@ async fn purify_csr_connector_proto(
             .parse()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
-                &mut normalize::options(&ccsr_options)?,
+                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
                 catalog.secrets_reader(),
             )?;
 
@@ -389,7 +389,7 @@ async fn purify_csr_connector_avro(
         let ccsr_config = task::block_in_place(|| {
             kafka_util::generate_ccsr_client_config(
                 url,
-                &mut normalize::options(ccsr_options)?,
+                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
                 catalog.secrets_reader(),
             )
         })?;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context};
 use aws_arn::ARN;
-use mz_dataflow_types::sources::MaybeStringId;
+use mz_dataflow_types::sources::StringOrSecret;
 use mz_sql_parser::ast::{CsrConnector, KafkaConnector, KafkaSourceConnector};
 use prost::Message;
 use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
@@ -199,7 +199,7 @@ async fn purify_source_format(
     format: &mut CreateSourceFormat<Aug>,
     connector: &mut CreateSourceConnector<Aug>,
     envelope: &Option<Envelope<Aug>>,
-    connector_options: &BTreeMap<String, MaybeStringId>,
+    connector_options: &BTreeMap<String, StringOrSecret>,
     with_options: &Vec<WithOption<Aug>>,
 ) -> Result<(), anyhow::Error> {
     if matches!(format, CreateSourceFormat::KeyValue { .. })
@@ -271,7 +271,7 @@ async fn purify_source_format_single(
     format: &mut Format<Aug>,
     connector: &mut CreateSourceConnector<Aug>,
     envelope: &Option<Envelope<Aug>>,
-    connector_options: &BTreeMap<String, MaybeStringId>,
+    connector_options: &BTreeMap<String, StringOrSecret>,
     with_options: &Vec<WithOption<Aug>>,
 ) -> Result<(), anyhow::Error> {
     match format {
@@ -389,7 +389,6 @@ async fn purify_csr_connector_proto(
             let kafka_options = kafka_util::extract_config(&mut normalize::options(with_options)?)?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
-                &kafka_options,
                 &mut normalize::options(&ccsr_options)?,
                 catalog.secrets_reader(),
             )?;
@@ -423,7 +422,7 @@ async fn purify_csr_connector_avro(
     connector: &mut CreateSourceConnector<Aug>,
     csr_connector: &mut CsrConnectorAvro<Aug>,
     envelope: &Option<Envelope<Aug>>,
-    connector_options: &BTreeMap<String, MaybeStringId>,
+    connector_options: &BTreeMap<String, StringOrSecret>,
 ) -> Result<(), anyhow::Error> {
     let topic = if let CreateSourceConnector::Kafka(KafkaSourceConnector { topic, .. }) = connector
     {
@@ -452,7 +451,6 @@ async fn purify_csr_connector_avro(
         let ccsr_config = task::block_in_place(|| {
             kafka_util::generate_ccsr_client_config(
                 url,
-                &connector_options,
                 &mut normalize::options(ccsr_options)?,
                 catalog.secrets_reader(),
             )

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -83,7 +83,7 @@ pub async fn purify_create_source(
                 }
                 KafkaConnector::Inline { broker } => (
                     broker.to_string(),
-                    kafka_util::extract_config(&mut with_options_map)?,
+                    kafka_util::extract_config(&mut with_options_map, catalog.secrets_reader())?,
                 ),
             };
             let consumer = kafka_util::create_consumer(
@@ -328,7 +328,10 @@ async fn purify_csr_connector_proto(
             .parse()?;
             let ccsr_config = kafka_util::generate_ccsr_client_config(
                 url,
-                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
+                &mut kafka_util::extract_config_ccsr(
+                    &mut normalize::options(&ccsr_options)?,
+                    catalog.secrets_reader(),
+                )?,
                 catalog.secrets_reader(),
             )?;
 
@@ -389,7 +392,10 @@ async fn purify_csr_connector_avro(
         let ccsr_config = task::block_in_place(|| {
             kafka_util::generate_ccsr_client_config(
                 url,
-                &mut kafka_util::extract_config_ccsr(&mut normalize::options(&ccsr_options)?)?,
+                &mut kafka_util::extract_config_ccsr(
+                    &mut normalize::options(&ccsr_options)?,
+                    catalog.secrets_reader(),
+                )?,
                 catalog.secrets_reader(),
             )
         })?;

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -22,6 +22,7 @@ use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
+use mz_secrets::SecretsReader;
 
 use crate::ast::Expr;
 use crate::catalog::{
@@ -292,6 +293,10 @@ impl SessionCatalog for TestCatalog {
 
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
         name
+    }
+
+    fn secrets_reader(&self) -> &SecretsReader {
+        unimplemented!()
     }
 }
 

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -66,6 +66,47 @@ a
 1
 2
 
+> CREATE SECRET ssl_key_location_kafka AS '/share/secrets/materialized-kafka.key'
+
+> CREATE SECRET ssl_certificate_location_kafka AS '/share/secrets/materialized-kafka.crt'
+
+> CREATE SECRET ssl_key_password_kafka AS 'mzmzmz'
+
+> CREATE SECRET ssl_key_location_csr AS '/share/secrets/materialized-schema-registry.key'
+
+> CREATE SECRET ssl_certificate_location_csr  AS '/share/secrets/materialized-schema-registry.crt'
+
+> CREATE SECRET username_csr AS 'materialize'
+
+> CREATE SECRET password_csr AS 'sekurity'
+
+> CREATE SECRET ssl_ca_location AS '/share/secrets/ca.crt'
+
+> CREATE MATERIALIZED SOURCE data_secret
+  FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}'
+  WITH (
+      security_protocol = 'SSL',
+      ssl_key_location = SECRET ssl_key_location_kafka,
+      ssl_certificate_location = SECRET ssl_certificate_location_kafka,
+      ssl_ca_location = SECRET ssl_ca_location,
+      ssl_key_password = SECRET ssl_key_password_kafka
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      ssl_key_location = SECRET ssl_key_location_csr,
+      ssl_certificate_location = SECRET ssl_certificate_location_csr,
+      ssl_ca_location = SECRET ssl_ca_location,
+      username = SECRET username_csr,
+      password = SECRET password_csr
+  )
+  ENVELOPE DEBEZIUM
+
+> SELECT * FROM data_secret
+a
+---
+1
+2
+
 # Ensure that our test infra correctly sets up certs by failing when CSR is not
 # specifically configured
 ! CREATE MATERIALIZED SOURCE data

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -165,6 +165,15 @@ contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport 
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:Invalid WITH option ssl_certificate_location='foo': file does not exist
 
+> CREATE SECRET invalid_ssl_certificate_location_secret AS 'foo'
+
+! CREATE SINK invalid_ssl_certificate_location FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (security_protocol = SSL , ssl_certificate_location = SECRET invalid_ssl_certificate_location_secret)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+regex:Invalid WITH option ssl_certificate_location=.*: file does not exist
+
 ! CREATE SINK invalid_ssl_key_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
@@ -172,12 +181,30 @@ contains:Invalid WITH option ssl_certificate_location='foo': file does not exist
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:Invalid WITH option ssl_key_location='foo': file does not exist
 
+> CREATE SECRET invalid_ssl_key_location_secret AS 'foo'
+
+! CREATE SINK invalid_ssl_key_location FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (security_protocol = SSL , ssl_key_location = SECRET invalid_ssl_key_location_secret)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+regex:Invalid WITH option ssl_key_location=.*: file does not exist
+
 ! CREATE SINK invalid_ssl_ca_location FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   WITH (security_protocol = SSL , ssl_ca_location = 'foo')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:Invalid WITH option ssl_ca_location='foo': file does not exist
+
+> CREATE SECRET invalid_ssl_ca_location_secret AS 'foo'
+
+! CREATE SINK invalid_ssl_ca_location FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
+  WITH (security_protocol = SSL , ssl_ca_location = SECRET invalid_ssl_ca_location_secret)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+regex:Invalid WITH option ssl_ca_location=.*: file does not exist
 
 #
 # Kerberos options


### PR DESCRIPTION
@cjubb39's fork seems to be locked down and I can't push edits to it, so this is just a duplicate of #12974 integrating the PR feedback.

Remaining content is from the original PR.

<hr/>

Introduce two new types:
- In sql-land: `SqlValueOrSecret`, an enum which can hold either a `Value` or a `GlobalId`
- In dataflow-land: `StringOrSecret`, an enum which can hold either a `String` or a `GlobalId`

We put a `SecretsReader` in the catalog so that it's accessible as we get to planning sources and sinks.  Currently we inline during planning -- however, there's a follow-up task (#13017) to pass a `SecretsReader` to storaged so it can inline at the last minute.

### Motivation
#12983 
Part of #11504 

### Tips for reviewer

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Can use `SECRET`s for Kafka and CSR with options
