### PR TITLE
mzcompose: remove all references to YAML

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -90,7 +90,6 @@ if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
         echo "lint: $(red error:) python formatting discrepancies found"
         echo "hint: run bin/pyfmt" >&2
     fi
-    try bin/mzcompose lint
     try bin/lint-cargo
     try bin/completion check
 fi

--- a/ci/README.md
+++ b/ci/README.md
@@ -221,9 +221,9 @@ copy of the repository to it. You can SSH in to the agent using the instance ID
 printed by the previous command and run the CI job that is failing.
 
 Every CI job is a combination of an mzcompose "composition" and a "workflow". A
-composition is the name of a directory containing an mzcompose.yml or
-mzcompose.py file. A workflow is the name of a service or Python function to run
-within the composition. You can see the definition of each CI job in
+composition is the name of a directory containing a mzcompose.py file. A
+workflow is the name of a service or Python function to run within the
+composition. You can see the definition of each CI job in
 [ci/test/pipeline.template.yml](./test/pipeline.template.yml). To invoke a
 workflow manually, you run `bin/mzcompose --find COMPOSITION run WORKFLOW`.
 

--- a/misc/python/materialize/cargo.py
+++ b/misc/python/materialize/cargo.py
@@ -114,12 +114,11 @@ class Crate:
         #
         # † As a development convenience, we omit mzcompose configuration files
         # within a crate. This is technically incorrect if someone writes
-        # `include!("mzcompose.yml")`, but that seems like a crazy thing to do.
+        # `include!("mzcompose.py")`, but that seems like a crazy thing to do.
         return git.expand_globs(
             self.root,
             f"{self.path}/**",
             f":(exclude){self.path}/mzcompose",
-            f":(exclude){self.path}/mzcompose.yml",
             f":(exclude){self.path}/mzcompose.py",
         )
 

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -47,7 +47,7 @@ def main(argv: List[str]) -> None:
         prog="mzcompose",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
-mzcompose orchestrates services defined in mzcompose.yml or mzcompose.py.
+mzcompose orchestrates services defined in mzcompose.py.
 It wraps Docker Compose to add some Materialize-specific features.""",
         epilog="""
 These are only the most common options. There are additional Docker Compose
@@ -68,7 +68,7 @@ For additional details on mzcompose, consult doc/developer/mzbuild.md.""",
     parser.add_argument(
         "--find",
         metavar="DIR",
-        help="use the mzcompose.yml file from DIR, rather than the current directory",
+        help="use the mzcompose.py file from DIR, rather than the current directory",
     )
     parser.add_argument(
         "--preserve-ports",
@@ -101,7 +101,6 @@ For additional details on mzcompose, consult doc/developer/mzbuild.md.""",
     help_command.register(parser, subparsers)
     ImagesCommand.register(parser, subparsers)
     KillCommand.register(parser, subparsers)
-    LintCommand().register(parser, subparsers)
     ListCompositionsCommand().register(parser, subparsers)
     ListWorkflowsCommand().register(parser, subparsers)
     LogsCommand.register(parser, subparsers)
@@ -152,7 +151,7 @@ def load_composition(args: argparse.Namespace) -> mzcompose.Composition:
             for path in repo.compositions.values():
                 hint += f"    {path.relative_to(Path.cwd())}\n"
             raise UIError(
-                "directory does not contain an mzcompose.yml or mzcompose.py",
+                "directory does not contain mzcompose.py",
                 hint,
             )
 
@@ -245,21 +244,6 @@ exec "$(dirname "$0")"/{}/bin/pyactivate -m materialize.cli.mzcompose "$@"
             with open(mzcompose_path, "w") as f:
                 f.write(template.format(os.path.relpath(repo.root, path)))
             mzbuild.chmod_x(mzcompose_path)
-
-
-class LintCommand(Command):
-    name = "lint"
-    help = "surface common errors in compositions"
-
-    def run(cls, args: argparse.Namespace) -> None:
-        repo = mzbuild.Repository.from_arguments(ROOT, args)
-        errors = []
-        for name in repo.compositions:
-            errors += mzcompose.Composition.lint(repo, name)
-        for error in sorted(errors):
-            print(error)
-        if errors:
-            raise UIError("lint errors discovered")
 
 
 class ListCompositionsCommand(Command):

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -743,7 +743,7 @@ class Repository:
 
     Attributes:
         images: A mapping from image name to `Image` for all contained images.
