### PR TITLE
Internal sinks, part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,7 +3930,6 @@ dependencies = [
  "datadriven",
  "itertools",
  "mz-ore",
- "mz-persist-client",
  "mz-walkabout",
  "phf",
  "phf_codegen",

--- a/src/compute/src/sink/kafka.rs
+++ b/src/compute/src/sink/kafka.rs
@@ -45,7 +45,6 @@ use tracing::{debug, error, info};
 
 use mz_avro::types::Value;
 use mz_dataflow_types::client::controller::storage::CollectionMetadata;
-use mz_interchange::json::JsonEncoder;
 use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sinks::{
     KafkaSinkConnection, KafkaSinkConsistencyConnection, PublishedSchemaInfo, SinkAsOf, SinkDesc,
@@ -55,6 +54,7 @@ use mz_interchange::avro::{
     self, get_debezium_transaction_schema, AvroEncoder, AvroSchemaGenerator,
 };
 use mz_interchange::encode::Encode;
+use mz_interchange::json::JsonEncoder;
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;

--- a/src/compute/src/sink/kafka.rs
+++ b/src/compute/src/sink/kafka.rs
@@ -22,7 +22,6 @@ use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::executor::block_on;
 use futures::{StreamExt, TryFutureExt};
 use itertools::Itertools;
-use mz_interchange::json::JsonEncoder;
 use prometheus::core::AtomicU64;
 use rdkafka::client::ClientContext;
 use rdkafka::config::ClientConfig;
@@ -45,6 +44,8 @@ use tokio::sync::Mutex;
 use tracing::{debug, error, info};
 
 use mz_avro::types::Value;
+use mz_dataflow_types::client::controller::storage::CollectionMetadata;
+use mz_interchange::json::JsonEncoder;
 use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sinks::{
     KafkaSinkConnection, KafkaSinkConsistencyConnection, PublishedSchemaInfo, SinkAsOf, SinkDesc,
@@ -88,7 +89,7 @@ where
     fn render_continuous_sink(
         &self,
         compute_state: &mut crate::compute_state::ComputeState,
-        sink: &SinkDesc,
+        sink: &SinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     ) -> Option<Rc<dyn Any>>

--- a/src/compute/src/sink/tail.rs
+++ b/src/compute/src/sink/tail.rs
@@ -22,7 +22,7 @@ use timely::progress::Antichain;
 
 use mz_dataflow_types::{
     sinks::{SinkAsOf, SinkDesc, TailSinkConnection},
-    TailResponse,
+    TailResponse, client::controller::storage::CollectionMetadata,
 };
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 
@@ -47,7 +47,7 @@ where
     fn render_continuous_sink(
         &self,
         compute_state: &mut crate::compute_state::ComputeState,
-        sink: &SinkDesc,
+        sink: &SinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     ) -> Option<Rc<dyn Any>>

--- a/src/compute/src/sink/tail.rs
+++ b/src/compute/src/sink/tail.rs
@@ -21,8 +21,9 @@ use timely::progress::timestamp::Timestamp as TimelyTimestamp;
 use timely::progress::Antichain;
 
 use mz_dataflow_types::{
+    client::controller::storage::CollectionMetadata,
     sinks::{SinkAsOf, SinkDesc, TailSinkConnection},
-    TailResponse, client::controller::storage::CollectionMetadata,
+    TailResponse,
 };
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 

--- a/src/coord/src/sink_connection.rs
+++ b/src/coord/src/sink_connection.rs
@@ -342,9 +342,7 @@ fn build_persist_sink(
     _id: GlobalId,
 ) -> Result<SinkConnection, CoordError> {
     Ok(SinkConnection::Persist(PersistSinkConnection {
-        consensus_uri: builder.consensus_uri,
-        blob_uri: builder.blob_uri,
-        shard_id: builder.shard_id,
         value_desc: builder.value_desc,
+        storage_metadata: (),
     }))
 }

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -612,6 +612,21 @@ where
             self.update_read_capabilities(&mut read_capability_changes)
                 .await?;
         }
+
+        // Tell the storage controller about new write frontiers for storage
+        // collections that are advanced by compute sinks.
+        // TODO(teskje): The storage controller should have a task to directly
+        // keep track of the frontiers of storage collections, instead of
+        // relying on others for that information.
+        let storage_updates: Vec<_> = updates
+            .iter()
+            .filter(|(id, _)| self.storage_mut().collection(*id).is_ok())
+            .cloned()
+            .collect();
+        self.storage_mut()
+            .update_write_frontiers(&storage_updates)
+            .await?;
+
         Ok(())
     }
 

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -37,7 +37,7 @@ use crate::client::replicated::ActiveReplication;
 use crate::client::{ComputeClient, ComputeCommand, ComputeInstanceId, InstanceConfig, ReplicaId};
 use crate::client::{GenericClient, Peek};
 use crate::logging::LoggingConfig;
-use crate::sinks::{SinkConnection, PersistSinkConnection, SinkDesc};
+use crate::sinks::{PersistSinkConnection, SinkConnection, SinkDesc};
 use crate::{DataflowDescription, SourceInstanceDesc};
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -11,6 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
+import "dataflow-types/src/client/controller/storage.proto";
 import "dataflow-types/src/types/connections.proto";
 import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
@@ -82,7 +83,5 @@ message ProtoPublishedSchemaInfo {
 
 message ProtoPersistSinkConnection {
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
-    string shard_id = 2;
-    string consensus_uri = 3;
-    string blob_uri = 4;
+    mz_dataflow_types.client.controller.storage.ProtoCollectionMetadata storage_metadata = 2;
 }

--- a/src/dataflow-types/src/types/sinks.rs
+++ b/src/dataflow-types/src/types/sinks.rs
@@ -16,7 +16,6 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 
-use mz_persist_client::ShardId;
 use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc};
 
@@ -446,9 +445,6 @@ pub enum SinkConnectionBuilder {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PersistSinkConnectionBuilder {
-    pub consensus_uri: String,
-    pub blob_uri: String,
-    pub shard_id: ShardId,
     pub value_desc: RelationDesc,
 }
 

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -11,10 +11,6 @@ publish = false
 anyhow = "1.0.58"
 itertools = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }
-# TODO(aljoscha): persist/storage sinks should have a human-readable
-# collection name and STORAGE needs to keep track of which shard IDs they map
-# to. Then we don't need this dependency here.
-mz-persist-client = { path = "../persist-client" }
 phf = { version = "0.10.1", features = ["uncased"] }
 tracing = "0.1.35"
 uncased = "0.9.7"

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -728,11 +728,7 @@ pub enum CreateSinkConnection<T: AstInfo> {
         key: Option<KafkaSinkKey>,
         consistency: Option<KafkaConsistency<T>>,
     },
-    Persist {
-        blob_uri: String,
-        consensus_uri: String,
-        shard_id: String,
-    },
+    Persist,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
@@ -757,18 +753,8 @@ impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
                     f.write_node(consistency);
                 }
             }
