### PR TITLE
aws: Allow the AWS test to start

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -600,7 +600,7 @@ class Testdrive(Service):
         propagate_uid_gid: bool = True,
         forward_buildkite_shard: bool = False,
         aws_region: Optional[str] = None,
-        aws_endpoint: str = "http://localstack:4566",
+        aws_endpoint: Optional[str] = "http://localstack:4566",
     ) -> None:
         if environment is None:
             environment = [

--- a/test/aws-config/mzcompose.py
+++ b/test/aws-config/mzcompose.py
@@ -46,6 +46,7 @@ SERVICES = [
     ),
     Testdrive(
         materialize_url=f"postgres://materialize@materialized:6875",
+        aws_endpoint=None,
         seed=SEED,
     ),
 ]


### PR DESCRIPTION
Make sure Testdrive is not called with both --aws-region
and --aws-endpoint at the same time.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

the AWS test in CI fails to start because of conflicting testdrive command-line arguments.