### PR TITLE
ci: Disable kafka-sasl-plain

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -204,6 +204,8 @@ steps:
 
   - id: kafka-sasl-plain
     label: Kafka SASL PLAIN smoke test
+    # https://github.com/MaterializeInc/materialize/issues/13289
+    soft_fail: true
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/kafka-sasl-plain/smoketest.td]


### PR DESCRIPTION
The test still uses the yaml format which does not guarantee
that Confluent services will be started in the proper order, causing
them to fail sporadically.

Disable the test until fixed by #13289

### Motivation


  * This PR fixes a recognized bug.

https://github.com/MaterializeInc/materialize/issues/13289