### PR TITLE
persist: remove per-reader sinces, add SinceHandle

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -165,6 +165,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                 // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
                 let (ok_stream, err_stream, token) = persist_source::persist_source(
                     region,
+                    format!("{}", source_id),
                     Arc::clone(&compute_state.persist_clients),
                     source.storage_metadata.clone(),
                     dataflow.as_of.clone().unwrap(),

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -32,7 +32,7 @@ use crate::r#impl::metrics::{
 };
 use crate::r#impl::state::{HollowBatch, SeqNoCapability, Since, State, StateCollections, Upper};
 use crate::r#impl::trace::{FueledMergeReq, FueledMergeRes};
-use crate::read::ReaderId;
+use crate::read::{ReaderId, SinceHandleId};
 use crate::ShardId;
 
 #[derive(Debug)]
@@ -108,7 +108,7 @@ where
 
     /// Opens a new `SinceHandle` for this shard and fences off any previously
     /// open handles, if any.
-    pub async fn open_since_handle(&mut self, since_handle_id: &ReaderId) -> Since<T> {
+    pub async fn open_since_handle(&mut self, since_handle_id: &SinceHandleId) -> Since<T> {
         let metrics = Arc::clone(&self.metrics);
         let (_seqno, since) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |seqno, state| {
@@ -186,9 +186,9 @@ where
 
     pub async fn downgrade_since(
         &mut self,
-        reader_id: &ReaderId,
+        reader_id: &SinceHandleId,
         new_since: &Antichain<T>,
-    ) -> (SeqNo, Result<Since<T>, Option<ReaderId>>) {
+    ) -> (SeqNo, Result<Since<T>, Option<SinceHandleId>>) {
         let metrics = Arc::clone(&self.metrics);
         let res = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.downgrade_since, |_, state| {

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -106,8 +106,13 @@ where
         (shard_upper, read_cap)
     }
 
-    /// Opens a new `SinceHandle` for this shard and fences off any previously
-    /// open handles, if any.
+    /// Opens a new `SinceHandle` for this shard and fences off previously open
+    /// handles, if any.
+    // TODO(aljoscha): This currently mints a fresh random ID as the fencing
+    // token. We should change this to be an explicit fencing token if/when
+    // storage controller is ready for that and wants it. Also, those fencing
+    // tokens should probably be EPOCHs with ordering semantics and we don't
+    // want to allow an "older" EPOCH to fence of a "younger" one.
     pub async fn open_since_handle(&mut self, since_handle_id: &SinceHandleId) -> Since<T> {
         let metrics = Arc::clone(&self.metrics);
         let (_seqno, since) = self

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -30,7 +30,7 @@ use crate::error::InvalidUsage;
 use crate::r#impl::metrics::{
     CmdMetrics, Metrics, MetricsRetryStream, RetriesMetrics, RetryMetrics,
 };
-use crate::r#impl::state::{HollowBatch, ReadCapability, Since, State, StateCollections, Upper};
+use crate::r#impl::state::{HollowBatch, SeqNoCapability, Since, State, StateCollections, Upper};
 use crate::r#impl::trace::{FueledMergeReq, FueledMergeRes};
 use crate::read::ReaderId;
 use crate::ShardId;
@@ -95,7 +95,7 @@ where
         self.state.upper()
     }
 
-    pub async fn register(&mut self, reader_id: &ReaderId) -> (Upper<T>, ReadCapability<T>) {
+    pub async fn register(&mut self, reader_id: &ReaderId) -> (Upper<T>, SeqNoCapability) {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, (shard_upper, read_cap)) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.register, |seqno, state| {
@@ -118,7 +118,7 @@ where
         since
     }
 
-    pub async fn clone_reader(&mut self, new_reader_id: &ReaderId) -> ReadCapability<T> {
+    pub async fn clone_reader(&mut self, new_reader_id: &ReaderId) -> SeqNoCapability {
         let metrics = Arc::clone(&self.metrics);
         let (seqno, read_cap) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.clone_reader, |seqno, state| {

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -157,8 +157,6 @@ where
         }
     }
 
-    // WIP: Do we still need this? When will we have use for the `SeqNo` that we
-    // hold in read capabilities?
     pub fn expire_reader(&mut self, reader_id: &ReaderId) -> ControlFlow<Infallible, bool> {
         let existed = self.readers.remove(reader_id).is_some();
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -370,10 +370,11 @@ impl PersistClient {
     /// since handle for this shard. This will prevent `SinceHandles` with a
     /// different id from calling [`SinceHandle::downgrade_since`], that is, we
     /// are fencing them off.
-    // WIP: When would we return InvalidUsage here?
-    // TODO: This currently mints a fresh random ID as the fencing token. We can
-    // change this to be an explicit fencing token if/when storage controller is
-    // ready for that and wants it.
+    // TODO(aljoscha): This currently mints a fresh random ID as the fencing
+    // token. We should change this to be an explicit fencing token if/when
+    // storage controller is ready for that and wants it. Also, those fencing
+    // tokens should probably be EPOCHs with ordering semantics and we don't
+    // want to allow an "older" EPOCH to fence of a "younger" one.
     #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
     pub async fn open_since_handle<K, V, T, D>(
         &self,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 use crate::error::InvalidUsage;
 use crate::r#impl::compact::Compactor;
 use crate::r#impl::machine::{retry_external, Machine};
-use crate::read::{ReadHandle, ReaderId, SinceHandleId};
+use crate::read::{ReadHandle, ReaderId, SinceHandle, SinceHandleId};
 use crate::write::WriteHandle;
 
 pub mod batch;
@@ -60,8 +60,6 @@ pub(crate) mod r#impl {
 // TODO: Remove this in favor of making it possible for all PersistClients to be
 // created by the PersistCache.
 pub use crate::r#impl::metrics::Metrics;
-
-use self::read::SinceHandle;
 
 /// A location in s3, other cloud storage, or otherwise "durable storage" used
 /// by persist.

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -347,8 +347,7 @@ impl PersistClient {
             )
         });
         let reader_id = ReaderId::new();
-        // WIP: We don't use the SeqNo that's now the only thing remaining in a
-        // ReadCapability.
+
         let (shard_upper, _read_cap) = machine.register(&reader_id).await;
         let writer = WriteHandle {
             cfg: self.cfg.clone(),

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -37,7 +37,7 @@ use uuid::Uuid;
 use crate::error::InvalidUsage;
 use crate::r#impl::compact::Compactor;
 use crate::r#impl::machine::{retry_external, Machine};
-use crate::read::{ReadHandle, ReaderId};
+use crate::read::{ReadHandle, ReaderId, SinceHandleId};
 use crate::write::WriteHandle;
 
 pub mod batch;
@@ -390,7 +390,7 @@ impl PersistClient {
     {
         trace!("Client::open_since_handle shard_id={:?}", shard_id);
 
-        let since_handle_id = ReaderId::new();
+        let since_handle_id = SinceHandleId::new();
 
         let mut machine = Machine::new(
             shard_id,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -505,7 +505,6 @@ where
         trace!("ReadHandle::clone");
         let new_reader_id = ReaderId::new();
         let mut machine = self.machine.clone();
-        // WIP: This is not used for anything right now.
         let _read_cap = machine.clone_reader(&self.reader_id).await;
         let new_reader = ReadHandle {
             metrics: Arc::clone(&self.metrics),
@@ -778,7 +777,6 @@ impl SinceHandleId {
 /// # };
 /// ```
 ///
-// WIP: Move to its own since_handle.rs?
 #[derive(Debug)]
 pub struct SinceHandle<K, V, T, D>
 where
@@ -790,7 +788,7 @@ where
 {
     #[allow(unused)]
     pub(crate) metrics: Arc<Metrics>,
-    // WIP: Introduce a `SinceHandleId`?
+
     pub(crate) since_handle_id: SinceHandleId,
     pub(crate) machine: Machine<K, V, T, D>,
 

--- a/src/storage/src/client.proto
+++ b/src/storage/src/client.proto
@@ -35,6 +35,7 @@ message ProtoIngestSourceCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     sources.ProtoIngestionDescription description = 2;
     mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
+    mz_persist.gen.persist.ProtoU64Antichain dependency_since = 4;
 }
 
 message ProtoIngestSources {

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -128,6 +128,7 @@ pub fn build_storage_dataflow<A: Allocate>(
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<mz_repr::Timestamp>,
+    dependency_since: Antichain<mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();
@@ -146,6 +147,7 @@ pub fn build_storage_dataflow<A: Allocate>(
                 id,
                 description.clone(),
                 resume_upper,
+                dependency_since,
                 // NOTE: For now sources never have LinearOperators but might have in the future
                 None,
                 storage_state,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -134,7 +134,7 @@ where
 
     let source_name = format!("{}-{}", connection.name(), id);
     let base_source_config = RawSourceCreationConfig {
-        name: source_name,
+        name: source_name.clone(),
         upstream_name: connection.upstream_name().map(ToOwned::to_owned),
         id,
         scope,
@@ -323,6 +323,7 @@ where
                             let (tx_source_ok_stream, tx_source_err_stream, tx_token) =
                                 persist_source::persist_source(
                                     scope,
+                                    format!("debezium_tx-{}", source_name),
                                     persist_clients,
                                     tx_storage_metadata,
                                     as_of,

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -76,7 +76,7 @@ where
             return;
         }
 
-        let mut read = persist_clients
+        let read = persist_clients
             .lock()
             .await
             .open(metadata.persist_location)
@@ -85,9 +85,6 @@ where
             .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(metadata.data_shard)
             .await
             .expect("could not open persist shard");
-
-        /// Aggressively downgrade `since`, to not hold back compaction.
-        read.downgrade_since(as_of.clone()).await;
 
         let mut snapshot_iter = read
             .snapshot(as_of.clone())

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -126,6 +126,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         ingestion.id,
                         ingestion.description,
                         ingestion.resume_upper,
+                        ingestion.dependency_since,
                     );
 
                     self.storage_state.reported_frontiers.insert(


### PR DESCRIPTION
The `SinceHandle` allows one holder to downgrade the since of a shard.
When creating a new `SinceHandle`, older `SinceHandles` are fenced off,
meaning they cannot downgrade the since anymore. This should be used by
the storage controller, and the fencing ensures that only one controller
can be active at a given time.

TODO: Right now, we mint a new random ID when creating a new `SinceHandle`. We should instead thread through an explicit fencing ID/leader epoch through to this call.

### Tips for reviewer

Pushing this our early so we can get a feel for the changed ergonomics. The thing that might feel surprising is that `ReadHandle` doesn't have a `since()` anymore. But that's exactly the point! The `ReadHandle` doesn't hold back the since anymore, so it cannot report a non-outdated since.

And we should think about where we actually need the `ReadCapability`, specifically the `SeqNo` contained in it. Likely for compaction, but I'm not sure anymore.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.