### PR TITLE
Propagate monotonicity flags through materialized views

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -6065,7 +6065,9 @@ pub mod fast_path_peek {
                             // An arrangement may or may not exist. If not, nothing to be done.
                             if let Some((key, permute, thinning)) = keys.arbitrary_arrangement() {
                                 // Just grab any arrangement, but be sure to de-permute the results.
-                                for (index_id, (desc, _typ)) in dataflow_plan.index_imports.iter() {
+                                for (index_id, (desc, _typ, _monotonic)) in
+                                    dataflow_plan.index_imports.iter()
+                                {
                                     if Id::Global(desc.on_id) == *id && &desc.key == key {
                                         let mut map_filter_project =
                                             mz_expr::MapFilterProject::new(_typ.arity())
@@ -6101,7 +6103,9 @@ pub mod fast_path_peek {
                                 })?;
                             // We should only get excited if we can track down an index for `id`.
                             // If `keys` is non-empty, that means we think one exists.
-                            for (index_id, (desc, _typ)) in dataflow_plan.index_imports.iter() {
+                            for (index_id, (desc, _typ, _monotonic)) in
+                                dataflow_plan.index_imports.iter()
+                            {
                                 if Id::Global(desc.on_id) == *id && &desc.key == key {
                                     // Indicate an early exit with a specific index and key_val.
                                     return Ok(Plan::PeekExisting(

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -59,7 +59,14 @@ message ProtoDataflowDescription {
         bool monotonic = 3;
     }
 
-    message ProtoIndex {
+    message ProtoIndexImport {
+        mz_repr.global_id.ProtoGlobalId id = 1;
+        ProtoIndexDesc index_desc = 2;
+        mz_repr.relation_and_scalar.ProtoRelationType typ = 3;
+        bool monotonic = 4;
+    }
+
+    message ProtoIndexExport {
         mz_repr.global_id.ProtoGlobalId id = 1;
         ProtoIndexDesc index_desc = 2;
         mz_repr.relation_and_scalar.ProtoRelationType typ = 3;
@@ -71,9 +78,9 @@ message ProtoDataflowDescription {
     }
 
     repeated ProtoSourceImport source_imports = 1;
-    repeated ProtoIndex index_imports = 2;
+    repeated ProtoIndexImport index_imports = 2;
     repeated ProtoBuildDesc objects_to_build = 3;
-    repeated ProtoIndex index_exports = 4;
+    repeated ProtoIndexExport index_exports = 4;
     repeated ProtoSinkExport sink_exports = 5;
     optional mz_persist.gen.persist.ProtoU64Antichain as_of = 6;
     string debug_name = 7;

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1440,7 +1440,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
         let mut arrangements = BTreeMap::new();
         // Sources might provide arranged forms of their data, in the future.
         // Indexes provide arranged forms of their data.
-        for (index_desc, r#type) in desc.index_imports.values() {
+        for (index_desc, r#type, _monotonic) in desc.index_imports.values() {
             let key = index_desc.key.clone();
             // TODO[btv] - We should be told the permutation by
             // `index_desc`, and it should have been generated

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -137,6 +137,7 @@ impl Row {
 
 /// These implementations order first by length, and then by slice contents.
 /// This allows many comparisons to complete without dereferencing memory.
+/// Warning: These order by the u8 array representation, and NOT by Datum::cmp.
 impl PartialOrd for Row {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         match self.data.len().cmp(&other.data.len()) {

--- a/src/storage/src/client/sources.rs
+++ b/src/storage/src/client/sources.rs
@@ -1302,7 +1302,7 @@ impl SourceDesc {
     // TODO(guswynn): consider enforcing this more completely at the
     // parsing/typechecking level, by not using an `envelope`
     // for sources like pg
-    pub fn append_only(&self) -> bool {
+    pub fn monotonic(&self) -> bool {
         match self {
             // Postgres can produce retractions (deletes)
             SourceDesc {

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -58,3 +58,389 @@ a min max
 ---
 1 2 1048577
 2 3 5
+
+# Propagating monotonicity analysis through materialized views
+# TODO: After https://github.com/MaterializeInc/materialize/pull/13238 is merged, modify these tests to dig into
+# the plans with `jq` and just check for `MonotonicTopK` being present.
+
+> CREATE MATERIALIZED VIEW m1 AS SELECT b FROM non_dbz_data
+
+> CREATE VIEW v2 AS SELECT * FROM m1 ORDER BY b LIMIT 3
+
+$ set-regex match=.User.:\s\d+ replacement=UID
+
+? EXPLAIN PHYSICAL PLAN FOR VIEW v2
+{
+  "TopK": {
+    "input": {
+      "ArrangeBy": {
+        "input": {
+          "Get": {
+            "id": {
+              "Global": {
+                UID
+              }
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0
+                  },
+                  []
+                ]
+              ]
+            },
+            "plan": "PassArrangements"
+          }
+        },
+        "forms": {
+          "raw": true,
+          "arranged": []
+        },
+        "input_key": [
+          {
+            "Column": 0
+          }
+        ],
+        "input_mfp": {
+          "expressions": [],
+          "predicates": [],
+          "projection": [
+            0
+          ],
+          "input_arity": 1
+        }
+      }
+    },
+    "top_k_plan": {
+      "MonotonicTopK": {
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 0,
+            "desc": false,
+            "nulls_last": true
+          }
+        ],
+        "limit": 3,
+        "arity": 1
+      }
+    }
+  }
+}
+
+
+> CREATE MATERIALIZED SOURCE non_dbz_data_materialized
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
+  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
+  ENVELOPE NONE
+
+# Propagating monotonicity analysis from a materialized source
+
+> CREATE VIEW v3 AS SELECT * FROM non_dbz_data_materialized ORDER BY b LIMIT 3
+
+? EXPLAIN PHYSICAL PLAN FOR VIEW v3
+{
+  "TopK": {
+    "input": {
+      "ArrangeBy": {
+        "input": {
+          "Get": {
+            "id": {
+              "Global": {
+                UID
+              }
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    },
+                    {
+                      "Column": 1
+                    }
+                  ],
+                  {
+                    "0": 0,
+                    "1": 1
+                  },
+                  []
+                ]
+              ]
+            },
+            "plan": "PassArrangements"
+          }
+        },
+        "forms": {
+          "raw": true,
+          "arranged": []
+        },
+        "input_key": [
+          {
+            "Column": 0
+          },
+          {
+            "Column": 1
+          }
+        ],
+        "input_mfp": {
+          "expressions": [],
+          "predicates": [],
+          "projection": [
+            0,
+            1
+          ],
+          "input_arity": 2
+        }
+      }
+    },
+    "top_k_plan": {
+      "MonotonicTopK": {
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 1,
+            "desc": false,
+            "nulls_last": true
+          }
+        ],
+        "limit": 3,
+        "arity": 2
+      }
+    }
+  }
+}
+
+
+> CREATE MATERIALIZED VIEW m4 AS SELECT b+1 as c FROM m1
+
+# Propagating monotonicity analysis through 2 materialized views (m1 and m4)
+
+> CREATE VIEW v5 AS SELECT * from m4 ORDER BY c LIMIT 2
+
+? EXPLAIN PHYSICAL PLAN FOR VIEW v5
+{
+  "TopK": {
+    "input": {
+      "ArrangeBy": {
+        "input": {
+          "Get": {
+            "id": {
+              "Global": {
+                UID
+              }
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0
+                  },
+                  []
+                ]
+              ]
+            },
+            "plan": "PassArrangements"
+          }
+        },
+        "forms": {
+          "raw": true,
+          "arranged": []
+        },
+        "input_key": [
+          {
+            "Column": 0
+          }
+        ],
+        "input_mfp": {
+          "expressions": [],
+          "predicates": [],
+          "projection": [
+            0
+          ],
+          "input_arity": 1
+        }
+      }
+    },
+    "top_k_plan": {
+      "MonotonicTopK": {
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 0,
+            "desc": false,
+            "nulls_last": true
+          }
+        ],
+        "limit": 2,
+        "arity": 1
+      }
+    }
+  }
+}
+
+> CREATE MATERIALIZED VIEW m6 AS SELECT c FROM v5
+
+# Non-monotonic materialized view -- v7 can't use a monotonic TopK plan, because m6 and v5 are not monotonic
+
+> CREATE VIEW v7 AS SELECT * from m6 ORDER BY c LIMIT 2
+
+? EXPLAIN PHYSICAL PLAN FOR VIEW v7
+{
+  "TopK": {
+    "input": {
+      "ArrangeBy": {
+        "input": {
+          "Get": {
+            "id": {
+              "Global": {
+                UID
+              }
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0
+                  },
+                  []
+                ]
+              ]
+            },
+            "plan": "PassArrangements"
+          }
+        },
+        "forms": {
+          "raw": true,
+          "arranged": []
+        },
+        "input_key": [
+          {
+            "Column": 0
+          }
+        ],
+        "input_mfp": {
+          "expressions": [],
+          "predicates": [],
+          "projection": [
+            0
+          ],
+          "input_arity": 1
+        }
+      }
+    },
+    "top_k_plan": {
+      "Basic": {
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 0,
+            "desc": false,
+            "nulls_last": true
+          }
+        ],
+        "limit": 2,
+        "offset": 0,
+        "arity": 1
+      }
+    }
+  }
+}
+
+
+> CREATE MATERIALIZED VIEW m8 AS SELECT * from (SELECT * FROM m1 UNION ALL SELECT * FROM m1)
+
+> CREATE MATERIALIZED VIEW m9 AS SELECT * from (SELECT * FROM m1 UNION ALL SELECT * FROM m8)
+
+> CREATE VIEW v10 as SELECT b FROM m9 ORDER BY b LIMIT 2;
+
+# Propagating monotonicity analysis in a complex situation: (m1, m1) -> m8; (m1, m8) -> m9
+
+? EXPLAIN PHYSICAL PLAN FOR VIEW v10;
+{
+  "TopK": {
+    "input": {
+      "ArrangeBy": {
+        "input": {
+          "Get": {
+            "id": {
+              "Global": {
+                UID
+              }
+            },
+            "keys": {
+              "raw": false,
+              "arranged": [
+                [
+                  [
+                    {
+                      "Column": 0
+                    }
+                  ],
+                  {
+                    "0": 0
+                  },
+                  []
+                ]
+              ]
+            },
+            "plan": "PassArrangements"
+          }
+        },
+        "forms": {
+          "raw": true,
+          "arranged": []
+        },
+        "input_key": [
+          {
+            "Column": 0
+          }
+        ],
+        "input_mfp": {
+          "expressions": [],
+          "predicates": [],
+          "projection": [
+            0
+          ],
+          "input_arity": 1
+        }
+      }
+    },
+    "top_k_plan": {
+      "MonotonicTopK": {
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 0,
+            "desc": false,
+            "nulls_last": true
+          }
+        ],
+        "limit": 2,
+        "arity": 1
+      }
+    }
+  }
+}

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -193,8 +193,8 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=4
 > SELECT * FROM group_by_in_top_1;
 0
 0
