### PR TITLE
storage: dont buffer the entire pg snapshot

### DIFF
--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -147,8 +147,8 @@ struct PostgresTaskInfo {
     lsn: PgLsn,
     metrics: PgSourceMetrics,
     source_tables: HashMap<u32, PostgresTableDesc>,
+    row_sender: RowSender,
     sender: Sender<InternalMessage>,
-    activator: SyncActivator,
 }
 
 impl SourceReader for PostgresSourceReader {
@@ -176,7 +176,9 @@ impl SourceReader for PostgresSourceReader {
             }
         };
 
-        let (dataflow_tx, dataflow_rx) = tokio::sync::mpsc::channel(10_000);
+        // TODO: figure out the best default here; currently this is optimized
+        // for the speed to pass pg-cdc-resumption tests on a local machine.
+        let (dataflow_tx, dataflow_rx) = tokio::sync::mpsc::channel(50_000);
 
         let task_info = PostgresTaskInfo {
             source_id: source_id.clone(),
@@ -187,8 +189,8 @@ impl SourceReader for PostgresSourceReader {
             source_tables: HashMap::from_iter(
                 connection.details.tables.iter().map(|t| (t.oid, t.clone())),
             ),
+            row_sender: RowSender::new(dataflow_tx.clone(), consumer_activator),
             sender: dataflow_tx,
-            activator: consumer_activator,
         };
 
         task::spawn(
@@ -254,8 +256,13 @@ async fn postgres_replication_loop(mut task_info: PostgresTaskInfo) {
         Err(e) => {
             // Drop the send error, as we have no way of communicating back to the
             // source operator if the channel is gone.
-            let _ = task_info.sender.send(InternalMessage::Err(e)).await;
+            let _ = task_info
+                .row_sender
+                .sender
+                .send(InternalMessage::Err(e))
+                .await;
             task_info
+                .row_sender
                 .activator
                 .activate()
                 .expect("postgres reader activation failed");
@@ -270,16 +277,12 @@ async fn postgres_replication_loop_inner(
     let source_id = task_info.source_id.clone();
     // Buffer rows from snapshot to retract and retry, if initial snapshot fails.
     // Postgres sources cannot proceed without a successful snapshot.
-    let mut snapshot_tx = Transaction::new();
-    match task_info.produce_snapshot(&mut snapshot_tx).await {
+    match task_info.produce_snapshot().await {
         Ok(_) => {
             info!(
                 "replication snapshot for source {} succeeded",
                 &task_info.source_id
             );
-            snapshot_tx
-                .close(task_info.lsn, &task_info.sender, &task_info.activator)
-                .await;
         }
         Err(ReplicationError::Recoverable(e)) => {
             // TODO: In the future we probably want to handle this more gracefully,
@@ -326,55 +329,77 @@ async fn postgres_replication_loop_inner(
     }
 }
 
-/// A helper struct build and produce transactions
-struct Transaction {
-    rows: Vec<(Row, Diff)>,
+/// A type that makes it easy to correctly send inserts and deletes.
+///
+/// Note: `RowSender::delete/insert` should be called with the same
+/// lsn until `close_lsn` is called, which should be called and awaited
+/// before dropping the `RowSender` or moving onto a new lsn.
+/// Internally, this type uses asserts to uphold the first requirement.
+struct RowSender {
+    sender: Sender<InternalMessage>,
+    activator: SyncActivator,
+    buffered_message: Option<(Row, PgLsn, i64)>,
 }
 
-impl Transaction {
-    pub fn new() -> Self {
-        Transaction { rows: vec![] }
+impl RowSender {
+    /// Create a new `RowSender`.
+    pub fn new(sender: Sender<InternalMessage>, activator: SyncActivator) -> Self {
+        Self {
+            sender,
+            activator,
+            buffered_message: None,
+        }
     }
 
-    /// Record an insertion of a row in the current transaction
-    pub fn insert(&mut self, row: Row) {
-        self.rows.push((row, 1));
+    /// Insert a row at an lsn.
+    pub async fn insert(&mut self, row: Row, lsn: PgLsn) {
+        if let Some((buffered_row, buffered_lsn, buffered_diff)) = self.buffered_message.take() {
+            assert_eq!(buffered_lsn, lsn);
+            self.send_row(buffered_row, buffered_lsn, buffered_diff, false)
+                .await;
+        }
+
+        self.buffered_message = Some((row, lsn, 1));
+    }
+    /// Delete a row at an lsn.
+    pub async fn delete(&mut self, row: Row, lsn: PgLsn) {
+        if let Some((buffered_row, buffered_lsn, buffered_diff)) = self.buffered_message.take() {
+            assert_eq!(buffered_lsn, lsn);
+            self.send_row(buffered_row, buffered_lsn, buffered_diff, false)
+                .await;
+        }
+
+        self.buffered_message = Some((row, lsn, -1));
     }
 
-    /// Record a deletion of a row in the current transaction
-    pub fn delete(&mut self, row: Row) {
-        self.rows.push((row, -1));
+    /// Finalize an lsn, making sure all messages that my be buffered are flushed, and that the
+    /// last message sent is marked as closing the `lsn` (which is the messages `offset` in the
+    /// rest of the source pipeline.
+    pub async fn close_lsn(&mut self, lsn: PgLsn) {
+        if let Some((buffered_row, buffered_lsn, buffered_diff)) = self.buffered_message.take() {
+            assert_eq!(buffered_lsn, lsn);
+            self.send_row(buffered_row, buffered_lsn, buffered_diff, true)
+                .await;
+        }
     }
 
-    /// Finalize a transaction and send it off through the channel
-    ///
-    /// Care must be taken to ALWAYS call this if inserts/deletes have occurred,
-    /// unless you are on an early-exit error path, and the `PostgresSourceReader`
-    /// is shutting down.
-    pub async fn close(
-        &mut self,
-        lsn: PgLsn,
-        sender: &Sender<InternalMessage>,
-        activator: &SyncActivator,
-    ) {
-        let num = self.rows.len();
-        for (i, (row, diff)) in self.rows.drain(..).enumerate() {
-            // a closed receiver means the source has been shutdown
-            // (dropped or the process is dying), so just continue on
-            // without activation
-            if let Ok(_) = sender
-                .send(InternalMessage::Value {
-                    value: row,
-                    lsn,
-                    diff,
-                    end: i == (num - 1),
-                })
-                .await
-            {
-                activator
-                    .activate()
-                    .expect("postgres reader activation failed");
-            }
+    async fn send_row(&self, row: Row, lsn: PgLsn, diff: i64, end: bool) {
+        // a closed receiver means the source has been shutdown
+        // (dropped or the process is dying), so just continue on
+        // without activation
+        if let Ok(_) = self
+            .sender
+            .send(InternalMessage::Value {
+                value: row,
+                lsn,
+                diff,
+                end,
+            })
+            .await
+        {
+            self.activator
+                .activate()
+                .expect("postgres reader activation failed");
         }
     }
 }
@@ -413,10 +438,7 @@ impl PostgresTaskInfo {
     ///
     /// After the initial snapshot has been produced it returns the name of the created slot and
     /// the LSN at which we should start the replication stream at.
-    async fn produce_snapshot(
-        &mut self,
-        snapshot_tx: &mut Transaction,
-    ) -> Result<(), ReplicationError> {
+    async fn produce_snapshot(&mut self) -> Result<(), ReplicationError> {
         let client =
             try_recoverable!(mz_postgres_util::connect_replication(&self.connection.conn).await);
 
@@ -506,13 +528,18 @@ impl PostgresTaskInfo {
                     }
                     Ok(())
                 }));
-                snapshot_tx.insert(mz_row.clone());
+
+                self.row_sender.insert(mz_row.clone(), self.lsn).await;
             }
 
             self.metrics.tables.inc();
         }
         self.metrics.lsn.set(self.lsn.into());
         client.simple_query("COMMIT;").await?;
+
+        // close the current `row_sender` context after we are sure we are not erroring out.
+        // Otherwise, `revert_snapshot` will close it
+        self.row_sender.close_lsn(self.lsn).await;
         Ok(())
     }
 
@@ -572,6 +599,7 @@ impl PostgresTaskInfo {
         let mut inserts = vec![];
         let mut deletes = vec![];
         let closer = self.sender.clone();
+
         loop {
             // This select is safe because `Sender::closed` is cancel-safe
             // and when `closed` finishes, dropping the `try_next` future is fine,
@@ -684,16 +712,14 @@ impl PostgresTaskInfo {
                                         self.metrics.transactions.inc();
                                         self.lsn = commit.end_lsn().into();
 
-                                        let mut tx = Transaction::new();
-
                                         for row in deletes.drain(..) {
-                                            tx.delete(row);
+                                            self.row_sender.delete(row, self.lsn).await;
                                         }
                                         for row in inserts.drain(..) {
-                                            tx.insert(row);
+                                            self.row_sender.insert(row, self.lsn).await;
                                         }
 
-                                        tx.close(self.lsn, &self.sender, &self.activator).await;
+                                        self.row_sender.close_lsn(self.lsn).await;
                                         self.metrics.lsn.set(self.lsn.into());
                                     }
                                     Relation(relation) => {


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/12856

Currently, the pg source always buffers entire transactions AND the entire snapshot. Transactions must be buffered, because we don't know the commit lsn until we have received all inserts and deletes. However, we know the snapshot lsn upfront, and can avoid buffering it. After petros's pr (https://github.com/MaterializeInc/materialize/pull/13123) we will also no longer buffer the snapshot in the reclock operator.

In this pr, I introduced a `RowSender` structure that is stored on `PostgresTaskInfo`. It accepts `insert`s and `delete`s, and buffers a single message. This is to allow it correctly send the final message and close the lsn when one calls `close_lsn`. It uses `assert`s to ensure its used properly. Some important notes:

- `produce_snapshot` is responsible for calling `close_lsn` itself, which it only does if all things have gone error-free. If it errors beforehand, either
  - A recoverable error takes place, and `revert_snapshot` takes over
  - A fatal error happens, erroring the source. In this case, the source is errored, so it is _strictly correct we never closed the lsn_
- `revert_snapshot`, upon taking over, is also responsible for calling `close_lsn`, which it only does on success. Previously, even if this function error'd we called `close`. This is wrong, and _now we never close the lsn on error, which is strictly more correct_, as we are no longer claiming an lsn is finished but also erroring the source (cc @petrosagg)
- transactions in `produce_replication` are now only buffered in the `inserts` and `deletes` vectors, and not also in `Transaction`

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
