### PR TITLE
coord: tracing-instrument message_compute_instance_status and send_builtin_table_updates

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -655,6 +655,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// Initializes coordinator state based on the contained catalog. Must be
     /// called after creating the coordinator and before calling the
     /// `Coordinator::serve` method.
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn bootstrap(
         &mut self,
         builtin_table_updates: Vec<BuiltinTableUpdate>,
@@ -1566,6 +1567,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn message_compute_instance_status(&mut self, event: ComputeInstanceEvent) {
         self.catalog_transact(
             None,
@@ -4907,6 +4909,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// function successfully returns on any built `DataflowDesc`.
     ///
     /// [`CatalogState`]: crate::catalog::CatalogState
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn catalog_transact<F, R>(
         &mut self,
         session: Option<&Session>,
@@ -5037,6 +5040,7 @@ impl<S: Append + 'static> Coordinator<S> {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn send_builtin_table_updates(&mut self, updates: Vec<BuiltinTableUpdate>) {
         // Most DDL queries cause writes to system tables. Unlike writes to user tables, system
         // table writes are not batched in a group commit. This is mostly due to the complexity


### PR DESCRIPTION
These internally call StorageController::append, which in turn goes
through persist. So understanding their performance is quite useful when
debugging.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
