### PR TITLE
zippy: Increase timeout to 10 minutes

### DIFF
--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -26,7 +26,7 @@ SERVICES = [
     SchemaRegistry(),
     # --persistent-kafka-sources can not be enabled due to gh#11711 , gh#11506
     Materialized(),
-    Testdrive(validate_data_dir=False, no_reset=True, seed=1, default_timeout="300s"),
+    Testdrive(validate_data_dir=False, no_reset=True, seed=1, default_timeout="600s"),
 ]
 
 


### PR DESCRIPTION
The performance of the product has slowed down to a point where
5 minutes are not enough to re-ingest all the Zippy data on Mz restart.
### Motivation

  * This PR fixes a previously unreported bug.

Zippy in failing in Nightly CI because 5 minutes are no longer enough to re-ingest all the data post-restart :-( 