### PR TITLE
persist: rename `BlobMulti` to just `Blob`

### DIFF
--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use mz_ore::task::RuntimeExt;
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::{Atomicity, BlobMulti, Consensus, ExternalError, SeqNo, VersionedData};
+use mz_persist::location::{Atomicity, Blob, Consensus, ExternalError, SeqNo, VersionedData};
 use mz_persist::workload::{self, DataGenerator};
 use mz_persist_client::ShardId;
 use mz_persist_types::Codec;
@@ -163,7 +163,7 @@ pub fn bench_blob_get(
     });
 }
 
-async fn bench_blob_get_one_iter(blob: &dyn BlobMulti, key: &str) -> Result<(), ExternalError> {
+async fn bench_blob_get_one_iter(blob: &dyn Blob, key: &str) -> Result<(), ExternalError> {
     let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
     let value = blob.get(deadline, &key).await?;
     assert!(value.is_some());
@@ -192,10 +192,7 @@ pub fn bench_blob_set(
     });
 }
 
-async fn bench_blob_set_one_iter(
-    blob: &dyn BlobMulti,
-    payload: &Bytes,
-) -> Result<(), ExternalError> {
+async fn bench_blob_set_one_iter(blob: &dyn Blob, payload: &Bytes) -> Result<(), ExternalError> {
     let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
     let key = ShardId::new().to_string();
     blob.set(

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -32,8 +32,8 @@ use mz_ore::metrics::MetricsRegistry;
 use tracing::{error, trace};
 
 use mz_ore::now::SYSTEM_TIME;
-use mz_persist::location::{BlobMulti, Consensus, ExternalError, Indeterminate};
-use mz_persist::unreliable::{UnreliableBlobMulti, UnreliableConsensus, UnreliableHandle};
+use mz_persist::location::{Blob, Consensus, ExternalError, Indeterminate};
+use mz_persist::unreliable::{UnreliableBlob, UnreliableConsensus, UnreliableHandle};
 use mz_persist_client::{Metrics, PersistClient, PersistConfig, PersistLocation};
 
 use self::impls::ConsensusTimestamper;
@@ -191,8 +191,8 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
     let should_happen = 1.0 - args.unreliability;
     let should_timeout = args.unreliability;
     unreliable.partially_available(should_happen, should_timeout);
-    let blob = Arc::new(UnreliableBlobMulti::new(blob, unreliable.clone()))
-        as Arc<dyn BlobMulti + Send + Sync>;
+    let blob =
+        Arc::new(UnreliableBlob::new(blob, unreliable.clone())) as Arc<dyn Blob + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
     PersistClient::new(PersistConfig::default(), blob, consensus, metrics).await

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -22,7 +22,7 @@ use differential_dataflow::trace::Description;
 use mz_ore::cast::CastFrom;
 use mz_persist::indexed::columnar::{ColumnarRecords, ColumnarRecordsVecBuilder};
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::{Atomicity, BlobMulti};
+use mz_persist::location::{Atomicity, Blob};
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
@@ -53,8 +53,8 @@ where
     /// Keys to blobs that make up this batch of updates.
     pub(crate) blob_keys: Vec<String>,
 
-    /// Handle to the [BlobMulti] that the blobs of this batch were uploaded to.
-    _blob: Arc<dyn BlobMulti + Send + Sync>,
+    /// Handle to the [Blob] that the blobs of this batch were uploaded to.
+    _blob: Arc<dyn Blob + Send + Sync>,
 
     // These provide a bit more safety against appending a batch with the wrong
     // type to a shard.
@@ -84,7 +84,7 @@ where
     D: Semigroup + Codec64,
 {
     pub(crate) fn new(
-        blob: Arc<dyn BlobMulti + Send + Sync>,
+        blob: Arc<dyn Blob + Send + Sync>,
         shard_id: ShardId,
         desc: Description<T>,
         blob_keys: Vec<String>,
@@ -155,7 +155,7 @@ where
 
     shard_id: ShardId,
     records: ColumnarRecordsVecBuilder,
-    blob: Arc<dyn BlobMulti + Send + Sync>,
+    blob: Arc<dyn Blob + Send + Sync>,
     metrics: Arc<Metrics>,
 
     parts: BatchParts<T>,
@@ -180,7 +180,7 @@ where
         metrics: Arc<Metrics>,
         size_hint: usize,
         lower: Antichain<T>,
-        blob: Arc<dyn BlobMulti + Send + Sync>,
+        blob: Arc<dyn Blob + Send + Sync>,
         shard_id: ShardId,
     ) -> Self {
         let parts = BatchParts::new(
@@ -310,7 +310,7 @@ struct BatchParts<T> {
     metrics: Arc<Metrics>,
     shard_id: ShardId,
     lower: Antichain<T>,
-    blob: Arc<dyn BlobMulti + Send + Sync>,
+    blob: Arc<dyn Blob + Send + Sync>,
     writing_parts: VecDeque<(String, JoinHandle<()>)>,
     finished_parts: Vec<String>,
 }
@@ -321,7 +321,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         metrics: Arc<Metrics>,
         shard_id: ShardId,
         lower: Antichain<T>,
-        blob: Arc<dyn BlobMulti + Send + Sync>,
+        blob: Arc<dyn Blob + Send + Sync>,
     ) -> Self {
         BatchParts {
             max_outstanding,

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -17,7 +17,7 @@ use bytes::Bytes;
 use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::{Counter, IntCounter, MetricsRegistry};
-use mz_persist::location::{Atomicity, BlobMulti, Consensus, ExternalError, SeqNo, VersionedData};
+use mz_persist::location::{Atomicity, Blob, Consensus, ExternalError, SeqNo, VersionedData};
 use mz_persist::retry::RetryStream;
 use prometheus::{CounterVec, IntCounterVec};
 
@@ -29,7 +29,7 @@ use prometheus::{CounterVec, IntCounterVec};
 pub struct Metrics {
     _vecs: MetricsVecs,
 
-    /// Metrics for [BlobMulti] usage.
+    /// Metrics for [Blob] usage.
     pub blob: BlobMetrics,
     /// Metrics for [Consensus] usage.
     pub consensus: ConsensusMetrics,
@@ -493,19 +493,19 @@ pub struct BlobMetrics {
 }
 
 #[derive(Debug)]
-pub struct MetricsBlobMulti {
-    blob: Arc<dyn BlobMulti + Send + Sync>,
+pub struct MetricsBlob {
+    blob: Arc<dyn Blob + Send + Sync>,
     metrics: Arc<Metrics>,
 }
 
-impl MetricsBlobMulti {
-    pub fn new(blob: Arc<dyn BlobMulti + Send + Sync>, metrics: Arc<Metrics>) -> Self {
-        MetricsBlobMulti { blob, metrics }
+impl MetricsBlob {
+    pub fn new(blob: Arc<dyn Blob + Send + Sync>, metrics: Arc<Metrics>) -> Self {
+        MetricsBlob { blob, metrics }
     }
 }
 
 #[async_trait]
-impl BlobMulti for MetricsBlobMulti {
+impl Blob for MetricsBlob {
     async fn get(&self, deadline: Instant, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
         let res = self
             .metrics

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -28,7 +28,7 @@ use tracing::{debug_span, info, instrument, trace, trace_span, warn, Instrument}
 use uuid::Uuid;
 
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
-use mz_persist::location::BlobMulti;
+use mz_persist::location::Blob;
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
 
@@ -85,7 +85,7 @@ pub struct SnapshotIter<K, V, T, D> {
     shard_id: ShardId,
     as_of: Antichain<T>,
     batches: Vec<(String, Description<T>)>,
-    blob: Arc<dyn BlobMulti + Send + Sync>,
+    blob: Arc<dyn Blob + Send + Sync>,
     _phantom: PhantomData<(K, V, T, D)>,
 }
 
@@ -183,7 +183,7 @@ pub struct Listen<K, V, T, D> {
     as_of: Antichain<T>,
     frontier: Antichain<T>,
     machine: Machine<K, V, T, D>,
-    blob: Arc<dyn BlobMulti + Send + Sync>,
+    blob: Arc<dyn Blob + Send + Sync>,
 }
 
 impl<K, V, T, D> Listen<K, V, T, D>
@@ -284,7 +284,7 @@ where
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) reader_id: ReaderId,
     pub(crate) machine: Machine<K, V, T, D>,
-    pub(crate) blob: Arc<dyn BlobMulti + Send + Sync>,
+    pub(crate) blob: Arc<dyn Blob + Send + Sync>,
 
     pub(crate) since: Antichain<T>,
     pub(crate) explicitly_expired: bool,
@@ -565,7 +565,7 @@ where
 }
 
 async fn fetch_batch_part<K, V, T, D, TFn>(
-    blob: &(dyn BlobMulti + Send + Sync),
+    blob: &(dyn Blob + Send + Sync),
     metrics: &Metrics,
     key: &str,
     desc: &Description<T>,
@@ -656,7 +656,7 @@ where
 mod tests {
     use mz_ore::metrics::MetricsRegistry;
     use mz_persist::location::Consensus;
-    use mz_persist::mem::{MemBlobMulti, MemBlobMultiConfig, MemConsensus};
+    use mz_persist::mem::{MemBlob, MemBlobConfig, MemConsensus};
     use mz_persist::unreliable::{UnreliableConsensus, UnreliableHandle};
 
     use crate::r#impl::metrics::Metrics;
@@ -677,7 +677,7 @@ mod tests {
             (("2".to_owned(), "two".to_owned()), 2, 1),
         ];
 
-        let blob = Arc::new(MemBlobMulti::open(MemBlobMultiConfig::default()));
+        let blob = Arc::new(MemBlob::open(MemBlobConfig::default()));
         let consensus = Arc::new(MemConsensus::default());
         let unreliable = UnreliableHandle::default();
         unreliable.totally_available();

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -17,7 +17,7 @@ use std::time::SystemTime;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use mz_persist::location::{BlobMulti, Indeterminate};
+use mz_persist::location::{Blob, Indeterminate};
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::{Antichain, Timestamp};
@@ -54,7 +54,7 @@ where
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) machine: Machine<K, V, T, D>,
-    pub(crate) blob: Arc<dyn BlobMulti + Send + Sync>,
+    pub(crate) blob: Arc<dyn Blob + Send + Sync>,
 
     pub(crate) upper: Antichain<T>,
 }

--- a/src/persist/src/indexed/encoding.rs
+++ b/src/persist/src/indexed/encoding.rs
@@ -33,7 +33,7 @@ use crate::gen::persist::{
 use crate::indexed::cache::{BlobCache, CacheHint};
 use crate::indexed::columnar::parquet::{decode_trace_parquet, encode_trace_parquet};
 use crate::indexed::columnar::ColumnarRecords;
-use crate::location::BlobMulti;
+use crate::location::Blob;
 
 /// The metadata necessary to reconstruct a list of [BlobTraceBatchPart]s.
 ///
@@ -61,7 +61,7 @@ pub struct TraceBatchMeta {
 }
 
 /// The structure serialized and stored as a value in
-/// [crate::location::BlobMulti] storage for data keys corresponding to trace
+/// [crate::location::Blob] storage for data keys corresponding to trace
 /// data.
 ///
 /// This batch represents the data that was originally written at some time in
@@ -113,7 +113,7 @@ impl TraceBatchMeta {
     }
 
     /// Assert that all of the [BlobTraceBatchPart]'s obey the required invariants.
-    pub async fn validate_data<B: BlobMulti + Send + Sync + 'static>(
+    pub async fn validate_data<B: Blob + Send + Sync + 'static>(
         &self,
         cache: &BlobCache<B>,
     ) -> Result<(), Error> {
@@ -385,7 +385,7 @@ mod tests {
     use crate::error::Error;
     use crate::indexed::columnar::ColumnarRecordsVec;
     use crate::indexed::metrics::Metrics;
-    use crate::mem::{MemBlobMulti, MemBlobMultiConfig};
+    use crate::mem::{MemBlob, MemBlobConfig};
     use crate::workload::DataGenerator;
 
     use super::*;
@@ -547,7 +547,7 @@ mod tests {
     async fn trace_batch_meta_validate_data() -> Result<(), Error> {
         let blob = BlobCache::new(
             Arc::new(Metrics::default()),
-            MemBlobMulti::open(MemBlobMultiConfig::default()),
+            MemBlob::open(MemBlobConfig::default()),
             None,
         );
         let format = ProtoBatchFormat::ParquetKvtd;

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -226,7 +226,7 @@ impl From<tokio::task::JoinError> for ExternalError {
     }
 }
 
-/// Configuration of whether a [BlobMulti::set] must occur atomically.
+/// Configuration of whether a [Blob::set] must occur atomically.
 #[derive(Debug)]
 pub enum Atomicity {
     /// Require the write be atomic and either succeed or leave the previous
@@ -353,10 +353,8 @@ pub trait Consensus: std::fmt::Debug {
 /// start reasoning about "this set hasn't show up yet" vs "the blob has already
 /// been deleted". Another tricky problem is the same but for a deletion when
 /// the first attempt timed out.
-///
-/// TODO: Rename this to Blob when we delete Blob.
 #[async_trait]
-pub trait BlobMulti: std::fmt::Debug {
+pub trait Blob: std::fmt::Debug {
     /// Returns a reference to the value corresponding to the key.
     async fn get(&self, deadline: Instant, key: &str) -> Result<Option<Vec<u8>>, ExternalError>;
 
@@ -400,8 +398,8 @@ pub mod tests {
         ret
     }
 
-    pub async fn blob_multi_impl_test<
-        B: BlobMulti,
+    pub async fn blob_impl_test<
+        B: Blob,
         F: Future<Output = Result<B, ExternalError>>,
         NewFn: Fn(&'static str) -> F,
     >(


### PR DESCRIPTION
### Motivation

Just crossing out a TODO item that had its prerequisites fulfilled (i.e that `trait Blob` is gone)
