### PR TITLE
scratch: Install docker 2.0 and docker-compose inside the instance

### DIFF
--- a/misc/scratch/provision.bash
+++ b/misc/scratch/provision.bash
@@ -18,8 +18,6 @@ set -euo pipefail
 apt-get update
 apt-get install -y \
     cmake \
-    docker.io \
-    docker-compose \
     g++ \
     postgresql \
     python3-venv \
@@ -31,6 +29,23 @@ curl -L "https://github.com/aws/aws-ec2-instance-connect-config/archive/refs/tag
 unzip ec2-instance-connect.zip
 cp aws-ec2-instance-connect-config-1.1.17/src/bin/* /usr/share/ec2-instance-connect/
 rm -r ec2-instance-connect.zip aws-ec2-instance-connect-config-1.1.17
+
+# Install docker as per the instructions from https://docs.docker.com/engine/install/ubuntu/
+sudo apt-get install -y \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release
+
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
 # Install Rust.
 sudo -u ubuntu sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q -y"


### PR DESCRIPTION
The older Docker from Ubuntu is no longer compatible with
mzcompose. Install Docker 2.0 from the upstream project using
the installation instructions from Docker's own web site.

### Motivation

  * This PR fixes a previously unreported bug.

After upgrading to Docker 2.0 , it was no longer possible to run mzcompose inside the instance...

### Tips for reviewer

@benesch . Unfortunately a different Docker and a different docker-compose will be installed on the Buildkite machines and on the scratch machines. I wish we could unify it all somehow to avoid suprises in the future.

