### PR TITLE
[LTS] Improve handling of CORS

### DIFF
--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -391,7 +391,10 @@ pub struct Args {
     /// specified origin.
     ///
     /// The special origin `*` enables CORS for all origins.
-    #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN")]
+    ///
+    /// To specify multiple origins, pass the option multiple times, or, if
+    /// using the environment variable, separate each origin with commas.
+    #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN", use_value_delimiter = true)]
     cors_allowed_origin: Vec<HeaderValue>,
 
     // === Storage options. ===

--- a/src/materialized/src/bin/materialized/main.rs
+++ b/src/materialized/src/bin/materialized/main.rs
@@ -389,7 +389,9 @@ pub struct Args {
     frontegg_password_prefix: Option<String>,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
     /// specified origin.
-    #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN", hide = true)]
+    ///
+    /// The special origin `*` enables CORS for all origins.
+    #[structopt(long, env = "MZ_CORS_ALLOWED_ORIGIN")]
     cors_allowed_origin: Vec<HeaderValue>,
 
     // === Storage options. ===


### PR DESCRIPTION
Improve handling of CORS in v0.26:

  * Backport support for using `*` to mean "any origin".
  * Enable the `use_value_delimiter` clap option to permit passing multiple values via the environment variable.
  * Unhide the option.

Note to self: needs a separate docs PR to the lts-docs branch once this lands.

### Motivation

  * This PR fixes a recognized bug: #13153.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
