### PR TITLE
test/debezium: enable test for removing NOT NULL constraint

### DIFF
--- a/test/debezium/postgres/09-add-nullability.td
+++ b/test/debezium/postgres/09-add-nullability.td
@@ -8,13 +8,15 @@
 # by the Apache License, Version 2.0.
 
 #
-# Change the definition of a column to be NOT NULL
+# Remove NOT NULL constraint from column
 #
 
 $ postgres-execute connection=postgres://postgres:postgres@postgres
 CREATE TABLE alter_allow_nullability (f1 INTEGER NOT NULL);
 ALTER TABLE alter_allow_nullability REPLICA IDENTITY FULL;
 INSERT INTO alter_allow_nullability VALUES (123),(234);
+
+$ schema-registry-wait-schema schema=postgres.public.alter_allow_nullability-value
 
 > CREATE MATERIALIZED SOURCE alter_allow_nullability
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'postgres.public.alter_allow_nullability'
@@ -31,6 +33,5 @@ INSERT INTO alter_allow_nullability VALUES (NULL);
 UPDATE alter_allow_nullability SET f1 = NULL WHERE f1 = 123;
 DELETE FROM alter_allow_nullability WHERE f1 = 234;
 
-> SELECT * FROM alter_allow_nullability;
-<null>
-<null>
+! SELECT * FROM alter_allow_nullability;
+contains:Decode error: Decoding error: Reader expected variant at index 1, got 0


### PR DESCRIPTION
@philip-stoev @umanwizard what _do_ we expect to happen here?

----

This no longer causes Materialize to panic. The error message could use
some work, though.

Touches #6522.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR touches a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
