### PR TITLE
Remove the notion of volatility

### DIFF
--- a/src/coord/src/catalog/builtin.rs
+++ b/src/coord/src/catalog/builtin.rs
@@ -989,7 +989,6 @@ pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("on_id", ScalarType::String.nullable(false))
-        .with_column("volatility", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::Int64.nullable(false)),
 });
 pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1029,8 +1028,7 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("type", ScalarType::String.nullable(false))
-        .with_column("volatility", ScalarType::String.nullable(false)),
+        .with_column("type", ScalarType::String.nullable(false)),
 });
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sinks",
@@ -1041,7 +1039,6 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("type", ScalarType::String.nullable(false))
-        .with_column("volatility", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::Int64.nullable(false)),
 });
 pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1052,7 +1049,6 @@ pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("oid", ScalarType::Oid.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
-        .with_column("volatility", ScalarType::String.nullable(false))
         .with_column("definition", ScalarType::String.nullable(false)),
 });
 pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {

--- a/src/coord/src/catalog/builtin_table_updates.rs
+++ b/src/coord/src/catalog/builtin_table_updates.rs
@@ -280,7 +280,6 @@ impl CatalogState {
                 Datum::Int64(u64::from(schema_id) as i64),
                 Datum::String(name),
                 Datum::String(source_connection_name),
-                Datum::String(self.is_volatile(id).as_str()),
             ]),
             diff,
         }]
@@ -344,7 +343,6 @@ impl CatalogState {
                 // TODO(jkosh44) when Uint64 is supported change below to Datum::Uint64
                 Datum::Int64(u64::from(schema_id) as i64),
                 Datum::String(name),
-                Datum::String(self.is_volatile(id).as_str()),
                 Datum::String(&query_string),
             ]),
             diff,
@@ -396,7 +394,6 @@ impl CatalogState {
                     Datum::Int64(u64::from(schema_id) as i64),
                     Datum::String(name),
                     Datum::String(connection.name()),
-                    Datum::String(self.is_volatile(id).as_str()),
                     // TODO(jkosh44) when Uint64 is supported change below to Datum::Uint64
                     Datum::Int64(sink.compute_instance as i64),
                 ]),
@@ -431,7 +428,6 @@ impl CatalogState {
                 Datum::UInt32(oid),
                 Datum::String(name),
                 Datum::String(&index.on.to_string()),
-                Datum::String(self.is_volatile(id).as_str()),
                 // TODO(jkosh44) when Uint64 is supported change below to Datum::Uint64
                 Datum::Int64(index.compute_instance as i64),
             ]),

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -392,7 +392,6 @@ fn show_sources<'a>(
                  name,
                  mz_internal.mz_classify_object_id(id) AS type,
                  mz_internal.mz_is_materialized(id) AS materialized,
-                 volatility,
                  type
              FROM
                  mz_catalog.mz_sources
@@ -404,7 +403,6 @@ fn show_sources<'a>(
             "SELECT
                  name,
                  mz_internal.mz_classify_object_id(id) AS type,
-                 volatility,
                  type
              FROM
                  mz_catalog.mz_sources
@@ -436,8 +434,7 @@ fn show_views<'a>(
             "SELECT
                 name,
                 mz_internal.mz_classify_object_id(id) AS type,
-                mz_internal.mz_is_materialized(id) AS materialized,
-                volatility
+                mz_internal.mz_is_materialized(id) AS materialized
              FROM mz_catalog.mz_views
              WHERE schema_id = {}",
             schema_spec,
