### PR TITLE
storage: use Debezium sequence numbers for PostgreSQL deduplication

### DIFF
--- a/doc/user/content/integrations/cdc-mysql.md
+++ b/doc/user/content/integrations/cdc-mysql.md
@@ -44,6 +44,8 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 Debezium is deployed as a set of Kafka Connect-compatible
 connectors, so you first need to define a MySQL connector configuration and then start the connector by adding it to Kafka Connect.
 
+{{< debezium-warning >}}
+
 {{< warning >}}
 If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html), you **must** override the default value of `After-state only` to `false`.
 {{</ warning >}}

--- a/doc/user/content/integrations/cdc-postgres.md
+++ b/doc/user/content/integrations/cdc-postgres.md
@@ -159,6 +159,8 @@ As a _superuser_:
 
 Debezium is deployed as a set of Kafka Connect-compatible connectors, so you first need to define a Postgres connector configuration and then start the connector by adding it to Kafka Connect.
 
+{{< debezium-warning >}}
+
 {{< warning >}}
 If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html), you **must** override the default value of `After-state only` to `false`.
 {{</ warning >}}

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -97,6 +97,8 @@ Primary keys are **automatically** inferred for Kafka sources using the `UPSERT`
 
 {{< debezium-json >}}
 
+{{< debezium-warning >}}
+
 Materialize provides a dedicated envelope (`ENVELOPE DEBEZIUM`) to decode Kafka messages produced by [Debezium](https://debezium.io/). To create a source that interprets Debezium messages:
 
 ```sql

--- a/doc/user/layouts/shortcodes/debezium-warning.html
+++ b/doc/user/layouts/shortcodes/debezium-warning.html
@@ -1,0 +1,3 @@
+<div class="warning">
+  <strong class="gutter">WARNING!</strong> Materialize requires Debezium v1.5+.
+</div>

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -129,11 +129,11 @@ message ProtoDebeziumMode {
 }
 
 message ProtoDebeziumDedupProjection {
-    uint64 source_idx = 1;
-    uint64 snapshot_idx = 2;
-    ProtoDebeziumSourceProjection source_projection = 3;
-    uint64 transaction_idx = 4;
-    uint64 total_order_idx = 5;
+    uint64 op_idx = 1;
+    uint64 source_idx = 2;
+    uint64 snapshot_idx = 3;
+    ProtoDebeziumSourceProjection source_projection = 4;
+    uint64 transaction_idx = 5;
     ProtoDebeziumTransactionMetadata tx_metadata = 6;
 }
 
@@ -145,7 +145,7 @@ message ProtoDebeziumSourceProjection {
     }
 
     message ProtoPostgres {
-        optional uint64 sequence = 1;
+        uint64 sequence = 1;
         uint64 lsn = 2;
     }
 

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -835,6 +835,8 @@ impl DebeziumMode {
 
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DebeziumDedupProjection {
+    /// The column index for the `op` field.
+    pub op_idx: usize,
     /// The column index containing the debezium source metadata
     pub source_idx: usize,
     /// The record index of the `source.snapshot` field
@@ -843,32 +845,31 @@ pub struct DebeziumDedupProjection {
     pub source_projection: DebeziumSourceProjection,
     /// The column index containing the debezium transaction metadata
     pub transaction_idx: usize,
-    /// The record index of the `transaction.total_order` field
-    pub total_order_idx: usize,
+    /// Details about the transaction metadata.
     pub tx_metadata: Option<DebeziumTransactionMetadata>,
 }
 
 impl RustType<ProtoDebeziumDedupProjection> for DebeziumDedupProjection {
     fn into_proto(self: &Self) -> ProtoDebeziumDedupProjection {
         ProtoDebeziumDedupProjection {
+            op_idx: self.op_idx.into_proto(),
             source_idx: self.source_idx.into_proto(),
             snapshot_idx: self.snapshot_idx.into_proto(),
             source_projection: Some(self.source_projection.into_proto()),
             transaction_idx: self.transaction_idx.into_proto(),
-            total_order_idx: self.total_order_idx.into_proto(),
             tx_metadata: self.tx_metadata.into_proto(),
         }
     }
 
     fn from_proto(proto: ProtoDebeziumDedupProjection) -> Result<Self, TryFromProtoError> {
         Ok(DebeziumDedupProjection {
+            op_idx: proto.op_idx.into_rust()?,
             source_idx: proto.source_idx.into_rust()?,
             snapshot_idx: proto.snapshot_idx.into_rust()?,
             source_projection: proto
                 .source_projection
                 .into_rust_if_some("ProtoDebeziumDedupProjection::source_projection")?,
             transaction_idx: proto.transaction_idx.into_rust()?,
-            total_order_idx: proto.total_order_idx.into_rust()?,
             tx_metadata: proto.tx_metadata.into_rust()?,
         })
     }
@@ -886,7 +887,7 @@ pub enum DebeziumSourceProjection {
         row: usize,
     },
     Postgres {
-        sequence: Option<usize>,
+        sequence: usize,
         lsn: usize,
     },
     SqlServer {

--- a/test/debezium/postgres/90-decimal-handling-mode.td
+++ b/test/debezium/postgres/90-decimal-handling-mode.td
@@ -43,7 +43,6 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.bootstrap.servers": "kafka:9092",
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
-  "provide.transaction.metadata": "true",
   "decimal.handling.mode": "double"
 }
 
@@ -123,7 +122,6 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.bootstrap.servers": "kafka:9092",
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
-  "provide.transaction.metadata": "true",
   "decimal.handling.mode": "precise"
 }
 

--- a/test/debezium/postgres/92-large-transaction.td
+++ b/test/debezium/postgres/92-large-transaction.td
@@ -9,6 +9,29 @@
 #
 # Test that large transactions are properly replicated
 
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "provide.transaction.metadata": "true",
+  "decimal.handling.mode": "precise"
+}
+
+# PUT requests do not take effect immediately, we need to sleep
+
+> SELECT mz_internal.mz_sleep(10)
+<null>
+
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 DROP TABLE IF EXISTS ten;
 CREATE TABLE ten (f1 INTEGER);
@@ -70,3 +93,27 @@ event_count data_collections
 20000       "{\"(public.large_distinct_rows,10000)\",\"(public.large_same_rows,10000)\"}"
 20000       "{\"(public.large_distinct_rows,20000)\"}"
 10000       "{\"(public.large_same_rows,10000)\"}"
+
+#
+# Restore default
+#
+
+$ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/config content-type=application/json
+{
+  "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+  "database.hostname": "postgres",
+  "database.port": "5432",
+  "database.user": "debezium",
+  "database.password": "debezium",
+  "database.dbname" : "postgres",
+  "database.server.name": "postgres",
+  "plugin.name": "pgoutput",
+  "slot.name" : "tester",
+  "database.history.kafka.bootstrap.servers": "kafka:9092",
+  "database.history.kafka.topic": "schema-changes.history",
+  "truncate.handling.mode": "include",
+  "decimal.handling.mode": "precise"
+}
+
+> SELECT mz_internal.mz_sleep(10)
+<null>

--- a/test/debezium/postgres/debezium-postgres.td.initialize
+++ b/test/debezium/postgres/debezium-postgres.td.initialize
@@ -54,7 +54,6 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
     "database.history.kafka.bootstrap.servers": "kafka:9092",
     "database.history.kafka.topic": "schema-changes.history",
     "truncate.handling.mode": "include",
-    "provide.transaction.metadata": "true",
     "decimal.handling.mode": "precise"
   }
 }

--- a/test/testdrive/debezium-multiple-partitions.td
+++ b/test/testdrive/debezium-multiple-partitions.td
@@ -30,6 +30,7 @@ $ set schema={
         ]
       },
       { "name": "after", "type": ["row", "null"] },
+      { "name": "op", "type": "string" },
       {
         "name": "source",
         "type": {
@@ -66,17 +67,29 @@ $ set schema={
       },
       {
         "name": "transaction",
-        "type": {
-          "type": "record",
-          "name": "Transaction",
-          "namespace": "whatever",
-          "fields": [
-            {
-              "name": "total_order",
-              "type": ["long", "null"]
-            }
-          ]
-        }
+        "type": [
+          "null",
+          {
+            "type": "record",
+            "name": "ConnectDefault",
+            "namespace": "io.confluent.connect.avro",
+            "fields": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "total_order",
+                "type": "long"
+              },
+              {
+                "name": "data_collection_order",
+                "type": "long"
+              }
+            ]
+          }
+        ],
+        "default": null
       }
     ]
   }
@@ -91,13 +104,13 @@ $ kafka-create-topic topic=data partitions=3
 
 # Ingest the data in the reverse order but in separate partitions
 $ kafka-ingest format=avro key-format=avro topic=data schema=${schema} key-schema=${key-schema} partition=2
-{"a":3} {"before":null,"after":{"row":{"a":3,"b":1}},"source":{"file":"binlog","pos":3,"row":0,"snapshot":{"boolean":false}},"transaction":{"total_order":null}}
+{"a":3} {"before":null,"after":{"row":{"a":3,"b":1}},"source":{"file":"binlog","pos":3,"row":0,"snapshot":{"boolean":false}}, "op": "c", "transaction": null}
 
 $ kafka-ingest format=avro key-format=avro topic=data schema=${schema} key-schema=${key-schema} partition=1
-{"a":2} {"before":null,"after":{"row":{"a":2,"b":1}},"source":{"file":"binlog","pos":2,"row":0,"snapshot":{"boolean":false}},"transaction":{"total_order":null}}
+{"a":2} {"before":null,"after":{"row":{"a":2,"b":1}},"source":{"file":"binlog","pos":2,"row":0,"snapshot":{"boolean":false}}, "op": "c", "transaction": null}
 
 $ kafka-ingest format=avro key-format=avro topic=data schema=${schema} key-schema=${key-schema} partition=0
-{"a":1} {"before":null,"after":{"row":{"a":1,"b":1}},"source":{"file":"binlog","pos":1,"row":0,"snapshot":{"boolean":false}},"transaction":{"total_order":null}}
+{"a":1} {"before":null,"after":{"row":{"a":1,"b":1}},"source":{"file":"binlog","pos":1,"row":0,"snapshot":{"boolean":false}}, "op": "c", "transaction": null}
 
 > SELECT a, b FROM multipartition
 a b

--- a/test/testdrive/github-5668.td
+++ b/test/testdrive/github-5668.td
@@ -31,6 +31,7 @@ $ set pg-dbz-schema={
         ]
       },
       { "name": "after", "type": ["row", "null"] },
+      { "name": "op", "type": "string" },
       {
         "name": "source",
         "type": {
@@ -67,17 +68,29 @@ $ set pg-dbz-schema={
       },
       {
         "name": "transaction",
-        "type": {
-          "type": "record",
-          "name": "Transaction",
-          "namespace": "whatever",
-          "fields": [
-            {
-              "name": "total_order",
-              "type": ["long", "null"]
-            }
-          ]
-        }
+        "type": [
+          "null",
+          {
+            "type": "record",
+            "name": "ConnectDefault",
+            "namespace": "io.confluent.connect.avro",
+            "fields": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "total_order",
+                "type": "long"
+              },
+              {
+                "name": "data_collection_order",
+                "type": "long"
+              }
+            ]
+          }
+        ],
+        "default": null
       }
     ]
   }
@@ -85,14 +98,14 @@ $ set pg-dbz-schema={
 $ kafka-create-topic topic=pg-dbz-data partitions=1
 
 $ kafka-ingest format=avro topic=pg-dbz-data schema=${pg-dbz-schema} timestamp=1
-{"before": null, "after": {"row":{"val": "foo"}}, "source": {"lsn": {"long": 3}, "sequence": {"string": "[null, \"3\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": {"row":{"val": "foo"}}, "after": {"row":{"val": "bar"}}, "source": {"lsn": {"long": 5}, "sequence": {"string": "[null, \"5\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": {"row":{"val": "bar"}}, "after": {"row":{"val": "baz"}}, "source": {"lsn": {"long": 7}, "sequence": {"string": "[null, \"7\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"val": "foo"}}, "source": {"lsn": {"long": 3}, "sequence": {"string": "[\"1\", \"3\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": {"row":{"val": "foo"}}, "after": {"row":{"val": "bar"}}, "source": {"lsn": {"long": 5}, "sequence": {"string": "[\"1\", \"5\"]"}, "snapshot": {"string": "false"}}, "op": "u", "transaction": null}
+{"before": {"row":{"val": "bar"}}, "after": {"row":{"val": "baz"}}, "source": {"lsn": {"long": 7}, "sequence": {"string": "[\"1\", \"7\"]"}, "snapshot": {"string": "false"}}, "op": "u", "transaction": null}
 
-{"before": null, "after": {"row":{"val": "hello,"}}, "source": {"lsn": {"long": 4}, "sequence": {"string": "[\"8\", \"4\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"val": "world!"}}, "source": {"lsn": {"long": 6}, "sequence": {"string": "[\"8\", \"6\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"val": "hello,"}}, "source": {"lsn": {"long": 4}, "sequence": {"string": "[\"8\", \"4\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"val": "world!"}}, "source": {"lsn": {"long": 6}, "sequence": {"string": "[\"8\", \"6\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
-{"before": null, "after": {"row":{"val": "too late"}}, "source": {"lsn": {"long": 1}, "sequence": {"string": "[null, \"1\"]"}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"val": "too late"}}, "source": {"lsn": {"long": 1}, "sequence": {"string": "[\"1\", \"1\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 > CREATE MATERIALIZED SOURCE pg_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-pg-dbz-data-${testdrive.seed}'

--- a/test/testdrive/kafka-avro-debezium-transaction.td
+++ b/test/testdrive/kafka-avro-debezium-transaction.td
@@ -27,6 +27,7 @@ $ set schema={
           "null"
         ]
       },
+      { "name": "op", "type": "string" },
       { "name": "after", "type": ["row", "null"] },
       {
         "name": "source",
@@ -174,8 +175,8 @@ $ kafka-create-topic topic=data
 $ kafka-create-topic topic=data2
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
-{"before": null, "after": {"row": {"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "1"}}
 
 #
 # Create a source using an inline schema.
@@ -195,7 +196,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   )
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 4, "b": 5}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 4, "b": 5}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "1"}}
 
 # Note that this should still work even if data2 (which shares the transaction metadata source) isn't able to progress!
 > SELECT a, b FROM data_schema_inline
@@ -211,7 +212,7 @@ $ kafka-ingest format=avro topic=data-txdata schema=${txschema} timestamp=2
 
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 8, "b": 9}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "5"}}
+{"before": null, "after": {"row": {"a": 8, "b": 9}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "5"}}
 
 
 > CREATE SINK data_sink FROM data_schema_inline
@@ -221,8 +222,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 4, "b": 5}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
-{"before": null, "after": {"row": {"a": 8, "b": 9}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "5"}}
+{"before": null, "after": {"row": {"a": 4, "b": 5}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 8, "b": 9}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "5"}}
 
 > SELECT a, b FROM data_schema_inline
 a  b
@@ -234,7 +235,7 @@ a  b
 
 # Now do data2
 $ kafka-ingest format=avro topic=data2 schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 101, "b": 101}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 101, "b": 101}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "1"}}
 
 > SELECT a, b FROM data2_schema_inline
 a    b
@@ -299,7 +300,7 @@ a  b
 
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 2, "b": 7}}, "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "7"}}
+{"before": null, "after": {"row": {"a": 2, "b": 7}}, "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "7"}}
 
 > SELECT a, b FROM data_schema_inline
 a  b
@@ -320,7 +321,7 @@ mz_timestamp  mz_progressed  mz_diff  a       b
 > COMMIT
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 3, "b": 9}}, "source": {"file": "binlog4", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "9"}}
+{"before": null, "after": {"row": {"a": 3, "b": 9}}, "source": {"file": "binlog4", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": {"total_order": null, "id": "9"}}
 
 > SELECT a, b FROM data_schema_inline
 a  b

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -62,6 +62,7 @@ $ set schema={
         ]
       },
       { "name": "after", "type": ["row", "null"] },
+      { "name": "op", "type": "string" },
       {
         "name": "source",
         "type": {
@@ -98,21 +99,29 @@ $ set schema={
       },
       {
         "name": "transaction",
-        "type": {
-          "type": "record",
-          "name": "Transaction",
-          "namespace": "whatever",
-          "fields": [
-            {
-              "name": "total_order",
-              "type": ["long", "null"]
-            },
-            {
-              "name": "id",
-              "type": "string"
-            }
-          ]
-        }
+        "type": [
+          "null",
+          {
+            "type": "record",
+            "name": "ConnectDefault",
+            "namespace": "io.confluent.connect.avro",
+            "fields": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "total_order",
+                "type": "long"
+              },
+              {
+                "name": "data_collection_order",
+                "type": "long"
+              }
+            ]
+          }
+        ],
+        "default": null
       }
     ]
   }
@@ -120,9 +129,9 @@ $ set schema={
 $ kafka-create-topic topic=data partitions=1
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 1, "b": 1, "json": "null", "c": "True", "d": "False", "e": {"nested_data_1": {"n1_a": 42, "n1_b": {"double": 86.5}}}, "f": null}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
-{"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": {"nested_data_1": {"n1_a": 43, "n1_b":{"nested_data_2": {"n2_a": 44, "n2_b": -1}}}}, "f": {"nested_data_2": {"n2_a": 45, "n2_b": -2}}}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
-{"before": null, "after": {"row": {"a": -1, "b": 7, "json": "[1, 2, 3]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 1, "b": 1, "json": "null", "c": "True", "d": "False", "e": {"nested_data_1": {"n1_a": 42, "n1_b": {"double": 86.5}}}, "f": null}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"boolean": false}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": {"nested_data_1": {"n1_a": 43, "n1_b":{"nested_data_2": {"n2_a": 44, "n2_b": -1}}}}, "f": {"nested_data_2": {"n2_a": 45, "n2_b": -2}}}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row": {"a": -1, "b": 7, "json": "[1, 2, 3]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": null}
 
 # We should refuse to create a source with invalid WITH options
 ! CREATE MATERIALIZED SOURCE invalid_with_option
@@ -154,7 +163,7 @@ name
 > SHOW CREATE SOURCE data_schema_inline
 Source   "Create Source"
 ------------------------
-materialize.public.data_schema_inline "CREATE SOURCE \"materialize\".\"public\".\"data_schema_inline\" FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' WITH (\"deduplication\" = 'ordered') FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"envelope\",   \"fields\": [     {       \"name\": \"before\",       \"type\": [         {           \"name\": \"row\",           \"type\": \"record\",           \"fields\": [             {\"name\": \"a\", \"type\": \"long\"},             {\"name\": \"b\", \"type\": \"long\"},             {               \"name\": \"json\",               \"type\": {                 \"connect.name\": \"io.debezium.data.Json\",                 \"type\": \"string\"               }             },             {               \"name\": \"c\",               \"type\": {                 \"type\": \"enum\",                 \"name\": \"Bool\",                 \"symbols\": [\"True\", \"False\", \"FileNotFound\"]               }             },             {\"name\": \"d\", \"type\": \"Bool\"},             {\"name\": \"e\", \"type\": [\"null\",{               \"type\": \"record\",               \"name\": \"nested_data_1\",               \"fields\": [                   {\"name\": \"n1_a\", \"type\": \"long\"},                   {\"name\": \"n1_b\", \"type\": [\"null\", \"double\", {                       \"type\": \"record\",                       \"name\": \"nested_data_2\",                       \"fields\": [                         {\"name\": \"n2_a\", \"type\": \"long\"},                         {\"name\": \"n2_b\", \"type\": \"int\"}                       ]                     }]                   }                 ]               }]             },             {\"name\": \"f\", \"type\": [\"null\", \"nested_data_2\"]}           ]         },         \"null\"       ]     },     { \"name\": \"after\", \"type\": [\"row\", \"null\"] },     {       \"name\": \"source\",       \"type\": {         \"type\": \"record\",         \"name\": \"Source\",         \"namespace\": \"io.debezium.connector.mysql\",         \"fields\": [           {             \"name\": \"file\",             \"type\": \"string\"           },           {             \"name\": \"pos\",             \"type\": \"long\"           },           {             \"name\": \"row\",             \"type\": \"int\"           },           {             \"name\": \"snapshot\",             \"type\": [               {                 \"type\": \"boolean\",                 \"connect.default\": false               },               \"null\"             ],             \"default\": false           }         ],         \"connect.name\": \"io.debezium.connector.mysql.Source\"       }     },     {       \"name\": \"transaction\",       \"type\": {         \"type\": \"record\",         \"name\": \"Transaction\",         \"namespace\": \"whatever\",         \"fields\": [           {             \"name\": \"total_order\",             \"type\": [\"long\", \"null\"]           },           {             \"name\": \"id\",             \"type\": \"string\"           }         ]       }     }   ] }' ENVELOPE DEBEZIUM"
+materialize.public.data_schema_inline "CREATE SOURCE \"materialize\".\"public\".\"data_schema_inline\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' WITH (\"deduplication\" = 'ordered') FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"envelope\",   \"fields\": [     {       \"name\": \"before\",       \"type\": [         {           \"name\": \"row\",           \"type\": \"record\",           \"fields\": [             {\"name\": \"a\", \"type\": \"long\"},             {\"name\": \"b\", \"type\": \"long\"},             {               \"name\": \"json\",               \"type\": {                 \"connect.name\": \"io.debezium.data.Json\",                 \"type\": \"string\"               }             },             {               \"name\": \"c\",               \"type\": {                 \"type\": \"enum\",                 \"name\": \"Bool\",                 \"symbols\": [\"True\", \"False\", \"FileNotFound\"]               }             },             {\"name\": \"d\", \"type\": \"Bool\"},             {\"name\": \"e\", \"type\": [\"null\",{               \"type\": \"record\",               \"name\": \"nested_data_1\",               \"fields\": [                   {\"name\": \"n1_a\", \"type\": \"long\"},                   {\"name\": \"n1_b\", \"type\": [\"null\", \"double\", {                       \"type\": \"record\",                       \"name\": \"nested_data_2\",                       \"fields\": [                         {\"name\": \"n2_a\", \"type\": \"long\"},                         {\"name\": \"n2_b\", \"type\": \"int\"}                       ]                     }]                   }                 ]               }]             },             {\"name\": \"f\", \"type\": [\"null\", \"nested_data_2\"]}           ]         },         \"null\"       ]     },     { \"name\": \"after\", \"type\": [\"row\", \"null\"] },     { \"name\": \"op\", \"type\": \"string\" },     {       \"name\": \"source\",       \"type\": {         \"type\": \"record\",         \"name\": \"Source\",         \"namespace\": \"io.debezium.connector.mysql\",         \"fields\": [           {             \"name\": \"file\",             \"type\": \"string\"           },           {             \"name\": \"pos\",             \"type\": \"long\"           },           {             \"name\": \"row\",             \"type\": \"int\"           },           {             \"name\": \"snapshot\",             \"type\": [               {                 \"type\": \"boolean\",                 \"connect.default\": false               },               \"null\"             ],             \"default\": false           }         ],         \"connect.name\": \"io.debezium.connector.mysql.Source\"       }     },     {       \"name\": \"transaction\",       \"type\": [         \"null\",         {           \"type\": \"record\",           \"name\": \"ConnectDefault\",           \"namespace\": \"io.confluent.connect.avro\",           \"fields\": [             {               \"name\": \"id\",               \"type\": \"string\"             },             {               \"name\": \"total_order\",               \"type\": \"long\"             },             {               \"name\": \"data_collection_order\",               \"type\": \"long\"             }           ]         }       ],       \"default\": null     }   ] }' ENVELOPE DEBEZIUM"
 
 > SELECT a, b, json, c, d, e::text, f::text FROM data_schema_inline
 a  b  json                     c            d             e                   f
@@ -176,8 +185,8 @@ a  b  json            c            d
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
-{"before": null, "after": {"row": {"a": 42, "b": 19, "json": "[4, 5, 6]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "transaction": {"total_order": null, "id": "1"}}
+{"before": null, "after": {"row": {"a": 2, "b": 3, "json": "{\"hello\": \"world\"}", "c": "False", "d": "FileNotFound", "e": null, "f": null}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"boolean": false}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row": {"a": 42, "b": 19, "json": "[4, 5, 6]", "c": "FileNotFound", "d": "True", "e": null, "f": null}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c", "transaction": null}
 
 > SELECT a, b, json, c, d, e::text, f::text FROM data_schema_inline
 a  b  json                     c            d             e                   f
@@ -207,7 +216,7 @@ $ file-append path=data-schema.json
 > SHOW CREATE SOURCE data_schema_file
 Source   "Create Source"
 ------------------------
-materialize.public.data_schema_file "CREATE SOURCE \"materialize\".\"public\".\"data_schema_file\" FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"envelope\",   \"fields\": [     {       \"name\": \"before\",       \"type\": [         {           \"name\": \"row\",           \"type\": \"record\",           \"fields\": [             {\"name\": \"a\", \"type\": \"long\"},             {\"name\": \"b\", \"type\": \"long\"},             {               \"name\": \"json\",               \"type\": {                 \"connect.name\": \"io.debezium.data.Json\",                 \"type\": \"string\"               }             },             {               \"name\": \"c\",               \"type\": {                 \"type\": \"enum\",                 \"name\": \"Bool\",                 \"symbols\": [\"True\", \"False\", \"FileNotFound\"]               }             },             {\"name\": \"d\", \"type\": \"Bool\"},             {\"name\": \"e\", \"type\": [\"null\",{               \"type\": \"record\",               \"name\": \"nested_data_1\",               \"fields\": [                   {\"name\": \"n1_a\", \"type\": \"long\"},                   {\"name\": \"n1_b\", \"type\": [\"null\", \"double\", {                       \"type\": \"record\",                       \"name\": \"nested_data_2\",                       \"fields\": [                         {\"name\": \"n2_a\", \"type\": \"long\"},                         {\"name\": \"n2_b\", \"type\": \"int\"}                       ]                     }]                   }                 ]               }]             },             {\"name\": \"f\", \"type\": [\"null\", \"nested_data_2\"]}           ]         },         \"null\"       ]     },     { \"name\": \"after\", \"type\": [\"row\", \"null\"] },     {       \"name\": \"source\",       \"type\": {         \"type\": \"record\",         \"name\": \"Source\",         \"namespace\": \"io.debezium.connector.mysql\",         \"fields\": [           {             \"name\": \"file\",             \"type\": \"string\"           },           {             \"name\": \"pos\",             \"type\": \"long\"           },           {             \"name\": \"row\",             \"type\": \"int\"           },           {             \"name\": \"snapshot\",             \"type\": [               {                 \"type\": \"boolean\",                 \"connect.default\": false               },               \"null\"             ],             \"default\": false           }         ],         \"connect.name\": \"io.debezium.connector.mysql.Source\"       }     },     {       \"name\": \"transaction\",       \"type\": {         \"type\": \"record\",         \"name\": \"Transaction\",         \"namespace\": \"whatever\",         \"fields\": [           {             \"name\": \"total_order\",             \"type\": [\"long\", \"null\"]           },           {             \"name\": \"id\",             \"type\": \"string\"           }         ]       }     }   ] }\n' ENVELOPE DEBEZIUM"
+materialize.public.data_schema_file "CREATE SOURCE \"materialize\".\"public\".\"data_schema_file\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '{   \"type\": \"record\",   \"name\": \"envelope\",   \"fields\": [     {       \"name\": \"before\",       \"type\": [         {           \"name\": \"row\",           \"type\": \"record\",           \"fields\": [             {\"name\": \"a\", \"type\": \"long\"},             {\"name\": \"b\", \"type\": \"long\"},             {               \"name\": \"json\",               \"type\": {                 \"connect.name\": \"io.debezium.data.Json\",                 \"type\": \"string\"               }             },             {               \"name\": \"c\",               \"type\": {                 \"type\": \"enum\",                 \"name\": \"Bool\",                 \"symbols\": [\"True\", \"False\", \"FileNotFound\"]               }             },             {\"name\": \"d\", \"type\": \"Bool\"},             {\"name\": \"e\", \"type\": [\"null\",{               \"type\": \"record\",               \"name\": \"nested_data_1\",               \"fields\": [                   {\"name\": \"n1_a\", \"type\": \"long\"},                   {\"name\": \"n1_b\", \"type\": [\"null\", \"double\", {                       \"type\": \"record\",                       \"name\": \"nested_data_2\",                       \"fields\": [                         {\"name\": \"n2_a\", \"type\": \"long\"},                         {\"name\": \"n2_b\", \"type\": \"int\"}                       ]                     }]                   }                 ]               }]             },             {\"name\": \"f\", \"type\": [\"null\", \"nested_data_2\"]}           ]         },         \"null\"       ]     },     { \"name\": \"after\", \"type\": [\"row\", \"null\"] },     { \"name\": \"op\", \"type\": \"string\" },     {       \"name\": \"source\",       \"type\": {         \"type\": \"record\",         \"name\": \"Source\",         \"namespace\": \"io.debezium.connector.mysql\",         \"fields\": [           {             \"name\": \"file\",             \"type\": \"string\"           },           {             \"name\": \"pos\",             \"type\": \"long\"           },           {             \"name\": \"row\",             \"type\": \"int\"           },           {             \"name\": \"snapshot\",             \"type\": [               {                 \"type\": \"boolean\",                 \"connect.default\": false               },               \"null\"             ],             \"default\": false           }         ],         \"connect.name\": \"io.debezium.connector.mysql.Source\"       }     },     {       \"name\": \"transaction\",       \"type\": [         \"null\",         {           \"type\": \"record\",           \"name\": \"ConnectDefault\",           \"namespace\": \"io.confluent.connect.avro\",           \"fields\": [             {               \"name\": \"id\",               \"type\": \"string\"             },             {               \"name\": \"total_order\",               \"type\": \"long\"             },             {               \"name\": \"data_collection_order\",               \"type\": \"long\"             }           ]         }       ],       \"default\": null     }   ] }\n' ENVELOPE DEBEZIUM"
 
 > SELECT a, b, json, c, d FROM data_schema_file
 a  b  json                     c            d
@@ -426,6 +435,7 @@ $ set new-dbz-schema={
         ]
       },
       { "name": "after", "type": ["row", "null"] },
+      { "name": "op", "type": "string" },
       {
         "name": "source",
         "type": {
@@ -467,17 +477,29 @@ $ set new-dbz-schema={
       },
       {
         "name": "transaction",
-        "type": {
-          "type": "record",
-          "name": "Transaction",
-          "namespace": "whatever",
-          "fields": [
-            {
-              "name": "total_order",
-              "type": ["long", "null"]
-            }
-          ]
-        }
+        "type": [
+          "null",
+          {
+            "type": "record",
+            "name": "ConnectDefault",
+            "namespace": "io.confluent.connect.avro",
+            "fields": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "total_order",
+                "type": "long"
+              },
+              {
+                "name": "data_collection_order",
+                "type": "long"
+              }
+            ]
+          }
+        ],
+        "default": null
       }
     ]
   }
@@ -487,13 +509,13 @@ $ kafka-create-topic topic=new-dbz-data partitions=1
 # We don't do anything sensible yet for snapshot "true" or "last", so just test that those are ingested.
 
 $ kafka-ingest format=avro topic=new-dbz-data schema=${new-dbz-schema} timestamp=1
-{"before": null, "after": {"row":{"a": 9, "b": 10}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "true"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 11, "b": 11}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "last"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 14, "b": 6}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": null}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"a": 9, "b": 10}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "true"}}, "op": "r", "transaction": null}
+{"before": null, "after": {"row":{"a": 11, "b": 11}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "last"}}, "op": "r", "transaction": null}
+{"before": null, "after": {"row":{"a": 14, "b": 6}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": null}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 0, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 > CREATE MATERIALIZED SOURCE new_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-new-dbz-data-${testdrive.seed}'
@@ -533,14 +555,14 @@ $ kafka-create-topic topic=misordered-dbz-data
 $ set new-dbz-key-schema={"type": "record", "name": "row", "fields": [{"name": "a", "type": "long"}]}
 
 $ kafka-ingest format=avro key-format=avro topic=misordered-dbz-data schema=${new-dbz-schema} key-schema=${new-dbz-key-schema} timestamp=1 publish=true
-{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}, "transaction": {"total_order": null}}
-{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}, "transaction": {"total_order": null}}
-{"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"a": -1} {"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"a": 3} {"before": null, "after": {"row":{"a": 3, "b": 4}}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}, "op": "c", "transaction": null}
+{"a": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}, "op": "c", "transaction": null}
+{"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"a": -1} {"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"a": 2} {"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"a": 1} {"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"file": "binlog", "pos": 2, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"a": 3} {"before": null, "after": {"row":{"a": 3, "b": 4}}, "source": {"file": "binlog2", "pos": 2, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 > CREATE MATERIALIZED SOURCE misordered_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-data-${testdrive.seed}'
@@ -564,7 +586,7 @@ $ kafka-create-topic topic=invalid-keyed-dbz-data
 $ set wrong-dbz-key-schema={"type": "record", "name": "row", "fields": [{"name": "c", "type": "long"}]}
 
 $ kafka-ingest format=avro key-format=avro topic=invalid-keyed-dbz-data schema=${new-dbz-schema} key-schema=${wrong-dbz-key-schema} timestamp=1 publish=true
-{"c": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}, "transaction": {"total_order": null}}
+{"c": 5} {"before": null, "after": {"row":{"a": 5, "b": 3}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "true"}}, "op": "c", "transaction": null}
 
 ! CREATE MATERIALIZED SOURCE invalid_keyed_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-invalid-keyed-dbz-data-${testdrive.seed}'
@@ -601,25 +623,25 @@ $ kafka-create-topic topic=misordered-dbz-in-range-data
 # * 1600005000000 = 2020-09-13 13:50 -- no longer possibly duplicate
 
 $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1599990000000
-{"before": null, "after": {"row":{"a": 1, "b": 0}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"a": 1, "b": 0}}, "source": {"file": "binlog", "pos": 1, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 # padding window
 $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1599999600000
-{"before": null, "after": {"row":{"a": 4, "b": 0}}, "source": {"file": "binlog", "pos": 4, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"a": 4, "b": 0}}, "source": {"file": "binlog", "pos": 4, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1600000000000
-{"before": null, "after": {"row":{"a": 3, "b": 1}}, "source": {"file": "binlog", "pos": 3, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 4, "b": 0}}, "source": {"file": "binlog", "pos": 4, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"a": 3, "b": 1}}, "source": {"file": "binlog", "pos": 3, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 4, "b": 0}}, "source": {"file": "binlog", "pos": 4, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 # full dedupe catches reversed, invalid data
 $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1600000000000
-{"before": null, "after": {"row":{"a": 6, "b": 0}}, "source": {"file": "binlog", "pos": 6, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 5, "b": 0}}, "source": {"file": "binlog", "pos": 5, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"a": 6, "b": 0}}, "source": {"file": "binlog", "pos": 6, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 5, "b": 0}}, "source": {"file": "binlog", "pos": 5, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 # return to just binlog-based deduplication, item 7 will be stripped because it is out of order!
 $ kafka-ingest format=avro topic=misordered-dbz-in-range-data schema=${new-dbz-schema} timestamp=1600005000000
-{"before": null, "after": {"row":{"a": 8, "b": 0}}, "source": {"file": "binlog", "pos": 8, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"row":{"a": 7, "b": 0}}, "source": {"file": "binlog", "pos": 7, "row": 0, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"row":{"a": 8, "b": 0}}, "source": {"file": "binlog", "pos": 8, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 7, "b": 0}}, "source": {"file": "binlog", "pos": 7, "row": 0, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 > CREATE MATERIALIZED SOURCE misordered_dbz_in_range
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-misordered-dbz-in-range-data-${testdrive.seed}'
@@ -706,6 +728,7 @@ $ set pg-dbz-schema={
         ]
       },
       { "name": "after", "type": ["row", "null"] },
+      { "name": "op", "type": "string" },
       {
         "name": "source",
         "type": {
@@ -732,34 +755,51 @@ $ set pg-dbz-schema={
             {
               "name": "lsn",
               "type": ["long", "null"]
+            },
+            {
+              "name": "sequence",
+              "type": ["string", "null"]
             }
           ]
         }
       },
       {
         "name": "transaction",
-        "type": {
-          "type": "record",
-          "name": "TransactionMetadata",
-          "fields": [
-            {
-              "name": "total_order",
-              "type": "long"
-            }
-          ]
-        }
+        "type": [
+          "null",
+          {
+            "type": "record",
+            "name": "ConnectDefault",
+            "namespace": "io.confluent.connect.avro",
+            "fields": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "total_order",
+                "type": "long"
+              },
+              {
+                "name": "data_collection_order",
+                "type": "long"
+              }
+            ]
+          }
+        ],
+        "default": null
       }
     ]
   }
 
 $ kafka-create-topic topic=pg-dbz-data partitions=1
 
-# The third and fourth records will be skipped, since `(lsn, total_order)` has gone backwards.
+# The third and fourth records will be skipped, since `sequence` has gone backwards.
 $ kafka-ingest format=avro topic=pg-dbz-data schema=${pg-dbz-schema} timestamp=1
-{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"lsn": {"long": 1}, "snapshot": {"string": "false"}}, "transaction": {"total_order": 0}}
-{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"lsn": {"long": 2}, "snapshot": {"string": "false"}}, "transaction": {"total_order": 1}}
-{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"lsn": {"long": 0}, "snapshot": {"string": "false"}}, "transaction": {"total_order": 0}}
-{"before": null, "after": {"row":{"a": 4, "b": 5}}, "source": {"lsn": {"long": 2}, "snapshot": {"string": "false"}}, "transaction": {"total_order": 0}}
+{"before": null, "after": {"row":{"a": 1, "b": 1}}, "source": {"lsn": {"long": 1}, "sequence": {"string": "[\"1\", \"1\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 2, "b": 3}}, "source": {"lsn": {"long": 2}, "sequence": {"string": "[\"1\", \"2\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"lsn": {"long": 0}, "sequence": {"string": "[\"0\", \"1\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"row":{"a": 4, "b": 5}}, "source": {"lsn": {"long": 2}, "sequence": {"string": "[\"1\", \"2\"]"}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 > CREATE MATERIALIZED SOURCE pg_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-pg-dbz-data-${testdrive.seed}'
@@ -806,6 +846,7 @@ $ set ms-dbz-schema={
           "Value"
         ]
       },
+      { "name": "op", "type": "string" },
       {
         "name": "source",
         "type": {
@@ -859,17 +900,29 @@ $ set ms-dbz-schema={
       },
       {
         "name": "transaction",
-        "type": {
-          "type": "record",
-          "name": "Transaction",
-          "namespace": "whatever",
-          "fields": [
-            {
-              "name": "total_order",
-              "type": ["long", "null"]
-            }
-          ]
-        }
+        "type": [
+          "null",
+          {
+            "type": "record",
+            "name": "ConnectDefault",
+            "namespace": "io.confluent.connect.avro",
+            "fields": [
+              {
+                "name": "id",
+                "type": "string"
+              },
+              {
+                "name": "total_order",
+                "type": "long"
+              },
+              {
+                "name": "data_collection_order",
+                "type": "long"
+              }
+            ]
+          }
+        ],
+        "default": null
       }
     ],
     "name": "Envelope",
@@ -881,9 +934,9 @@ $ kafka-create-topic topic=ms-dbz-data partitions=1
 
 # The third record will be skipped, since `lsn` has gone backwards.
 $ kafka-ingest format=avro topic=ms-dbz-data schema=${ms-dbz-schema} timestamp=1
-{"before": null, "after": {"Value":{"a": 1, "b": 1}}, "source": {"change_lsn": {"string": "00000025:00000728:001b"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"Value":{"a": 2, "b": 3}}, "source": {"change_lsn": {"string": "00000025:00000728:001c"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
-{"before": null, "after": {"Value":{"a": -1, "b": 7}}, "source": {"change_lsn": {"string": "00000025:00000728:001a"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "transaction": {"total_order": null}}
+{"before": null, "after": {"Value":{"a": 1, "b": 1}}, "source": {"change_lsn": {"string": "00000025:00000728:001b"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"Value":{"a": 2, "b": 3}}, "source": {"change_lsn": {"string": "00000025:00000728:001c"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
+{"before": null, "after": {"Value":{"a": -1, "b": 7}}, "source": {"change_lsn": {"string": "00000025:00000728:001a"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "op": "c", "transaction": null}
 
 > CREATE MATERIALIZED SOURCE ms_dbz
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-ms-dbz-data-${testdrive.seed}'


### PR DESCRIPTION
Since Debezium 1.5, the "sequence" and "lsn" fields of the PostgreSQL
source metadata has been sufficient to perform correct, constant-space
deduplication of PostgreSQL. This commit updates our PostgreSQL
deduplication code to rely exclusively on these fields.

The code previously relied on a the `transaction.total_order` field, but
that field was only available when users explicitly enabled the
transaction metadata topic.

The one wrinkle here is that updates to the primary key result in two
events at the same sequence number: a deletion of the old value and a
creation of the new value. This commit accounts for that by including
the operation type in the sequence number and sorting delete events
before create events.

Fix https://github.com/MaterializeInc/materialize/issues/7557.

I'm going to say this fixes #6464 as well, as it adds warnings to the docs about not supporting Debezium versions before 1.5, which we cannot correctly deduplicate. It also makes using Materialize with a pre-1.5 Debezium topic a hard error.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