-        compose_dirs: The set of directories containing an `mzcompose.yml` or `mzcompose.py` file.
+        compose_dirs: The set of directories containing a `mzcompose.py` file.
     """
 
     def __init__(
@@ -777,7 +777,7 @@ class Repository:
                 if image.name in self.images:
                     raise ValueError(f"image {image.name} exists twice")
                 self.images[image.name] = image
-            if "mzcompose.yml" in files or "mzcompose.py" in files:
+            if "mzcompose.py" in files:
                 name = Path(path).name
                 if name in self.compositions:
                     raise ValueError(f"composition {name} exists twice")

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -93,7 +93,7 @@ impl S3BlobConfig {
     /// On CI, these tests are enabled by adding the scratch-aws-access plugin
     /// to the `cargo-test` step in `ci/test/pipeline.template.yml` and setting
     /// `MZ_PERSIST_EXTERNAL_STORAGE_TEST_S3_BUCKET` in
-    /// `ci/test/cargo-test/mzcompose.yml`.
+    /// `ci/test/cargo-test/mzcompose.py`.
     ///
     /// For a Materialize developer, to opt in to these tests locally for
     /// development, follow the AWS access guide:

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -83,7 +83,7 @@ $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
 {"before": null, "after": {"row": {"a": 1}}}
 {"before": null, "after": {"row": {"a": 2}}}
 
-# Check environment variables; defined in mzcompose.yml
+# Check environment variables; defined in mzcompose.py
 
 > CREATE MATERIALIZED SOURCE env_pw_data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -104,7 +104,7 @@ $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
 {"before": null, "after": {"row":{"a": 1}}}
 {"before": null, "after": {"row":{"a": 2}}}
 
-# Check environment variables; defined in mzcompose.yml
+# Check environment variables; defined in mzcompose.py
 
 > CREATE SINK env_pw_snk FROM data
   INTO KAFKA BROKER 'kafka' TOPIC 'snk'

--- a/test/s3-resumption/README.md
+++ b/test/s3-resumption/README.md
@@ -3,7 +3,7 @@ An end-to-end test for the S3 resumption logic.
 Toxiproxy is used to interrupt the TCP connection between Mz and S3/SQS
 at different stages of processing.
 
-By regulating the number of bytes that are allowed to go through, mzcompose.yml
+By regulating the number of bytes that are allowed to go through, mzcompose.py
 can use the same sequence of .td steps but inject the a failure that
 impacts a different operation. A smaller limit does not allow much to happen,
 wheres a larger limit only prevents the actual S3 value from being read,

--- a/test/upgrade/README.md
+++ b/test/upgrade/README.md
@@ -85,7 +85,7 @@ There are also two other special version identifiers:
 
 ### For an existing feature
 
-1. Decide which is the earlest version ```vX.Y.Z``` that supports the desired functionality and create a test named ```create-in-vX.Y.Z-feature_under_test.td``` where you will be creating the database objects that will be surviving an upgrade attempt. Use ```any_version``` if the feature exists in all versions listed in ```mzcompose.yml``` and `current_source` if you are adding the feature just now and it does not exist in any previously released version.
+1. Decide which is the earlest version ```vX.Y.Z``` that supports the desired functionality and create a test named ```create-in-vX.Y.Z-feature_under_test.td``` where you will be creating the database objects that will be surviving an upgrade attempt. Use ```any_version``` if the feature exists in all versions listed in ```mzcompose.py``` and `current_source` if you are adding the feature just now and it does not exist in any previously released version.
 
 2. In a file named ```check-from-vX.Y.Z-feature_undex_test.td``` put the queries that will be testing that the object has survived the upgrade intact. This may include any of the following:
 


### PR DESCRIPTION
The last YAML-based workflow was removed in #13326. This commit removes
all support for and references to `mzcompose.yml`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes code which recently became dead.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
