### PR TITLE
doc/user: improve navigation in sidebar

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -181,10 +181,6 @@ body {
             padding: 4px 0;
             font-weight: bold;
             color: $medium-purple-v2;
-            &:hover,
-            &.active {
-                color: $purple-v2;
-            }
         }
 
         & > ul {

--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -69,6 +69,31 @@ versions = [
 ]
 
 [[menu.main]]
+identifier = "overview"
+name = "Overview"
+weight= 5
+
+[[menu.main]]
+identifier = "quickstarts"
+name = "Quickstarts"
+weight= 10
+
+[[menu.main]]
+identifier = "reference"
+name = "Reference"
+weight= 15
+
+[[menu.main]]
+identifier = "ops"
+name = "Operating Materialize"
+weight= 20
+
+[[menu.main]]
+identifier = "integrations"
+name = "Tools and integrations"
+weight= 25
+
+[[menu.main]]
 identifier = "cs_redpanda"
 name = "Redpanda"
 parent = "create-source"
@@ -139,14 +164,12 @@ weight = 5
 identifier = "integration-guides"
 name = "Integration guides"
 parent = "integrations"
-url = "/integrations"
 weight = 40
 
 [[menu.main]]
 identifier = "client-libraries"
 name = "Client libraries"
 parent = "integrations"
-url = "/integrations/#libraries-and-drivers"
 weight = 30
 
 [[menu.main]]

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Tools and Integrations
+title: Tools and integrations
 description: "Get details about third-party tools and integrations supported by Materialize"
 disable_list: true
 aliases:
@@ -8,10 +8,6 @@ aliases:
   - /third-party/postgres-cloud/
   - /guides/postgres-cloud/
   - /guides/
-menu:
-  main:
-    identifier: integrations
-weight: 50
 ---
 
 [//]: # "TODO(morsapaes) Once #8396 lands, link the page here"

--- a/doc/user/content/ops/_index.md
+++ b/doc/user/content/ops/_index.md
@@ -2,8 +2,6 @@
 title: "Operating Materialize"
 description: "Find details about running your Materialize instances"
 disable_toc: true
-menu:
-  main:
-    identifier: ops
-    weight: 40
 ---
+
+[//]: # "TODO(morsapaes) Re-hash this page into something more useful, and add it as an Overview sub-menu under Operating Materialize"

--- a/doc/user/content/overview/_index.md
+++ b/doc/user/content/overview/_index.md
@@ -1,13 +1,12 @@
 ---
-title: "What Is Materialize?"
+title: "What is Materialize?"
 description: "Learn more about Materialize"
 aliases:
   - /overview/what-is-materialize/
 menu:
   main:
-    identifier: overview
-    weight: 10
-    name: "Overview"
+    parent: overview
+    weight: 5
 ---
 
 Materialize is a streaming SQL materialized view engine.

--- a/doc/user/content/sql/_index.md
+++ b/doc/user/content/sql/_index.md
@@ -1,12 +1,10 @@
 ---
-title: "SQL Reference"
+title: "Reference"
 description: "A single page with every SQL command, function, type, and keyword."
-menu:
-  main:
-    identifier: 'reference'
-    name: 'Reference'
-    weight: 30
+disable_list: true
 ---
+
+[//]: # "TODO(morsapaes) Re-hash this page into something more useful, and add it as an Overview sub-menu under Reference"
 
 We want Materialize to be easy to use, so we designed it to work with SQL. However, every database implements SQL a little differently, and none matches the full standard. In general, we model our implementation after PostgreSQL.
 

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -4,7 +4,7 @@
     <ul>
       {{ range .Site.Menus.main.ByWeight }}
       <li class="level-1">
-        <a {{with .URL}}href="{{.}}"{{end}} class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
+        <a class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">
           {{.Name | markdownify}}
         </a>
 


### PR DESCRIPTION
Minor tweaks to make top sections unclickable, and make their linked pages clickable from the sidebar (instead of hidden behind the top sections, where they're easily missed).