### PR TITLE
doc/user: hide `CREATE SINK` documentation and remove mentions

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -94,12 +94,6 @@ url = "/sql/create-materialized-view/"
 weight= 45
 
 [[menu.main]]
-name = "Sinks"
-parent = "reference"
-url = "/sql/create-sink/"
-weight= 60
-
-[[menu.main]]
 name = "Queries (`SELECT`)"
 parent = "reference"
 url = "/sql/select/"

--- a/doc/user/content/cloud/security.md
+++ b/doc/user/content/cloud/security.md
@@ -23,9 +23,9 @@ In the future, the enterprise product will also provide secure network ingress a
 
 All Materialize [Cloud deployments](../cloud-deployments/) come with a static IP address.
 
-This gives you the ability to connect your Materialize Cloud deployments to [sources](../../sql/create-source) and [sinks](../../sql/create-sink/) secured with a firewall.
+This gives you the ability to connect your Materialize Cloud deployments to [sources](../../sql/create-source) secured with a firewall.
 
-Allowing the static IP address enables the connection from your Materialize Cloud deployments to your sources and sinks.
+Allowing the static IP address enables the connection from your Materialize Cloud deployments to your sources.
 
 The specific commands to allow the static IP address will vary depending on your operating system and firewall (e.g. `iptables`, `firewall-cmd`, UFW, AWS, Azure, and etc). Please refer to the appropriate documentation for your specific firewall.
 

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -36,22 +36,22 @@ For listed tools that are not yet production-ready, you can register your intere
 
 ### Kafka
 
