### PR TITLE
storage: remove `DiffernetialRow` envelope

### DIFF
--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -65,7 +65,6 @@ message ProtoSourceEnvelope {
         ProtoDebeziumEnvelope debezium = 2;
         ProtoUpsertEnvelope upsert = 3;
         google.protobuf.Empty cdc_v2 = 4;
-        google.protobuf.Empty differential_row = 5;
     }
 }
 

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -418,9 +418,6 @@ pub enum Envelope<T: AstInfo> {
     Debezium(DbzMode<T>),
     Upsert,
     CdcV2,
-    /// An envelope for sources that directly read differential Rows. This is internal and cannot
-    /// be requested via SQL.
-    DifferentialRow,
 }
 
 impl<T: AstInfo> AstDisplay for Envelope<T> {
@@ -439,9 +436,6 @@ impl<T: AstInfo> AstDisplay for Envelope<T> {
             }
             Self::CdcV2 => {
                 f.write_str("MATERIALIZE");
-            }
-            Self::DifferentialRow => {
-                f.write_str("DIFFERENTIAL ROW");
             }
         }
     }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -593,10 +593,6 @@ pub fn plan_create_source(
         mz_sql_parser::ast::Envelope::None => {
             UnplannedSourceEnvelope::None(key_envelope.unwrap_or(KeyEnvelope::None))
         }
-        mz_sql_parser::ast::Envelope::DifferentialRow => {
-            assert!(key_envelope.is_none());
-            UnplannedSourceEnvelope::DifferentialRow
-        }
         mz_sql_parser::ast::Envelope::Debezium(mode) => {
             //TODO check that key envelope is not set
             let (before_idx, after_idx) = typecheck_debezium(&value_desc)?;
@@ -2163,7 +2159,6 @@ pub fn plan_create_sink(
         None if matches!(connection, CreateSinkConnection::Persist { .. }) => {
             SinkEnvelope::DifferentialRow
         }
-        Some(Envelope::DifferentialRow) => unreachable!("not expressable in SQL"),
         // Other sinks default to ENVELOPE DEBEZIUM. Not sure that's good, though...
         None => SinkEnvelope::Debezium,
         Some(Envelope::Debezium(mz_sql_parser::ast::DbzMode::Plain { tx_metadata })) => {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -412,9 +412,6 @@ where
                             (stream.as_collection(), Some(errors))
                         }
                         SourceEnvelope::CdcV2 => unreachable!(),
-                        SourceEnvelope::DifferentialRow => {
-                            unreachable!("persist sources go through a special render path")
-                        }
                     }
                 }
             };


### PR DESCRIPTION
This envelope was added to support the persist source but internal sinks
will follow a slightly different design that won't need a special
envelope.
