### PR TITLE
storage: rename "connector" to "connection"

### DIFF
--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -26,8 +26,8 @@ _schema&lowbar;name_ | The schema to show sources from. Defaults to `public` in 
 `SHOW FULL SOURCES`'s output is a table, with this structure:
 
 ```nofmt
- name  | type | materialized | volatility | connector_type
--------+------+--------------+------------+---------------
+ name  | type | materialized | volatility | type
+-------+------+--------------+------------+-----
  ...   | ...  | ...          | ...        | ...
 ```
 
@@ -37,7 +37,7 @@ Field | Meaning
 **type** | Whether the source was created by the `user` or the `system`.
 **materialized** | Does the source have an in-memory index? For more details, see [`CREATE INDEX`](../create-index).
 **volatility** | Whether the source is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
-**connector_type** | The type of the source:  `kafka`, `postgres`, or `pubnub`.
+**type** | The type of the source:  `kafka`, `postgres`, or `pubnub`.
 
 ### Internal statistic sources
 

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -461,7 +461,7 @@ Field            | Type        | Meaning
 `oid`            | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the sink.
 `schema_id`      | [`bigint`]  | The ID of the schema to which the sink belongs.
 `name`           | [`text`]    | The name of the sink.
-`connector_type` | [`text`]    | The type of the sink: `kafka`.
+`type`           | [`text`]    | The type of the sink: `kafka`.
 `volatility`     | [`text`]    | Whether the sink is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
 
 ### `mz_sources`
@@ -474,7 +474,7 @@ Field            | Type       | Meaning
 `oid`            | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the source.
 `schema_id`      | [`bigint`] | The ID of the schema to which the source belongs.
 `name`           | [`text`]   | The name of the source.
-`connector_type` | [`text`]   | The type of the source: `kafka`, `postgres`, or `pubnub`.
+`type`           | [`text`]   | The type of the source: `kafka`, `postgres`, or `pubnub`.
 `volatility`     | [`text`]   | Whether the source is [volatile](/overview/volatility). Either `volatile`, `nonvolatile`, or `unknown`.
 
 ### `mz_tables`

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -126,6 +126,7 @@ def main() -> int:
         for test in args.test:
             command += ["--test", test]
         command += args.args
+        command += ["--", "--nocapture"]
         os.environ["POSTGRES_URL"] = args.postgres
     else:
         raise UIError(f"unknown program {args.program}")

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -20,7 +20,7 @@ use tracing::info;
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::{ComputeClient, ComputeCommand, ComputeResponse, GenericClient};
 use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::ConnectionContext;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::metrics::MetricsRegistry;
@@ -165,7 +165,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         comm_config,
         metrics_registry,
         now: SYSTEM_TIME.clone(),
-        connector_context: ConnectorContext::from_cli_args(
+        connection_context: ConnectionContext::from_cli_args(
             &args.tracing.log_filter.inner,
             args.aws_external_id,
         ),

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -19,8 +19,8 @@ use tracing::info;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::{ComputeClient, ComputeCommand, ComputeResponse, GenericClient};
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::reconciliation::command::ComputeCommandReconcile;
-use mz_dataflow_types::ConnectionContext;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::metrics::MetricsRegistry;

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -30,7 +30,7 @@ use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, InstanceConfig, Peek, ReplicaId};
 use mz_dataflow_types::logging::LoggingConfig;
 use mz_dataflow_types::{
-    ConnectorContext, DataflowDescription, DataflowError, PeekResponse, Plan, TailResponse,
+    ConnectionContext, DataflowDescription, DataflowError, PeekResponse, Plan, TailResponse,
 };
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
@@ -70,9 +70,9 @@ pub struct ComputeState {
     pub sink_metrics: SinkBaseMetrics,
     /// The logger, from Timely's logging framework, if logs are enabled.
     pub materialized_logger: Option<logging::materialized::Logger>,
-    /// Configuration for sink connectors.
+    /// Configuration for sink connections.
     // TODO: remove when sinks move to storage.
-    pub connector_context: ConnectorContext,
+    pub connection_context: ConnectionContext,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers.
     pub persist_clients: Arc<Mutex<PersistClientCache>>,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -28,10 +28,9 @@ use tokio::sync::{mpsc, Mutex};
 
 use mz_dataflow_types::client::controller::storage::CollectionMetadata;
 use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, InstanceConfig, Peek, ReplicaId};
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::logging::LoggingConfig;
-use mz_dataflow_types::{
-    ConnectionContext, DataflowDescription, DataflowError, PeekResponse, Plan, TailResponse,
-};
+use mz_dataflow_types::{DataflowDescription, DataflowError, PeekResponse, Plan, TailResponse};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_timely_util::activator::RcActivator;

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -38,7 +38,7 @@ where
         sink_id: GlobalId,
         sink: &SinkDesc,
     ) {
-        let sink_render = get_sink_render_for(&sink.connector);
+        let sink_render = get_sink_render_for(&sink.connection);
 
         // put together tokens that belong to the export
         let mut needed_tokens = Vec::new();
@@ -99,7 +99,7 @@ fn apply_sink_envelope<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    // Some connectors support keys - extract them.
+    // Some connections support keys - extract them.
     let keyed = if sink_render.uses_keys() {
         let user_key_indices = sink_render
             .get_key_indices()
@@ -223,13 +223,13 @@ where
         G: Scope<Timestamp = Timestamp>;
 }
 
-fn get_sink_render_for<G>(connector: &SinkConnector) -> Box<dyn SinkRender<G>>
+fn get_sink_render_for<G>(connection: &SinkConnection) -> Box<dyn SinkRender<G>>
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    match connector {
-        SinkConnector::Kafka(connector) => Box::new(connector.clone()),
-        SinkConnector::Tail(connector) => Box::new(connector.clone()),
-        SinkConnector::Persist(connector) => Box::new(connector.clone()),
+    match connection {
+        SinkConnection::Kafka(connection) => Box::new(connection.clone()),
+        SinkConnection::Tail(connection) => Box::new(connection.clone()),
+        SinkConnection::Persist(connection) => Box::new(connection.clone()),
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc;
 use tracing::warn;
 
 use mz_dataflow_types::client::{ComputeCommand, ComputeResponse, LocalClient, LocalComputeClient};
-use mz_dataflow_types::ConnectionContext;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -19,14 +19,14 @@ use timely::dataflow::Scope;
 use timely::progress::Antichain;
 use timely::progress::Timestamp as TimelyTimestamp;
 
-use mz_dataflow_types::sinks::{PersistSinkConnector, SinkDesc};
+use mz_dataflow_types::sinks::{PersistSinkConnection, SinkDesc};
 use mz_persist_client::PersistLocation;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::render::sinks::SinkRender;
 
-impl<G> SinkRender<G> for PersistSinkConnector
+impl<G> SinkRender<G> for PersistSinkConnection
 where
     G: Scope<Timestamp = Timestamp>,
 {

--- a/src/compute/src/sink/tail.rs
+++ b/src/compute/src/sink/tail.rs
@@ -21,14 +21,14 @@ use timely::progress::timestamp::Timestamp as TimelyTimestamp;
 use timely::progress::Antichain;
 
 use mz_dataflow_types::{
-    sinks::{SinkAsOf, SinkDesc, TailSinkConnector},
+    sinks::{SinkAsOf, SinkDesc, TailSinkConnection},
     TailResponse,
 };
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 
 use crate::render::sinks::SinkRender;
 
-impl<G> SinkRender<G> for TailSinkConnector
+impl<G> SinkRender<G> for TailSinkConnection
 where
     G: Scope<Timestamp = Timestamp>,
 {

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1019,7 +1019,7 @@ pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("connection_type", ScalarType::String.nullable(false)),
+        .with_column("type", ScalarType::String.nullable(false)),
 });
 pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sources",
@@ -1029,7 +1029,7 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("connection_type", ScalarType::String.nullable(false))
+        .with_column("type", ScalarType::String.nullable(false))
         .with_column("volatility", ScalarType::String.nullable(false)),
 });
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1040,7 +1040,7 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("connection_type", ScalarType::String.nullable(false))
+        .with_column("type", ScalarType::String.nullable(false))
         .with_column("volatility", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::Int64.nullable(false)),
 });

--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -1011,15 +1011,15 @@ pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false)),
 });
-pub static MZ_CONNECTORS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_connectors",
+pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_connections",
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("connector_type", ScalarType::String.nullable(false)),
+        .with_column("connection_type", ScalarType::String.nullable(false)),
 });
 pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sources",
@@ -1029,7 +1029,7 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("connector_type", ScalarType::String.nullable(false))
+        .with_column("connection_type", ScalarType::String.nullable(false))
         .with_column("volatility", ScalarType::String.nullable(false)),
 });
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1040,7 +1040,7 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("connector_type", ScalarType::String.nullable(false))
+        .with_column("connection_type", ScalarType::String.nullable(false))
         .with_column("volatility", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::Int64.nullable(false)),
 });
@@ -2095,7 +2095,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_FUNCTIONS),
         Builtin::Table(&MZ_CLUSTERS),
         Builtin::Table(&MZ_SECRETS),
-        Builtin::Table(&MZ_CONNECTORS),
+        Builtin::Table(&MZ_CONNECTIONS),
         Builtin::Table(&MZ_CLUSTER_REPLICAS_BASE),
         Builtin::Table(&MZ_CLUSTER_REPLICAS_STATUS),
         Builtin::Table(&MZ_AUDIT_EVENTS),

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -14,7 +14,7 @@ use mz_dataflow_types::client::controller::ComputeInstanceStatus;
 use mz_dataflow_types::client::{
     ComputeInstanceId, ConcreteComputeInstanceReplicaConfig, ProcessId, ReplicaId,
 };
-use mz_dataflow_types::sinks::KafkaSinkConnector;
+use mz_dataflow_types::sinks::KafkaSinkConnection;
 use mz_expr::MirScalarExpr;
 use mz_ore::collections::CollectionExt;
 use mz_repr::adt::array::ArrayDimension;
@@ -27,13 +27,13 @@ use mz_sql_parser::ast::display::AstDisplay;
 
 use crate::catalog::builtin::{
     MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS_BASE,
-    MZ_CLUSTER_REPLICAS_STATUS, MZ_COLUMNS, MZ_CONNECTORS, MZ_DATABASES, MZ_FUNCTIONS, MZ_INDEXES,
+    MZ_CLUSTER_REPLICAS_STATUS, MZ_COLUMNS, MZ_CONNECTIONS, MZ_DATABASES, MZ_FUNCTIONS, MZ_INDEXES,
     MZ_INDEX_COLUMNS, MZ_KAFKA_SINKS, MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_PSEUDO_TYPES, MZ_ROLES,
     MZ_SCHEMAS, MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
-    CatalogItem, CatalogState, Connector, Error, ErrorKind, Func, Index, Sink, SinkConnector,
-    SinkConnectorState, Type, View, SYSTEM_CONN_ID,
+    CatalogItem, CatalogState, Connection, Error, ErrorKind, Func, Index, Sink, SinkConnection,
+    SinkConnectionState, Type, View, SYSTEM_CONN_ID,
 };
 
 /// An update to a built-in table.
@@ -190,15 +190,15 @@ impl CatalogState {
             CatalogItem::Index(index) => self.pack_index_update(id, oid, name, index, diff),
             CatalogItem::Table(_) => self.pack_table_update(id, oid, schema_id, name, diff),
             CatalogItem::Source(source) => {
-                self.pack_source_update(id, oid, schema_id, name, source.connector.name(), diff)
+                self.pack_source_update(id, oid, schema_id, name, source.connection.name(), diff)
             }
             CatalogItem::View(view) => self.pack_view_update(id, oid, schema_id, name, view, diff),
             CatalogItem::Sink(sink) => self.pack_sink_update(id, oid, schema_id, name, sink, diff),
             CatalogItem::Type(ty) => self.pack_type_update(id, oid, schema_id, name, ty, diff),
             CatalogItem::Func(func) => self.pack_func_update(id, schema_id, name, func, diff),
             CatalogItem::Secret(_) => self.pack_secret_update(id, schema_id, name, diff),
-            CatalogItem::Connector(connector) => {
-                self.pack_connector_update(id, oid, schema_id, name, connector, diff)
+            CatalogItem::Connection(connection) => {
+                self.pack_connection_update(id, oid, schema_id, name, connection, diff)
             }
         };
 
@@ -259,7 +259,7 @@ impl CatalogState {
         oid: u32,
         schema_id: &SchemaSpecifier,
         name: &str,
-        source_connector_name: &str,
+        source_connection_name: &str,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
@@ -269,32 +269,32 @@ impl CatalogState {
                 Datum::UInt32(oid),
                 Datum::Int64(schema_id.into()),
                 Datum::String(name),
-                Datum::String(source_connector_name),
+                Datum::String(source_connection_name),
                 Datum::String(self.is_volatile(id).as_str()),
             ]),
             diff,
         }]
     }
 
