### PR TITLE
Internal sinks, part 3: coordinator plumbing

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1051,6 +1051,17 @@ pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("definition", ScalarType::String.nullable(false)),
 });
+pub static MZ_RECORDED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_recorded_views",
+    schema: MZ_CATALOG_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("oid", ScalarType::Oid.nullable(false))
+        .with_column("schema_id", ScalarType::Int64.nullable(false))
+        .with_column("name", ScalarType::String.nullable(false))
+        .with_column("cluster_id", ScalarType::Int64.nullable(false))
+        .with_column("definition", ScalarType::String.nullable(false)),
+});
 pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_types",
     schema: MZ_CATALOG_SCHEMA,
@@ -2089,6 +2100,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_SOURCES),
         Builtin::Table(&MZ_SINKS),
         Builtin::Table(&MZ_VIEWS),
+        Builtin::Table(&MZ_RECORDED_VIEWS),
         Builtin::Table(&MZ_TYPES),
         Builtin::Table(&MZ_ARRAY_TYPES),
         Builtin::Table(&MZ_BASE_TYPES),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -203,6 +203,7 @@ impl CatalogState {
                 self.pack_source_update(id, oid, schema_id, name, source.source_desc.name(), diff)
             }
             CatalogItem::View(view) => self.pack_view_update(id, oid, schema_id, name, view, diff),
+            CatalogItem::RecordedView(_) => todo!(),
             CatalogItem::Sink(sink) => self.pack_sink_update(id, oid, schema_id, name, sink, diff),
             CatalogItem::Type(ty) => self.pack_type_update(id, oid, schema_id, name, ty, diff),
             CatalogItem::Func(func) => self.pack_func_update(id, schema_id, name, func, diff),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -26,17 +26,16 @@ use mz_storage::client::sinks::KafkaSinkConnection;
 
 use crate::catalog::builtin::{
     MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS_BASE,
-    MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS, MZ_DATABASES, MZ_FUNCTIONS,
-    MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_SINKS, MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_PSEUDO_TYPES,
-    MZ_ROLES, MZ_SCHEMAS, MZ_SECRETS, MZ_SINKS, MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
+    MZ_CLUSTER_REPLICA_HEARTBEATS, MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS, MZ_CONNECTIONS,
+    MZ_DATABASES, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_SINKS, MZ_LIST_TYPES,
+    MZ_MAP_TYPES, MZ_PSEUDO_TYPES, MZ_RECORDED_VIEWS, MZ_ROLES, MZ_SCHEMAS, MZ_SECRETS, MZ_SINKS,
+    MZ_SOURCES, MZ_TABLES, MZ_TYPES, MZ_VIEWS,
 };
 use crate::catalog::{
-    CatalogItem, CatalogState, Connection, Error, ErrorKind, Func, Index, Sink, SinkConnection,
-    SinkConnectionState, Type, View, SYSTEM_CONN_ID,
+    CatalogItem, CatalogState, Connection, Error, ErrorKind, Func, Index, RecordedView, Sink,
+    SinkConnection, SinkConnectionState, Type, View, SYSTEM_CONN_ID,
 };
 use crate::coord::ReplicaMetadata;
-
-use super::builtin::MZ_CLUSTER_REPLICA_HEARTBEATS;
 
 /// An update to a built-in table.
 #[derive(Debug)]
@@ -203,7 +202,9 @@ impl CatalogState {
                 self.pack_source_update(id, oid, schema_id, name, source.source_desc.name(), diff)
             }
             CatalogItem::View(view) => self.pack_view_update(id, oid, schema_id, name, view, diff),
-            CatalogItem::RecordedView(_) => todo!(),
+            CatalogItem::RecordedView(rview) => {
+                self.pack_recorded_view_update(id, oid, schema_id, name, rview, diff)
+            }
             CatalogItem::Sink(sink) => self.pack_sink_update(id, oid, schema_id, name, sink, diff),
             CatalogItem::Type(ty) => self.pack_type_update(id, oid, schema_id, name, ty, diff),
             CatalogItem::Func(func) => self.pack_func_update(id, schema_id, name, func, diff),
