### PR TITLE
sql[-parser]: support bare `SHOW INDEXES`

### DIFF
--- a/doc/user/content/sql/show-index.md
+++ b/doc/user/content/sql/show-index.md
@@ -17,7 +17,9 @@ aliases:
 
 Field | Use
 ------|-----
-_on&lowbar;name_ | The name of the object whose indexes you want to show. This can be the name of a table, source, or view.
+_on&lowbar;name_ | The name of the object whose indexes you want to show. This can be the name of a table, source, or view. If omitted, all indexes in the cluster are shown.
+_cluster&lowbar;name_ | The cluster to show indexes from. If omitted, indexes from all clusters are shown.
+**EXTENDED** | Returns system indexes as well as user-created indexes. By default, only user-created indexes are returned.
 
 ## Details
 

--- a/doc/user/layouts/partials/sql-grammar/show-index.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-index.svg
@@ -1,86 +1,113 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="475" height="235">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="64" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="559" height="361">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="3" width="62" height="32" rx="10"/>
-   <rect x="133"
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="137" y="35" width="96" height="32" rx="10"/>
+   <rect x="135"
+         y="33"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="53">EXTENDED</text>
+   <rect x="293" y="3" width="62" height="32" rx="10"/>
+   <rect x="291"
          y="1"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="143" y="21">INDEX</text>
-   <rect x="135" y="47" width="80" height="32" rx="10"/>
-   <rect x="133"
+   <text class="terminal" x="301" y="21">INDEX</text>
+   <rect x="293" y="47" width="80" height="32" rx="10"/>
+   <rect x="291"
          y="45"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="143" y="65">INDEXES</text>
-   <rect x="135" y="91" width="58" height="32" rx="10"/>
-   <rect x="133"
+   <text class="terminal" x="301" y="65">INDEXES</text>
+   <rect x="293" y="91" width="58" height="32" rx="10"/>
+   <rect x="291"
          y="89"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="143" y="109">KEYS</text>
-   <rect x="275" y="3" width="60" height="32" rx="10"/>
-   <rect x="273"
-         y="1"
+   <text class="terminal" x="301" y="109">KEYS</text>
+   <rect x="203" y="173" width="60" height="32" rx="10"/>
+   <rect x="201"
+         y="171"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="283" y="21">FROM</text>
-   <rect x="275" y="47" width="34" height="32" rx="10"/>
-   <rect x="273"
-         y="45"
+   <text class="terminal" x="211" y="191">FROM</text>
+   <rect x="203" y="217" width="34" height="32" rx="10"/>
+   <rect x="201"
+         y="215"
          width="34"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="283" y="65">IN</text>
-   <rect x="375" y="3" width="78" height="32"/>
-   <rect x="373" y="1" width="78" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="383" y="21">on_name</text>
-   <rect x="287" y="157" width="50" height="32" rx="10"/>
-   <rect x="285"
-         y="155"
+   <text class="terminal" x="211" y="235">IN</text>
+   <rect x="303" y="173" width="78" height="32"/>
+   <rect x="301" y="171" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="311" y="191">on_name</text>
+   <rect x="45" y="315" width="34" height="32" rx="10"/>
+   <rect x="43"
+         y="313"
+         width="34"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="333">IN</text>
+   <rect x="99" y="315" width="84" height="32" rx="10"/>
+   <rect x="97"
+         y="313"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="107" y="333">CLUSTER</text>
+   <rect x="203" y="315" width="108" height="32"/>
+   <rect x="201" y="313" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="211" y="333">cluster_name</text>
+   <rect x="371" y="283" width="50" height="32" rx="10"/>
+   <rect x="369"
+         y="281"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="295" y="175">LIKE</text>
-   <rect x="357" y="157" width="70" height="32" rx="10"/>
-   <rect x="355"
-         y="155"
+   <text class="terminal" x="379" y="301">LIKE</text>
+   <rect x="441" y="283" width="70" height="32" rx="10"/>
+   <rect x="439"
+         y="281"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="365" y="175">pattern</text>
-   <rect x="287" y="201" width="70" height="32" rx="10"/>
-   <rect x="285"
-         y="199"
+   <text class="terminal" x="449" y="301">pattern</text>
+   <rect x="371" y="327" width="70" height="32" rx="10"/>
+   <rect x="369"
+         y="325"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="295" y="219">WHERE</text>
-   <rect x="377" y="201" width="48" height="32"/>
-   <rect x="375" y="199" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="385" y="219">expr</text>
+   <text class="terminal" x="379" y="345">WHERE</text>
+   <rect x="461" y="327" width="48" height="32"/>
+   <rect x="459" y="325" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="469" y="345">expr</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m62 0 h10 m0 0 h18 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m58 0 h10 m0 0 h22 m40 -88 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m34 0 h10 m0 0 h26 m20 -44 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-230 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
-   <polygon points="465 171 473 167 473 175"/>
-   <polygon points="465 171 457 167 457 175"/>
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m62 0 h10 m0 0 h18 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m58 0 h10 m0 0 h22 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-274 138 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h208 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v12 m238 0 v-12 m-238 12 q0 10 10 10 m218 0 q10 0 10 -10 m-208 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m34 0 h10 m0 0 h26 m20 -44 h10 m78 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-420 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
+   <polygon points="549 297 557 293 557 301"/>
+   <polygon points="549 297 541 293 541 301"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -295,7 +295,9 @@ show_create_view ::=
 show_databases ::=
     'SHOW' 'DATABASES' ('LIKE' 'pattern' | 'WHERE' expr)
 show_index ::=
