### PR TITLE
sql: support implied values in new with option handling

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -761,14 +761,16 @@ impl AstDisplay for IndexOptionName {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct IndexOption<T: AstInfo> {
     pub name: IndexOptionName,
-    pub value: WithOptionValue<T>,
+    pub value: Option<WithOptionValue<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for IndexOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.name);
-        f.write_str(" = ");
-        f.write_node(&self.value);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
     }
 }
 
@@ -998,14 +1000,16 @@ impl AstDisplay for ReplicaOptionName {
 /// An option in a `CREATE CLUSTER` or `CREATE CLUSTER REPLICA` statement.
 pub struct ReplicaOption<T: AstInfo> {
     pub name: ReplicaOptionName,
-    pub value: WithOptionValue<T>,
+    pub value: Option<WithOptionValue<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for ReplicaOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_node(&self.name);
-        f.write_str(" ");
-        f.write_node(&self.value);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
     }
 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1675,11 +1675,44 @@ impl AstDisplay for RollbackStatement {
 }
 impl_display!(RollbackStatement);
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TailOptionName {
+    Snapshot,
+    Progress,
+}
+
+impl AstDisplay for TailOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            TailOptionName::Snapshot => f.write_str("SNAPSHOT"),
+            TailOptionName::Progress => f.write_str("PROGRESS"),
+        }
+    }
+}
+impl_display!(TailOptionName);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TailOption<T: AstInfo> {
+    pub name: TailOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for TailOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
+impl_display_t!(TailOption);
+
 /// `TAIL`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TailStatement<T: AstInfo> {
     pub relation: TailRelation<T>,
-    pub options: Vec<WithOption<T>>,
+    pub options: Vec<TailOption<T>>,
     pub as_of: Option<AsOf<T>>,
 }
 

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -223,6 +223,7 @@ Preceding
 Precision
 Prepare
 Primary
+Progress
 Protobuf
 Publication
 Pubnub

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -732,7 +732,7 @@ CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
 ----
 CREATE INDEX foo ON myschema.bar (a, b) WITH (LOGICAL COMPACTION WINDOW = 0)
 =>
-CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: LogicalCompactionWindow, value: Value(Number("0")) }], if_not_exists: false })
+CreateIndex(CreateIndexStatement { name: Some(Ident("foo")), in_cluster: None, on_name: Name(UnresolvedObjectName([Ident("myschema"), Ident("bar")])), key_parts: Some([Identifier([Ident("a")]), Identifier([Ident("b")])]), with_options: [IndexOption { name: LogicalCompactionWindow, value: Some(Value(Number("0"))) }], if_not_exists: false })
 
 parse-statement
 CREATE INDEX fizz ON baz (ascii(x), a IS NOT NULL, (EXISTS (SELECT y FROM boop WHERE boop.z = z)), delta)
@@ -961,23 +961,23 @@ Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ide
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT) AS OF now()
 ----
-TAIL foo.bar WITH (snapshot) AS OF now()
+TAIL foo.bar WITH (SNAPSHOT) AS OF now()
 =>
-Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [WithOption { key: Ident("snapshot"), value: None }], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [TailOption { name: Snapshot, value: None }], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
 ----
-TAIL foo.bar WITH (snapshot = false, timestamps) AS OF now()
-=>
-Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [WithOption { key: Ident("snapshot"), value: Some(Value(Boolean(false))) }, WithOption { key: Ident("timestamps"), value: None }], as_of: Some(At(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }))) })
+error: Expected one of PROGRESS or SNAPSHOT, found identifier "timestamps"
+TAIL foo.bar WITH (SNAPSHOT = false, TIMESTAMPS) AS OF now()
+                                     ^
 
 parse-statement
 TAIL foo.bar WITH (SNAPSHOT false)
 ----
-error: Expected equals sign, found FALSE
-TAIL foo.bar WITH (SNAPSHOT false)
-                            ^
+TAIL foo.bar WITH (SNAPSHOT = false)
+=>
+Tail(TailStatement { relation: Name(Name(UnresolvedObjectName([Ident("foo"), Ident("bar")]))), options: [TailOption { name: Snapshot, value: Some(Value(Boolean(false))) }], as_of: None })
 
 parse-statement
 TAIL (SELECT * FROM a)
@@ -1187,9 +1187,9 @@ CREATE CLUSTER cluster REPLICAS (), BADOPT
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }])] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
@@ -1201,9 +1201,9 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')) INTROSPECTI
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
 ----
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1'], SIZE = '1'))
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }, ReplicaOption { name: Size, value: Value(String("1")) }] }])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
 
 parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ['host1']
@@ -1229,30 +1229,30 @@ CREATE CLUSTER REPLICA replica SIZE 'small', (REMOTE ['host1'])
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small'
 ----
-CREATE CLUSTER REPLICA default.replica SIZE 'small'
+CREATE CLUSTER REPLICA default.replica SIZE = 'small'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Value(String("small")) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
 ----
-CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica SIZE = 'small', AVAILABILITY ZONE = 'a'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Value(String("small")) }, ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 ----
-CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
+CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE = 'a', AVAILABILITY ZONE = 'b'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }, ReplicaOption { name: AvailabilityZone, value: Value(String("b")) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("b"))) }] } })
 
 parse-statement
 CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 ----
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE = ['host1'], AVAILABILITY ZONE = 'a'
 =>
-CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Value(Array([String("host1")])) }, ReplicaOption { name: AvailabilityZone, value: Value(String("a")) }] } })
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: AvailabilityZone, value: Some(Value(String("a"))) }] } })
 
 parse-statement
 DROP CLUSTER cluster

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -83,7 +83,7 @@ use crate::normalize::{self, SqlValueOrSecret};
 use crate::plan::error::PlanError;
 use crate::plan::query::QueryLifetime;
 use crate::plan::statement::{StatementContext, StatementDesc};
-use crate::plan::with_options::{OptionalInterval, ProcessOption};
+use crate::plan::with_options::{OptionalInterval, TryFromValue};
 use crate::plan::{
     plan_utils, query, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan, AlterItemRenamePlan,
     AlterNoopPlan, AlterSecretPlan, ComputeInstanceIntrospectionConfig, Connector,

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -252,6 +252,9 @@ SELECT COUNT(name) FROM mz_indexes;
 ----
 17
 
+statement error nvalid SIZE: must provide a string value
+CREATE CLUSTER REPLICA default.size_1 SIZE;
+
 statement ok
 CREATE CLUSTER REPLICA default.size_1 SIZE '1';
 


### PR DESCRIPTION
The previous version of with option handling supported an implied value of `true` for boolean-expecting options. This PR adds that feature to the refactored option handling. I propagated this change to other options for simplicity's sake.

### Motivation

This PR adds a known-desirable feature, part of #5390

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