@@ -346,6 +347,44 @@ impl CatalogState {
                 // TODO(jkosh44) when Uint64 is supported change below to Datum::Uint64
                 Datum::Int64(u64::from(schema_id) as i64),
                 Datum::String(name),
+                Datum::String(&query_string),
+            ]),
+            diff,
+        }]
+    }
+
+    fn pack_recorded_view_update(
+        &self,
+        id: GlobalId,
+        oid: u32,
+        schema_id: &SchemaSpecifier,
+        name: &str,
+        rview: &RecordedView,
+        diff: Diff,
+    ) -> Vec<BuiltinTableUpdate> {
+        let create_sql = mz_sql::parse::parse(&rview.create_sql)
+            .expect("create_sql cannot be invalid")
+            .into_element();
+        let query = match create_sql {
+            Statement::CreateRecordedView(stmt) => stmt.query,
+            _ => unreachable!(),
+        };
+
+        let mut query_string = query.to_ast_string_stable();
+        // PostgreSQL appends a semicolon in `pg_views.definition`, we
+        // do the same for compatibility's sake.
+        query_string.push(';');
+
+        vec![BuiltinTableUpdate {
+            id: self.resolve_builtin_table(&MZ_RECORDED_VIEWS),
+            row: Row::pack_slice(&[
+                Datum::String(&id.to_string()),
+                Datum::UInt32(oid),
+                // TODO(jkosh44) when Uint64 is supported change below to Datum::Uint64
+                Datum::Int64(u64::from(schema_id) as i64),
+                Datum::String(name),
+                // TODO(jkosh44) when Uint64 is supported change below to Datum::Uint64
+                Datum::Int64(rview.compute_instance as i64),
                 Datum::String(&query_string),
             ]),
             diff,

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -492,6 +492,7 @@ impl SessionClient {
                 | ExecuteResponse::CreatedSources
                 | ExecuteResponse::CreatedSink { existed: _ }
                 | ExecuteResponse::CreatedView { existed: _ }
+                | ExecuteResponse::CreatedRecordedView { existed: _ }
                 | ExecuteResponse::CreatedType
                 | ExecuteResponse::Deleted(_)
                 | ExecuteResponse::DiscardedTemp

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -228,6 +228,10 @@ pub enum ExecuteResponse {
     CreatedView {
         existed: bool,
     },
+    /// The requested recorded view was created.
+    CreatedRecordedView {
+        existed: bool,
+    },
     /// The requested type was created.
     CreatedType,
     /// The requested prepared statement was removed.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3548,7 +3548,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     compute_id: instance.id,
                 });
             }
-            let ids_to_drop: Vec<GlobalId> = instance.indexes().iter().cloned().collect();
+            let ids_to_drop: Vec<GlobalId> = instance.exports().iter().cloned().collect();
             ops.extend(self.catalog.drop_items_ops(&ids_to_drop));
             ops.push(catalog::Op::DropComputeInstance { name });
         }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -818,6 +818,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                 }
                 CatalogItem::View(_) => (),
+                CatalogItem::RecordedView(_) => todo!(),
                 CatalogItem::Sink(sink) => {
                     // Re-create the sink on the compute instance.
                     let builder = match &sink.connection {
@@ -5509,6 +5510,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 CatalogItem::View(view) => {
                     ids.extend(view.optimized_expr.depends_on());
+                }
+                CatalogItem::RecordedView(rview) => {
+                    ids.extend(rview.optimized_expr.depends_on());
                 }
                 CatalogItem::Table(table) => {
                     timelines.insert(id, table.timeline());

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -148,6 +148,11 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                         let expr = view.optimized_expr.clone();
                         self.import_view_into_dataflow(id, &expr, dataflow)?;
                     }
+                    CatalogItem::RecordedView(_) => {
+                        // TODO(teskje): Figure out whether we need to handle
+                        // this case.
+                        unreachable!()
+                    }
                     _ => unreachable!(),
                 }
             }

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -14,6 +14,8 @@
 //! and indicate which identifiers have arrangements available. This module
 //! isolates that logic from the rest of the somewhat complicated coordinator.
 
