### PR TITLE
dataflow-types: allow read frontier lag of zero

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -596,8 +596,10 @@ impl ReadPolicy<mz_repr::Timestamp> {
             } else {
                 // Subtract the lag from the time, and then round down to a multiple thereof to cut chatter.
                 let mut time = upper[0];
-                time = time.saturating_sub(lag);
-                time = time.saturating_sub(time % lag);
+                if lag != 0 {
+                    time = time.saturating_sub(lag);
+                    time = time.saturating_sub(time % lag);
+                }
                 Antichain::from_elem(time)
             }
         }))
@@ -619,5 +621,17 @@ impl<T: Timestamp> ReadPolicy<T> {
                 frontier
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lag_writes_by_zero() {
+        let policy = ReadPolicy::lag_writes_by(0);
+        let write_frontier = Antichain::from_elem(5);
+        assert_eq!(policy.frontier(write_frontier.borrow()), write_frontier);
     }
 }


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

    Fixes #13197.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).