### PR TITLE
[LTS] backport kafka ENVELOPE NONE null key handling

### DIFF
--- a/src/dataflow/src/storage/source/file.rs
+++ b/src/dataflow/src/storage/source/file.rs
@@ -25,9 +25,10 @@ use tracing::{debug, error, trace};
 use mz_avro::Block;
 use mz_avro::BlockIter;
 use mz_avro::{AvroRead, Schema, Skip};
+use mz_dataflow_types::sources::encoding::DataEncodingInner;
 use mz_dataflow_types::sources::{
-    encoding::AvroOcfEncoding, encoding::DataEncoding, encoding::SourceDataEncoding, Compression,
-    ExternalSourceConnector, MzOffset,
+    encoding::AvroOcfEncoding, encoding::SourceDataEncoding, Compression, ExternalSourceConnector,
+    MzOffset,
 };
 use mz_expr::{PartitionId, SourceInstanceId};
 
@@ -124,8 +125,10 @@ impl SourceReader for FileSourceReader {
                         unreachable!("A KeyValue encoding for an OCF source should have been rejected in the planner.")
                     }
                 };
-                let reader_schema = match value_encoding {
-                    DataEncoding::AvroOcf(AvroOcfEncoding { reader_schema }) => &*reader_schema,
+                let reader_schema = match &value_encoding.inner {
+                    DataEncodingInner::AvroOcf(AvroOcfEncoding { reader_schema }) => {
+                        &*reader_schema
+                    }
                     // We should be checking for this in the planner.
                     _ => unreachable!("Wrong encoding for OCF file"),
                 };

--- a/test/testdrive/kafka-envelope-none.td
+++ b/test/testdrive/kafka-envelope-none.td
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ kafka-create-topic topic=missing_keys_or_values partitions=1
+
+> CREATE MATERIALIZED SOURCE missing_keys_or_values
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-missing_keys_or_values-${testdrive.seed}'
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  INCLUDE KEY
+  ENVELOPE NONE
+
+# make sure a record with both key and value goes through
+
+$ kafka-ingest topic=missing_keys_or_values format=bytes key-format=bytes key-terminator=:
+hello:world
+
+> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+key   text mz_offset
+---------------------------------
+hello world 1
+
+
+# send a value without a key. key columns should be null
+
+$ kafka-ingest topic=missing_keys_or_values format=bytes omit-key=true
+foo
+
+> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+key    text  mz_offset
+---------------------------------
+hello  world 1
+<null> foo   2
+
+
+# send an empty record with neither key nor value, should be skipped
+
+$ kafka-ingest topic=missing_keys_or_values format=bytes omit-value=true omit-key=true
+
+> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+key    text  mz_offset
+---------------------------------
+hello  world 1
+<null> foo   2
+
+
+# send a key without a value, should error
+
+$ kafka-ingest topic=missing_keys_or_values key-format=bytes format=bytes omit-value=true
+bar
+
+! SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+contains: Decode error: Text: Value not present for message

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -151,6 +151,8 @@ $ set noconflictschema={
 $ kafka-create-topic topic=avro-data-record
 $ kafka-ingest format=avro key-format=avro topic=avro-data-record key-schema=${multikeyschema} schema=${noconflictschema} timestamp=1
 {"id": 1, "geo": "nyc"} {"a": 99}
+$ kafka-ingest format=avro topic=avro-data-record schema=${noconflictschema} timestamp=2 omit-key=true
+{"a": 88}
 
 > CREATE MATERIALIZED SOURCE avro_key_record_flattened
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-record-${testdrive.seed}'
@@ -159,10 +161,11 @@ $ kafka-ingest format=avro key-format=avro topic=avro-data-record key-schema=${m
   INCLUDE KEY
   ENVELOPE NONE
 
-> SELECT * FROM avro_key_record_flattened
-id geo a
---------
-1 nyc 99
+> SELECT * FROM avro_key_record_flattened ORDER BY a ASC
+id     geo    a
+----------------
+<null> <null> 88
+1      nyc    99
 
 > CREATE MATERIALIZED SOURCE avro_key_record_renamed
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-data-record-${testdrive.seed}'
@@ -171,10 +174,11 @@ id geo a
   INCLUDE KEY AS named
   ENVELOPE NONE
 
-> SELECT (named).id as named_id, (named).geo as named_geo, a FROM avro_key_record_renamed
+> SELECT (named).id as named_id, (named).geo as named_geo, a FROM avro_key_record_renamed ORDER BY a ASC
 named_id named_geo a
---------------------
-1 nyc 99
+---------------------
+<null>   <null>    88
+1        nyc       99
 
 ! CREATE MATERIALIZED SOURCE avro_debezium
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avro-dbz-${testdrive.seed}'
@@ -190,6 +194,7 @@ $ kafka-create-topic topic=textsrc partitions=1
 $ kafka-ingest topic=textsrc format=bytes key-format=bytes key-terminator=:
 one,1:horse,apple
 two,2:bee,honey
+:cow,grass
 
 > CREATE MATERIALIZED SOURCE textsrc
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -197,12 +202,12 @@ two,2:bee,honey
   VALUE FORMAT TEXT
   INCLUDE KEY
 
-> SELECT * FROM textsrc
-key   text        mz_offset
+> SELECT * FROM textsrc ORDER BY mz_offset ASC
+key    text        mz_offset
 ---------------------------
-one,1 horse,apple 1
-two,2 bee,honey   2
-
+one,1  horse,apple 1
+two,2  bee,honey   2
+<null> cow,grass   3
 
 > CREATE MATERIALIZED SOURCE regexvalue
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -211,10 +216,11 @@ two,2 bee,honey   2
   INCLUDE KEY
 
 > SELECT * FROM regexvalue
-key   animal food  mz_offset
+key   animal  food  mz_offset
 ----------------------------
-one,1 horse  apple 1
-two,2 bee    honey 2
+one,1  horse  apple 1
+two,2  bee    honey 2
+<null> cow    grass 3
 
 > CREATE MATERIALIZED SOURCE regexboth
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -222,12 +228,12 @@ two,2 bee    honey 2
   VALUE FORMAT REGEX '(?P<animal>[^,]+),(?P<food>\w+)'
   INCLUDE KEY
 
-> SELECT * FROM regexboth
-id_name id animal food  mz_offset
+> SELECT * FROM regexboth ORDER BY mz_offset ASC
+id_name id     animal food  mz_offset
 ---------------------------------
-one     1  horse  apple 1
-two     2  bee    honey 2
-
+one     1      horse  apple 1
+two     2      bee    honey 2
+<null>  <null> cow    grass 3
 
 > CREATE MATERIALIZED SOURCE regexbothnest
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -236,10 +242,11 @@ two     2  bee    honey 2
   INCLUDE KEY AS nest
 
 > SELECT (nest).id_name, (nest).id, animal FROM regexbothnest
-id_name id animal
------------------
-one     1  horse
-two     2  bee
+id_name id     animal
+--------------------
+<null>  <null> cow
+one     1      horse
+two     2      bee
 
 $ file-append path=test.proto
 syntax = "proto3";
@@ -266,16 +273,20 @@ $ kafka-ingest topic=proto
   format=protobuf descriptor-file=test.proto message=Value
 {"id": "a"} {"measurement": 10}
 
+$ kafka-ingest topic=proto format=protobuf descriptor-file=test.proto message=Value omit-key=true
+{"measurement": 11}
+
 > CREATE MATERIALIZED SOURCE input_proto
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-proto-${testdrive.seed}'
   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
   INCLUDE KEY
 
-> SELECT * FROM input_proto
-id  measurement  mz_offset
+> SELECT * FROM input_proto ORDER BY measurement ASC
+id     measurement  mz_offset
 --------------------------
-a   10           1
+a      10           1
+<null> 11           2
 
 $ kafka-create-topic topic=proto-structured partitions=1
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Backports https://github.com/MaterializeInc/materialize/pull/12929 into LTS. This change allows sources to correctly handle Kafka messages without keys when using `INCLUDE KEY` for an `ENVELOPE NONE` source.

The LTS code is only minorly changed from the original PR, mostly the types live in different files now, so it's nearly a 1:1 port

### Motivation

* This PR fixes a recognized bug. 
https://github.com/MaterializeInc/materialize/issues/12275

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - When INCLUDE KEY is used with an ENVELOPE NONE Kafka source, records with missing keys now produce NULL column values, rather than raising an error.
