### PR TITLE
switch unusual self receiver syntax to standard syntax

### DIFF
--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -263,7 +263,7 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
 }
 
 impl RustType<ProtoCompaction> for (GlobalId, Antichain<u64>) {
-    fn into_proto(self: &Self) -> ProtoCompaction {
+    fn into_proto(&self) -> ProtoCompaction {
         ProtoCompaction {
             id: Some(self.0.into_proto()),
             frontier: Some((&self.1).into()),

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -716,7 +716,7 @@ impl RustType<ProtoPlan> for Plan {
 }
 
 impl RustType<proto_plan::ProtoRowDiff> for (Row, u64, i64) {
-    fn into_proto(self: &Self) -> proto_plan::ProtoRowDiff {
+    fn into_proto(&self) -> proto_plan::ProtoRowDiff {
         proto_plan::ProtoRowDiff {
             row: Some(self.0.into_proto()),
             timestamp: self.1.clone(),
@@ -734,7 +734,7 @@ impl RustType<proto_plan::ProtoRowDiff> for (Row, u64, i64) {
 }
 
 impl RustType<proto_plan::ProtoRowDiffVec> for Vec<(Row, u64, i64)> {
-    fn into_proto(self: &Self) -> proto_plan::ProtoRowDiffVec {
+    fn into_proto(&self) -> proto_plan::ProtoRowDiffVec {
         proto_plan::ProtoRowDiffVec {
             rows: self.into_proto(),
         }

--- a/src/dataflow-types/src/types/connections.rs
+++ b/src/dataflow-types/src/types/connections.rs
@@ -231,7 +231,7 @@ impl CsrConnection {
 }
 
 impl RustType<ProtoCsrConnection> for CsrConnection {
-    fn into_proto(self: &Self) -> ProtoCsrConnection {
+    fn into_proto(&self) -> ProtoCsrConnection {
         ProtoCsrConnection {
             url: Some(self.url.into_proto()),
             root_certs: self.root_certs.into_proto(),
@@ -282,7 +282,7 @@ pub struct CsrConnectionTlsIdentity {
 }
 
 impl RustType<ProtoCsrConnectionTlsIdentity> for CsrConnectionTlsIdentity {
-    fn into_proto(self: &Self) -> ProtoCsrConnectionTlsIdentity {
+    fn into_proto(&self) -> ProtoCsrConnectionTlsIdentity {
         ProtoCsrConnectionTlsIdentity {
             cert: Some(self.cert.into_proto()),
             key: Some(self.key.into_proto()),
@@ -311,7 +311,7 @@ pub struct CsrConnectionHttpAuth {
 }
 
 impl RustType<ProtoCsrConnectionHttpAuth> for CsrConnectionHttpAuth {
-    fn into_proto(self: &Self) -> ProtoCsrConnectionHttpAuth {
+    fn into_proto(&self) -> ProtoCsrConnectionHttpAuth {
         ProtoCsrConnectionHttpAuth {
             username: Some(self.username.into_proto()),
             password: self.password.into_proto(),

--- a/src/dataflow-types/src/types/sinks.rs
+++ b/src/dataflow-types/src/types/sinks.rs
@@ -198,7 +198,7 @@ pub struct KafkaSinkConsistencyConnection {
 }
 
 impl RustType<ProtoKafkaSinkConsistencyConnection> for KafkaSinkConsistencyConnection {
-    fn into_proto(self: &Self) -> ProtoKafkaSinkConsistencyConnection {
+    fn into_proto(&self) -> ProtoKafkaSinkConsistencyConnection {
         ProtoKafkaSinkConsistencyConnection {
             topic: self.topic.clone(),
             schema_id: self.schema_id,
@@ -350,7 +350,7 @@ pub struct PublishedSchemaInfo {
 }
 
 impl RustType<ProtoPublishedSchemaInfo> for PublishedSchemaInfo {
-    fn into_proto(self: &Self) -> ProtoPublishedSchemaInfo {
+    fn into_proto(&self) -> ProtoPublishedSchemaInfo {
         ProtoPublishedSchemaInfo {
             key_schema_id: self.key_schema_id.clone(),
             value_schema_id: self.value_schema_id,
@@ -372,7 +372,7 @@ pub struct PersistSinkConnection<S> {
 }
 
 impl RustType<ProtoPersistSinkConnection> for PersistSinkConnection<CollectionMetadata> {
-    fn into_proto(self: &Self) -> ProtoPersistSinkConnection {
+    fn into_proto(&self) -> ProtoPersistSinkConnection {
         ProtoPersistSinkConnection {
             value_desc: Some(self.value_desc.into_proto()),
             storage_metadata: Some(self.storage_metadata.into_proto()),

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -97,7 +97,7 @@ impl RustType<ProtoIngestionDescription>
         mz_repr::Timestamp,
     >
 {
-    fn into_proto(self: &Self) -> ProtoIngestionDescription {
+    fn into_proto(&self) -> ProtoIngestionDescription {
         // we have to turn a BTreeMap into a vec here
         let source_imports: Vec<_> = self
             .source_imports
@@ -308,7 +308,7 @@ pub enum IncludedColumnSource {
 }
 
 impl RustType<ProtoIncludedColumnSource> for IncludedColumnSource {
-    fn into_proto(self: &Self) -> ProtoIncludedColumnSource {
+    fn into_proto(&self) -> ProtoIncludedColumnSource {
         use proto_included_column_source::Kind;
         ProtoIncludedColumnSource {
             kind: Some(match self {
@@ -356,7 +356,7 @@ pub enum KeyEnvelope {
 }
 
 impl RustType<ProtoKeyEnvelope> for KeyEnvelope {
-    fn into_proto(self: &Self) -> ProtoKeyEnvelope {
+    fn into_proto(&self) -> ProtoKeyEnvelope {
         use proto_key_envelope::Kind;
         ProtoKeyEnvelope {
             kind: Some(match self {
@@ -429,7 +429,7 @@ pub enum Timeline {
 }
 
 impl RustType<ProtoTimeline> for Timeline {
-    fn into_proto(self: &Self) -> ProtoTimeline {
+    fn into_proto(&self) -> ProtoTimeline {
         use proto_timeline::Kind;
         ProtoTimeline {
             kind: Some(match self {
@@ -486,7 +486,7 @@ pub enum SourceEnvelope {
 }
 
 impl RustType<ProtoSourceEnvelope> for SourceEnvelope {
-    fn into_proto(self: &Self) -> ProtoSourceEnvelope {
+    fn into_proto(&self) -> ProtoSourceEnvelope {
         use proto_source_envelope::Kind;
         ProtoSourceEnvelope {
             kind: Some(match self {
@@ -563,7 +563,7 @@ pub struct UpsertEnvelope {
 }
 
 impl RustType<ProtoUpsertEnvelope> for UpsertEnvelope {
-    fn into_proto(self: &Self) -> ProtoUpsertEnvelope {
+    fn into_proto(&self) -> ProtoUpsertEnvelope {
         ProtoUpsertEnvelope {
             style: Some(self.style.into_proto()),
             key_indices: self.key_indices.into_proto(),
@@ -590,7 +590,7 @@ pub enum UpsertStyle {
 }
 
 impl RustType<ProtoUpsertStyle> for UpsertStyle {
-    fn into_proto(self: &Self) -> ProtoUpsertStyle {
+    fn into_proto(&self) -> ProtoUpsertStyle {
         use proto_upsert_style::{Kind, ProtoDebezium};
         ProtoUpsertStyle {
             kind: Some(match self {
@@ -626,7 +626,7 @@ pub struct DebeziumEnvelope {
 }
 
 impl RustType<ProtoDebeziumEnvelope> for DebeziumEnvelope {
-    fn into_proto(self: &Self) -> ProtoDebeziumEnvelope {
+    fn into_proto(&self) -> ProtoDebeziumEnvelope {
         ProtoDebeziumEnvelope {
             before_idx: self.before_idx.into_proto(),
             after_idx: self.after_idx.into_proto(),
@@ -658,7 +658,7 @@ pub struct DebeziumTransactionMetadata {
 }
 
 impl RustType<ProtoDebeziumTransactionMetadata> for DebeziumTransactionMetadata {
-    fn into_proto(self: &Self) -> ProtoDebeziumTransactionMetadata {
+    fn into_proto(&self) -> ProtoDebeziumTransactionMetadata {
         ProtoDebeziumTransactionMetadata {
             tx_metadata_global_id: Some(self.tx_metadata_global_id.into_proto()),
             tx_status_idx: self.tx_status_idx.into_proto(),
@@ -773,7 +773,7 @@ impl Arbitrary for DebeziumMode {
 }
 
 impl RustType<ProtoDebeziumMode> for DebeziumMode {
-    fn into_proto(self: &Self) -> ProtoDebeziumMode {
+    fn into_proto(&self) -> ProtoDebeziumMode {
         use proto_debezium_mode::{Kind, ProtoFullInRange};
         ProtoDebeziumMode {
             kind: Some(match self {
@@ -849,7 +849,7 @@ pub struct DebeziumDedupProjection {
 }
 
 impl RustType<ProtoDebeziumDedupProjection> for DebeziumDedupProjection {
-    fn into_proto(self: &Self) -> ProtoDebeziumDedupProjection {
+    fn into_proto(&self) -> ProtoDebeziumDedupProjection {
         ProtoDebeziumDedupProjection {
             source_idx: self.source_idx.into_proto(),
             snapshot_idx: self.snapshot_idx.into_proto(),
@@ -896,7 +896,7 @@ pub enum DebeziumSourceProjection {
 }
 
 impl RustType<ProtoDebeziumSourceProjection> for DebeziumSourceProjection {
-    fn into_proto(self: &Self) -> ProtoDebeziumSourceProjection {
+    fn into_proto(&self) -> ProtoDebeziumSourceProjection {
         use proto_debezium_source_projection::{Kind, ProtoMySql, ProtoPostgres, ProtoSqlServer};
         ProtoDebeziumSourceProjection {
             kind: Some(match self {
@@ -1299,7 +1299,7 @@ pub struct SourceDesc {
 }
 
 impl RustType<ProtoSourceDesc> for SourceDesc {
-    fn into_proto(self: &Self) -> ProtoSourceDesc {
+    fn into_proto(&self) -> ProtoSourceDesc {
         ProtoSourceDesc {
             connection: Some(self.connection.into_proto()),
             desc: Some(self.desc.into_proto()),
@@ -1368,7 +1368,7 @@ impl Arbitrary for SourceConnection {
 }
 
 impl RustType<ProtoSourceConnection> for SourceConnection {
-    fn into_proto(self: &Self) -> ProtoSourceConnection {
+    fn into_proto(&self) -> ProtoSourceConnection {
         use proto_source_connection::{Kind, ProtoExternal, ProtoLocal};
         ProtoSourceConnection {
             kind: Some(match self {

--- a/src/dataflow-types/src/types/sources/encoding.rs
+++ b/src/dataflow-types/src/types/sources/encoding.rs
@@ -69,7 +69,7 @@ pub enum SourceDataEncoding {
 }
 
 impl RustType<ProtoSourceDataEncoding> for SourceDataEncoding {
-    fn into_proto(self: &Self) -> ProtoSourceDataEncoding {
+    fn into_proto(&self) -> ProtoSourceDataEncoding {
         use proto_source_data_encoding::{Kind, ProtoKeyValue};
         ProtoSourceDataEncoding {
             kind: Some(match self {
@@ -186,7 +186,7 @@ pub struct DataEncoding {
 }
 
 impl RustType<ProtoDataEncoding> for DataEncoding {
-    fn into_proto(self: &Self) -> ProtoDataEncoding {
+    fn into_proto(&self) -> ProtoDataEncoding {
         ProtoDataEncoding {
             force_nullable_columns: self.force_nullable_columns,
             inner: Some(self.inner.into_proto()),
@@ -319,7 +319,7 @@ pub struct AvroEncoding {
 }
 
 impl RustType<ProtoAvroEncoding> for AvroEncoding {
-    fn into_proto(self: &Self) -> ProtoAvroEncoding {
+    fn into_proto(&self) -> ProtoAvroEncoding {
         ProtoAvroEncoding {
             schema: self.schema.clone(),
             csr_connection: self.csr_connection.into_proto(),
@@ -345,7 +345,7 @@ pub struct ProtobufEncoding {
 }
 
 impl RustType<ProtoProtobufEncoding> for ProtobufEncoding {
-    fn into_proto(self: &Self) -> ProtoProtobufEncoding {
+    fn into_proto(&self) -> ProtoProtobufEncoding {
         ProtoProtobufEncoding {
             descriptors: self.descriptors.clone(),
             message_name: self.message_name.clone(),
@@ -370,7 +370,7 @@ pub struct CsvEncoding {
 }
 
 impl RustType<ProtoCsvEncoding> for CsvEncoding {
-    fn into_proto(self: &Self) -> ProtoCsvEncoding {
+    fn into_proto(&self) -> ProtoCsvEncoding {
         ProtoCsvEncoding {
             columns: Some(self.columns.into_proto()),
             delimiter: self.delimiter.into_proto(),
@@ -399,7 +399,7 @@ pub enum ColumnSpec {
 }
 
 impl RustType<ProtoColumnSpec> for ColumnSpec {
-    fn into_proto(self: &Self) -> ProtoColumnSpec {
+    fn into_proto(&self) -> ProtoColumnSpec {
         use proto_column_spec::{Kind, ProtoHeader};
         ProtoColumnSpec {
             kind: Some(match self {
@@ -457,7 +457,7 @@ impl Arbitrary for RegexEncoding {
 }
 
 impl RustType<ProtoRegexEncoding> for RegexEncoding {
-    fn into_proto(self: &Self) -> ProtoRegexEncoding {
+    fn into_proto(&self) -> ProtoRegexEncoding {
         ProtoRegexEncoding {
             regex: Some(self.regex.into_proto()),
         }

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -172,7 +172,7 @@ impl RustType<ProtoMatcherImpl> for MatcherImpl {
 }
 
 impl RustType<ProtoSubpatternVec> for Vec<Subpattern> {
-    fn into_proto(self: &Self) -> ProtoSubpatternVec {
+    fn into_proto(&self) -> ProtoSubpatternVec {
         ProtoSubpatternVec {
             vec: self.into_proto(),
         }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1840,7 +1840,7 @@ impl RustType<ProtoEvalError> for EvalError {
 }
 
 impl RustType<ProtoDims> for (usize, usize) {
-    fn into_proto(self: &Self) -> ProtoDims {
+    fn into_proto(&self) -> ProtoDims {
         ProtoDims {
             f0: self.0.into_proto(),
             f1: self.1.into_proto(),

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -174,7 +174,7 @@ pub fn format_str_pad(s: &str, length: Option<CharLength>) -> String {
 }
 
 impl RustType<ProtoCharLength> for CharLength {
-    fn into_proto(self: &Self) -> ProtoCharLength {
+    fn into_proto(&self) -> ProtoCharLength {
         ProtoCharLength { value: self.0 }
     }
 

--- a/src/repr/src/proto.rs
+++ b/src/repr/src/proto.rs
@@ -383,7 +383,7 @@ impl RustType<u64> for std::num::NonZeroUsize {
 }
 
 impl RustType<ProtoDuration> for std::time::Duration {
-    fn into_proto(self: &Self) -> ProtoDuration {
+    fn into_proto(&self) -> ProtoDuration {
         ProtoDuration {
             secs: self.as_secs(),
             nanos: self.subsec_nanos(),
@@ -415,7 +415,7 @@ impl RustType<String> for ShardId {
 /// Clients should only implement [`RustType`].
 pub trait ProtoType<Rust>: Sized {
     /// See [`RustType::from_proto`].
-    fn into_rust(self: Self) -> Result<Rust, TryFromProtoError>;
+    fn into_rust(self) -> Result<Rust, TryFromProtoError>;
 
     /// See [`RustType::into_proto`].
     fn from_rust(rust: &Rust) -> Self;
@@ -428,7 +428,7 @@ where
     R: RustType<P>,
 {
     #[inline]
-    fn into_rust(self: Self) -> Result<R, TryFromProtoError> {
+    fn into_rust(self) -> Result<R, TryFromProtoError> {
         R::from_proto(self)
     }
 

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -227,7 +227,7 @@ impl RustType<ProtoRelationType> for RelationType {
 }
 
 impl RustType<ProtoKey> for Vec<usize> {
-    fn into_proto(self: &Self) -> ProtoKey {
+    fn into_proto(&self) -> ProtoKey {
         ProtoKey {
             keys: self.into_proto(),
         }
@@ -334,7 +334,7 @@ pub struct RelationDesc {
 }
 
 impl RustType<ProtoRelationDesc> for RelationDesc {
-    fn into_proto(self: &Self) -> ProtoRelationDesc {
+    fn into_proto(&self) -> ProtoRelationDesc {
         ProtoRelationDesc {
             typ: Some(self.typ.into_proto()),
             names: self.names.into_proto(),

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -263,7 +263,7 @@ impl TryFrom<&ProtoRow> for Row {
 }
 
 impl RustType<ProtoRow> for Row {
-    fn into_proto(self: &Self) -> ProtoRow {
+    fn into_proto(&self) -> ProtoRow {
         let datums = self.iter().map(|x| x.into()).collect();
         ProtoRow { datums }
     }

--- a/src/repr/src/url.rs
+++ b/src/repr/src/url.rs
@@ -17,7 +17,7 @@ use crate::proto::{RustType, TryFromProtoError};
 include!(concat!(env!("OUT_DIR"), "/mz_repr.url.rs"));
 
 impl RustType<ProtoUrl> for Url {
-    fn into_proto(self: &Self) -> ProtoUrl {
+    fn into_proto(&self) -> ProtoUrl {
         ProtoUrl {
             url: self.to_string(),
         }


### PR DESCRIPTION
Somehow a lot of these trait implementations (I assume through copy
paste of an initial one) got a self receiver syntax that is pretty
unusual to see.

This PR switches all of them to the standard shorthand notation.
