### PR TITLE
docs: Separate correctness prop 1 into two props

### DIFF
--- a/doc/developer/platform/ux.md
+++ b/doc/developer/platform/ux.md
@@ -792,12 +792,9 @@ tables or sources in the system catalog.
 Materialize maintains three correctness guarantees.
 
 1. *Transactions in Materialize are strictly serializable with
-   respect to the operations that occur inside of Materialize.*
-   Operations include:
-    * `SELECT`, `INSERT`, `UPDATE`, and `DELETE` statements (but not `TAIL`)
-    * Materialize initiated acknowledgements of upstream sources (*e.g., the
-      commit of an offset by a Kafka source, the acknowledge of an LSN by a
-      PostgresSQL source, etcetera*)
+   respect to the client initiated operations that occur inside of Materialize.*
+   Operations include: `SELECT`, `INSERT`, `UPDATE`, and `DELETE` statements
+   (but not `TAIL`).
 2. *Materialize respects the explicit or implied event order of its sources.
    This includes partial orders.*  In practice this means Materialize assigns
    new timestamps to events in sources.  This assignment of new timestamps is called
@@ -815,6 +812,11 @@ Materialize maintains three correctness guarantees.
    must block on a query until it has complete certainty about the events.
    Blocking may not be desirable in practice, so Materialize makes the behavior
    optional. Non-blocking behavior comes with no guarantees of recency.
+4. *Materialize provides durability guarantees with respect to acknowledgements of
+   upstream sources.* This means that any data from an upstream source that
+   Materialize sends an acknowledgement for (*e.g., the commit of an offset by a
+   Kafka source, the acknowledgement of an LSN by a PostgresSQL source, etcetera*),
+   will be saved in durable storage.
 
 ## Discussion
 


### PR DESCRIPTION
Originally we wanted strict serializability for acknowledgements of
upstream sources. However, we decided that this property was too strong
for our uses, due to its negative availability ramifications. Once an
acknowledgement has been sent by Materialize, then no reads can be
serviced until the upstream source has confirmed that it has received
our acknowledgement. Before the confirmation, Materialize has no way of
knowing if the acknowledgement has been received, and any timestamp
selected for a read will be susceptible to some consistency violation.

For now we have removed this correctness property and changed it so
that upstream acknowledgements only indicate that the data has been
made durable. In the future we may want to include some consistency
guarantees around upstream acknowledgements. Specifically it could be
useful for synchronous replication with upstream sources.

Fixes #13018

### Motivation
Fixes documentation

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
