### PR TITLE
secrets: add SecretsReader to ConnectionContext

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -179,6 +179,8 @@ class Computed(Service):
             command_list.append(f"--process {peers.index(name)}")
             command_list.append(" ".join(f"{peer}:2102" for peer in peers))
 
+        command_list.append("--secrets-path=/mzdata/secrets")
+
         config.update(
             {
                 "command": " ".join(command_list),

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -70,6 +70,9 @@ struct Args {
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
     #[clap(long, value_name = "ID")]
     aws_external_id: Option<String>,
+    /// The path at which secrets are stored.
+    #[clap(long)]
+    secrets_path: PathBuf,
     /// Whether or not process should die when connection with ADAPTER is lost.
     #[clap(long)]
     linger: bool,
@@ -168,6 +171,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         connection_context: ConnectionContext::from_cli_args(
             &args.tracing.log_filter.inner,
             args.aws_external_id,
+            args.secrets_path,
         ),
     };
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -120,7 +120,7 @@ use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
 use mz_repr::{
     Datum, Diff, GlobalId, RelationDesc, RelationType, Row, RowArena, ScalarType, Timestamp,
 };
-use mz_secrets::{SecretOp, SecretsController, SecretsReader};
+use mz_secrets::{SecretOp, SecretsController};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{
     CreateIndexStatement, CreateSourceStatement, ExplainStage, FetchStatement, Ident,
@@ -249,7 +249,6 @@ pub struct Config<S> {
     pub metrics_registry: MetricsRegistry,
     pub now: NowFn,
     pub secrets_controller: Box<dyn SecretsController>,
-    pub secrets_reader: SecretsReader,
     pub availability_zones: Vec<String>,
     pub replica_sizes: ClusterReplicaSizeMap,
     pub connection_context: ConnectionContext,
@@ -5385,7 +5384,6 @@ pub async fn serve<S: Append + 'static>(
         metrics_registry,
         now,
         secrets_controller,
-        secrets_reader,
         replica_sizes,
         availability_zones,
         connection_context,
@@ -5402,7 +5400,7 @@ pub async fn serve<S: Append + 'static>(
         now: now.clone(),
         skip_migrations: false,
         metrics_registry: &metrics_registry,
-        secrets_reader,
+        secrets_reader: connection_context.secrets_reader.clone(),
     })
     .await?;
     let cluster_id = catalog.config().cluster_id;

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -227,6 +227,14 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                     "--pid-file-location={}",
                     pid_file_locations[i].as_ref().unwrap().display()
                 ));
+                args.push(format!(
+                    "--secrets-path={}",
+                    // TODO(benesch): avoid hardcoding this path. The
+                    // integration between the orchestrator and secrets
+                    // controller is about to change substantially, so I don't
+                    // want to do this now.
+                    self.data_dir.join("secrets").display()
+                ));
 
                 let command_wrapper = self.command_wrapper.clone();
                 handles.push(AbortOnDrop(Box::new(mz_ore::task::spawn(

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -73,6 +73,9 @@ struct Args {
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
     #[clap(long, value_name = "ID")]
     aws_external_id: Option<String>,
+    /// The path at which secrets are stored.
+    #[clap(long)]
+    secrets_path: PathBuf,
     /// Whether or not process should die when connection with ADAPTER is lost.
     #[clap(long)]
     linger: bool,
@@ -177,6 +180,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
         connection_context: ConnectionContext::from_cli_args(
             &args.tracing.log_filter.inner,
             args.aws_external_id,
+            args.secrets_path,
         ),
     };
 


### PR DESCRIPTION
This is a small step towards #13017. By putting the `SecretsReader` in
the `ConnectionContext`, we'll have easy access to it in `storaged` (and
`computed`, while sinks still live there) at the moment that we go to
instantiate a Kafka or Confluent Schema Registry connection. The
orchestrators are wired up to pass a new `--secrets-path` argument to
`storaged` and `computed` that tells them where secrets are mounted.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR is a step towards fixing a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
