### PR TITLE
mzcompose: Allow multiple Mz containers on the same host

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -383,7 +383,7 @@ class Composition:
         ports = self.compose["services"][service]["ports"]
         if not ports:
             raise UIError(f"service f{service!r} does not expose any ports")
-        private_port = str(ports[0]).split(":")[0]
+        private_port = str(ports[0]).split(":")[-1]
         return self.port(service, private_port)
 
     def workflow(self, name: str, *args: str) -> None:

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -40,6 +40,7 @@ class Materialized(Service):
         name: str = "materialized",
         hostname: Optional[str] = None,
         image: Optional[str] = None,
+        ports: Optional[List[str]] = None,
         extra_ports: List[int] = [],
         memory: Optional[str] = None,
         data_directory: str = "/mzdata",
@@ -52,6 +53,7 @@ class Materialized(Service):
         volumes: Optional[List[str]] = None,
         volumes_extra: Optional[List[str]] = None,
         depends_on: Optional[List[str]] = None,
+        allow_host_ports: bool = False,
     ) -> None:
         if environment is None:
             environment = [
@@ -89,7 +91,9 @@ class Materialized(Service):
             f"--timestamp-frequency {timestamp_frequency}",
         ]
 
-        config_ports = [6875, 5432, *extra_ports, 6876]
+        config_ports: List[Union[str, int]] = (
+            [*ports, *extra_ports] if ports else [6875, 5432, *extra_ports, 6876]
+        )
 
         if isinstance(image, str) and ":v" in image:
             requested_version = image.split(":v")[1]
@@ -124,6 +128,7 @@ class Materialized(Service):
                 "ports": config_ports,
                 "environment": environment,
                 "volumes": volumes,
+                "allow_host_ports": allow_host_ports,
             }
         )
 

--- a/misc/rqg/mzcompose
+++ b/misc/rqg/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/misc/rqg/mzcompose.py
+++ b/misc/rqg/mzcompose.py
@@ -1,0 +1,49 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services import Materialized
+
+
+def workflow_start_two_mzs(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Starts two Mz instances from different git tags for the purpose of manually running
+    RQG comparison tests.
+    """
+    parser.add_argument(
+        "--this-tag", help="Run Materialize with this git tag on port 6875"
+    )
+
+    parser.add_argument(
+        "--other-tag", help="Run Materialize with this git tag on port 16875"
+    )
+    args = parser.parse_args()
+
+    with c.override(
+        Materialized(
+            name="mz_this",
+            image=f"materialize/materialized:{args.this_tag}"
+            if args.this_tag
+            else None,
+            volumes=[],  # Keep the mzdata, pgdata, etc. private to the container
+            allow_host_ports=True,
+            ports=["6875:6875"],
+        ),
+        Materialized(
+            name="mz_other",
+            image=f"materialize/materialized:{args.other_tag}"
+            if args.other_tag
+            else None,
+            volumes=[],
+            allow_host_ports=True,
+            ports=["16875:6875"],
+        ),
+    ):
+        for mz in ["mz_this", "mz_other"]:
+            c.up(mz)
+            c.wait_for_materialized(service=mz)


### PR DESCRIPTION
For RQG comparison testing, two Mz versions need to be running
in a manner that also exposes them both on the host. For the purpose,
Materialized() instances need to be able to pass a 'HOSTPORT:CONTAINERPORT'
pair as part of their service definitions while keeping all the
internal Mz and Pg ports private.

### Motivation

  * This PR adds a feature that has not yet been specified.
Previously, it was not possible to use mzcompose to start 2 mz instances that both exposed a port to the host.