### PR TITLE
mzcompose: Remove --log-error from all docker compose commands

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -341,7 +341,6 @@ class Composition:
                 [
                     "docker",
                     "compose",
-                    *(["--log-level=ERROR"] if self.silent else []),
                     f"-f/dev/fd/{self.file.fileno()}",
                     "--project-directory",
                     self.path,


### PR DESCRIPTION
--log-error is no longer supported in Docker 2.0 without an
alternative being provided.

### Motivation

  * This PR fixes a previously unreported bug.

Nighlly feature benchmark was failing on startup.

@benesch  FYI