### PR TITLE
test/testdrive: simplify some ancient tests

### DIFF
--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -10,24 +10,11 @@
 # Test basic create and drop functionality
 
 $ set schema={
+    "name": "row",
     "type": "record",
-    "name": "envelope",
     "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "X", "type": "long"},
-              {"name": "Y", "type": "long"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+      {"name": "X", "type": "long"},
+      {"name": "Y", "type": "long"}
     ]
   }
 
@@ -36,16 +23,12 @@ $ kafka-create-topic topic=data
 > CREATE SOURCE s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=33
-{"before": null, "after": {"row":{"X": 1, "Y": 1}}}
-{"before": null, "after": {"row":{"X": 2, "Y": 1}}}
-{"before": null, "after": {"row":{"X": 3, "Y": 1}}}
-{"before": null, "after": {"row":{"X": 1, "Y": 2}}}
-
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=34
-{"before": null, "after": null}
+$ kafka-ingest format=avro topic=data schema=${schema}
+{"X": 1, "Y": 1}
+{"X": 2, "Y": 1}
+{"X": 3, "Y": 1}
+{"X": 1, "Y": 2}
 
 > CREATE MATERIALIZED VIEW v AS SELECT 42 AS a
 
@@ -99,13 +82,11 @@ $ set dummy={
 ! CREATE SOURCE v2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${dummy}'
-  ENVELOPE DEBEZIUM
 contains:catalog item 'v2' already exists
 
 ! CREATE SOURCE i
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${dummy}'
-  ENVELOPE DEBEZIUM
 contains:catalog item 'i' already exists
 
 ! CREATE INDEX s ON v2(x)
@@ -167,7 +148,6 @@ contains:s is not of type VIEW
 > CREATE SOURCE i
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 > CREATE INDEX v ON s(b)
 

--- a/test/testdrive/decimal.td
+++ b/test/testdrive/decimal.td
@@ -11,49 +11,31 @@
 # pgwire). Operations on decimals are more thoroughly tested in decimal.slt.
 
 $ set schema={
+    "name": "row",
     "type": "record",
-    "name": "envelope",
     "fields": [
       {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {
-                "name": "a",
-                "type": {
-                  "type": "bytes",
-                  "scale": 2,
-                  "precision": 15,
-                  "logicalType": "decimal"
-                }
-              }
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+        "name": "a",
+        "type": {
+          "type": "bytes",
+          "scale": 2,
+          "precision": 15,
+          "logicalType": "decimal"
+        }
+      }
     ]
   }
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row":{"a": [7, 2]}}}
-{"before": null, "after": {"row":{"a": [186]}}}
+$ kafka-ingest format=avro topic=data schema=${schema}
+{"a": [7, 2]}
+{"a": [186]}
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
-{"before": null, "after": null}
-
-> CREATE SOURCE data
+> CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}'
 
-> CREATE MATERIALIZED VIEW data_view as SELECT * from data
-
-> SELECT * FROM data_view
+> SELECT * FROM data
 17.94
 -0.7

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -13,42 +13,26 @@
 $ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
 
 $ set schema={
+    "name": "row",
     "type": "record",
-    "name": "envelope",
     "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "x", "type": "long"},
-              {"name": "y", "type": "string"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+      {"name": "x", "type": "long"},
+      {"name": "y", "type": "string"}
     ]
   }
 
 > CREATE SOURCE s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 ! CREATE SOURCE s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-blah-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 contains:catalog item 's' already exists
 
 > CREATE SOURCE IF NOT EXISTS s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-blah-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 > CREATE MATERIALIZED VIEW test1 AS SELECT 1;
 
@@ -117,7 +101,6 @@ contains:unknown catalog item 'test4'
 > CREATE SOURCE s
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 > CREATE SINK s1 FROM s
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'v'
@@ -268,7 +251,6 @@ contains:unknown catalog item 'i4'
 > CREATE MATERIALIZED SOURCE s3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 # Test that dependent indexes do not prevent source deletion when restrict is specified
 > CREATE INDEX j1 on s3(ascii(y))
@@ -293,7 +275,6 @@ contains:unknown catalog item 'j1'
 > CREATE MATERIALIZED SOURCE s4
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 > CREATE INDEX j2 on s4(x+2);
 
@@ -332,7 +313,6 @@ contains:unknown catalog item 'j2'
 > CREATE MATERIALIZED SOURCE s5
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 > DROP INDEX s5_primary_idx CASCADE;
 

