### PR TITLE
sql: enum-named connector options

### DIFF
--- a/src/dataflow-types/src/types/connections.rs
+++ b/src/dataflow-types/src/types/connections.rs
@@ -89,6 +89,12 @@ impl RustType<ProtoStringOrSecret> for StringOrSecret {
     }
 }
 
+impl<V: std::string::ToString> From<V> for StringOrSecret {
+    fn from(v: V) -> StringOrSecret {
+        StringOrSecret::String(V::to_string(&v))
+    }
+}
+
 /// Extra context to pass through when instantiating a connection for a source
 /// or sink.
 ///

--- a/src/kafka-util/src/addr.rs
+++ b/src/kafka-util/src/addr.rs
@@ -23,6 +23,13 @@ include!(concat!(env!("OUT_DIR"), "/mz_kafka_util.addr.rs"));
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct KafkaAddrs(Vec<(String, u16)>);
 
+impl KafkaAddrs {
+    /// Returns the inner vec's len
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
 impl FromStr for KafkaAddrs {
     type Err = KafkaAddrsParseError;
 

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -44,6 +44,7 @@ Boolean
 Both
 Bpchar
 Broker
+Brokers
 Bucket
 By
 Bytes

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -33,6 +33,7 @@ Array
 As
 Asc
 At
+Authority
 Availability
 Avro
 Begin
@@ -49,6 +50,7 @@ Bytes
 Cascade
 Case
 Cast
+Certificate
 Chain
 Channel
 Char
@@ -213,6 +215,7 @@ Ordinality
 Outer
 Over
 Partition
+Password
 Persist
 Physical
 Plan
@@ -276,6 +279,7 @@ Some
 Source
 Sources
 Sqs
+Ssl
 Start
 Stdin
 Stdout

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1923,13 +1923,9 @@ impl<'a> Parser<'a> {
         self.expect_keyword(FOR)?;
         let connection = match self.expect_one_of_keywords(&[KAFKA, CONFLUENT])? {
             Keyword::Kafka => {
-                self.expect_keyword(BROKER)?;
-                let broker = self.parse_literal_string()?;
-                let with_options = self.parse_kafka_connection_options()?;
-                CreateConnection::Kafka {
-                    broker,
-                    with_options,
-                }
+                let with_options =
+                    self.parse_comma_separated(Parser::parse_kafka_connection_options)?;
+                CreateConnection::Kafka { with_options }
             }
             Keyword::Confluent => {
                 self.expect_keywords(&[SCHEMA, REGISTRY])?;
@@ -1951,39 +1947,30 @@ impl<'a> Parser<'a> {
 
     fn parse_kafka_connection_options(
         &mut self,
-    ) -> Result<Vec<KafkaConnectionOption<Raw>>, ParserError> {
-        Ok(match self.parse_one_of_keywords(&[SSL]) {
-            Some(SSL) => {
-                self.expect_token(&Token::LParen)?;
-                let o = self.parse_comma_separated(Parser::parse_kafka_connection_ssl_options)?;
-                self.expect_token(&Token::RParen)?;
-                o
-            }
-            None => vec![],
-            _ => unreachable!(),
-        })
-    }
-
-    fn parse_kafka_connection_ssl_options(
-        &mut self,
     ) -> Result<KafkaConnectionOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[KEY, CERTIFICATE])? {
-            KEY => {
-                if self.parse_keyword(PASSWORD) {
-                    KafkaConnectionOptionName::SslKeyPassword
-                } else {
-                    KafkaConnectionOptionName::SslKey
+        let name = match self.expect_one_of_keywords(&[BROKER, BROKERS, SSL])? {
+            BROKER => KafkaConnectionOptionName::Broker,
+            BROKERS => KafkaConnectionOptionName::Brokers,
+            SSL => match self.expect_one_of_keywords(&[KEY, CERTIFICATE])? {
+                KEY => {
+                    if self.parse_keyword(PASSWORD) {
+                        KafkaConnectionOptionName::SslKeyPassword
+                    } else {
+                        KafkaConnectionOptionName::SslKey
+                    }
                 }
-            }
-            CERTIFICATE => {
-                if self.parse_keyword(AUTHORITY) {
-                    KafkaConnectionOptionName::SslCertificateAuthority
-                } else {
-                    KafkaConnectionOptionName::SslCertificate
+                CERTIFICATE => {
+                    if self.parse_keyword(AUTHORITY) {
+                        KafkaConnectionOptionName::SslCertificateAuthority
+                    } else {
+                        KafkaConnectionOptionName::SslCertificate
+                    }
                 }
-            }
+                _ => unreachable!(),
+            },
             _ => unreachable!(),
         };
+
         let _ = self.consume_token(&Token::Eq);
         Ok(KafkaConnectionOption {
             name,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1352,13 +1352,12 @@ ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 =>
 AlterSecret(AlterSecretStatement { name: UnresolvedObjectName([Ident("secret")]), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
-
 parse-statement
-CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234' SSL (KEY = 'foo', KEY PASSWORD = 'bar', CERTIFICATE = 'qux');
+CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL KEY PASSWORD = 'bar', SSL CERTIFICATE = 'qux';
 ----
-CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234' SSL (CERTIFICATE = 'qux', KEY = 'foo', KEY PASSWORD = 'bar')
+CREATE CONNECTION conn1 FOR KAFKA BROKER = 'kafka:1234', SSL KEY = 'foo', SSL KEY PASSWORD = 'bar', SSL CERTIFICATE = 'qux'
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { broker: "kafka:1234", with_options: [KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslKeyPassword, value: Some(Value(String("bar"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(Value(String("kafka:1234"))) }, KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslKeyPassword, value: Some(Value(String("bar"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
 
 parse-statement
 DROP CONNECTION conn1

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1354,58 +1354,58 @@ AlterSecret(AlterSecretStatement { name: UnresolvedObjectName([Ident("secret")])
 
 
 parse-statement
-CREATE CONNECTOR conn1 FOR KAFKA BROKER 'kafka:1234' WITH (security_protocol = 'SASL_SSL', sasl_mechanisms = 'PLAIN')
+CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234' SSL (KEY = 'foo', KEY PASSWORD = 'bar', CERTIFICATE = 'qux');
 ----
-error: Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE, SECRET or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found identifier "connector"
-CREATE CONNECTOR conn1 FOR KAFKA BROKER 'kafka:1234' WITH (security_protocol = 'SASL_SSL', sasl_mechanisms = 'PLAIN')
-       ^
+CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234' SSL (CERTIFICATE = 'qux', KEY = 'foo', KEY PASSWORD = 'bar')
+=>
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { broker: "kafka:1234", with_options: [KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslKeyPassword, value: Some(Value(String("bar"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
 
 parse-statement
-DROP CONNECTOR conn1
+DROP CONNECTION conn1
 ----
-error: Expected one of CONNECTION or CLUSTER or DATABASE or INDEX or ROLE or SECRET or SCHEMA or SINK or SOURCE or TABLE or TYPE or USER or VIEW, found identifier "connector"
-DROP CONNECTOR conn1
-     ^
+DROP CONNECTION conn1
+=>
+DropObjects(DropObjectsStatement { materialized: false, object_type: Connection, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
 ----
-error: Expected one of BROKER or CONNECTION, found identifier "connector"
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
-                              ^
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
-CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
+CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
 ----
-error: Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE, SECRET or [OR REPLACE] [TEMPORARY] [MATERIALIZED] VIEW or VIEWS after CREATE, found identifier "connector"
-CREATE CONNECTOR conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
-       ^
+CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = 'user', password = 'word')
+=>
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { url: "http://localhost:8081", with_options: [WithOption { key: Ident("username"), value: Some(Value(String("user"))) }, WithOption { key: Ident("password"), value: Some(Value(String("word"))) }] }, if_not_exists: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 ----
-error: Expected one of BROKER or CONNECTION, found identifier "connector"
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
-                              ^
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn2")])) }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, materialized: false, key_constraint: None })
 
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 ----
-error: Expected one of BROKER or CONNECTION, found identifier "connector"
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTOR conn2 ENVELOPE DEBEZIUM
-                              ^
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProto { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn2")])) }, seed: None, with_options: [] } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
 ----
-error: Expected one of BROKER or CONNECTION, found identifier "connector"
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
-                              ^
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")]))), Collection(Value(String("foo")))] })), if_not_exists: false, materialized: false, key_constraint: None })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
-error: Expected one of BROKER or CONNECTION, found identifier "connector"
-CREATE SOURCE src1 FROM KAFKA CONNECTOR conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
-                              ^
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, materialized: false, key_constraint: None })

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -9,11 +9,17 @@
 
 //! Provides parsing and convenience functions for working with Kafka from the `sql` package.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::convert::{self, TryInto};
 use std::sync::{Arc, Mutex};
 
 use anyhow::bail;
+
+use rdkafka::client::ClientContext;
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
+use rdkafka::{Offset, TopicPartitionList};
+use reqwest::Url;
+use tokio::time::Duration;
 
 use mz_dataflow_types::connections::{
     CsrConnection, CsrConnectionHttpAuth, CsrConnectionTlsIdentity, StringOrSecret,
@@ -21,16 +27,15 @@ use mz_dataflow_types::connections::{
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::task;
 use mz_secrets::SecretsReader;
-use rdkafka::client::ClientContext;
-use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
-use rdkafka::{Offset, TopicPartitionList};
-use reqwest::Url;
-use tokio::time::Duration;
-
-use mz_sql_parser::ast::Value;
+use mz_sql_parser::ast::display::AstDisplay;
+use mz_sql_parser::ast::{
+    KafkaConnectionOption, KafkaConnectionOptionName, Value, WithOptionValue,
+};
 
 use crate::catalog::{CatalogItemType, SessionCatalog};
+use crate::names::Aug;
 use crate::normalize::SqlValueOrSecret;
+use crate::plan::with_options::TryFromValue;
 
 enum ValType {
     String { transform: fn(String) -> String },
@@ -39,6 +44,126 @@ enum ValType {
     // Number with range [lower, upper]
     Number(i32, i32),
     Boolean,
+}
+
+impl ValType {
+    fn try_from_value(
+        &self,
+        catalog: &dyn SessionCatalog,
+        v: Option<WithOptionValue<Aug>>,
+    ) -> Result<StringOrSecret, anyhow::Error> {
+        let s = match self {
+            ValType::String { transform } => {
+                let s = String::try_from_value(v)?;
+                transform(s).into()
+            }
+            ValType::StringOrSecret => StringOrSecret::try_from_value(v)?,
+            ValType::Secret => match StringOrSecret::try_from_value(v)? {
+                StringOrSecret::String(_) => bail!("must provide a secret"),
+                secret @ StringOrSecret::Secret(_) => secret,
+            },
+            ValType::Number(lower, upper) => {
+                let i = i32::try_from_value(v)?;
+                if i < *lower || *upper < i {
+                    bail!("must be a number between {} and {}", lower, upper)
+                }
+                i.into()
+            }
+            ValType::Boolean => bool::try_from_value(v)?.into(),
+        };
+        validate_secret(catalog, &s)?;
+        Ok(s)
+    }
+}
+
+fn validate_secret(
+    catalog: &dyn SessionCatalog,
+    s: &mz_dataflow_types::connections::StringOrSecret,
+) -> Result<(), anyhow::Error> {
+    if let StringOrSecret::Secret(id) = s {
+        let item = catalog.get_item(&id);
+        if item.item_type() != CatalogItemType::Secret {
+            bail!(
+                "'{}' is not a SECRET",
+                catalog.resolve_full_name(&item.name())
+            );
+        }
+    }
+
+    Ok(())
+}
+
+trait ConfigGen {
+    fn config_key(&self) -> &str;
+    fn config_val(&self) -> ValType;
+}
+
+impl ConfigGen for KafkaConnectionOptionName {
+    fn config_key(&self) -> &str {
+        match self {
+            KafkaConnectionOptionName::SslKey => "ssl.key.pem",
+            KafkaConnectionOptionName::SslKeyPassword => "ssl.key.password",
+            KafkaConnectionOptionName::SslCertificate => "ssl.certificate.pem",
+            KafkaConnectionOptionName::SslCertificateAuthority => "ssl.ca.pem",
+            _ => unreachable!(),
+        }
+    }
+
+    fn config_val(&self) -> ValType {
+        match self {
+            KafkaConnectionOptionName::SslKey => ValType::Secret,
+            KafkaConnectionOptionName::SslKeyPassword => ValType::Secret,
+            KafkaConnectionOptionName::SslCertificate => ValType::StringOrSecret,
+            KafkaConnectionOptionName::SslCertificateAuthority => ValType::StringOrSecret,
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub fn kafka_connection_config(
+    catalog: &dyn SessionCatalog,
+    options: Vec<KafkaConnectionOption<Aug>>,
+) -> Result<BTreeMap<String, StringOrSecret>, anyhow::Error> {
+    let mut group = None;
+    let mut seen = HashSet::<KafkaConnectionOptionName>::new();
+    let mut res = BTreeMap::new();
+    for KafkaConnectionOption { name, value } in options {
+        match group {
+            None => group = Some(name.group()),
+            Some(g) => {
+                if g != name.group() {
+                    debug_assert!(false, "parsed too many groups");
+                    bail!("invalid connector; too many types of configuration permitted");
+                }
+            }
+        }
+        if !seen.insert(name.clone()) {
+            bail!(
+                "{} ({}...) specified more than once",
+                group.unwrap(),
+                name.to_ast_string()
+            );
+        }
+
+        assert!(res
+            .insert(
+                name.config_key().to_string(),
+                name.config_val().try_from_value(catalog, value)?,
+            )
+            .is_none());
+    }
+
+    assert!(res
+        .insert(
+            "security.protocol".to_string(),
+            match group {
+                Some("SSL") => StringOrSecret::from("ssl"),
+                _ => unreachable!(),
+            },
+        )
+        .is_none());
+
+    Ok(res)
 }
 
 // Describes Kafka cluster configurations users can supply using `CREATE
@@ -144,15 +269,7 @@ fn extract(
                 );
             }
         };
-        if let StringOrSecret::Secret(id) = value {
-            let item = catalog.get_item(&id);
-            if item.item_type() != CatalogItemType::Secret {
-                bail!(
-                    "{} is not a SECRET",
-                    catalog.resolve_full_name(&item.name())
-                );
-            }
-        }
+        validate_secret(catalog, &value)?;
         out.insert(config.get_kafka_config_key(), value);
     }
     Ok(out)

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::bail;
 
+use mz_kafka_util::KafkaAddrs;
 use rdkafka::client::ClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::{Offset, TopicPartitionList};
@@ -44,6 +45,7 @@ enum ValType {
     // Number with range [lower, upper]
     Number(i32, i32),
     Boolean,
+    KafkaAddrs { limit_one: bool },
 }
 
 impl ValType {
@@ -70,6 +72,13 @@ impl ValType {
                 i.into()
             }
             ValType::Boolean => bool::try_from_value(v)?.into(),
+            ValType::KafkaAddrs { limit_one } => {
+                let addrs = KafkaAddrs::try_from_value(v)?;
+                if *limit_one && addrs.len() > 1 {
+                    bail!("cannot specify multiple broker addresses")
+                }
+                addrs.into()
+            }
         };
         validate_secret(catalog, &s)?;
         Ok(s)
@@ -94,13 +103,30 @@ fn validate_secret(
 }
 
 trait ConfigGen {
+    fn group(&self) -> Option<&'static str>;
     fn config_key(&self) -> &str;
     fn config_val(&self) -> ValType;
 }
 
 impl ConfigGen for KafkaConnectionOptionName {
+    fn group(&self) -> Option<&'static str> {
+        match self {
+            KafkaConnectionOptionName::Broker | KafkaConnectionOptionName::Brokers => None,
+            KafkaConnectionOptionName::SslKey
+            | KafkaConnectionOptionName::SslKeyPassword
+            | KafkaConnectionOptionName::SslCertificate
+            | KafkaConnectionOptionName::SslCertificateAuthority => Some("SSL"),
+            KafkaConnectionOptionName::SaslMechanisms
+            | KafkaConnectionOptionName::SaslUsername
+            | KafkaConnectionOptionName::SaslPassword => Some("SASL"),
+        }
+    }
+
     fn config_key(&self) -> &str {
         match self {
+            KafkaConnectionOptionName::Broker | KafkaConnectionOptionName::Brokers => {
+                "bootstrap.servers"
+            }
             KafkaConnectionOptionName::SslKey => "ssl.key.pem",
             KafkaConnectionOptionName::SslKeyPassword => "ssl.key.password",
             KafkaConnectionOptionName::SslCertificate => "ssl.certificate.pem",
@@ -111,6 +137,8 @@ impl ConfigGen for KafkaConnectionOptionName {
 
     fn config_val(&self) -> ValType {
         match self {
+            KafkaConnectionOptionName::Broker => ValType::KafkaAddrs { limit_one: true },
+            KafkaConnectionOptionName::Brokers => ValType::KafkaAddrs { limit_one: false },
             KafkaConnectionOptionName::SslKey => ValType::Secret,
             KafkaConnectionOptionName::SslKeyPassword => ValType::Secret,
             KafkaConnectionOptionName::SslCertificate => ValType::StringOrSecret,
@@ -128,40 +156,50 @@ pub fn kafka_connection_config(
     let mut seen = HashSet::<KafkaConnectionOptionName>::new();
     let mut res = BTreeMap::new();
     for KafkaConnectionOption { name, value } in options {
-        match group {
-            None => group = Some(name.group()),
-            Some(g) => {
-                if g != name.group() {
-                    debug_assert!(false, "parsed too many groups");
-                    bail!("invalid connector; too many types of configuration permitted");
-                }
+        match (group, name.group()) {
+            (None, other) => group = other,
+            (Some(g), Some(o)) if g != o => {
+                bail!("invalid connector: multiple protocols specified")
             }
+            _ => {}
         }
         if !seen.insert(name.clone()) {
-            bail!(
-                "{} ({}...) specified more than once",
-                group.unwrap(),
-                name.to_ast_string()
-            );
+            bail!("{} specified more than once", name.to_ast_string());
         }
 
-        assert!(res
+        if res
             .insert(
                 name.config_key().to_string(),
                 name.config_val().try_from_value(catalog, value)?,
             )
-            .is_none());
+            .is_some()
+        {
+            bail!(
+                "{} sets Kafka config option {}, which another option already set",
+                name.to_ast_string(),
+                name.config_key()
+            );
+        }
     }
 
-    assert!(res
-        .insert(
-            "security.protocol".to_string(),
-            match group {
-                Some("SSL") => StringOrSecret::from("ssl"),
-                _ => unreachable!(),
-            },
+    if !(seen.contains(&KafkaConnectionOptionName::Broker)
+        || seen.contains(&KafkaConnectionOptionName::Brokers))
+    {
+        bail!(
+            "must specify {} or {}",
+            KafkaConnectionOptionName::Broker.to_ast_string(),
+            KafkaConnectionOptionName::Brokers.to_ast_string()
         )
-        .is_none());
+    }
+
+    if let Some(group) = group {
+        assert!(res
+            .insert(
+                "security.protocol".to_string(),
+                StringOrSecret::from(group.to_lowercase()),
+            )
+            .is_none());
+    }
 
     Ok(res)
 }

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -153,7 +153,7 @@ pub fn options(
                 SqlValueOrSecret::Value(Value::String(data_type.to_ast_string()))
             }
             Some(WithOptionValue::Secret(ResolvedObjectName::Object { id, .. })) => {
-                SqlValueOrSecret::Secret(id.clone())
+                SqlValueOrSecret::Secret(*id)
             }
             Some(WithOptionValue::Secret(_)) => {
                 panic!("SECRET option {} must be Object", option.key)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2865,13 +2865,10 @@ pub fn plan_create_connection(
         CreateConnection::Kafka {
             broker,
             with_options,
-        } => {
-            let mut with_options = normalize::options(&with_options)?;
-            Connection::Kafka(KafkaConnection {
-                broker: broker.parse()?,
-                options: kafka_util::extract_config(scx.catalog, &mut with_options)?,
-            })
-        }
+        } => Connection::Kafka(KafkaConnection {
+            broker: broker.parse()?,
+            options: kafka_util::kafka_connection_config(scx.catalog, with_options)?,
+        }),
         CreateConnection::Csr { url, with_options } => {
             let connection = kafka_util::generate_ccsr_connection(
                 scx.catalog,

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -12,10 +12,13 @@
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 
+use mz_dataflow_types::connections::StringOrSecret;
 use mz_repr::adt::interval::Interval;
 use mz_repr::strconv;
 
 use crate::ast::{AstInfo, IntervalValue, Value, WithOptionValue};
+use crate::names::ResolvedObjectName;
+use crate::plan::Aug;
 
 pub trait TryFromValue<T>: Sized {
     fn try_from_value(v: T) -> Result<Self, anyhow::Error>;
@@ -23,6 +26,23 @@ pub trait TryFromValue<T>: Sized {
 
 pub trait ImpliedValue: Sized {
     fn implied_value() -> Result<Self, anyhow::Error>;
+}
+
+impl TryFromValue<WithOptionValue<Aug>> for StringOrSecret {
+    fn try_from_value(v: WithOptionValue<Aug>) -> Result<Self, anyhow::Error> {
+        Ok(match v {
+            WithOptionValue::Secret(ResolvedObjectName::Object { id, .. }) => {
+                StringOrSecret::Secret(id)
+            }
+            v => StringOrSecret::String(String::try_from_value(v)?),
+        })
+    }
+}
+
+impl ImpliedValue for StringOrSecret {
+    fn implied_value() -> Result<Self, anyhow::Error> {
+        bail!("must provide a string or secret value")
+    }
 }
 
 impl TryFromValue<Value> for Interval {

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -165,13 +165,12 @@ contains:self signed certificate in certificate chain
 # Ensure that connectors work with SSL basic_auth
 > CREATE CONNECTION kafka_ssl
   FOR KAFKA BROKER 'kafka:9092'
-  WITH (
-      security_protocol = 'SSL',
-      ssl_key_pem = SECRET ssl_key_kafka,
-      ssl_certificate_pem = '${arg.materialized-kafka-crt}',
-      ssl_ca_pem = '${arg.ca-crt}',
-      ssl_key_password = SECRET ssl_key_password_kafka
-  )
+  SSL (
+    KEY = SECRET ssl_key_kafka,
+    KEY PASSWORD = SECRET ssl_key_password_kafka,
+    CERTIFICATE = '${arg.materialized-kafka-crt}',
+    CERTIFICATE AUTHORITY = '${arg.ca-crt}'
+  );
 
 > CREATE MATERIALIZED SOURCE connector_source
   FROM KAFKA CONNECTION kafka_ssl

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -164,13 +164,12 @@ contains:self signed certificate in certificate chain
 
 # Ensure that connectors work with SSL basic_auth
 > CREATE CONNECTION kafka_ssl
-  FOR KAFKA BROKER 'kafka:9092'
-  SSL (
-    KEY = SECRET ssl_key_kafka,
-    KEY PASSWORD = SECRET ssl_key_password_kafka,
-    CERTIFICATE = '${arg.materialized-kafka-crt}',
-    CERTIFICATE AUTHORITY = '${arg.ca-crt}'
-  );
+  FOR KAFKA
+    BROKER 'kafka:9092',
+    SSL KEY = SECRET ssl_key_kafka,
+    SSL KEY PASSWORD = SECRET ssl_key_password_kafka,
+    SSL CERTIFICATE = '${arg.materialized-kafka-crt}',
+    SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}';
 
 > CREATE MATERIALIZED SOURCE connector_source
   FROM KAFKA CONNECTION kafka_ssl

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -28,7 +28,7 @@ testconn   kafka
 > SHOW CREATE CONNECTION testconn
 Connection   "Create Connection"
 ---------------------------------
-materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER '${testdrive.kafka-addr}'"
+materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER = '${testdrive.kafka-addr}'"
 
 
 > DROP CONNECTION testconn


### PR DESCRIPTION
Proposes a change to the Kafka connection object to use keywords rather than free-form strings, as well as an extensible engine for extracting these configs.

If this general approach looks good, I'll create a set of tests tomorrow.

### Motivation

This PR adds a known-desirable feature. Part of #11504

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `CREATE CONNECTION...FOR KAFKA BROKER` now uses a set of keywords to specify security parameters to connect to Kafka brokers via SSL.