### PR TITLE
coord: use correct controller method to drop indexes

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5316,7 +5316,7 @@ impl<S: Append + 'static> Coordinator<S> {
             self.dataflow_client
                 .compute_mut(compute_instance)
                 .unwrap()
-                .drop_sinks(ids)
+                .drop_indexes(ids)
                 .await
                 .unwrap();
         }


### PR DESCRIPTION
Prior to this, coord would call the compute controller's `drop_sinks` method to signal that an index can be dropped. While this was not strictly a bug, because `drop_sinks` has the same code as `drop_indexes`, it was very confusing and surely a copy-paste error.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).