### PR TITLE
persist: support s3 object tags

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -108,6 +108,9 @@ where
                 // Row. Our output type is `(Row, Row)` instead of `(Option<Row>, Option<Row>)`.
                 let empty_row = Row::default();
 
+                // TODO: Get these from somewhere.
+                let s3_object_tags = HashMap::new();
+
                 // TODO(aljoscha): We need to figure out what to do with error results from these calls.
                 let persist_client = persist_location
                     .open()
@@ -115,7 +118,7 @@ where
                     .expect("cannot open persist client");
 
                 let mut write = persist_client
-                    .open_writer::<Row, Row, Timestamp, Diff>(shard_id)
+                    .open_writer::<Row, Row, Timestamp, Diff>(shard_id, s3_object_tags)
                     .await
                     .expect("could not open persist shard");
 

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -372,11 +372,13 @@ where
 
         // Install collection state for each bound source.
         for ingestion in ingestions {
+            // TODO: Get these from somewhere.
+            let s3_object_tags = HashMap::new();
             // TODO(petrosagg): durably record the persist shard we mint here
             let persist_shard = ShardId::new();
             let (write, read) = self
                 .persist_client
-                .open(persist_shard)
+                .open(persist_shard, s3_object_tags)
                 .await
                 .expect("invalid persist usage");
             self.state

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -153,6 +153,7 @@ pub fn bench_blob_get(
                 &key,
                 Bytes::clone(&payload),
                 Atomicity::RequireAtomic,
+                &HashMap::new(),
             ))
             .expect("failed to set blob");
         b.iter(|| {
@@ -203,6 +204,7 @@ async fn bench_blob_set_one_iter(
         &key,
         Bytes::clone(payload),
         Atomicity::RequireAtomic,
+        &HashMap::new(),
     )
     .await
 }

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
 use std::time::Instant;
 
 use criterion::{black_box, Criterion, Throughput};
@@ -59,7 +60,7 @@ async fn bench_writes_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let mut write = client
-        .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new())
+        .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new(), HashMap::new())
         .await?;
 
     // Write the data as fast as we can while keeping each batch in its own
@@ -104,7 +105,7 @@ async fn bench_write_to_listen_one_iter(
     data: &DataGenerator,
 ) -> Result<usize, anyhow::Error> {
     let (mut write, read) = client
-        .open::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new())
+        .open::<Vec<u8>, Vec<u8>, u64, i64>(ShardId::new(), HashMap::new())
         .await?;
 
     // Start the listener in a task before the write so it can't "cheat" by