+use timely::progress::Antichain;
+
 use mz_compute_client::command::{BuildDesc, DataflowDesc, IndexDesc};
 use mz_compute_client::controller::{ComputeController, ComputeInstanceId};
 use mz_expr::visit::Visit;
@@ -24,9 +26,9 @@ use mz_expr::{
 use mz_ore::stack::maybe_grow;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::numeric::Numeric;
-use mz_repr::{Datum, GlobalId, Row};
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_stash::Append;
-use mz_storage::client::sinks::SinkDesc;
+use mz_storage::client::sinks::{PersistSinkConnection, SinkAsOf, SinkConnection, SinkDesc};
 
 use crate::catalog::{CatalogItem, CatalogState};
 use crate::coord::{CatalogTxn, Coordinator};
@@ -148,10 +150,8 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                         let expr = view.optimized_expr.clone();
                         self.import_view_into_dataflow(id, &expr, dataflow)?;
                     }
-                    CatalogItem::RecordedView(_) => {
-                        // TODO(teskje): Figure out whether we need to handle
-                        // this case.
-                        unreachable!()
+                    CatalogItem::RecordedView(rview) => {
+                        dataflow.import_source(*id, rview.desc.typ().clone(), false);
                     }
                     _ => unreachable!(),
                 }
@@ -254,6 +254,52 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
         mz_transform::optimize_dataflow(dataflow, &self.index_oracle())?;
 
         Ok(())
+    }
+
+    /// Builds a dataflow description for the recorded view specified by `id`.
+    ///
+    /// For this, we first build a dataflow for the view expression, then we
+    /// add a sink that writes that dataflow's output to storage.
+    /// `internal_view_id` is the ID we assign to the view dataflow internally,
+    /// so we can connect the sink to it.
+    pub fn build_recorded_view_dataflow(
+        &mut self,
+        id: GlobalId,
+        as_of: Antichain<Timestamp>,
+        internal_view_id: GlobalId,
+    ) -> Result<DataflowDesc, AdapterError> {
+        let rview_entry = self.catalog.get_entry(&id);
+        let rview = match rview_entry.item() {
+            CatalogItem::RecordedView(rv) => rv,
+            _ => unreachable!(
+                "cannot create recorded view dataflow on something that is not a recorded view"
+            ),
+        };
+
+        let name = rview_entry.name().to_string();
+        let mut dataflow = DataflowDesc::new(name);
+
+        self.import_view_into_dataflow(&internal_view_id, &rview.optimized_expr, &mut dataflow)?;
+        for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
+            prep_relation_expr(self.catalog, plan, ExprPrepStyle::Index)?;
+        }
+
+        let sink_description = SinkDesc {
+            from: internal_view_id,
+            from_desc: rview.desc.clone(),
+            connection: SinkConnection::Persist(PersistSinkConnection {
+                value_desc: rview.desc.clone(),
+                storage_metadata: (),
+            }),
+            envelope: None,
+            as_of: SinkAsOf {
+                frontier: as_of,
+                strict: false,
+            },
+        };
+        self.build_sink_dataflow_into(&mut dataflow, id, sink_description)?;
+
+        Ok(dataflow)
     }
 }
 

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -75,9 +75,9 @@ impl<T: CoordTimestamp> ComputeInstanceIndexOracle<'_, T> {
                     view @ CatalogItem::View(_) => {
                         todo.extend(view.uses());
                     }
