### PR TITLE
sql: promote array subqueries out of unsafe mode

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -3414,7 +3414,6 @@ fn plan_array_subquery(
     ecx: &ExprContext,
     query: &Query<Aug>,
 ) -> Result<CoercibleScalarExpr, PlanError> {
-    ecx.require_unsafe_mode("array subquery")?;
     plan_vector_like_subquery(
         ecx,
         query,


### PR DESCRIPTION
So that the `\d` command in psql can be used without unsafe mode. As
best as @jkosh44 and I can tell, array subqueries were previously marked
as unsafe because they depended on the unsafe array_cat function, but
that function is now stabilized.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.
### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
