### PR TITLE
storage: fix reclocking correctness bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,6 +4012,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "globset",
+ "itertools",
  "mz-avro",
  "mz-ccsr",
  "mz-dataflow-types",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -91,6 +91,10 @@ server = [
     "thiserror"
 ]
 
+[dev-dependencies]
+itertools = "0.10.3"
+tokio = { version = "1.19.2", features = ["test-util"] }
+
 [build-dependencies]
 prost-build = { version = "0.10.3", features = ["vendored"] }
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -157,6 +157,7 @@ where
                 base_metrics: &storage_state.source_metrics,
                 as_of: ingestion.since.clone(),
                 storage_metadata: ingestion.storage_metadata,
+                persist_clients: Arc::clone(&storage_state.persist_clients),
             };
 
             // Build the _raw_ ok and error sources using `create_raw_source` and the
@@ -167,7 +168,6 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
-                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::Delimited(ok), err), cap)
                 }
@@ -177,7 +177,6 @@ where
                             base_source_config,
                             &connection,
                             storage_state.connection_context.clone(),
-                            Arc::clone(&storage_state.persist_clients),
                         );
                     ((SourceType::Delimited(ok), err), cap)
                 }
@@ -186,7 +185,6 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
-                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::ByteStream(ok), err), cap)
                 }
@@ -195,7 +193,6 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
-                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::AppendRow(ok), err), cap)
                 }
@@ -204,7 +201,6 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
-                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::Row(ok), err), cap)
                 }


### PR DESCRIPTION
The reclock operator previously exposed an API that allowed the caller
to map the max observed offset to a reclocked timestamp. This API
allowed for non-definite behaviour in the face of restarts.

The way this would happen is that on the first run a `storaged` would
read data until some offset `X`, and produce some bindings, and then
upon restart another `storaged` instance would read data until some
offset `Y > X` and also try to produce bindings. Since `Y > X` a later
timestamp would be chosen but instead of reclocking only the messages
at offsets `X < offset <= Y` at this new timestamp all the data was
being pushed to the future.

The result is that duplicated data end up in the output.

This PR fixes the above by changing the relock operator API to reclock
individual messages intead of just the upper frontier and also breaks
down the various steps it performs in order to aid understanding and
allow unit testing the code.