### PR TITLE
persist: hook up an initial implementation of compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3635,6 +3635,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
+ "datadriven",
  "differential-dataflow",
  "futures",
  "futures-task",

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -58,7 +58,7 @@ async-trait = "0.1.56"
 axum = "0.5.9"
 clap = { version = "3.2.6", features = ["derive", "env"] }
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["html_reports"] }
-datadriven = "0.6.0"
+datadriven = { version = "0.6.0", features = ["async"] }
 futures-task = "0.3.21"
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -58,6 +58,7 @@ async-trait = "0.1.56"
 axum = "0.5.9"
 clap = { version = "3.2.6", features = ["derive", "env"] }
 criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["html_reports"] }
+datadriven = "0.6.0"
 futures-task = "0.3.21"
 mz-http-util = { path = "../http-util" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }

--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -213,7 +213,7 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
     let trace = BlobTraceBatchPart {
         desc: Description::new(
             Antichain::from_elem(0),
-            Antichain::from_elem(1),
+            Antichain::new(),
             Antichain::from_elem(0),
         ),
         index: 0,

--- a/src/persist-client/src/impl/compact.rs
+++ b/src/persist-client/src/impl/compact.rs
@@ -1,0 +1,292 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::time::Instant;
+
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
+use mz_persist::indexed::columnar::ColumnarRecordsVecBuilder;
+use mz_persist::location::Blob;
+use mz_persist_types::{Codec, Codec64};
+use timely::progress::Timestamp;
+use tokio::runtime::Handle;
+use tracing::{debug_span, warn, Instrument, Span};
+
+use crate::batch::BatchParts;
+use crate::r#impl::machine::Machine;
+use crate::r#impl::state::HollowBatch;
+use crate::r#impl::trace::FueledMergeRes;
+use crate::read::fetch_batch_part;
+use crate::{Metrics, PersistConfig, ShardId};
+
+/// A request for compaction.
+///
+/// This is similar to FueledMergeReq, but intentionally a different type. If we
+/// move compaction to an rpc server, this one will become a protobuf; the type
+/// parameters will become names of codecs to look up in some registry.
+#[derive(Debug, Clone)]
+pub struct CompactReq<T> {
+    /// The shard the input and output batches belong to.
+    pub shard_id: ShardId,
+    /// A description for the output batch.
+    pub desc: Description<T>,
+    /// The updates to include in the output batch. Any data in these outside of
+    /// the output descriptions bounds should be ignored.
+    pub inputs: Vec<HollowBatch<T>>,
+}
+
+/// A response from compaction.
+#[derive(Debug)]
+pub struct CompactRes<T> {
+    /// The compacted batch.
+    pub output: HollowBatch<T>,
+}
+
+/// A service for performing physical and logical compaction.
+///
+/// This will possibly be called over RPC in the future. Physical compaction is
+/// merging adjacent batches. Logical compaction is advancing timestamps to a
+/// new since and consolidating the resulting updates.
+#[derive(Debug, Clone)]
+pub struct Compactor {
+    cfg: PersistConfig,
+    blob: Arc<dyn Blob + Send + Sync>,
+    metrics: Arc<Metrics>,
+}
+
+impl Compactor {
+    pub fn new(
+        cfg: PersistConfig,
+        blob: Arc<dyn Blob + Send + Sync>,
+        metrics: Arc<Metrics>,
+    ) -> Self {
+        Compactor { cfg, blob, metrics }
+    }
+
+    pub fn compact_and_apply<K, V, T, D>(&self, machine: &Machine<K, V, T, D>, req: CompactReq<T>)
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        assert_eq!(req.shard_id, machine.shard_id());
+
+        // Run some initial heuristics to ignore some requests for compaction.
+        // We don't gain much from e.g. compacting two very small batches that
+        // were just written, but it does result in non-trivial blob traffic
+        // (especially in aggregate). This heuristic is something we'll need to
+        // tune over time.
+        let should_compact = req.inputs.len() >= self.cfg.compaction_heuristic_min_inputs
+            || req.inputs.iter().map(|x| x.len).sum::<usize>()
+                >= self.cfg.compaction_heuristic_min_updates;
+        if !should_compact {
+            self.metrics.compaction.skipped.inc();
+            return;
+        }
+
+        let cfg = self.cfg.clone();
+        let blob = Arc::clone(&self.blob);
+        let metrics = Arc::clone(&self.metrics);
+        let mut machine = machine.clone();
+
+        // Spawn compaction in a background task, so the write that triggered it
+        // isn't blocked on it.
+        let compact_span =
+            debug_span!(parent: None, "compact::apply", shard_id=%machine.shard_id());
+        compact_span.follows_from(&Span::current());
+
+        let _ = mz_ore::task::spawn(
+            || "persist::compact::apply",
+            async move {
+                metrics.compaction.started.inc();
+                let start = Instant::now();
+                let res =
+                    Self::compact::<T, D>(cfg, Handle::current(), blob, Arc::clone(&metrics), req)
+                        .await;
+                metrics
+                    .compaction
+                    .seconds
+                    .inc_by(start.elapsed().as_secs_f64());
+
+                let res = match res {
+                    Ok(res) => res,
+                    Err(err) => {
+                        metrics.compaction.failed.inc();
+                        warn!("compaction for {} failed: {:#}", machine.shard_id(), err);
+                        return;
+                    }
+                };
+                let applied = machine
+                    .merge_res(FueledMergeRes { output: res.output })
+                    .await;
+                if applied {
+                    metrics.compaction.applied.inc();
+                } else {
+                    metrics.compaction.noop.inc();
+                }
+            }
+            .instrument(compact_span),
+        );
+    }
+
+    pub async fn compact<T, D>(
+        cfg: PersistConfig,
+        handle: Handle,
+        blob: Arc<dyn Blob + Send + Sync>,
+        metrics: Arc<Metrics>,
+        req: CompactReq<T>,
+    ) -> Result<CompactRes<T>, anyhow::Error>
+    where
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let compact_blocking = move || {
+            let mut parts = BatchParts::new(
+                cfg.batch_builder_max_outstanding_parts,
+                Arc::clone(&metrics),
+                req.shard_id,
+                req.desc.lower().clone(),
+                Arc::clone(&blob),
+                &metrics.compaction.batch,
+            );
+
+            // TODO: Do this in a bounded amount of memory. The pattern for how
+            // to do this has already been established in old persist (see
+            // background.rs). We'll have to generalize that from 2 to N batches
+            // and also resolve the (much much harder) issue of new persist
+            // batch sorted-ness.
+            let mut updates = Vec::new();
+            for part in req.inputs.iter() {
+                for key in part.keys.iter() {
+                    handle.block_on(fetch_batch_part(
+                        &req.shard_id,
+                        blob.as_ref(),
+                        &metrics,
+                        &key,
+                        &part.desc,
+                        |k, v, mut t, d| {
+                            t.advance_by(req.desc.since().borrow());
+                            let d = D::decode(d);
+                            updates.push(((k.to_vec(), v.to_vec()), t, d));
+                        },
+                    ));
+                }
+            }
+            consolidate_updates(&mut updates);
+
+            let len = updates.len();
+            let mut builder = ColumnarRecordsVecBuilder::new_with_len(cfg.blob_target_size);
+            for ((k, v), t, d) in updates.iter() {
+                builder.push(((k, v), T::encode(t), D::encode(d)));
+
+                // Flush out filled parts as we go to keep bounded memory use.
+                for chunk in builder.take_filled() {
+                    handle.block_on(parts.write(
+                        chunk,
+                        req.desc.upper().clone(),
+                        req.desc.since().clone(),
+                    ));
+                }
+            }
+            for chunk in builder.finish() {
+                handle.block_on(parts.write(
+                    chunk,
+                    req.desc.upper().clone(),
+                    req.desc.since().clone(),
+                ));
+            }
+            let keys = handle.block_on(parts.finish());
+
+            Ok(CompactRes {
+                output: HollowBatch {
+                    desc: req.desc,
+                    keys,
+                    len,
+                },
+            })
+        };
+
+        // Compaction is cpu intensive, so be polite and spawn it on the
+        // blocking threadpool.
+        let compact_span = debug_span!("compact::consolidate");
+        mz_ore::task::spawn_blocking(
+            || "persist::compact::consolidate",
+            move || compact_span.in_scope(compact_blocking),
+        )
+        .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use timely::progress::Antichain;
+
+    use crate::tests::{all_ok, expect_fetch_part, new_test_client};
+
+    use super::*;
+
+    // A regression test for a bug caught during development of #13160 (never
+    // made it to main) where batches written by compaction would always have a
+    // since of the minimum timestamp.
+    #[tokio::test]
+    async fn regression_minimum_since() {
+        mz_ore::test::init_logging();
+
+        let data = vec![
+            (("0".to_owned(), "zero".to_owned()), 0, 1),
+            (("0".to_owned(), "zero".to_owned()), 1, -1),
+            (("1".to_owned(), "one".to_owned()), 1, 1),
+        ];
+
+        let (mut write, _) = new_test_client()
+            .await
+            .expect_open::<String, String, u64, i64>(ShardId::new())
+            .await;
+        let b0 = write
+            .expect_batch(&data[..1], 0, 1)
+            .await
+            .into_hollow_batch();
+        let b1 = write
+            .expect_batch(&data[1..], 1, 2)
+            .await
+            .into_hollow_batch();
+
+        let req = CompactReq {
+            shard_id: write.machine.shard_id(),
+            desc: Description::new(
+                b0.desc.lower().clone(),
+                b1.desc.upper().clone(),
+                Antichain::from_elem(10u64),
+            ),
+            inputs: vec![b0, b1],
+        };
+        let res = Compactor::compact::<u64, i64>(
+            write.cfg.clone(),
+            Handle::current(),
+            Arc::clone(&write.blob),
+            Arc::clone(&write.metrics),
+            req.clone(),
+        )
+        .await
+        .expect("compaction failed");
+
+        assert_eq!(res.output.desc, req.desc);
+        assert_eq!(res.output.len, 1);
+        assert_eq!(res.output.keys.len(), 1);
+        let key = &res.output.keys[0];
+        let (part, updates) = expect_fetch_part(write.blob.as_ref(), key).await;
+        assert_eq!(part.desc, res.output.desc);
+        assert_eq!(updates, all_ok(&data, 10));
+    }
+}

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -30,6 +30,13 @@ pub struct ReadCapability<T> {
     pub since: Antichain<T>,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct HollowBatch<T> {
+    pub(crate) desc: Description<T>,
+    pub(crate) keys: Vec<String>,
+    pub(crate) len: usize,
+}
+
 // TODO: Document invariants.
 #[derive(Debug, Clone)]
 pub struct StateCollections<T> {

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -21,6 +21,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 use crate::error::{Determinacy, InvalidUsage};
+use crate::r#impl::trace::Trace;
 use crate::read::ReaderId;
 use crate::ShardId;
 
@@ -42,8 +43,7 @@ pub struct HollowBatch<T> {
 pub struct StateCollections<T> {
     readers: HashMap<ReaderId, ReadCapability<T>>,
 
-    since: Antichain<T>,
-    trace: Vec<(Vec<String>, Description<T>)>,
+    trace: Trace<T>,
 }
 
 impl<T> StateCollections<T>
@@ -59,10 +59,10 @@ where
         // retry).
         let read_cap = ReadCapability {
             seqno,
-            since: self.since.clone(),
+            since: self.trace.since().clone(),
         };
         self.readers.insert(reader_id.clone(), read_cap.clone());
-        Continue((Upper(self.upper()), read_cap))
+        Continue((Upper(self.trace.upper().clone()), read_cap))
     }
 
     pub fn clone_reader(
@@ -73,7 +73,7 @@ where
         // TODO: Handle if the reader already exists (probably with a retry).
         let read_cap = ReadCapability {
             seqno,
-            since: self.since.clone(),
+            since: self.trace.since().clone(),
         };
         self.readers.insert(new_reader_id.clone(), read_cap.clone());
         Continue(read_cap)
@@ -81,32 +81,34 @@ where
 
     pub fn compare_and_append(
         &mut self,
-        keys: &[String],
-        desc: &Description<T>,
+        batch: &HollowBatch<T>,
     ) -> ControlFlow<Result<Upper<T>, InvalidUsage<T>>, ()> {
-        if PartialOrder::less_than(desc.upper(), desc.lower()) {
+        if PartialOrder::less_than(batch.desc.upper(), batch.desc.lower()) {
             return Break(Err(InvalidUsage::InvalidBounds {
-                lower: desc.lower().clone(),
-                upper: desc.upper().clone(),
+                lower: batch.desc.lower().clone(),
+                upper: batch.desc.upper().clone(),
             }));
         }
 
-        // If the time iterval is empty, the list of updates must also be empty.
-        if desc.upper() == desc.lower() && !keys.is_empty() {
+        // If the time interval is empty, the list of updates must also be
+        // empty.
+        if batch.desc.upper() == batch.desc.lower() && !batch.keys.is_empty() {
             return Break(Err(InvalidUsage::InvalidEmptyTimeInterval {
-                lower: desc.lower().clone(),
-                upper: desc.upper().clone(),
-                keys: keys.to_vec(),
+                lower: batch.desc.lower().clone(),
+                upper: batch.desc.upper().clone(),
+                keys: batch.keys.to_vec(),
             }));
         }
 
-        let shard_upper = self.upper();
-        if &shard_upper != desc.lower() {
-            return Break(Ok(Upper(shard_upper)));
+        let shard_upper = self.trace.upper();
+        if shard_upper != batch.desc.lower() {
+            return Break(Ok(Upper(shard_upper.clone())));
         }
 
-        self.push_batch(keys, desc);
-        debug_assert_eq!(&self.upper(), desc.upper());
+        if batch.desc.upper() != batch.desc.lower() {
+            self.trace.push_batch(batch.clone());
+        }
+        debug_assert_eq!(self.trace.upper(), batch.desc.upper());
 
         Continue(())
     }
@@ -139,13 +141,6 @@ where
         Continue(existed)
     }
 
-    fn upper(&self) -> Antichain<T> {
-        self.trace.last().map_or_else(
-            || Antichain::from_elem(T::minimum()),
-            |(_, desc)| desc.upper().clone(),
-        )
-    }
-
     fn reader(&mut self, id: &ReaderId) -> &mut ReadCapability<T> {
         self.readers
             .get_mut(id)
@@ -169,31 +164,7 @@ where
         while let Some(reader) = readers.next() {
             since.meet_assign(&reader.since);
         }
-        self.since = since;
-    }
-
-    fn push_batch(&mut self, keys: &[String], desc: &Description<T>) {
-        // Sneaky optimization! If there are no keys in this batch, we can
-        // simply extend the description of the last one (assuming there is
-        // one). This will be an absurdly common case in actual usage because
-        // empty batches are used to communicate progress and most things will
-        // be low-traffic.
-        //
-        // To make things easier to reason about, we avoid mutating any batch
-        // that actually has data, and only apply the optimization if the most
-        // recent batch _also_ has no keys. We call these batches with no keys
-        // "padding batches".
-        if let Some((last_batch_keys, last_desc)) = self.trace.last_mut() {
-            if keys.is_empty() && last_batch_keys.is_empty() {
-                *last_desc = Description::new(
-                    last_desc.lower().clone(),
-                    desc.upper().clone(),
-                    last_desc.since().clone(),
-                );
-                return;
-            }
-        }
-        self.trace.push((keys.to_owned(), desc.clone()));
+        self.trace.downgrade_since(since);
     }
 }
 
@@ -240,8 +211,7 @@ where
             seqno: SeqNo::minimum(),
             collections: StateCollections {
                 readers: HashMap::new(),
-                since: Antichain::from_elem(T::minimum()),
-                trace: Vec::new(),
+                trace: Trace::default(),
             },
             _phantom: PhantomData,
         }
@@ -267,7 +237,7 @@ where
     }
 
     pub fn upper(&self) -> Antichain<T> {
-        self.collections.upper()
+        self.collections.trace.upper().clone()
     }
 
     pub fn clone_apply<R, E, WorkFn>(&self, work_fn: &mut WorkFn) -> ControlFlow<E, (R, Self)>
@@ -291,50 +261,53 @@ where
         &self,
         as_of: &Antichain<T>,
     ) -> Result<Result<Vec<(String, Description<T>)>, Upper<T>>, Since<T>> {
-        if PartialOrder::less_than(as_of, &self.collections.since) {
-            return Err(Since(self.collections.since.clone()));
+        if PartialOrder::less_than(as_of, self.collections.trace.since()) {
+            return Err(Since(self.collections.trace.since().clone()));
         }
-        let upper = self.collections.upper();
-        if PartialOrder::less_equal(&upper, as_of) {
-            return Ok(Err(Upper(upper)));
+        let upper = self.collections.trace.upper();
+        if PartialOrder::less_equal(upper, as_of) {
+            return Ok(Err(Upper(upper.clone())));
         }
-        let batches = self
-            .collections
-            .trace
-            .iter()
-            .filter(|(_keys, desc)| !PartialOrder::less_than(as_of, desc.lower()))
-            .flat_map(|(keys, desc)| keys.iter().map(|key| (key.clone(), desc.clone())))
-            .collect();
 
+        let mut batches = Vec::new();
+        self.collections.trace.map_batches(|b| {
+            if PartialOrder::less_than(as_of, b.desc.lower()) {
+                return;
+            }
+            for key in b.keys.iter() {
+                batches.push((key.clone(), b.desc.clone()))
+            }
+        });
         Ok(Ok(batches))
     }
 
     // NB: Unlike the other methods here, this one is read-only.
     pub fn verify_listen(&self, as_of: &Antichain<T>) -> Result<Result<(), Upper<T>>, Since<T>> {
-        if PartialOrder::less_than(as_of, &self.collections.since) {
-            return Err(Since(self.collections.since.clone()));
+        if PartialOrder::less_than(as_of, self.collections.trace.since()) {
+            return Err(Since(self.collections.trace.since().clone()));
         }
-        let upper = self.collections.upper();
-        if PartialOrder::less_equal(&upper, as_of) {
-            return Ok(Err(Upper(upper)));
+        let upper = self.collections.trace.upper();
+        if PartialOrder::less_equal(upper, as_of) {
+            return Ok(Err(Upper(upper.clone())));
         }
         Ok(Ok(()))
     }
 
-    pub fn next_listen_batch(
-        &self,
-        frontier: &Antichain<T>,
-    ) -> Option<(&[String], &Description<T>)> {
+    pub fn next_listen_batch(&self, frontier: &Antichain<T>) -> Option<HollowBatch<T>> {
         // TODO: Avoid the O(n^2) here: `next_listen_batch` is called once per
         // batch and this iterates through all batches to find the next one.
-        for (keys, desc) in self.collections.trace.iter() {
-            if PartialOrder::less_equal(desc.lower(), frontier)
-                && PartialOrder::less_than(frontier, desc.upper())
-            {
-                return Some((keys.as_slice(), desc));
+        let mut ret = None;
+        self.collections.trace.map_batches(|b| {
+            if ret.is_some() {
+                return;
             }
-        }
-        return None;
+            if PartialOrder::less_equal(b.desc.lower(), frontier)
+                && PartialOrder::less_than(frontier, b.desc.upper())
+            {
+                ret = Some(b.clone());
+            }
+        });
+        ret
     }
 }
 
@@ -367,6 +340,20 @@ pub struct DescriptionMeta {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct BatchMeta {
+    desc: DescriptionMeta,
+    keys: Vec<String>,
+    len: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TraceMeta {
+    since: AntichainMeta,
+    // TODO: Should this more directly reflect the SpineBatch structure?
+    spine: Vec<BatchMeta>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct StateRollupMeta {
     shard_id: ShardId,
     key_codec: String,
@@ -376,8 +363,7 @@ struct StateRollupMeta {
 
     seqno: SeqNo,
     readers: Vec<(ReaderId, AntichainMeta, SeqNo)>,
-    since: AntichainMeta,
-    trace: Vec<(Vec<String>, DescriptionMeta)>,
+    trace: TraceMeta,
 }
 
 mod codec_impls {
@@ -387,11 +373,14 @@ mod codec_impls {
     use differential_dataflow::trace::Description;
     use mz_persist_types::{Codec, Codec64};
     use timely::progress::{Antichain, Timestamp};
+    use timely::PartialOrder;
 
     use crate::error::InvalidUsage;
     use crate::r#impl::state::{
-        AntichainMeta, DescriptionMeta, ReadCapability, State, StateCollections, StateRollupMeta,
+        AntichainMeta, BatchMeta, DescriptionMeta, HollowBatch, ReadCapability, State,
+        StateCollections, StateRollupMeta, TraceMeta,
     };
+    use crate::r#impl::trace::Trace;
 
     impl<K, V, T, D> Codec for State<K, V, T, D>
     where
@@ -425,7 +414,7 @@ mod codec_impls {
     where
         K: Codec,
         V: Codec,
-        T: Codec64,
+        T: Timestamp + Lattice + Codec64,
         D: Codec64,
     {
         fn from(x: &State<K, V, T, D>) -> Self {
@@ -442,13 +431,7 @@ mod codec_impls {
                     .iter()
                     .map(|(id, cap)| (id.clone(), (&cap.since).into(), cap.seqno))
                     .collect(),
-                since: (&x.collections.since).into(),
-                trace: x
-                    .collections
-                    .trace
-                    .iter()
-                    .map(|(key, desc)| (key.clone(), desc.into()))
-                    .collect(),
+                trace: (&x.collections.trace).into(),
             }
         }
     }
@@ -457,7 +440,7 @@ mod codec_impls {
     where
         K: Codec,
         V: Codec,
-        T: Timestamp + Codec64,
+        T: Timestamp + Lattice + Codec64,
         D: Codec64,
     {
         type Error = InvalidUsage<T>;
@@ -495,16 +478,9 @@ mod codec_impls {
                     (id.clone(), cap)
                 })
                 .collect();
-            let since = (&x.since).into();
-            let trace = x
-                .trace
-                .iter()
-                .map(|(key, desc)| (key.clone(), desc.into()))
-                .collect();
             let collections = StateCollections {
                 readers,
-                since,
-                trace,
+                trace: (&x.trace).into(),
             };
             Ok(State {
                 shard_id: x.shard_id,
@@ -512,6 +488,68 @@ mod codec_impls {
                 collections,
                 _phantom: PhantomData,
             })
+        }
+    }
+
+    impl<T> From<&Trace<T>> for TraceMeta
+    where
+        T: Timestamp + Lattice + Codec64,
+    {
+        fn from(x: &Trace<T>) -> Self {
+            let mut spine = Vec::new();
+            x.map_batches(|b| {
+                spine.push(BatchMeta {
+                    desc: (&b.desc).into(),
+                    keys: b.keys.clone(),
+                    len: b.len,
+                })
+            });
+            TraceMeta {
+                since: x.since().into(),
+                spine,
+            }
+        }
+    }
+
+    impl<T> From<&TraceMeta> for Trace<T>
+    where
+        T: Timestamp + Lattice + Codec64,
+    {
+        fn from(x: &TraceMeta) -> Self {
+            let mut ret = Trace::default();
+            ret.downgrade_since((&x.since).into());
+            for batch in x.spine.iter() {
+                let batch = HollowBatch::from(batch);
+                if PartialOrder::less_than(ret.since(), batch.desc.since()) {
+                    panic!(
+                        "invalid TraceMeta: the spine's since was less than a batch's since: {:?}",
+                        x
+                    )
+                }
+                // TODO: Can we rehydrate the Spine more directly?
+                ret.push_batch(batch);
+            }
+            ret
+        }
+    }
+
+    impl<T: Codec64> From<&HollowBatch<T>> for BatchMeta {
+        fn from(x: &HollowBatch<T>) -> Self {
+            BatchMeta {
+                desc: (&x.desc).into(),
+                keys: x.keys.clone(),
+                len: x.len,
+            }
+        }
+    }
+
+    impl<T: Timestamp + Codec64> From<&BatchMeta> for HollowBatch<T> {
+        fn from(x: &BatchMeta) -> Self {
+            HollowBatch {
+                desc: (&x.desc).into(),
+                keys: x.keys.clone(),
+                len: x.len,
+            }
         }
     }
 
@@ -558,6 +596,18 @@ mod tests {
         )
     }
 
+    fn hollow<T: Timestamp>(lower: T, upper: T, keys: &[&str], len: usize) -> HollowBatch<T> {
+        HollowBatch {
+            desc: Description::new(
+                Antichain::from_elem(lower),
+                Antichain::from_elem(upper),
+                Antichain::from_elem(T::minimum()),
+            ),
+            keys: keys.iter().map(|x| (*x).to_owned()).collect(),
+            len,
+        }
+    }
+
     #[test]
     fn downgrade_since() {
         let mut state = State::<(), (), u64, i64>::new(ShardId::new());
@@ -565,7 +615,7 @@ mod tests {
         let _ = state.collections.register(SeqNo::minimum(), &reader);
 
         // The shard global since == 0 initially.
-        assert_eq!(state.collections.since, Antichain::from_elem(0));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(0));
 
         // Greater
         assert_eq!(
@@ -574,7 +624,7 @@ mod tests {
                 .downgrade_since(&reader, &Antichain::from_elem(2)),
             Continue(Since(Antichain::from_elem(2)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(2));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(2));
         // Equal (no-op)
         assert_eq!(
             state
@@ -582,7 +632,7 @@ mod tests {
                 .downgrade_since(&reader, &Antichain::from_elem(2)),
             Continue(Since(Antichain::from_elem(2)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(2));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(2));
         // Less (no-op)
         assert_eq!(
             state
@@ -590,7 +640,7 @@ mod tests {
                 .downgrade_since(&reader, &Antichain::from_elem(1)),
             Continue(Since(Antichain::from_elem(2)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(2));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(2));
 
         // Create a second reader.
         let reader2 = ReaderId::new();
@@ -603,7 +653,7 @@ mod tests {
                 .downgrade_since(&reader2, &Antichain::from_elem(3)),
             Continue(Since(Antichain::from_elem(3)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(2));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(2));
         // Shard since == 3 when all readers have since >= 3.
         assert_eq!(
             state
@@ -611,11 +661,11 @@ mod tests {
                 .downgrade_since(&reader, &Antichain::from_elem(5)),
             Continue(Since(Antichain::from_elem(5)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(3));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
 
         // Shard since unaffected readers with since > shard since expiring.
         assert_eq!(state.collections.expire_reader(&reader), Continue(true));
-        assert_eq!(state.collections.since, Antichain::from_elem(3));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
 
         // Create a third reader.
         let reader3 = ReaderId::new();
@@ -628,18 +678,21 @@ mod tests {
                 .downgrade_since(&reader3, &Antichain::from_elem(10)),
             Continue(Since(Antichain::from_elem(10)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(3));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
 
         // Shard since advances when reader with the minimal since expires.
         assert_eq!(state.collections.expire_reader(&reader2), Continue(true));
-        assert_eq!(state.collections.since, Antichain::from_elem(10));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
 
         // Shard since unaffected when all readers are expired.
         assert_eq!(state.collections.expire_reader(&reader3), Continue(true));
-        assert_eq!(state.collections.since, Antichain::from_elem(10));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
     }
 
+    // WIP Spine already has an empty batch optimization but it's not quite as
+    // aggressive as our current one. Resolve.
     #[test]
+    #[cfg(WIP)]
     fn empty_batch_optimization() {
         mz_ore::test::init_logging();
 
@@ -694,21 +747,25 @@ mod tests {
         mz_ore::test::init_logging();
         let mut state = State::<String, String, u64, i64>::new(ShardId::new()).collections;
 
-        // State is initally empty.
-        assert_eq!(state.trace.len(), 0);
+        // State is initially empty.
+        assert_eq!(state.trace.num_spine_batches(), 0);
+        assert_eq!(state.trace.num_hollow_batches(), 0);
+        assert_eq!(state.trace.num_updates(), 0);
 
         // Cannot insert a batch with a lower != current shard upper.
         assert_eq!(
-            state.compare_and_append(&["key1".to_owned()], &desc(1, 2)),
+            state.compare_and_append(&hollow(1, 2, &["key1"], 1)),
             Break(Ok(Upper(Antichain::from_elem(0))))
         );
 
         // Insert an empty batch with an upper > lower..
-        assert_eq!(state.compare_and_append(&[], &desc(0, 5)), Continue(()));
+        assert!(state
+            .compare_and_append(&hollow(0, 5, &[], 0))
+            .is_continue());
 
         // Cannot insert a batch with a upper less than the lower.
         assert_eq!(
-            state.compare_and_append(&["key1".to_owned()], &desc(5, 4)),
+            state.compare_and_append(&hollow(5, 4, &["key1"], 1)),
             Break(Err(InvalidBounds {
                 lower: Antichain::from_elem(5),
                 upper: Antichain::from_elem(4)
@@ -717,7 +774,7 @@ mod tests {
 
         // Cannot insert a nonempty batch with an upper equal to lower.
         assert_eq!(
-            state.compare_and_append(&["key1".to_owned()], &desc(5, 5)),
+            state.compare_and_append(&hollow(5, 5, &["key1"], 1)),
             Break(Err(InvalidEmptyTimeInterval {
                 lower: Antichain::from_elem(5),
                 upper: Antichain::from_elem(5),
@@ -726,7 +783,9 @@ mod tests {
         );
 
         // Can insert an empty batch with an upper equal to lower.
-        assert_eq!(state.compare_and_append(&[], &desc(5, 5)), Continue(()));
+        assert!(state
+            .compare_and_append(&hollow(5, 5, &[], 0))
+            .is_continue());
     }
 
     #[test]
@@ -747,12 +806,10 @@ mod tests {
         );
 
         // Advance upper to 5.
-        assert_eq!(
-            state
-                .collections
-                .compare_and_append(&["key1".to_owned()], &desc(0, 5)),
-            Continue(())
-        );
+        assert!(state
+            .collections
+            .compare_and_append(&hollow(0, 5, &["key1"], 1))
+            .is_continue());
 
         // Can take a snapshot with as_of < upper.
         assert_eq!(
@@ -785,7 +842,7 @@ mod tests {
                 .downgrade_since(&reader, &Antichain::from_elem(2)),
             Continue(Since(Antichain::from_elem(2)))
         );
-        assert_eq!(state.collections.since, Antichain::from_elem(2));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(2));
         // Cannot take a snapshot with as_of < shard_since.
         assert_eq!(
             state.snapshot(&Antichain::from_elem(1)),
@@ -793,10 +850,10 @@ mod tests {
         );
 
         // Advance the upper to 10 via an empty batch.
-        assert_eq!(
-            state.collections.compare_and_append(&[], &desc(5, 10)),
-            Continue(())
-        );
+        assert!(state
+            .collections
+            .compare_and_append(&hollow(5, 10, &[], 0))
+            .is_continue());
 
         // Can still take snapshots at times < upper, but the empty batch is missing
         // because of a performance optimization.
@@ -812,12 +869,10 @@ mod tests {
         );
 
         // Advance upper to 15.
-        assert_eq!(
-            state
-                .collections
-                .compare_and_append(&["key2".to_owned()], &desc(10, 15)),
-            Continue(())
-        );
+        assert!(state
+            .collections
+            .compare_and_append(&hollow(10, 15, &["key2"], 1))
+            .is_continue());
 
         // Filter out batches whose lowers are less than the requested as of (the
         // batches that are too far in the future for the requested as_of).
@@ -856,24 +911,20 @@ mod tests {
         assert_eq!(state.next_listen_batch(&Antichain::new()), None);
 
         // Add two batches of data, one from [0, 5) and then another from [5, 10).
-        assert_eq!(
-            state
-                .collections
-                .compare_and_append(&["key1".to_owned()], &desc(0, 5)),
-            Continue(())
-        );
-        assert_eq!(
-            state
-                .collections
-                .compare_and_append(&["key2".to_owned()], &desc(5, 10)),
-            Continue(())
-        );
+        assert!(state
+            .collections
+            .compare_and_append(&hollow(0, 5, &["key1"], 1))
+            .is_continue());
+        assert!(state
+            .collections
+            .compare_and_append(&hollow(5, 10, &["key2"], 1))
+            .is_continue());
 
         // All frontiers in [0, 5) return the first batch.
         for t in 0..=4 {
             assert_eq!(
                 state.next_listen_batch(&Antichain::from_elem(t)),
-                Some((vec!["key1".to_owned()].as_slice(), &desc(0, 5)))
+                Some(hollow(0, 5, &["key1"], 1))
             );
         }
 
@@ -881,7 +932,7 @@ mod tests {
         for t in 5..=9 {
             assert_eq!(
                 state.next_listen_batch(&Antichain::from_elem(t)),
-                Some((vec!["key2".to_owned()].as_slice(), &desc(5, 10)))
+                Some(hollow(5, 10, &["key2"], 1))
             );
         }
 

--- a/src/persist-client/src/impl/trace.rs
+++ b/src/persist-client/src/impl/trace.rs
@@ -1,0 +1,965 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt::Debug;
+
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::logging::{BatchEvent, DropEvent, Logger, MergeEvent};
+use differential_dataflow::trace::cursor::{Cursor, CursorList};
+use differential_dataflow::trace::{Batch, BatchReader, Builder, Merger};
+use timely::dataflow::operators::generic::OperatorInfo;
+use timely::order::PartialOrder;
+use timely::progress::Timestamp;
+use timely::progress::{frontier::AntichainRef, Antichain};
+use timely::scheduling::Activator;
+
+/// An append-only collection of update batches.
+///
+/// The `Spine` is a general-purpose trace implementation based on collection
+/// and merging immutable batches of updates. It is generic with respect to the
+/// batch type, and can be instantiated for any implementor of `trace::Batch`.
+///
+/// ## Design
+///
+/// This spine is represented as a list of layers, where each element in the
+/// list is either
+///
+///   1. MergeState::Vacant  empty
+///   2. MergeState::Single  a single batch
+///   3. MergeState::Double  a pair of batches
+///
+/// Each "batch" has the option to be `None`, indicating a non-batch that
+/// nonetheless acts as a number of updates proportionate to the level at which
+/// it exists (for bookkeeping).
+///
+/// Each of the batches at layer i contains at most 2^i elements. The sequence
+/// of batches should have the upper bound of one match the lower bound of the
+/// next. Batches may be logically empty, with matching upper and lower bounds,
+/// as a bookkeeping mechanism.
+///
+/// Each batch at layer i is treated as if it contains exactly 2^i elements,
+/// even though it may actually contain fewer elements. This allows us to
+/// decouple the physical representation from logical amounts of effort invested
+/// in each batch. It allows us to begin compaction and to reduce the number of
+/// updates, without compromising our ability to continue to move updates along
+/// the spine. We are explicitly making the trade-off that while some batches
+/// might compact at lower levels, we want to treat them as if they contained
+/// their full set of updates for accounting reasons (to apply work to higher
+/// levels).
+///
+/// We maintain the invariant that for any in-progress merge at level k there
+/// should be fewer than 2^k records at levels lower than k. That is, even if we
+/// were to apply an unbounded amount of effort to those records, we would not
+/// have enough records to prompt a merge into the in-progress merge. Ideally,
+/// we maintain the extended invariant that for any in-progress merge at level
+/// k, the remaining effort required (number of records minus applied effort) is
+/// less than the number of records that would need to be added to reach 2^k
+/// records in layers below.
+///
+/// ## Mathematics
+///
+/// When a merge is initiated, there should be a non-negative *deficit* of
+/// updates before the layers below could plausibly produce a new batch for the
+/// currently merging layer. We must determine a factor of proportionality, so
+/// that newly arrived updates provide at least that amount of "fuel" towards
+/// the merging layer, so that the merge completes before lower levels invade.
+///
+/// ### Deficit:
+///
+/// A new merge is initiated only in response to the completion of a prior
+/// merge, or the introduction of new records from outside. The latter case is
+/// special, and will maintain our invariant trivially, so we will focus on the
+/// former case.
+///
+/// When a merge at level k completes, assuming we have maintained our invariant
+/// then there should be fewer than 2^k records at lower levels. The newly
+/// created merge at level k+1 will require up to 2^k+2 units of work, and
+/// should not expect a new batch until strictly more than 2^k records are
+/// added. This means that a factor of proportionality of four should be
+/// sufficient to ensure that the merge completes before a new merge is
+/// initiated.
+///
+/// When new records get introduced, we will need to roll up any batches at
+/// lower levels, which we treat as the introduction of records. Each of these
+/// virtual records introduced should either be accounted for the fuel it should
+/// contribute, as it results in the promotion of batches closer to in-progress
+/// merges.
+///
+/// ### Fuel sharing
+///
+/// We like the idea of applying fuel preferentially to merges at *lower*
+/// levels, under the idea that they are easier to complete, and we benefit from
+/// fewer total merges in progress. This does delay the completion of merges at
+/// higher levels, and may not obviously be a total win. If we choose to do
+/// this, we should make sure that we correctly account for completed merges at
+/// low layers: they should still extract fuel from new updates even though they
+/// have completed, at least until they have paid back any "debt" to higher
+/// layers by continuing to provide fuel as updates arrive.
+pub struct Spine<B: Batch>
+where
+    B::Time: Lattice + Ord,
+    B::R: Semigroup,
+{
+    operator: OperatorInfo,
+    logger: Option<Logger>,
+    logical_frontier: Antichain<B::Time>, // Times after which the trace must accumulate correctly.
+    physical_frontier: Antichain<B::Time>, // Times after which the trace must be able to subset its inputs.
+    merging: Vec<MergeState<B>>,           // Several possibly shared collections of updates.
+    pending: Vec<B>,                       // Batches at times in advance of `frontier`.
+    upper: Antichain<B::Time>,
+    effort: usize,
+    activator: Option<timely::scheduling::activate::Activator>,
+}
+
+impl<B> Spine<B>
+where
+    B: Batch + Clone + 'static,
+    B::Key: Ord + Clone, // Clone is required by `batch::advance_*` (in-place could remove).
+    B::Val: Ord + Clone, // Clone is required by `batch::advance_*` (in-place could remove).
+    B::Time: Lattice + timely::progress::Timestamp + Ord + Clone + Debug,
+    B::R: Semigroup,
+{
+    /// Allocates a new empty trace.
+    pub fn new(info: OperatorInfo, logging: Option<Logger>, activator: Option<Activator>) -> Self {
+        Self::with_effort(1, info, logging, activator)
+    }
+
+    /// Allocates a fueled `Spine` with a specified effort multiplier.
+    ///
+    /// This trace will merge batches progressively, with each inserted batch
+    /// applying a multiple of the batch's length in effort to each merge. The
+    /// `effort` parameter is that multiplier. This value should be at least one
+    /// for the merging to happen; a value of zero is not helpful.
+    pub fn with_effort(
+        mut effort: usize,
+        operator: OperatorInfo,
+        logger: Option<Logger>,
+        activator: Option<Activator>,
+    ) -> Self {
+        // Zero effort is .. not smart.
+        if effort == 0 {
+            effort = 1;
+        }
+
+        Spine {
+            operator,
+            logger,
+            logical_frontier: Antichain::from_elem(
+                <B::Time as timely::progress::Timestamp>::minimum(),
+            ),
+            physical_frontier: Antichain::from_elem(
+                <B::Time as timely::progress::Timestamp>::minimum(),
+            ),
+            merging: Vec::new(),
+            pending: Vec::new(),
+            upper: Antichain::from_elem(<B::Time as timely::progress::Timestamp>::minimum()),
+            effort,
+            activator,
+        }
+    }
+
+    // Ideally, this method acts as insertion of `batch`, even if we are not yet
+    // able to begin merging the batch. This means it is a good time to perform
+    // amortized work proportional to the size of batch.
+    pub fn insert(&mut self, batch: B) {
+        // Log the introduction of a batch.
+        self.logger.as_ref().map(|l| {
+            l.log(BatchEvent {
+                operator: self.operator.global_id,
+                length: batch.len(),
+            })
+        });
+
+        assert!(batch.lower() != batch.upper());
+        assert_eq!(batch.lower(), &self.upper);
+
+        self.upper.clone_from(batch.upper());
+
+        // TODO: Consolidate or discard empty batches.
+        self.pending.push(batch);
+        self.consider_merges();
+    }
+
+    /// Completes the trace with a final empty batch.
+    pub fn close(&mut self) {
+        if !self.upper.borrow().is_empty() {
+            let builder = B::Builder::new();
+            let batch = builder.done(
+                self.upper.clone(),
+                Antichain::new(),
+                Antichain::from_elem(<B::Time as Timestamp>::minimum()),
+            );
+            self.insert(batch);
+        }
+    }
+
+    /// Apply some amount of effort to trace maintenance.
+    ///
+    /// The units of effort are updates, and the method should be thought of as
+    /// analogous to inserting as many empty updates, where the trace is
+    /// permitted to perform proportionate work.
+    pub fn exert(&mut self, effort: &mut isize) {
+        // If there is work to be done, ...
+        self.tidy_layers();
+        if !self.reduced() {
+            // If any merges exist, we can directly call `apply_fuel`.
+            if self.merging.iter().any(|b| b.is_double()) {
+                self.apply_fuel(effort);
+            }
+            // Otherwise, we'll need to introduce fake updates to move merges
+            // along.
+            else {
+                // Introduce an empty batch with roughly *effort number of
+                // virtual updates.
+                let level = (*effort as usize).next_power_of_two().trailing_zeros() as usize;
+                self.introduce_batch(None, level);
+            }
+            // We were not in reduced form, so let's check again in the future.
+            if let Some(activator) = &self.activator {
+                activator.activate();
+            }
+        }
+    }
+
+    pub fn cursor_through(
+        &mut self,
+        upper: AntichainRef<B::Time>,
+    ) -> Option<(
+        CursorList<<B as BatchReader>::Cursor>,
+        <CursorList<<B as BatchReader>::Cursor> as Cursor>::Storage,
+    )> {
+        // If `upper` is the minimum frontier, we can return an empty cursor.
+        // This can happen with operators that are written to expect the ability
+        // to acquire cursors for their prior frontiers, and which start at
+        // `[T::minimum()]`, such as `Reduce`, sadly.
+        if upper.less_equal(&<B::Time as Timestamp>::minimum()) {
+            let cursors = Vec::new();
+            let storage = Vec::new();
+            return Some((CursorList::new(cursors, &storage), storage));
+        }
+
+        // The supplied `upper` should have the property that for each of our
+        // batch `lower` and `upper` frontiers, the supplied upper is comparable
+        // to the frontier; it should not be incomparable, because the frontiers
+        // that we created form a total order. If it is, there is a bug.
+        //
+        // We should acquire a cursor including all batches whose upper is less
+        // or equal to the supplied upper, excluding all batches whose lower is
+        // greater or equal to the supplied upper, and if a batch straddles the
+        // supplied upper it had better be empty.
+
+        // We shouldn't grab a cursor into a closed trace, right?
+        assert!(self.logical_frontier.borrow().len() > 0);
+
+        // Check that `upper` is greater or equal to `self.physical_frontier`.
+        // Otherwise, the cut could be in `self.merging` and it is user error
+        // anyhow. assert!(upper.iter().all(|t1|
+        // self.physical_frontier.iter().any(|t2| t2.less_equal(t1))));
+        assert!(PartialOrder::less_equal(
+            &self.physical_frontier.borrow(),
+            &upper
+        ));
+
+        let mut cursors = Vec::new();
+        let mut storage = Vec::new();
+
+        for merge_state in self.merging.iter().rev() {
+            match merge_state {
+                MergeState::Double(variant) => match variant {
+                    MergeVariant::InProgress(batch1, batch2, _) => {
+                        if !batch1.is_empty() {
+                            cursors.push(batch1.cursor());
+                            storage.push(batch1.clone());
+                        }
+                        if !batch2.is_empty() {
+                            cursors.push(batch2.cursor());
+                            storage.push(batch2.clone());
+                        }
+                    }
+                    MergeVariant::Complete(Some((batch, _))) => {
+                        if !batch.is_empty() {
+                            cursors.push(batch.cursor());
+                            storage.push(batch.clone());
+                        }
+                    }
+                    MergeVariant::Complete(None) => {}
+                },
+                MergeState::Single(Some(batch)) => {
+                    if !batch.is_empty() {
+                        cursors.push(batch.cursor());
+                        storage.push(batch.clone());
+                    }
+                }
+                MergeState::Single(None) => {}
+                MergeState::Vacant => {}
+            }
+        }
+
+        for batch in self.pending.iter() {
+            if !batch.is_empty() {
+                // For a non-empty `batch`, it is a catastrophic error if
+                // `upper` requires some-but-not-all of the updates in the
+                // batch. We can determine this from `upper` and the lower and
+                // upper bounds of the batch itself.
+                //
+                // TODO: It is not clear if this is the 100% correct logic, due
+                // to the possible non-total-orderedness of the frontiers.
+
+                let include_lower = PartialOrder::less_equal(&batch.lower().borrow(), &upper);
+                let include_upper = PartialOrder::less_equal(&batch.upper().borrow(), &upper);
+
+                if include_lower != include_upper && upper != batch.lower().borrow() {
+                    panic!("`cursor_through`: `upper` straddles batch");
+                }
+
+                // include pending batches
+                if include_upper {
+                    cursors.push(batch.cursor());
+                    storage.push(batch.clone());
+                }
+            }
+        }
+
+        Some((CursorList::new(cursors, &storage), storage))
+    }
+    pub fn set_logical_compaction(&mut self, frontier: AntichainRef<B::Time>) {
+        self.logical_frontier.clear();
+        self.logical_frontier.extend(frontier.iter().cloned());
+    }
+    pub fn get_logical_compaction(&mut self) -> AntichainRef<B::Time> {
+        self.logical_frontier.borrow()
+    }
+    pub fn set_physical_compaction(&mut self, frontier: AntichainRef<B::Time>) {
+        // We should never request to rewind the frontier.
+        debug_assert!(
+            PartialOrder::less_equal(&self.physical_frontier.borrow(), &frontier),
+            "FAIL\tthrough frontier !<= new frontier {:?} {:?}\n",
+            self.physical_frontier,
+            frontier
+        );
+        self.physical_frontier.clear();
+        self.physical_frontier.extend(frontier.iter().cloned());
+        self.consider_merges();
+    }
+    pub fn get_physical_compaction(&mut self) -> AntichainRef<B::Time> {
+        self.physical_frontier.borrow()
+    }
+
+    pub fn map_batches<F: FnMut(&B)>(&self, mut f: F) {
+        for batch in self.merging.iter().rev() {
+            match batch {
+                MergeState::Double(MergeVariant::InProgress(batch1, batch2, _)) => {
+                    f(batch1);
+                    f(batch2);
+                }
+                MergeState::Double(MergeVariant::Complete(Some((batch, _)))) => f(batch),
+                MergeState::Single(Some(batch)) => f(batch),
+                _ => {}
+            }
+        }
+        for batch in self.pending.iter() {
+            f(batch);
+        }
+    }
+
+    /// True iff there is at most one non-empty batch in `self.merging`.
+    ///
+    /// When true, there is no maintenance work to perform in the trace, other
+    /// than compaction. We do not yet have logic in place to determine if
+    /// compaction would improve a trace, so for now we are ignoring that.
+    fn reduced(&self) -> bool {
+        let mut non_empty = 0;
+        for index in 0..self.merging.len() {
+            if self.merging[index].is_double() {
+                return false;
+            }
+            if self.merging[index].len() > 0 {
+                non_empty += 1;
+            }
+            if non_empty > 1 {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Describes the merge progress of layers in the trace.
+    ///
+    /// Intended for diagnostics rather than public consumption.
+    #[allow(dead_code)]
+    fn describe(&self) -> Vec<(usize, usize)> {
+        self.merging
+            .iter()
+            .map(|b| match b {
+                MergeState::Vacant => (0, 0),
+                x @ MergeState::Single(_) => (1, x.len()),
+                x @ MergeState::Double(_) => (2, x.len()),
+            })
+            .collect()
+    }
+
+    /// Migrate data from `self.pending` into `self.merging`.
+    ///
+    /// This method reflects on the bookmarks held by others that may prevent
+    /// merging, and in the case that new batches can be introduced to the pile
+    /// of mergeable batches, it gets on that.
+    #[inline(never)]
+    fn consider_merges(&mut self) {
+        // TODO: Consider merging pending batches before introducing them. TODO:
+        // We could use a `VecDeque` here to draw from the front and append to
+        // the back.
+        while self.pending.len() > 0
+            && PartialOrder::less_equal(self.pending[0].upper(), &self.physical_frontier)
+        //   self.physical_frontier.iter().all(|t1|
+        //   self.pending[0].upper().iter().any(|t2| t2.less_equal(t1)))
+        {
+            // Batch can be taken in optimized insertion. Otherwise it is
+            // inserted normally at the end of the method.
+            let mut batch = Some(self.pending.remove(0));
+
+            // If `batch` and the most recently inserted batch are both empty,
+            // we can just fuse them. We can also replace a structurally empty
+            // batch with this empty batch, preserving the apparent record count
+            // but now with non-trivial lower and upper bounds.
+            if batch.as_ref().unwrap().len() == 0 {
+                if let Some(position) = self.merging.iter().position(|m| !m.is_vacant()) {
+                    if self.merging[position].is_single() && self.merging[position].len() == 0 {
+                        self.insert_at(batch.take(), position);
+                        let merged = self.complete_at(position);
+                        self.merging[position] = MergeState::Single(merged);
+                    }
+                }
+            }
+
+            // Normal insertion for the batch.
+            if let Some(batch) = batch {
+                let index = batch.len().next_power_of_two();
+                self.introduce_batch(Some(batch), index.trailing_zeros() as usize);
+            }
+        }
+
+        // Having performed all of our work, if more than one batch remains
+        // reschedule ourself.
+        if !self.reduced() {
+            if let Some(activator) = &self.activator {
+                activator.activate();
+            }
+        }
+    }
+
+    /// Introduces a batch at an indicated level.
+    ///
+    /// The level indication is often related to the size of the batch, but it
+    /// can also be used to artificially fuel the computation by supplying empty
+    /// batches at non-trivial indices, to move merges along.
+    pub fn introduce_batch(&mut self, batch: Option<B>, batch_index: usize) {
+        // Step 0.  Determine an amount of fuel to use for the computation.
+        //
+        //          Fuel is used to drive maintenance of the data structure,
+        //          and in particular are used to make progress through merges
+        //          that are in progress. The amount of fuel to use should be
+        //          proportional to the number of records introduced, so that
+        //          we are guaranteed to complete all merges before they are
+        //          required as arguments to merges again.
+        //
+        //          The fuel use policy is negotiable, in that we might aim
+        //          to use relatively less when we can, so that we return
+        //          control promptly, or we might account more work to larger
+        //          batches. Not clear to me which are best, of if there
+        //          should be a configuration knob controlling this.
+
+        // The amount of fuel to use is proportional to 2^batch_index, scaled by
+        // a factor of self.effort which determines how eager we are in
+        // performing maintenance work. We need to ensure that each merge in
+        // progress receives fuel for each introduced batch, and so multiply by
+        // that as well.
+        if batch_index > 32 {
+            println!("Large batch index: {}", batch_index);
+        }
+
+        // We believe that eight units of fuel is sufficient for each introduced
+        // record, accounted as four for each record, and a potential four more
+        // for each virtual record associated with promoting existing smaller
+        // batches. We could try and make this be less, or be scaled to merges
+        // based on their deficit at time of instantiation. For now, we remain
+        // conservative.
+        let mut fuel = 8 << batch_index;
+        // Scale up by the effort parameter, which is calibrated to one as the
+        // minimum amount of effort.
+        fuel *= self.effort;
+        // Convert to an `isize` so we can observe any fuel shortfall.
+        let mut fuel = fuel as isize;
+
+        // Step 1.  Apply fuel to each in-progress merge.
+        //
+        //          Before we can introduce new updates, we must apply any
+        //          fuel to in-progress merges, as this fuel is what ensures
+        //          that the merges will be complete by the time we insert
+        //          the updates.
+        self.apply_fuel(&mut fuel);
+
+        // Step 2.  We must ensure the invariant that adjacent layers do not
+        //          contain two batches will be satisfied when we insert the
+        //          batch. We forcibly completing all merges at layers lower
+        //          than and including `batch_index`, so that the new batch is
+        //          inserted into an empty layer.
+        //
+        //          We could relax this to "strictly less than `batch_index`"
+        //          if the layer above has only a single batch in it, which
+        //          seems not implausible if it has been the focus of effort.
+        //
+        //          This should be interpreted as the introduction of some
+        //          volume of fake updates, and we will need to fuel merges
+        //          by a proportional amount to ensure that they are not
+        //          surprised later on. The number of fake updates should
+        //          correspond to the deficit for the layer, which perhaps
+        //          we should track explicitly.
+        self.roll_up(batch_index);
+
+        // Step 3. This insertion should be into an empty layer. It is a logical
+        //         error otherwise, as we may be violating our invariant, from
+        //         which all wonderment derives.
+        self.insert_at(batch, batch_index);
+
+        // Step 4. Tidy the largest layers.
+        //
+        //         It is important that we not tidy only smaller layers,
+        //         as their ascension is what ensures the merging and
+        //         eventual compaction of the largest layers.
+        self.tidy_layers();
+    }
+
+    /// Ensures that an insertion at layer `index` will succeed.
+    ///
+    /// This method is subject to the constraint that all existing batches
+    /// should occur at higher levels, which requires it to "roll up" batches
+    /// present at lower levels before the method is called. In doing this, we
+    /// should not introduce more virtual records than 2^index, as that is the
+    /// amount of excess fuel we have budgeted for completing merges.
+    fn roll_up(&mut self, index: usize) {
+        // Ensure entries sufficient for `index`.
+        while self.merging.len() <= index {
+            self.merging.push(MergeState::Vacant);
+        }
+
+        // We only need to roll up if there are non-vacant layers.
+        if self.merging[..index].iter().any(|m| !m.is_vacant()) {
+            // Collect and merge all batches at layers up to but not including
+            // `index`.
+            let mut merged = None;
+            for i in 0..index {
+                self.insert_at(merged, i);
+                merged = self.complete_at(i);
+            }
+
+            // The merged results should be introduced at level `index`, which
+            // should be ready to absorb them (possibly creating a new merge at
+            // the time).
+            self.insert_at(merged, index);
+
+            // If the insertion results in a merge, we should complete it to
+            // ensure the upcoming insertion at `index` does not panic.
+            if self.merging[index].is_double() {
+                let merged = self.complete_at(index);
+                self.insert_at(merged, index + 1);
+            }
+        }
+    }
+
+    /// Applies an amount of fuel to merges in progress.
+    ///
+    /// The supplied `fuel` is for each in progress merge, and if we want to
+    /// spend the fuel non-uniformly (e.g. prioritizing merges at low layers) we
+    /// could do so in order to maintain fewer batches on average (at the risk
+    /// of completing merges of large batches later, but tbh probably not much
+    /// later).
+    pub fn apply_fuel(&mut self, fuel: &mut isize) {
+        // For the moment our strategy is to apply fuel independently to each
+        // merge in progress, rather than prioritizing small merges. This sounds
+        // like a great idea, but we need better accounting in place to ensure
+        // that merges that borrow against later layers but then complete still
+        // "acquire" fuel to pay back their debts.
+        for index in 0..self.merging.len() {
+            // Give each level independent fuel, for now.
+            let mut fuel = *fuel;
+            // Pass along various logging stuffs, in case we need to report
+            // success.
+            self.merging[index].work(&mut fuel);
+            // `fuel` could have a deficit at this point, meaning we over-spent
+            // when we took a merge step. We could ignore this, or maintain the
+            // deficit and account future fuel against it before spending again.
+            // It isn't clear why that would be especially helpful to do; we
+            // might want to avoid overspends at multiple layers in the same
+            // invocation (to limit latencies), but there is probably a rich
+            // policy space here.
+
+            // If a merge completes, we can immediately merge it in to the next
+            // level, which is "guaranteed" to be complete at this point, by our
+            // fueling discipline.
+            if self.merging[index].is_complete() {
+                let complete = self.complete_at(index);
+                self.insert_at(complete, index + 1);
+            }
+        }
+    }
+
+    /// Inserts a batch at a specific location.
+    ///
+    /// This is a non-public internal method that can panic if we try and insert
+    /// into a layer which already contains two batches (and is still in the
+    /// process of merging).
+    fn insert_at(&mut self, batch: Option<B>, index: usize) {
+        // Ensure the spine is large enough.
+        while self.merging.len() <= index {
+            self.merging.push(MergeState::Vacant);
+        }
+
+        // Insert the batch at the location.
+        match self.merging[index].take() {
+            MergeState::Vacant => {
+                self.merging[index] = MergeState::Single(batch);
+            }
+            MergeState::Single(old) => {
+                // Log the initiation of a merge.
+                self.logger.as_ref().map(|l| {
+                    l.log(MergeEvent {
+                        operator: self.operator.global_id,
+                        scale: index,
+                        length1: old.as_ref().map(|b| b.len()).unwrap_or(0),
+                        length2: batch.as_ref().map(|b| b.len()).unwrap_or(0),
+                        complete: None,
+                    })
+                });
+                let compaction_frontier = Some(self.logical_frontier.borrow());
+                self.merging[index] = MergeState::begin_merge(old, batch, compaction_frontier);
+            }
+            MergeState::Double(_) => {
+                panic!("Attempted to insert batch into incomplete merge!")
+            }
+        };
+    }
+
+    /// Completes and extracts what ever is at layer `index`.
+    fn complete_at(&mut self, index: usize) -> Option<B> {
+        if let Some((merged, inputs)) = self.merging[index].complete() {
+            if let Some((input1, input2)) = inputs {
+                // Log the completion of a merge from existing parts.
+                self.logger.as_ref().map(|l| {
+                    l.log(MergeEvent {
+                        operator: self.operator.global_id,
+                        scale: index,
+                        length1: input1.len(),
+                        length2: input2.len(),
+                        complete: Some(merged.len()),
+                    })
+                });
+            }
+            Some(merged)
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to draw down large layers to size appropriate layers.
+    fn tidy_layers(&mut self) {
+        // If the largest layer is complete (not merging), we can attempt to
+        // draw it down to the next layer. This is permitted if we can maintain
+        // our invariant that below each merge there are at most half the
+        // records that would be required to invade the merge.
+        if !self.merging.is_empty() {
+            let mut length = self.merging.len();
+            if self.merging[length - 1].is_single() {
+                // To move a batch down, we require that it contain few enough
+                // records that the lower level is appropriate, and that moving
+                // the batch would not create a merge violating our invariant.
+
+                let appropriate_level = self.merging[length - 1]
+                    .len()
+                    .next_power_of_two()
+                    .trailing_zeros() as usize;
+
+                // Continue only as far as is appropriate
+                while appropriate_level < length - 1 {
+                    match self.merging[length - 2].take() {
+                        // Vacant or structurally empty batches can be absorbed.
+                        MergeState::Vacant | MergeState::Single(None) => {
+                            self.merging.remove(length - 2);
+                            length = self.merging.len();
+                        }
+                        // Single batches may initiate a merge, if sizes are
+                        // within bounds, but terminate the loop either way.
+                        MergeState::Single(Some(batch)) => {
+                            // Determine the number of records that might lead
+                            // to a merge. Importantly, this is not the number
+                            // of actual records, but the sum of upper bounds
+                            // based on indices.
+                            let mut smaller = 0;
+                            for (index, batch) in self.merging[..(length - 2)].iter().enumerate() {
+                                match batch {
+                                    MergeState::Vacant => {}
+                                    MergeState::Single(_) => {
+                                        smaller += 1 << index;
+                                    }
+                                    MergeState::Double(_) => {
+                                        smaller += 2 << index;
+                                    }
+                                }
+                            }
+
+                            if smaller <= (1 << length) / 8 {
+                                self.merging.remove(length - 2);
+                                self.insert_at(Some(batch), length - 2);
+                            } else {
+                                self.merging[length - 2] = MergeState::Single(Some(batch));
+                            }
+                            return;
+                        }
+                        // If a merge is in progress there is nothing to do.
+                        MergeState::Double(state) => {
+                            self.merging[length - 2] = MergeState::Double(state);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<B> Spine<B>
+where
+    B: Batch,
+    B::Time: Lattice + Ord,
+    B::R: Semigroup,
+{
+    /// Drops and logs batches. Used in `set_logical_compaction` and drop.
+    fn drop_batches(&mut self) {
+        if let Some(logger) = &self.logger {
+            for batch in self.merging.drain(..) {
+                match batch {
+                    MergeState::Single(Some(batch)) => {
+                        logger.log(DropEvent {
+                            operator: self.operator.global_id,
+                            length: batch.len(),
+                        });
+                    }
+                    MergeState::Double(MergeVariant::InProgress(batch1, batch2, _)) => {
+                        logger.log(DropEvent {
+                            operator: self.operator.global_id,
+                            length: batch1.len(),
+                        });
+                        logger.log(DropEvent {
+                            operator: self.operator.global_id,
+                            length: batch2.len(),
+                        });
+                    }
+                    MergeState::Double(MergeVariant::Complete(Some((batch, _)))) => {
+                        logger.log(DropEvent {
+                            operator: self.operator.global_id,
+                            length: batch.len(),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            for batch in self.pending.drain(..) {
+                logger.log(DropEvent {
+                    operator: self.operator.global_id,
+                    length: batch.len(),
+                });
+            }
+        }
+    }
+}
+
+// Drop implementation allows us to log batch drops, to zero out maintained
+// totals.
+impl<B> Drop for Spine<B>
+where
+    B: Batch,
+    B::Time: Lattice + Ord,
+    B::R: Semigroup,
+{
+    fn drop(&mut self) {
+        self.drop_batches();
+    }
+}
+
+/// Describes the state of a layer.
+///
+/// A layer can be empty, contain a single batch, or contain a pair of batches
+/// that are in the process of merging into a batch for the next layer.
+enum MergeState<B: Batch> {
+    /// An empty layer, containing no updates.
+    Vacant,
+    /// A layer containing a single batch.
+    ///
+    /// The `None` variant is used to represent a structurally empty batch
+    /// present to ensure the progress of maintenance work.
+    Single(Option<B>),
+    /// A layer containing two batches, in the process of merging.
+    Double(MergeVariant<B>),
+}
+
+impl<B: Batch> MergeState<B>
+where
+    B::Time: Eq,
+{
+    /// The number of actual updates contained in the level.
+    fn len(&self) -> usize {
+        match self {
+            MergeState::Single(Some(b)) => b.len(),
+            MergeState::Double(MergeVariant::InProgress(b1, b2, _)) => b1.len() + b2.len(),
+            MergeState::Double(MergeVariant::Complete(Some((b, _)))) => b.len(),
+            _ => 0,
+        }
+    }
+
+    /// True only for the MergeState::Vacant variant.
+    fn is_vacant(&self) -> bool {
+        if let MergeState::Vacant = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// True only for the MergeState::Single variant.
+    fn is_single(&self) -> bool {
+        if let MergeState::Single(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// True only for the MergeState::Double variant.
+    fn is_double(&self) -> bool {
+        if let MergeState::Double(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Immediately complete any merge.
+    ///
+    /// The result is either a batch, if there is a non-trivial batch to return
+    /// or `None` if there is no meaningful batch to return. This does not
+    /// distinguish between Vacant entries and structurally empty batches, which
+    /// should be done with the `is_complete()` method.
+    ///
+    /// There is the addional option of input batches.
+    fn complete(&mut self) -> Option<(B, Option<(B, B)>)> {
+        match std::mem::replace(self, MergeState::Vacant) {
+            MergeState::Vacant => None,
+            MergeState::Single(batch) => batch.map(|b| (b, None)),
+            MergeState::Double(variant) => variant.complete(),
+        }
+    }
+
+    /// True iff the layer is a complete merge, ready for extraction.
+    fn is_complete(&mut self) -> bool {
+        if let MergeState::Double(MergeVariant::Complete(_)) = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Performs a bounded amount of work towards a merge.
+    ///
+    /// If the merge completes, the resulting batch is returned. If a batch is
+    /// returned, it is the obligation of the caller to correctly install the
+    /// result.
+    fn work(&mut self, fuel: &mut isize) {
+        // We only perform work for merges in progress.
+        if let MergeState::Double(layer) = self {
+            layer.work(fuel)
+        }
+    }
+
+    /// Extract the merge state, typically temporarily.
+    fn take(&mut self) -> Self {
+        std::mem::replace(self, MergeState::Vacant)
+    }
+
+    /// Initiates the merge of an "old" batch with a "new" batch.
+    ///
+    /// The upper frontier of the old batch should match the lower frontier of
+    /// the new batch, with the resulting batch describing their composed
+    /// interval, from the lower frontier of the old batch to the upper frontier
+    /// of the new batch.
+    ///
+    /// Either batch may be `None` which corresponds to a structurally empty
+    /// batch whose upper and lower froniers are equal. This option exists
+    /// purely for bookkeeping purposes, and no computation is performed to
+    /// merge the two batches.
+    fn begin_merge(
+        batch1: Option<B>,
+        batch2: Option<B>,
+        compaction_frontier: Option<AntichainRef<B::Time>>,
+    ) -> MergeState<B> {
+        let variant = match (batch1, batch2) {
+            (Some(batch1), Some(batch2)) => {
+                assert!(batch1.upper() == batch2.lower());
+                let begin_merge = <B as Batch>::begin_merge(&batch1, &batch2, compaction_frontier);
+                MergeVariant::InProgress(batch1, batch2, begin_merge)
+            }
+            (None, Some(x)) => MergeVariant::Complete(Some((x, None))),
+            (Some(x), None) => MergeVariant::Complete(Some((x, None))),
+            (None, None) => MergeVariant::Complete(None),
+        };
+
+        MergeState::Double(variant)
+    }
+}
+
+enum MergeVariant<B: Batch> {
+    /// Describes an actual in-progress merge between two non-trivial batches.
+    InProgress(B, B, <B as Batch>::Merger),
+    /// A merge that requires no further work. May or may not represent a
+    /// non-trivial batch.
+    Complete(Option<(B, Option<(B, B)>)>),
+}
+
+impl<B: Batch> MergeVariant<B> {
+    /// Completes and extracts the batch, unless structurally empty.
+    ///
+    /// The result is either `None`, for structurally empty batches, or a batch
+    /// and optionally input batches from which it derived.
+    fn complete(mut self) -> Option<(B, Option<(B, B)>)> {
+        let mut fuel = isize::max_value();
+        self.work(&mut fuel);
+        if let MergeVariant::Complete(batch) = self {
+            batch
+        } else {
+            panic!("Failed to complete a merge!");
+        }
+    }
+
+    /// Applies some amount of work, potentially completing the merge.
+    ///
+    /// In case the work completes, the source batches are returned. This allows
+    /// the caller to manage the released resources.
+    fn work(&mut self, fuel: &mut isize) {
+        let variant = std::mem::replace(self, MergeVariant::Complete(None));
+        if let MergeVariant::InProgress(b1, b2, mut merge) = variant {
+            merge.work(&b1, &b2, fuel);
+            if *fuel > 0 {
+                *self = MergeVariant::Complete(Some((merge.done(), Some((b1, b2)))));
+            } else {
+                *self = MergeVariant::InProgress(b1, b2, merge);
+            }
+        } else {
+            *self = variant;
+        }
+    }
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) mod r#impl {
     pub mod machine;
     pub mod metrics;
     pub mod state;
+    pub mod trace;
 }
 
 // TODO: Remove this in favor of making it possible for all PersistClients to be

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -35,6 +35,7 @@ use tracing::{debug, instrument, trace};
 use uuid::Uuid;
 
 use crate::error::InvalidUsage;
+use crate::r#impl::compact::Compactor;
 use crate::r#impl::machine::{retry_external, Machine};
 use crate::read::{ReadHandle, ReaderId};
 use crate::write::WriteHandle;
@@ -49,6 +50,7 @@ pub use crate::r#impl::state::{Since, Upper};
 
 /// An implementation of the public crate interface.
 pub(crate) mod r#impl {
+    pub mod compact;
     pub mod machine;
     pub mod metrics;
     pub mod state;
@@ -188,6 +190,16 @@ pub struct PersistConfig {
     /// will pipeline before back-pressuring [crate::batch::BatchBuilder::add]
     /// calls on previous ones finishing.
     pub batch_builder_max_outstanding_parts: usize,
+    /// Whether to physically and logically compact batches in blob storage.
+    pub compaction_enabled: bool,
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of inputs is at least this many. Compaction is performed
+    /// if any of the heuristic criteria are met (they are OR'd).
+    pub compaction_heuristic_min_inputs: usize,
+    /// In Compactor::compact_and_apply, we do the compaction (don't skip it)
+    /// if the number of updates is at least this many. Compaction is performed
+    /// if any of the heuristic criteria are met (they are OR'd).
+    pub compaction_heuristic_min_updates: usize,
 }
 
 // Tuning inputs:
@@ -206,6 +218,13 @@ pub struct PersistConfig {
 //   point).
 // - A smaller batch_builder_max_outstanding_parts provides a bound on the
 //   amount of memory used by a writer.
+// - A larger compaction_heuristic_min_inputs means state size is larger.
+// - A smaller compaction_heuristic_min_inputs means more compactions happen
+//   (higher write amp).
+// - A larger compaction_heuristic_min_updates means more consolidations are
+//   discovered while reading a snapshot (higher read amp and higher space amp).
+// - A smaller compaction_heuristic_min_updates means more compactions happen
+//   (higher write amp).
 //
 // Tuning logic:
 // - blob_target_size was initially selected to be an exact multiple of 8MiB
@@ -215,12 +234,27 @@ pub struct PersistConfig {
 //   as possible without harming pipelining. 0 means no pipelining, 1 is full
 //   pipelining as long as generating data takes less time than writing to s3
 //   (hopefully a fair assumption), 2 is a little extra slop on top of 1.
+// - compaction_heuristic_min_inputs was set by running the open-loop benchmark
+//   with batches of size 10,240 bytes (selected to be small but such that the
+//   overhead of our columnar encoding format was less than 10%) and manually
+//   increased until the write amp stopped going down. This becomes much less
+//   important once we have incremental state. The initial value is a
+//   placeholder and should be revisited at some point.
+// - compaction_heuristic_min_updates was set via a thought experiment. This is
+//   an `O(n*log(n))` upper bound on the number of unconsolidated updates that
+//   would be consolidated if we compacted as the in-mem Spine does. The initial
+//   value is a placeholder and should be revisited at some point.
 impl Default for PersistConfig {
     fn default() -> Self {
+        // Escape hatch in case we need to disable compaction.
+        let compaction_disabled = mz_ore::env::is_var_truthy("MZ_PERSIST_COMPACTION_DISABLED");
         const MB: usize = 1024 * 1024;
         Self {
             blob_target_size: 128 * MB,
             batch_builder_max_outstanding_parts: 2,
+            compaction_enabled: !compaction_disabled,
+            compaction_heuristic_min_inputs: 8,
+            compaction_heuristic_min_updates: 1024,
         }
     }
 }
@@ -303,12 +337,20 @@ impl PersistClient {
             Arc::clone(&self.metrics),
         )
         .await?;
+        let compactor = self.cfg.compaction_enabled.then(|| {
+            Compactor::new(
+                self.cfg.clone(),
+                Arc::clone(&self.blob),
+                Arc::clone(&self.metrics),
+            )
+        });
         let reader_id = ReaderId::new();
         let (shard_upper, read_cap) = machine.register(&reader_id).await;
         let writer = WriteHandle {
             cfg: self.cfg.clone(),
             metrics: Arc::clone(&self.metrics),
             machine: machine.clone(),
+            compactor,
             blob: Arc::clone(&self.blob),
             upper: shard_upper.0,
         };
@@ -369,11 +411,19 @@ impl PersistClient {
             Arc::clone(&self.metrics),
         )
         .await?;
+        let compactor = self.cfg.compaction_enabled.then(|| {
+            Compactor::new(
+                self.cfg.clone(),
+                Arc::clone(&self.blob),
+                Arc::clone(&self.metrics),
+            )
+        });
         let shard_upper = machine.fetch_upper().await;
         let writer = WriteHandle {
             cfg: self.cfg.clone(),
             metrics: Arc::clone(&self.metrics),
             machine,
+            compactor,
             blob: Arc::clone(&self.blob),
             upper: shard_upper,
         };
@@ -395,6 +445,13 @@ impl PersistClient {
     {
         self.open(shard_id).await.expect("codec mismatch")
     }
+
+    /// Return the metrics being used by this client.
+    ///
+    /// Only exposed for tests, persistcli, and benchmarks.
+    pub fn metrics(&self) -> &Arc<Metrics> {
+        &self.metrics
+    }
 }
 
 #[cfg(test)]
@@ -404,8 +461,11 @@ mod tests {
     use std::pin::Pin;
     use std::str::FromStr;
     use std::task::Context;
+    use std::time::{Duration, Instant};
 
+    use differential_dataflow::consolidation::consolidate_updates;
     use futures_task::noop_waker;
+    use mz_persist::indexed::encoding::BlobTraceBatchPart;
     use mz_persist::workload::DataGenerator;
     use mz_proto::protobuf_roundtrip;
     use timely::progress::Antichain;
@@ -427,6 +487,9 @@ mod tests {
         cache.cfg.blob_target_size = 10;
         cache.cfg.batch_builder_max_outstanding_parts = 1;
 
+        // Enable compaction in tests to ensure we get coverage.
+        cache.cfg.compaction_enabled = true;
+
         cache
             .open(PersistLocation {
                 blob_uri: "mem://".to_owned(),
@@ -441,20 +504,52 @@ mod tests {
         as_of: T,
     ) -> Vec<((Result<K, String>, Result<V, String>), T, D)>
     where
-        K: Clone + 'a,
-        V: Clone + 'a,
-        T: Lattice + Clone + 'a,
-        D: Clone + 'a,
+        K: Ord + Clone + 'a,
+        V: Ord + Clone + 'a,
+        T: Timestamp + Lattice + Clone + 'a,
+        D: Semigroup + Clone + 'a,
         I: IntoIterator<Item = &'a ((K, V), T, D)>,
     {
         let as_of = Antichain::from_elem(as_of);
-        iter.into_iter()
+        let mut ret = iter
+            .into_iter()
             .map(|((k, v), t, d)| {
                 let mut t = t.clone();
                 t.advance_by(as_of.borrow());
                 ((Ok(k.clone()), Ok(v.clone())), t, d.clone())
             })
-            .collect()
+            .collect();
+        consolidate_updates(&mut ret);
+        ret
+    }
+
+    pub async fn expect_fetch_part<K, V, T, D>(
+        blob: &(dyn Blob + Send + Sync),
+        key: &str,
+    ) -> (
+        BlobTraceBatchPart,
+        Vec<((Result<K, String>, Result<V, String>), T, D)>,
+    )
+    where
+        K: Codec,
+        V: Codec,
+        T: Codec64,
+        D: Codec64,
+    {
+        let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
+        let value = blob
+            .get(deadline, key)
+            .await
+            .expect("failed to fetch part")
+            .expect("missing part");
+        let part = BlobTraceBatchPart::decode(&value).expect("failed to decode part");
+        let mut updates = Vec::new();
+        for chunk in part.updates.iter() {
+            for ((k, v), t, d) in chunk.iter() {
+                updates.push(((K::decode(k), V::decode(v)), T::decode(t), D::decode(d)));
+            }
+        }
+        (part, updates)
     }
 
     #[tokio::test]
@@ -494,13 +589,10 @@ mod tests {
         assert_eq!(write.upper(), &Antichain::from_elem(4));
 
         // Listen should have part of the initial write plus the new one.
-        let expected_events = vec![
-            ListenEvent::Updates(all_ok(&data[1..2], 1)),
-            ListenEvent::Progress(Antichain::from_elem(3)),
-            ListenEvent::Updates(all_ok(&data[2..], 1)),
-            ListenEvent::Progress(Antichain::from_elem(4)),
-        ];
-        assert_eq!(listen.read_until(&4).await, expected_events);
+        assert_eq!(
+            listen.read_until(&4).await,
+            (all_ok(&data[1..], 1), Antichain::from_elem(4))
+        );
 
         // Downgrading the since is tracked locally (but otherwise is a no-op).
         read.downgrade_since(Antichain::from_elem(2)).await;
@@ -988,15 +1080,10 @@ mod tests {
         let mut snap = read.expect_snapshot(5).await;
         assert_eq!(snap.read_all().await, all_ok(&data, 5));
 
-        let expected_events = vec![
-            ListenEvent::Updates(all_ok(&data[0..2], 1)),
-            ListenEvent::Progress(Antichain::from_elem(3)),
-            ListenEvent::Updates(all_ok(&data[2..4], 1)),
-            ListenEvent::Progress(Antichain::from_elem(5)),
-            ListenEvent::Updates(all_ok(&data[4..5], 1)),
-            ListenEvent::Progress(Antichain::from_elem(6)),
-        ];
-        assert_eq!(listen.read_until(&6).await, expected_events);
+        assert_eq!(
+            listen.read_until(&6).await,
+            (all_ok(&data[..], 1), Antichain::from_elem(6))
+        );
     }
 
     // Appends need to be contiguous for a shard, meaning the lower of an appended batch must not

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -28,7 +28,7 @@ use crate::batch::{Batch, BatchBuilder};
 use crate::error::InvalidUsage;
 use crate::r#impl::machine::{Machine, INFO_MIN_ATTEMPTS};
 use crate::r#impl::metrics::Metrics;
-use crate::r#impl::state::Upper;
+use crate::r#impl::state::{HollowBatch, Upper};
 use crate::PersistConfig;
 
 /// A "capability" granting the ability to apply updates to some shard at times
@@ -397,7 +397,11 @@ where
 
         let res = self
             .machine
-            .compare_and_append(&batch.blob_keys, &desc)
+            .compare_and_append(&HollowBatch {
+                desc: desc.clone(),
+                keys: batch.blob_keys.clone(),
+                len: batch.num_updates,
+            })
             .await?;
 
         match res {

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -24,8 +24,9 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tracing::{debug, info, instrument, trace};
 
-use crate::batch::{Batch, BatchBuilder};
+use crate::batch::{validate_truncate_batch, Batch, BatchBuilder};
 use crate::error::InvalidUsage;
+use crate::r#impl::compact::{CompactReq, Compactor};
 use crate::r#impl::machine::{Machine, INFO_MIN_ATTEMPTS};
 use crate::r#impl::metrics::Metrics;
 use crate::r#impl::state::{HollowBatch, Upper};
@@ -54,6 +55,7 @@ where
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) machine: Machine<K, V, T, D>,
+    pub(crate) compactor: Option<Compactor>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
 
     pub(crate) upper: Antichain<T>,
@@ -384,15 +386,8 @@ where
         let since = Antichain::from_elem(T::minimum());
         let desc = Description::new(lower, upper, since);
 
-        if !PartialOrder::less_equal(batch.lower(), desc.lower())
-            || PartialOrder::less_than(batch.upper(), desc.upper())
-        {
-            return Ok(Err(InvalidUsage::InvalidBatchBounds {
-                batch_lower: batch.lower().clone(),
-                batch_upper: batch.upper().clone(),
-                append_lower: desc.lower().clone(),
-                append_upper: desc.upper().clone(),
-            }));
+        if let Err(err) = validate_truncate_batch(&batch.desc, &desc) {
+            return Ok(Err(err));
         }
 
         let res = self
@@ -404,20 +399,34 @@ where
             })
             .await?;
 
-        match res {
-            Ok(Ok(_seqno)) => {
+        let merge_reqs = match res {
+            Ok(Ok((_seqno, merge_reqs))) => {
                 self.upper = desc.upper().clone();
                 batch.mark_consumed();
-                Ok(Ok(Ok(())))
+                merge_reqs
             }
             Ok(Err(current_upper)) => {
                 // We tried to to a compare_and_append with the wrong expected upper, that
                 // won't work. Update the cached upper to the current upper.
                 self.upper = current_upper.0.clone();
-                Ok(Ok(Err(current_upper)))
+                return Ok(Ok(Err(current_upper)));
             }
-            Err(err) => Ok(Err(err)),
+            Err(err) => return Ok(Err(err)),
+        };
+
+        // If the compactor isn't enabled, just ignore the requests.
+        if let Some(compactor) = self.compactor.as_ref() {
+            for req in merge_reqs {
+                let req = CompactReq {
+                    shard_id: self.machine.shard_id(),
+                    desc: req.desc,
+                    inputs: req.inputs,
+                };
+                compactor.compact_and_apply(&self.machine, req);
+            }
         }
+
+        Ok(Ok(Ok(())))
     }
 
     /// Returns a [BatchBuilder] that can be used to write a batch of updates to
@@ -461,7 +470,6 @@ where
         DB: Borrow<D>,
         I: IntoIterator<Item = SB>,
     {
-        // WIP: Should we have logging for these helpers?
         trace!("WriteHandle::batch lower={:?} upper={:?}", lower, upper);
 
         let iter = updates.into_iter();
@@ -516,6 +524,24 @@ where
         .expect("external durability failed")
         .expect("invalid usage")
         .expect("unexpected upper")
+    }
+
+    /// Test helper for an [Self::append] call that is expected to succeed.
+    #[cfg(test)]
+    #[track_caller]
+    pub async fn expect_batch(
+        &mut self,
+        updates: &[((K, V), T, D)],
+        lower: T,
+        upper: T,
+    ) -> Batch<K, V, T, D> {
+        self.batch(
+            updates.iter(),
+            Antichain::from_elem(lower),
+            Antichain::from_elem(upper),
+        )
+        .await
+        .expect("invalid usage")
     }
 }
 

--- a/src/persist-client/tests/machine/compaction
+++ b/src/persist-client/tests/machine/compaction
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Sanity check for the "normal" case
+
+write-batch output=b0 lower=0 upper=1
+zero 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+zero 1 -1
+one 1 1
+----
+parts=1 len=2
+
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=10
+----
+parts=1 len=1
+
+fetch-batch input=b0_1
+----
+<part 0>
+one 10 1

--- a/src/persist-client/tests/machine/compaction_empty
+++ b/src/persist-client/tests/machine/compaction_empty
@@ -1,0 +1,41 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Compaction with empty inputs and outputs
+
+write-batch output=b0 lower=0 upper=1
+zero 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+zero 1 -1
+----
+parts=1 len=1
+
+compact output=b_empty_output inputs=(b0,b1) lower=0 upper=2 since=1
+----
+parts=0 len=0
+
+fetch-batch input=b_empty_output
+----
+<empty>
+
+write-batch output=b_empty lower=1 upper=2
+----
+parts=0 len=0
+
+compact output=b_empty_input inputs=(b0,b_empty) lower=0 upper=2 since=0
+----
+parts=1 len=1
+
+fetch-batch input=b_empty_input
+----
+<part 0>
+zero 0 1

--- a/src/persist-client/tests/machine/compaction_multipart
+++ b/src/persist-client/tests/machine/compaction_multipart
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Compaction with multipart inputs and outputs
+
+write-batch output=b0 lower=0 upper=3 target_size=0
+zero 0 1
+one 1 1
+two 2 1
+----
+parts=3 len=3
+
+fetch-batch input=b0
+----
+<part 0>
+zero 0 1
+<part 1>
+one 1 1
+<part 2>
+two 2 1
+
+write-batch output=b1 lower=3 upper=6 target_size=0
+zero 3 1
+one 4 1
+two 5 1
+----
+parts=3 len=3
+
+fetch-batch input=b1
+----
+<part 0>
+zero 3 1
+<part 1>
+one 4 1
+<part 2>
+two 5 1
+
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=6 since=6 target_size=0
+----
+parts=3 len=3
+
+fetch-batch input=b0_1
+----
+<part 0>
+one 6 2
+<part 1>
+two 6 2
+<part 2>
+zero 6 2

--- a/src/persist-client/tests/machine/compaction_truncate
+++ b/src/persist-client/tests/machine/compaction_truncate
@@ -1,0 +1,63 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify the compaction indeed ignores truncated data when a batch was handed to
+# compare_and_append with a tighter bound than the actual data in the batch (a
+# performance optimization to allow compare_and_append users to selectively
+# retry without writing the batch again).
+#
+# We can't apply the truncation logic if the since has advanced past the lower
+# (the data is no longer at its original fidelity). Luckily, the only batches
+# that need truncation are ones written directly by a persist user, which always
+# have a since of the minimum timestamp.
+
+write-batch output=b0 lower=0 upper=3
+zero 0 1
+one 1 1
+two 2 1
+----
+parts=1 len=3
+
+truncate-batch-desc input=b0 output=b0trunc lower=1 upper=2
+----
+parts=1 len=3
+
+write-batch output=b1 lower=1 upper=4
+one 1 1
+two 2 1
+three 3 1
+----
+parts=1 len=3
+
+# Compact b1 to advance the since and lose the distinctions of the original
+# data. The truncating logic relies on the data being original fidelity and this
+# ensures that it doesn't get applied too eagerly.
+
+truncate-batch-desc input=b1 output=b1trunc lower=2 upper=3
+----
+parts=1 len=3
+
+compact output=b1advanced inputs=(b1trunc) lower=2 upper=3 since=6
+----
+parts=1 len=1
+
+fetch-batch input=b1advanced
+----
+<part 0>
+two 6 1
+
+compact output=b0_1trunc inputs=(b0trunc,b1advanced) lower=1 upper=3 since=10
+----
+parts=1 len=2
+
+fetch-batch input=b0_1trunc
+----
+<part 0>
+one 10 1
+two 10 1

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -1,0 +1,69 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for a bug during the initial compaction implementation where a
+# Listen would emit a batch, then the batch would get compacted, then the Listen
+# would emit the entire merged batch, which double emitted the first batch.
+
+# Write a batch and emit it from a Listen
+write-batch output=b0 lower=0 upper=2
+one 1 1
+----
+parts=1 len=1
+
+compare-and-append input=b0
+----
+ok
+
+register-listen output=l0 as-of=0
+----
+ok
+
+listen-through input=l0 frontier=2
+----
+one 1 1
+
+# Write another batch and compact it with the one we've emitted from the Listen
+write-batch output=b1 lower=2 upper=3
+two 2 1
+----
+parts=1 len=1
+
+compare-and-append input=b1
+----
+ok
+
+compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0
+----
+parts=1 len=2
+
+# Give enough fuel to the Spine that we generate a merge req for b0 and b1
+# (unfortuante implementation detail).
+write-batch output=b2 lower=3 upper=4
+threeA 3 1
+threeB 3 1
+threeC 3 1
+threeD 3 1
+----
+parts=1 len=4
+
+compare-and-append input=b2
+----
+ok
+
+# Now apply the merged batch.
+apply-merge-res input=b0_1
+----
+true
+
+# Finally, verify that the listener correctly skips [1, 2) when it grabs the
+# merged batch. Without the fix, this also gets a "one 1 1" line.
+listen-through input=l0 frontier=2
+----
+two 2 1

--- a/src/persist-client/tests/machine/truncate
+++ b/src/persist-client/tests/machine/truncate
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+write-batch output=b0 lower=0 upper=3
+zero 0 1
+one 1 1
+two 2 1
+----
+parts=1 len=3
+
+fetch-batch input=b0
+----
+<part 0>
+zero 0 1
+one 1 1
+two 2 1
+
+truncate-batch-desc input=b0 output=b1 lower=1 upper=2
+----
+parts=1 len=3
+
+fetch-batch input=b1
+----
+<part 0>
+one 1 1
+
+write-batch output=nope lower=1 upper=3
+----
+parts=0 len=0
+
+truncate-batch-desc input=nope output=nope0 lower=0 upper=2
+----
+error: invalid batch bounds [Antichain { elements: [1] }, Antichain { elements: [3] }) for append call with [Antichain { elements: [0] }, Antichain { elements: [2] })
+
+write-batch output=nope lower=0 upper=2
+----
+parts=0 len=0
+
+truncate-batch-desc input=nope output=nope1 lower=1 upper=3
+----
+error: invalid batch bounds [Antichain { elements: [0] }, Antichain { elements: [2] }) for append call with [Antichain { elements: [1] }, Antichain { elements: [3] })

--- a/src/persist-client/tests/trace/compaction
+++ b/src/persist-client/tests/trace/compaction
@@ -1,0 +1,99 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Batches start empty
+batches
+----
+
+# Insert a len=1 batch.
+insert
+0 1 0 1 k0
+----
+ok
+
+batches
+----
+[0][1][0] 1 k0
+
+take-merge-reqs
+----
+<empty>
+
+# Insert more len=1 batches.
+insert
+1 2 0 1 k1
+2 3 0 1 k2
+3 4 0 1 k3
+4 5 0 1 k4
+5 6 0 1 k5
+6 7 0 1 k6
+7 8 0 1 k7
+----
+ok
+
+batches
+----
+[0][4][0] 4/4 k0 k1 k2 k3
+[4][6][0] 2/2 k4 k5
+[6][7][0] 1 k6
+[7][8][0] 1 k7
+
+take-merge-reqs
+----
+[0][2][0] k0 k1
+[0][4][0] k0 k1 k2 k3
+[4][6][0] k4 k5
+
+# Insert a large batch, which because of spine's invariants, must be inserted at
+# a higher level. This causes the len=1 batches to smash together at the level
+# above it and generate a merge.
+insert
+8 9 0 100 k8
+----
+ok
+
+batches
+----
+[0][8][0] 8/8 k0 k1 k2 k3 k4 k5 k6 k7
+[8][9][0] 100 k8
+
+take-merge-reqs
+----
+[0][8][0] k0 k1 k2 k3 k4 k5 k6 k7
+
+# Merge responses that we didn't generate are ignored.
+apply-merge-res
+1 3 0 0 nope
+----
+no-op
+
+# For now, we only apply a merge req if it exactly matches the bounds of some
+# SpineBatch. In practice, this means a merge req that is outdated when it
+# arrives will be a no-op.
+apply-merge-res
+0 2 0 2 nope
+----
+no-op
+
+# Verify that nothing has been changed by the no-op.
+batches
+----
+[0][8][0] 8/8 k0 k1 k2 k3 k4 k5 k6 k7
+[8][9][0] 100 k8
+
+# Successfully apply a merge res
+apply-merge-res
+0 8 0 5 k0-7
+----
+applied
+
+batches
+----
+[0][8][0] 5 k0-7
+[8][9][0] 100 k8

--- a/src/persist-client/tests/trace/empty_batch_optimization
+++ b/src/persist-client/tests/trace/empty_batch_optimization
@@ -1,0 +1,58 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test an optimization that, even without compaction, we merge together
+# completely empty batches to save space in the state.
+
+# Batches start empty
+batches
+----
+
+# Insert a bunch of empty batches. These happen to all get merged, even without
+# compaction.
+insert
+0 1 0 0
+1 2 0 0
+2 3 0 0
+----
+ok
+
+batches
+----
+[0][3][0] 0
+
+# Now insert a non-empty batch to fence off the optimization.
+insert
+3 4 0 10 k0
+----
+ok
+
+batches
+----
+[0][3][0] 0
+[3][4][0] 10 k0
+
+# Insert some more empty batches, they again get merged together.
+insert
+4 5 0 0
+5 6 0 0
+6 7 0 0
+----
+ok
+
+batches
+----
+[0][3][0] 0
+[3][4][0] 10 k0
+[4][7][0] 0
+
+# All this happens without needing/generating an external merge req (compaction)
+take-merge-reqs
+----
+<empty>

--- a/src/persist-client/tests/trace/since_upper
+++ b/src/persist-client/tests/trace/since_upper
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# since and upper start a minimum ts
+since-upper
+----
+[0][0]
+
+# A [0,1) batch advances the upper to [1]
+insert
+0 1 0 0
+----
+ok
+
+since-upper
+----
+[0][1]
+
+# Downgrade the since to [1]
+downgrade-since
+1
+----
+ok
+
+since-upper
+----
+[1][1]
+
+# It's legal (though of unclear benefit) to advance the since past the upper
+downgrade-since
+2
+----
+ok
+
+since-upper
+----
+[2][1]
+
+
+# Advance the upper again
+insert
+1 3 0 0
+----
+ok
+
+since-upper
+----
+[2][3]

--- a/src/persist-client/tests/trace/since_upper
+++ b/src/persist-client/tests/trace/since_upper
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# since and upper start a minimum ts
+# since and upper start at minimum ts
 since-upper
 ----
 [0][0]

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -13,15 +13,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use tracing::warn;
 use url::Url;
 
 use crate::file::{FileBlob, FileBlobConfig};
 use crate::location::{Blob, Consensus, ExternalError};
+use crate::mem::{MemBlob, MemBlobConfig, MemConsensus};
 use crate::postgres::{PostgresConsensus, PostgresConsensusConfig};
 use crate::s3::{S3Blob, S3BlobConfig};
-
-#[cfg(any(test, debug_assertions))]
-use crate::mem::{MemBlob, MemBlobConfig, MemConsensus};
 
 /// Config for an implementation of [Blob].
 #[derive(Debug, Clone)]
@@ -32,7 +31,6 @@ pub enum BlobConfig {
     S3(S3BlobConfig),
     /// Config for [MemBlob], only available in testing to prevent
     /// footguns.
-    #[cfg(any(test, debug_assertions))]
     Mem,
 }
 
@@ -46,7 +44,6 @@ impl BlobConfig {
             BlobConfig::S3(config) => S3Blob::open(config)
                 .await
                 .map(|x| Arc::new(x) as Arc<dyn Blob + Send + Sync>),
-            #[cfg(any(test, debug_assertions))]
             BlobConfig::Mem => {
                 Ok(Arc::new(MemBlob::open(MemBlobConfig::default()))
                     as Arc<dyn Blob + Send + Sync>)
@@ -79,8 +76,10 @@ impl BlobConfig {
                 let config = S3BlobConfig::new(bucket, prefix, role_arn).await?;
                 Ok(BlobConfig::S3(config))
             }
-            #[cfg(any(test, debug_assertions))]
             "mem" => {
+                if !cfg!(debug_assertions) {
+                    warn!("persist unexpectedly using in-mem blob in a release binary");
+                }
                 query_params.clear();
                 Ok(BlobConfig::Mem)
             }
@@ -113,7 +112,6 @@ pub enum ConsensusConfig {
     /// Config for [PostgresConsensus].
     Postgres(PostgresConsensusConfig),
     /// Config for [MemConsensus], only available in testing.
-    #[cfg(any(test, debug_assertions))]
     Mem,
 }
 
@@ -124,7 +122,6 @@ impl ConsensusConfig {
             ConsensusConfig::Postgres(config) => PostgresConsensus::open(config)
                 .await
                 .map(|x| Arc::new(x) as Arc<dyn Consensus + Send + Sync>),
-            #[cfg(any(test, debug_assertions))]
             ConsensusConfig::Mem => {
                 Ok(Arc::new(MemConsensus::default()) as Arc<dyn Consensus + Send + Sync>)
             }
@@ -145,8 +142,12 @@ impl ConsensusConfig {
             "postgres" | "postgresql" => Ok(ConsensusConfig::Postgres(
                 PostgresConsensusConfig::new(value).await?,
             )),
-            #[cfg(any(test, debug_assertions))]
-            "mem" => Ok(ConsensusConfig::Mem),
+            "mem" => {
+                if !cfg!(debug_assertions) {
+                    warn!("persist unexpectedly using in-mem consensus in a release binary");
+                }
+                Ok(ConsensusConfig::Mem)
+            }
             p => Err(anyhow!(
                 "unknown persist consensus scheme {}: {}",
                 p,

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -276,19 +276,16 @@ impl<B: Blob + Send + Sync + 'static> Maintainer<B> {
                 builder.push(((key, val), u64::encode(time), i64::encode(diff)));
 
                 // Move data from builder into storage as we fill up ColumnarRecords.
-                if let Some(filled) = builder.take_filled() {
-                    for part in filled {
-                        debug_assert!(part.len() > 0);
-                        let (key, part_size_bytes) =
-                            handle.block_on(Self::write_trace_batch_part(
-                                &blob,
-                                desc.clone(),
-                                part,
-                                u64::cast_from(keys.len()),
-                            ))?;
-                        keys.push(key);
-                        new_size_bytes += part_size_bytes;
-                    }
+                for part in builder.take_filled() {
+                    debug_assert!(part.len() > 0);
+                    let (key, part_size_bytes) = handle.block_on(Self::write_trace_batch_part(
+                        &blob,
+                        desc.clone(),
+                        part,
+                        u64::cast_from(keys.len()),
+                    ))?;
+                    keys.push(key);
+                    new_size_bytes += part_size_bytes;
                 }
             }
 

--- a/src/persist/src/indexed/background.rs
+++ b/src/persist/src/indexed/background.rs
@@ -644,6 +644,7 @@ mod tests {
         };
 
         let test_cases = vec![
+            // "Normal" case
             CompactionTestCase {
                 b0: vec![vec![
                     (("k".as_bytes(), "v".as_bytes()), 0, 1),
@@ -680,6 +681,7 @@ mod tests {
                     (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
                 ],
             },
+            // One of the inputs has multiple parts
             CompactionTestCase {
                 b0: vec![
                     vec![(("k".as_bytes(), "v".as_bytes()), 0, 1)],
@@ -716,6 +718,7 @@ mod tests {
                     (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
                 ],
             },
+            // Both of the inputs have multiple parts
             CompactionTestCase {
                 b0: vec![
                     vec![(("k".as_bytes(), "v".as_bytes()), 0, 1)],
@@ -752,6 +755,7 @@ mod tests {
                     (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
                 ],
             },
+            // One of the inputs has empty parts
             CompactionTestCase {
                 b0: vec![
                     vec![],
@@ -791,6 +795,7 @@ mod tests {
                     (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
                 ],
             },
+            // One of the inputs has only empty parts
             CompactionTestCase {
                 b0: vec![vec![], vec![], vec![]],
                 b0_desc: desc_from(0, 1, 0),
@@ -825,6 +830,7 @@ mod tests {
                     (("k3".as_bytes(), "v3".as_bytes()), 2, 1),
                 ],
             },
+            // One of the inputs has no parts
             CompactionTestCase {
                 b0: vec![],
                 b0_desc: desc_from(0, 1, 0),

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -567,17 +567,26 @@ impl ColumnarRecordsVecBuilder {
     /// Add a record to Self.
     pub fn push(&mut self, record: ((&[u8], &[u8]), [u8; 8], [u8; 8])) {
         let ((key, val), ts, diff) = record;
-        if !self.current.can_fit(key, val, self.key_val_data_max_len) {
+        let mut needs_flush = !self.current.can_fit(key, val, self.key_val_data_max_len);
+        if needs_flush && self.current.len() > 0 {
             // We don't have room in this ColumnarRecords, finish it up and
             // try in a fresh one.
             let prev = std::mem::take(&mut self.current);
             self.filled.push(prev.finish());
+            needs_flush = false;
         }
         // If it fails now, this individual record is too big to fit
         // in a ColumnarRecords by itself. The limits are big, so this
         // is a pretty extreme case that we intentionally don't handle
         // right now.
         assert!(self.current.push(((key, val), ts, diff)));
+        if needs_flush {
+            // This only happens when an individual record is larger than the
+            // max len, which probably only happens in tests where we set it
+            // artificially small.
+            let prev = std::mem::take(&mut self.current);
+            self.filled.push(prev.finish());
+        }
     }
 
     /// Finalize constructing a [Vec<ColumnarRecords>].
@@ -590,11 +599,11 @@ impl ColumnarRecordsVecBuilder {
     }
 
     /// Returns the list of filled [ColumnarRecords].
-    pub fn take_filled(&mut self) -> Option<Vec<ColumnarRecords>> {
+    pub fn take_filled(&mut self) -> Vec<ColumnarRecords> {
         if self.filled.len() > 0 {
-            Some(std::mem::take(&mut self.filled))
+            std::mem::take(&mut self.filled)
         } else {
-            None
+            vec![]
         }
     }
 }
@@ -690,5 +699,16 @@ mod tests {
         // Tests for not exactly filling ColumnarRecords
         testcase(40, (ten_k, ""), 23, 12);
         testcase(40, ("", ten_v), 23, 12);
+    }
+
+    // Regression test for a bug where an empty ColumnarRecords would be
+    // produced if the first record added was larger than
+    // `key_val_data_max_len`. This really only comes up in tests.
+    #[test]
+    fn regression_empty_chunk() {
+        let mut builder = ColumnarRecordsVecBuilder::new_with_len(0);
+        builder.push(((&[], &[]), [0u8; 8], [0u8; 8]));
+        assert_eq!(builder.take_filled().len(), 1);
+        assert_eq!(builder.finish().len(), 0);
     }
 }

--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -103,6 +103,12 @@ impl ColumnarRecords {
         self.len
     }
 
+    /// The number of logical bytes in the represented data, excluding offsets
+    /// and lengths.
+    pub fn goodbytes(&self) -> usize {
+        self.key_data.len() + self.val_data.len() + 8 * self.timestamps.len() + 8 * self.diffs.len()
+    }
+
     /// Read the record at `idx`, if there is one.
     ///
     /// Returns None if `idx >= self.len()`.

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -32,6 +32,8 @@ const INLINE_METADATA_KEY: &'static str = "MZ:inline";
 
 /// Encodes an BlobTraceBatchPart into the Parquet format.
 pub fn encode_trace_parquet<W: Write>(w: &mut W, batch: &BlobTraceBatchPart) -> Result<(), Error> {
+    // Better to error now than write out an invalid batch.
+    batch.validate()?;
     encode_parquet_kvtd(
         w,
         encode_trace_inline_meta(batch, ProtoBatchFormat::ParquetKvtd),

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -233,7 +233,7 @@ impl Codec for BlobTraceBatchPart {
     where
         B: BufMut,
     {
-        encode_trace_parquet(&mut buf.writer(), self).expect("writes to BufMut are infallible");
+        encode_trace_parquet(&mut buf.writer(), self).expect("batch was invalid");
     }
 
     fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
@@ -635,7 +635,7 @@ mod tests {
             let trace = BlobTraceBatchPart {
                 desc: Description::new(
                     Antichain::from_elem(0),
-                    Antichain::from_elem(1),
+                    Antichain::new(),
                     Antichain::from_elem(0),
                 ),
                 index: 0,
@@ -657,7 +657,7 @@ mod tests {
                 sizes(DataGenerator::new(1_000, record_size_bytes, 1_000)),
                 sizes(DataGenerator::new(1_000, record_size_bytes, 1_000 / 100)),
             ),
-            "1/1=1031 25/1=2782 1000/1=73026 1000/100=113071"
+            "1/1=1027 25/1=2778 1000/1=73022 1000/100=113067"
         );
     }
 }


### PR DESCRIPTION
See the comments in trace.rs for an overview of how this is set up.

Compaction tests can quickly become a maintenance burden as it's
difficult to balance invariant verification against needing lots of
diffs when small compaction heuristics change. Invest early in
datadriven tests (the same style and underlying library as testdrive).

In production initially disabled by default, but turned on by the
`MZ_PERSIST_COMPACTION_ENABLED` env var for easy testing. In test,
enabled by default.
### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

I'd recommend taking a quick scan of the entire PR's diff to get a high level picture (maybe start with the comment in trace.rs) and then going back commit by commit.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
