### PR TITLE
sql: Prepare new `EXPLAIN` structures

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1785,15 +1785,43 @@ impl<T: AstInfo> AstDisplay for TailRelation<T> {
 }
 impl_display_t!(TailRelation);
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ExplainStatement<T: AstInfo> {
+    New(ExplainStatementNew<T>),
+    Old(ExplainStatementOld<T>),
+}
+
+impl<T: AstInfo> AstDisplay for ExplainStatement<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            Self::Old(old) => old.fmt(f),
+            Self::New(new) => new.fmt(f),
+        }
+    }
+}
+impl_display_t!(ExplainStatement);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExplainStatementNew<T: AstInfo> {
+    pub explainee: Explainee<T>,
+}
+
+impl<T: AstInfo> AstDisplay for ExplainStatementNew<T> {
+    fn fmt<W: fmt::Write>(&self, _f: &mut AstFormatter<W>) {
+        // TODO #13294
+    }
+}
+impl_display_t!(ExplainStatementNew);
+
 /// `EXPLAIN ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ExplainStatement<T: AstInfo> {
+pub struct ExplainStatementOld<T: AstInfo> {
     pub stage: ExplainStage,
     pub explainee: Explainee<T>,
     pub options: ExplainOptions,
 }
 
-impl<T: AstInfo> AstDisplay for ExplainStatement<T> {
+impl<T: AstInfo> AstDisplay for ExplainStatementOld<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("EXPLAIN ");
         if self.options.timing {
@@ -1809,7 +1837,7 @@ impl<T: AstInfo> AstDisplay for ExplainStatement<T> {
         f.write_node(&self.explainee);
     }
 }
-impl_display_t!(ExplainStatement);
+impl_display_t!(ExplainStatementOld);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum InsertSource<T: AstInfo> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4827,6 +4827,22 @@ impl<'a> Parser<'a> {
     /// Parse an `EXPLAIN` statement, assuming that the `EXPLAIN` token
     /// has already been consumed.
     fn parse_explain(&mut self) -> Result<Statement<Raw>, ParserError> {
+        if let Some(parse) = self.maybe_parse(Self::parse_explain_new) {
+            Ok(parse)
+        } else {
+            self.parse_explain_old()
+        }
+    }
+
+    /// Parse an `EXPLAIN` statement, assuming that the `EXPLAIN` token
+    /// has already been consumed.
+    fn parse_explain_new(&mut self) -> Result<Statement<Raw>, ParserError> {
+        Err(ParserError::new(self.index, "unimplemented"))
+    }
+
+    /// Parse an `EXPLAIN` statement, assuming that the `EXPLAIN` token
+    /// has already been consumed (old code path).
+    fn parse_explain_old(&mut self) -> Result<Statement<Raw>, ParserError> {
         // (TYPED)?
         let typed = self.parse_keyword(TYPED);
         let mut timing = false;
@@ -4906,11 +4922,13 @@ impl<'a> Parser<'a> {
         };
 
         let options = ExplainOptions { typed, timing };
-        Ok(Statement::Explain(ExplainStatement {
-            stage,
-            explainee,
-            options,
-        }))
+        Ok(Statement::Explain(ExplainStatement::Old(
+            ExplainStatementOld {
+                stage,
+                explainee,
+                options,
+            },
+        )))
     }
 
     /// Parse a `DECLARE` statement, assuming that the `DECLARE` token

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -23,49 +23,49 @@ EXPLAIN SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN RAW PLAN FOR SELECT 665
 ----
 EXPLAIN RAW PLAN FOR SELECT 665
 =>
-Explain(ExplainStatement { stage: RawPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: RawPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN DECORRELATED PLAN FOR SELECT 665
 ----
 EXPLAIN DECORRELATED PLAN FOR SELECT 665
 =>
-Explain(ExplainStatement { stage: DecorrelatedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: DecorrelatedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN PLAN FOR SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: true, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: true, timing: false } }))
 
 parse-statement
 EXPLAIN (TIMING false) TYPED OPTIMIZED PLAN FOR VIEW foo
@@ -93,46 +93,46 @@ EXPLAIN (TIMING false) VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN (TIMING false, TIMING true) VIEW foo
 ----
 EXPLAIN (TIMING true) OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: true } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: true } }))
 
 parse-statement
 EXPLAIN (TIMING false, TIMING true) DECORRELATED PLAN FOR VIEW foo
 ----
 EXPLAIN (TIMING true) DECORRELATED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: DecorrelatedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: true } })