-    'SHOW' ('INDEX' | 'INDEXES' | 'KEYS') ('FROM' | 'IN') on_name
+    'SHOW' 'EXTENDED'? ('INDEX' | 'INDEXES' | 'KEYS')
+    (('FROM' | 'IN') on_name)?
+    ('IN' 'CLUSTER' cluster_name)?
     ('LIKE' 'pattern' | 'WHERE' expr)
 show_schemas ::=
     'SHOW' 'SCHEMAS' ('FROM' database_name)?

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1519,13 +1519,13 @@ impl<T: AstInfo> AstDisplay for ShowIndexesStatement<T> {
         if self.extended {
             f.write_str("EXTENDED ");
         }
-        f.write_str("INDEXES ");
+        f.write_str("INDEXES");
         if let Some(table_name) = &self.table_name {
-            f.write_str("FROM ");
+            f.write_str(" FROM ");
             f.write_node(table_name);
         }
         if let Some(in_cluster) = &self.in_cluster {
-            f.write_str("IN CLUSTER ");
+            f.write_str(" IN CLUSTER ");
             f.write_node(in_cluster);
         }
         if let Some(filter) = &self.filter {

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -201,6 +201,27 @@ SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
 ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: true, filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("index_name")]), expr2: Some(Value(String("bar"))) })) })
 
 parse-statement
+SHOW INDEXES
+----
+SHOW INDEXES
+=>
+ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: None, extended: false, filter: None })
+
+parse-statement
+SHOW INDEXES IN CLUSTER c
+----
+SHOW INDEXES IN CLUSTER c
+=>
+ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: Some(Unresolved(Ident("c"))), extended: false, filter: None })
+
+parse-statement
+SHOW INDEXES FROM c IN CLUSTER c
+----
+SHOW INDEXES FROM c IN CLUSTER c
+=>
+ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("c")]))), in_cluster: Some(Unresolved(Ident("c"))), extended: false, filter: None })
+
+parse-statement
 SHOW CREATE VIEW foo
 ----
 SHOW CREATE VIEW foo

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -95,6 +95,68 @@ SHOW INDEXES ON v IN CLUSTER bar;
 ----
 bar v v_primary_idx 1 ?column? NULL false
 
