### PR TITLE
make `ENVELOPE NONE` nullable columns part of encoding

### DIFF
--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -1133,7 +1133,7 @@ pub fn provide_default_metadata(
     envelope: &UnplannedSourceEnvelope,
     encoding: &encoding::DataEncoding,
 ) -> bool {
-    let is_avro = matches!(encoding, encoding::DataEncoding::Avro(_));
+    let is_avro = matches!(encoding.inner, encoding::DataEncodingInner::Avro(_));
     let is_stateless_dbz = match envelope {
         UnplannedSourceEnvelope::Debezium(_) => true,
         _ => false,

--- a/src/dataflow-types/src/types/sources/encoding.proto
+++ b/src/dataflow-types/src/types/sources/encoding.proto
@@ -29,7 +29,7 @@ message ProtoSourceDataEncoding {
     }
 }
 
-message ProtoDataEncoding {
+message ProtoDataEncodingInner {
     oneof kind {
         ProtoAvroEncoding avro = 1;
         ProtoProtobufEncoding protobuf = 2;
@@ -40,6 +40,11 @@ message ProtoDataEncoding {
         google.protobuf.Empty text = 7;
         mz_repr.relation_and_scalar.ProtoRelationDesc row_codec = 8;
     }
+}
+
+message ProtoDataEncoding {
+    bool force_nullable_columns = 1;
+    ProtoDataEncodingInner inner = 2;
 }
 
 message ProtoAvroEncoding {

--- a/src/dataflow-types/src/types/sources/encoding.rs
+++ b/src/dataflow-types/src/types/sources/encoding.rs
@@ -24,6 +24,35 @@ include!(concat!(
     "/mz_dataflow_types.types.sources.encoding.rs"
 ));
 
+pub enum SourceDataEncodingInner {
+    Single(DataEncodingInner),
+    KeyValue {
+        key: DataEncodingInner,
+        value: DataEncodingInner,
+    },
+}
+
+impl SourceDataEncodingInner {
+    pub fn into_source_data_encoding(self, force_nullable_columns: bool) -> SourceDataEncoding {
+        match self {
+            SourceDataEncodingInner::Single(inner) => SourceDataEncoding::Single(DataEncoding {
+                inner,
+                force_nullable_columns,
+            }),
+            SourceDataEncodingInner::KeyValue { key, value } => SourceDataEncoding::KeyValue {
+                key: DataEncoding {
+                    inner: key,
+                    force_nullable_columns,
+                },
+                value: DataEncoding {
+                    inner: value,
+                    force_nullable_columns,
+                },
+            },
+        }
+    }
+}
+
 /// A description of how to interpret data from various sources
 ///
 /// Almost all sources only present values as part of their records, but Kafka allows a key to be
@@ -100,7 +129,7 @@ impl SourceDataEncoding {
 /// A description of how each row should be decoded, from a string of bytes to a sequence of
 /// Differential updates.
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub enum DataEncoding {
+pub enum DataEncodingInner {
     Avro(AvroEncoding),
     Protobuf(ProtobufEncoding),
     Csv(CsvEncoding),
@@ -111,37 +140,61 @@ pub enum DataEncoding {
     RowCodec(RelationDesc),
 }
 
-impl RustType<ProtoDataEncoding> for DataEncoding {
-    fn into_proto(self: &Self) -> ProtoDataEncoding {
-        use proto_data_encoding::Kind;
-        ProtoDataEncoding {
+impl RustType<ProtoDataEncodingInner> for DataEncodingInner {
+    fn into_proto(&self) -> ProtoDataEncodingInner {
+        use proto_data_encoding_inner::Kind;
+        ProtoDataEncodingInner {
             kind: Some(match self {
-                DataEncoding::Avro(e) => Kind::Avro(e.into_proto()),
-                DataEncoding::Protobuf(e) => Kind::Protobuf(e.into_proto()),
-                DataEncoding::Csv(e) => Kind::Csv(e.into_proto()),
-                DataEncoding::Regex(e) => Kind::Regex(e.into_proto()),
-                DataEncoding::Postgres => Kind::Postgres(()),
-                DataEncoding::Bytes => Kind::Bytes(()),
-                DataEncoding::Text => Kind::Text(()),
-                DataEncoding::RowCodec(e) => Kind::RowCodec(e.into_proto()),
+                DataEncodingInner::Avro(e) => Kind::Avro(e.into_proto()),
+                DataEncodingInner::Protobuf(e) => Kind::Protobuf(e.into_proto()),
+                DataEncodingInner::Csv(e) => Kind::Csv(e.into_proto()),
+                DataEncodingInner::Regex(e) => Kind::Regex(e.into_proto()),
+                DataEncodingInner::Postgres => Kind::Postgres(()),
+                DataEncodingInner::Bytes => Kind::Bytes(()),
+                DataEncodingInner::Text => Kind::Text(()),
+                DataEncodingInner::RowCodec(e) => Kind::RowCodec(e.into_proto()),
             }),
         }
     }
 
-    fn from_proto(proto: ProtoDataEncoding) -> Result<Self, TryFromProtoError> {
-        use proto_data_encoding::Kind;
+    fn from_proto(proto: ProtoDataEncodingInner) -> Result<Self, TryFromProtoError> {
+        use proto_data_encoding_inner::Kind;
         let kind = proto
             .kind
-            .ok_or_else(|| TryFromProtoError::missing_field("ProtoDataEncoding::kind"))?;
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoDataEncodingInner::kind"))?;
         Ok(match kind {
-            Kind::Avro(e) => DataEncoding::Avro(e.into_rust()?),
-            Kind::Protobuf(e) => DataEncoding::Protobuf(e.into_rust()?),
-            Kind::Csv(e) => DataEncoding::Csv(e.into_rust()?),
-            Kind::Regex(e) => DataEncoding::Regex(e.into_rust()?),
-            Kind::Postgres(()) => DataEncoding::Postgres,
-            Kind::Bytes(()) => DataEncoding::Bytes,
-            Kind::Text(()) => DataEncoding::Text,
-            Kind::RowCodec(e) => DataEncoding::RowCodec(e.into_rust()?),
+            Kind::Avro(e) => DataEncodingInner::Avro(e.into_rust()?),
+            Kind::Protobuf(e) => DataEncodingInner::Protobuf(e.into_rust()?),
+            Kind::Csv(e) => DataEncodingInner::Csv(e.into_rust()?),
+            Kind::Regex(e) => DataEncodingInner::Regex(e.into_rust()?),
+            Kind::Postgres(()) => DataEncodingInner::Postgres,
+            Kind::Bytes(()) => DataEncodingInner::Bytes,
+            Kind::Text(()) => DataEncodingInner::Text,
+            Kind::RowCodec(e) => DataEncodingInner::RowCodec(e.into_rust()?),
+        })
+    }
+}
+
+/// A description of how each row should be decoded, from a string of bytes to a sequence of
+/// Differential updates.
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct DataEncoding {
+    pub force_nullable_columns: bool,
+    pub inner: DataEncodingInner,
+}
+
+impl RustType<ProtoDataEncoding> for DataEncoding {
+    fn into_proto(self: &Self) -> ProtoDataEncoding {
+        ProtoDataEncoding {
+            force_nullable_columns: self.force_nullable_columns,
+            inner: Some(self.inner.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoDataEncoding) -> Result<Self, TryFromProtoError> {
+        Ok(DataEncoding {
+            force_nullable_columns: proto.force_nullable_columns.into_rust()?,
+            inner: proto.inner.into_rust_if_some("ProtoDataEncoding::inner")?,
         })
     }
 }
@@ -155,21 +208,28 @@ pub fn included_column_desc(included_columns: Vec<(&str, ColumnType)>) -> Relati
 }
 
 impl DataEncoding {
+    pub fn new(inner: DataEncodingInner) -> DataEncoding {
+        DataEncoding {
+            inner,
+            force_nullable_columns: false,
+        }
+    }
+
     /// Computes the [`RelationDesc`] for the relation specified by this
     /// data encoding and envelope.
     ///
     /// If a key desc is provided it will be prepended to the returned desc
     fn desc(&self) -> Result<RelationDesc, anyhow::Error> {
         // Add columns for the data, based on the encoding format.
-        Ok(match self {
-            DataEncoding::Bytes => {
+        let desc = match &self.inner {
+            DataEncodingInner::Bytes => {
                 RelationDesc::empty().with_column("data", ScalarType::Bytes.nullable(false))
             }
-            DataEncoding::Avro(AvroEncoding { schema, .. }) => {
+            DataEncodingInner::Avro(AvroEncoding { schema, .. }) => {
                 let parsed_schema = avro::parse_schema(schema).context("validating avro schema")?;
                 avro::schema_to_relationdesc(parsed_schema).context("validating avro schema")?
             }
-            DataEncoding::Protobuf(ProtobufEncoding {
+            DataEncodingInner::Protobuf(ProtobufEncoding {
                 descriptors,
                 message_name,
                 confluent_wire_format: _,
@@ -179,7 +239,7 @@ impl DataEncoding {
                 .fold(RelationDesc::empty(), |desc, (name, ty)| {
                     desc.with_column(name, ty.clone())
                 }),
-            DataEncoding::Regex(RegexEncoding { regex }) => regex
+            DataEncodingInner::Regex(RegexEncoding { regex }) => regex
                 .capture_names()
                 .enumerate()
                 // The first capture is the entire matched string. This will
@@ -195,7 +255,7 @@ impl DataEncoding {
                     let ty = ScalarType::String.nullable(true);
                     desc.with_column(name, ty)
                 }),
-            DataEncoding::Csv(CsvEncoding { columns, .. }) => match columns {
+            DataEncodingInner::Csv(CsvEncoding { columns, .. }) => match columns {
                 ColumnSpec::Count(n) => {
                     (1..=*n).into_iter().fold(RelationDesc::empty(), |desc, i| {
                         desc.with_column(format!("column{}", i), ScalarType::String.nullable(false))
@@ -208,10 +268,10 @@ impl DataEncoding {
                         desc.with_column(name, ScalarType::String.nullable(false))
                     }),
             },
-            DataEncoding::Text => {
+            DataEncodingInner::Text => {
                 RelationDesc::empty().with_column("text", ScalarType::String.nullable(false))
             }
-            DataEncoding::Postgres => RelationDesc::empty()
+            DataEncodingInner::Postgres => RelationDesc::empty()
                 .with_column("oid", ScalarType::Int32.nullable(false))
                 .with_column(
                     "row_data",
@@ -221,20 +281,29 @@ impl DataEncoding {
                     }
                     .nullable(false),
                 ),
-            DataEncoding::RowCodec(desc) => desc.clone(),
-        })
+            DataEncodingInner::RowCodec(desc) => desc.clone(),
+        };
+
+        if self.force_nullable_columns {
+            Ok(RelationDesc::from_names_and_types(
+                desc.into_iter()
+                    .map(|(name, typ)| (name, typ.nullable(true))),
+            ))
+        } else {
+            Ok(desc)
+        }
     }
 
     pub fn op_name(&self) -> &'static str {
-        match self {
-            DataEncoding::Bytes => "Bytes",
-            DataEncoding::Avro(_) => "Avro",
-            DataEncoding::Protobuf(_) => "Protobuf",
-            DataEncoding::Regex { .. } => "Regex",
-            DataEncoding::Csv(_) => "Csv",
-            DataEncoding::Text => "Text",
-            DataEncoding::Postgres => "Postgres",
-            DataEncoding::RowCodec(_) => "RowCodec",
+        match &self.inner {
+            DataEncodingInner::Bytes => "Bytes",
+            DataEncodingInner::Avro(_) => "Avro",
+            DataEncodingInner::Protobuf(_) => "Protobuf",
+            DataEncodingInner::Regex { .. } => "Regex",
+            DataEncodingInner::Csv(_) => "Csv",
+            DataEncodingInner::Text => "Text",
+            DataEncodingInner::Postgres => "Postgres",
+            DataEncodingInner::RowCodec(_) => "RowCodec",
         }
     }
 }

--- a/src/dataflow-types/src/types/sources/encoding.rs
+++ b/src/dataflow-types/src/types/sources/encoding.rs
@@ -33,20 +33,20 @@ pub enum SourceDataEncodingInner {
 }
 
 impl SourceDataEncodingInner {
-    pub fn into_source_data_encoding(self, force_nullable_columns: bool) -> SourceDataEncoding {
+    pub fn into_source_data_encoding(self, force_nullable_keys: bool) -> SourceDataEncoding {
         match self {
             SourceDataEncodingInner::Single(inner) => SourceDataEncoding::Single(DataEncoding {
                 inner,
-                force_nullable_columns,
+                force_nullable_columns: false,
             }),
             SourceDataEncodingInner::KeyValue { key, value } => SourceDataEncoding::KeyValue {
                 key: DataEncoding {
                     inner: key,
-                    force_nullable_columns,
+                    force_nullable_columns: force_nullable_keys,
                 },
                 value: DataEncoding {
                     inner: value,
-                    force_nullable_columns,
+                    force_nullable_columns: false,
                 },
             },
         }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1177,8 +1177,6 @@ fn get_encoding(
     format: &CreateSourceFormat<Aug>,
     envelope: &Envelope<Aug>,
 ) -> Result<SourceDataEncoding, anyhow::Error> {
-    let force_nullable_columns = matches!(envelope, Envelope::None);
-
     let encoding = match format {
         CreateSourceFormat::None => bail!("Source format must be specified"),
         CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format)?,
@@ -1195,6 +1193,7 @@ fn get_encoding(
         }
     };
 
+    let force_nullable_columns = matches!(envelope, Envelope::None);
     let encoding = encoding.into_source_data_encoding(force_nullable_columns);
 
     let requires_keyvalue = matches!(

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -227,8 +227,8 @@ where
                         schema,
                         schema_registry_config,
                         confluent_wire_format,
-                    } = match value_encoding {
-                        DataEncoding::Avro(enc) => enc,
+                    } = match value_encoding.inner {
+                        DataEncodingInner::Avro(enc) => enc,
                         _ => unreachable!("Attempted to create non-Avro CDCv2 source"),
                     };
                     let ok_source = match ok_source {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Follow up PR to https://github.com/MaterializeInc/materialize/pull/12929 to better separate concerns. Previously we were marking columns `nullable` in the planner when handling `ENVELOPE NONE` Kafka sources. This PR moves this logic into a more proper home of `DataEncoding` instead.

The biggest change is moving the existing `DataEncoding` enum to `DataEncodingInner`, and creating a `DataEncoding` that understands whether to mark columns nullable:

```rust
pub enum DataEncodingInner {
    Avro(AvroEncoding),
    Protobuf(ProtobufEncoding),
    Csv(CsvEncoding),
    Regex(RegexEncoding),
    Postgres,
    Bytes,
    Text,
    RowCodec(RelationDesc),
}

pub struct DataEncoding {
  pub force_nullable_columns: bool,
  pub inner: DataEncodingInner,
}
```

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

* This PR refactors existing code per @sploiselle's advice in https://github.com/MaterializeInc/materialize/pull/12929#issuecomment-1150184163

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

There should be no observable changes, so if the tests pass we should be good

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
