### PR TITLE
dbt-materialize: mark adapter as not supporting cancellation

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,8 +1,15 @@
 # dbt-materialize Changelog
 
+## 1.1.2 - 2022-06-15
+
+* Mark the adapter as not supporting query cancellation, as Materialize does not
+  support the `pg_terminate_backend` function that dbt uses to cancel
+  queries.
+
 ## 1.1.1 - 2022-05-04
 
-* Provide support for storing the results of a test query in a `materializedview` using the [`store_failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures).
+* Provide support for storing the results of a test query in a `materializedview`
+  using the [`store_failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures).
 
 ## 1.1.0 - 2022-05-02
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.1.1"
+version = "1.1.2"

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -23,6 +23,12 @@ class MaterializeAdapter(PostgresAdapter):
     ConnectionManager = MaterializeConnectionManager
     Relation = MaterializeRelation
 
+    @classmethod
+    def is_cancelable(cls) -> bool:
+        # TODO: we can support cancellation if Materialize gets support for
+        # pg_terminate_backend.
+        return False
+
     def _link_cached_relations(self, manifest):
         # NOTE(benesch): this *should* reimplement the parent class's method
         # for Materialize, but presently none of our tests care if we just

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.1.1",
+    version="1.1.2",
     description="The Materialize adapter plugin for dbt (data build tool).",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
As we don't support the pg_terminate_backend function that dbt-postgres
uses to cancel queries.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported by a customer on Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
