### PR TITLE
doc: add docs for the new window functions on LTS docs

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -632,6 +632,28 @@
   functions:
   - signature: 'dense_rank() -> int'
     description: Returns the rank of the current row within its partition without gaps, counting from 1.
+  - signature: 'first_value(value anycompatible) -> anyelement'
+    description: >-
+      Returns `value` evaluated at the first row of the window frame. The default window frame is
+      `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`.
+  - signature: 'lag(value anycompatible [, offset integer [, default anycompatible ]]) -> int'
+    description: >-
+      Returns `value` evaluated at the row that is `offset` rows before the current row within the partition;
+      if there is no such row, instead returns `default` (which must be of a type compatible with `value`).
+      If `offset` is `NULL`, `NULL` is returned instead.
+      Both `offset` and `default` are evaluated with respect to the current row.
+      If omitted, `offset` defaults to 1 and `default` to `NULL`.
+  - signature: 'last_value(value anycompatible) -> anyelement'
+    description: >-
+      Returns `value` evaluated at the last row of the window frame. The default window frame is
+      `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW`.
+  - signature: 'lead(value anycompatible [, offset integer [, default anycompatible ]]) -> int'
+    description: >-
+      Returns `value` evaluated at the row that is `offset` rows after the current row within the partition;
+      if there is no such row, instead returns `default` (which must be of a type compatible with `value`).
+      If `offset` is `NULL`, `NULL` is returned instead.
+      Both `offset` and `default` are evaluated with respect to the current row.
+      If omitted, `offset` defaults to 1 and `default` to `NULL`.
   - signature: 'row_number() -> int'
     description: Returns the number of the current row within its partition, counting from 1.
 


### PR DESCRIPTION
Add docs for the new window functions:
- `first_value`
- `last_value`
- `lag`
- `lead`

This PR is targeting the `lts-docs` branch, not `main`.

I think we might want to have a longer section explaining window functions and window frames, but I'll leave the decision on when to do that to @morsapaes.