### PR TITLE
storage: use `WriteHandle::append` when sinking data

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -131,13 +131,12 @@ pub fn render<G>(
                     if finalized_timestamps.is_empty() {
                         let expected_upper = current_upper.borrow().clone();
                         write
-                            .compare_and_append(
+                            .append(
                                 Vec::<((SourceData, ()), Timestamp, Diff)>::new(),
                                 expected_upper,
                                 input_upper.clone(),
                             )
                             .await
-                            .expect("cannot append updates")
                             .expect("cannot append updates")
                             .expect("invalid/outdated upper");
 


### PR DESCRIPTION
There is no good reason to use `compare_and_append` while sinking data
and switching to `append` has the added benefit of giving us a quick and
easy HA option for ingestion.

The original code did use `append` and I incorrectly changed it to
`compare_and_append` thinking that the final behaviour would be better.

After discussing with @aljoscha we concluded that `append` is the right
thing to do, at least until we start seeing performance issues with
persist.
