### PR TITLE
coord: Include table advancements in group commit

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -172,7 +172,7 @@ mod dataflow_builder;
 mod indexes;
 
 #[derive(Debug)]
-pub enum Message<T = mz_repr::Timestamp> {
+pub enum Message {
     Command(Command),
     ControllerReady,
     CreateSourceStatementReady(CreateSourceStatementReady),
@@ -180,14 +180,13 @@ pub enum Message<T = mz_repr::Timestamp> {
     SendDiffs(SendDiffs),
     WriteLockGrant(tokio::sync::OwnedMutexGuard<()>),
     AdvanceLocalInputs,
-    AdvanceLocalInput(AdvanceLocalInput<T>),
+    AdvanceLocalInput(AdvanceLocalInput),
     GroupCommit,
     ComputeInstanceStatus(ComputeInstanceEvent),
 }
 
 #[derive(Debug)]
-pub struct AdvanceLocalInput<T> {
-    advance_to: T,
+pub struct AdvanceLocalInput {
     ids: Vec<GlobalId>,
 }
 
@@ -273,6 +272,26 @@ pub enum PeekResponseUnary {
     Rows(Vec<Row>),
     Error(String),
     Canceled,
+}
+
+struct GroupCommit {
+    pending_writes: Vec<PendingWriteTxn>,
+    table_advances: HashSet<GlobalId>,
+}
+
+impl GroupCommit {
+    fn new() -> Self {
+        GroupCommit {
+            pending_writes: Vec::new(),
+            table_advances: HashSet::new(),
+        }
+    }
+    fn is_empty(&self) -> bool {
+        self.pending_writes.is_empty() && self.table_advances.is_empty()
+    }
+    fn len(&self) -> usize {
+        self.pending_writes.len() + self.table_advances.len()
+    }
 }
 
 /// A pending write transaction that will be committing during the next group commit.
@@ -361,7 +380,7 @@ fn concretize_replica_config(
 }
 
 /// Holds tables needing advancement.
-struct AdvanceTables<T> {
+struct AdvanceTables {
     /// The current number of tables to advance in a single batch.
     batch_size: usize,
     /// The set of tables to advance.
@@ -369,24 +388,19 @@ struct AdvanceTables<T> {
     /// An ordered set of work to ensure fairness. Elements may be duplicated here,
     /// so there's no guarantee that there is a corresponding element in `set`.
     work: VecDeque<GlobalId>,
-    /// Timestamp at which to advance the tables.
-    advance_to: T,
 }
 
-impl<T: CoordTimestamp> AdvanceTables<T> {
+impl AdvanceTables {
     fn new() -> Self {
         Self {
             batch_size: 1,
             set: HashSet::new(),
             work: VecDeque::new(),
-            advance_to: T::minimum(),
         }
     }
 
     // Inserts ids to be advanced to ts.
-    fn insert<I: Iterator<Item = GlobalId>>(&mut self, ts: T, ids: I) {
-        assert!(self.advance_to.less_than(&ts));
-        self.advance_to = ts;
+    fn insert<I: Iterator<Item = GlobalId>>(&mut self, ids: I) {
         let ids = ids.collect::<Vec<_>>();
         self.set.extend(&ids);
         self.work.extend(ids);
@@ -395,15 +409,12 @@ impl<T: CoordTimestamp> AdvanceTables<T> {
     /// Returns the set of tables to advance. Blocks forever if there are none.
     ///
     /// This method is cancel-safe because there are no await points when the set is non-empty.
-    async fn recv(&mut self) -> AdvanceLocalInput<T> {
+    async fn recv(&mut self) -> AdvanceLocalInput {
         if self.set.is_empty() {
             futures::future::pending::<()>().await;
         }
         let mut remaining = self.batch_size;
-        let mut inputs = AdvanceLocalInput {
-            advance_to: self.advance_to.clone(),
-            ids: Vec::new(),
-        };
+        let mut inputs = AdvanceLocalInput { ids: Vec::new() };
         // Fetch out of the work queue to ensure that no table is starved from
         // advancement in the case that the periodic advancement interval is less than
         // the total time to advance all tables.
@@ -459,7 +470,7 @@ pub struct Coordinator<S> {
 
     /// Tracks tables needing advancement, which can be processed at a low priority
     /// in the biased select loop.
-    advance_tables: AdvanceTables<Timestamp>,
+    advance_tables: AdvanceTables,
 
     transient_id_counter: u64,
     /// A map from connection ID to metadata about that connection for all
@@ -492,8 +503,9 @@ pub struct Coordinator<S> {
     write_lock: Arc<tokio::sync::Mutex<()>>,
     /// Holds plans deferred due to write lock.
     write_lock_wait_group: VecDeque<Deferred>,
-    /// Pending writes waiting for a group commit
-    pending_writes: Vec<PendingWriteTxn>,
+
+    /// Pending writes and table advancements waiting for a group commit
+    pending_group_commit: GroupCommit,
 
     /// Handle to secret manager that can create and delete secrets from
     /// an arbitrary secret storage engine.
@@ -606,10 +618,6 @@ impl<S: Append + 'static> Coordinator<S> {
     /// NOTE: This can be removed once DDL is included in group commits.
     fn peek_local_ts(&self) -> Timestamp {
         self.global_timeline.peek_ts()
-    }
-
-    fn local_fast_forward(&mut self, lower_bound: Timestamp) {
-        self.global_timeline.fast_forward(lower_bound);
     }
 
     fn now(&self) -> EpochMillis {
@@ -1014,7 +1022,9 @@ impl<S: Append + 'static> Coordinator<S> {
                                 self.sequence_plan(ready.tx, ready.session, ready.plan, depends_on)
                                     .await;
                             }
-                            Deferred::GroupCommit => self.group_commit().await,
+                            Deferred::GroupCommit => {
+                                self.group_commit(Some(write_lock_guard)).await
+                            }
                         }
                     }
                     // N.B. if no deferred plans, write lock is released by drop
@@ -1024,16 +1034,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 Message::AdvanceLocalInputs => {
                     // Convince the coordinator it needs to open a new timestamp
                     // and advance inputs.
-                    // Fast forwarding puts the `TimestampOracle` in write mode,
-                    // which means the next read will have to advance a table
-                    // after reading from it. To prevent this we explicitly put
-                    // the `TimestampOracle` in read mode. Writes will always
-                    // advance a table no matter what mode the `TimestampOracle`
-                    // is in. We step back the value of `now()` so that the
-                    // next write can happen at `now()` and not a value above
-                    // `now()`
-                    let now = self.now();
-                    self.local_fast_forward(now.step_back().unwrap_or(now));
+                    self.advance_local_inputs();
                     let _ = self.get_local_read_ts();
                 }
                 Message::AdvanceLocalInput(inputs) => {
@@ -1046,9 +1047,8 @@ impl<S: Append + 'static> Coordinator<S> {
                     self.message_compute_instance_status(status).await
                 }
             }
-
-            if let Some(timestamp) = self.global_timeline.should_advance_to() {
-                self.advance_local_inputs(timestamp).await;
+            if let Some(_) = self.global_timeline.should_advance_to() {
+                self.advance_local_inputs();
             }
         }
     }
@@ -1059,83 +1059,22 @@ impl<S: Append + 'static> Coordinator<S> {
     // because they currently processed serially by persist. In order to allow
     // other coordinator messages to be processed (like user queries), split up the
     // processing of this work.
-    async fn advance_local_inputs(&mut self, advance_to: mz_repr::Timestamp) {
-        self.advance_tables.insert(
-            advance_to,
-            self.catalog
-                .entries()
-                .filter_map(|e| if e.is_table() { Some(e.id()) } else { None }),
-        );
+    fn advance_local_inputs(&mut self) {
+        self.advance_tables
+            .insert(self.catalog.entries().filter_map(|e| {
+                if e.is_table() {
+                    Some(e.id())
+                } else {
+                    None
+                }
+            }));
     }
 
-    // Advance a local input (table). This downgrades the capabilitiy of a table,
-    // which means that it can no longer produce new data before this timestamp.
+    // Advance a local input (table). This downgrades the capability of a table,
+    // which means that it can no longer produce new data before the assigned timestamp.
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn advance_local_input(&mut self, inputs: AdvanceLocalInput<mz_repr::Timestamp>) {
-        // We split up table advancement into batches of requests so that user queries
-        // are not blocked waiting for this periodic work to complete. MAX_WAIT is the
-        // maximum amount of time we are willing to block user queries for. We could
-        // process tables one at a time, but that increases the overall processing time
-        // because we miss out on batching the requests to the postgres server. To
-        // balance these two goals (not blocking user queries, minimizing time to
-        // advance tables), we record how long a batch takes to process, and will
-        // adjust the size of the next batch up or down based on the response time.
-        //
-        // On one extreme, should we ever be able to advance all tables in less time
-        // than MAX_WAIT (probably due to connection pools or other actual parallelism
-        // on the persist side), great, we've minimized the total processing time
-        // without blocking user queries for more than our target. On the other extreme
-        // where we can only process one table at a time (probably due to the postgres
-        // server being over used or some other cloud/network slowdown inbetween), the
-        // AdvanceTables struct will gracefully attempt to close tables in a bounded
-        // and fair manner.
-        const MAX_WAIT: Duration = Duration::from_millis(50);
-        // Advancement that occurs within WINDOW from MAX_WAIT is fine, and won't
-        // change the batch size.
-        const WINDOW: Duration = Duration::from_millis(10);
-        let start = Instant::now();
-        let storage = self.dataflow_client.storage();
-        let appends = inputs
-            .ids
-            .into_iter()
-            .filter_map(|id| {
-                if self.catalog.try_get_entry(&id).is_none()
-                    || !storage
-                        .collection(id)
-                        .unwrap()
-                        .write_frontier
-                        .less_than(&inputs.advance_to)
-                {
-                    // Filter out tables that were dropped while waiting for advancement.
-                    // Filter out tables whose upper is already advanced. This is not needed for
-                    // correctness (advance_to and write_frontier should be equal here), just
-                    // performance, as it's a no-op.
-                    None
-                } else {
-                    Some((id, vec![], inputs.advance_to))
-                }
-            })
-            .collect::<Vec<_>>();
-        let num_updates = appends.len();
-        self.dataflow_client
-            .storage_mut()
-            .append(appends)
-            .await
-            .unwrap();
-        let elapsed = start.elapsed();
-        trace!(
-            "advance_local_inputs for {} tables to {} took: {} ms",
-            num_updates,
-            inputs.advance_to,
-            elapsed.as_millis()
-        );
-        if elapsed > (MAX_WAIT + WINDOW) {
-            self.advance_tables.decrease_batch();
-        } else if elapsed < (MAX_WAIT - WINDOW) && num_updates == self.advance_tables.batch_size {
-            // Only increase the batch size if it completed under the window and the batch
-            // was full.
-            self.advance_tables.increase_batch();
-        }
+    async fn advance_local_input(&mut self, inputs: AdvanceLocalInput) {
+        self.submit_table_advancement(inputs.ids);
     }
 
     /// Attempts to commit all pending write transactions in a group commit. If the timestamp
@@ -1143,7 +1082,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// immediately. Otherwise we must wait for `now()` to advance past the timestamp chosen for the
     /// writes.
     async fn try_group_commit(&mut self) {
-        if self.pending_writes.is_empty() {
+        if self.pending_group_commit.is_empty() {
             return;
         }
 
@@ -1169,90 +1108,170 @@ impl<S: Append + 'static> Coordinator<S> {
                     .send(Message::GroupCommit)
                     .expect("sending to internal_cmd_tx cannot fail");
             });
-        } else if self
-            .pending_writes
-            .iter()
-            .any(|pending_write| pending_write.has_write_lock())
-            || self.write_lock.try_lock().is_ok()
-        {
-            // If some transaction already holds the write lock, then we can execute a group
-            // commit.
-            self.group_commit().await;
-        } else if let Ok(_guard) = Arc::clone(&self.write_lock).try_lock_owned() {
-            // If no transaction holds the write lock, then we need to acquire it.
-            self.group_commit().await;
+            // Advance next batch of tables
+            self.group_commit(None).await;
         } else {
-            // If some running transaction already holds the write lock, then one of the
-            // following things will happen:
-            //   1. The transaction will submit a write which will transfer the
-            //      ownership of the lock to group commit and trigger another group
-            //      group commit.
-            //   2. The transaction will complete without submitting a write (abort,
-            //      empty writes, etc) which will drop the lock. The deferred group
-            //      commit will then acquire the lock and execute a group commit.
-            self.defer_write(Deferred::GroupCommit);
+            // Try and get the write lock from either one of the pending write transaction or by
+            // acquiring it ourselves.
+            let write_lock_guard = {
+                if let Some(idx) = self
+                    .pending_group_commit
+                    .pending_writes
+                    .iter()
+                    .position(|write| write.has_write_lock())
+                {
+                    std::mem::replace(
+                        &mut self.pending_group_commit.pending_writes[idx].write_lock_guard,
+                        None,
+                    )
+                } else {
+                    Arc::clone(&self.write_lock).try_lock_owned().ok()
+                }
+            };
+            if write_lock_guard.is_none() && !self.pending_group_commit.pending_writes.is_empty() {
+                self.defer_write(Deferred::GroupCommit);
+            }
+            self.group_commit(write_lock_guard).await;
         }
     }
 
-    /// Commits all pending write transactions at the same timestamp. All pending writes will be
-    /// combined into a single Append command and sent to STORAGE as a single batch. All writes will
-    /// happen at the same timestamp and all involved tables will be advanced to some timestamp
-    /// larger than the timestamp of the write.
-    async fn group_commit(&mut self) {
-        if self.pending_writes.is_empty() {
+    /// Commits all pending write transactions and table advancements at the same timestamp. All
+    /// pending writes and table advancements will be combined into a single Append command and
+    /// sent to STORAGE as a single batch. All writes will happen at the same timestamp and all
+    /// involved tables will be advanced to some timestamp larger than the timestamp of the write.
+    ///
+    /// If the [`write_lock_guard`] is [`Some`] then both pending write transaction and table
+    /// advancements will be committed, and the global timestamp will be increased.
+    /// If the [`write_lock_guard`] is [`None`] then only table advancements will be committed, and
+    /// the global timestamp will not be increased.
+    async fn group_commit(&mut self, write_lock_guard: Option<OwnedMutexGuard<()>>) {
+        if self.pending_group_commit.is_empty() {
             return;
         }
-
         // The value returned here still might be ahead of `now()` if `now()` has gone backwards at
         // any point during this method. We will still commit the write without waiting for `now()`
         // to advance. This is ok because the next batch of writes will trigger the wait loop in
         // `try_group_commit()` if `now()` hasn't advanced past the global timeline, preventing
-        // an unbounded advancin of the global timeline ahead of `now()`.
+        // an unbounded advancing of the global timeline ahead of `now()`.
         let WriteTimestamp {
             timestamp,
             advance_to,
-        } = self.get_and_step_local_write_ts();
+        } = if write_lock_guard.is_some() {
+            self.get_and_step_local_write_ts()
+        } else {
+            let timestamp = self.get_local_read_ts();
+            WriteTimestamp {
+                timestamp,
+                advance_to: timestamp.step_forward(),
+            }
+        };
+
         let mut appends: HashMap<GlobalId, Vec<Update<Timestamp>>> =
-            HashMap::with_capacity(self.pending_writes.len());
-        let mut responses = Vec::with_capacity(self.pending_writes.len());
-        for PendingWriteTxn {
-            writes,
-            client_transmitter,
-            response,
-            session,
-            action,
-            write_lock_guard: _,
-        } in self.pending_writes.drain(..)
+            HashMap::with_capacity(self.pending_group_commit.len());
+        let mut responses = Vec::with_capacity(self.pending_group_commit.pending_writes.len());
+
+        // Only add non-empty writes if we have the write lock
+        if let Some(_guard) = write_lock_guard {
+            for PendingWriteTxn {
+                writes,
+                client_transmitter,
+                response,
+                session,
+                action,
+                write_lock_guard: _,
+            } in self.pending_group_commit.pending_writes.drain(..)
+            {
+                for WriteOp { id, rows } in writes {
+                    // If the table that some write was targeting has been deleted while the write was
+                    // waiting, then the write will be ignored and we respond to the client that the
+                    // write was successful. This is only possible if the write and the delete were
+                    // concurrent. Therefore, we are free to order the write before the delete without
+                    // violating any consistency guarantees.
+                    if self.catalog.try_get_entry(&id).is_some() {
+                        let updates = rows
+                            .into_iter()
+                            .map(|(row, diff)| Update {
+                                row,
+                                diff,
+                                timestamp,
+                            })
+                            .collect::<Vec<_>>();
+                        appends.entry(id).or_default().extend(updates);
+                    }
+                }
+                responses.push((client_transmitter, response, session, action));
+            }
+        }
+
+        // Table advancements are ok to execute without the lock
         {
-            for WriteOp { id, rows } in writes {
-                // If the table that some write was targeting has been deleted while the write was
-                // waiting, then the write will be ignored and we respond to the client that the
-                // write was successful. This is only possible if the write and the delete were
-                // concurrent. Therefore, we are free to order the write before the delete without
-                // violating any consistency guarantees.
-                if self.catalog.try_get_entry(&id).is_some() {
-                    let updates = rows
-                        .into_iter()
-                        .map(|(row, diff)| Update {
-                            row,
-                            diff,
-                            timestamp,
-                        })
-                        .collect::<Vec<_>>();
-                    appends.entry(id).or_default().extend(updates);
+            let storage = self.dataflow_client.storage();
+            for id in self.pending_group_commit.table_advances.drain() {
+                // If the table was deleted while the table advancement was waiting, then the
+                // table advancement will be ignored.
+                // If the table was already advanced then the table advancement will be ignored.
+                if self.catalog.try_get_entry(&id).is_some()
+                    && storage
+                        .collection(id)
+                        .unwrap()
+                        .write_frontier
+                        .less_than(&advance_to)
+                {
+                    appends.entry(id).or_insert(Vec::new());
                 }
             }
-            responses.push((client_transmitter, response, session, action));
         }
-        let appends = appends
+
+        let appends: Vec<_> = appends
             .into_iter()
             .map(|(id, updates)| (id, updates, advance_to))
             .collect();
+
+        // We split up table advancement into batches of requests so that user queries
+        // are not blocked waiting for this periodic work to complete. MAX_WAIT is the
+        // maximum amount of time we are willing to block user queries for. We could
+        // process tables one at a time, but that increases the overall processing time
+        // because we miss out on batching the requests to the postgres server. To
+        // balance these two goals (not blocking user queries, minimizing time to
+        // advance tables), we record how long a batch takes to process, and will
+        // adjust the size of the next batch up or down based on the response time. We
+        // include regular table write times in this calculation so that when we are
+        // experiencing a lot of writes we will lower the number of table advancements
+        // to compensate and vice versa.
+        //
+        // On one extreme, should we ever be able to advance all tables in less time
+        // than MAX_WAIT (probably due to connection pools or other actual parallelism
+        // on the persist side), great, we've minimized the total processing time
+        // without blocking user queries for more than our target. On the other extreme
+        // where we can only process one table at a time (probably due to the postgres
+        // server being over used or some other cloud/network slowdown inbetween), the
+        // AdvanceTables struct will gracefully attempt to close tables in a bounded
+        // and fair manner.
+        const MAX_WAIT: Duration = Duration::from_millis(333);
+        // Advancement that occurs within WINDOW from MAX_WAIT is fine, and won't
+        // change the batch size.
+        const WINDOW: Duration = Duration::from_millis(10);
+        let num_tables = appends.len();
+        let start = Instant::now();
         self.dataflow_client
             .storage_mut()
             .append(appends)
             .await
             .unwrap();
+        let elapsed = start.elapsed();
+        trace!(
+            "group commit for {} tables to {} took: {} ms",
+            num_tables,
+            advance_to,
+            elapsed.as_millis()
+        );
+        if elapsed > (MAX_WAIT + WINDOW) {
+            self.advance_tables.decrease_batch();
+        } else if elapsed < (MAX_WAIT - WINDOW) && num_tables >= self.advance_tables.batch_size {
+            // Only increase the batch size if it completed under the window and the batch
+            // was full.
+            self.advance_tables.increase_batch();
+        }
         for (client_transmitter, response, mut session, action) in responses {
             session.vars_mut().end_transaction(action);
             client_transmitter.send(response, session);
@@ -1264,7 +1283,19 @@ impl<S: Append + 'static> Coordinator<S> {
         self.internal_cmd_tx
             .send(Message::GroupCommit)
             .expect("sending to internal_cmd_tx cannot fail");
-        self.pending_writes.push(pending_write_txn);
+        self.pending_group_commit
+            .pending_writes
+            .push(pending_write_txn);
+    }
+
+    /// Submit a table to be advanced during the next group commit.
+    fn submit_table_advancement(&mut self, ids: Vec<GlobalId>) {
+        if self.pending_group_commit.is_empty() {
+            self.internal_cmd_tx
+                .send(Message::GroupCommit)
+                .expect("sending to internal_cmd_tx cannot fail");
+        }
+        self.pending_group_commit.table_advances.extend(ids);
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
@@ -2003,6 +2034,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
             // Cancel pending writes. There is at most one pending write per session.
             if let Some(idx) = self
+                .pending_group_commit
                 .pending_writes
                 .iter()
                 .position(|PendingWriteTxn { session, .. }| session.conn_id() == conn_id)
@@ -2011,7 +2043,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     client_transmitter,
                     session,
                     ..
-                } = self.pending_writes.remove(idx);
+                } = self.pending_group_commit.pending_writes.remove(idx);
                 let _ = client_transmitter.send(Ok(ExecuteResponse::Canceled), session);
             }
 
@@ -5551,7 +5583,7 @@ pub async fn serve<S: Append + 'static>(
                 pending_tails: HashMap::new(),
                 write_lock: Arc::new(tokio::sync::Mutex::new(())),
                 write_lock_wait_group: VecDeque::new(),
-                pending_writes: Vec::new(),
+                pending_group_commit: GroupCommit::new(),
                 secrets_controller,
                 replica_sizes,
                 availability_zones,
@@ -6288,28 +6320,6 @@ mod timeline {
             }
         }
 
-        /// Electively advance the tracked times.
-        ///
-        /// If `lower_bound` is strictly greater than the current time (of either state), the
-        /// resulting state will be `Writing(lower_bound)`.
-        pub fn fast_forward(&mut self, lower_bound: T) {
-            match &self.state {
-                TimestampOracleState::Writing(ts) => {
-                    if ts.less_than(&lower_bound) {
-                        self.advance_to = Some(lower_bound.clone());
-                        self.state = TimestampOracleState::Writing(lower_bound);
-                    }
-                }
-                TimestampOracleState::Reading(ts) => {
-                    if ts.less_than(&lower_bound) {
-                        // This may result in repetition in the case `lower_bound == ts + 1`.
-                        // This is documented as fine, and concerned users can protect themselves.
-                        self.advance_to = Some(lower_bound.clone());
-                        self.state = TimestampOracleState::Writing(lower_bound);
-                    }
-                }
-            }
-        }
         /// Whether and to what the next value of `self.write_ts() has advanced since this method was last called.
         ///
         /// This method may produce the same value multiple times, and should not be used as a test for whether


### PR DESCRIPTION
Previously, all writes to user tables would be batched in group commit.
However, writes that are part of periodic table advancements were not
included in group commit and could still push the global timestamp
ahead.
    
This commit adds periodic table advancements to group commits.
    
Works towards resolving #11631

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
* This is directly extracted from #12979.
* This PR extends #13314

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
