### PR TITLE
dataflow-types,sql: don't hide connector enum behind trait

### DIFF
--- a/src/ccsr/src/config.rs
+++ b/src/ccsr/src/config.rs
@@ -22,7 +22,7 @@ use crate::tls::{Certificate, Identity};
 
 include!(concat!(env!("OUT_DIR"), "/mz_ccsr.config.rs"));
 
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Auth {
     pub username: String,
     pub password: Option<String>,
@@ -45,7 +45,7 @@ impl RustType<ProtoAuth> for Auth {
 }
 
 /// Configuration for a `Client`.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ClientConfig {
     url: Url,
     root_certs: Vec<Certificate>,

--- a/src/ccsr/src/tls.rs
+++ b/src/ccsr/src/tls.rs
@@ -23,7 +23,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_ccsr.tls.rs"));
 /// A [Serde][serde]-enabled wrapper around [`reqwest::Identity`].
 ///
 /// [Serde]: serde
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Identity {
     der: Vec<u8>,
     pass: String,
@@ -88,7 +88,7 @@ impl RustType<ProtoIdentity> for Identity {
 /// A [Serde][serde]-enabled wrapper around [`reqwest::Certificate`].
 ///
 /// [Serde]: serde
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Certificate {
     der: Vec<u8>,
 }

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -15,7 +15,6 @@ use mz_dataflow_types::client::{
     ComputeInstanceId, ConcreteComputeInstanceReplicaConfig, ProcessId, ReplicaId,
 };
 use mz_dataflow_types::sinks::KafkaSinkConnector;
-use mz_dataflow_types::sources::ConnectorInner;
 use mz_expr::MirScalarExpr;
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::array::ArrayDimension;
@@ -294,8 +293,10 @@ impl CatalogState {
                 Datum::Int64(schema_id.into()),
                 Datum::String(name),
                 Datum::String(match connector.connector {
-                    ConnectorInner::Kafka { .. } => "kafka",
-                    ConnectorInner::CSR { .. } => "schema registry",
+                    mz_dataflow_types::connectors::Connector::Kafka { .. } => "kafka",
+                    mz_dataflow_types::connectors::Connector::Csr { .. } => {
+                        "confluent-schema-registry"
+                    }
                 }),
             ]),
             diff,

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -38,6 +38,7 @@ use crate::Plan;
 use proto_dataflow_description::*;
 
 pub mod aws;
+pub mod connectors;
 pub mod sinks;
 pub mod sources;
 

--- a/src/dataflow-types/src/types/connectors.rs
+++ b/src/dataflow-types/src/types/connectors.rs
@@ -1,0 +1,45 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Connector types.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use mz_kafka_util::KafkaAddrs;
+use mz_repr::GlobalId;
+use mz_secrets::SecretsReader;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum StringOrSecret {
+    String(String),
+    Secret(GlobalId),
+}
+
+impl StringOrSecret {
+    pub fn get_string(&self, secrets_reader: &SecretsReader) -> anyhow::Result<String> {
+        match self {
+            StringOrSecret::String(s) => Ok(s.clone()),
+            StringOrSecret::Secret(id) => secrets_reader.read_string(*id),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub enum Connector {
+    Kafka(KafkaConnector),
+    Csr(mz_ccsr::ClientConfig),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct KafkaConnector {
+    pub broker: KafkaAddrs,
+    pub options: BTreeMap<String, StringOrSecret>,
+}

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -19,7 +19,6 @@ use bytes::BufMut;
 use chrono::NaiveDateTime;
 
 use globset::{Glob, GlobBuilder};
-use mz_secrets::SecretsReader;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Just, Strategy};
 use proptest::prop_oneof;
 use proptest_derive::Arbitrary;
@@ -1141,49 +1140,6 @@ pub fn provide_default_metadata(
     };
 
     !is_avro && !is_stateless_dbz
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum StringOrSecret {
-    String(String),
-    Secret(GlobalId),
-}
-
-impl StringOrSecret {
-    pub fn get_string(&self, secrets_reader: &SecretsReader) -> anyhow::Result<String> {
-        match self {
-            StringOrSecret::String(s) => Ok(s.clone()),
-            StringOrSecret::Secret(id) => secrets_reader.read_string(*id),
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum ConnectorInner {
-    Kafka {
-        broker: KafkaAddrs,
-        config_options: BTreeMap<String, StringOrSecret>,
-    },
-    CSR {
-        registry: String,
-        with_options: BTreeMap<String, StringOrSecret>,
-    },
-}
-
-impl ConnectorInner {
-    pub fn uri(&self) -> String {
-        match self {
-            ConnectorInner::Kafka { broker, .. } => broker.to_string(),
-            ConnectorInner::CSR { registry, .. } => registry.to_owned(),
-        }
-    }
-
-    pub fn options(&self) -> BTreeMap<String, StringOrSecret> {
-        match self {
-            ConnectorInner::Kafka { config_options, .. } => config_options.clone(),
-            ConnectorInner::CSR { with_options, .. } => with_options.clone(),
-        }
-    }
 }
 
 #[derive(Arbitrary, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -521,8 +521,8 @@ pub enum CreateConnector<T: AstInfo> {
         broker: String,
         with_options: Vec<WithOption<T>>,
     },
-    CSR {
-        registry: String,
+    Csr {
+        url: String,
         with_options: Vec<WithOption<T>>,
     },
 }
@@ -543,8 +543,8 @@ impl<T: AstInfo> AstDisplay for CreateConnector<T> {
                     f.write_str(")");
                 }
             }
-            Self::CSR {
-                registry,
+            Self::Csr {
+                url: registry,
                 with_options,
             } => {
                 f.write_str("CONFLUENT SCHEMA REGISTRY '");

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1925,8 +1925,8 @@ impl<'a> Parser<'a> {
                 self.expect_keywords(&[SCHEMA, REGISTRY])?;
                 let registry = self.parse_literal_string()?;
                 let with_options = self.parse_opt_with_options()?;
-                CreateConnector::CSR {
-                    registry,
+                CreateConnector::Csr {
+                    url: registry,
                     with_options,
                 }
             }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1379,7 +1379,7 @@ CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WIT
 ----
 CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = 'user', password = 'word')
 =>
-CreateConnector(CreateConnectorStatement { name: UnresolvedObjectName([Ident("conn1")]), connector: CSR { registry: "http://localhost:8081", with_options: [WithOption { key: Ident("username"), value: Some(Value(String("user"))) }, WithOption { key: Ident("password"), value: Some(Value(String("word"))) }] }, if_not_exists: false })
+CreateConnector(CreateConnectorStatement { name: UnresolvedObjectName([Ident("conn1")]), connector: Csr { url: "http://localhost:8081", with_options: [WithOption { key: Ident("username"), value: Some(Value(String("user"))) }, WithOption { key: Ident("password"), value: Some(Value(String("word"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,7 +23,8 @@ use once_cell::sync::Lazy;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_dataflow_types::client::ComputeInstanceId;
-use mz_dataflow_types::sources::{SourceConnector, StringOrSecret};
+use mz_dataflow_types::connectors::Connector;
+use mz_dataflow_types::sources::SourceConnector;
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
@@ -270,15 +271,6 @@ pub trait CatalogComputeInstance<'a> {
     fn replica_names(&self) -> HashSet<&String>;
 }
 
-/// A connector in a [`SessionCatalog`]
-pub trait CatalogConnector {
-    /// Returns the connection URI for this connector regardless of type
-    fn uri(&self) -> String;
-
-    /// Returns the options associated with this connector as a Vec, if the type does not support options or none were specified this will be empty
-    fn options(&self) -> std::collections::BTreeMap<String, StringOrSecret>;
-}
-
 /// An item in a [`SessionCatalog`].
 ///
 /// Note that "item" has a very specific meaning in the context of a SQL
@@ -315,7 +307,7 @@ pub trait CatalogItem {
     ///
     /// If the catalog item is not of a type that implements `CatalogConnector`
     /// it returns an error
-    fn catalog_connector(&self) -> Result<&dyn CatalogConnector, CatalogError>;
+    fn connector(&self) -> Result<&Connector, CatalogError>;
 
     /// Returns the type of the catalog item.
     fn item_type(&self) -> CatalogItemType;

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail};
 
-use mz_dataflow_types::sources::StringOrSecret;
+use mz_dataflow_types::connectors::StringOrSecret;
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::task;
 use mz_secrets::SecretsReader;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_dataflow_types::client::ComputeInstanceId;
 use mz_dataflow_types::sinks::{SinkConnectorBuilder, SinkEnvelope};
-use mz_dataflow_types::sources::{ConnectorInner, SourceConnector};
+use mz_dataflow_types::sources::SourceConnector;
 use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
@@ -458,7 +458,7 @@ pub struct Source {
 #[derive(Clone, Debug)]
 pub struct Connector {
     pub create_sql: String,
-    pub connector: ConnectorInner,
+    pub connector: mz_dataflow_types::connectors::Connector,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_build_info::DUMMY_BUILD_INFO;
+use mz_dataflow_types::connectors::Connector;
 use mz_dataflow_types::sources::SourceConnector;
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_lowertest::*;
@@ -26,9 +27,8 @@ use mz_secrets::SecretsReader;
 
 use crate::ast::Expr;
 use crate::catalog::{
-    CatalogComputeInstance, CatalogConfig, CatalogConnector, CatalogDatabase, CatalogError,
-    CatalogItem, CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, IdReference,
-    SessionCatalog,
+    CatalogComputeInstance, CatalogConfig, CatalogDatabase, CatalogError, CatalogItem,
+    CatalogItemType, CatalogRole, CatalogSchema, CatalogTypeDetails, IdReference, SessionCatalog,
 };
 use crate::func::{Func, MZ_CATALOG_BUILTINS, MZ_INTERNAL_BUILTINS, PG_CATALOG_BUILTINS};
 use crate::names::{
@@ -139,7 +139,7 @@ impl CatalogItem for TestCatalogItem {
         unimplemented!()
     }
 
-    fn catalog_connector(&self) -> Result<&dyn CatalogConnector, CatalogError> {
+    fn connector(&self) -> Result<&Connector, CatalogError> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
This is the next work item in source connectors (#11504). The
`Connector` enum isn't something that can be meaningfully abstracted,
since each connector type has such a distinct set of fields. So just
expose that enum directly to the SQL layer, rather than trying to hide
it behind a trait. This will fix at least one of the bugs in #12472.

Fix #12982.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