+Explain(Old(ExplainStatementOld { stage: DecorrelatedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: false, timing: true } }))
 
 parse-statement
 EXPLAIN TYPED (TIMING false) OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW foo
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: true, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))), options: ExplainOptions { typed: true, timing: false } }))
 
 parse-statement
 EXPLAIN ((SELECT 1))
 ----
 EXPLAIN OPTIMIZED PLAN FOR SELECT 1
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN (WITH A AS (SELECT 1) SELECT * from A)
 ----
 EXPLAIN OPTIMIZED PLAN FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-Explain(ExplainStatement { stage: OptimizedPlan, explainee: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: OptimizedPlan, explainee: Query(Query { ctes: [Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
 ----
 EXPLAIN TIMESTAMP FOR SELECT 1
 =>
-Explain(ExplainStatement { stage: Timestamp, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } })
+Explain(Old(ExplainStatementOld { stage: Timestamp, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -339,7 +339,19 @@ pub struct CopyFromPlan {
 }
 
 #[derive(Debug)]
-pub struct ExplainPlan {
+pub enum ExplainPlan {
+    New(ExplainPlanNew),
+    Old(ExplainPlanOld),
+}
+
+#[derive(Debug)]
+pub struct ExplainPlanNew {
+    pub raw_plan: HirRelationExpr,
+    pub row_set_finishing: Option<RowSetFinishing>,
+}
+
+#[derive(Debug)]
+pub struct ExplainPlanOld {
     pub raw_plan: HirRelationExpr,
     pub row_set_finishing: Option<RowSetFinishing>,
     pub stage: ExplainStage,

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -409,7 +409,7 @@ impl<'a> Explanation<'a> {
                 writeln!(f, " offset={}", offset)?
             }
             Negate { .. } => writeln!(f, "| Negate")?,
-            Threshold { .. } => write!(f, "| Threshold")?,
+            Threshold { .. } => writeln!(f, "| Threshold")?,
             Union { base, inputs } => writeln!(
                 f,
                 "| Union %{} {}",

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -114,6 +114,7 @@ pub enum HirRelationExpr {
     Negate {
         input: Box<HirRelationExpr>,
     },
+    /// Keep rows from a dataflow where the row counts are positive.
     Threshold {
         input: Box<HirRelationExpr>,
     },


### PR DESCRIPTION
Closes #13293.

### Motivation

* This PR refactors existing code.

This is a needed first step on the path towards revamping `EXPLAIN`. 
See #13137 for motivation and a full list of tasks.

### Tips for reviewer

Structural changes:
- Suffix existing `AST` and `Plan` variants with `~Old`.
- Provision `~New` structures for the AST and Plan IRs.
- Provision a temporary enum that wraps the `~Old` and `~New` IRs.

API changes:
- Provision `~_explain_new` methods for the new `EXPLAIN` path.
- Suffix existing code to `~_explain_old` methods.
- Write simple strucutre-based dispatch for the `plan_explain` and `sequence_explain` methods.

cc-ing @mjibson for visibility (@wangandi will review this). We will remove the additional bloat and migrate to the new `AST` and `Plan` structures once we are done with #13137.

### Testing

Tested manually by running `bin/environmentd` and ensuring that the old `EXPLAIN` path sill correctly handles `EXPLAIN` statements.

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A