@@ -191,7 +192,7 @@ pub fn bench_snapshot(
         let shard_id = ShardId::new();
         let (_, as_of) = runtime.block_on(async {
             let mut write = client
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(shard_id)
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(shard_id, HashMap::new())
                 .await
                 .expect("failed to open shard");
             load(&mut write, data).await

--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -219,6 +219,7 @@ impl BlobMulti for MaelstromBlobMulti {
         key: &str,
         value: Bytes,
         _atomic: Atomicity,
+        _tags: &HashMap<String, String>,
     ) -> Result<(), ExternalError> {
         // lin_kv_write is always atomic, so we're free to ignore the atomic
         // param.
@@ -295,10 +296,11 @@ impl BlobMulti for CachingBlobMulti {
         key: &str,
         value: Bytes,
         atomic: Atomicity,
+        tags: &HashMap<String, String>,
     ) -> Result<(), ExternalError> {
         // Intentionally don't put this in the cache on set, so that this blob
         // gets fetched at least once (exercising those code paths).
-        self.blob.set(deadline, key, value, atomic).await
+        self.blob.set(deadline, key, value, atomic, tags).await
     }
 
     async fn delete(&self, deadline: Instant, key: &str) -> Result<(), ExternalError> {

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -106,7 +106,7 @@ pub struct Transactor {
 
 impl Transactor {
     pub async fn new(client: &PersistClient, shard_id: ShardId) -> Result<Self, MaelstromError> {
-        let (mut write, read) = client.open(shard_id).await?;
+        let (mut write, read) = client.open(shard_id, HashMap::new()).await?;
         let since_ts = Self::extract_ts(read.since())?;
         let read_ts = Self::maybe_init_shard(&mut write).await?;
         Ok(Transactor {

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -461,6 +461,8 @@ mod api {
 }
 
 mod raw_persist_benchmark {
+    use std::collections::HashMap;
+
     use async_trait::async_trait;
     use timely::progress::Antichain;
     use tokio::sync::mpsc::Sender;
@@ -496,7 +498,9 @@ mod raw_persist_benchmark {
 
         let mut readers = vec![];
         for _ in 0..num_readers {
-            let (_writer, reader) = persist.open::<Vec<u8>, Vec<u8>, u64, i64>(id).await?;
+            let (_writer, reader) = persist
+                .open::<Vec<u8>, Vec<u8>, u64, i64>(id, HashMap::new())
+                .await?;
 
             let listen = reader
                 .listen(Antichain::from_elem(0))
@@ -525,7 +529,7 @@ mod raw_persist_benchmark {
             let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel(10);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id)
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id, HashMap::new())
                 .await?;
 
             // Intentionally create the span outside the task to set the parent.
@@ -569,7 +573,7 @@ mod raw_persist_benchmark {
             handles.push(handle);
 
             let mut write = persist
-                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id)
+                .open_writer::<Vec<u8>, Vec<u8>, u64, i64>(id, HashMap::new())
                 .await?;
 
             // Intentionally create the span outside the task to set the parent.

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -9,6 +9,7 @@
 
 //! Prometheus monitoring metrics.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -453,13 +454,14 @@ impl BlobMulti for MetricsBlobMulti {
         key: &str,
         value: Bytes,
         atomic: Atomicity,
+        tags: &HashMap<String, String>,
     ) -> Result<(), ExternalError> {
         let bytes = value.len();
         let res = self
             .metrics
             .blob
             .set
-            .run_op(|| self.blob.set(deadline, key, value, atomic))
+            .run_op(|| self.blob.set(deadline, key, value, atomic, &tags))
             .await;
         if res.is_ok() {
             self.metrics.blob.set.bytes.inc_by(u64::cast_from(bytes));

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -10,6 +10,7 @@
 //! Write capabilities and handles
 
 use std::borrow::Borrow;
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -55,6 +56,7 @@ where
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) machine: Machine<K, V, T, D>,
     pub(crate) blob: Arc<dyn BlobMulti + Send + Sync>,
+    pub(crate) blob_tags: HashMap<String, String>,
 
     pub(crate) upper: Antichain<T>,
 }
@@ -436,6 +438,7 @@ where
             size_hint,
             lower,
             Arc::clone(&self.blob),
+            self.blob_tags.clone(),
             self.machine.shard_id().clone(),
         )
     }

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -9,6 +9,7 @@
 
 //! File backed implementations for testing and benchmarking.
 
+use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -114,6 +115,7 @@ impl BlobMulti for FileBlobMulti {
         key: &str,
         value: Bytes,
         atomic: Atomicity,
+        _tags: &HashMap<String, String>,
     ) -> Result<(), ExternalError> {
         let file_path = self.blob_path(key);
         match atomic {

--- a/src/persist/src/indexed/cache.rs
+++ b/src/persist/src/indexed/cache.rs
@@ -164,7 +164,13 @@ impl<B: BlobMulti + Send + Sync + 'static> BlobCache<B> {
         let write_start = Instant::now();
         let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
         self.blob
-            .set(deadline, &key, val, Atomicity::AllowNonAtomic)
+            .set(
+                deadline,
+                &key,
+                val,
+                Atomicity::AllowNonAtomic,
+                &HashMap::new(),
+            )
             .await
             .map_err(|err| self.metric_set_error(err.into()))?;
         self.metrics

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -115,6 +115,7 @@ impl BlobMulti for MemBlobMulti {
         key: &str,
         value: Bytes,
         _atomic: Atomicity,
+        _tags: &HashMap<String, String>,
     ) -> Result<(), ExternalError> {
         // NB: This is always atomic, so we're free to ignore the atomic param.
         self.core.lock().await.set(key, value)

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -9,6 +9,7 @@
 
 //! Test utilities for injecting latency and errors.
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::{Instant, UNIX_EPOCH};
@@ -162,10 +163,11 @@ impl BlobMulti for UnreliableBlobMulti {
         key: &str,
         value: Bytes,
         atomic: Atomicity,
+        tags: &HashMap<String, String>,
     ) -> Result<(), ExternalError> {
         self.handle
             .run_op(deadline, "set", || {
-                self.blob.set(deadline, key, value, atomic)
+                self.blob.set(deadline, key, value, atomic, tags)
             })
             .await
     }

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -64,6 +64,9 @@ pub fn render<G>(
             let mut buffer = Vec::new();
             let mut stash: HashMap<_, Vec<_>> = HashMap::new();
 
+            // TODO: Get these from somewhere.
+            let s3_object_tags = HashMap::new();
+
             let mut write = persist_clients
                 .lock()
                 .await
@@ -72,6 +75,7 @@ pub fn render<G>(
                 .expect("could not open persist client")
                 .open_writer::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(
                     storage_metadata.persist_shard,
+                    s3_object_tags,
                 )
                 .await
                 .expect("could not open persist shard");

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -63,8 +63,11 @@ impl ReclockOperator {
             .await
             .with_context(|| "error creating persist client")?;
 
+        // TODO: Get these from somewhere.
+        let s3_object_tags = HashMap::new();
+
         let (write_handle, read_handle) = persist_client
-            .open::<_, _, _, MzOffset>(timestamp_shard_id)
+            .open::<_, _, _, MzOffset>(timestamp_shard_id, s3_object_tags)
             .await
             .expect("persist handles open err");
 


### PR DESCRIPTION
In the future, these might be targetable by AWS Cost and Usage Reports.
In the interim, they could likely be used for other things internally.

At the request of the cloud team.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Initially marking as draft because it's not 100% clear to me exactly how these should be plumbed into persist. If we only care about tagging things that vary per customer, then it might be nice to avoid all this explicit plumbing and magic them out of thin air inside S3BlobMulti. But if they need to be per-source, then we'll have to plumb them down either from where we make the WriteHandle (this strawman) or perhaps add them to PersistLocation? Hopefully Nikhil or Storage has an opinion on this.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
