### PR TITLE
coord: Implement consistent timestamp recovery

### DIFF
--- a/src/coord/src/catalog.rs
+++ b/src/coord/src/catalog.rs
@@ -2129,6 +2129,16 @@ impl<S: Append> Catalog<S> {
         self.state.allocate_oid()
     }
 
+    /// Get the global timestamp that has been persisted to disk.
+    pub async fn get_persisted_timestamp(&mut self) -> Result<mz_repr::Timestamp, Error> {
+        self.storage().await.get_persisted_timestamp().await
+    }
+
+    /// Persist new global timestamp to disk.
+    pub async fn persist_timestamp(&mut self, timestamp: mz_repr::Timestamp) -> Result<(), Error> {
+        self.storage().await.persist_timestamp(timestamp).await
+    }
+
     pub fn resolve_database(&self, database_name: &str) -> Result<&Database, SqlCatalogError> {
         self.state.resolve_database(database_name)
     }

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -16,6 +16,7 @@ use futures::future::BoxFuture;
 use itertools::max;
 use mz_repr::proto::{IntoRustIfSome, RustType};
 use prost::{self, Message};
+use timely::progress::Timestamp;
 use uuid::Uuid;
 
 use mz_audit_log::VersionedEvent;
@@ -55,6 +56,8 @@ const SCHEMA_ID_ALLOC_KEY: &str = "schema";
 const ROLE_ID_ALLOC_KEY: &str = "role";
 const COMPUTE_ID_ALLOC_KEY: &str = "compute";
 const REPLICA_ID_ALLOC_KEY: &str = "replica";
+
+const EPOCH_MILLIS_TIMESTAMP_KEY: &str = "epoch_millis";
 
 async fn migrate<S: Append>(stash: &mut S, version: u64) -> Result<(), StashError> {
     // Initial state.
@@ -246,6 +249,19 @@ async fn migrate<S: Append>(stash: &mut S, version: u64) -> Result<(), StashErro
                                     } \
                                 }"
                                 .into(),
+                            },
+                        )],
+                    )
+                    .await?;
+                COLLECTION_TIMESTAMP
+                    .upsert(
+                        stash,
+                        vec![(
+                            TimestampKey {
+                                id: EPOCH_MILLIS_TIMESTAMP_KEY.into(),
+                            },
+                            TimestampValue {
+                                ts: mz_repr::Timestamp::minimum(),
                             },
                         )],
                     )
