### PR TITLE
audit-log: use kebab case and add docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,6 +3032,7 @@ dependencies = [
  "bytesize",
  "serde",
  "serde_json",
+ "serde_plain",
  "uuid 1.1.2",
 ]
 
@@ -5579,6 +5580,15 @@ dependencies = [
  "indexmap",
  "itoa 1.0.1",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_plain"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95455e7e29fada2052e72170af226fbe368a4ca33dee847875325d9fdb133858"
+dependencies = [
  "serde",
 ]
 

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -81,6 +81,20 @@ Field      | Type       | Meaning
 `records`  | [`bigint`] | The number of records in the arrangement.
 `batches`  | [`bigint`] | The number of batches in the arrangement.
 
+### `mz_audit_events`
+
+The `mz_audit_events` table records create, alter, and drop events for the
+other objects in the system catalog.
+
+Field           | Type                         | Meaning
+----------------|------------------------------|--------
+`uuid`          | [`uuid`]                     | A unique identifier for the event.
+`event_type`    | [`text`]                     | The type of the event: `create`, `drop`, `alter`, or `rename`.
+`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `index`, `sink`, `source`, or `view`.
+`event_details` | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
+`user`          | [`text`]                     | The user who triggered the event.
+`occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
+
 ### `mz_base_types`
 
 The `mz_base_types` table contains a row for each base type in the system.

--- a/src/audit-log/Cargo.toml
+++ b/src/audit-log/Cargo.toml
@@ -11,4 +11,5 @@ anyhow = "1.0.57"
 bytesize = { version = "1.1.0", features = ["serde"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
+serde_plain = "1.0.0"
 uuid = { version = "1.1.2", features = ["serde", "v4"] }

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -82,6 +82,7 @@ impl VersionedEvent {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum EventType {
     Create,
     Drop,
@@ -89,7 +90,10 @@ pub enum EventType {
     Rename,
 }
 
+serde_plain::derive_display_from_serialize!(EventType);
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ObjectType {
     Cluster,
     ClusterReplica,
@@ -98,6 +102,8 @@ pub enum ObjectType {
     Source,
     View,
 }
+
+serde_plain::derive_display_from_serialize!(ObjectType);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum EventDetails {
@@ -201,7 +207,7 @@ fn test_audit_log() -> Result<(), anyhow::Error> {
             "user".into(),
             1,
         )),
-        r#"{"V1":{"uuid":"00000000-0000-0000-0000-000000000001","event_type":"Create","object_type":"View","event_details":{"NameV1":{"name":"name"}},"user":"user","occurred_at":1}}"#,
+        r#"{"V1":{"uuid":"00000000-0000-0000-0000-000000000001","event_type":"create","object_type":"view","event_details":{"NameV1":{"name":"name"}},"user":"user","occurred_at":1}}"#,
     )];
 
     for (event, expected_bytes) in cases {

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -632,8 +632,8 @@ impl CatalogState {
             id: self.resolve_builtin_table(&MZ_AUDIT_EVENTS),
             row: Row::pack_slice(&[
                 Datum::Uuid(id),
-                Datum::String(&format!("{:?}", event_type)),
-                Datum::String(&format!("{:?}", object_type)),
+                Datum::String(&format!("{}", event_type)),
+                Datum::String(&format!("{}", object_type)),
                 event_details,
                 Datum::String(user),
                 Datum::TimestampTz(DateTime::from_utc(dt, Utc)),

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -46,17 +46,17 @@ CHANNEL 'pubnub-market-orders';
 query TTTT
 SELECT event_type, object_type, event_details, user FROM mz_audit_events ORDER BY occurred_at
 ----
-Create  Cluster  {"name":"foo"}  materialize
-Create  ClusterReplica  {"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
-Create  View  {"database":"materialize","item":"v2","schema":"public"}  materialize
-Create  Index  {"database":"materialize","item":"v2_primary_idx","schema":"public"}  materialize
-Create  View  {"database":"materialize","item":"unmat","schema":"public"}  materialize
-Create  Index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
-Rename  View  {"new_name":"renamed","previous_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
-Drop  Index  {"database":"materialize","item":"v2_primary_idx","schema":"public"}  materialize
-Drop  View  {"database":"materialize","item":"v2","schema":"public"}  materialize
-Create  View  {"database":"materialize","item":"v2","schema":"public"}  materialize
-Create  Index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
-Drop  Index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
-Drop  View  {"database":"materialize","item":"renamed","schema":"public"}  materialize
-Create  Source  {"database":"materialize","item":"s","schema":"public"}  materialize
+create  cluster  {"name":"foo"}  materialize
+create  cluster-replica  {"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+create  view  {"database":"materialize","item":"v2","schema":"public"}  materialize
+create  index  {"database":"materialize","item":"v2_primary_idx","schema":"public"}  materialize
+create  view  {"database":"materialize","item":"unmat","schema":"public"}  materialize
+create  index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
+rename  view  {"new_name":"renamed","previous_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
+drop  index  {"database":"materialize","item":"v2_primary_idx","schema":"public"}  materialize
+drop  view  {"database":"materialize","item":"v2","schema":"public"}  materialize
+create  view  {"database":"materialize","item":"v2","schema":"public"}  materialize
+create  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
+drop  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
+drop  view  {"database":"materialize","item":"renamed","schema":"public"}  materialize
+create  source  {"database":"materialize","item":"s","schema":"public"}  materialize


### PR DESCRIPTION
Use kebab case for the audit log event and object types. This matches
the rest of our system catalog. Also add user facing documentation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code and adds docs.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
