### PR TITLE
coord: Remove extra condition from group commit

### DIFF
--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -1228,7 +1228,6 @@ impl<S: Append + 'static> Coordinator<S> {
             .pending_writes
             .iter()
             .any(|pending_write| pending_write.has_write_lock())
-            || self.write_lock.try_lock().is_ok()
         {
             // If some transaction already holds the write lock, then we can execute a group
             // commit.


### PR DESCRIPTION
Previously, there were two places where the Coordinator tried to
acquire the global write lock for group commit. This commit reduces
that so there's only a single place where the Coordinator tries to
acquire the global write lock.

### Motivation
This PR refactors existing code.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