@@ -607,6 +623,30 @@ impl<S: Append> Connection<S> {
             .upsert_key(&mut self.stash, &key, &next)
             .await?;
         Ok((id..next.next_id).collect())
+    }
+
+    /// Get the global timestamp that has been persisted to disk.
+    pub async fn get_persisted_timestamp(&mut self) -> Result<mz_repr::Timestamp, Error> {
+        let key = TimestampKey {
+            id: EPOCH_MILLIS_TIMESTAMP_KEY.to_string(),
+        };
+        Ok(COLLECTION_TIMESTAMP
+            .peek_key_one(&mut self.stash, &key)
+            .await?
+            .expect("must have a persisted timestamp")
+            .ts)
+    }
+
+    /// Persist new global timestamp to disk.
+    pub async fn persist_timestamp(&mut self, timestamp: mz_repr::Timestamp) -> Result<(), Error> {
+        let key = TimestampKey {
+            id: EPOCH_MILLIS_TIMESTAMP_KEY.to_string(),
+        };
+        let value = TimestampValue { ts: timestamp };
+        COLLECTION_TIMESTAMP
+            .upsert_key(&mut self.stash, &key, &value)
+            .await?;
+        Ok(())
     }
 
     pub async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a, S>, Error> {
@@ -1299,6 +1339,20 @@ struct AuditLogKey {
 }
 impl_codec!(AuditLogKey);
 
+#[derive(Clone, Message, PartialOrd, PartialEq, Eq, Ord, Hash)]
+struct TimestampKey {
+    #[prost(string)]
+    id: String,
+}
+impl_codec!(TimestampKey);
+
+#[derive(Clone, Message, PartialOrd, PartialEq, Eq, Ord)]
+struct TimestampValue {
+    #[prost(uint64)]
+    ts: u64,
+}
+impl_codec!(TimestampValue);
+
 static COLLECTION_CONFIG: TypedCollection<String, ConfigValue> = TypedCollection::new("config");
 static COLLECTION_SETTING: TypedCollection<SettingKey, SettingValue> =
     TypedCollection::new("setting");
@@ -1322,3 +1376,5 @@ static COLLECTION_SCHEMA: TypedCollection<SchemaKey, SchemaValue> = TypedCollect
 static COLLECTION_ITEM: TypedCollection<ItemKey, ItemValue> = TypedCollection::new("item");
 static COLLECTION_ROLE: TypedCollection<RoleKey, RoleValue> = TypedCollection::new("role");
 static COLLECTION_AUDIT_LOG: TypedCollection<AuditLogKey, ()> = TypedCollection::new("audit_log");
+static COLLECTION_TIMESTAMP: TypedCollection<TimestampKey, TimestampValue> =
+    TypedCollection::new("timestamp");

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -6235,7 +6235,7 @@ mod timeline {
 
     /// A type that wraps a [`TimestampOracle`] and provides durable timestamps. This allows us to
     /// recover a timestamp that is larger than all previous timestamps on restart. The protocol
-    /// is based on timestamp recovery from Percolator (https://research.google/pubs/pub36726/). We
+    /// is based on timestamp recovery from Percolator <https://research.google/pubs/pub36726/>. We
     /// "pre-allocate" a group of timestamps at once, and only durably store the largest of those
     /// timestamps. All timestamps within that interval can be served directly from memory, without
     /// going to disk. On restart, we re-initialize the current timestamp to a value one larger

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -17,6 +17,7 @@ use std::error::Error;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::thread;
 use std::time::{Duration, Instant};
 
 use axum::response::IntoResponse;
@@ -32,7 +33,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::info;
 
 use mz_ore::assert_contains;
-use mz_ore::now::{NowFn, NOW_ZERO, SYSTEM_TIME};
+use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO, SYSTEM_TIME};
 use mz_ore::task::{self, AbortOnDropHandle, JoinHandleExt};
 
 use crate::util::{MzTimestamp, PostgresErrorExt, KAFKA_ADDRS};
@@ -1217,4 +1218,75 @@ fn test_tail_outlive_cluster() {
             .get::<_, i64>(0),
         0
     );
+}
+
+#[test]
+fn test_timestamp_recovery() -> Result<(), Box<dyn Error>> {
+    mz_ore::test::init_logging();
+    let now = Arc::new(Mutex::new(1_000_000_000));
+    let now_fn = {
+        let timestamp = Arc::clone(&now);
+        NowFn::from(move || *timestamp.lock().unwrap())
+    };
+    let data_dir = tempfile::tempdir()?;
+    let config = util::Config::default()
+        .with_now(now_fn)
+        .data_directory(data_dir.path());
+
+    // Start a server and insert some data to establish the current global timestamp
+    let global_timestamp = {
+        let server = util::start_server(config.clone())?;
+        let mut client = server.connect(postgres::NoTls)?;
+
+        client.batch_execute("CREATE TABLE t1 (i1 INT)")?;
+        insert_with_deterministic_timestamps("t1", "(42)", &server, Arc::clone(&now))?;
+        get_explain_timestamp("t1", &mut client)
+    };
+
+    // Rollback the current time and ensure that a value larger than the old global timestamp is
+    // recovered
+    {
+        *now.lock().expect("lock poisoned") = 0;
+        let server = util::start_server(config)?;
+        let mut client = server.connect(postgres::NoTls)?;
+        let recovered_timestamp = get_explain_timestamp("t1", &mut client);
+        assert!(recovered_timestamp > global_timestamp);
+    }
+
+    Ok(())
+}
+
+/// Group commit will block writes until the current time has advanced. This can make
+/// performing inserts while using deterministic time difficult. This is a helper
+/// method to perform writes and advance the current time.
+fn insert_with_deterministic_timestamps(
+    table: &'static str,
+    values: &'static str,
+    server: &util::Server,
+    now: Arc<Mutex<EpochMillis>>,
+) -> Result<(), Box<dyn Error>> {
+    let mut client_write = server.connect(postgres::NoTls)?;
+    let mut client_read = server.connect(postgres::NoTls)?;
+
+    let current_ts = get_explain_timestamp(table, &mut client_read);
+    let write_thread = thread::spawn(move || {
+        client_write
+            .execute(&format!("INSERT INTO {table} VALUES {values}"), &[])
+            .unwrap();
+    });
+    // Bump `now` by enough for the write to succeed. Table advancements may have increased
+    // the global timestamp by an unknown amount so we bump `now` by a large amount to be safe.
+    *now.lock().expect("lock poisoned") = current_ts + 1_000;
+    write_thread.join().unwrap();
+    Ok(())
+}
+
+fn get_explain_timestamp(table: &str, client: &mut postgres::Client) -> EpochMillis {
+    let row = client
+        .query_one(&format!("EXPLAIN TIMESTAMP FOR SELECT * FROM {table}"), &[])
+        .unwrap();
+    let explain: String = row.get(0);
+    let timestamp_re = Regex::new(r"^\s+timestamp:\s+(\d+)\n").unwrap();
+    let timestamp_caps = timestamp_re.captures(&explain).unwrap();
+    timestamp_caps.get(1).unwrap().as_str().parse().unwrap()
 }


### PR DESCRIPTION
The consistency of certain queries relies on the Coordinator to return
strictly increasing timestamps. The Coordinator returns timestamps with
the help of a global timestamp. Previously, when the Coordinator
started it initialized the global timestamp to the current system
clock. This is fine if the system clock always goes forward, but this
is not always the case. The system clock can go backwards or the
Coordinator can be restarted on a separate machine with a different
clock. As a consequence, it was possible for the global timestamp to
decrease after a restart.

This commit implements a timestamp recovery protocol that is based on
Percolator timestamp recovery (https://research.google/pubs/pub36726/).
When serving a timestamp, we "pre-allocate" a group of timestamps at
once, and only durably store the largest of those timestamps. All
timestamps within that interval can be served directly from memory,
without going to disk. On restart, we re-initialize the current
timestamp to a value one larger than the persisted timestamp.

Works toward resolving #11631

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
* Read section "2.3 Timestamps" of the Percolator paper for context: https://research.google/pubs/pub36726/

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