-            CreateSinkConnection::Persist {
-                blob_uri,
-                consensus_uri,
-                shard_id,
-            } => {
-                f.write_str("PERSIST CONSENSUS '");
-                f.write_node(&display::escape_single_quote_string(consensus_uri));
-                f.write_str("' BLOB '");
-                f.write_node(&display::escape_single_quote_string(blob_uri));
-                f.write_str("' SHARD '");
-                f.write_node(&display::escape_single_quote_string(shard_id));
-                f.write_str("'");
+            CreateSinkConnection::Persist => {
+                f.write_str("PERSIST");
             }
         }
     }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -38,7 +38,6 @@ Avro
 Begin
 Between
 Bigint
-Blob
 Boolean
 Both
 Bpchar
@@ -70,7 +69,6 @@ Compression
 Confluent
 Connection
 Connections
-Consensus
 Consistency
 Constraint
 Copy
@@ -265,7 +263,6 @@ Sequences
 Serializable
 Session
 Set
-Shard
 Show
 Sink
 Sinks

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -24,7 +24,6 @@ use std::error::Error;
 use std::fmt;
 
 use itertools::Itertools;
-use mz_persist_client::ShardId;
 use tracing::warn;
 
 use mz_ore::collections::CollectionExt;
@@ -2258,35 +2257,7 @@ impl<'a> Parser<'a> {
                     consistency,
                 })
             }
