### PR TITLE
*: finish plumbing PersistClientCache

### DIFF
--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -251,7 +251,6 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
 
     // Initialize dataflow controller.
     let dataflow_controller = mz_dataflow_types::client::Controller::new(config.controller).await;
-
     // Initialize coordinator.
     let (coord_handle, coord_client) = mz_coord::serve(mz_coord::Config {
         dataflow_client: dataflow_controller,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 use bytes::BufMut;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
-use mz_ore::metrics::MetricsRegistry;
 use mz_persist::cfg::{BlobMultiConfig, ConsensusConfig};
 use mz_persist::location::{BlobMulti, Consensus, ExternalError};
 use mz_persist_types::{Codec, Codec64};
@@ -33,7 +32,6 @@ use timely::progress::Timestamp;
 use tracing::{debug, instrument, trace};
 use uuid::Uuid;
 
-use crate::cache::PersistClientCache;
 use crate::error::InvalidUsage;
 use crate::r#impl::machine::{retry_external, Machine};
 use crate::read::{ReadHandle, ReaderId};
@@ -73,18 +71,10 @@ pub struct PersistLocation {
 }
 
 impl PersistLocation {
-    /// TODO: Plumb [PersistClientCache] to the necessary places and remove
-    /// this.
-    pub async fn open(&self) -> Result<PersistClient, ExternalError> {
-        PersistClientCache::new(&MetricsRegistry::new())
-            .open(self.clone())
-            .await
-    }
-
     /// Opens the associated implementations of [BlobMulti] and [Consensus].
     ///
     /// This is exposed mostly for testing. Persist users likely want
-    /// [Self::open].
+    /// [crate::cache::PersistClientCache::open].
     pub async fn open_locations(
         &self,
         metrics: &Metrics,
@@ -251,7 +241,7 @@ impl PersistClient {
     /// the given [BlobMulti] and [Consensus].
     ///
     /// This is exposed mostly for testing. Persist users likely want
-    /// [PersistClientCache::open].
+    /// [crate::cache::PersistClientCache::open].
     pub async fn new(
         cfg: PersistConfig,
         blob: Arc<dyn BlobMulti + Send + Sync>,
@@ -408,6 +398,7 @@ mod tests {
     use timely::PartialOrder;
     use tokio::task::JoinHandle;
 
+    use crate::cache::PersistClientCache;
     use crate::r#impl::state::Upper;
     use crate::read::ListenEvent;
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -167,6 +167,7 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
+                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::Delimited(ok), err), cap)
                 }
@@ -176,6 +177,7 @@ where
                             base_source_config,
                             &connection,
                             storage_state.connection_context.clone(),
+                            Arc::clone(&storage_state.persist_clients),
                         );
                     ((SourceType::Delimited(ok), err), cap)
                 }
@@ -184,6 +186,7 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
+                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::ByteStream(ok), err), cap)
                 }
@@ -192,6 +195,7 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
+                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::AppendRow(ok), err), cap)
                 }
@@ -200,6 +204,7 @@ where
                         base_source_config,
                         &connection,
                         storage_state.connection_context.clone(),
+                        Arc::clone(&storage_state.persist_clients),
                     );
                     ((SourceType::Row(ok), err), cap)
                 }

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -35,6 +35,7 @@ use differential_dataflow::Hashable;
 use futures::stream::LocalBoxStream;
 use futures::{Stream, StreamExt as _};
 use mz_dataflow_types::client::controller::storage::CollectionMetadata;
+use mz_persist_client::cache::PersistClientCache;
 use prometheus::core::{AtomicI64, AtomicU64};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract};
@@ -46,6 +47,7 @@ use timely::progress::Antichain;
 use timely::scheduling::activate::SyncActivator;
 use timely::scheduling::ActivateOnDrop;
 use timely::Data;
+use tokio::sync::Mutex;
 use tokio::time::MissedTickBehavior;
 use tracing::error;
 
@@ -702,6 +704,7 @@ pub fn create_raw_source<G, S: 'static>(
     config: RawSourceCreationConfig<G>,
     source_connection: &ExternalSourceConnection,
     connection_context: ConnectionContext,
+    persist_clients: Arc<Mutex<PersistClientCache>>,
 ) -> (
     (
         timely::dataflow::Stream<G, SourceOutput<S::Key, S::Value, S::Diff>>,
@@ -750,6 +753,7 @@ where
                 now,
                 timestamp_frequency.clone(),
                 as_of.clone(),
+                persist_clients,
             )
             .await
             {


### PR DESCRIPTION
These were missed in #12934

We need a singleton PersistClientCache so that it can internally share
postgres/aurora connections. It also needs to have access to a
MetricsRegistry so persist can internally hook up its metrics. So,
replace the workaround with instantiating it once at storaged/computed
startup and explictly plumbing it everywhere it needs to go.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
