### PR TITLE
dataflow-types: proto-ize StorageCommand and StorageResponse

### DIFF
--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -36,6 +36,20 @@ message ProtoAllowCompaction {
     repeated ProtoCompaction collections = 1;
 }
 
+message ProtoFrontierUppersKind {
+    repeated ProtoTrace traces = 1;
+}
+
+message ProtoTrace {
+    mz_repr.global_id.ProtoGlobalId id = 1;
+    repeated ProtoUpdate updates = 2;
+}
+
+message ProtoUpdate {
+    uint64 timestamp = 1;
+    int64 diff = 2;
+}
+
 message ProtoInstanceConfig {
     mz_dataflow_types.logging.ProtoLoggingConfig logging = 1;
     uint64 replica_id = 2;
@@ -72,20 +86,6 @@ message ProtoComputeCommand {
 }
 
 message ProtoComputeResponse {
-    message ProtoUpdate {
-        uint64 timestamp = 1;
-        int64 diff = 2;
-    }
-
-    message ProtoTrace {
-        mz_repr.global_id.ProtoGlobalId id = 1;
-        repeated ProtoUpdate updates = 2;
-    }
-
-    message ProtoFrontierUppersKind {
-        repeated ProtoTrace traces = 1;
-    }
-
     message ProtoPeekResponseKind {
         mz_repr.proto.ProtoU128 id = 1;
         mz_dataflow_types.types.ProtoPeekResponse resp = 2;
@@ -115,3 +115,13 @@ message ProtoStorageCommand {
     }
 }
 
+message ProtoStorageResponse {
+    message ProtoLinearizedTimestampBindingFeedback {
+        uint64 timestamp = 1;
+        mz_repr.proto.ProtoU128 peek_id = 3;
+    }
+    oneof kind {
+        ProtoFrontierUppersKind frontier_uppers = 1;
+        ProtoLinearizedTimestampBindingFeedback linearized_timestamps = 2;
+    }
+}

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -11,6 +11,7 @@ syntax = "proto3";
 
 import "dataflow-types/src/logging.proto";
 import "dataflow-types/src/types.proto";
+import "dataflow-types/src/types/sources.proto";
 import "expr/src/linear.proto";
 import "expr/src/relation.proto";
 import "persist/src/persist.proto";
@@ -24,6 +25,15 @@ package mz_dataflow_types.client;
 
 service ProtoCompute {
     rpc CommandResponseStream (stream ProtoComputeCommand) returns (stream ProtoComputeResponse);
+}
+
+message ProtoCompaction {
+    mz_repr.global_id.ProtoGlobalId id = 1;
+    mz_persist.gen.persist.ProtoU64Antichain frontier = 2;
+}
+
+message ProtoAllowCompaction {
+    repeated ProtoCompaction collections = 1;
 }
 
 message ProtoInstanceConfig {
@@ -45,15 +55,6 @@ message ProtoPeek {
 message ProtoComputeCommand {
     message ProtoCreateDataflows {
         repeated mz_dataflow_types.types.ProtoDataflowDescription dataflows = 1;
-    }
-
-    message ProtoCompaction {
-        mz_repr.global_id.ProtoGlobalId id = 1;
-        mz_persist.gen.persist.ProtoU64Antichain frontier = 2;
-    }
-
-    message ProtoAllowCompaction {
-        repeated ProtoCompaction collections = 1;
     }
 
     message ProtoCancelPeeks {
@@ -102,3 +103,15 @@ message ProtoComputeResponse {
         ProtoTailResponseKind tail_response = 3;
     }
 }
+
+message ProtoStorageCommand {
+    message ProtoCreateSources {
+        repeated mz_dataflow_types.types.sources.ProtoIngestionDescription ingestion_descriptions = 1;
+    }
+
+    oneof kind {
+        ProtoCreateSources create_sources = 1;
+        ProtoAllowCompaction allow_compaction = 2;
+    }
+}
+

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -16,10 +16,12 @@ import "repr/src/global_id.proto";
 import "repr/src/proto.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
+import "persist/src/persist.proto";
 import "dataflow-types/src/errors.proto";
 import "dataflow-types/src/types/connections/aws.proto";
 import "dataflow-types/src/types/connections.proto";
 import "dataflow-types/src/types/sources/encoding.proto";
+import "dataflow-types/src/client/controller/storage.proto";
 import "postgres-util/src/desc.proto";
 
 package mz_dataflow_types.types.sources;
@@ -254,4 +256,17 @@ message ProtoCompression {
 message ProtoSourceDesc {
     ProtoSourceConnection connection = 1;
     mz_repr.relation_and_scalar.ProtoRelationDesc desc = 2;
+}
+
+message ProtoIngestionDescription {
+    // ProtoSourceImport is taken by ProtoDataflowDescription
+    message ProtoSourceMetadataImport {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 2;
+    }
+    repeated ProtoSourceMetadataImport source_imports = 1;
+    mz_repr.global_id.ProtoGlobalId id = 2;
+    ProtoSourceDesc desc = 3;
+    mz_persist.gen.persist.ProtoU64Antichain since = 4;
+    mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 5;
 }


### PR DESCRIPTION
This follows up on @andrioni's work, and implements `StorageCommand` and `StorageResponse` in separate commits:

## `StorageCommand`

- We first have to implement `RustType` and `Arbitrary` for `IngestionDescription<CollectionMetadata, mz_repr::Timestamp`. That struct is used as `IngestionMetadata<(), T>`, internally, but we don't worry about that
- We can share some messages with `ProtoComputeCommand`
- The test runs in a few seconds, and we don't test `IngestionDescription` independently
- We have to convert a `BTreeMap` into a vector to write down the list of source metadata's in `IngestionDescription`. @andrioni, you may know more here, but because we need the ordering, I feel like we have to use `repeated` on the proto side, which does come at a serialization cost to convert to and from

## `StorageResponse`
- We mostly share messages with `ComputeResponse`. Therefore, the test and `RustType` impls are bit of copied code, to share `ChangeBatch`, but I will factor that out in a later commit
- The test runs in a few seconds

### Motivation
  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes
None