-0
-0
+-234
+-234
 -234
 -234
 
@@ -217,10 +217,10 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=5
 {"f1": null, "f2": {"int": -234}}
 
 > SELECT * from limit_only;
-<null>
+0
 
 > SELECT * from group_by_limit;
-<null>
+0
 
 > SELECT * FROM order_by_limit;
 0
@@ -233,9 +233,9 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=5
 -234
 0
 0
-<null>
-<null>
-<null>
+0
+-234
+-234
 <null>
 <null>
 <null>


### PR DESCRIPTION
Monotonicity analysis propagates monotonicity flags from the sources through operator trees. However, currently this happens only inside a single dataflow. Since a dataflow stops at materialized views, this means that our current analysis doesn't see the sources if they are hidden behind a materialized view.

This PR adds monotonicity information to the `index_imports` in `DataflowDescription`, and then the monotonicity analysis of the dataflow can start from both sources and indexes.

I avoided adding the monotonicity information of indexes to the catalog, in order to avoid potential issues with updating this value on system upgrades (see https://materializeinc.slack.com/archives/CMHDK0DK8/p1656015042925059 ). Instead I always recompute the monotonicity information of indexes when building `index_imports`.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/11374

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

The tests are currently super long and brittle, because they involve physical plans. Once https://github.com/MaterializeInc/materialize/pull/13238 is merged, we should modify these tests to dig into the plans with `jq` and just check for `MonotonicTopK` being present.
(We can also consider commenting out these tests for now before merging this PR.)

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Min and max aggregations and TopK operators can now take advantage of monotonic sources to significantly reduce their memory consumption, even when the source is hidden behind a materialized view.