-    fn pack_connector_update(
+    fn pack_connection_update(
         &self,
         id: GlobalId,
         oid: u32,
         schema_id: &SchemaSpecifier,
         name: &str,
-        connector: &Connector,
+        connection: &Connection,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
-            id: self.resolve_builtin_table(&MZ_CONNECTORS),
+            id: self.resolve_builtin_table(&MZ_CONNECTIONS),
             row: Row::pack_slice(&[
                 Datum::String(&id.to_string()),
                 Datum::UInt32(oid),
                 Datum::Int64(schema_id.into()),
                 Datum::String(name),
-                Datum::String(match connector.connector {
-                    mz_dataflow_types::connectors::Connector::Kafka { .. } => "kafka",
-                    mz_dataflow_types::connectors::Connector::Csr { .. } => {
+                Datum::String(match connection.connection {
+                    mz_dataflow_types::connections::Connection::Kafka { .. } => "kafka",
+                    mz_dataflow_types::connections::Connection::Csr { .. } => {
                         "confluent-schema-registry"
                     }
                 }),
@@ -350,12 +350,12 @@ impl CatalogState {
     ) -> Vec<BuiltinTableUpdate> {
         let mut updates = vec![];
         if let Sink {
-            connector: SinkConnectorState::Ready(connector),
+            connection: SinkConnectionState::Ready(connection),
             ..
         } = sink
         {
-            match connector {
-                SinkConnector::Kafka(KafkaSinkConnector {
+            match connection {
+                SinkConnection::Kafka(KafkaSinkConnection {
                     topic, consistency, ..
                 }) => {
                     let consistency_topic = if let Some(consistency) = consistency {
@@ -382,7 +382,7 @@ impl CatalogState {
                     Datum::UInt32(oid),
                     Datum::Int64(schema_id.into()),
                     Datum::String(name),
-                    Datum::String(connector.name()),
+                    Datum::String(connection.name()),
                     Datum::String(self.is_volatile(id).as_str()),
                     Datum::Int64(sink.compute_instance),
                 ]),

--- a/src/coord/src/client.rs
+++ b/src/coord/src/client.rs
@@ -473,7 +473,7 @@ impl SessionClient {
                 ExecuteResponse::Canceled => {
                     results.push(SimpleResult::err("statement canceled due to user request"));
                 }
-                ExecuteResponse::CreatedConnector { existed: _ }
+                ExecuteResponse::CreatedConnection { existed: _ }
                 | ExecuteResponse::CreatedDatabase { existed: _ }
                 | ExecuteResponse::CreatedSchema { existed: _ }
                 | ExecuteResponse::CreatedRole
@@ -502,7 +502,7 @@ impl SessionClient {
                 | ExecuteResponse::DroppedView
                 | ExecuteResponse::DroppedType
                 | ExecuteResponse::DroppedSecret
-                | ExecuteResponse::DroppedConnector
+                | ExecuteResponse::DroppedConnection
                 | ExecuteResponse::EmptyQuery
                 | ExecuteResponse::Inserted(_)
                 | ExecuteResponse::StartedTransaction { duplicated: _ }

--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -183,8 +183,8 @@ pub enum ExecuteResponse {
         columns: Vec<usize>,
         params: mz_sql::plan::CopyParams,
     },
-    /// The requested connector was created.
-    CreatedConnector {
+    /// The requested connection was created.
+    CreatedConnection {
         existed: bool,
     },
     /// The requested database was created.
@@ -245,8 +245,8 @@ pub enum ExecuteResponse {
     DiscardedTemp,
     /// All state associated with the session has been discarded.
     DiscardedAll,
-    /// The requested connector was dropped
-    DroppedConnector,
+    /// The requested connection was dropped
+    DroppedConnection,
     /// The requested compute instance was dropped.
     DroppedComputeInstance,
     /// The requested compute instance replicas were dropped.

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -97,14 +97,14 @@ use mz_dataflow_types::client::{
     ComputeInstanceId, ConcreteComputeInstanceReplicaConfig, ControllerResponse,
     LinearizedTimestampBindingFeedback, ReplicaId,
 };
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sinks::{SinkAsOf, SinkConnection, SinkDesc, TailSinkConnection};
 use mz_dataflow_types::sources::{
     ExternalSourceConnection, IngestionDescription, PostgresSourceConnection, SourceConnection,
     Timeline,
 };
 use mz_dataflow_types::{
-    BuildDesc, ConnectionContext, DataflowDesc, DataflowDescription, IndexDesc, PeekResponse,
-    Update,
+    BuildDesc, DataflowDesc, DataflowDescription, IndexDesc, PeekResponse, Update,
 };
 use mz_expr::{
     permutation_for_arrangement, CollectionPlan, ExprHumanizer, MirRelationExpr, MirScalarExpr,

--- a/src/coord/src/coord/dataflow_builder.rs
+++ b/src/coord/src/coord/dataflow_builder.rs
@@ -240,7 +240,7 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
     }
 
     /// Builds a dataflow description for the sink with the specified name,
-    /// ID, source, and output connector.
+    /// ID, source, and output connection.
     ///
     /// For as long as this dataflow is active, `id` can be used to reference
     /// the sink (primarily to drop it, at the moment).

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -14,7 +14,7 @@ use std::num::TryFromIntError;
 use dec::TryFromDecimalError;
 use tokio::sync::oneshot;
 
-use mz_dataflow_types::sources::{ExternalSourceConnector, SourceConnector};
+use mz_dataflow_types::sources::{ExternalSourceConnection, SourceConnection};
 use mz_expr::{EvalError, UnmaterializableFunc};
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::str::StrExt;
@@ -513,10 +513,10 @@ impl RematerializedSourceType {
     ///
     /// If the source is of a type that is allowed to be rematerialized
     pub fn for_source(source: &catalog::Source) -> RematerializedSourceType {
-        match &source.connector {
-            SourceConnector::External { connector, .. } => match connector {
-                ExternalSourceConnector::S3(_) => RematerializedSourceType::S3,
-                ExternalSourceConnector::Postgres(_) => RematerializedSourceType::Postgres,
+        match &source.connection {
+            SourceConnection::External { connection, .. } => match connection {
+                ExternalSourceConnection::S3(_) => RematerializedSourceType::S3,
+                ExternalSourceConnection::Postgres(_) => RematerializedSourceType::Postgres,
                 _ => unreachable!(),
             },
             _ => unreachable!(),

--- a/src/coord/src/lib.rs
+++ b/src/coord/src/lib.rs
@@ -36,7 +36,7 @@ mod client;
 mod command;
 mod coord;
 mod error;
-mod sink_connector;
+mod sink_connection;
 mod tail;
 mod util;
 

--- a/src/coord/src/sink_connection.rs
+++ b/src/coord/src/sink_connection.rs
@@ -12,12 +12,12 @@ use std::time::Duration;
 use anyhow::{anyhow, Context};
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
 
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sinks::{
     KafkaSinkConnection, KafkaSinkConnectionBuilder, KafkaSinkConnectionRetention,
     KafkaSinkConsistencyConnection, PersistSinkConnection, PersistSinkConnectionBuilder,
     PublishedSchemaInfo, SinkConnection, SinkConnectionBuilder,
 };
-use mz_dataflow_types::ConnectionContext;
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::collections::CollectionExt;
 use mz_repr::GlobalId;

--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -33,7 +33,7 @@ fn main() {
                 "dataflow-types/src/client/controller/storage.proto",
                 "dataflow-types/src/errors.proto",
                 "dataflow-types/src/logging.proto",
-                "dataflow-types/src/types/aws.proto",
+                "dataflow-types/src/types/connections/aws.proto",
                 "dataflow-types/src/types/sinks.proto",
                 "dataflow-types/src/types/sources.proto",
                 "dataflow-types/src/types/sources/encoding.proto",

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -54,7 +54,7 @@ use crate::client::controller::ReadPolicy;
 use crate::client::{
     GenericClient, StorageClient, StorageCommand, StorageResponse, StoragedRemoteClient,
 };
-use crate::sources::{IngestionDescription, SourceConnector, SourceData, SourceDesc};
+use crate::sources::{IngestionDescription, SourceConnection, SourceData, SourceDesc};
 use crate::Update;
 
 include!(concat!(
@@ -298,7 +298,7 @@ impl<T: Timestamp + Lattice + Codec64> StorageControllerState<T> {
             &tokio_postgres::config::Config::from_str(&postgres_url)
                 .expect("invalid postgres url for storage stash"),
         )
-        .expect("could not make storage TLS connector");
+        .expect("could not make storage TLS connection");
         let stash = mz_stash::Postgres::new(postgres_url, None, tls)
             .await
             .expect("could not connect to postgres storage stash");
@@ -400,7 +400,7 @@ where
 
             // TODO(petrosagg): it's weird that tables go through this path and we filter them
             // manually. Think how to make better types to reflect their differences
-            if matches!(ingestion.desc.connector, SourceConnector::External { .. }) {
+            if matches!(ingestion.desc.connection, SourceConnection::External { .. }) {
                 external_ingestions.push(ingestion);
             }
         }

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -38,7 +38,7 @@ use crate::Plan;
 use proto_dataflow_description::*;
 
 pub mod aws;
-pub mod connectors;
+pub mod connections;
 pub mod sinks;
 pub mod sources;
 
@@ -457,20 +457,20 @@ impl Arbitrary for DataflowDescription<Plan, CollectionMetadata, mz_repr::Timest
     }
 }
 
-/// Extra context to pass through when instantiating a connector for a source or
-/// sink.
+/// Extra context to pass through when instantiating a connection for a source
+/// or sink.
 ///
 /// Should be kept cheaply cloneable.
 #[derive(Debug, Clone)]
-pub struct ConnectorContext {
+pub struct ConnectionContext {
     /// The level for librdkafka's logs.
     pub librdkafka_log_level: tracing::Level,
     /// A prefix for an external ID to use for all AWS AssumeRole operations.
     pub aws_external_id_prefix: Option<AwsExternalIdPrefix>,
 }
 
-impl ConnectorContext {
-    /// Constructs a new connector context from command line arguments.
+impl ConnectionContext {
+    /// Constructs a new connection context from command line arguments.
     ///
     /// **WARNING:** it is critical for security that the `aws_external_id` be
     /// provided by the operator of the Materialize service (i.e., via a CLI
@@ -480,17 +480,17 @@ impl ConnectorContext {
     pub fn from_cli_args(
         filter: &tracing_subscriber::filter::Targets,
         aws_external_id_prefix: Option<String>,
-    ) -> ConnectorContext {
-        ConnectorContext {
+    ) -> ConnectionContext {
+        ConnectionContext {
             librdkafka_log_level: mz_ore::tracing::target_level(filter, "librdkafka"),
             aws_external_id_prefix: aws_external_id_prefix.map(AwsExternalIdPrefix),
         }
     }
 }
 
-impl Default for ConnectorContext {
-    fn default() -> ConnectorContext {
-        ConnectorContext {
+impl Default for ConnectionContext {
+    fn default() -> ConnectionContext {
+        ConnectionContext {
             librdkafka_log_level: tracing::Level::INFO,
             aws_external_id_prefix: None,
         }

--- a/src/dataflow-types/src/types/aws.rs
+++ b/src/dataflow-types/src/types/aws.rs
@@ -62,9 +62,9 @@ impl RustType<ProtoSerdeUri> for SerdeUri {
 ///
 /// This type protects against accidental construction of an
 /// `AwsExternalIdPrefix`. The only approved way to construct an `AwsExternalIdPrefix`
-/// is via [`ConnectorContext::from_cli_args`].
+/// is via [`ConnectionContext::from_cli_args`].
 ///
-/// [`ConnectorContext::from_cli_args`]: crate::ConnectorContext::from_cli_args
+/// [`ConnectionContext::from_cli_args`]: crate::ConnectionContext::from_cli_args
 /// [external ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AwsExternalIdPrefix(pub(super) String);

--- a/src/dataflow-types/src/types/connections.rs
+++ b/src/dataflow-types/src/types/connections.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Connector types.
+//! Connection types.
 
 use std::collections::BTreeMap;
 
@@ -33,13 +33,13 @@ impl StringOrSecret {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum Connector {
-    Kafka(KafkaConnector),
+pub enum Connection {
+    Kafka(KafkaConnection),
     Csr(mz_ccsr::ClientConfig),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct KafkaConnector {
+pub struct KafkaConnection {
     pub broker: KafkaAddrs,
     pub options: BTreeMap<String, StringOrSecret>,
 }

--- a/src/dataflow-types/src/types/connections.rs
+++ b/src/dataflow-types/src/types/connections.rs
@@ -17,6 +17,10 @@ use mz_kafka_util::KafkaAddrs;
 use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 
+use crate::types::connections::aws::AwsExternalIdPrefix;
+
+pub mod aws;
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum StringOrSecret {
     String(String),
@@ -28,6 +32,46 @@ impl StringOrSecret {
         match self {
             StringOrSecret::String(s) => Ok(s.clone()),
             StringOrSecret::Secret(id) => secrets_reader.read_string(*id),
+        }
+    }
+}
+
+/// Extra context to pass through when instantiating a connection for a source
+/// or sink.
+///
+/// Should be kept cheaply cloneable.
+#[derive(Debug, Clone)]
+pub struct ConnectionContext {
+    /// The level for librdkafka's logs.
+    pub librdkafka_log_level: tracing::Level,
+    /// A prefix for an external ID to use for all AWS AssumeRole operations.
+    pub aws_external_id_prefix: Option<AwsExternalIdPrefix>,
+}
+
+impl ConnectionContext {
+    /// Constructs a new connection context from command line arguments.
+    ///
+    /// **WARNING:** it is critical for security that the `aws_external_id` be
+    /// provided by the operator of the Materialize service (i.e., via a CLI
+    /// argument or environment variable) and not the end user of Materialize
+    /// (e.g., via a configuration option in a SQL statement). See
+    /// [`AwsExternalIdPrefix`] for details.
+    pub fn from_cli_args(
+        filter: &tracing_subscriber::filter::Targets,
+        aws_external_id_prefix: Option<String>,
+    ) -> ConnectionContext {
+        ConnectionContext {
+            librdkafka_log_level: mz_ore::tracing::target_level(filter, "librdkafka"),
+            aws_external_id_prefix: aws_external_id_prefix.map(AwsExternalIdPrefix),
+        }
+    }
+}
+
+impl Default for ConnectionContext {
+    fn default() -> ConnectionContext {
+        ConnectionContext {
+            librdkafka_log_level: tracing::Level::INFO,
+            aws_external_id_prefix: None,
         }
     }
 }

--- a/src/dataflow-types/src/types/connections/aws.proto
+++ b/src/dataflow-types/src/types/connections/aws.proto
@@ -11,7 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package mz_dataflow_types.types.aws;
+package mz_dataflow_types.types.connections.aws;
 
 message ProtoSerdeUri {
     string uri = 1;

--- a/src/dataflow-types/src/types/connections/aws.rs
+++ b/src/dataflow-types/src/types/connections/aws.rs
@@ -18,7 +18,10 @@ use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::URL_PATTERN;
 use mz_repr::GlobalId;
 
-include!(concat!(env!("OUT_DIR"), "/mz_dataflow_types.types.aws.rs"));
+include!(concat!(
+    env!("OUT_DIR"),
+    "/mz_dataflow_types.types.connections.aws.rs"
+));
 
 /// A wrapper for [`Uri`] that implements [`Serialize`] and `Deserialize`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -64,7 +67,7 @@ impl RustType<ProtoSerdeUri> for SerdeUri {
 /// `AwsExternalIdPrefix`. The only approved way to construct an `AwsExternalIdPrefix`
 /// is via [`ConnectionContext::from_cli_args`].
 ///
-/// [`ConnectionContext::from_cli_args`]: crate::ConnectionContext::from_cli_args
+/// [`ConnectionContext::from_cli_args`]: crate::connections::ConnectionContext::from_cli_args
 /// [external ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AwsExternalIdPrefix(pub(super) String);

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -21,7 +21,7 @@ package mz_dataflow_types.types.sinks;
 message ProtoSinkDesc {
     mz_repr.global_id.ProtoGlobalId from = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc from_desc = 2;
-    ProtoSinkConnector connector = 3;
+    ProtoSinkConnection connection = 3;
     optional ProtoSinkEnvelope envelope = 4;
     ProtoSinkAsOf as_of = 5;
 }
@@ -34,15 +34,15 @@ message ProtoSinkEnvelope {
     }
 }
 
-message ProtoSinkConnector {
+message ProtoSinkConnection {
     oneof kind {
-        ProtoKafkaSinkConnector kafka = 1;
+        ProtoKafkaSinkConnection kafka = 1;
         google.protobuf.Empty tail = 2;
-        ProtoPersistSinkConnector persist = 3;
+        ProtoPersistSinkConnection persist = 3;
     }
 }
 
-message ProtoKafkaSinkConsistencyConnector {
+message ProtoKafkaSinkConsistencyConnection {
     string topic = 1;
     int32 schema_id = 2;
 }
@@ -52,7 +52,7 @@ message ProtoSinkAsOf {
     bool strict = 2;
 }
 
-message ProtoKafkaSinkConnector {
+message ProtoKafkaSinkConnection {
     message ProtoKeyDescAndIndices {
         mz_repr.relation_and_scalar.ProtoRelationDesc desc = 1;
         repeated uint64 indices = 2;
@@ -69,7 +69,7 @@ message ProtoKafkaSinkConnector {
     optional ProtoRelationKeyIndicesVec relation_key_indices = 5;
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
     optional ProtoPublishedSchemaInfo published_schema_info = 7;
-    ProtoKafkaSinkConsistencyConnector consistency = 8;
+    ProtoKafkaSinkConsistencyConnection consistency = 8;
     bool exactly_once = 9;
     repeated mz_repr.global_id.ProtoGlobalId transitive_source_dependencies = 10;
     uint64 fuel = 11;
@@ -81,7 +81,7 @@ message ProtoPublishedSchemaInfo {
     int32 value_schema_id = 2;
 }
 
-message ProtoPersistSinkConnector {
+message ProtoPersistSinkConnection {
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
     string shard_id = 2;
     string consensus_uri = 3;

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -159,7 +159,7 @@ message ProtoDebeziumSourceProjection {
     }
 }
 
-message ProtoKafkaSourceConnector {
+message ProtoKafkaSourceConnection {
     mz_kafka_util.addr.ProtoKafkaAddrs addrs = 1;
     string topic = 2;
     map<string, string> config_options = 3;
@@ -173,9 +173,9 @@ message ProtoKafkaSourceConnector {
     ProtoIncludedColumnPos include_headers = 11;
 }
 
-message ProtoSourceConnector {
+message ProtoSourceConnection {
     message ProtoExternal {
-        ProtoExternalSourceConnector connector = 1;
+        ProtoExternalSourceConnection connection = 1;
         mz_dataflow_types.types.sources.encoding.ProtoSourceDataEncoding encoding = 2;
         ProtoSourceEnvelope envelope = 3;
         repeated ProtoIncludedColumnSource metadata_columns = 4;
@@ -193,13 +193,13 @@ message ProtoSourceConnector {
     }
 }
 
-message ProtoExternalSourceConnector {
+message ProtoExternalSourceConnection {
     oneof kind {
-        ProtoKafkaSourceConnector kafka = 1;
-        ProtoKinesisSourceConnector kinesis = 2;
-        ProtoS3SourceConnector s3 = 3;
-        ProtoPostgresSourceConnector postgres = 4;
-        ProtoPubNubSourceConnector pubnub = 5;
+        ProtoKafkaSourceConnection kafka = 1;
+        ProtoKinesisSourceConnection kinesis = 2;
+        ProtoS3SourceConnection s3 = 3;
+        ProtoPostgresSourceConnection postgres = 4;
+        ProtoPubNubSourceConnection pubnub = 5;
     }
 }
 
@@ -210,12 +210,12 @@ message ProtoSourceData {
     }
 }
 
-message ProtoKinesisSourceConnector {
+message ProtoKinesisSourceConnection {
     string stream_name = 1;
     mz_dataflow_types.types.aws.ProtoAwsConfig aws = 2;
 }
 
-message ProtoPostgresSourceConnector {
+message ProtoPostgresSourceConnection {
     string conn = 1;
     string publication = 2;
     ProtoPostgresSourceDetails details = 4;
@@ -226,12 +226,12 @@ message ProtoPostgresSourceDetails {
     string slot = 2;
 }
 
-message ProtoPubNubSourceConnector {
+message ProtoPubNubSourceConnection {
     string subscribe_key = 1;
     string channel = 2;
 }
 
-message ProtoS3SourceConnector {
+message ProtoS3SourceConnection {
     repeated ProtoS3KeySource key_sources = 1;
     optional string pattern = 2;
     mz_dataflow_types.types.aws.ProtoAwsConfig aws = 3;
@@ -253,6 +253,6 @@ message ProtoCompression {
 }
 
 message ProtoSourceDesc {
-    ProtoSourceConnector connector = 1;
+    ProtoSourceConnection connection = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc desc = 2;
 }

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -17,7 +17,7 @@ import "repr/src/proto.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 import "dataflow-types/src/errors.proto";
-import "dataflow-types/src/types/aws.proto";
+import "dataflow-types/src/types/connections/aws.proto";
 import "dataflow-types/src/types/sources/encoding.proto";
 import "kafka-util/src/addr.proto";
 import "postgres-util/src/desc.proto";
@@ -212,7 +212,7 @@ message ProtoSourceData {
 
 message ProtoKinesisSourceConnection {
     string stream_name = 1;
-    mz_dataflow_types.types.aws.ProtoAwsConfig aws = 2;
+    mz_dataflow_types.types.connections.aws.ProtoAwsConfig aws = 2;
 }
 
 message ProtoPostgresSourceConnection {
@@ -234,7 +234,7 @@ message ProtoPubNubSourceConnection {
 message ProtoS3SourceConnection {
     repeated ProtoS3KeySource key_sources = 1;
     optional string pattern = 2;
-    mz_dataflow_types.types.aws.ProtoAwsConfig aws = 3;
+    mz_dataflow_types.types.connections.aws.ProtoAwsConfig aws = 3;
     ProtoCompression compression = 4;
 }
 

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -36,7 +36,7 @@ use mz_repr::{ColumnType, GlobalId, RelationDesc, RelationType, Row, ScalarType}
 
 pub mod encoding;
 
-use crate::aws::AwsConfig;
+use crate::connections::aws::AwsConfig;
 use crate::DataflowError;
 
 include!(concat!(

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -46,7 +46,7 @@ use uuid::Uuid;
 use materialized::{
     OrchestratorBackend, OrchestratorConfig, SecretsControllerConfig, TlsConfig, TlsMode,
 };
-use mz_dataflow_types::ConnectionContext;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_frontegg_auth::{FronteggAuthentication, FronteggConfig};
 use mz_orchestrator_kubernetes::{KubernetesImagePullPolicy, KubernetesOrchestratorConfig};
 use mz_orchestrator_process::ProcessOrchestratorConfig;

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -46,7 +46,7 @@ use uuid::Uuid;
 use materialized::{
     OrchestratorBackend, OrchestratorConfig, SecretsControllerConfig, TlsConfig, TlsMode,
 };
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::ConnectionContext;
 use mz_frontegg_auth::{FronteggAuthentication, FronteggConfig};
 use mz_orchestrator_kubernetes::{KubernetesImagePullPolicy, KubernetesOrchestratorConfig};
 use mz_orchestrator_process::ProcessOrchestratorConfig;
@@ -699,7 +699,7 @@ max log level: {max_log_level}",
         now: SYSTEM_TIME.clone(),
         replica_sizes,
         availability_zones: args.availability_zone,
-        connector_context: ConnectorContext::from_cli_args(
+        connection_context: ConnectionContext::from_cli_args(
             &args.tracing.log_filter.inner,
             args.aws_external_id_prefix,
         ),

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -31,7 +31,7 @@ use tower_http::cors::AllowOrigin;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::controller::ClusterReplicaSizeMap;
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::ConnectionContext;
 use mz_frontegg_auth::FronteggAuthentication;
 use mz_orchestrator::Orchestrator;
 use mz_orchestrator_kubernetes::{KubernetesOrchestrator, KubernetesOrchestratorConfig};
@@ -98,11 +98,11 @@ pub struct Config {
     /// Postgres connection string for storage's stash.
     pub storage_postgres_stash: String,
 
-    // === Connector options. ===
-    /// Configuration for source and sink connectors created by the storage
+    // === Connection options. ===
+    /// Configuration for source and sink connections created by the storage
     /// layer. This can include configuration for external
     /// sources.
-    pub connector_context: ConnectorContext,
+    pub connection_context: ConnectionContext,
 
     // === Platform options. ===
     /// Configuration of service orchestration.
@@ -341,7 +341,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         secrets_reader,
         replica_sizes: config.replica_sizes.clone(),
         availability_zones: config.availability_zones.clone(),
-        connector_context: config.connector_context,
+        connection_context: config.connection_context,
     })
     .await?;
 

--- a/src/materialized/src/lib.rs
+++ b/src/materialized/src/lib.rs
@@ -31,7 +31,7 @@ use tower_http::cors::AllowOrigin;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::controller::ClusterReplicaSizeMap;
-use mz_dataflow_types::ConnectionContext;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_frontegg_auth::FronteggAuthentication;
 use mz_orchestrator::Orchestrator;
 use mz_orchestrator_kubernetes::{KubernetesOrchestrator, KubernetesOrchestratorConfig};

--- a/src/materialized/tests/util.rs
+++ b/src/materialized/tests/util.rs
@@ -197,7 +197,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         cors_allowed_origin: AllowOrigin::list([]),
         replica_sizes: Default::default(),
         availability_zones: Default::default(),
-        connector_context: Default::default(),
+        connection_context: Default::default(),
     }))?;
     let server = Server {
         inner,

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1067,8 +1067,8 @@ where
                 self.complete_portal(&portal_name);
                 command_complete!("CLOSE CURSOR")
             }
-            ExecuteResponse::CreatedConnector { existed } => {
-                created!(existed, SqlState::DUPLICATE_OBJECT, "connector")
+            ExecuteResponse::CreatedConnection { existed } => {
+                created!(existed, SqlState::DUPLICATE_OBJECT, "connection")
             }
             ExecuteResponse::CreatedDatabase { existed } => {
                 created!(existed, SqlState::DUPLICATE_DATABASE, "database")
@@ -1127,7 +1127,7 @@ where
             ExecuteResponse::DroppedView => command_complete!("DROP VIEW"),
             ExecuteResponse::DroppedType => command_complete!("DROP TYPE"),
             ExecuteResponse::DroppedSecret => command_complete!("DROP SECRET"),
-            ExecuteResponse::DroppedConnector => command_complete!("DROP CONNECTOR"),
+            ExecuteResponse::DroppedConnection => command_complete!("DROP CONNECTION"),
             ExecuteResponse::EmptyQuery => {
                 self.send(BackendMessage::EmptyQueryResponse).await?;
                 Ok(State::Ready)

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -86,7 +86,7 @@ impl<T: AstInfo> AstDisplay for AvroSchemaOption<T> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum AvroSchema<T: AstInfo> {
     Csr {
-        csr_connector: CsrConnectorAvro<T>,
+        csr_connection: CsrConnectionAvro<T>,
     },
     InlineSchema {
         schema: Schema,
@@ -97,8 +97,8 @@ pub enum AvroSchema<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for AvroSchema<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Self::Csr { csr_connector } => {
-                f.write_node(csr_connector);
+            Self::Csr { csr_connection } => {
+                f.write_node(csr_connection);
             }
             Self::InlineSchema {
                 schema,
@@ -120,7 +120,7 @@ impl_display_t!(AvroSchema);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ProtobufSchema<T: AstInfo> {
     Csr {
-        csr_connector: CsrConnectorProto<T>,
+        csr_connection: CsrConnectionProto<T>,
     },
     InlineSchema {
         message_name: String,
@@ -131,8 +131,8 @@ pub enum ProtobufSchema<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for ProtobufSchema<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Self::Csr { csr_connector } => {
-                f.write_node(csr_connector);
+            Self::Csr { csr_connection } => {
+                f.write_node(csr_connection);
             }
             Self::InlineSchema {
                 message_name,
@@ -149,30 +149,30 @@ impl<T: AstInfo> AstDisplay for ProtobufSchema<T> {
 impl_display_t!(ProtobufSchema);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum CsrConnector<T: AstInfo> {
+pub enum CsrConnection<T: AstInfo> {
     Inline { url: String },
-    Reference { connector: T::ObjectName },
+    Reference { connection: T::ObjectName },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CsrConnectorAvro<T: AstInfo> {
-    pub connector: CsrConnector<T>,
+pub struct CsrConnectionAvro<T: AstInfo> {
+    pub connection: CsrConnection<T>,
     pub seed: Option<CsrSeed>,
     pub with_options: Vec<WithOption<T>>,
 }
 
-impl<T: AstInfo> AstDisplay for CsrConnectorAvro<T> {
+impl<T: AstInfo> AstDisplay for CsrConnectionAvro<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("USING CONFLUENT SCHEMA REGISTRY ");
-        match &self.connector {
-            CsrConnector::Inline { url: uri, .. } => {
+        match &self.connection {
+            CsrConnection::Inline { url: uri, .. } => {
                 f.write_str("'");
                 f.write_node(&display::escape_single_quote_string(uri));
                 f.write_str("'");
             }
-            CsrConnector::Reference { connector, .. } => {
-                f.write_str("CONNECTOR ");
-                f.write_node(connector);
+            CsrConnection::Reference { connection, .. } => {
+                f.write_str("CONNECTION ");
+                f.write_node(connection);
             }
         }
         if let Some(seed) = &self.seed {
@@ -186,27 +186,27 @@ impl<T: AstInfo> AstDisplay for CsrConnectorAvro<T> {
         }
     }
 }
-impl_display_t!(CsrConnectorAvro);
+impl_display_t!(CsrConnectionAvro);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CsrConnectorProto<T: AstInfo> {
-    pub connector: CsrConnector<T>,
+pub struct CsrConnectionProto<T: AstInfo> {
+    pub connection: CsrConnection<T>,
     pub seed: Option<CsrSeedCompiledOrLegacy>,
     pub with_options: Vec<WithOption<T>>,
 }
 
-impl<T: AstInfo> AstDisplay for CsrConnectorProto<T> {
+impl<T: AstInfo> AstDisplay for CsrConnectionProto<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("USING CONFLUENT SCHEMA REGISTRY ");
-        match &self.connector {
-            CsrConnector::Inline { url: uri, .. } => {
+        match &self.connection {
+            CsrConnection::Inline { url: uri, .. } => {
                 f.write_str("'");
                 f.write_node(&display::escape_single_quote_string(uri));
                 f.write_str("'");
             }
-            CsrConnector::Reference { connector, .. } => {
-                f.write_str("CONNECTOR ");
-                f.write_node(connector);
+            CsrConnection::Reference { connection, .. } => {
+                f.write_str("CONNECTION ");
+                f.write_node(connection);
             }
         }
 
@@ -222,7 +222,7 @@ impl<T: AstInfo> AstDisplay for CsrConnectorProto<T> {
         }
     }
 }
-impl_display_t!(CsrConnectorProto);
+impl_display_t!(CsrConnectionProto);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CsrSeed {
@@ -546,7 +546,7 @@ impl<T: AstInfo> AstDisplay for DbzTxMetadataOption<T> {
 impl_display_t!(DbzTxMetadataOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum CreateConnector<T: AstInfo> {
+pub enum CreateConnection<T: AstInfo> {
     Kafka {
         broker: String,
         with_options: Vec<WithOption<T>>,
@@ -557,7 +557,7 @@ pub enum CreateConnector<T: AstInfo> {
     },
 }
 
-impl<T: AstInfo> AstDisplay for CreateConnector<T> {
+impl<T: AstInfo> AstDisplay for CreateConnection<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
             Self::Kafka {
@@ -589,41 +589,41 @@ impl<T: AstInfo> AstDisplay for CreateConnector<T> {
         }
     }
 }
-impl_display_t!(CreateConnector);
+impl_display_t!(CreateConnection);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum KafkaConnector<T: AstInfo> {
+pub enum KafkaConnection<T: AstInfo> {
     Inline { broker: String },
-    Reference { connector: T::ObjectName },
+    Reference { connection: T::ObjectName },
 }
 
-impl<T: AstInfo> AstDisplay for KafkaConnector<T> {
+impl<T: AstInfo> AstDisplay for KafkaConnection<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            KafkaConnector::Inline { broker } => {
+            KafkaConnection::Inline { broker } => {
                 f.write_str("BROKER '");
                 f.write_node(&display::escape_single_quote_string(broker));
                 f.write_str("'");
             }
-            KafkaConnector::Reference { connector, .. } => {
-                f.write_str("CONNECTOR ");
-                f.write_node(connector);
+            KafkaConnection::Reference { connection, .. } => {
+                f.write_str("CONNECTION ");
+                f.write_node(connection);
             }
         }
     }
 }
-impl_display_t!(KafkaConnector);
+impl_display_t!(KafkaConnection);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct KafkaSourceConnector<T: AstInfo> {
-    pub connector: KafkaConnector<T>,
+pub struct KafkaSourceConnection<T: AstInfo> {
+    pub connection: KafkaConnection<T>,
     pub topic: String,
     pub key: Option<Vec<Ident>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum CreateSourceConnector<T: AstInfo> {
-    Kafka(KafkaSourceConnector<T>),
+pub enum CreateSourceConnection<T: AstInfo> {
+    Kafka(KafkaSourceConnection<T>),
     Kinesis {
         arn: String,
     },
@@ -650,16 +650,16 @@ pub enum CreateSourceConnector<T: AstInfo> {
     },
 }
 
-impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
+impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            CreateSourceConnector::Kafka(KafkaSourceConnector {
-                connector,
+            CreateSourceConnection::Kafka(KafkaSourceConnection {
+                connection,
                 topic,
                 key,
             }) => {
                 f.write_str("KAFKA ");
-                f.write_node(connector);
+                f.write_node(connection);
                 f.write_str(" TOPIC '");
                 f.write_node(&display::escape_single_quote_string(topic));
                 f.write_str("'");
@@ -669,12 +669,12 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
                     f.write_str(")");
                 }
             }
-            CreateSourceConnector::Kinesis { arn } => {
+            CreateSourceConnection::Kinesis { arn } => {
                 f.write_str("KINESIS ARN '");
                 f.write_node(&display::escape_single_quote_string(arn));
                 f.write_str("'");
             }
-            CreateSourceConnector::S3 {
+            CreateSourceConnection::S3 {
                 key_sources,
                 pattern,
                 compression,
@@ -690,7 +690,7 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
                 f.write_str(" COMPRESSION ");
                 f.write_node(compression);
             }
-            CreateSourceConnector::Postgres {
+            CreateSourceConnection::Postgres {
                 conn,
                 publication,
                 details,
@@ -705,7 +705,7 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
                 }
                 f.write_str("'");
             }
-            CreateSourceConnector::PubNub {
+            CreateSourceConnection::PubNub {
                 subscribe_key,
                 channel,
             } => {
@@ -718,10 +718,10 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnector<T> {
         }
     }
 }
-impl_display_t!(CreateSourceConnector);
+impl_display_t!(CreateSourceConnection);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum CreateSinkConnector<T: AstInfo> {
+pub enum CreateSinkConnection<T: AstInfo> {
     Kafka {
         broker: String,
         topic: String,
@@ -735,10 +735,10 @@ pub enum CreateSinkConnector<T: AstInfo> {
     },
 }
 
-impl<T: AstInfo> AstDisplay for CreateSinkConnector<T> {
+impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            CreateSinkConnector::Kafka {
+            CreateSinkConnection::Kafka {
                 broker,
                 topic,
                 key,
@@ -757,7 +757,7 @@ impl<T: AstInfo> AstDisplay for CreateSinkConnector<T> {
                     f.write_node(consistency);
                 }
             }
-            CreateSinkConnector::Persist {
+            CreateSinkConnection::Persist {
                 blob_uri,
                 consensus_uri,
                 shard_id,
@@ -773,7 +773,7 @@ impl<T: AstInfo> AstDisplay for CreateSinkConnector<T> {
         }
     }
 }
-impl_display_t!(CreateSinkConnector);
+impl_display_t!(CreateSinkConnection);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KafkaConsistency<T: AstInfo> {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -69,8 +69,7 @@ Compiled
 Compression
 Confluent
 Connection
-Connector
-Connectors
+Connections
 Consensus
 Consistency
 Constraint

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1585,8 +1585,8 @@ impl<'a> Parser<'a> {
             self.parse_create_table()
         } else if self.peek_keyword(SECRET) {
             self.parse_create_secret()
-        } else if self.peek_keyword(CONNECTOR) {
-            self.parse_create_connector()
+        } else if self.peek_keyword(CONNECTION) {
+            self.parse_create_connection()
         } else {
             let index = self.index;
 
@@ -1679,8 +1679,8 @@ impl<'a> Parser<'a> {
 
     fn parse_avro_schema(&mut self) -> Result<AvroSchema<Raw>, ParserError> {
         let avro_schema = if self.parse_keywords(&[CONFLUENT, SCHEMA, REGISTRY]) {
-            let csr_connector = self.parse_csr_connector_avro()?;
-            AvroSchema::Csr { csr_connector }
+            let csr_connection = self.parse_csr_connection_avro()?;
+            AvroSchema::Csr { csr_connection }
         } else if self.parse_keyword(SCHEMA) {
             self.prev_token();
             let schema = self.parse_schema()?;
@@ -1718,8 +1718,8 @@ impl<'a> Parser<'a> {
 
     fn parse_protobuf_schema(&mut self) -> Result<ProtobufSchema<Raw>, ParserError> {
         if self.parse_keywords(&[USING, CONFLUENT, SCHEMA, REGISTRY]) {
-            let csr_connector = self.parse_csr_connector_proto()?;
-            Ok(ProtobufSchema::Csr { csr_connector })
+            let csr_connection = self.parse_csr_connection_proto()?;
+            Ok(ProtobufSchema::Csr { csr_connection })
         } else if self.parse_keyword(MESSAGE) {
             let message_name = self.parse_literal_string()?;
             self.expect_keyword(USING)?;
@@ -1737,13 +1737,13 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_csr_connector_avro(&mut self) -> Result<CsrConnectorAvro<Raw>, ParserError> {
-        let connector = if self.parse_keyword(CONNECTOR) {
-            CsrConnector::Reference {
-                connector: self.parse_raw_name()?,
+    fn parse_csr_connection_avro(&mut self) -> Result<CsrConnectionAvro<Raw>, ParserError> {
+        let connection = if self.parse_keyword(CONNECTION) {
+            CsrConnection::Reference {
+                connection: self.parse_raw_name()?,
             }
         } else {
-            CsrConnector::Inline {
+            CsrConnection::Inline {
                 url: self.parse_literal_string()?,
             }
         };
@@ -1771,20 +1771,20 @@ impl<'a> Parser<'a> {
         } else {
             vec![]
         };
-        Ok(CsrConnectorAvro {
-            connector,
+        Ok(CsrConnectionAvro {
+            connection,
             seed,
             with_options,
         })
     }
 
-    fn parse_csr_connector_proto(&mut self) -> Result<CsrConnectorProto<Raw>, ParserError> {
-        let connector = if self.parse_keyword(CONNECTOR) {
-            CsrConnector::Reference {
-                connector: self.parse_raw_name()?,
+    fn parse_csr_connection_proto(&mut self) -> Result<CsrConnectionProto<Raw>, ParserError> {
+        let connection = if self.parse_keyword(CONNECTION) {
+            CsrConnection::Reference {
+                connection: self.parse_raw_name()?,
             }
         } else {
-            CsrConnector::Inline {
+            CsrConnection::Inline {
                 url: self.parse_literal_string()?,
             }
         };
@@ -1840,8 +1840,8 @@ impl<'a> Parser<'a> {
             vec![]
         };
 
-        Ok(CsrConnectorProto {
-            connector,
+        Ok(CsrConnectionProto {
+            connection,
             seed,
             with_options,
         })
@@ -1916,17 +1916,17 @@ impl<'a> Parser<'a> {
         Ok(compression)
     }
 
-    fn parse_create_connector(&mut self) -> Result<Statement<Raw>, ParserError> {
-        self.expect_keyword(CONNECTOR)?;
+    fn parse_create_connection(&mut self) -> Result<Statement<Raw>, ParserError> {
+        self.expect_keyword(CONNECTION)?;
         let if_not_exists = self.parse_if_not_exists()?;
         let name = self.parse_object_name()?;
         self.expect_keyword(FOR)?;
-        let connector = match self.expect_one_of_keywords(&[KAFKA, CONFLUENT])? {
+        let connection = match self.expect_one_of_keywords(&[KAFKA, CONFLUENT])? {
             Keyword::Kafka => {
                 self.expect_keyword(BROKER)?;
                 let broker = self.parse_literal_string()?;
                 let with_options = self.parse_opt_with_options()?;
-                CreateConnector::Kafka {
+                CreateConnection::Kafka {
                     broker,
                     with_options,
                 }
@@ -1935,16 +1935,16 @@ impl<'a> Parser<'a> {
                 self.expect_keywords(&[SCHEMA, REGISTRY])?;
                 let registry = self.parse_literal_string()?;
                 let with_options = self.parse_opt_with_options()?;
-                CreateConnector::Csr {
+                CreateConnection::Csr {
                     url: registry,
                     with_options,
                 }
             }
             _ => unreachable!(),
         };
-        Ok(Statement::CreateConnector(CreateConnectorStatement {
+        Ok(Statement::CreateConnection(CreateConnectionStatement {
             name,
-            connector,
+            connection,
             if_not_exists,
         }))
     }
@@ -1956,7 +1956,7 @@ impl<'a> Parser<'a> {
         let name = self.parse_object_name()?;
         let (col_names, key_constraint) = self.parse_source_columns()?;
         self.expect_keyword(FROM)?;
-        let connector = self.parse_create_source_connector()?;
+        let connection = self.parse_create_source_connection()?;
         let with_options = self.parse_opt_with_options()?;
         // legacy upsert format syntax allows setting the key format after the keyword UPSERT, so we
         // may mutate this variable in the next block
@@ -1999,7 +1999,7 @@ impl<'a> Parser<'a> {
         Ok(Statement::CreateSource(CreateSourceStatement {
             name,
             col_names,
-            connector,
+            connection,
             with_options,
             format,
             include_metadata,
@@ -2060,7 +2060,7 @@ impl<'a> Parser<'a> {
         self.expect_keyword(FROM)?;
         let from = self.parse_raw_name()?;
         self.expect_keyword(INTO)?;
-        let connector = self.parse_create_sink_connector()?;
+        let connection = self.parse_create_sink_connection()?;
         let mut with_options = vec![];
         if self.parse_keyword(WITH) {
             if let Some(Token::LParen) = self.next_token() {
@@ -2095,7 +2095,7 @@ impl<'a> Parser<'a> {
             name,
             in_cluster,
             from,
-            connector,
+            connection,
             with_options,
             format,
             envelope,
@@ -2105,7 +2105,9 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_create_source_connector(&mut self) -> Result<CreateSourceConnector<Raw>, ParserError> {
+    fn parse_create_source_connection(
+        &mut self,
+    ) -> Result<CreateSourceConnection<Raw>, ParserError> {
         match self.expect_one_of_keywords(&[KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
@@ -2113,7 +2115,7 @@ impl<'a> Parser<'a> {
                 self.expect_keyword(CHANNEL)?;
                 let channel = self.parse_literal_string()?;
 
-                Ok(CreateSourceConnector::PubNub {
+                Ok(CreateSourceConnection::PubNub {
                     subscribe_key,
                     channel,
                 })
@@ -2129,19 +2131,19 @@ impl<'a> Parser<'a> {
                     None
                 };
 
-                Ok(CreateSourceConnector::Postgres {
+                Ok(CreateSourceConnection::Postgres {
                     conn,
                     publication,
                     details,
                 })
             }
             KAFKA => {
-                let connector = match self.expect_one_of_keywords(&[BROKER, CONNECTOR])? {
-                    BROKER => KafkaConnector::Inline {
+                let connection = match self.expect_one_of_keywords(&[BROKER, CONNECTION])? {
+                    BROKER => KafkaConnection::Inline {
                         broker: self.parse_literal_string()?,
                     },
-                    CONNECTOR => KafkaConnector::Reference {
-                        connector: self.parse_raw_name()?,
+                    CONNECTION => KafkaConnection::Reference {
+                        connection: self.parse_raw_name()?,
                     },
                     _ => unreachable!(),
                 };
@@ -2158,8 +2160,8 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                Ok(CreateSourceConnector::Kafka(KafkaSourceConnector {
-                    connector,
+                Ok(CreateSourceConnection::Kafka(KafkaSourceConnection {
+                    connection,
                     topic,
                     key,
                 }))
@@ -2167,7 +2169,7 @@ impl<'a> Parser<'a> {
             KINESIS => {
                 self.expect_keyword(ARN)?;
                 let arn = self.parse_literal_string()?;
-                Ok(CreateSourceConnector::Kinesis { arn })
+                Ok(CreateSourceConnection::Kinesis { arn })
             }
             S3 => {
                 // FROM S3 DISCOVER OBJECTS
@@ -2208,7 +2210,7 @@ impl<'a> Parser<'a> {
                 } else {
                     Compression::None
                 };
-                Ok(CreateSourceConnector::S3 {
+                Ok(CreateSourceConnection::S3 {
                     key_sources,
                     pattern,
                     compression,
@@ -2218,7 +2220,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_create_sink_connector(&mut self) -> Result<CreateSinkConnector<Raw>, ParserError> {
+    fn parse_create_sink_connection(&mut self) -> Result<CreateSinkConnection<Raw>, ParserError> {
         match self.expect_one_of_keywords(&[KAFKA, AVRO, PERSIST])? {
             KAFKA => {
                 self.expect_keyword(BROKER)?;
@@ -2248,7 +2250,7 @@ impl<'a> Parser<'a> {
                     None
                 };
                 let consistency = self.parse_kafka_consistency()?;
-                Ok(CreateSinkConnector::Kafka {
+                Ok(CreateSinkConnection::Kafka {
                     broker,
                     topic,
                     key,
@@ -2278,7 +2280,7 @@ impl<'a> Parser<'a> {
                     format!("{}", shard_id)
                 };
 
-                Ok(CreateSinkConnector::Persist {
+                Ok(CreateSinkConnection::Persist {
                     consensus_uri,
                     blob_uri,
                     shard_id,
@@ -2716,11 +2718,11 @@ impl<'a> Parser<'a> {
     fn parse_drop(&mut self) -> Result<Statement<Raw>, ParserError> {
         let materialized = self.parse_keyword(MATERIALIZED);
 
-        let object_type = match self.parse_one_of_keywords(&[
-            DATABASE, INDEX, ROLE, CLUSTER, SECRET, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW,
-            CONNECTOR,
-        ]) {
-            Some(DATABASE) => {
+        let object_type = match self.expect_one_of_keywords(&[
+            CONNECTION, CLUSTER, DATABASE, INDEX, ROLE, SECRET, SCHEMA, SINK, SOURCE, TABLE, TYPE,
+            USER, VIEW,
+        ])? {
+            DATABASE => {
                 let if_exists = self.parse_if_exists()?;
                 let name = self.parse_database_name()?;
                 let restrict = matches!(
@@ -2733,7 +2735,7 @@ impl<'a> Parser<'a> {
                     restrict,
                 }));
             }
-            Some(SCHEMA) => {
+            SCHEMA => {
                 let if_exists = self.parse_if_exists()?;
                 let name = self.parse_schema_name()?;
                 let cascade = matches!(
@@ -2746,7 +2748,7 @@ impl<'a> Parser<'a> {
                     cascade,
                 }));
             }
-            Some(ROLE) | Some(USER) => {
+            ROLE | USER => {
                 let if_exists = self.parse_if_exists()?;
                 let names = self.parse_comma_separated(Parser::parse_object_name)?;
                 return Ok(Statement::DropRoles(DropRolesStatement {
@@ -2754,21 +2756,21 @@ impl<'a> Parser<'a> {
                     names,
                 }));
             }
-            Some(CLUSTER) => {
+            CLUSTER => {
                 return if self.peek_keyword(REPLICA) {
                     self.parse_drop_cluster_replicas()
                 } else {
                     self.parse_drop_clusters()
                 };
             }
-            Some(INDEX) => ObjectType::Index,
-            Some(SINK) => ObjectType::Sink,
-            Some(SOURCE) => ObjectType::Source,
-            Some(TABLE) => ObjectType::Table,
-            Some(TYPE) => ObjectType::Type,
-            Some(VIEW) => ObjectType::View,
-            Some(SECRET) => ObjectType::Secret,
-            Some(CONNECTOR) => ObjectType::Connector,
+            INDEX => ObjectType::Index,
+            SINK => ObjectType::Sink,
+            SOURCE => ObjectType::Source,
+            TABLE => ObjectType::Table,
+            TYPE => ObjectType::Type,
+            VIEW => ObjectType::View,
+            SECRET => ObjectType::Secret,
+            CONNECTION => ObjectType::Connection,
             _ => {
                 return self.expected(
                     self.peek_pos(),
@@ -3074,7 +3076,7 @@ impl<'a> Parser<'a> {
             // HACK(benesch): temporarily allow secret references of the form
             // `KEY = SECRET db.schema.item`. `KEY = SECRET` is still allowed
             // for backwards copmatibility and parses as the ident `secret`.
-            // Once we have connectors with explicit fields for secret
+            // Once we have connections with explicit fields for secret
             // references, we can remove this hack.
             if let Some(secret) = self.maybe_parse(Parser::parse_raw_name) {
                 Ok(WithOptionValue::Secret(secret))
@@ -4163,7 +4165,16 @@ impl<'a> Parser<'a> {
         let extended = self.parse_keyword(EXTENDED);
         if extended {
             self.expect_one_of_keywords(&[
-                COLUMNS, CONNECTORS, FULL, INDEX, INDEXES, KEYS, OBJECTS, SCHEMAS, TABLES, TYPES,
+                COLUMNS,
+                CONNECTIONS,
+                FULL,
+                INDEX,
+                INDEXES,
+                KEYS,
+                OBJECTS,
+                SCHEMAS,
+                TABLES,
+                TYPES,
             ])?;
             self.prev_token();
         }
@@ -4175,7 +4186,7 @@ impl<'a> Parser<'a> {
             } else {
                 self.expect_one_of_keywords(&[
                     COLUMNS,
-                    CONNECTORS,
+                    CONNECTIONS,
                     MATERIALIZED,
                     OBJECTS,
                     ROLES,
@@ -4211,8 +4222,18 @@ impl<'a> Parser<'a> {
                 filter: self.parse_show_statement_filter()?,
             }))
         } else if let Some(object_type) = self.parse_one_of_keywords(&[
-            OBJECTS, ROLES, CLUSTER, CLUSTERS, SINKS, SOURCES, TABLES, TYPES, USERS, VIEWS,
-            SECRETS, CONNECTORS,
+            OBJECTS,
+            ROLES,
+            CLUSTER,
+            CLUSTERS,
+            SINKS,
+            SOURCES,
+            TABLES,
+            TYPES,
+            USERS,
+            VIEWS,
+            SECRETS,
+            CONNECTIONS,
         ]) {
             let object_type = match object_type {
                 OBJECTS => ObjectType::Object,
@@ -4233,7 +4254,7 @@ impl<'a> Parser<'a> {
                 TYPES => ObjectType::Type,
                 VIEWS => ObjectType::View,
                 SECRETS => ObjectType::Secret,
-                CONNECTORS => ObjectType::Connector,
+                CONNECTIONS => ObjectType::Connection,
                 _ => unreachable!(),
             };
 
@@ -4323,10 +4344,10 @@ impl<'a> Parser<'a> {
             Ok(Statement::ShowCreateIndex(ShowCreateIndexStatement {
                 index_name: self.parse_raw_name()?,
             }))
-        } else if self.parse_keywords(&[CREATE, CONNECTOR]) {
-            Ok(Statement::ShowCreateConnector(
-                ShowCreateConnectorStatement {
-                    connector_name: self.parse_raw_name()?,
+        } else if self.parse_keywords(&[CREATE, CONNECTION]) {
+            Ok(Statement::ShowCreateConnection(
+                ShowCreateConnectionStatement {
+                    connection_name: self.parse_raw_name()?,
                 },
             ))
         } else {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -379,126 +379,126 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("crobat")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("crobat")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Timestamp, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Timestamp, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Partition, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Partition, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Topic, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Topic, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC as kafka_topic ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC AS kafka_topic
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("mykey")) }, SourceIncludeMetadata { ty: Timestamp, alias: None }, SourceIncludeMetadata { ty: Partition, alias: None }, SourceIncludeMetadata { ty: Topic, alias: Some(Ident("kafka_topic")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("mykey")) }, SourceIncludeMetadata { ty: Timestamp, alias: None }, SourceIncludeMetadata { ty: Partition, alias: None }, SourceIncludeMetadata { ty: Topic, alias: Some(Ident("kafka_topic")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Avro(Csr { csr_connector: CsrConnectorAvro { connector: Inline { url: "http://localhost:8081" }, seed: None, with_options: [] } }), value: Avro(Csr { csr_connector: CsrConnectorAvro { connector: Inline { url: "http://localhost:8081" }, seed: None, with_options: [] } }) }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: Inline { url: "http://localhost:8081" }, seed: None, with_options: [] } }), value: Avro(Csr { csr_connection: CsrConnectionAvro { connection: Inline { url: "http://localhost:8081" }, seed: None, with_options: [] } }) }, envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Inline { url: "http://localhost:8081" }, seed: None, with_options: [] } })), envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: Inline { url: "http://localhost:8081" }, seed: None, with_options: [] } })), envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT FORMAT AVRO USING SCHEMA 'long'
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING SCHEMA 'long' VALUE FORMAT AVRO USING SCHEMA 'string' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: KeyValue { key: Avro(InlineSchema { schema: Inline("long"), with_options: [] }), value: Avro(InlineSchema { schema: Inline("string"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: KeyValue { key: Avro(InlineSchema { schema: Inline("long"), with_options: [] }), value: Avro(InlineSchema { schema: Inline("string"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (CONFLUENT WIRE FORMAT = false) ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (CONFLUENT WIRE FORMAT = false)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(InlineSchema { schema: Inline("string"), with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] })), envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(InlineSchema { schema: Inline("string"), with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] })), envelope: Some(None), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = 2) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Number("2"))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Number("2"))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = []) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset = [2, 40000000]) KEY FORMAT TEXT VALUE FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2"), Number("40000000")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("start_offset"), value: Some(Value(Array([Number("2"), Number("40000000")]))) }], include_metadata: [], format: KeyValue { key: Text, value: Avro(InlineSchema { schema: File("path"), with_options: [] }) }, envelope: Some(Upsert), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SEKRET)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = sekret)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("sekret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("sekret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = secret)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("secret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("secret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement roundtrip
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
@@ -515,35 +515,35 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a.b.c)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source (a, PRIMARY KEY (a) NOT ENFORCED, b) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source (PRIMARY, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (primary, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connector: Kafka(KafkaSourceConnector { connector: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }) })
 
 parse-statement
 CREATE SOURCE source PRIMARY KEY (a) NOT ENFORCED FROM KAFKA BROKER 'broker' TOPIC 'topic'
@@ -571,14 +571,14 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION 'host=kanto user=ash password=tea
 ----
 CREATE SOURCE psychic FROM POSTGRES CONNECTION 'host=kanto user=ash password=teamrocket dbname=pokemon' PUBLICATION 'red'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", details: None }, with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { conn: "host=kanto user=ash password=teamrocket dbname=pokemon", publication: "red", details: None }, with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel';
 ----
 CREATE SOURCE psychic FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' CHANNEL 'channel'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connector: PubNub { subscribe_key: "subscribe_key", channel: "channel" }, with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: PubNub { subscribe_key: "subscribe_key", channel: "channel" }, with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
 CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES
@@ -599,35 +599,35 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [WithOption { key: Ident("replication_factor"), value: Some(Value(Number("7"))) }, WithOption { key: Ident("retention_ms"), value: Some(Value(Number("10000"))) }, WithOption { key: Ident("retention_bytes"), value: Some(Value(Number("10000000000"))) }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: None, consistency: None }, with_options: [WithOption { key: Ident("replication_factor"), value: Some(Value(Number("7"))) }, WithOption { key: Ident("retention_ms"), value: Some(Value(Number("10000"))) }, WithOption { key: Ident("retention_bytes"), value: Some(Value(Number("10000000000"))) }], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) NOT ENFORCED FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) NOT ENFORCED FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }), consistency: None }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY TOPIC 'consistency' CONSISTENCY FORMAT BYTES FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency') FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency') FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: None }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: None }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' CONSISTENCY FORMAT BYTES) FORMAT BYTES
@@ -641,14 +641,14 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSIS
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Bytes) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username=user)) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = user)) FORMAT BYTES WITH SNAPSHOT
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connector: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Inline { url: "http://localhost:8081" }, seed: None, with_options: [WithOption { key: Ident("username"), value: Some(Ident(Ident("user"))) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), in_cluster: None, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { broker: "baz", topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }), consistency: Some(KafkaConsistency { topic: "consistency", topic_format: Some(Avro(Csr { csr_connection: CsrConnectionAvro { connection: Inline { url: "http://localhost:8081" }, seed: None, with_options: [WithOption { key: Ident("username"), value: Some(Ident(Ident("user"))) }] } })) }) }, with_options: [], format: Some(Bytes), envelope: None, with_snapshot: true, as_of: None, if_not_exists: false })
 
 parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
@@ -1356,56 +1356,56 @@ AlterSecret(AlterSecretStatement { name: UnresolvedObjectName([Ident("secret")])
 parse-statement
 CREATE CONNECTOR conn1 FOR KAFKA BROKER 'kafka:1234' WITH (security_protocol = 'SASL_SSL', sasl_mechanisms = 'PLAIN')
 ----
+error: Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE, SECRET or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found identifier "connector"
 CREATE CONNECTOR conn1 FOR KAFKA BROKER 'kafka:1234' WITH (security_protocol = 'SASL_SSL', sasl_mechanisms = 'PLAIN')
-=>
-CreateConnector(CreateConnectorStatement { name: UnresolvedObjectName([Ident("conn1")]), connector: Kafka { broker: "kafka:1234", with_options: [WithOption { key: Ident("security_protocol"), value: Some(Value(String("SASL_SSL"))) }, WithOption { key: Ident("sasl_mechanisms"), value: Some(Value(String("PLAIN"))) }] }, if_not_exists: false })
+       ^
 
 parse-statement
 DROP CONNECTOR conn1
 ----
+error: Expected one of CONNECTION or CLUSTER or DATABASE or INDEX or ROLE or SECRET or SCHEMA or SINK or SOURCE or TABLE or TYPE or USER or VIEW, found identifier "connector"
 DROP CONNECTOR conn1
-=>
-DropObjects(DropObjectsStatement { materialized: false, object_type: Connector, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
+     ^
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
 ----
+error: Expected one of BROKER or CONNECTION, found identifier "connector"
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
+                              ^
 
 parse-statement
 CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
 ----
-CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = 'user', password = 'word')
-=>
-CreateConnector(CreateConnectorStatement { name: UnresolvedObjectName([Ident("conn1")]), connector: Csr { url: "http://localhost:8081", with_options: [WithOption { key: Ident("username"), value: Some(Value(String("user"))) }, WithOption { key: Ident("password"), value: Some(Value(String("word"))) }] }, if_not_exists: false })
+error: Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE, SECRET or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found identifier "connector"
+CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
+       ^
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
 ----
+error: Expected one of BROKER or CONNECTION, found identifier "connector"
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connector: CsrConnectorAvro { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])) }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, materialized: false, key_constraint: None })
+                              ^
 
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
 ----
+error: Expected one of BROKER or CONNECTION, found identifier "connector"
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connector: CsrConnectorProto { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn2")])) }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, materialized: false, key_constraint: None })
+                              ^
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
 ----
+error: Expected one of BROKER or CONNECTION, found identifier "connector"
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")]))), Collection(Value(String("foo")))] })), if_not_exists: false, materialized: false, key_constraint: None })
+                              ^
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
+error: Expected one of BROKER or CONNECTION, found identifier "connector"
 CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connector: Kafka(KafkaSourceConnector { connector: Reference { connector: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, materialized: false, key_constraint: None })
+                              ^

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail};
 
-use mz_dataflow_types::connectors::StringOrSecret;
+use mz_dataflow_types::connections::StringOrSecret;
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::task;
 use mz_secrets::SecretsReader;

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -25,7 +25,7 @@ use mz_repr::{ColumnName, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};
 use mz_sql_parser::ast::{
-    CreateConnectorStatement, CreateIndexStatement, CreateSecretStatement, CreateSinkStatement,
+    CreateConnectionStatement, CreateIndexStatement, CreateSecretStatement, CreateSinkStatement,
     CreateSourceStatement, CreateTableStatement, CreateTypeAs, CreateTypeStatement,
     CreateViewStatement, Function, FunctionArgs, Ident, IfExistsBehavior, Op, Query, Statement,
     TableFactor, TableFunction, UnresolvedObjectName, UnresolvedSchemaName, Value, ViewDefinition,
@@ -351,7 +351,7 @@ pub fn create_statement(
         Statement::CreateSource(CreateSourceStatement {
             name,
             col_names: _,
-            connector: _,
+            connection: _,
             with_options: _,
             format: _,
             include_metadata: _,
@@ -390,7 +390,7 @@ pub fn create_statement(
 
         Statement::CreateSink(CreateSinkStatement {
             name,
-            connector: _,
+            connection: _,
             with_options: _,
             in_cluster: _,
             format: _,
@@ -486,9 +486,9 @@ pub fn create_statement(
             *name = allocate_name(name)?;
             *if_not_exists = false;
         }
-        Statement::CreateConnector(CreateConnectorStatement {
+        Statement::CreateConnection(CreateConnectionStatement {
             name,
-            connector: _,
+            connection: _,
             if_not_exists,
         }) => {
             *name = allocate_name(name)?;

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -20,7 +20,7 @@ use std::fmt;
 use anyhow::{bail, Context};
 use itertools::Itertools;
 
-use mz_dataflow_types::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
+use mz_dataflow_types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
 use mz_repr::{ColumnName, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::visit_mut::{self, VisitMut};

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -33,8 +33,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use mz_dataflow_types::client::ComputeInstanceId;
-use mz_dataflow_types::sinks::{SinkConnectorBuilder, SinkEnvelope};
-use mz_dataflow_types::sources::SourceConnector;
+use mz_dataflow_types::sinks::{SinkConnectionBuilder, SinkEnvelope};
+use mz_dataflow_types::sources::SourceConnection;
 use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
@@ -72,7 +72,7 @@ pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementD
 /// Instructions for executing a SQL query.
 #[derive(Debug)]
 pub enum Plan {
-    CreateConnector(CreateConnectorPlan),
+    CreateConnection(CreateConnectionPlan),
     CreateDatabase(CreateDatabasePlan),
     CreateSchema(CreateSchemaPlan),
     CreateRole(CreateRolePlan),
@@ -190,10 +190,10 @@ pub struct CreateSourcePlan {
 }
 
 #[derive(Debug)]
-pub struct CreateConnectorPlan {
+pub struct CreateConnectionPlan {
     pub name: QualifiedObjectName,
     pub if_not_exists: bool,
-    pub connector: Connector,
+    pub connection: Connection,
 }
 
 #[derive(Debug)]
@@ -451,14 +451,14 @@ pub struct Table {
 #[derive(Clone, Debug)]
 pub struct Source {
     pub create_sql: String,
-    pub connector: SourceConnector,
+    pub connection: SourceConnection,
     pub desc: RelationDesc,
 }
 
 #[derive(Clone, Debug)]
-pub struct Connector {
+pub struct Connection {
     pub create_sql: String,
-    pub connector: mz_dataflow_types::connectors::Connector,
+    pub connection: mz_dataflow_types::connections::Connection,
 }
 
 #[derive(Clone, Debug)]
@@ -471,7 +471,7 @@ pub struct Secret {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    pub connector_builder: SinkConnectorBuilder,
+    pub connection_builder: SinkConnectionBuilder,
     pub envelope: SinkEnvelope,
     pub compute_instance: ComputeInstanceId,
 }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -111,7 +111,7 @@ pub fn describe(
         Statement::AlterSecret(stmt) => ddl::describe_alter_secret_options(&scx, stmt)?,
         Statement::CreateCluster(stmt) => ddl::describe_create_cluster(&scx, stmt)?,
         Statement::CreateClusterReplica(stmt) => ddl::describe_create_cluster_replica(&scx, stmt)?,
-        Statement::CreateConnector(stmt) => ddl::describe_create_connector(&scx, stmt)?,
+        Statement::CreateConnection(stmt) => ddl::describe_create_connection(&scx, stmt)?,
         Statement::CreateDatabase(stmt) => ddl::describe_create_database(&scx, stmt)?,
         Statement::CreateIndex(stmt) => ddl::describe_create_index(&scx, stmt)?,
         Statement::CreateRole(stmt) => ddl::describe_create_role(&scx, stmt)?,
@@ -132,7 +132,7 @@ pub fn describe(
 
         // `SHOW` statements.
         Statement::ShowColumns(stmt) => show::show_columns(&scx, stmt)?.describe()?,
-        Statement::ShowCreateConnector(stmt) => show::describe_show_create_connector(&scx, stmt)?,
+        Statement::ShowCreateConnection(stmt) => show::describe_show_create_connection(&scx, stmt)?,
         Statement::ShowCreateIndex(stmt) => show::describe_show_create_index(&scx, stmt)?,
         Statement::ShowCreateSink(stmt) => show::describe_show_create_sink(&scx, stmt)?,
         Statement::ShowCreateSource(stmt) => show::describe_show_create_source(&scx, stmt)?,
@@ -214,7 +214,7 @@ pub fn plan(
         Statement::AlterSecret(stmt) => ddl::plan_alter_secret(scx, stmt),
         Statement::CreateCluster(stmt) => ddl::plan_create_cluster(scx, stmt),
         Statement::CreateClusterReplica(stmt) => ddl::plan_create_cluster_replica(scx, stmt),
-        Statement::CreateConnector(stmt) => ddl::plan_create_connector(scx, stmt),
+        Statement::CreateConnection(stmt) => ddl::plan_create_connection(scx, stmt),
         Statement::CreateDatabase(stmt) => ddl::plan_create_database(scx, stmt),
         Statement::CreateIndex(stmt) => ddl::plan_create_index(scx, stmt),
         Statement::CreateRole(stmt) => ddl::plan_create_role(scx, stmt),
@@ -244,7 +244,7 @@ pub fn plan(
 
         // `SHOW` statements.
         Statement::ShowColumns(stmt) => show::show_columns(scx, stmt)?.plan(),
-        Statement::ShowCreateConnector(stmt) => show::plan_show_create_connector(scx, stmt),
+        Statement::ShowCreateConnection(stmt) => show::plan_show_create_connection(scx, stmt),
         Statement::ShowCreateIndex(stmt) => show::plan_show_create_index(scx, stmt),
         Statement::ShowCreateSink(stmt) => show::plan_show_create_sink(scx, stmt),
         Statement::ShowCreateSource(stmt) => show::plan_show_create_source(scx, stmt),
@@ -304,7 +304,7 @@ impl PartialEq<ObjectType> for CatalogItemType {
             | (CatalogItemType::Index, ObjectType::Index)
             | (CatalogItemType::Type, ObjectType::Type)
             | (CatalogItemType::Secret, ObjectType::Secret)
-            | (CatalogItemType::Connector, ObjectType::Connector) => true,
+            | (CatalogItemType::Connection, ObjectType::Connection) => true,
             (_, _) => false,
         }
     }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -335,7 +335,7 @@ pub fn plan_tail(
                 | CatalogItemType::Sink
                 | CatalogItemType::Type
                 | CatalogItemType::Secret
-                | CatalogItemType::Connector => bail!(
+                | CatalogItemType::Connection => bail!(
                     "'{}' cannot be tailed because it is a {}",
                     name.full_name_str(),
                     entry.item_type(),

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -393,7 +393,7 @@ fn show_sources<'a>(
                  mz_internal.mz_classify_object_id(id) AS type,
                  mz_internal.mz_is_materialized(id) AS materialized,
                  volatility,
-                 connection_type
+                 type
              FROM
                  mz_catalog.mz_sources
              WHERE
@@ -405,7 +405,7 @@ fn show_sources<'a>(
                  name,
                  mz_internal.mz_classify_object_id(id) AS type,
                  volatility,
-                 connection_type
+                 type
              FROM
                  mz_catalog.mz_sources
              WHERE

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -24,10 +24,9 @@ use tracing::info;
 use uuid::Uuid;
 
 use mz_ccsr::{Client, GetBySubjectError};
-use mz_dataflow_types::aws::{AwsConfig, AwsExternalIdPrefix};
-use mz_dataflow_types::connections::Connection;
+use mz_dataflow_types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
+use mz_dataflow_types::connections::{Connection, ConnectionContext};
 use mz_dataflow_types::sources::PostgresSourceDetails;
-use mz_dataflow_types::ConnectionContext;
 use mz_repr::proto::RustType;
 use mz_repr::strconv;
 

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_build_info::DUMMY_BUILD_INFO;
-use mz_dataflow_types::connectors::Connector;
-use mz_dataflow_types::sources::SourceConnector;
+use mz_dataflow_types::connections::Connection;
+use mz_dataflow_types::sources::SourceConnection;
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
@@ -104,7 +104,7 @@ impl CatalogItem for TestCatalogItem {
         }
     }
 
-    fn source_connector(&self) -> Result<&SourceConnector, CatalogError> {
+    fn source_connection(&self) -> Result<&SourceConnection, CatalogError> {
         unimplemented!()
     }
 
@@ -139,7 +139,7 @@ impl CatalogItem for TestCatalogItem {
         unimplemented!()
     }
 
-    fn connector(&self) -> Result<&Connector, CatalogError> {
+    fn connection(&self) -> Result<&Connection, CatalogError> {
         unimplemented!()
     }
 }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -626,7 +626,7 @@ impl Runner {
             now: SYSTEM_TIME.clone(),
             replica_sizes: Default::default(),
             availability_zones: Default::default(),
-            connector_context: Default::default(),
+            connection_context: Default::default(),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -253,7 +253,7 @@ fn get_decoder(
     // If the decoding elects to perform them, it should replace this with
     // `None`.
     operators: &mut Option<LinearOperator>,
-    is_connector_delimited: bool,
+    is_connection_delimited: bool,
     metrics: DecodeMetrics,
 ) -> DataDecoder {
     match encoding {
@@ -292,7 +292,7 @@ fn get_decoder(
                 DataEncoding::Text => PreDelimitedFormat::Text,
                 _ => unreachable!(),
             };
-            let inner = if is_connector_delimited {
+            let inner = if is_connection_delimited {
                 DataDecoderInner::PreDelimited(after_delimiting)
             } else {
                 DataDecoderInner::DelimitedBytes {
@@ -345,7 +345,7 @@ fn try_decode(
 /// that have already separated the stream into records/messages/etc. before we
 /// decode them.
 ///
-/// Because we expect the upstream connector to have already delimited the data,
+/// Because we expect the upstream connection to have already delimited the data,
 /// we return an error here if the decoder does not consume all the bytes. This
 /// often lets us, for example, detect when Avro decoding has gone off the rails
 /// (which is not always possible otherwise, since often gibberish strings can be interpreted as Avro,
@@ -439,12 +439,12 @@ where
 
 /// Decode arbitrary chunks of bytes into rows.
 ///
-/// This decode API is used for upstream connectors
+/// This decode API is used for upstream connections
 /// that don't discover delimiters themselves; i.e., those
 /// (like CSV files) that need help from the decoding stage to discover where
 /// one record ends and another begins.
 ///
-/// As such, the connectors simply present arbitrary chunks of bytes about which
+/// As such, the connections simply present arbitrary chunks of bytes about which
 /// we can't assume any alignment properties. The `DataDecoder` API accepts these,
 /// and returns `None` if it needs more bytes to discover the boundary between messages.
 /// In that case, this function remembers the already-seen bytes and waits for new ones

--- a/src/storage/src/render/debezium.rs
+++ b/src/storage/src/render/debezium.rs
@@ -458,7 +458,7 @@ where
 /// highest-ever seen binlog offset.
 #[derive(Debug)]
 struct DebeziumDeduplicationState {
-    /// Last recorded binlog position and connector offset
+    /// Last recorded binlog position and connection offset
     ///
     /// [`DebeziumEnvelope`] determines whether messages that are not ahead
     /// of the last recorded position will be skipped.
@@ -759,7 +759,7 @@ impl DebeziumDeduplicationState {
         &mut self,
         key: Option<Row>,
         value: &Row,
-        connector_offset: MzOffset,
+        connection_offset: MzOffset,
         upstream_time_millis: Option<i64>,
         debug_name: &str,
     ) -> Result<bool, DataflowError> {
@@ -784,7 +784,7 @@ impl DebeziumDeduplicationState {
                     }
                 }
                 None => {
-                    self.last_position_and_offset = Some((position.clone(), connector_offset));
+                    self.last_position_and_offset = Some((position.clone(), connection_offset));
                     None
                 }
             },
@@ -868,7 +868,7 @@ impl DebeziumDeduplicationState {
 
                     log_duplication_info(
                         position,
-                        connector_offset,
+                        connection_offset,
                         upstream_time_millis,
                         debug_name,
                         is_new,
@@ -919,7 +919,7 @@ struct SkipInfo {
 
 fn log_duplication_info(
     position: RowCoordinates,
-    connector_offset: MzOffset,
+    connection_offset: MzOffset,
     upstream_time_millis: Option<i64>,
     debug_name: &str,
     is_new: bool,
@@ -938,12 +938,12 @@ fn log_duplication_info(
             // that label is omitted from this log message
             warn!(
                 "Created a new record behind the highest point in source={} \
-                 new deduplication position: {:?}, new connector offset: {}, \
+                 new deduplication position: {:?}, new connection offset: {}, \
                  old deduplication position: {:?} \
                  message_time={} max_seen_time={}",
                 debug_name,
                 position,
-                connector_offset,
+                connection_offset,
                 skipinfo.old_position,
                 fmt_timestamp(upstream_time_millis),
                 fmt_timestamp(*max_seen_time),
@@ -954,7 +954,7 @@ fn log_duplication_info(
             debug!(
                 "already ingested source={} new deduplication position: {:?}, \
                  old deduplication position: {:?}\
-                 connector offset={} message_time={} message_first_seen={} max_seen_time={}",
+                 connection offset={} message_time={} message_first_seen={} max_seen_time={}",
                 debug_name,
                 position,
                 skipinfo.old_position,
@@ -971,10 +971,10 @@ fn log_duplication_info(
         (false, None) => {
             error!(
                 "We surprisingly are seeing a duplicate record that \
-                    is beyond the highest record we've ever seen. {:?} connector offset={} \
+                    is beyond the highest record we've ever seen. {:?} connection offset={} \
                     message_time={} message_first_seen={} max_seen_time={}",
                 position,
-                connector_offset,
+                connection_offset,
                 fmt_timestamp(upstream_time_millis),
                 fmt_timestamp(*original_time),
                 fmt_timestamp(*max_seen_time),

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -18,7 +18,7 @@ use timely::communication::initialize::WorkerGuards;
 use tokio::sync::mpsc;
 
 use mz_dataflow_types::client::{LocalClient, LocalStorageClient};
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::ConnectionContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 
@@ -36,8 +36,8 @@ pub struct Config {
     pub now: NowFn,
     /// Metrics registry through which dataflow metrics will be reported.
     pub metrics_registry: MetricsRegistry,
-    /// Configuration for source and sink connectors.
-    pub connector_context: ConnectorContext,
+    /// Configuration for source and sink connection.
+    pub connection_context: ConnectionContext,
 }
 
 /// A handle to a running dataflow server.
@@ -107,7 +107,7 @@ pub fn serve(config: Config) -> Result<(Server, LocalStorageClient), anyhow::Err
                 source_metrics,
                 timely_worker_index,
                 timely_worker_peers,
-                connector_context: config.connector_context.clone(),
+                connection_context: config.connection_context.clone(),
                 persist_clients,
             },
             response_tx,

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -18,7 +18,7 @@ use timely::communication::initialize::WorkerGuards;
 use tokio::sync::mpsc;
 
 use mz_dataflow_types::client::{LocalClient, LocalStorageClient};
-use mz_dataflow_types::ConnectionContext;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -24,10 +24,10 @@ use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use mz_dataflow_types::sources::{
-    encoding::SourceDataEncoding, ExternalSourceConnector, KafkaOffset, KafkaSourceConnector,
+    encoding::SourceDataEncoding, ExternalSourceConnection, KafkaOffset, KafkaSourceConnection,
     MzOffset,
 };
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::ConnectionContext;
 use mz_expr::PartitionId;
 use mz_kafka_util::{client::create_new_client_config, client::MzClientContext, KafkaAddrs};
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
@@ -88,17 +88,17 @@ impl SourceReader for KafkaSourceReader {
         worker_id: usize,
         worker_count: usize,
         consumer_activator: SyncActivator,
-        connector: ExternalSourceConnector,
+        connection: ExternalSourceConnection,
         restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _: SourceDataEncoding,
         metrics: crate::source::metrics::SourceBaseMetrics,
-        connector_context: ConnectorContext,
+        connection_context: ConnectionContext,
     ) -> Result<Self, anyhow::Error> {
-        let kc = match connector {
-            ExternalSourceConnector::Kafka(kc) => kc,
+        let kc = match connection {
+            ExternalSourceConnection::Kafka(kc) => kc,
             _ => unreachable!(),
         };
-        let KafkaSourceConnector {
+        let KafkaSourceConnection {
             addrs,
             config_options,
             topic,
@@ -112,7 +112,7 @@ impl SourceReader for KafkaSourceReader {
             group_id_prefix,
             cluster_id,
             &config_options,
-            connector_context.librdkafka_log_level,
+            connection_context.librdkafka_log_level,
         );
         let (stats_tx, stats_rx) = crossbeam_channel::unbounded();
         let consumer: BaseConsumer<GlueConsumerContext> = kafka_config

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -23,11 +23,11 @@ use timely::scheduling::activate::SyncActivator;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::{
     encoding::SourceDataEncoding, ExternalSourceConnection, KafkaOffset, KafkaSourceConnection,
     MzOffset,
 };
-use mz_dataflow_types::ConnectionContext;
 use mz_expr::PartitionId;
 use mz_kafka_util::{client::create_new_client_config, client::MzClientContext, KafkaAddrs};
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -21,10 +21,11 @@ use prometheus::core::AtomicI64;
 use timely::scheduling::SyncActivator;
 use tracing::error;
 
-use mz_dataflow_types::aws::AwsExternalIdPrefix;
+use mz_dataflow_types::connections::aws::AwsExternalIdPrefix;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::encoding::SourceDataEncoding;
 use mz_dataflow_types::sources::{ExternalSourceConnection, KinesisSourceConnection, MzOffset};
-use mz_dataflow_types::{ConnectionContext, SourceErrorDetails};
+use mz_dataflow_types::SourceErrorDetails;
 use mz_expr::PartitionId;
 use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 use mz_repr::GlobalId;

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -23,8 +23,8 @@ use tracing::error;
 
 use mz_dataflow_types::aws::AwsExternalIdPrefix;
 use mz_dataflow_types::sources::encoding::SourceDataEncoding;
-use mz_dataflow_types::sources::{ExternalSourceConnector, KinesisSourceConnector, MzOffset};
-use mz_dataflow_types::{ConnectorContext, SourceErrorDetails};
+use mz_dataflow_types::sources::{ExternalSourceConnection, KinesisSourceConnection, MzOffset};
+use mz_dataflow_types::{ConnectionContext, SourceErrorDetails};
 use mz_expr::PartitionId;
 use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 use mz_repr::GlobalId;
@@ -129,21 +129,21 @@ impl SourceReader for KinesisSourceReader {
         _worker_id: usize,
         _worker_count: usize,
         _consumer_activator: SyncActivator,
-        connector: ExternalSourceConnector,
+        connection: ExternalSourceConnection,
         _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _encoding: SourceDataEncoding,
         metrics: crate::source::metrics::SourceBaseMetrics,
-        connector_context: ConnectorContext,
+        connection_context: ConnectionContext,
     ) -> Result<Self, anyhow::Error> {
-        let kc = match connector {
-            ExternalSourceConnector::Kinesis(kc) => kc,
+        let kc = match connection {
+            ExternalSourceConnection::Kinesis(kc) => kc,
             _ => unreachable!(),
         };
 
         let state = block_on(create_state(
             &metrics.kinesis,
             kc,
-            connector_context.aws_external_id_prefix.as_ref(),
+            connection_context.aws_external_id_prefix.as_ref(),
             source_id,
         ));
         match state {
@@ -270,7 +270,7 @@ impl SourceReader for KinesisSourceReader {
 // todo: Better error handling here! Not all errors mean we're done/can't progress.
 async fn create_state(
     base_metrics: &KinesisMetrics,
-    c: KinesisSourceConnector,
+    c: KinesisSourceConnection,
     aws_external_id_prefix: Option<&AwsExternalIdPrefix>,
     source_id: GlobalId,
 ) -> Result<

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -50,9 +50,10 @@ use tokio::time::MissedTickBehavior;
 use tracing::error;
 
 use mz_avro::types::Value;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::encoding::SourceDataEncoding;
 use mz_dataflow_types::sources::{ExternalSourceConnection, MzOffset};
-use mz_dataflow_types::{ConnectionContext, DecodeError, SourceError, SourceErrorDetails};
+use mz_dataflow_types::{DecodeError, SourceError, SourceErrorDetails};
 use mz_expr::PartitionId;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -27,10 +27,10 @@ use tokio_postgres::types::PgLsn;
 use tokio_postgres::SimpleQueryMessage;
 use tracing::{error, info, warn};
 
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::{
     encoding::SourceDataEncoding, ExternalSourceConnection, MzOffset, PostgresSourceConnection,
 };
-use mz_dataflow_types::ConnectionContext;
 use mz_dataflow_types::SourceErrorDetails;
 use mz_expr::PartitionId;
 use mz_ore::task;

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -17,8 +17,10 @@ use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport, PubNub};
 use timely::scheduling::SyncActivator;
 use tracing::info;
 
-use mz_dataflow_types::sources::{encoding::SourceDataEncoding, ExternalSourceConnector, MzOffset};
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::sources::{
+    encoding::SourceDataEncoding, ExternalSourceConnection, MzOffset,
+};
+use mz_dataflow_types::ConnectionContext;
 use mz_expr::PartitionId;
 use mz_repr::{Datum, GlobalId, Row};
 
@@ -43,17 +45,17 @@ impl SourceReader for PubNubSourceReader {
         _worker_id: usize,
         _worker_count: usize,
         _consumer_activator: SyncActivator,
-        connector: ExternalSourceConnector,
+        connection: ExternalSourceConnection,
         _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _encoding: SourceDataEncoding,
         _: crate::source::metrics::SourceBaseMetrics,
-        _: ConnectorContext,
+        _: ConnectionContext,
     ) -> Result<Self, anyhow::Error> {
-        let pubnub_conn = match connector {
-            ExternalSourceConnector::PubNub(pubnub_conn) => pubnub_conn,
+        let pubnub_conn = match connection {
+            ExternalSourceConnection::PubNub(pubnub_conn) => pubnub_conn,
             _ => {
                 panic!(
-                    "PubNub is the only legitimate ExternalSourceConnector for PubNubSourceReader"
+                    "PubNub is the only legitimate ExternalSourceConnection for PubNubSourceReader"
                 )
             }
         };

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -17,10 +17,10 @@ use pubnub_hyper::{Builder, DefaultRuntime, DefaultTransport, PubNub};
 use timely::scheduling::SyncActivator;
 use tracing::info;
 
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::{
     encoding::SourceDataEncoding, ExternalSourceConnection, MzOffset,
 };
-use mz_dataflow_types::ConnectionContext;
 use mz_expr::PartitionId;
 use mz_repr::{Datum, GlobalId, Row};
 

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -47,10 +47,10 @@ use tokio::time::{self, Duration};
 use tokio_util::io::{ReaderStream, StreamReader};
 use tracing::{debug, error, trace, warn};
 
-use mz_dataflow_types::aws::{AwsConfig, AwsExternalIdPrefix};
+use mz_dataflow_types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::encoding::SourceDataEncoding;
 use mz_dataflow_types::sources::{Compression, ExternalSourceConnection, MzOffset, S3KeySource};
-use mz_dataflow_types::ConnectionContext;
 use mz_expr::PartitionId;
 use mz_ore::retry::{Retry, RetryReader};
 use mz_ore::task;

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -49,8 +49,8 @@ use tracing::{debug, error, trace, warn};
 
 use mz_dataflow_types::aws::{AwsConfig, AwsExternalIdPrefix};
 use mz_dataflow_types::sources::encoding::SourceDataEncoding;
-use mz_dataflow_types::sources::{Compression, ExternalSourceConnector, MzOffset, S3KeySource};
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::sources::{Compression, ExternalSourceConnection, MzOffset, S3KeySource};
+use mz_dataflow_types::ConnectionContext;
 use mz_expr::PartitionId;
 use mz_ore::retry::{Retry, RetryReader};
 use mz_ore::task;
@@ -792,16 +792,16 @@ impl SourceReader for S3SourceReader {
         worker_id: usize,
         _worker_count: usize,
         consumer_activator: SyncActivator,
-        connector: ExternalSourceConnector,
+        connection: ExternalSourceConnection,
         _restored_offsets: Vec<(PartitionId, Option<MzOffset>)>,
         _encoding: SourceDataEncoding,
         metrics: crate::source::metrics::SourceBaseMetrics,
-        connector_context: ConnectorContext,
+        connection_context: ConnectionContext,
     ) -> Result<Self, anyhow::Error> {
-        let s3_conn = match connector {
-            ExternalSourceConnector::S3(s3_conn) => s3_conn,
+        let s3_conn = match connection {
+            ExternalSourceConnection::S3(s3_conn) => s3_conn,
             _ => {
-                panic!("S3 is the only legitimate ExternalSourceConnector for S3SourceReader")
+                panic!("S3 is the only legitimate ExternalSourceConnection for S3SourceReader")
             }
         };
 
@@ -820,7 +820,7 @@ impl SourceReader for S3SourceReader {
                     dataflow_tx,
                     shutdown_rx.clone(),
                     s3_conn.aws.clone(),
-                    connector_context.aws_external_id_prefix.clone(),
+                    connection_context.aws_external_id_prefix.clone(),
                     consumer_activator,
                     s3_conn.compression,
                     metrics.clone(),
@@ -842,7 +842,7 @@ impl SourceReader for S3SourceReader {
                                 source_id,
                                 glob.clone(),
                                 s3_conn.aws.clone(),
-                                connector_context.aws_external_id_prefix.clone(),
+                                connection_context.aws_external_id_prefix.clone(),
                                 keys_tx.clone(),
                                 metrics.clone(),
                             ),
@@ -860,7 +860,7 @@ impl SourceReader for S3SourceReader {
                                 glob.clone(),
                                 queue,
                                 s3_conn.aws.clone(),
-                                connector_context.aws_external_id_prefix.clone(),
+                                connection_context.aws_external_id_prefix.clone(),
                                 keys_tx.clone(),
                                 shutdown_rx.clone(),
                                 metrics.clone(),

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -21,8 +21,8 @@ use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, Mutex};
 
 use mz_dataflow_types::client::{StorageCommand, StorageResponse};
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sources::SourceConnection;
-use mz_dataflow_types::ConnectionContext;
 use mz_ore::now::NowFn;
 
 use mz_repr::{GlobalId, Timestamp};

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -25,7 +25,7 @@ use tracing::info;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::{GenericClient, StorageClient};
-use mz_dataflow_types::ConnectionContext;
+use mz_dataflow_types::connections::ConnectionContext;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::metrics::MetricsRegistry;

--- a/src/storaged/src/main.rs
+++ b/src/storaged/src/main.rs
@@ -25,7 +25,7 @@ use tracing::info;
 
 use mz_build_info::{build_info, BuildInfo};
 use mz_dataflow_types::client::{GenericClient, StorageClient};
-use mz_dataflow_types::ConnectorContext;
+use mz_dataflow_types::ConnectionContext;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::metrics::MetricsRegistry;
@@ -174,7 +174,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         timely_config,
         metrics_registry,
         now: SYSTEM_TIME.clone(),
-        connector_context: ConnectorContext::from_cli_args(
+        connection_context: ConnectionContext::from_cli_args(
             &args.tracing.log_filter.inner,
             args.aws_external_id,
         ),

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -351,7 +351,7 @@ where
 pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
     let mut monotonic = std::collections::HashSet::new();
     for (source_id, source) in dataflow.source_imports.iter_mut() {
-        if source.description.connector.append_only() {
+        if source.description.connection.append_only() {
             monotonic.insert(source_id.clone());
         }
     }

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -147,7 +147,7 @@ contains:error publishing kafka schemas for sink: unable to publish value schema
 contains:self signed certificate in certificate chain
 
 # Ensure that connectors work with SSL basic_auth
-> CREATE CONNECTOR kafka_ssl
+> CREATE CONNECTION kafka_ssl
   FOR KAFKA BROKER 'kafka:9092'
   WITH (
       security_protocol = 'SSL',
@@ -158,7 +158,7 @@ contains:self signed certificate in certificate chain
   )
 
 > CREATE MATERIALIZED SOURCE connector_source
-  FROM KAFKA CONNECTOR kafka_ssl
+  FROM KAFKA CONNECTION kafka_ssl
   TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   WITH (

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -237,7 +237,7 @@ public.bool
 > DROP DATABASE foo
 
 ! DROP OBJECT v1
-contains:Expected DATABASE, INDEX, ROLE, CLUSTER, SECRET, SCHEMA, SINK, SOURCE, TABLE, TYPE, USER, VIEW after DROP, found identifier
+contains:Expected one of CONNECTION or CLUSTER or DATABASE or INDEX or ROLE or SECRET or SCHEMA or SINK or SOURCE or TABLE or TYPE or USER or VIEW, found identifier
 
 > SHOW FULL OBJECTS
 name            type
@@ -371,8 +371,8 @@ mz_scheduling_parks_internal
 mz_worker_materialization_frontiers
 
 > SHOW FULL SOURCES FROM mz_catalog
-name                                          type   materialized  volatility  connector_type
----------------------------------------------------------------------------------------------
+name                                          type   materialized  volatility  type
+-----------------------------------------------------------------------------------
 mz_arrangement_sharing_internal               system true          volatile    log
 mz_arrangement_batches_internal               system true          volatile    log
 mz_arrangement_records_internal               system true          volatile    log
@@ -399,7 +399,7 @@ mz_clusters
 mz_cluster_replicas_base
 mz_cluster_replicas_status
 mz_columns
-mz_connectors
+mz_connections
 mz_databases
 mz_functions
 mz_index_columns
@@ -429,7 +429,7 @@ mz_clusters                 system
 mz_cluster_replicas_base    system
 mz_cluster_replicas_status  system
 mz_columns                  system
-mz_connectors               system
+mz_connections               system
 mz_databases                system
 mz_functions                system
 mz_index_columns            system
@@ -461,7 +461,7 @@ mz_clusters
 mz_cluster_replicas_base
 mz_cluster_replicas_status
 mz_columns
-mz_connectors
+mz_connections
 mz_databases
 mz_functions
 mz_index_columns
@@ -494,7 +494,7 @@ mz_clusters
 mz_cluster_replicas_base
 mz_cluster_replicas_status
 mz_columns
-mz_connectors
+mz_connections
 mz_databases
 mz_functions
 mz_index_columns

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -20,8 +20,8 @@ $ kafka-ingest format=bytes topic=connection_test
 > CREATE CONNECTION testconn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
-> SELECT name, connection_type from mz_connections
-name  connection_type
+> SELECT name, type from mz_connections
+name       type
 ------------------------------
 testconn   kafka
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -7,62 +7,62 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# Test basic connector functionality
+# Test basic connection functionality
 
 ###
-# Test core functionality by creating, introspecting and dropping a connector
+# Test core functionality by creating, introspecting and dropping a connection
 ###
-$ kafka-create-topic topic=connector_test partitions=1
-$ kafka-ingest format=bytes topic=connector_test
+$ kafka-create-topic topic=connection_test partitions=1
+$ kafka-ingest format=bytes topic=connection_test
 1,2
 2,3
 
-> CREATE CONNECTOR testconn
+> CREATE CONNECTION testconn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
-> SELECT name, connector_type from mz_connectors
-name  connector_type
+> SELECT name, connection_type from mz_connections
+name  connection_type
 ------------------------------
 testconn   kafka
 
-> SHOW CREATE CONNECTOR testconn
-Connector   "Create Connector"
+> SHOW CREATE CONNECTION testconn
+Connection   "Create Connection"
 ---------------------------------
-materialize.public.testconn   "CREATE CONNECTOR \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER '${testdrive.kafka-addr}'"
+materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER '${testdrive.kafka-addr}'"
 
 
-> DROP CONNECTOR testconn
+> DROP CONNECTION testconn
 
 ###
-# Test that connectors work in creating a source
+# Test that connections work in creating a source
 ###
-> CREATE CONNECTOR testconn
+> CREATE CONNECTION testconn
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
-> CREATE MATERIALIZED SOURCE connector_source (first, second)
-  FROM KAFKA CONNECTOR testconn
-  TOPIC 'testdrive-connector_test-${testdrive.seed}'
+> CREATE MATERIALIZED SOURCE connection_source (first, second)
+  FROM KAFKA CONNECTION testconn
+  TOPIC 'testdrive-connection_test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
 
-> SELECT * FROM connector_source
+> SELECT * FROM connection_source
 first second mz_offset
 ----------------------
 1     2      1
 2     3      2
 
-# Confirm we cannot drop the connector while a source depends upon it
-! DROP CONNECTOR testconn;
-contains:depended upon by catalog item 'materialize.public.connector_source'
+# Confirm we cannot drop the connection while a source depends upon it
+! DROP CONNECTION testconn;
+contains:depended upon by catalog item 'materialize.public.connection_source'
 
 # Confirm the drop works if we add cascade
-> DROP CONNECTOR testconn CASCADE;
+> DROP CONNECTION testconn CASCADE;
 
 # Validate the cascading drop actually happened
-! SELECT * FROM connector_source
-contains:unknown catalog item 'connector_source'
+! SELECT * FROM connection_source
+contains:unknown catalog item 'connection_source'
 
 ###
-# Test schema registry connector create and drop
+# Test schema registry connection create and drop
 ###
 
 # Setup kafka topic with schema
@@ -114,12 +114,12 @@ $ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema
 
 
 
-> CREATE CONNECTOR csr_conn
+> CREATE CONNECTION csr_conn
   FOR CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE MATERIALIZED SOURCE csr_source
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-csr_test-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR csr_conn
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 
 > SELECT * from csr_source
@@ -128,28 +128,28 @@ id creature
 1  lizard
 
 
-> CREATE CONNECTOR broker_connector
+> CREATE CONNECTION broker_connection
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
 
-> CREATE MATERIALIZED SOURCE two_connector_source
-  FROM KAFKA CONNECTOR broker_connector
+> CREATE MATERIALIZED SOURCE two_connection_source
+  FROM KAFKA CONNECTION broker_connection
   TOPIC 'testdrive-csr_test-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR csr_conn
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 
-> SELECT * from two_connector_source
+> SELECT * from two_connection_source
 id creature
 -----------
 1  lizard
 
-! DROP CONNECTOR csr_conn
+! DROP CONNECTION csr_conn
 contains:depended upon by catalog item 'materialize.public.csr_source'
 
-> DROP CONNECTOR csr_conn CASCADE
+> DROP CONNECTION csr_conn CASCADE
 
 ! CREATE MATERIALIZED SOURCE should_fail
-  FROM KAFKA CONNECTOR does_not_exist
+  FROM KAFKA CONNECTION does_not_exist
   TOPIC 'error_topic'
   FORMAT TEXT
 contains: unknown catalog item 'does_not_exist'
@@ -157,11 +157,11 @@ contains: unknown catalog item 'does_not_exist'
 ! CREATE MATERIALIZED SOURCE should_fail
   FROM KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-csr_test-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR does_not_exist
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION does_not_exist
   ENVELOPE DEBEZIUM UPSERT
 contains: unknown catalog item 'does_not_exist'
 
-# Test protobuf CSR connector
+# Test protobuf CSR connection
 # Duplicated from protobuf-import.td since once a topic has been read we can only create the source again by forcing offsets which is itself a different test case
 $ set empty-schema
 syntax = "proto3";
@@ -229,14 +229,14 @@ $ schema-registry-publish subject=testdrive-import-csr-${testdrive.seed}-value s
 $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb message=Importer confluent-wire-format=true
 {"importee1": {"b": false}, "importee2": {"ts": "1970-01-01T00:20:34.000005678Z"}}
 
-> CREATE CONNECTOR proto_csr
+> CREATE CONNECTION proto_csr
   FOR CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> CREATE MATERIALIZED SOURCE import_connector_csr FROM
+> CREATE MATERIALIZED SOURCE import_connection_csr FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-import-csr-${testdrive.seed}'
-  FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR proto_csr
+  FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION proto_csr
 
-> SELECT importee1::text, importee2::text, mz_offset FROM import_connector_csr
+> SELECT importee1::text, importee2::text, mz_offset FROM import_connection_csr
 importee1  importee2            mz_offset
 -----------------------------------------
 (f)        "(\"(1234,5678)\")"  1

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -319,14 +319,14 @@ name
 mat_data
 
 > SHOW FULL SOURCES
-name     type materialized  volatility connector_type
------------------------------------------------------
+name     type materialized  volatility type
+--------------------------------------------
 data     user false         unknown    kafka
 mat_data user true          unknown    kafka
 
 > SHOW FULL MATERIALIZED SOURCES
-name     type  volatility connector_type
-----------------------------------------
+name     type  volatility type
+-------------------------------
 mat_data user  unknown    kafka
 
 # If there exists another index, dropping the primary index will not #


### PR DESCRIPTION
Per DevEx's request. The primary goal here is to say

    CREATE CONNECTION ...

rather than

    CREATE CONNECTOR ...

but I did a search and replace across the entire codebase 
rather than just the parser to reduce confusion.

Touches #11504.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
