### PR TITLE
tracing: make query execution the root span

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -299,7 +299,8 @@ pub struct OpenTelemetryContext {
 }
 
 impl OpenTelemetryContext {
-    /// Attaches this `Context` to the current [`tracing`] span.
+    /// Attaches this `Context` to the current [`tracing`] span,
+    /// as its parent.
     ///
     /// If there is not enough information in this `OpenTelemetryContext`
     /// to create a context, then the current thread's `Context` is used

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -193,6 +193,28 @@ pub enum FrontendMessage {
     },
 }
 
+impl FrontendMessage {
+    pub fn name(&self) -> &'static str {
+        match self {
+            FrontendMessage::Query { .. } => "query",
+            FrontendMessage::Parse { .. } => "parse",
+            FrontendMessage::DescribeStatement { .. } => "describe_statement",
+            FrontendMessage::DescribePortal { .. } => "describe_portal",
+            FrontendMessage::Bind { .. } => "bind",
+            FrontendMessage::Execute { .. } => "execute",
+            FrontendMessage::Flush => "flush",
+            FrontendMessage::Sync => "sync",
+            FrontendMessage::CloseStatement { .. } => "close_statement",
+            FrontendMessage::ClosePortal { .. } => "close_portal",
+            FrontendMessage::Terminate => "terminate",
+            FrontendMessage::CopyData(_) => "copy_data",
+            FrontendMessage::CopyDone => "copy_done",
+            FrontendMessage::CopyFail(_) => "copy_fail",
+            FrontendMessage::Password { .. } => "password",
+        }
+    }
+}
+
 /// Internal representation of a backend [message]
 ///
 /// [message]: https://www.postgresql.org/docs/11/protocol-message-formats.html


### PR DESCRIPTION
Many people mentioned that having the connection as the root of the trace is confusing, so lets try per-query roots. **Note that this increases the number of spans going to honeycomb, but its much more useable for ad-hoc testing. If we find in prod we want full parental connections between queries and connections (this pr instead links them), we can make it configurable later on!

![Screen Shot 2022-06-13 at 2 23 12 PM](https://user-images.githubusercontent.com/5404303/173448253-9b7b5f15-a597-44cf-90c1-d5af966878e5.png)


Here is a `one_query`, that doesn't talk to compute (I think its a system table?)
![Screen Shot 2022-06-13 at 2 24 10 PM](https://user-images.githubusercontent.com/5404303/173448321-c6a87e24-1663-4114-8bc1-cbc435b8fcff.png)



### Motivation
  * This PR adds a known-desirable feature.
 https://github.com/MaterializeInc/materialize/issues/13019

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes
None