-                    CatalogItem::Source(_) | CatalogItem::Table(_) => {
-                        // Unmaterialized source or table. Record that we are
-                        // missing at least one index.
+                    CatalogItem::Source(_) | CatalogItem::Table(_) | CatalogItem::RecordedView(_) => {
+                        // Unmaterialized source, table, or recorded view.
+                        // Record that we are missing at least one index.
                         id_bundle.storage_ids.insert(id);
                     }
                     _ => {

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -75,7 +75,9 @@ impl<T: CoordTimestamp> ComputeInstanceIndexOracle<'_, T> {
                     view @ CatalogItem::View(_) => {
                         todo.extend(view.uses());
                     }
-                    CatalogItem::Source(_) | CatalogItem::Table(_) | CatalogItem::RecordedView(_) => {
+                    CatalogItem::Source(_)
+                    | CatalogItem::Table(_)
+                    | CatalogItem::RecordedView(_) => {
                         // Unmaterialized source, table, or recorded view.
                         // Record that we are missing at least one index.
                         id_bundle.storage_ids.insert(id);

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1118,6 +1118,9 @@ where
             ExecuteResponse::CreatedView { existed } => {
                 created!(existed, SqlState::DUPLICATE_OBJECT, "view")
             }
+            ExecuteResponse::CreatedRecordedView { existed } => {
+                created!(existed, SqlState::DUPLICATE_OBJECT, "recorded view")
+            }
             ExecuteResponse::CreatedType => command_complete!("CREATE TYPE"),
             ExecuteResponse::DeclaredCursor => {
                 self.complete_portal(&portal_name);

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -260,8 +260,9 @@ pub trait CatalogComputeInstance<'a> {
     /// Returns a stable ID for the compute instance.
     fn id(&self) -> ComputeInstanceId;
 
-    /// Returns the set of non-transient indexes on this cluster.
-    fn indexes(&self) -> &std::collections::HashSet<GlobalId>;
+    /// Returns the set of non-transient exports (indexes, sinks, recorded
+    /// views) of this cluster.
+    fn exports(&self) -> &std::collections::HashSet<GlobalId>;
 
     /// Returns the set of non-transient indexes on this cluster.
     fn replica_names(&self) -> HashSet<&String>;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3283,9 +3283,9 @@ pub fn plan_drop_cluster(
         match scx.catalog.resolve_compute_instance(Some(name.as_str())) {
             Ok(instance) => {
                 if !cascade
-                    && (!instance.indexes().is_empty() || !instance.replica_names().is_empty())
+                    && (!instance.exports().is_empty() || !instance.replica_names().is_empty())
                 {
-                    bail!("cannot drop cluster with active indexes, sinks, or replicas");
+                    bail!("cannot drop cluster with active indexes, sinks, recorded views, or replicas");
                 }
                 out.push(name.into_string());
             }

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -217,7 +217,7 @@ default
 statement error unknown cluster 'baz'
 DROP CLUSTER baz
 
-statement error cannot drop cluster with active indexes, sinks, or replicas
+statement error cannot drop cluster with active indexes, sinks, recorded views, or replicas
 DROP CLUSTER bar
 
 query TTTTTTT
@@ -252,7 +252,7 @@ CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234']))
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
 
-statement error cannot drop cluster with active indexes, sinks, or replicas
+statement error cannot drop cluster with active indexes, sinks, recorded views, or replicas
 DROP CLUSTER baz
 
 statement ok

--- a/test/sqllogictest/github-13366.slt
+++ b/test/sqllogictest/github-13366.slt
@@ -12,7 +12,7 @@
 statement ok
 CREATE CLUSTER c REPLICAS (r (SIZE '1'))
 
-statement error cannot drop cluster with active indexes, sinks, or replicas
+statement error cannot drop cluster with active indexes, sinks, recorded views, or replicas
 DROP CLUSTER c
 
 statement ok
@@ -24,7 +24,7 @@ CREATE TABLE t (a int)
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER c ON t
 
-statement error cannot drop cluster with active indexes, sinks, or replicas
+statement error cannot drop cluster with active indexes, sinks, recorded views, or replicas
 DROP CLUSTER c
 
 statement ok

--- a/test/sqllogictest/recorded_views.slt
+++ b/test/sqllogictest/recorded_views.slt
@@ -1,0 +1,300 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Setup
+
+statement ok
+CREATE TABLE t (a int, b int)
+
+statement ok
+INSERT INTO t VALUES (1, 2), (3, 4), (5, 6)
+
+statement ok
+CREATE CLUSTER other REPLICAS (r1 (SIZE '1'), r2 (SIZE '2-2'))
+
+
+# Test: Recorded view can be created.
+
+statement ok
+CREATE RECORDED VIEW rv AS SELECT 1
+
+
+# Test: Recorded view can be replaced.
+
+statement ok
+CREATE OR REPLACE RECORDED VIEW rv AS SELECT 2
+
+query I
+SELECT * FROM rv
+----
+2
+
+
+# Test: Recorded view creation can be skipped if a recorded view already exists.
+
+statement error catalog item 'rv' already exists
+CREATE RECORDED VIEW rv AS SELECT 1
+
+statement ok
+CREATE RECORDED VIEW IF NOT EXISTS rv AS SELECT 1
+
+query I
+SELECT * FROM rv
+----
+2
+
+
+# Test: Recorded view can have explicit column names.
+
+statement ok
+CREATE OR REPLACE RECORDED VIEW rv (name, age) AS SELECT 'jon', 12
+
+query TI colnames
+SELECT * FROM rv
+----
+name age
+jon  12
+
+
+# Test: Explicit column names must have the right cardinality.
+
+statement error recorded view .+ definition names 2 columns, but recorded view .+ has 1 column
+CREATE RECORDED VIEW error (name, age) AS SELECT 'jon'
+
+
+# Test: Recorded view can be created in another cluster.
+
+statement ok
+CREATE RECORDED VIEW other_rv IN CLUSTER other AS SELECT 1
+
+query TTT colnames,rowsort
+SHOW FULL RECORDED VIEWS
+----
+cluster name     type
+default rv       user
+other   other_rv user
+
+statement ok
+DROP RECORDED VIEW other_rv
+
+
+# Test: Recorded view can not be created in a non-existing cluster.
+
+statement error unknown cluster 'doesnotexist'
+CREATE RECORDED VIEW error IN CLUSTER doesnotexist AS SELECT 1
+
+
+# Test: Recorded view data is accessible from the same cluster.
+
+statement ok
+CREATE OR REPLACE RECORDED VIEW rv AS SELECT a + b FROM t
+
+query I rowsort
+SELECT * FROM rv
+----
+3
+7
+11
+
+
+# Test: Recorded view data is accessible from other clusters.
+
+statement ok
+SET cluster = other
+
+query I rowsort
+SELECT * FROM rv
+----
+3
+7
+11
+
+statement ok
+RESET cluster
+
+
+# Test: Recorded view reflects input data changes.
+
+statement ok
+INSERT INTO t VALUES (7, 8)
+
+query I rowsort
+SELECT * FROM rv
+----
+3
+7
+11
+15
+
+statement ok
+DELETE FROM t WHERE a = 1
+
+query I rowsort
+SELECT * FROM rv
+----
+7
+11
+15
+
+
+# Test: Recorded views can be nested.
+
+statement ok
+CREATE RECORDED VIEW rv2 AS SELECT count(*) FROM rv
+
+query I
+SELECT * FROM rv2
+----
+3
+
+statement ok
+DROP RECORDED VIEW rv2
+
+
+# Test: Recorded views can have indexes on top.
+
+statement ok
+CREATE DEFAULT INDEX ON rv;
+
+
+# Test: Recorded views can be dropped.
+
+statement ok
+CREATE OR REPLACE RECORDED VIEW rv AS SELECT 1
+
+statement ok
+DROP RECORDED VIEW rv
+
+
+# Test: Recorded views can not be dropped if they have dependants.
+
+statement ok
+CREATE RECORDED VIEW rv AS SELECT 1
+
+statement ok
+CREATE VIEW v AS SELECT * FROM rv
+
+statement error cannot drop materialize.public.rv: still depended upon by catalog item 'materialize.public.v'
+DROP RECORDED VIEW rv
+
+
+# Test: Recorded views with dependants can be dropped with CASCADE.
+
+statement ok
+DROP RECORDED VIEW rv CASCADE
+
+query error unknown catalog item 'v'
+SELECT * FROM v
+
+
+# Test: Recorded view prevents dropping its cluster.
+
+statement ok
+CREATE CLUSTER to_drop REPLICAS ()
+
+statement ok
+CREATE RECORDED VIEW to_drop_rv IN CLUSTER to_drop AS SELECT 1
+
+statement error cannot drop cluster with active indexes, sinks, recorded views, or replicas
+DROP CLUSTER to_drop
+
+
+# Test: Cluster with dependent recorded view can be dropped with CASCADE.
+
+statement ok
+DROP CLUSTER to_drop CASCADE
+
+query error unknown catalog item 'to_drop_rv'
+SELECT * FROM to_drop_rv
+
+
+# Test: SHOW CREATE RECORDED VIEW
+
+statement ok
+CREATE RECORDED VIEW rv AS SELECT 1
+
+query TT colnames
+SHOW CREATE RECORDED VIEW rv
+----
+Recorded␠View         Create␠Recorded␠View
+materialize.public.rv CREATE␠RECORDED␠VIEW␠"materialize"."public"."rv"␠IN␠CLUSTER␠[1]␠AS␠SELECT␠1
+
+
+# Test: SHOW RECORDED VIEWS
+
+statement ok
+CREATE RECORDED VIEW other_rv IN CLUSTER other AS SELECT 1
+
+query T colnames,rowsort
+SHOW RECORDED VIEWS
+----
+name
+rv
+other_rv
+
+query TTT colnames,rowsort
+SHOW FULL RECORDED VIEWS
+----
+cluster name     type
+default rv       user
+other   other_rv user
+
+query TTT colnames,rowsort
+SHOW FULL RECORDED VIEWS IN CLUSTER other
+----
+cluster name     type
+other   other_rv user
+
+statement ok
+DROP RECORDED VIEW other_rv
+
+
+# Test: Recorded view can be renamed.
+
+statement ok
+ALTER RECORDED VIEW rv RENAME TO rv2
+
+query I
+SELECT * FROM rv2
+----
+1
+
+statement ok
+DROP RECORDED VIEW rv2
+
+
+# Test: Recorded views show up in mz_recorded_views.
+
+statement ok
+CREATE RECORDED VIEW rv AS SELECT 1
+
+query TT colnames
+SELECT name, definition FROM mz_recorded_views
+----
+name definition
+rv   SELECT␠1;
+
+statement ok
+DROP RECORDED VIEW rv
+
+query I
+SELECT count(*) FROM mz_recorded_views
+----
+0
+
+
+# Cleanup
+
+statement ok
+DROP TABLE t CASCADE
+
+statement ok
+DROP CLUSTER other CASCADE

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -409,6 +409,7 @@ mz_kafka_sinks
 mz_list_types
 mz_map_types
 mz_pseudo_types
+mz_recorded_views
 mz_roles
 mz_schemas
 mz_secrets
@@ -440,6 +441,7 @@ mz_kafka_sinks                system
 mz_list_types                 system
 mz_map_types                  system
 mz_pseudo_types               system
+mz_recorded_views             system
 mz_roles                      system
 mz_schemas                    system
 mz_secrets                    system
@@ -473,6 +475,7 @@ mz_kafka_sinks
 mz_list_types
 mz_map_types
 mz_pseudo_types
+mz_recorded_views
 mz_roles
 mz_schemas
 mz_secrets
@@ -507,6 +510,7 @@ mz_kafka_sinks
 mz_list_types
 mz_map_types
 mz_pseudo_types
+mz_recorded_views
 mz_roles
 mz_schemas
 mz_secrets
@@ -521,7 +525,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-27
+28
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/recorded-views.td
+++ b/test/testdrive/recorded-views.td
@@ -1,0 +1,80 @@
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Additional test for recorded views, on top of those in test/sqllogictest/recorded_views.slt
+
+
+
+# Kafka source as a source for a recorded view
+
+$ set recorded-views={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"}
+        ]
+    }
+
+$ kafka-create-topic topic=recorded-views
+
+$ kafka-ingest format=avro topic=recorded-views schema=${recorded-views} publish=true
+{"f1": "123"}
+
+> CREATE MATERIALIZED SOURCE s1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
+  'testdrive-recorded-views-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+$ kafka-ingest format=avro topic=recorded-views schema=${recorded-views} publish=true
+{"f1": "234"}
+
+> SELECT COUNT(*) FROM s1;
+2
+
+> CREATE RECORDED VIEW v1 AS SELECT COUNT(f1::integer) AS c1 FROM s1;
+
+$ kafka-ingest format=avro topic=recorded-views schema=${recorded-views} publish=true
+{"f1": "345"}
+
+> CREATE SINK sink1 FROM v1
+  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+  TOPIC 'recorded-view-sink'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ kafka-ingest format=avro topic=recorded-views schema=${recorded-views} publish=true
+{"f1": "456"}
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+> SELECT * FROM v1;
+4
+
+$ kafka-verify format=avro sink=materialize.public.sink1 sort-messages=true
+{"before": null, "after": {"row": {"c1": 2}}}
+{"before": {"row": {"c1": 2}}, "after": {"row": {"c1": 4}}}
+
+> BEGIN
+
+> DECLARE c CURSOR FOR TAIL v1;
+
+> FETCH ALL c;
+<TIMESTAMP> 1 4
+
+> COMMIT
+
+# Inject failure in the source
+
+$ kafka-ingest format=avro topic=recorded-views schema=${recorded-views} publish=true
+{"f1": "ABC"}
+
+# TODO(teskje): Fix propagation of errors through recorded views.
+#! SELECT * FROM v1;
+#contains: invalid input syntax for type integer


### PR DESCRIPTION
This is the third PR in support of the internal storage sinks feature (#12860).

* Part 1 (#13251) massaged our existing persist sinks implementation to look like the internal sinks we want.
* Part 2 (#13324) added support for the `RECORDED VIEW` syntax in SQL.

Part 3 now introduces the necessary plumbing in the coordinator to connect everything together. This means recorded views work now (roughly) as intended:

```sql
-- demo that we can sink and source
materialize=> CREATE TABLE t (a int, b int);
CREATE TABLE
materialize=> INSERT INTO t VALUES (1, 2), (3, 4), (5, 6);
INSERT 0 3
materialize=> CREATE RECORDED VIEW v AS SELECT a + b FROM t;
CREATE RECORDED VIEW
materialize=> SELECT * FROM v;
 ?column?
----------
        3
        7
       11
(3 rows)

-- demo that other stuff can build on top of recorded views
materialize=> CREATE DEFAULT INDEX ON v;
CREATE INDEX
materialize=> CREATE RECORDED VIEW v2 AS SELECT * FROM v;
CREATE RECORDED VIEW
materialize=> DELETE FROM t WHERE a != 1;
DELETE 2
materialize=> SELECT * FROM v2;
 ?column?
----------
        3
(1 row)

-- demo that dropping takes dependents into account
materialize=> DROP RECORDED VIEW v;
ERROR:  cannot drop materialize.public.v: still depended upon by catalog item 'materialize.public.v2'
materialize=> DROP RECORDED VIEW v CASCADE;
DROP RECORDED VIEW
```

#### Future Work

After this PR, the following TODOs are left for the internal sinks feature to be complete:
* Remove support for `CREATE SINK ... INTO PERSIST` (https://github.com/MaterializeInc/materialize/pull/13380)
* Introduce a helpful error when a user does `DROP VIEW <recorded-view>`, `ALTER VIEW <recorded-view>`, or `SHOW CREATE VIEW <recorded-view>`
* Disallow creating recorded views on log sources.
* Add support for `EXPLAIN`.
* Add support for `SHOW OBJECTS`.
* Add support for `SHOW INDEXES`.
* Propagate dataflow errors.

Also, there is work left to switch away from the placeholder `RECORDED VIEW` name to something better (see [Internal storage sink syntax](https://www.notion.so/materialize/Internal-storage-sink-syntax-017251c532df465fb3a3ec7c344df54b)).

### Motivation

  * This PR adds a known-desirable feature.

Part of #12860.

### Tips for reviewer

I tried to split the change into sensible commits to make it more digestible.

If you can think of an edge-case that's not covered by recorded_views.slt, chances are I have not considered it and it is currently broken. Let me know!

Relevant design docs:

- [Internal storage sink syntax](https://www.notion.so/materialize/Internal-storage-sink-syntax-017251c532df465fb3a3ec7c344df54b)
- [Internal storage sink](https://www.notion.so/materialize/Internal-Storage-Sink-505983857bb24ae2b36cdc15ff9cc3a4)

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Make recorded views functional.