-Kafka is supported as a [**source**](/overview/key-concepts/#sources) and as a [**sink**](/overview/key-concepts/#sinks), with features like **upserts**, **Debezium** CDC, and **exactly-once** processing.
+Kafka is supported as a [**source**](/overview/key-concepts/#sources), with features like **upserts** and **Debezium** CDC.
 
 | Service | Support level | Notes |  |
 | --- | --- | --- | --- |
-| Apache Kafka | {{< supportLevel production >}} | See the [source](/sql/create-source/kafka/) and [sink](/sql/create-sink/#kafka-sinks) documentation for more details. |  |
-| Confluent Cloud Kafka | {{< supportLevel production >}} | See the [source](/sql/create-source/kafka/#saslplain) and [sink](/sql/create-sink/#kafka-sinks) documentation for more details. |  |
+| Apache Kafka | {{< supportLevel production >}} | See the [source](/sql/create-source/kafka/) documentation for more details. |  |
+| Confluent Cloud Kafka | {{< supportLevel production >}} | See the [source](/sql/create-source/kafka/#saslplain) documentation for more details. |  |
 | AWS MSK (Managed Streaming for Kafka) | {{< supportLevel production >}} | See the [source documentation](/sql/create-source/kafka/) for more details, and the [AWS MSK guide](/integrations/aws-msk/) for a step-by-step breakdown of the integration.  |  |
-| Heroku Kafka | {{< supportLevel alpha >}} | Use [`SSL` Authentication](/sql/create-source/kafka/#ssl) and the Heroku-provided provided keys and certificates for security, and the `KAFKA_URL` as the broker address (replacing `kafka+ssl://` with `ssl://`). Heroku is not supported as a sink yet ([#8378](https://github.com/MaterializeInc/materialize/issues/8378#issuecomment-1061317275)). | [](#notify) |
+| Heroku Kafka | {{< supportLevel alpha >}} | Use [`SSL` Authentication](/sql/create-source/kafka/#ssl) and the Heroku-provided provided keys and certificates for security, and the `KAFKA_URL` as the broker address (replacing `kafka+ssl://` with `ssl://`). | [](#notify) |
 
 ### Redpanda
 
-Being Kafka API-compatible, Redpanda is supported as a [**source**](/overview/key-concepts/#sources) and as a [**sink**](/overview/key-concepts/#sinks) at the same level and with the same features as Kafka.
+Being Kafka API-compatible, Redpanda is supported as a [**source**](/overview/key-concepts/#sources) at the same level and with the same features as Kafka.
 
 | Service | Support level | Notes |  |
 | --- | --- | --- | --- |
-| Redpanda | {{< supportLevel beta >}} | See the [source](/sql/create-source/kafka/) and [sink](/sql/create-sink/#kafka-sinks) documentation for more details. | [](#notify) |
+| Redpanda | {{< supportLevel beta >}} | See the [source](/sql/create-source/kafka/) and documentation for more details. | [](#notify) |
 | Redpanda Cloud | {{< supportLevel beta >}} | Use [`SASL` authentication](/sql/create-source/kafka/#sasl) to securely connect to Redpanda Cloud clusters. See the [Redpanda documentation](https://docs.redpanda.com/docs/security/acls/#acls) for more details. | [](#notify) |
 
 ### Kinesis Data Streams

--- a/doc/user/content/integrations/redpanda.md
+++ b/doc/user/content/integrations/redpanda.md
@@ -26,4 +26,3 @@ For more information on general Redpanda configuration, see the [Redpanda docume
 ## Related pages
 
 - [`CREATE SOURCE`](/sql/create-source/kafka/)
-- [`CREATE SINK`](/sql/create-sink/#kafka-sinks)

--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -24,9 +24,8 @@ Component | Use
 **Sources** | Sources represent streams (e.g. Kafka) or files that provide data to Materialize.
 **Views** | Views represent queries of sources and other views that you want to save for repeated execution.
 **Indexes** | Indexes represent query results stored in memory.
-**Sinks** | Sinks represent output streams or files that Materialize sends data to.
-**Clusters** | Clusters represent a logical set of indexes and sinks that share physical resources.
-**Cluster replicas** | Cluster replicas provide physical resources for a cluster's indexes and sinks.
+**Clusters** | Clusters represent a logical set of indexes that share physical resources.
+**Cluster replicas** | Cluster replicas provide physical resources for a cluster's indexes.
 
 ## Sources
 
@@ -178,21 +177,10 @@ Creating additional indexes on materialized views lets you store some subset of 
 
 For a deeper dive into arrangments, see [Arrangments](/overview/arrangements/).
 
-## Sinks
-
-Sinks are the inverse of sources and represent a connection to an external stream
-where Materialize outputs data. When a user defines a sink over a materialized view
-or source, Materialize automatically generates the required schema and writes down
-the stream of changes to that view or source. In effect, Materialize sinks act as
-change data capture (CDC) producers for the given source or view.
-
-Currently, Materialize only supports sending sink data to Kafka,
-encoded in Avro with the [Debezium diff envelope](/sql/create-sink#debezium-envelope-details).
-
 ## Clusters
 
 Clusters are logical components that let you express resource isolation for all
-dataflow-powered objects, e.g. indexes and sinks. When creating dataflow-powered
+dataflow-powered objects, e.g. indexes. When creating dataflow-powered
 objects, you must specify which cluster you want to use. (Not explicitly naming
 a cluster uses your session's default cluster.)
 
@@ -256,7 +244,6 @@ Add replicas to a cluster | Greater tolerance to replica failure
 - [`CREATE MATERIALIZED VIEW`](/sql/create-materialized-view)
 - [`CREATE VIEW`](/sql/create-view)
 - [`CREATE INDEX`](/sql/create-index)
-- [`CREATE SINK`](/sql/create-sink)
 - [`CREATE CLUSTER`](/sql/create-cluster)
 - [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica)
 

--- a/doc/user/content/overview/volatility.md
+++ b/doc/user/content/overview/volatility.md
@@ -20,9 +20,7 @@ default) data is only retained for 7 days. If Materialize restarts after
 reading a Kafka stream for longer than this retention period, it might be unable to recover part of the data.
 
 While it is possible to connect to volatile sources in Materialize, the system
-internally tracks the volatility. Features that rely on
-deterministic replay, like [exactly-once sinks](/sql/create-sink/#exactly-once-sinks-with-topic-reuse-after-restart), will not
-support construction atop volatile sources.
+internally tracks the volatility.
 
 ## Rules
 

--- a/doc/user/content/sql/alter-index.md
+++ b/doc/user/content/sql/alter-index.md
@@ -53,4 +53,3 @@ ALTER INDEX some_primary_idx RESET (logical_compaction_window);
 - [`SHOW CREATE VIEW`](/sql/show-create-view)
 - [`SHOW VIEWS`](/sql/show-views)
 - [`SHOW SOURCES`](/sql/show-sources)
-- [`SHOW SINKS`](/sql/show-sinks)

--- a/doc/user/content/sql/alter-rename.md
+++ b/doc/user/content/sql/alter-rename.md
@@ -124,4 +124,3 @@ SHOW VIEWS;
 - [`SHOW VIEWS`](/sql/show-views)
 - [`SHOW SOURCES`](/sql/show-sources)
 - [`SHOW INDEXES`](/sql/show-indexes)
-- [`SHOW SINKS`](/sql/show-sinks)

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -1,18 +1,18 @@
 ---
 title: "CREATE CLUSTER"
-description: "`CREATE CLUSTER` creates a logical cluster, which contains indexes and sinks."
+description: "`CREATE CLUSTER` creates a logical cluster, which contains indexes."
 menu:
   main:
     parent: commands
 ---
 
 `CREATE CLUSTER` creates a logical [cluster](/overview/key-concepts#clusters), which
-contains indexes and sinks.
+contains indexes.
 
 ## Conceptual framework
 
 Clusters are logical components that let you express resource isolation for all
-dataflow-powered objects, e.g. indexes and sinks. When creating dataflow-powered
+dataflow-powered objects, e.g. indexes. When creating dataflow-powered
 objects, you must specify which cluster you want to use. (Not explicitly naming
 a cluster uses your session's default cluster.)
 

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -23,7 +23,7 @@ query in memory. For more information, see [Key Concepts: Materialized views](/o
 Field | Use
 ------|-----
 **TEMP** / **TEMPORARY** | Mark the materialized view as [temporary](#temporary-materialized-views).
-**OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views or sinks depend on, nor can you replace a non-view object with a view.
+**OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views depend on, nor can you replace a non-view object with a view.
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a view of the same name already exists. <br/><br/>If _not_ specified, throw an error if a view of the same name already exists. _(Default)_
 _view&lowbar;name_ | A name for the view.
 **(** _col_ident_... **)** | Rename the `SELECT` statement's columns to the list of identifiers, both of which must be the same length. Note that this is required for statements that return multiple columns with the same identifier.

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -9,7 +9,7 @@ draft: true
     #parent: 'commands'
 ---
 
-[//]: # "NOTE(morsapaes) Once we're ready to bring sinks back, check #12991 to restore the previous docs state."
+[//]: # "NOTE(morsapaes) Once we're ready to bring sinks back, check #13104 to restore the previous docs state."
 
 `CREATE SINK` sends data from Materialize to an external sink.
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -1,12 +1,15 @@
 ---
 title: "CREATE SINK"
 description: "`CREATE SINK` sends data from Materialize to an external sink."
-menu:
+draft: true
+#menu:
   # This should also have a "non-content entry" under Connect, which is
   # configured in doc/user/config.toml
-  main:
-    parent: 'commands'
+  #main:
+    #parent: 'commands'
 ---
+
+[//]: # "NOTE(morsapaes) Once we're ready to bring sinks back, check #12991 to restore the previous docs state."
 
 `CREATE SINK` sends data from Materialize to an external sink.
 

--- a/doc/user/content/sql/create-source/s3.md
+++ b/doc/user/content/sql/create-source/s3.md
@@ -14,7 +14,7 @@ aliases:
     - /sql/create-source/csv-s3
 ---
 
-[//]: # "NOTE(morsapaes) Once we're ready to bring the KDS source back, check #12991 to restore the previous docs state."
+[//]: # "NOTE(morsapaes) Once we're ready to bring the S3 source back, check #12991 to restore the previous docs state."
 
 {{< beta />}}
 

--- a/doc/user/content/sql/create-view.md
+++ b/doc/user/content/sql/create-view.md
@@ -27,7 +27,7 @@ shorthand for performing the query. For more information, see [Key Concepts: Non
 Field | Use
 ------|-----
 **TEMP** / **TEMPORARY** | Mark the view as [temporary](#temporary-views).
-**OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views or sinks depend on, nor can you replace a non-view object with a view.
+**OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views depend on, nor can you replace a non-view object with a view.
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a view of the same name already exists. <br/><br/>If _not_ specified, throw an error if a view of the same name already exists. _(Default)_
 _view&lowbar;name_ | A name for the view.
 **(** _col_ident_... **)** | Rename the `SELECT` statement's columns to the list of identifiers, both of which must be the same length. Note that this is required for statements that return multiple columns with the same identifier.

--- a/doc/user/content/sql/drop-sink.md
+++ b/doc/user/content/sql/drop-sink.md
@@ -1,9 +1,10 @@
 ---
 title: "DROP SINK"
 description: "`DROP SINK` removes a sink from your Materialize instances."
-menu:
-  main:
-    parent: commands
+draft: true
+#menu:
+  #main:
+    #parent: commands
 ---
 
 `DROP SINK` removes a sink from your Materialize instances.

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -1,9 +1,10 @@
 ---
 title: "SHOW CREATE SINK"
 description: "`SHOW CREATE SINK` returns the statement used to create the sink."
-menu:
-  main:
-    parent: commands
+draft: true
+#menu:
+  #main:
+    #parent: commands
 ---
 
 `SHOW CREATE SINK` returns the DDL statement used to create the sink.

--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -9,7 +9,7 @@ aliases:
 ---
 
 `SHOW OBJECTS` returns a list of all objects available to your Materialize instances in a given schema.
-Objects include tables, sources, views, indexes, and sinks.
+Objects include tables, sources, views, and indexes.
 
 ## Syntax
 
@@ -40,8 +40,8 @@ SHOW OBJECTS FROM public;
 ```nofmt
 my_table
 my_source
-my_sink
-my_other_sink
+my_view
+my_other_source
 ```
 ```sql
 SHOW OBJECTS;
@@ -49,18 +49,17 @@ SHOW OBJECTS;
 ```nofmt
 my_table
 my_source
-my_sink
-my_other_sink
+my_view
 ```
 
 ```sql
 SHOW FULL OBJECTS;
 ```
 ```nofmt
-my_table        user
-my_source       user
-my_sink         user
-my_other_sink   user
+my_table
+my_source
+my_view
+my_other_source
 ```
 
 ```sql
@@ -69,8 +68,8 @@ SHOW EXTENDED FULL OBJECTS;
 ```nofmt
 my_table        user
 my_source       user
-my_sink         user
-my_other_sink   user
+my_view         user
+my_other_source user
 builtin_view    system
 ```
 
@@ -80,4 +79,3 @@ builtin_view    system
 - [`SHOW SOURCES`](../show-sources)
 - [`SHOW VIEWS`](../show-views)
 - [`SHOW INDEXES`](../show-indexes)
-- [`SHOW SINKS`](../show-sinks)

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -1,9 +1,10 @@
 ---
 title: "SHOW SINKS"
 description: "`SHOW SINKS` returns a list of all sinks available to your Materialize instances."
-menu:
-  main:
-    parent: commands
+draft: true
+#menu:
+  #main:
+    #parent: commands
 aliases:
     - /sql/show-sink
 ---

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -40,9 +40,7 @@ These schemas contain sources, tables, and views that expose metadata like:
 Whenever possible, applications should prefer to query `mz_catalog` over
 `pg_catalog`. The mapping between Materialize concepts and PostgreSQL concepts
 is not one-to-one, and so the data in `pg_catalog` cannot accurately represent
-the particulars of Materialize. For example, PostgreSQL has no notion of
-[sinks](/sql/create-sink), and therefore `pg_catalog` does not display
-information about the sinks available in a Materialize.
+the particulars of Materialize.
 
 ## `mz_catalog`
 

--- a/doc/user/layouts/partials/sql-grammar/alter-rename.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-rename.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="573" height="213">
+<svg xmlns="http://www.w3.org/2000/svg" width="573" height="169">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="66" height="32" rx="10"/>
@@ -17,38 +17,30 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="145" y="21">INDEX</text>
-   <rect x="137" y="47" width="52" height="32" rx="10"/>
+   <rect x="137" y="47" width="78" height="32" rx="10"/>
    <rect x="135"
          y="45"
-         width="52"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="145" y="65">SINK</text>
-   <rect x="137" y="91" width="78" height="32" rx="10"/>
-   <rect x="135"
-         y="89"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="109">SOURCE</text>
-   <rect x="137" y="135" width="58" height="32" rx="10"/>
+   <text class="terminal" x="145" y="65">SOURCE</text>
+   <rect x="137" y="91" width="58" height="32" rx="10"/>
    <rect x="135"
-         y="133"
+         y="89"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="153">VIEW</text>
-   <rect x="137" y="179" width="66" height="32" rx="10"/>
+   <text class="terminal" x="145" y="109">VIEW</text>
+   <rect x="137" y="135" width="66" height="32" rx="10"/>
    <rect x="135"
-         y="177"
+         y="133"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="197">TABLE</text>
+   <text class="terminal" x="145" y="153">TABLE</text>
    <rect x="255" y="3" width="56" height="32"/>
    <rect x="253" y="1" width="56" height="32" class="nonterminal"/>
    <text class="nonterminal" x="263" y="21">name</text>
@@ -64,7 +56,7 @@
    <rect x="453" y="1" width="90" height="32" class="nonterminal"/>
    <text class="nonterminal" x="463" y="21">new_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m62 0 h10 m0 0 h16 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m52 0 h10 m0 0 h26 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m58 0 h10 m0 0 h20 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m66 0 h10 m0 0 h12 m20 -176 h10 m56 0 h10 m0 0 h10 m104 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m62 0 h10 m0 0 h16 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m58 0 h10 m0 0 h20 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m66 0 h10 m0 0 h12 m20 -132 h10 m56 0 h10 m0 0 h10 m104 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
    <polygon points="563 17 571 13 571 21"/>
    <polygon points="563 17 555 13 555 21"/>
 </svg>

--- a/doc/user/layouts/shortcodes/dbt-materializations.html
+++ b/doc/user/layouts/shortcodes/dbt-materializations.html
@@ -5,5 +5,5 @@ view             | Creates a [view](/sql/create-view).
 materializedview | Creates a [materialized view](/sql/create-materialized-view).
 table            | Creates a [materialized view](/sql/create-materialized-view) (actual table support pending [#5266](https://github.com/MaterializeInc/materialize/issues/5266)).
 index            | (Deprecated) Creates an index.
-sink             | Creates a [sink](/sql/create-sink).
+sink             | Creates a sink.
 ephemeral        | Executes queries using CTEs.

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -1,6 +1,6 @@
 aggregate_with_filter ::= aggregate_name '(' expression ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 alter_rename ::=
-  'ALTER' ('INDEX' | 'SINK' | 'SOURCE' | 'VIEW' | 'TABLE') name 'RENAME TO' new_name
+  'ALTER' ('INDEX' | 'SOURCE' | 'VIEW' | 'TABLE') name 'RENAME TO' new_name
 alter_index ::=
   'ALTER' 'INDEX' name (
     'SET' (


### PR DESCRIPTION
#12894 restricted sinks to `--unsafe-mode`. This PR hides any sink-related reference documentation, and removes mentions to sinks from user-facing docs.

@benesch: I purposely didn't touch `system_catalog.md` (since AFAIU the whole catalog topic will be revisited at some point) + I'll remove `volatility.md` (which has some mentions to sinks) entirely in a separate PR.