### PR TITLE
sql: add Default option to generate_extracted_config

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1211,7 +1211,7 @@ fn get_encoding(
     Ok(encoding)
 }
 
-generate_extracted_config!(AvroSchemaOption, (ConfluentWireFormat, bool));
+generate_extracted_config!(AvroSchemaOption, (ConfluentWireFormat, bool, Default(true)));
 
 fn get_encoding_inner(
     scx: &StatementContext,
@@ -1241,7 +1241,7 @@ fn get_encoding_inner(
                         key_schema: None,
                         value_schema: schema.clone(),
                         schema_registry_config: None,
-                        confluent_wire_format: confluent_wire_format.unwrap_or(true),
+                        confluent_wire_format,
                     }
                 }
                 AvroSchema::InlineSchema {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -410,7 +410,7 @@ fn plan_copy_from(
 
 generate_extracted_config!(
     CopyOption,
-    (Format, String),
+    (Format, String, Default("text")),
     (Delimiter, String),
     (Null, String),
     (Escape, String),
@@ -437,17 +437,12 @@ pub fn plan_copy(
     } = CopyOptionExtracted::try_from(options)?;
 
     let copy_params = CopyParams {
-        format: format
-            .map(|f| {
-                Ok(match f.to_lowercase().as_str() {
-                    "text" => CopyFormat::Text,
-                    "csv" => CopyFormat::Csv,
-                    "binary" => CopyFormat::Binary,
-                    _ => bail!("unknown FORMAT: {}", f),
-                })
-            })
-            .transpose()?
-            .unwrap_or(CopyFormat::Text),
+        format: match format.to_lowercase().as_str() {
+            "text" => CopyFormat::Text,
+            "csv" => CopyFormat::Csv,
+            "binary" => CopyFormat::Binary,
+            _ => bail!("unknown FORMAT: {}", format),
+        },
         delimiter,
         null,
         escape,

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -143,6 +143,18 @@ impl<V: TryFromValue<Value>> ImpliedValue for Vec<V> {
     }
 }
 
+impl<V: TryFromValue<Value>> TryFromValue<Value> for Option<V> {
+    fn try_from_value(v: Value) -> Result<Self, anyhow::Error> {
+        Ok(Some(V::try_from_value(v)?))
+    }
+}
+
+impl<V: ImpliedValue> ImpliedValue for Option<V> {
+    fn implied_value() -> Result<Self, anyhow::Error> {
+        Ok(Some(V::implied_value()?))
+    }
+}
+
 impl<V: TryFromValue<Value>, T: AstInfo + std::fmt::Debug> TryFromValue<WithOptionValue<T>> for V {
     fn try_from_value(v: WithOptionValue<T>) -> Result<Self, anyhow::Error> {
         match v {


### PR DESCRIPTION
### Motivation

This PR adds a feature that has not yet been specified.

When handling `WITH` options, you occasionally want to set a default value for the parameter. We haven't previously had a macro that does this, but this inelegant implementation makes it configurable.

This feature isn't necessarily worth the complexity, so I'm very happy to axe the PR.

### Tips for reviewer

@benesch @petrosagg I wrestled with the iterative parsing using a declarative macro for most of the day today, and this was where I landed. Requires twin match arms per permutation--one that handles the trailing comma and one that doesn't. I went through the other options (i.e. no commas, commas everywhere), and figured this was the most ergonomic for end users, even if the maintenance becomes more fraught. `$(,)?` doesn't work (at least not naively) because we want to take the remaining token tree.

Do either of you have suggestions/opinions on how to approach this?

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
