### PR TITLE
environmentd: fix test flake in test_auth_expiry

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -536,7 +536,7 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
             .max_duration(Duration::from_secs(EXPIRES_IN_SECS + 1))
             .retry(|_| {
                 let refreshes = *frontegg_server.refreshes.lock().unwrap();
-                if refreshes == expected {
+                if refreshes >= expected {
                     Ok(())
                 } else {
                     Err(format!(


### PR DESCRIPTION
Allow for more refreshes than expected, which can happen if the Retry
loop waits longer than the refresh interval.

Fixes #12342

### Motivation

  * This PR fixes a recognized bug. #12342

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
