### PR TITLE
coord: Refactor RemovePendingPeeks command

### DIFF
--- a/src/coord/src/command.rs
+++ b/src/coord/src/command.rs
@@ -82,10 +82,6 @@ pub enum Command {
         secret_key: u32,
     },
 
-    RemovePendingPeeks {
-        conn_id: u32,
-    },
-
     DumpCatalog {
         session: Session,
         tx: oneshot::Sender<Response<String>>,

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -183,6 +183,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     AdvanceLocalInput(AdvanceLocalInput<T>),
     GroupCommit,
     ComputeInstanceStatus(ComputeInstanceEvent),
+    RemovePendingPeeks { conn_id: u32 },
 }
 
 #[derive(Debug)]
@@ -1010,6 +1011,31 @@ impl<S: Append + 'static> Coordinator<S> {
                 Message::ComputeInstanceStatus(status) => {
                     self.message_compute_instance_status(status).await
                 }
+                // Processing this message DOES NOT send a response to the client;
+                // in any situation where you use it, you must also have a code
+                // path that responds to the client (e.g. reporting an error).
+                Message::RemovePendingPeeks { conn_id } => {
+                    // The peek is present on some specific compute instance.
+                    // Allow dataflow to cancel any pending peeks.
+                    if let Some(uuids) = self.client_pending_peeks.remove(&conn_id) {
+                        let mut inverse: BTreeMap<ComputeInstanceId, BTreeSet<Uuid>> =
+                            Default::default();
+                        for (uuid, compute_instance) in &uuids {
+                            inverse.entry(*compute_instance).or_default().insert(*uuid);
+                        }
+                        for (compute_instance, uuids) in inverse {
+                            self.dataflow_client
+                                .compute_mut(compute_instance)
+                                .unwrap()
+                                .cancel_peeks(&uuids)
+                                .await
+                                .unwrap();
+                        }
+                        for (uuid, _) in uuids {
+                            self.pending_peeks.remove(&uuid);
+                        }
+                    }
+                }
             }
 
             if let Some(timestamp) = self.global_timeline.should_advance_to() {
@@ -1547,32 +1573,6 @@ impl<S: Append + 'static> Coordinator<S> {
                 let result = self.verify_prepared_statement(&mut session, &name);
                 let _ = tx.send(Response { result, session });
             }
-
-            // Processing this command DOES NOT send a response to the client;
-            // in any situation where you use it, you must also have a code
-            // path that responds to the client (e.g. reporting an error).
-            Command::RemovePendingPeeks { conn_id } => {
-                // The peek is present on some specific compute instance.
-                // Allow dataflow to cancel any pending peeks.
-                if let Some(uuids) = self.client_pending_peeks.remove(&conn_id) {
-                    let mut inverse: BTreeMap<ComputeInstanceId, BTreeSet<Uuid>> =
-                        Default::default();
-                    for (uuid, compute_instance) in &uuids {
-                        inverse.entry(*compute_instance).or_default().insert(*uuid);
-                    }
-                    for (compute_instance, uuids) in inverse {
-                        self.dataflow_client
-                            .compute_mut(compute_instance)
-                            .unwrap()
-                            .cancel_peeks(&uuids)
-                            .await
-                            .unwrap();
-                    }
-                    for (uuid, _) in uuids {
-                        self.pending_peeks.remove(&uuid);
-                    }
-                }
-            }
         }
     }
 
@@ -1994,9 +1994,9 @@ impl<S: Append + 'static> Coordinator<S> {
             .expect("unable to drop temporary schema");
         self.active_conns.remove(&session.conn_id());
         self.internal_cmd_tx
-            .send(Message::Command(Command::RemovePendingPeeks {
+            .send(Message::RemovePendingPeeks {
                 conn_id: session.conn_id(),
-            }))
+            })
             .expect("sending to internal_cmd_tx cannot fail");
     }
 
@@ -4777,9 +4777,9 @@ impl<S: Append + 'static> Coordinator<S> {
                             // best-effort and doesn't guarantee we won't
                             // receive a response.
                             internal_cmd_tx
-                                .send(Message::Command(Command::RemovePendingPeeks {
+                                .send(Message::RemovePendingPeeks {
                                     conn_id: session.conn_id(),
-                                }))
+                                })
                                 .expect("sending to internal_cmd_tx cannot fail");
                             Err(CoordError::StatementTimeout)
                         }


### PR DESCRIPTION
All `Command`s correspond to some client initiated operation via one
of our APIs. The one exception to this is the `RemovePendingPeeks`
command, which is a message that the Coordinator sends to itself to
signal that some pending peek should be removed. This probably does not
belong in the `Command` enum and instead should be it's own message
type.

### Motivation
This PR refactors existing code.

### Tips for reviewer
* This doesn't change any logic and just moves the enum value `RemovePendingPeeks` from the `Command` enum to the `Message` enum.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