--- a/test/testdrive/joins.td
+++ b/test/testdrive/joins.td
@@ -7,79 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set names-schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "num", "type": "long"},
-              {"name": "name", "type": "string"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=names
-
-$ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
-{"before": null, "after": {"row":{"num": 1, "name": "one"}}}
-{"before": null, "after": {"row":{"num": 2, "name": "two"}}}
-{"before": null, "after": {"row":{"num": 3, "name": "three"}}}
-
-$ set mods-schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "num", "type": "long"},
-              {"name": "mod", "type": "string"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=mods
-
-$ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=1
-{"before": null, "after": {"row":{"num": 0, "mod": "even"}}}
-{"before": null, "after": {"row":{"num": 1, "mod": "odd"}}}
-{"before": null, "after": {"row":{"num": 2, "mod": "even"}}}
-
-$ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
-{"before": null, "after": null}
-
-$ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=2
-{"before": null, "after": null}
-
-> CREATE MATERIALIZED SOURCE names
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${names-schema}'
-  ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED SOURCE mods
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${mods-schema}'
-  ENVELOPE DEBEZIUM
+> CREATE TABLE names (num bigint, name text)
+> INSERT INTO names VALUES (1, 'one'), (2, 'two'), (3, 'three')
+> CREATE TABLE mods (num bigint, mod text)
+> INSERT INTO mods VALUES (0, 'even'), (1, 'odd'), (2, 'even')
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT * FROM names JOIN mods USING (num);
@@ -225,31 +156,3 @@ names_num names_name mods_num mods_mod
 <null> <null> 0 even
 <null> <null> 1 odd
 <null> <null> 2 even
-
-> CREATE SOURCE mods_unmat
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${mods-schema}'
-  ENVELOPE DEBEZIUM
-
-> CREATE VIEW test15 (names_num, names_name, mods_num, mods_mod) AS
-  SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
-
-# TODO(guswynn|benesch): re-enable this test when we resolve
-# consistency unknowns
-#> SELECT * FROM test15;
-#names_num names_name mods_num mods_mod
-#--------------------------------------
-#1 one <null> <null>
-#2 two <null> <null>
-#3 three <null> <null>
-#<null> <null> 0 even
-#<null> <null> 1 odd
-#<null> <null> 2 even
-#
-#> SELECT * FROM names FULL OUTER JOIN mods_unmat ON 1 = 0;
-#1 one <null> <null>
-#2 two <null> <null>
-#3 three <null> <null>
-#<null> <null> 0 even
-#<null> <null> 1 odd
-#<null> <null> 2 even

--- a/test/testdrive/multijoins.td
+++ b/test/testdrive/multijoins.td
@@ -7,117 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set names-schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-        {
-            "name": "before",
-            "type": [
-                {
-                    "name": "row",
-                    "type": "record",
-                    "fields": [
-                        {"name": "num", "type": "long"},
-                        {"name": "name", "type": "string"}
-                    ]
-                },
-                "null"
-            ]
-        },
-        { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=names
-
-$ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=1
-{"before": null, "after": {"row":{"num": 1, "name": "one"}}}
-{"before": null, "after": {"row":{"num": 2, "name": "two"}}}
-{"before": null, "after": {"row":{"num": 3, "name": "three"}}}
-
-$ set mods-schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-        {
-            "name": "before",
-            "type": [
-                {
-                    "name": "row",
-                    "type": "record",
-                    "fields": [
-                        {"name": "num", "type": "long"},
-                        {"name": "mod", "type": "string"}
-                    ]
-                },
-                "null"
-            ]
-        },
-        { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=mods
-
-$ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=1
-{"before": null, "after": {"row":{"num": 0, "mod": "even"}}}
-{"before": null, "after": {"row":{"num": 1, "mod": "odd"}}}
-{"before": null, "after": {"row":{"num": 2, "mod": "even"}}}
-
-$ set plurals-schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-        {
-            "name": "before",
-            "type": [
-                {
-                    "name": "row",
-                    "type": "record",
-                    "fields": [
-                        {"name": "num", "type": "string"},
-                        {"name": "noun", "type": "string"}
-                    ]
-                },
-                "null"
-            ]
-        },
-        { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=plurals
-
-$ kafka-ingest format=avro topic=plurals schema=${plurals-schema} timestamp=1
-{"before": null, "after": {"row":{"num": "one", "noun": "sheep"}}}
-{"before": null, "after": {"row":{"num": "two", "noun": "sheep"}}}
-{"before": null, "after": {"row":{"num": "one", "noun": "mouse"}}}
-{"before": null, "after": {"row":{"num": "two", "noun": "meeses"}}}
-
-$ kafka-ingest format=avro topic=names schema=${names-schema} timestamp=2
-{"before": null, "after": null}
-
-$ kafka-ingest format=avro topic=mods schema=${mods-schema} timestamp=2
-{"before": null, "after": null}
-
-$ kafka-ingest format=avro topic=plurals schema=${plurals-schema} timestamp=2
-{"before": null, "after": null}
-
-> CREATE MATERIALIZED SOURCE names
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-names-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${names-schema}'
-  ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED SOURCE mods
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-mods-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${mods-schema}'
-  ENVELOPE DEBEZIUM
-
-> CREATE MATERIALIZED SOURCE plurals
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-plurals-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${plurals-schema}'
-  ENVELOPE DEBEZIUM
+> CREATE TABLE names (num bigint, name text)
+> INSERT INTO names VALUES (1, 'one'), (2, 'two'), (3, 'three')
+> CREATE TABLE mods (num bigint, mod text)
+> INSERT INTO mods VALUES (0, 'even'), (1, 'odd'), (2, 'even')
+> CREATE TABLE plurals (num text, noun text)
+> INSERT INTO plurals VALUES ('one', 'sheep'), ('two', 'sheep'), ('one', 'mouse'), ('two', 'meeses')
 
 > CREATE MATERIALIZED VIEW test1 (names_num, names_name, mods_num, mods_mod, nouns_num, nouns_noun) AS
   SELECT * FROM names, mods, plurals WHERE names.num = mods.num AND names.name = plurals.num;

--- a/test/testdrive/nulls.td
+++ b/test/testdrive/nulls.td
@@ -8,39 +8,23 @@
 # by the Apache License, Version 2.0.
 
 $ set foo-schema={
+    "name": "row",
     "type": "record",
-    "name": "envelope",
     "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "a", "type": ["null", "long"]}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+      {"name": "a", "type": ["null", "long"]}
     ]
   }
 
 $ kafka-create-topic topic=foo
 
 $ kafka-ingest format=avro topic=foo schema=${foo-schema} timestamp=1
-{"before": null, "after": {"row":{"a": {"long": 1}}}}
-{"before": null, "after": {"row":{"a": {"long": 2}}}}
-{"before": null, "after": {"row":{"a": null}}}
-
-$ kafka-ingest format=avro topic=foo schema=${foo-schema} timestamp=2
-{"before": null, "after": null}
+{"a": {"long": 1}}
+{"a": {"long": 2}}
+{"a": null}
 
 > CREATE SOURCE foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${foo-schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${foo-schema}'
 
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT * FROM foo JOIN foo as foo2 USING (a);

--- a/test/testdrive/runtime-errors.td
+++ b/test/testdrive/runtime-errors.td
@@ -7,39 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set schema={
-    "type": "record",
-    "name": "envelope",
-    "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "id", "type": "string"},
-              {"name": "a", "type": "long"},
-              {"name": "b", "type": "long"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
-    ]
-  }
-
-$ kafka-create-topic topic=data
-
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row":{"id": "valid1", "a": 2, "b": 1}}}
-{"before": null, "after": {"row":{"id": "valid2", "a": 17, "b": 5}}}
-
-> CREATE SOURCE data
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
+> CREATE TABLE data (id text, a bigint, b bigint)
+> INSERT INTO data VALUES ('valid1', 2, 1), ('valid2', 17, 5)
 
 > CREATE MATERIALIZED VIEW multiply AS SELECT id, a * b AS product FROM data
 
@@ -52,8 +21,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 valid1  2   2
 valid2  85  3
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=2
-{"before": null, "after": {"row": {"id": "bad1", "a": 7, "b": 0}}}
+> INSERT INTO data VALUES ('bad1', 7, 0)
 
 > SELECT * FROM multiply
 valid1  2
@@ -66,8 +34,7 @@ contains:division by zero
 ! SELECT * FROM both
 contains:division by zero
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=3
-{"before": {"row": {"id": "bad1", "a": 7, "b": 0}}, "after": null}
+> DELETE FROM data WHERE id = 'bad1'
 
 > SELECT * FROM both
 valid1  2   2

--- a/test/testdrive/sort.td
+++ b/test/testdrive/sort.td
@@ -9,23 +9,10 @@
 
 $ set schema={
     "type": "record",
-    "name": "envelope",
+    "name": "row",
     "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "type": "record",
-            "name": "row",
-            "fields": [
-              { "name": "quote", "type": "string" },
-              { "name": "val", "type": "long" }
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+      { "name": "quote", "type": "string" },
+      { "name": "val", "type": "long" }
     ]
   }
 
@@ -34,21 +21,17 @@ $ kafka-create-topic topic=foobar
 > CREATE MATERIALIZED SOURCE foobar FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foobar-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 $ kafka-ingest format=avro topic=foobar schema=${schema} timestamp=42
-{"before": null, "after": {"row":{"quote": "I have a theory that it's impossible to prove anything, but I can't prove it.", "val": 2079}}}
-{"before": null, "after": {"row":{"quote": "It was a virgin forest, a place where the Hand of Man had never set foot.", "val": 12345}}}
-{"before": null, "after": {"row":{"quote": "If it pours before seven, it has rained by eleven.", "val": 12345}}}
-{"before": null, "after": {"row":{"quote": "All power corrupts, but we need electricity.", "val": 12345}}}
-{"before": null, "after": {"row":{"quote": "I want to read my new poem about pork brains and outer space ...", "val": 6745}}}
-{"before": null, "after": {"row":{"quote": "You are magnetic in your bearing.", "val": 24223}}}
-{"before": null, "after": {"row":{"quote": "Yes, but every time I try to see things your way, I get a headache.", "val": 21243}}}
-{"before": null, "after": {"row":{"quote": "Ring around the collar.", "val": 1735}}}
-{"before": null, "after": {"row":{"quote": "New York is real.  The rest is done with mirrors.", "val": 25040}}}
-
-$ kafka-ingest format=avro topic=foobar schema=${schema} timestamp=43
-{"before": null, "after": null}
+{"quote": "I have a theory that it's impossible to prove anything, but I can't prove it.", "val": 2079}
+{"quote": "It was a virgin forest, a place where the Hand of Man had never set foot.", "val": 12345}
+{"quote": "If it pours before seven, it has rained by eleven.", "val": 12345}
+{"quote": "All power corrupts, but we need electricity.", "val": 12345}
+{"quote": "I want to read my new poem about pork brains and outer space ...", "val": 6745}
+{"quote": "You are magnetic in your bearing.", "val": 24223}
+{"quote": "Yes, but every time I try to see things your way, I get a headache.", "val": 21243}
+{"quote": "Ring around the collar.", "val": 1735}
+{"quote": "New York is real.  The rest is done with mirrors.", "val": 25040}
 
 > SELECT val, quote FROM foobar ORDER BY quote LIMIT 5
 val    quote

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -86,37 +86,23 @@ a    b
 1    "a"
 
 $ set schema={
+    "name": "row",
     "type": "record",
-    "name": "envelope",
     "fields": [
-      {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {"name": "id", "type": "string"},
-              {"name": "a", "type": "long"},
-              {"name": "b", "type": "long"}
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+      {"name": "id", "type": "string"},
+      {"name": "a", "type": "long"},
+      {"name": "b", "type": "long"}
     ]
   }
 
 $ kafka-create-topic topic=data
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row":{"id": "valid1", "a": 2, "b": 1}}}
+{"id": "valid1", "a": 2, "b": 1}
 
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
-  ENVELOPE DEBEZIUM
 
 > SELECT * FROM t CROSS JOIN data
 1  a  valid1  2  1

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -12,53 +12,35 @@
 # uuid.slt.
 
 $ set schema={
+    "name": "row",
     "type": "record",
-    "name": "envelope",
     "fields": [
       {
-        "name": "before",
-        "type": [
-          {
-            "name": "row",
-            "type": "record",
-            "fields": [
-              {
-                "name": "u",
-                "type": {
-                  "type": "string",
-                  "logicalType": "uuid"
-                }
-              }
-            ]
-          },
-          "null"
-        ]
-      },
-      { "name": "after", "type": ["row", "null"] }
+        "name": "u",
+        "type": {
+          "type": "string",
+          "logicalType": "uuid"
+        }
+      }
     ]
   }
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
-{"before": null, "after": {"row":{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}}}
-{"before": null, "after": {"row":{"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}}}
-
-$ kafka-ingest format=avro topic=data schema=${schema} timestamp=10
-{"before": null, "after": null}
+$ kafka-ingest format=avro topic=data schema=${schema}
+{"u": "16fd95b0-65b7-4249-9b66-1547cd95923d"}
+{"u": "b141698b-fb7f-492d-bc8a-0d159641c7a3"}
 
 > CREATE SOURCE data FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM
+  FORMAT AVRO USING SCHEMA '${schema}'
 
-> CREATE MATERIALIZED VIEW data_view as SELECT * from data
-
-> SHOW COLUMNS FROM data_view
+> SHOW COLUMNS FROM data
 name   nullable  type
 ---------------------
 u      false     uuid
 
-> SELECT * FROM data_view
+> SELECT * FROM data
 "16fd95b0-65b7-4249-9b66-1547cd95923d"
 "b141698b-fb7f-492d-bc8a-0d159641c7a3"
 
@@ -68,7 +50,7 @@ u      false     uuid
 > SELECT '85907cb9-ac9b-4e35-84b8-60dc69368aca'::uuid::text
 "85907cb9-ac9b-4e35-84b8-60dc69368aca"
 
-> CREATE SINK uuid_sink_${testdrive.seed} FROM data_view
+> CREATE SINK uuid_sink_${testdrive.seed} FROM data
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 


### PR DESCRIPTION
A number of our test scripts are from an era where Materialize required
Debezium-formatted data and explicit timestamp closing messages. This
commit simplifies those tests by using append-only Avro sources.

This reduces the amount of work required to update test scripts when we
change our Debezium handling--e.g., in #13263, when we depend on
additional fields that are provided by real Debezium but not by our test
scripts which only approximate Debezium data.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