+statement ok
+CREATE DEFAULT INDEX foo_v_idx IN CLUSTER foo ON v
+
+query TTTTTTT
+SHOW INDEXES IN CLUSTER bar;
+----
+bar  v  v_primary_idx  1  ?column?  NULL  false
+
+query TTTTTTT
+SHOW EXTENDED INDEXES IN CLUSTER bar;
+----
+bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_3_primary_idx  1  operator  NULL  false
+bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_3_primary_idx  2  worker  NULL  false
+bar  mz_arrangement_records_internal  mz_arrangement_records_internal_3_primary_idx  1  operator  NULL  false
+bar  mz_arrangement_records_internal  mz_arrangement_records_internal_3_primary_idx  2  worker  NULL  false
+bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_3_primary_idx  1  operator  NULL  false
+bar  mz_arrangement_sharing_internal  mz_arrangement_sharing_internal_3_primary_idx  2  worker  NULL  false
+bar  mz_dataflow_channels  mz_dataflow_channels_3_primary_idx  1  id  NULL  false
+bar  mz_dataflow_channels  mz_dataflow_channels_3_primary_idx  2  worker  NULL  false
+bar  mz_dataflow_operator_addresses  mz_dataflow_operator_addresses_3_primary_idx  1  id  NULL  false
+bar  mz_dataflow_operator_addresses  mz_dataflow_operator_addresses_3_primary_idx  2  worker  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_3_primary_idx  1  address  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_3_primary_idx  2  port  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_3_primary_idx  3  worker  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_3_primary_idx  4  update_type  NULL  false
+bar  mz_dataflow_operator_reachability_internal  mz_dataflow_operator_reachability_internal_3_primary_idx  5  timestamp  NULL  true
+bar  mz_dataflow_operators  mz_dataflow_operators_3_primary_idx  1  id  NULL  false
+bar  mz_dataflow_operators  mz_dataflow_operators_3_primary_idx  2  worker  NULL  false
+bar  mz_materialization_dependencies  mz_materialization_dependencies_3_primary_idx  1  dataflow  NULL  false
+bar  mz_materialization_dependencies  mz_materialization_dependencies_3_primary_idx  2  source  NULL  false
+bar  mz_materialization_dependencies  mz_materialization_dependencies_3_primary_idx  3  worker  NULL  false
+bar  mz_materializations  mz_materializations_3_primary_idx  1  name  NULL  false
+bar  mz_materializations  mz_materializations_3_primary_idx  2  worker  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_3_primary_idx  1  channel  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_3_primary_idx  2  source_worker  NULL  false
+bar  mz_message_counts_received_internal  mz_message_counts_received_internal_3_primary_idx  3  target_worker  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_3_primary_idx  1  channel  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_3_primary_idx  2  source_worker  NULL  false
+bar  mz_message_counts_sent_internal  mz_message_counts_sent_internal_3_primary_idx  3  target_worker  NULL  false
+bar  mz_peek_active  mz_peek_active_3_primary_idx  1  id  NULL  false
+bar  mz_peek_active  mz_peek_active_3_primary_idx  2  worker  NULL  false
+bar  mz_peek_durations  mz_peek_durations_3_primary_idx  1  worker  NULL  false
+bar  mz_peek_durations  mz_peek_durations_3_primary_idx  2  duration_ns  NULL  false
+bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_3_primary_idx  1  id  NULL  false
+bar  mz_scheduling_elapsed_internal  mz_scheduling_elapsed_internal_3_primary_idx  2  worker  NULL  false
+bar  mz_scheduling_histogram_internal  mz_scheduling_histogram_internal_3_primary_idx  1  id  NULL  false
+bar  mz_scheduling_histogram_internal  mz_scheduling_histogram_internal_3_primary_idx  2  worker  NULL  false
+bar  mz_scheduling_histogram_internal  mz_scheduling_histogram_internal_3_primary_idx  3  duration_ns  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_3_primary_idx  1  worker  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_3_primary_idx  2  slept_for  NULL  false
+bar  mz_scheduling_parks_internal  mz_scheduling_parks_internal_3_primary_idx  3  requested  NULL  false
+bar  mz_worker_materialization_frontiers  mz_worker_materialization_frontiers_3_primary_idx  1  global_id  NULL  false
+bar  mz_worker_materialization_frontiers  mz_worker_materialization_frontiers_3_primary_idx  2  worker  NULL  false
+bar  mz_worker_materialization_frontiers  mz_worker_materialization_frontiers_3_primary_idx  3  time  NULL  false
+bar  v  v_primary_idx  1  ?column?  NULL  false
+
+query TTTTTTT
+SHOW INDEXES;
+----
+bar  v  v_primary_idx  1  ?column?  NULL  false
+foo  v  foo_v_idx  1  ?column?  NULL  false
+
 query T
 SELECT
 	mz_clusters.name
@@ -130,6 +192,7 @@ SET cluster = 'default'
 query T
 SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 ----
+foo_v_idx
 v_primary_idx
 
 statement ok
@@ -175,7 +238,7 @@ statement ok
 DROP CLUSTER bar
 
 statement ok
-DROP CLUSTER foo
+DROP CLUSTER foo CASCADE
 
 statement ok
 CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234']))


### PR DESCRIPTION
Support a bare `SHOW INDEXES` statement, which displays all non indexes
system in all clusters. The `EXTENDED` keyword additionally displays
system indexes.

Fix #13098.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
