### PR TITLE
persist,storage: document that snap&persist_source advance by as_of

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -102,6 +102,11 @@ where
 
     /// Attempt to pull out the next values of this iterator.
     ///
+    /// All times emitted will have been [advanced by] the [Self::as_of]
+    /// frontier.
+    ///
+    /// [advanced by]: Lattice::advance_by
+    ///
     /// The returned updates are not consolidated. In the presence of
     /// compaction, consolidation can take an unbounded amount of memory so it's
     /// not safe for persist to consolidate in the general case. Persist users


### PR DESCRIPTION
Clarify and document the contract that a persist `SnapshotIter` (and by
extension a storage `persist_source`) will have advanced all times by
the requested as_of before outputting them. Compute relies on this
property and this documentation allows them to remove what was a
redundant call to advance_by.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
