### PR TITLE
sql: better plan for single table function in scalar position

### DIFF
--- a/test/sqllogictest/table_func.slt
+++ b/test/sqllogictest/table_func.slt
@@ -1364,3 +1364,20 @@ WITH a(x) AS (SELECT 'a') SELECT generate_series(1, 2), * FROM a ORDER BY genera
 ----
 1 a
 2 a
+
+# Test optimization for single table function in scalar position
+# Plan should be just a simple FlatMap + Project
+# Regression test for #10801
+query T multiline
+EXPLAIN PLAN FOR SELECT jsonb_object_keys(a) FROM y;
+----
+Source materialize.public.y (u1):
+| Project (#0)
+
+Query:
+%0 =
+| Get materialize.public.y (u1)
+| FlatMap jsonb_object_keys(#0)
+| Project (#1)
+
+EOF


### PR DESCRIPTION
Table functions (set-returning functions) in scalar position are
currently planned as if they were inside a `ROWS FROM` lateral join,
as Postgres does. The issue fixed in this work arises when there is
a single function, which is indistinguishable from a regular lateral
join, but still used to be planned as if using `ROWS FROM`, which
involves adding ordinality information via `row_number()`, which
unfortunately was quite expensive computationally.

More context in #10801.

### Motivation

  * This PR fixes a recognized bug: #10801

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
