### PR TITLE
Replace `start_block` and `end_block` with a harder-to-misuse function that does both

### DIFF
--- a/src/ore/src/codegen.rs
+++ b/src/ore/src/codegen.rs
@@ -75,14 +75,17 @@ impl CodegenBuf {
         self.write("\n");
     }
 
-    /// Starts a new indented block.
+    /// Writes a new indented block.
     ///
     /// Specifically, if `s` is empty, the method writes the line `{` into the
     /// buffer; otherwise writes the line `s {` into the buffer at the current
-    /// indentation level. Then it increments the buffer's indentation level.
-    pub fn start_block<S>(&mut self, s: S)
+    /// indentation level. Then it increments the buffer's indentation level,
+    /// runs the provided function, then decrements the indentation level and writes
+    /// a closing `}`.
+    pub fn write_block<S, F>(&mut self, s: S, f: F)
     where
         S: AsRef<str>,
+        F: FnOnce(&mut Self),
     {
         self.start_line();
         self.write(s.as_ref());
@@ -91,6 +94,9 @@ impl CodegenBuf {
         }
         self.write("{\n");
         self.level += 1;
+        f(self);
+        self.level -= 1;
+        self.writeln("}");
     }
 
     /// Closes the current indented block and starts a new one at the same
@@ -112,18 +118,5 @@ impl CodegenBuf {
         self.write(s.as_ref());
         self.write(" {\n");
         self.level += 1;
-    }
-
-    /// Ends the current indented block.
-    ///
-    /// Specifically, the method decrements the current indentation level, then
-    /// writes a line containing `}` into the buffer.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the current indentation level is zero.
-    pub fn end_block(&mut self) {
-        self.level -= 1;
-        self.writeln("}");
     }
 }

