### PR TITLE
mzbuild: Default to the host's architecture

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -824,7 +824,7 @@ class Repository:
         )
         parser.add_argument(
             "--arch",
-            default=Arch.X86_64,
+            default=Arch.host(),
             help="the CPU architecture to build for",
             type=Arch,
             choices=Arch,


### PR DESCRIPTION
The --arch flag to mzbuild defaulted to Arch.X86_64, which
broke the ARM build in CI. Default to the host's architecture
instead.
### Motivation

  * This PR fixes a previously unreported bug.

The ARM CI job in Nightly has been failing for ~1 month because of this.