### PR TITLE
sql-parser: Add new EXPLAIN code path.

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -122,8 +122,8 @@ use mz_repr::{
 use mz_secrets::{SecretOp, SecretsController};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{
-    CreateIndexStatement, CreateSourceStatement, ExplainStage, FetchStatement, Ident,
-    IndexOptionName, InsertSource, ObjectType, Query, Raw, RawClusterName, RawObjectName, SetExpr,
+    CreateIndexStatement, CreateSourceStatement, FetchStatement, Ident, IndexOptionName,
+    InsertSource, ObjectType, OldExplainStage, Query, Raw, RawClusterName, RawObjectName, SetExpr,
     Statement,
 };
 use mz_sql::catalog::{
@@ -4273,7 +4273,7 @@ impl<S: Append + 'static> Coordinator<S> {
             };
 
         let mut explanation_string = match stage {
-            ExplainStage::RawPlan => {
+            OldExplainStage::RawPlan => {
                 let catalog = self.catalog.for_session(session);
                 let mut explanation = mz_sql::plan::Explanation::new(&raw_plan, &catalog);
                 if let Some(row_set_finishing) = row_set_finishing {
@@ -4284,18 +4284,18 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 explanation.to_string()
             }
-            ExplainStage::QueryGraph => {
+            OldExplainStage::QueryGraph => {
                 let catalog = self.catalog.for_session(session);
                 let mut model = mz_sql::query_model::Model::try_from(raw_plan)?;
                 model.as_dot("", &catalog, options.typed)?
             }
-            ExplainStage::OptimizedQueryGraph => {
+            OldExplainStage::OptimizedQueryGraph => {
                 let catalog = self.catalog.for_session(session);
                 let mut model = mz_sql::query_model::Model::try_from(raw_plan)?;
                 model.optimize();
                 model.as_dot("", &catalog, options.typed)?
             }
-            ExplainStage::DecorrelatedPlan => {
+            OldExplainStage::DecorrelatedPlan => {
                 let decorrelated_plan = OptimizedMirRelationExpr::declare_optimized(decorrelate(
                     &mut timings,
                     raw_plan,
@@ -4310,7 +4310,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 explanation.to_string()
             }
-            ExplainStage::OptimizedPlan => {
+            OldExplainStage::OptimizedPlan => {
                 let decorrelated_plan = decorrelate(&mut timings, raw_plan)?;
                 self.validate_timeline(decorrelated_plan.depends_on())?;
                 let dataflow = optimize(&mut timings, self, decorrelated_plan)?;
@@ -4325,7 +4325,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 explanation.to_string()
             }
-            ExplainStage::PhysicalPlan => {
+            OldExplainStage::PhysicalPlan => {
                 let decorrelated_plan = decorrelate(&mut timings, raw_plan)?;
                 self.validate_timeline(decorrelated_plan.depends_on())?;
                 let dataflow = optimize(&mut timings, self, decorrelated_plan)?;
@@ -4343,7 +4343,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 explanation.to_string()
             }
-            ExplainStage::Timestamp => {
+            OldExplainStage::Timestamp => {
                 let decorrelated_plan = decorrelate(&mut timings, raw_plan)?;
                 let optimized_plan = self.view_optimizer.optimize(decorrelated_plan)?;
                 self.validate_timeline(optimized_plan.depends_on())?;

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1803,9 +1803,9 @@ impl_display_t!(ExplainStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExplainStatementNew<T: AstInfo> {
-    pub stage: NewExplainStage,
+    pub stage: ExplainStageNew,
+    pub config_flags: Vec<Ident>,
     pub format: ExplainFormat,
-    pub configs: Vec<Ident>,
     pub explainee: Explainee<T>,
 }
 
@@ -1813,19 +1813,14 @@ impl<T: AstInfo> AstDisplay for ExplainStatementNew<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("EXPLAIN ");
         f.write_node(&self.stage);
-        f.write_str(" ");
+        if !self.config_flags.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.config_flags));
+            f.write_str(")");
+        }
+        f.write_str(" AS ");
         f.write_node(&self.format);
-        if self.stage == NewExplainStage::Trace {
-            f.write_str(" TRACE ")
-        } else {
-            f.write_str(" PLAN ")
-        }
-        if !self.configs.is_empty() {
-            f.write_str("WITH (");
-            f.write_node(&display::comma_separated(&self.configs));
-            f.write_str(") ");
-        }
-        f.write_str("FOR ");
+        f.write_str(" FOR ");
         f.write_node(&self.explainee);
     }
 }
@@ -1834,7 +1829,7 @@ impl_display_t!(ExplainStatementNew);
 /// `EXPLAIN ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ExplainStatementOld<T: AstInfo> {
-    pub stage: OldExplainStage,
+    pub stage: ExplainStageOld,
     pub explainee: Explainee<T>,
     pub options: ExplainOptions,
 }
@@ -2070,7 +2065,7 @@ impl_display_t!(Assignment);
 
 /// Specifies what [Statement::Explain] is actually explaining
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum OldExplainStage {
+pub enum ExplainStageOld {
     /// The sql::HirRelationExpr after parsing
     RawPlan,
     /// Query Graph
@@ -2087,25 +2082,25 @@ pub enum OldExplainStage {
     Timestamp,
 }
 
-impl AstDisplay for OldExplainStage {
+impl AstDisplay for ExplainStageOld {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            OldExplainStage::RawPlan => f.write_str("RAW PLAN"),
-            OldExplainStage::OptimizedQueryGraph => f.write_str("OPTIMIZED QUERY GRAPH"),
-            OldExplainStage::QueryGraph => f.write_str("QUERY GRAPH"),
-            OldExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
-            OldExplainStage::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
-            OldExplainStage::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
-            OldExplainStage::Timestamp => f.write_str("TIMESTAMP"),
+            ExplainStageOld::RawPlan => f.write_str("RAW PLAN"),
+            ExplainStageOld::OptimizedQueryGraph => f.write_str("OPTIMIZED QUERY GRAPH"),
+            ExplainStageOld::QueryGraph => f.write_str("QUERY GRAPH"),
+            ExplainStageOld::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
+            ExplainStageOld::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
+            ExplainStageOld::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
+            ExplainStageOld::Timestamp => f.write_str("TIMESTAMP"),
         }
     }
 }
-impl_display!(OldExplainStage);
+impl_display!(ExplainStageOld);
 
 /// Specifies what [Statement::Explain] is actually explaining
 /// The new API
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum NewExplainStage {
+pub enum ExplainStageNew {
     /// The mz_sql::HirRelationExpr after parsing
     RawPlan,
     /// Query Graph
@@ -2122,20 +2117,20 @@ pub enum NewExplainStage {
     Trace,
 }
 
-impl AstDisplay for NewExplainStage {
+impl AstDisplay for ExplainStageNew {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            NewExplainStage::RawPlan => f.write_str("RAW"),
-            NewExplainStage::OptimizedQueryGraph => f.write_str("OPTIMIZED QUERY GRAPH"),
-            NewExplainStage::QueryGraph => f.write_str("QUERY GRAPH"),
-            NewExplainStage::DecorrelatedPlan => f.write_str("DECORRELATED"),
-            NewExplainStage::OptimizedPlan => f.write_str("OPTIMIZED"),
-            NewExplainStage::PhysicalPlan => f.write_str("PHYSICAL"),
-            NewExplainStage::Trace => f.write_str("OPTIMIZER"),
+            ExplainStageNew::RawPlan => f.write_str("RAW PLAN"),
+            ExplainStageNew::OptimizedQueryGraph => f.write_str("OPTIMIZED QUERY GRAPH"),
+            ExplainStageNew::QueryGraph => f.write_str("QUERY GRAPH"),
+            ExplainStageNew::DecorrelatedPlan => f.write_str("DECORRELATED PLAN"),
+            ExplainStageNew::OptimizedPlan => f.write_str("OPTIMIZED PLAN"),
+            ExplainStageNew::PhysicalPlan => f.write_str("PHYSICAL PLAN"),
+            ExplainStageNew::Trace => f.write_str("OPTIMIZER TRACE"),
         }
     }
 }
-impl_display!(NewExplainStage);
+impl_display!(ExplainStageNew);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Explainee<T: AstInfo> {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -204,6 +204,7 @@ On
 Only
 Operator
 Optimized
+Optimizer
 Option
 Or
 Order
@@ -294,6 +295,7 @@ Timestamp
 Timing
 To
 Topic
+Trace
 Trailing
 Transaction
 Trim

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -136,3 +136,26 @@ EXPLAIN TIMESTAMP FOR SELECT 1
 EXPLAIN TIMESTAMP FOR SELECT 1
 =>
 Explain(Old(ExplainStatementOld { stage: Timestamp, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
+
+parse-statement
+EXPLAIN OPTIMIZED QUERY GRAPH TEXT PLAN WITH (monotonicity, types) FOR VIEW foo
+----
+EXPLAIN OPTIMIZED QUERY GRAPH TEXT PLAN WITH (monotonicity, types) FOR VIEW foo
+=>
+Explain(New(ExplainStatementNew { stage: OptimizedQueryGraph, format: Text, configs: [Ident("monotonicity"), Ident("types")], explainee: View(Name(UnresolvedObjectName([Ident("foo")]))) }))
+
+parse-statement
+EXPLAIN JSON PLAN FOR SELECT * FROM foo
+----
+EXPLAIN OPTIMIZED JSON PLAN FOR SELECT * FROM foo
+=>
+Explain(New(ExplainStatementNew { stage: OptimizedPlan, format: Json, configs: [], explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }))
+
+parse-statement
+EXPLAIN OPTIMIZER TEXT TRACE WITH (est_cost) FOR SELECT 1 + 1
+----
+EXPLAIN OPTIMIZER TEXT TRACE WITH (est_cost) FOR SELECT 1 + 1
+=>
+Explain(New(ExplainStatementNew { stage: Trace, format: Text, configs: [Ident("est_cost")], explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }))
+
+# TODO (#13137): Add negative tests for new explain API.

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -138,24 +138,24 @@ EXPLAIN TIMESTAMP FOR SELECT 1
 Explain(Old(ExplainStatementOld { stage: Timestamp, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }), options: ExplainOptions { typed: false, timing: false } }))
 
 parse-statement
-EXPLAIN OPTIMIZED QUERY GRAPH TEXT PLAN WITH (monotonicity, types) FOR VIEW foo
+EXPLAIN OPTIMIZED QUERY GRAPH WITH (monotonicity, types) AS TEXT FOR VIEW foo
 ----
-EXPLAIN OPTIMIZED QUERY GRAPH TEXT PLAN WITH (monotonicity, types) FOR VIEW foo
+EXPLAIN OPTIMIZED QUERY GRAPH WITH (monotonicity, types) AS TEXT FOR VIEW foo
 =>
-Explain(New(ExplainStatementNew { stage: OptimizedQueryGraph, format: Text, configs: [Ident("monotonicity"), Ident("types")], explainee: View(Name(UnresolvedObjectName([Ident("foo")]))) }))
+Explain(New(ExplainStatementNew { stage: OptimizedQueryGraph, config_flags: [Ident("monotonicity"), Ident("types")], format: Text, explainee: View(Name(UnresolvedObjectName([Ident("foo")]))) }))
 
 parse-statement
-EXPLAIN JSON PLAN FOR SELECT * FROM foo
+EXPLAIN AS JSON FOR SELECT * FROM foo
 ----
-EXPLAIN OPTIMIZED JSON PLAN FOR SELECT * FROM foo
+EXPLAIN OPTIMIZED PLAN AS JSON FOR SELECT * FROM foo
 =>
-Explain(New(ExplainStatementNew { stage: OptimizedPlan, format: Json, configs: [], explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }))
+Explain(New(ExplainStatementNew { stage: OptimizedPlan, config_flags: [], format: Json, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedObjectName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }))
 
 parse-statement
-EXPLAIN OPTIMIZER TEXT TRACE WITH (est_cost) FOR SELECT 1 + 1
+EXPLAIN OPTIMIZER TRACE WITH (est_cost) AS TEXT FOR SELECT 1 + 1
 ----
-EXPLAIN OPTIMIZER TEXT TRACE WITH (est_cost) FOR SELECT 1 + 1
+EXPLAIN OPTIMIZER TRACE WITH (est_cost) AS TEXT FOR SELECT 1 + 1
 =>
-Explain(New(ExplainStatementNew { stage: Trace, format: Text, configs: [Ident("est_cost")], explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }))
+Explain(New(ExplainStatementNew { stage: Trace, config_flags: [Ident("est_cost")], format: Text, explainee: Query(Query { ctes: [], body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: [], op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) }))
 
-# TODO (#13137): Add negative tests for new explain API.
+# TODO (#13299): Add negative tests for new explain API.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -41,8 +41,8 @@ use mz_pgcopy::CopyFormatParams;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
-    ExplainOptions, ExplainStage, Expr, FetchDirection, IndexOptionName, NoticeSeverity,
-    ObjectType, Raw, SetVariableValue, Statement, TransactionAccessMode,
+    ExplainOptions, Expr, FetchDirection, IndexOptionName, NoticeSeverity, ObjectType,
+    OldExplainStage, Raw, SetVariableValue, Statement, TransactionAccessMode,
 };
 use crate::catalog::{CatalogType, IdReference};
 use crate::names::{
@@ -354,7 +354,7 @@ pub struct ExplainPlanNew {
 pub struct ExplainPlanOld {
     pub raw_plan: HirRelationExpr,
     pub row_set_finishing: Option<RowSetFinishing>,
-    pub stage: ExplainStage,
+    pub stage: OldExplainStage,
     pub options: ExplainOptions,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -41,8 +41,8 @@ use mz_pgcopy::CopyFormatParams;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 
 use crate::ast::{
-    ExplainOptions, Expr, FetchDirection, IndexOptionName, NoticeSeverity, ObjectType,
-    OldExplainStage, Raw, SetVariableValue, Statement, TransactionAccessMode,
+    ExplainOptions, ExplainStageOld, Expr, FetchDirection, IndexOptionName, NoticeSeverity,
+    ObjectType, Raw, SetVariableValue, Statement, TransactionAccessMode,
 };
 use crate::catalog::{CatalogType, IdReference};
 use crate::names::{
@@ -354,7 +354,7 @@ pub struct ExplainPlanNew {
 pub struct ExplainPlanOld {
     pub raw_plan: HirRelationExpr,
     pub row_set_finishing: Option<RowSetFinishing>,
-    pub stage: OldExplainStage,
+    pub stage: ExplainStageOld,
     pub options: ExplainOptions,
 }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -27,8 +27,8 @@ use mz_sql_parser::ast::{AstInfo, ExplainStatementNew, ExplainStatementOld};
 use crate::ast::display::AstDisplay;
 use crate::ast::{
     CopyDirection, CopyOption, CopyOptionName, CopyRelation, CopyStatement, CopyTarget,
-    CreateViewStatement, DeleteStatement, ExplainStatement, Explainee, Ident, InsertStatement,
-    ExplainStageOld, Query, SelectStatement, Statement, TailOption, TailOptionName, TailRelation,
+    CreateViewStatement, DeleteStatement, ExplainStageOld, ExplainStatement, Explainee, Ident,
+    InsertStatement, Query, SelectStatement, Statement, TailOption, TailOptionName, TailRelation,
     TailStatement, UpdateStatement, ViewDefinition,
 };
 use crate::catalog::CatalogItemType;

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -27,8 +27,8 @@ use mz_sql_parser::ast::{AstInfo, ExplainStatementNew, ExplainStatementOld};
 use crate::ast::display::AstDisplay;
 use crate::ast::{
     CopyDirection, CopyOption, CopyOptionName, CopyRelation, CopyStatement, CopyTarget,
-    CreateViewStatement, DeleteStatement, ExplainStage, ExplainStatement, Explainee, Ident,
-    InsertStatement, Query, SelectStatement, Statement, TailOption, TailOptionName, TailRelation,
+    CreateViewStatement, DeleteStatement, ExplainStatement, Explainee, Ident, InsertStatement,
+    OldExplainStage, Query, SelectStatement, Statement, TailOption, TailOptionName, TailRelation,
     TailStatement, UpdateStatement, ViewDefinition,
 };
 use crate::catalog::CatalogItemType;
@@ -180,7 +180,7 @@ pub fn describe_explain_new(
     _scx: &StatementContext,
     _explain: ExplainStatementNew<Aug>,
 ) -> Result<StatementDesc, anyhow::Error> {
-    unimplemented!() // TODO: #13295
+    Err(anyhow!("unimplemented interface")) // TODO: #13295
 }
 
 pub fn describe_explain_old(
@@ -191,13 +191,13 @@ pub fn describe_explain_old(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(RelationDesc::empty().with_column(
         match stage {
-            ExplainStage::RawPlan => "Raw Plan",
-            ExplainStage::QueryGraph => "Query Graph",
-            ExplainStage::OptimizedQueryGraph => "Optimized Query Graph",
-            ExplainStage::DecorrelatedPlan => "Decorrelated Plan",
-            ExplainStage::OptimizedPlan { .. } => "Optimized Plan",
-            ExplainStage::PhysicalPlan => "Physical Plan",
-            ExplainStage::Timestamp => "Timestamp",
+            OldExplainStage::RawPlan => "Raw Plan",
+            OldExplainStage::QueryGraph => "Query Graph",
+            OldExplainStage::OptimizedQueryGraph => "Optimized Query Graph",
+            OldExplainStage::DecorrelatedPlan => "Decorrelated Plan",
+            OldExplainStage::OptimizedPlan { .. } => "Optimized Plan",
+            OldExplainStage::PhysicalPlan => "Physical Plan",
+            OldExplainStage::Timestamp => "Timestamp",
         },
         ScalarType::String.nullable(false),
     )))
@@ -287,7 +287,7 @@ pub fn plan_explain_new(
     _explain: ExplainStatementNew<Aug>,
     _params: &Params,
 ) -> Result<Plan, anyhow::Error> {
-    unimplemented!() // TODO: #13295
+    Err(anyhow!("unimplemented interface")) // TODO: #13295
 }
 
 /// Plans and decorrelates a `Query`. Like `query::plan_root_query`, but returns

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -28,7 +28,7 @@ use crate::ast::display::AstDisplay;
 use crate::ast::{
     CopyDirection, CopyOption, CopyOptionName, CopyRelation, CopyStatement, CopyTarget,
     CreateViewStatement, DeleteStatement, ExplainStatement, Explainee, Ident, InsertStatement,
-    OldExplainStage, Query, SelectStatement, Statement, TailOption, TailOptionName, TailRelation,
+    ExplainStageOld, Query, SelectStatement, Statement, TailOption, TailOptionName, TailRelation,
     TailStatement, UpdateStatement, ViewDefinition,
 };
 use crate::catalog::CatalogItemType;
@@ -191,13 +191,13 @@ pub fn describe_explain_old(
 ) -> Result<StatementDesc, anyhow::Error> {
     Ok(StatementDesc::new(Some(RelationDesc::empty().with_column(
         match stage {
-            OldExplainStage::RawPlan => "Raw Plan",
-            OldExplainStage::QueryGraph => "Query Graph",
-            OldExplainStage::OptimizedQueryGraph => "Optimized Query Graph",
-            OldExplainStage::DecorrelatedPlan => "Decorrelated Plan",
-            OldExplainStage::OptimizedPlan { .. } => "Optimized Plan",
-            OldExplainStage::PhysicalPlan => "Physical Plan",
-            OldExplainStage::Timestamp => "Timestamp",
+            ExplainStageOld::RawPlan => "Raw Plan",
+            ExplainStageOld::QueryGraph => "Query Graph",
+            ExplainStageOld::OptimizedQueryGraph => "Optimized Query Graph",
+            ExplainStageOld::DecorrelatedPlan => "Decorrelated Plan",
+            ExplainStageOld::OptimizedPlan { .. } => "Optimized Plan",
+            ExplainStageOld::PhysicalPlan => "Physical Plan",
+            ExplainStageOld::Timestamp => "Timestamp",
         },
         ScalarType::String.nullable(false),
     )))


### PR DESCRIPTION
TODO: we forgot when planning explain format consolidation what do about:
* EXPLAIN QUERY GRAPH
* EXPLAIN OPTIMIZED QUERY GRAPH
* EXPLAIN TIMESTAMP.

My opinion is that we should keep `EXPLAIN QUERY GRAPH` and `EXPLAIN OPTIMIZED QUERY GRAPH` in the new explain interface, but `EXPLAIN TIMESTAMP FOR ...` should be changed to `EXPLAIN ... PLAN WITH (timestamp) FOR ...` because I perceive timestamps as an attribute that can be appended onto a plan just like column types, but @mjibson is the authority on `EXPLAIN TIMESTAMP`.

### Motivation

  * This PR adds a known-desirable feature.

Closes #13294, which is part of #13137.

### Tips for reviewer

* I renamed our existing `ExplainStage` to `OldExplainStage` and created a separate `NewExplainStage`.
* I changed some `unimplemented!()` calls to be `Err(anyhow!("unimplemented interface")` calls to prevent `environmentd` from crashing if someone manages to stumble into the new explain interface.

### Testing

I added some positive tests for the new explain interface, but I didn't add negative tests. I think negative tests should be added after the old explain interface is removed.

### Release notes

No user-facing behavior changes.