@@ -451,7 +448,7 @@ fn show_views<'a>(
         )
     } else {
         format!(
-            "SELECT name, mz_internal.mz_classify_object_id(id) AS type, volatility
+            "SELECT name, mz_internal.mz_classify_object_id(id) AS type
              FROM mz_catalog.mz_views
              WHERE schema_id = {} AND mz_internal.mz_is_materialized(id)",
             schema_spec,
@@ -486,8 +483,7 @@ fn show_sinks<'a>(
             "SELECT
             clusters.name AS cluster,
             sinks.name,
-            mz_internal.mz_classify_object_id(sinks.id) AS type,
-            sinks.volatility
+            mz_internal.mz_classify_object_id(sinks.id) AS type
         FROM
             mz_catalog.mz_sinks AS sinks
             JOIN mz_catalog.mz_clusters AS clusters ON

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -371,25 +371,25 @@ mz_scheduling_parks_internal
 mz_worker_materialization_frontiers
 
 > SHOW FULL SOURCES FROM mz_catalog
-name                                          type   materialized  volatility  type
------------------------------------------------------------------------------------
-mz_arrangement_sharing_internal               system true          volatile    log
-mz_arrangement_batches_internal               system true          volatile    log
-mz_arrangement_records_internal               system true          volatile    log
-mz_dataflow_channels                          system true          volatile    log
-mz_dataflow_operator_addresses                system true          volatile    log
-mz_dataflow_operator_reachability_internal    system true          volatile    log
-mz_dataflow_operators                         system true          volatile    log
-mz_materialization_dependencies               system true          volatile    log
-mz_materializations                           system true          volatile    log
-mz_message_counts_received_internal           system true          volatile    log
-mz_message_counts_sent_internal               system true          volatile    log
-mz_peek_active                                system true          volatile    log
-mz_peek_durations                             system true          volatile    log
-mz_scheduling_elapsed_internal                system true          volatile    log
-mz_scheduling_histogram_internal              system true          volatile    log
-mz_scheduling_parks_internal                  system true          volatile    log
-mz_worker_materialization_frontiers           system true          volatile    log
+name                                          type   materialized  type
+-----------------------------------------------------------------------
+mz_arrangement_sharing_internal               system true          log
+mz_arrangement_batches_internal               system true          log
+mz_arrangement_records_internal               system true          log
+mz_dataflow_channels                          system true          log
+mz_dataflow_operator_addresses                system true          log
+mz_dataflow_operator_reachability_internal    system true          log
+mz_dataflow_operators                         system true          log
+mz_materialization_dependencies               system true          log
+mz_materializations                           system true          log
+mz_message_counts_received_internal           system true          log
+mz_message_counts_sent_internal               system true          log
+mz_peek_active                                system true          log
+mz_peek_durations                             system true          log
+mz_scheduling_elapsed_internal                system true          log
+mz_scheduling_histogram_internal              system true          log
+mz_scheduling_parks_internal                  system true          log
+mz_worker_materialization_frontiers           system true          log
 
 > SHOW TABLES FROM mz_catalog
 mz_array_types
@@ -547,29 +547,29 @@ mz_scheduling_histogram
 mz_scheduling_parks
 
 > SHOW FULL VIEWS FROM mz_catalog
-name                              type   materialized  volatility
------------------------------------------------------------------
-mz_arrangement_sharing            system false         volatile
-mz_arrangement_sizes              system false         volatile
-mz_dataflow_names                 system false         volatile
-mz_dataflow_operator_dataflows    system false         volatile
-mz_dataflow_operator_reachability system false         volatile
-mz_materialization_frontiers      system false         volatile
-mz_message_counts                 system false         volatile
-mz_objects                        system false         volatile
-mz_perf_arrangement_records       system false         volatile
-mz_perf_peek_durations_aggregates system false         volatile
-mz_perf_peek_durations_bucket     system false         volatile
-mz_perf_peek_durations_core       system false         volatile
-mz_records_per_dataflow           system false         volatile
-mz_records_per_dataflow_global    system false         volatile
-mz_records_per_dataflow_operator  system false         volatile
-mz_relations                      system false         volatile
-mz_catalog_names                  system false         volatile
-mz_cluster_replicas               system false         volatile
-mz_scheduling_elapsed             system false         volatile
-mz_scheduling_histogram           system false         volatile
-mz_scheduling_parks               system false         volatile
+name                              type   materialized
+-----------------------------------------------------
+mz_arrangement_sharing            system false
+mz_arrangement_sizes              system false
+mz_dataflow_names                 system false
+mz_dataflow_operator_dataflows    system false
+mz_dataflow_operator_reachability system false
+mz_materialization_frontiers      system false
+mz_message_counts                 system false
+mz_objects                        system false
+mz_perf_arrangement_records       system false
+mz_perf_peek_durations_aggregates system false
+mz_perf_peek_durations_bucket     system false
+mz_perf_peek_durations_core       system false
+mz_records_per_dataflow           system false
+mz_records_per_dataflow_global    system false
+mz_records_per_dataflow_operator  system false
+mz_relations                      system false
+mz_catalog_names                  system false
+mz_cluster_replicas               system false
+mz_scheduling_elapsed             system false
+mz_scheduling_histogram           system false
+mz_scheduling_parks               system false
 
 > SHOW MATERIALIZED SOURCES FROM mz_catalog LIKE '%peek%';
 mz_peek_active

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -35,18 +35,18 @@ $ kafka-create-topic topic=data
   SELECT b, sum(a) FROM data GROUP BY b
 
 > SHOW FULL VIEWS
-name        type     materialized  volatility
----------------------------------------------
-data_view   user     false         unknown
-test1       user     true          unknown
+name        type     materialized
+---------------------------------
+data_view   user     false
+test1       user     true
 
 > SHOW MATERIALIZED VIEWS
 test1
 
 > SHOW FULL MATERIALIZED VIEWS
-name     type  volatility
--------------------------
-test1    user  unknown
+name     type
+-------------
+test1    user
 
 > SELECT * FROM test1
 b  sum
@@ -169,9 +169,9 @@ contains:catalog item 'materialize.public.idx1' is an index and so cannot be dep
 > DROP INDEX test5_primary_idx
 
 > SHOW FULL VIEWS LIKE 'test5'
-name        type     materialized  volatility
----------------------------------------------
-test5       user     true          unknown
+name        type     materialized
+---------------------------------
+test5       user     true
 
 > SELECT * from test5
 b  c
@@ -194,9 +194,9 @@ b  c
 2  1
 
 > SHOW FULL VIEWS LIKE 'test5'
-name        type     materialized  volatility
----------------------------------------------
-test5       user     false         unknown
+name        type     materialized
+---------------------------------
+test5       user     false
 
 # Test that materialized views can be even if it requires multiple layers of
 # recursing through the AST to find a source.
@@ -333,15 +333,15 @@ name
 mat_data
 
 > SHOW FULL SOURCES
-name     type materialized  volatility type
---------------------------------------------
-data     user false         unknown    kafka
-mat_data user true          unknown    kafka
+name     type materialized  type
+---------------------------------
+data     user false         kafka
+mat_data user true          kafka
 
 > SHOW FULL MATERIALIZED SOURCES
-name     type  volatility type
--------------------------------
-mat_data user  unknown    kafka
+name     type  type
+--------------------
+mat_data user  kafka
 
 # If there exists another index, dropping the primary index will not #
 # unmaterialize the source. This also tests creating a default index when the

--- a/test/testdrive/pubnub.td
+++ b/test/testdrive/pubnub.td
@@ -28,27 +28,3 @@
 # See the data change
 > SELECT COUNT(*) > 0 FROM avg_bid;
 true
-
-# Test that the volatility bit is set correctly.
-> SELECT name, volatility FROM mz_sources WHERE name = 'market_orders_raw'
-market_orders_raw   volatile
-> SELECT name, volatility from mz_views WHERE name = 'avg_bid'
-avg_bid   volatile
-> CREATE MATERIALIZED VIEW nonvol AS SELECT 1
-> SELECT name, volatility from mz_views WHERE name = 'nonvol'
-nonvol   nonvolatile
-> CREATE MATERIALIZED VIEW depends_vol_nonvol AS SELECT * FROM nonvol, avg_bid
-> SELECT name, volatility from mz_views WHERE name = 'depends_vol_nonvol'
-depends_vol_nonvol   volatile
-$ file-append path=test
-ignored
-> CREATE MATERIALIZED SOURCE kafka_src
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'ignored' FORMAT BYTES
-> SELECT name, volatility FROM mz_sources WHERE name = 'kafka_src'
-kafka_src  unknown
-> CREATE MATERIALIZED VIEW depends_nonvol_unknown AS SELECT * FROM nonvol, kafka_src
-> SELECT name, volatility from mz_views WHERE name = 'depends_nonvol_unknown'
-depends_nonvol_unknown   unknown
-> CREATE MATERIALIZED VIEW depends_vol_unknown AS SELECT * FROM avg_bid, kafka_src
-> SELECT name, volatility from mz_views WHERE name = 'depends_vol_unknown'
-depends_vol_unknown   volatile

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -106,13 +106,13 @@ snk4
 snk5
 
 > SHOW FULL SINKS
-cluster name   type  volatility
------------------------
-<CLUSTER_NAME> snk1   user  unknown
-<CLUSTER_NAME> snk2   user  unknown
-<CLUSTER_NAME> snk3   user  unknown
-<CLUSTER_NAME> snk4   user  unknown
-<CLUSTER_NAME> snk5   user  unknown
+cluster        name   type
+--------------------------
+<CLUSTER_NAME> snk1   user
+<CLUSTER_NAME> snk2   user
+<CLUSTER_NAME> snk3   user
+<CLUSTER_NAME> snk4   user
+<CLUSTER_NAME> snk5   user
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
@@ -190,18 +190,18 @@ $ kafka-verify format=avro sink=materialize.public.sink10 sort-messages=true
 {"before": null, "after": {"row":{"column1": 3}}}
 
 > SHOW FULL SINKS
-cluster    name        type  volatility
------------------------------------------
-<CLUSTER_NAME>    snk1        user  unknown
-<CLUSTER_NAME>    snk2        user  unknown
-<CLUSTER_NAME>    snk3        user  unknown
-<CLUSTER_NAME>    snk4        user  unknown
-<CLUSTER_NAME>    snk5        user  unknown
-<CLUSTER_NAME>    snk6        user  unknown
-<CLUSTER_NAME>    snk7        user  unknown
-<CLUSTER_NAME>    snk8        user  unknown
-<CLUSTER_NAME>    sink9       user  nonvolatile
-<CLUSTER_NAME>    sink10      user  nonvolatile
+cluster           name        type
+----------------------------------
+<CLUSTER_NAME>    snk1        user
+<CLUSTER_NAME>    snk2        user
+<CLUSTER_NAME>    snk3        user
+<CLUSTER_NAME>    snk4        user
+<CLUSTER_NAME>    snk5        user
+<CLUSTER_NAME>    snk6        user
+<CLUSTER_NAME>    snk7        user
+<CLUSTER_NAME>    snk8        user
+<CLUSTER_NAME>    sink9       user
+<CLUSTER_NAME>    sink10      user
 
 # test explicit partition count
 > CREATE SINK sink11 FROM foo

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -182,16 +182,16 @@ contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW values_system_view AS SELECT * FROM input_values_view, source_system;
 > CREATE VIEW values_system_user_view AS SELECT * FROM input_values_view, source_system_user;
 > CREATE VIEW values_cdcv2_view AS SELECT * FROM input_values_view, source_cdcv2;
-> CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k, l) AS SELECT * FROM input_values_view, mz_catalog_names, mz_views, mz_dataflow_operators;
+> CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM input_values_view, mz_catalog_names, mz_views, mz_dataflow_operators;
 
 # System sources, tables, and logs should be joinable with eachother.
-> CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators;
+> CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators;
 
 # System things should be joinable only with system sources.
-! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_cdcv2;
+! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
-> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_system;
-> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, input_table;
+> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_system;
+> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, input_table;
 
 # EXPLAIN should complain too.
 ! EXPLAIN SELECT * FROM source_system, source_cdcv2;


### PR DESCRIPTION
In the Platform, all source data is written to durable storage, rendering it definite, so there are no volatile sources anymore.

### Motivation

  * This PR adds a feature that has not yet been specified.

See the discussion on [this Slack thread](https://materializeinc.slack.com/archives/CMHDK0DK8/p1656419446007409).

### Tips for reviewer

This PR does not include any changes to the docs. I'll create a second one for this, since the set of sensible reviewers is likely different.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove all "volatility" columns from the system tables in `mz_catalog`.
