### PR TITLE
doc/user: Update Cloud CTA to Early Access

### DIFF
--- a/doc/user/content/cloud/_index.md
+++ b/doc/user/content/cloud/_index.md
@@ -19,7 +19,7 @@ aliases:
 Materialize Cloud hosts and maintains [Materialize](/overview/what-is-materialize) deployments for you, **automating administration tasks** like hardware provisioning, database setup, upgrades, and backups. You can sign up for an account in less than 30 seconds and try out Materialize with your own streaming and historical data sources.
 
 {{< cta href="https://materialize.com/materialize-cloud-access/" >}}
-Sign up for Materialize Cloud →
+Get Early Access to Materialize Cloud →
 {{</ cta >}}
 
 **Trial period**

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -20,7 +20,7 @@
       <a role="menuitem" class="hoverable" href="https://materialize.com/company/">Company</a>
     </div>
     <a class="secondary" role="menuitem" href="https://cloud.materialize.com/">Log In</a>
-    <a class="btn featured" role="menuitem"  href="https://materialize.com/materialize-cloud-access/">Register for Cloud</a>
+    <a class="btn featured" role="menuitem"  href="https://materialize.com/materialize-cloud-access/">Get Early Access</a>
   </div>
 </nav>
 


### PR DESCRIPTION
The CTA for Cloud was adjusted on the website, but not in the documentation. Merging this in to make things at least consistent for now.

@ruf-io @heeringa, we should consider nuking most Cloud-related pages on `lts-docs` and put up a temporary page with Cloud 2.0 info to give folks some context about what's coming up and why automatic account creation is disabled. The current state of affairs makes things very confusing.