### PR TITLE
syncify GenericClient::send

### DIFF
--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -375,7 +375,7 @@ where
             self.compute_orchestrator
                 .drop_service(&format!("cluster-{instance}"))
                 .await?;
-            compute.client.send(ComputeCommand::DropInstance).await?;
+            compute.client.send(ComputeCommand::DropInstance)?;
         }
         Ok(())
     }

--- a/src/dataflow-types/src/client/controller/compute.rs
+++ b/src/dataflow-types/src/client/controller/compute.rs
@@ -162,12 +162,10 @@ where
             }
         }
         let mut client = crate::client::replicated::ActiveReplication::default();
-        client
-            .send(ComputeCommand::CreateInstance(InstanceConfig {
-                replica_id: Default::default(),
-                logging: logging.clone(),
-            }))
-            .await?;
+        client.send(ComputeCommand::CreateInstance(InstanceConfig {
+            replica_id: Default::default(),
+            logging: logging.clone(),
+        }))?;
 
         Ok(Self {
             client,
@@ -402,7 +400,6 @@ where
         self.compute
             .client
             .send(ComputeCommand::CreateDataflows(augmented_dataflows))
-            .await
             .expect("Compute command failed; unrecoverable");
 
         Ok(())
@@ -469,7 +466,6 @@ where
                 // tree to forward it on to the compute worker.
                 otel_ctx: OpenTelemetryContext::obtain(),
             }))
-            .await
             .map_err(ComputeError::from)
     }
 
@@ -491,7 +487,6 @@ where
             .send(ComputeCommand::CancelPeeks {
                 uuids: uuids.clone(),
             })
-            .await
             .map_err(ComputeError::from)
     }
 
@@ -692,7 +687,6 @@ where
             self.compute
                 .client
                 .send(ComputeCommand::AllowCompaction(compaction_commands))
-                .await
                 .expect("Compute instance command failed; unrecoverable");
         }
 

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -524,7 +524,6 @@ where
 
             client
                 .send(StorageCommand::CreateSources(vec![augmented_ingestion]))
-                .await
                 .expect("Storage command failed; unrecoverable");
 
             self.state.clients.insert(source.ingestion.id, client);
@@ -741,12 +740,10 @@ where
 
         for (id, frontier) in compaction_commands {
             if let Some(client) = self.state.clients.get_mut(&id) {
-                client
-                    .send(StorageCommand::AllowCompaction(vec![(
-                        id,
-                        frontier.clone(),
-                    )]))
-                    .await?;
+                client.send(StorageCommand::AllowCompaction(vec![(
+                    id,
+                    frontier.clone(),
+                )]))?;
 
                 if frontier.is_empty() {
                     self.state.clients.remove(&id);

--- a/src/dataflow-types/src/client/partitioned.rs
+++ b/src/dataflow-types/src/client/partitioned.rs
@@ -133,13 +133,13 @@ where
     C: fmt::Debug + Send,
     R: fmt::Debug + Send,
 {
-    async fn send(&mut self, cmd: C) -> Result<(), anyhow::Error> {
+    fn send(&mut self, cmd: C) -> Result<(), anyhow::Error> {
         if self.reconnect.is_some() {
             anyhow::bail!("client is reconnecting");
         }
         let cmd_parts = self.state.split_command(cmd);
         for (shard, cmd_part) in self.parts.iter_mut().zip(cmd_parts) {
-            shard.send(cmd_part).await?;
+            shard.send(cmd_part)?;
         }
         Ok(())
     }

--- a/src/dataflow-types/src/client/replicated.rs
+++ b/src/dataflow-types/src/client/replicated.rs
@@ -68,7 +68,7 @@ pub fn spawn_client_task<
                         Some(c) => {
                             // Issues should be detected, and
                             // reconnect attempted, on the `client.recv` path.
-                            let _ = client.send(c).await;
+                            let _ = client.send(c);
                         },
                         None => break,
                     }
@@ -210,7 +210,7 @@ where
     ///
     /// If this function every become blocking (e.g. making networking calls),
     /// the ADAPTER must amend its contract with COMPUTE.
-    async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+    fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         // Update our tracking of peek commands.
         match &cmd {
             ComputeCommand::Peek(Peek { uuid, otel_ctx, .. }) => {

--- a/src/dataflow-types/src/reconciliation/command.rs
+++ b/src/dataflow-types/src/reconciliation/command.rs
@@ -65,8 +65,8 @@ where
     C: ComputeClient<T>,
     T: timely::progress::Timestamp + Copy,
 {
-    async fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
-        self.absorb_command(cmd).await
+    fn send(&mut self, cmd: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+        self.absorb_command(cmd)
     }
 
     async fn recv(&mut self) -> Result<Option<ComputeResponse<T>>, anyhow::Error> {
@@ -161,7 +161,7 @@ where
         }
     }
 
-    async fn absorb_command(&mut self, command: ComputeCommand<T>) -> Result<(), anyhow::Error> {
+    fn absorb_command(&mut self, command: ComputeCommand<T>) -> Result<(), anyhow::Error> {
         use ComputeCommand::*;
         match command {
             CreateInstance(config) => {
@@ -175,7 +175,7 @@ where
                             }
                         }
                     }
-                    self.client.send(CreateInstance(config)).await?;
+                    self.client.send(CreateInstance(config))?;
                     self.created = true;
                 }
                 Ok(())
@@ -184,7 +184,7 @@ where
                 if self.created {
                     self.created = false;
                     self.uppers.clear();
-                    self.client.send(cmd).await
+                    self.client.send(cmd)
                 } else {
                     Ok(())
                 }
@@ -210,7 +210,7 @@ where
                     }
                 }
                 if !create.is_empty() {
-                    self.client.send(CreateDataflows(create)).await?
+                    self.client.send(CreateDataflows(create))?
                 }
                 Ok(())
             }
@@ -220,17 +220,17 @@ where
                         self.stop_tracking(*id);
                     }
                 }
-                self.client.send(AllowCompaction(frontiers)).await
+                self.client.send(AllowCompaction(frontiers))
             }
             Peek(peek) => {
                 self.peeks.insert(peek.uuid);
-                self.client.send(ComputeCommand::Peek(peek)).await
+                self.client.send(ComputeCommand::Peek(peek))
             }
             CancelPeeks { uuids } => {
                 for uuid in &uuids {
                     self.peeks.remove(uuid);
                 }
-                self.client.send(CancelPeeks { uuids }).await
+                self.client.send(CancelPeeks { uuids })
             }
         }
     }


### PR DESCRIPTION
Make `GenericClient::send` a normal function, rather than an `async` one.

### Motivation

I don't think this needs to be `async` anymore, and having it be so is actively confusing (at least to me).

### Tips for reviewer

Please let me know if I'm missing some hidden reason for the asyncness.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

If it compiles, it should work

### Release notes

None