--- a/src/sql-parser/build.rs
+++ b/src/sql-parser/build.rs
@@ -46,21 +46,21 @@ fn main() -> Result<()> {
         let mut buf = CodegenBuf::new();
 
         buf.writeln("#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]");
-        buf.start_block("pub enum Keyword");
-        for kw in &keywords {
-            buf.writeln(format!("{},", kw));
-        }
-        buf.end_block();
+        buf.write_block("pub enum Keyword", |buf| {
+            for kw in &keywords {
+                buf.writeln(format!("{},", kw));
+            }
+        });
 
-        buf.start_block("impl Keyword");
-        buf.start_block("pub fn as_str(&self) -> &'static str");
-        buf.start_block("match self");
-        for kw in &keywords {
-            buf.writeln(format!("Keyword::{} => {:?},", kw, kw.to_uppercase()));
-        }
-        buf.end_block();
-        buf.end_block();
-        buf.end_block();
+        buf.write_block("impl Keyword", |buf| {
+            buf.write_block("pub fn as_str(&self) -> &'static str", |buf| {
+                buf.write_block("match self", |buf| {
+                    for kw in &keywords {
+                        buf.writeln(format!("Keyword::{} => {:?},", kw, kw.to_uppercase()));
+                    }
+                });
+            });
+        });
 
         for kw in &keywords {
             buf.writeln(format!(

--- a/src/walkabout/src/gen.rs
+++ b/src/walkabout/src/gen.rs
@@ -73,9 +73,7 @@ pub fn gen_fold_root(ir: &Ir) -> String {
                         let generics2 = item_generics(item, "2");
                         let fn_name = fold_fn_name(name);
                         buf.write_block(
-                            format!(
-                        "fn {fn_name}(&mut self, node: {name}{generics}) -> {name}{generics2}"
-                    ),
+                            format!("fn {fn_name}(&mut self, node: {name}{generics}) -> {name}{generics2}"),
                             |buf| buf.writeln(format!("{fn_name}(self, node)")),
                         );
                     }

--- a/src/walkabout/src/gen.rs
+++ b/src/walkabout/src/gen.rs
@@ -55,37 +55,44 @@ pub fn gen_fold_root(ir: &Ir) -> String {
 
     let mut buf = CodegenBuf::new();
 
-    buf.start_block(format!("pub trait Fold<{trait_generics_and_bounds}>"));
-    for (name, item) in &ir.items {
-        match item {
-            Item::Abstract => {
-                // The intent is to replace `T::FooBar` with `T2::FooBar`. This
-                // is a bit gross, but it seems reliable enough, and is so far
-                // simpler than trying to use a structured type for `name`.
-                let name2 = name.replacen("::", "2::", 1);
-                let fn_name = fold_fn_name(name);
-                buf.writeln(format!("fn {fn_name}(&mut self, node: {name}) -> {name2};"))
+    buf.write_block(
+        format!("pub trait Fold<{trait_generics_and_bounds}>"),
+        |buf| {
+            for (name, item) in &ir.items {
+                match item {
+                    Item::Abstract => {
+                        // The intent is to replace `T::FooBar` with `T2::FooBar`. This
+                        // is a bit gross, but it seems reliable enough, and is so far
+                        // simpler than trying to use a structured type for `name`.
+                        let name2 = name.replacen("::", "2::", 1);
+                        let fn_name = fold_fn_name(name);
+                        buf.writeln(format!("fn {fn_name}(&mut self, node: {name}) -> {name2};"))
+                    }
+                    Item::Struct(_) | Item::Enum(_) => {
+                        let generics = item_generics(item, "");
+                        let generics2 = item_generics(item, "2");
+                        let fn_name = fold_fn_name(name);
+                        buf.write_block(
+                            format!(
+                        "fn {fn_name}(&mut self, node: {name}{generics}) -> {name}{generics2}"
+                    ),
+                            |buf| buf.writeln(format!("{fn_name}(self, node)")),
+                        );
+                    }
+                }
             }
-            Item::Struct(_) | Item::Enum(_) => {
-                let generics = item_generics(item, "");
-                let generics2 = item_generics(item, "2");
-                let fn_name = fold_fn_name(name);
-                buf.start_block(format!(
-                    "fn {fn_name}(&mut self, node: {name}{generics}) -> {name}{generics2}"
-                ));
-                buf.writeln(format!("{fn_name}(self, node)"));
-                buf.end_block();
-            }
-        }
-    }
-    buf.end_block();
+        },
+    );
 
-    buf.start_block(format!("pub trait FoldNode<{trait_generics_and_bounds}>"));
-    buf.writeln(format!("type Folded;"));
-    buf.writeln(format!(
-        "fn fold<F: Fold<{trait_generics}>>(self, folder: &mut F) -> Self::Folded;"
-    ));
-    buf.end_block();
+    buf.write_block(
+        format!("pub trait FoldNode<{trait_generics_and_bounds}>"),
+        |buf| {
+            buf.writeln(format!("type Folded;"));
+            buf.writeln(format!(
+                "fn fold<F: Fold<{trait_generics}>>(self, folder: &mut F) -> Self::Folded;"
+            ));
+        },
+    );
 
     for (name, item) in &ir.items {
         if let Item::Abstract = item {
@@ -94,70 +101,73 @@ pub fn gen_fold_root(ir: &Ir) -> String {
         let generics = item_generics(item, "");
         let generics2 = item_generics(item, "2");
         let fn_name = fold_fn_name(name);
-        buf.start_block(format!(
-            "impl<{trait_generics_and_bounds}> FoldNode<{trait_generics}> for {name}{generics}"
-        ));
-        buf.writeln(format!("type Folded = {name}{generics2};"));
-        buf.start_block(format!(
-            "fn fold<F: Fold<{trait_generics}>>(self, folder: &mut F) -> Self::Folded"
-        ));
-        buf.writeln(format!("folder.{fn_name}(self)"));
-        buf.end_block();
-        buf.end_block();
+        buf.write_block(
+            format!(
+                "impl<{trait_generics_and_bounds}> FoldNode<{trait_generics}> for {name}{generics}"
+            ),
+            |buf| {
+                buf.writeln(format!("type Folded = {name}{generics2};"));
+                buf.write_block(
+                    format!(
+                        "fn fold<F: Fold<{trait_generics}>>(self, folder: &mut F) -> Self::Folded"
+                    ),
+                    |buf| buf.writeln(format!("folder.{fn_name}(self)")),
+                );
+            },
+        );
+
         buf.writeln(format!(
             "pub fn {fn_name}<F, {trait_generics_and_bounds}>(folder: &mut F, node: {name}{generics}) -> {name}{generics2}"
         ));
         buf.writeln(format!("where"));
         buf.writeln(format!("    F: Fold<{trait_generics}> + ?Sized,"));
-        buf.start_block("");
-        match item {
+        buf.write_block("", |buf| match item {
             Item::Struct(s) => {
-                buf.start_block(name);
-                for (i, f) in s.fields.iter().enumerate() {
-                    let field_name = match &f.name {
-                        Some(name) => name.clone(),
-                        None => i.to_string(),
-                    };
-                    let binding = format!("node.{field_name}");
-                    buf.start_line();
-                    buf.write(format!("{field_name}: "));
-                    gen_fold_element(&mut buf, &binding, &f.ty);
-                    buf.write(",");
-                    buf.end_line();
-                }
-                buf.end_block();
-            }
-            Item::Enum(e) => {
-                buf.start_block("match node");
-                for v in &e.variants {
-                    let vname = &v.name;
-                    buf.start_block(format!("{name}::{vname}"));
-                    for (i, f) in v.fields.iter().enumerate() {
-                        let name = f.name.clone().unwrap_or_else(|| i.to_string());
-                        buf.writeln(format!("{name}: binding{i},"));
-                    }
-                    buf.restart_block("=>");
-                    buf.start_block(format!("{name}::{vname}"));
-                    for (i, f) in v.fields.iter().enumerate() {
+                buf.write_block(name, |buf| {
+                    for (i, f) in s.fields.iter().enumerate() {
                         let field_name = match &f.name {
                             Some(name) => name.clone(),
                             None => i.to_string(),
                         };
-                        let binding = format!("binding{i}");
+                        let binding = format!("node.{field_name}");
                         buf.start_line();
                         buf.write(format!("{field_name}: "));
-                        gen_fold_element(&mut buf, &binding, &f.ty);
+                        gen_fold_element(buf, &binding, &f.ty);
                         buf.write(",");
                         buf.end_line();
                     }
-                    buf.end_block();
-                    buf.end_block();
-                }
-                buf.end_block();
+                });
+            }
+            Item::Enum(e) => {
+                buf.write_block("match node", |buf| {
+                    for v in &e.variants {
+                        let vname = &v.name;
+                        buf.write_block(format!("{name}::{vname}"), |buf| {
+                            for (i, f) in v.fields.iter().enumerate() {
+                                let name = f.name.clone().unwrap_or_else(|| i.to_string());
+                                buf.writeln(format!("{name}: binding{i},"));
+                            }
+                            buf.restart_block("=>");
+                            buf.write_block(format!("{name}::{vname}"), |buf| {
+                                for (i, f) in v.fields.iter().enumerate() {
+                                    let field_name = match &f.name {
+                                        Some(name) => name.clone(),
+                                        None => i.to_string(),
+                                    };
+                                    let binding = format!("binding{i}");
+                                    buf.start_line();
+                                    buf.write(format!("{field_name}: "));
+                                    gen_fold_element(buf, &binding, &f.ty);
+                                    buf.write(",");
+                                    buf.end_line();
+                                }
+                            });
+                        });
+                    }
+                });
             }
             Item::Abstract => (),
-        }
-        buf.end_block();
+        });
     }
 
     buf.into_string()
@@ -214,41 +224,37 @@ fn gen_visit_root(c: &VisitConfig, ir: &Ir) -> String {
 
     let mut buf = CodegenBuf::new();
 
-    buf.start_block(format!(
-        "pub trait {trait_name}<'ast, {trait_generics_and_bounds}>"
-    ));
-    for (name, item) in &ir.items {
-        let generics = item_generics(item, "");
-        let fn_name = visit_fn_name(c, name);
-        buf.start_block(format!(
-            "fn {fn_name}(&mut self, node: &'ast {muta}{name}{generics})"
-        ));
-        buf.writeln(format!("{fn_name}(self, node)"));
-        buf.end_block();
-    }
-    buf.end_block();
+    buf.write_block(
+        format!("pub trait {trait_name}<'ast, {trait_generics_and_bounds}>"),
+        |buf| {
+            for (name, item) in &ir.items {
+                let generics = item_generics(item, "");
+                let fn_name = visit_fn_name(c, name);
+                buf.write_block(
+                    format!("fn {fn_name}(&mut self, node: &'ast {muta}{name}{generics})"),
+                    |buf| buf.writeln(format!("{fn_name}(self, node)")),
+                );
+            }
+        },
+    );
 
-    buf.start_block(format!(
+    buf.write_block(format!(
         "pub trait {trait_name}Node<'ast, {trait_generics_and_bounds}>"
-    ));
-    buf.writeln(format!(
+    ), |buf| buf.writeln(format!(
         "fn {fn_name_base}<V: {trait_name}<'ast, {trait_generics}>>(&'ast {muta}self, visitor: &mut V);"
-    ));
-    buf.end_block();
+    )));
 
     for (name, item) in &ir.items {
         let generics = item_generics(item, "");
         let fn_name = visit_fn_name(c, name);
         if !matches!(item, Item::Abstract) {
-            buf.start_block(format!(
+            buf.write_block(format!(
                 "impl<'ast, {trait_generics_and_bounds}> {trait_name}Node<'ast, {trait_generics}> for {name}{generics}"
-            ));
-            buf.start_block(format!(
-                "fn {fn_name_base}<V: {trait_name}<'ast, {trait_generics}>>(&'ast {muta}self, visitor: &mut V)"
-            ));
-            buf.writeln(format!("visitor.{fn_name}(self)"));
-            buf.end_block();
-            buf.end_block();
+            ), |buf| {
+                buf.write_block(format!(
+                    "fn {fn_name_base}<V: {trait_name}<'ast, {trait_generics}>>(&'ast {muta}self, visitor: &mut V)"
+                ), |buf| buf.writeln(format!("visitor.{fn_name}(self)")));
+            });
         }
         buf.writeln(format!(
             "pub fn {fn_name}<'ast, V, {trait_generics_and_bounds}>(visitor: &mut V, node: &'ast {muta}{name}{generics})"
@@ -257,38 +263,36 @@ fn gen_visit_root(c: &VisitConfig, ir: &Ir) -> String {
         buf.writeln(format!(
             "    V: {trait_name}<'ast, {trait_generics}> + ?Sized,"
         ));
-        buf.start_block("");
-        match item {
+        buf.write_block("", |buf| match item {
             Item::Struct(s) => {
                 for (i, f) in s.fields.iter().enumerate() {
                     let binding = match &f.name {
                         Some(name) => format!("&{muta}node.{name}"),
                         None => format!("&{muta}node.{i}"),
                     };
-                    gen_visit_element(c, &mut buf, &binding, &f.ty);
+                    gen_visit_element(c, buf, &binding, &f.ty);
                 }
             }
             Item::Enum(e) => {
-                buf.start_block("match node");
-                for v in &e.variants {
-                    let vname = &v.name;
-                    buf.start_block(format!("{name}::{vname}"));
-                    for (i, f) in v.fields.iter().enumerate() {
-                        let name = f.name.clone().unwrap_or_else(|| i.to_string());
-                        buf.writeln(format!("{name}: binding{i},"));
+                buf.write_block("match node", |buf| {
+                    for v in &e.variants {
+                        let vname = &v.name;
+                        buf.write_block(format!("{name}::{vname}"), |buf| {
+                            for (i, f) in v.fields.iter().enumerate() {
+                                let name = f.name.clone().unwrap_or_else(|| i.to_string());
+                                buf.writeln(format!("{name}: binding{i},"));
+                            }
+                            buf.restart_block("=>");
+                            for (i, f) in v.fields.iter().enumerate() {
+                                let binding = format!("binding{i}");
+                                gen_visit_element(c, buf, &binding, &f.ty);
+                            }
+                        });
                     }
-                    buf.restart_block("=>");
-                    for (i, f) in v.fields.iter().enumerate() {
-                        let binding = format!("binding{i}");
-                        gen_visit_element(c, &mut buf, &binding, &f.ty);
-                    }
-                    buf.end_block();
-                }
-                buf.end_block();
+                });
             }
             Item::Abstract => (),
-        }
-        buf.end_block();
+        });
     }
 
     buf.into_string()
@@ -302,14 +306,14 @@ fn gen_visit_element(c: &VisitConfig, buf: &mut CodegenBuf, binding: &str, ty: &
             buf.writeln(format!("visitor.{fn_name}({binding});"));
         }
         Type::Option(ty) => {
-            buf.start_block(format!("if let Some(v) = {binding}"));
-            gen_visit_element(c, buf, "v", ty);
-            buf.end_block();
+            buf.write_block(format!("if let Some(v) = {binding}"), |buf| {
+                gen_visit_element(c, buf, "v", ty)
+            });
         }
         Type::Vec(ty) => {
-            buf.start_block(format!("for v in {binding}"));
-            gen_visit_element(c, buf, "v", ty);
-            buf.end_block();
+            buf.write_block(format!("for v in {binding}"), |buf| {
+                gen_visit_element(c, buf, "v", ty)
+            });
         }
         Type::Box(ty) => {
             let binding = match c.mutable {
@@ -323,9 +327,9 @@ fn gen_visit_element(c: &VisitConfig, buf: &mut CodegenBuf, binding: &str, ty: &
             buf.writeln(format!("visitor.{fn_name}({binding});"));
         }
         Type::Map { value, .. } => {
-            buf.start_block(format!("for (_, value) in {binding}"));
-            gen_visit_element(c, buf, "value", value);
-            buf.end_block();
+            buf.write_block(format!("for (_, value) in {binding}"), |buf| {
+                gen_visit_element(c, buf, "value", value)
+            });
         }
     }
 }


### PR DESCRIPTION
### Motivation

This makes the indentation of codegen code better match the indentation of the produced code, and also is harder to misuse, because every opened block is automatically closed.

### Tips for reviewer

All changes except in codegen.rs are trivial/mechanical.

### Testing

- [N/A] This PR has adequate test coverage / QA involvement has been duly considered.