-            PERSIST => {
-                // TODO(aljoscha): We should not require (or allow) passing in consensus/blob
-                // configuration on the sink. Instead, we need to pick up the config that was given
-                // to materialized/storaged when starting up.
-                self.expect_keyword(CONSENSUS)?;
-                let consensus_uri = self.parse_literal_string()?;
-
-                self.expect_keyword(BLOB)?;
-                let blob_uri = self.parse_literal_string()?;
-
-                let shard_id = if self.peek_keyword(SHARD) {
-                    let _ = self.expect_keyword(SHARD)?;
-                    self.parse_literal_string()?
-                } else {
-                    // TODO(aljoscha): persist/storage sinks should have a human-readable
-                    // collection name and STORAGE needs to keep track of which shard IDs they map
-                    // to. Also, the lifecycle of collections created by a sink should be tracked
-                    // separate from the sink. And we can expose something like a `mz_collections`
-                    // to allow querying them.
-                    let shard_id = ShardId::new();
-                    format!("{}", shard_id)
-                };
-
-                Ok(CreateSinkConnection::Persist {
-                    consensus_uri,
-                    blob_uri,
-                    shard_id,
-                })
-            }
+            PERSIST => Ok(CreateSinkConnection::Persist),
             _ => unreachable!(),
         }
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2044,9 +2044,6 @@ fn get_kafka_sink_consistency_config(
 fn persist_sink_builder(
     format: Option<Format<Aug>>,
     envelope: SinkEnvelope,
-    blob_uri: String,
-    consensus_uri: String,
-    shard_id: String,
     value_desc: RelationDesc,
 ) -> Result<SinkConnectionBuilder, anyhow::Error> {
     if format.is_some() {
@@ -2058,12 +2055,7 @@ fn persist_sink_builder(
     }
 
     Ok(SinkConnectionBuilder::Persist(
-        PersistSinkConnectionBuilder {
-            consensus_uri,
-            blob_uri,
-            shard_id: shard_id.parse().map_err(anyhow::Error::msg)?,
-            value_desc,
-        },
+        PersistSinkConnectionBuilder { value_desc },
     ))
 }
 
@@ -2225,18 +2217,7 @@ pub fn plan_create_sink(
             suffix_nonce,
             &root_user_dependencies,
         )?,
-        CreateSinkConnection::Persist {
-            consensus_uri,
-            blob_uri,
-            shard_id,
-        } => persist_sink_builder(
-            format,
-            envelope,
-            blob_uri,
-            consensus_uri,
-            shard_id,
-            desc.into_owned(),
-        )?,
+        CreateSinkConnection::Persist => persist_sink_builder(format, envelope, desc.into_owned())?,
     };
 
     normalize::ensure_empty_options(&with_options, "CREATE SINK")?;


### PR DESCRIPTION
This PR is the first step towards enabling internal sinks in Materialize. It includes various changes to the existing persist sinks, to make them work like the envisioned internal sinks.

The PR does not make significant changes to the UI, the `CREATE SINK ... INTO PERSIST` syntax remains (albeit in a simpler form). Replacing it with the new `CREATE RECORDED VIEW` syntax will be the subject of a follow-up PR. The intention of this split is to keep the amount of changes that need to be reviewed somewhat manageable.

Changes made in this PR (see the separate commits for more detail):
* `SinkDesc` receives a type parameter for storage metadata, akin to `SourceInstanceDesc`.
* The persist location parameters are removed from `CREATE SINK ... INTO PERSIST`. Instead, the persist location is provided by the storage controller now.
* When creating a persist sink, a source is registered with the storage controller. Right now this is only done to get a storage collection, but later we will use that source to read back sinked data.
* computed's persist_sink is made compatible to storaged's persist_source, so sinked data can be read back.
* The compute controller is extended to report updates of persist sink uppers to the storage controller, so the storage controller can track the frontiers of sink collections.

### Usage

Sinking data now looks as follows from SQL:

```sql
CREATE TABLE table (a int);
CREATE SINK sink FROM table INTO PERSIST;
INSERT INTO table VALUES (1), (2), (2);
DELETE FROM table WHERE a != 1;
```

It is not currently possible to read back sinked data from SQL. Instead, you can write a simple tail command using the mz-persist-client crate directly, or clone https://github.com/teskje/persist-test.

When you crate a persist sink, `computed` prints the shard ID in an INFO trace:
```
[...] INFO mz_compute::sink::persist_sink: persist_sink shard ID: s00e6f38f-ccfc-4471-bb8c-49718abccc19
```

You can plug that into your tail command, e.g.:
```
$ cargo run --bin tail -- 'postgres://jan@%2Ftmp?options=--search_path=consensus' 'file:///Users/jan/devel/materialize/mzdata/persist/blob' 's00e6f38f-ccfc-4471-bb8c-49718abccc19'
[...]
(2), 1656079696243, -2
(1), 1656079696243, 1
(2), 1656079696243, 2
```

(Here, inserts and deletes appear to happen at the same time because the `since` of the persist shard has already advanced beyond the times of both events. If you want to see them happen in real-time, attach the tail first, before inserting/deleting from the table.)

### Caveats

Persist sinks should behave correctly on replicated compute instances and when compute replicas are killed and restarted. They currently don't survive restarts of `environmentd`: The sink gets recreated but gets a new persist shard ID, so data is written to a new storage collection instead of the existing one. This happens because [the storage controller currently doesn't persist shard ID](https://github.com/MaterializeInc/materialize/blob/f77cc5f87d9d01ac5a5a2b757cd09814688cd3c1/src/dataflow-types/src/client/controller/storage.rs#L359).

### Motivation

  * This PR adds a known-desirable feature.

    Part of https://github.com/MaterializeInc/materialize/issues/12860.

### Tips for reviewer

I would suggest looking at the individual commits separately.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).