### PR TITLE
persist: fix invariants of in-memory blob and consensus implementations

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -413,10 +413,11 @@ mod tests {
         cache.cfg.blob_target_size = 10;
         cache.cfg.batch_builder_max_outstanding_parts = 1;
 
+        let uuid = uuid::Uuid::new_v4();
         cache
             .open(PersistLocation {
-                blob_uri: "mem://".to_owned(),
-                consensus_uri: "mem://".to_owned(),
+                blob_uri: format!("mem:///{uuid}/blob"),
+                consensus_uri: format!("mem:///{uuid}/consensus"),
             })
             .await
             .expect("client construction failed")

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -23,6 +23,7 @@ pub mod file;
 pub mod gen;
 pub mod indexed;
 pub mod location;
+#[cfg(any(test, debug_assertions))]
 pub mod mem;
 pub mod postgres;
 pub mod retry;


### PR DESCRIPTION
`persist` uses a `PersistLocation` to identify the location of the data.
When used normally this usually points to S3 or a Postgres database and
the expectation is that two identical `PersistLocation` instances will
point to the same data once opened.

This is violated by the in-memory implementations used during tests
which makes it impossible to test the expected behaviour of
`PersistLocation` or, even worse, allows for tests to pass with the
in-memory locations that wouldn't otherwise pass because the data would
be shared.

The problems above have already forced us to work around them by
introducing a manual `MemBlobRegistry` type that tries to bring back the
expected behaviour.

This PR fixes all the above and deletes the `MemBlobRegistry` workaround
by making the `mem://<path>` scheme work as expected within the same
process. If two locations with identical paths are instanciated they
will end up pointing to the same data, just like a Postgres or S3
location would.
