### PR TITLE
Revert "[coord] Enable multi-statement alter secret transactions (#12592)"

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1818,12 +1818,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         // is always safe.
                     }
 
-                    Statement::AlterSecret(_)
-                        if self.secrets_controller.supports_multi_statement_txn() =>
-                    {
-                        // if the controller supports this, its safe combine
-                    }
-
                     // Statements below must by run singly (in Started).
                     Statement::AlterIndex(_)
                     | Statement::AlterSecret(_)
@@ -2270,10 +2264,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 tx.send(self.sequence_alter_index_reset_options(plan).await, session);
             }
             Plan::AlterSecret(plan) => {
-                tx.send(
-                    self.sequence_alter_secret(&mut session, plan).await,
-                    session,
-                );
+                tx.send(self.sequence_alter_secret(&session, plan).await, session);
             }
             Plan::DiscardTemp => {
                 self.drop_temp_items(&session).await;
@@ -3493,9 +3484,6 @@ impl<S: Append + 'static> Coordinator<S> {
                             sender: tx,
                             conn_id: session.conn_id(),
                         });
-                    }
-                    TransactionOps::Secrets(secrets) => {
-                        self.secrets_controller.apply(secrets).await?
                     }
                     _ => {}
                 }
@@ -4903,17 +4891,19 @@ impl<S: Append + 'static> Coordinator<S> {
 
     async fn sequence_alter_secret(
         &mut self,
-        session: &mut Session,
+        session: &Session,
         plan: AlterSecretPlan,
     ) -> Result<ExecuteResponse, CoordError> {
         let AlterSecretPlan { id, mut secret_as } = plan;
 
         let payload = self.extract_secret(session, &mut secret_as)?;
 
-        session.add_transaction_ops(TransactionOps::Secrets(vec![SecretOp::Ensure {
-            id,
-            contents: payload,
-        }]))?;
+        self.secrets_controller
+            .apply(vec![SecretOp::Ensure {
+                id,
+                contents: payload,
+            }])
+            .await?;
 
         Ok(ExecuteResponse::AlteredObject(ObjectType::Secret))
     }

--- a/src/coord/src/error.rs
+++ b/src/coord/src/error.rs
@@ -155,8 +155,6 @@ pub enum CoordError {
     WriteOnlyTransaction,
     /// The transaction only supports single table writes
     MultiTableWriteTransaction,
-    /// The transaction is in secrets-only mode.
-    SecretsOnlyTransaction,
 }
 
 impl CoordError {
@@ -420,7 +418,6 @@ impl fmt::Display for CoordError {
             CoordError::MultiTableWriteTransaction => {
                 f.write_str("write transactions only support writes to a single table")
             }
-            CoordError::SecretsOnlyTransaction => f.write_str("transaction in secrets-only mode"),
         }
     }
 }

--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -23,7 +23,6 @@ use tokio::sync::OwnedMutexGuard;
 use mz_dataflow_types::client::ComputeInstanceId;
 use mz_pgrepr::Format;
 use mz_repr::{Datum, Diff, GlobalId, Row, ScalarType};
-use mz_secrets::SecretOp;
 use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
 
@@ -217,12 +216,6 @@ impl<T: CoordTimestamp> Session<T> {
                         _ => {
                             return Err(CoordError::WriteOnlyTransaction);
                         }
-                    },
-                    TransactionOps::Secrets(secret_txn_ops) => match add_ops {
-                        TransactionOps::Secrets(mut add_secret_ops) => {
-                            secret_txn_ops.append(&mut add_secret_ops);
-                        }
-                        _ => return Err(CoordError::SecretsOnlyTransaction),
                     },
                 }
             }
@@ -655,8 +648,6 @@ pub enum TransactionOps<T> {
     /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must only do
     /// other writes.
     Writes(Vec<WriteOp>),
-    /// This transaction has had a secrets DDL operation and must only do other secrets operations
-    Secrets(Vec<SecretOp>),
 }
 
 /// An `INSERT` waiting to be committed.

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -398,7 +398,6 @@ impl ErrorResponse {
             // code, so it's probably the best choice.
             CoordError::WriteOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             CoordError::MultiTableWriteTransaction => SqlState::INVALID_TRANSACTION_STATE,
-            CoordError::SecretsOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
         };
         ErrorResponse {
             severity,

--- a/src/secrets-filesystem/src/lib.rs
+++ b/src/secrets-filesystem/src/lib.rs
@@ -62,8 +62,4 @@ impl SecretsController for FilesystemSecretsController {
 
         return Ok(());
     }
-
-    fn supports_multi_statement_txn(&self) -> bool {
-        false
-    }
 }

--- a/src/secrets-kubernetes/src/lib.rs
+++ b/src/secrets-kubernetes/src/lib.rs
@@ -173,8 +173,4 @@ impl SecretsController for KubernetesSecretsController {
 
         return Ok(());
     }
-
-    fn supports_multi_statement_txn(&self) -> bool {
-        true
-    }
 }

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -30,13 +30,9 @@ pub trait SecretsController: Send + Sync {
     /// Implementations are permitted to reject combinations of operations which
     /// they cannot apply atomically.
     async fn apply(&mut self, ops: Vec<SecretOp>) -> Result<(), anyhow::Error>;
-
-    /// Returns true, if the controller supports multiple ops in a single atomic apply call
-    fn supports_multi_statement_txn(&self) -> bool;
 }
 
 /// An operation on a [`SecretsController`].
-#[derive(Debug, Clone, PartialEq)]
 pub enum SecretOp {
     /// Create or update the contents of a secret.
     Ensure {


### PR DESCRIPTION


This reverts commit c1c7f6037988cf3c30e059d99e47b21448f2e30c. We're
removing support for multi-statement `ALTER SECRET` to facilitate an
otherwise improved secret storage story. See #13012 for details.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes a feature in preparation for a refactor.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
