### PR TITLE
coord: Fix read-then-write serializability issue

### DIFF
--- a/src/coord/src/session.rs
+++ b/src/coord/src/session.rs
@@ -545,13 +545,17 @@ pub enum TransactionStatus<T> {
 }
 
 impl<T> TransactionStatus<T> {
-    /// Extracts the inner transaction ops if not failed.
-    pub fn into_ops(self) -> Option<TransactionOps<T>> {
+    /// Extracts the inner transaction ops and write lock guard if not failed.
+    pub fn into_ops_and_lock_guard(
+        self,
+    ) -> (Option<TransactionOps<T>>, Option<OwnedMutexGuard<()>>) {
         match self {
-            TransactionStatus::Default | TransactionStatus::Failed(_) => None,
+            TransactionStatus::Default | TransactionStatus::Failed(_) => (None, None),
             TransactionStatus::Started(txn)
             | TransactionStatus::InTransaction(txn)
-            | TransactionStatus::InTransactionImplicit(txn) => Some(txn.ops),
+            | TransactionStatus::InTransactionImplicit(txn) => {
+                (Some(txn.ops), txn.write_lock_guard)
+            }
         }
     }
 


### PR DESCRIPTION
Previously, read-then-write statements would release the global write
lock, before queuing their writes for a group commit. This allowed two
read-then-write statements to interleave their reads and writes, which
can lead to a serializable consistency violation.

An example of one such violation is the following:
1. Txn 1 acquires lock
2. Txn 1 reads from A
3. Txn 1 releases lock
4. Txn 1 submites write to A
5. Txn 2 acquires lock
6. Txn 2 reads from A
7. Txn 2 releases lock
8. Txn 2 submits write to A
9. Group commit executes
There is no serial order that would be equivalent to this order.

This commit updates the behavior of read-then-write statements to hold
on to the global write lock until group commit executes. This means
that no two read-then-write statements can be part of the same group
commit.

However, we can include one read-then-write statements and many write
transactions in the same group commit without violating
serializability. Specifically, the serial order would be to order all
of the write transactions after the read-then-write statement.

### Motivation
This PR fixes a previously unreported bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
