### PR TITLE
developer docs: clarify name resolution + minor optimizer 101 changes.

### DIFF
--- a/doc/developer/101-query-compilation.md
+++ b/doc/developer/101-query-compilation.md
@@ -48,8 +48,9 @@ Transformations in the compile-time lifecycle of a SQL statement.
     * [Construct a dataflow for the query](https://github.com/MaterializeInc/materialize/blob/main/src/coord/src/coord/dataflow_builder.rs):
         * If the query depends on not-materialized views, the definitions of the
           not-materialized views get inlined.
-        * Import all indexes belonging to a materialized view that the query
-          depends on.
+        * For each materialized view that a query depends on, import all of its
+          materializations. (This corresponds to all indexes on that view, which
+          you can see if you call `SHOW INDEXES IN <view>`).
     * Run optimizations against the dataflow:
         * [Per-view logical](https://github.com/MaterializeInc/materialize/blob/main/src/transform/src/lib.rs#L282-L337).
         * [Cross-view logical](https://github.com/MaterializeInc/materialize/blob/main/src/transform/src/dataflow.rs#L31-L60).

--- a/doc/developer/101-query-compilation.md
+++ b/doc/developer/101-query-compilation.md
@@ -32,6 +32,10 @@ Transformations in the compile-time lifecycle of a SQL statement.
     * If the SQL query is a one-off, the outermost `TopK` is converted to a
       RowSetFinishing at this point.
     * `EXPLAIN RAW` returns the result of transformations up to this point.
+* [`HIR ⇒ HIR`](https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/plan/lowering.rs#L149-L150)
+    * Predecorrelation rewrites:
+        * [Split out subquery conditions out as a separate predicate.](https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/plan/transform_expr.rs#L54)
+        * [Try to rewrite other types of subqueries into EXISTS subqueries.](https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/plan/transform_expr.rs#L156)
 * [`HIR ⇒ MIR`](https://github.com/MaterializeInc/materialize/blob/main/src/sql/src/plan/lowering.rs).
     * Decorrelation:
         * Correlated queries are rewritten as graphs with join and distinct.


### PR DESCRIPTION
### Motivation

As previously discussed,
* "name resolution" in AST => AST has been clarified to "resolve names against the catalog".
* "name resolution" in AST => HIR has been clarified to "resolve column references and aliases".

I decided to add two additional things to the optimizer 101 doc:
1) A link to the Materialized performance 101 video.
2) A note that a dataflow is constructed for the query at the MIR => MIR stage, and that the view definition saved in the catalog is MIR.

### Tips for reviewer

View the new file itself, instead of the diffs.

### Testing

- Irrelevant

### Release notes

No user-facing behavior changes.
