### PR TITLE
zippy: increase Nightly CI timeout to 120m

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -246,7 +246,7 @@ steps:
 
   - id: zippy-kafka-sources
     label: "Zippy"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 120
     agents:
       queue: linux-x86_64
     plugins:


### PR DESCRIPTION
Due to further degradation in product performance the timeout
of the job needs to be increased.
### Motivation

  * This PR fixes a previously unreported bug.
Zippy has started to fail in Nightly after the product became even slower than before.