### PR TITLE
stash: don't record empty collections during writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,6 +4017,7 @@ dependencies = [
  "postgres-openssl",
  "rand",
  "rusqlite",
+ "tempfile",
  "timely",
  "tokio",
  "tokio-postgres",

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -34,4 +34,5 @@ anyhow = "1.0.57"
 # benchmark is currently unused
 # criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = [ "html_reports" ] }
 mz-postgres-util = { path = "../postgres-util" }
+tempfile = "3.2.0"
 tokio = { version = "1.19.2", features = ["macros"] }


### PR DESCRIPTION
The memory stash was incorrectly setting the collection state to empty on
some write operations instead of reading them from disk when attempting
to update the current cache. Instead, do nothing if we haven't yet read
the other data from disk.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/pull/13115#issuecomment-1157882950

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
