### PR TITLE
proto: split common proto stuff into a new crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3071,6 +3071,7 @@ dependencies = [
  "mz-pgcopy",
  "mz-pgrepr",
  "mz-postgres-util",
+ "mz-proto",
  "mz-repr",
  "mz-secrets",
  "mz-sql",
@@ -3137,6 +3138,7 @@ dependencies = [
  "mz-persist-client",
  "mz-persist-types",
  "mz-postgres-util",
+ "mz-proto",
  "mz-repr",
  "mz-secrets",
  "mz-sql-parser",
@@ -3274,6 +3276,7 @@ dependencies = [
  "mz-ore",
  "mz-persist-types",
  "mz-pgrepr",
+ "mz-proto",
  "mz-repr",
  "num",
  "num_enum",
@@ -3378,7 +3381,7 @@ dependencies = [
  "mz-avro",
  "mz-ccsr",
  "mz-ore",
- "mz-repr",
+ "mz-proto",
  "num_cpus",
  "proptest",
  "proptest-derive",
@@ -3641,6 +3644,7 @@ dependencies = [
  "mz-ore",
  "mz-persist",
  "mz-persist-types",
+ "mz-proto",
  "num_cpus",
  "num_enum",
  "prometheus",
@@ -3743,11 +3747,10 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "mz-ore",
- "mz-repr",
+ "mz-proto",
  "openssl",
  "postgres-openssl",
  "proptest",
- "proptest-derive",
  "prost",
  "serde",
  "tokio-postgres",
@@ -3780,6 +3783,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mz-proto"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "globset",
+ "http",
+ "mz-ore",
+ "proptest",
+ "prost",
+ "prost-build",
+ "regex",
+ "serde_json",
+ "url",
+ "uuid 1.1.2",
+]
+
+[[package]]
 name = "mz-repr"
 version = "0.0.0"
 dependencies = [
@@ -3797,8 +3817,8 @@ dependencies = [
  "itertools",
  "mz-lowertest",
  "mz-ore",
- "mz-persist-client",
  "mz-persist-types",
+ "mz-proto",
  "num-traits",
  "num_enum",
  "once_cell",
@@ -3905,6 +3925,7 @@ dependencies = [
  "mz-pgcopy",
  "mz-pgrepr",
  "mz-postgres-util",
+ "mz-proto",
  "mz-repr",
  "mz-secrets",
  "mz-sql-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "src/pid-file",
     "src/postgres-util",
     "src/prof",
+    "src/proto",
     "src/repr-test-util",
     "src/repr",
     "src/s3-datagen",

--- a/doc/developer/command-and-response-binary-encoding.md
+++ b/doc/developer/command-and-response-binary-encoding.md
@@ -270,7 +270,7 @@ use proptest_derive::Arbitrary;
 
 use mz_repr::adt::char::CharLength;
 use mz_repr::chrono::any_naive_date;
-use mz_repr::proto::*;
+use mz_proto::*;
 
 // `$T` is a struct
 #[derive(Arbitrary, Debug, PartialEq, Eq)]
@@ -330,7 +330,7 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
 
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     // snip
 

--- a/src/coord/Cargo.toml
+++ b/src/coord/Cargo.toml
@@ -29,6 +29,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
+mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets"}
 mz-sql = { path = "../sql" }

--- a/src/coord/src/catalog/storage.rs
+++ b/src/coord/src/catalog/storage.rs
@@ -14,7 +14,7 @@ use std::iter::once;
 use bytes::BufMut;
 use futures::future::BoxFuture;
 use itertools::max;
-use mz_repr::proto::{IntoRustIfSome, RustType};
+use mz_proto::{IntoRustIfSome, RustType};
 use prost::{self, Message};
 use uuid::Uuid;
 

--- a/src/dataflow-types/Cargo.toml
+++ b/src/dataflow-types/Cargo.toml
@@ -35,6 +35,7 @@ mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-postgres-util = { path = "../postgres-util" }
+mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }

--- a/src/dataflow-types/build.rs
+++ b/src/dataflow-types/build.rs
@@ -20,7 +20,7 @@ fn main() {
         .extern_path(".mz_repr.adt.regex", "::mz_repr::adt::regex")
         .extern_path(".mz_repr.chrono", "::mz_repr::chrono")
         .extern_path(".mz_repr.global_id", "::mz_repr::global_id")
-        .extern_path(".mz_repr.proto", "::mz_repr::proto")
+        .extern_path(".mz_proto", "::mz_proto")
         .extern_path(".mz_repr.relation_and_scalar", "::mz_repr")
         .extern_path(".mz_repr.row", "::mz_repr")
         .extern_path(".mz_repr.url", "::mz_repr::url")

--- a/src/dataflow-types/src/client.proto
+++ b/src/dataflow-types/src/client.proto
@@ -17,7 +17,7 @@ import "expr/src/relation.proto";
 import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
-import "repr/src/proto.proto";
+import "proto/src/proto.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -71,7 +71,7 @@ message ProtoInstanceConfig {
 message ProtoPeek {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_repr.row.ProtoRow key = 2;
-    mz_repr.proto.ProtoU128 uuid = 3;
+    mz_proto.ProtoU128 uuid = 3;
     uint64 timestamp = 4;
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
@@ -85,7 +85,7 @@ message ProtoComputeCommand {
     }
 
     message ProtoCancelPeeks {
-        repeated mz_repr.proto.ProtoU128 uuids = 1;
+        repeated mz_proto.ProtoU128 uuids = 1;
     }
 
     oneof kind {
@@ -100,7 +100,7 @@ message ProtoComputeCommand {
 
 message ProtoComputeResponse {
     message ProtoPeekResponseKind {
-        mz_repr.proto.ProtoU128 id = 1;
+        mz_proto.ProtoU128 id = 1;
         mz_dataflow_types.types.ProtoPeekResponse resp = 2;
     map<string, string> otel_ctx = 3;
     }
@@ -127,7 +127,7 @@ message ProtoStorageCommand {
 message ProtoStorageResponse {
     message ProtoLinearizedTimestampBindingFeedback {
         uint64 timestamp = 1;
-        mz_repr.proto.ProtoU128 peek_id = 3;
+        mz_proto.ProtoU128 peek_id = 3;
     }
     oneof kind {
         ProtoFrontierUppersKind frontier_uppers = 1;

--- a/src/dataflow-types/src/client.rs
+++ b/src/dataflow-types/src/client.rs
@@ -35,8 +35,8 @@ use uuid::Uuid;
 
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
-use mz_repr::proto::any_uuid;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::any_uuid;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, Row};
 
 use crate::logging::LoggingConfig;
@@ -1150,8 +1150,8 @@ pub mod process_local {
 
 /// A client to a remote dataflow server.
 pub mod grpc {
-    use mz_repr::proto::ProtoType;
-    use mz_repr::proto::RustType;
+    use mz_proto::ProtoType;
+    use mz_proto::RustType;
     use std::cmp;
     use std::fmt;
     use std::net::ToSocketAddrs;
@@ -1741,7 +1741,7 @@ pub mod grpc {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]

--- a/src/dataflow-types/src/client/controller.rs
+++ b/src/dataflow-types/src/client/controller.rs
@@ -47,7 +47,7 @@ use mz_orchestrator::{
 };
 use mz_persist_client::PersistLocation;
 use mz_persist_types::Codec64;
-use mz_repr::proto::RustType;
+use mz_proto::RustType;
 
 use crate::client::{
     ComputeClient, ComputeCommand, ComputeInstanceId, ComputeResponse,

--- a/src/dataflow-types/src/client/controller/storage.rs
+++ b/src/dataflow-types/src/client/controller/storage.rs
@@ -49,7 +49,7 @@ use mz_persist_client::{
     read::ReadHandle, write::WriteHandle, PersistClient, PersistLocation, ShardId,
 };
 use mz_persist_types::{Codec, Codec64};
-use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, RelationDesc};
 use mz_stash::{self, StashError, TypedCollection};
 

--- a/src/dataflow-types/src/errors.rs
+++ b/src/dataflow-types/src/errors.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_expr::EvalError;
 use mz_persist_types::Codec;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::GlobalId;
 
 include!(concat!(env!("OUT_DIR"), "/mz_dataflow_types.errors.rs"));

--- a/src/dataflow-types/src/logging.proto
+++ b/src/dataflow-types/src/logging.proto
@@ -11,7 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 import "repr/src/global_id.proto";
-import "repr/src/proto.proto";
+import "proto/src/proto.proto";
 
 package mz_dataflow_types.logging;
 
@@ -60,7 +60,7 @@ message ProtoLogVariant {
 }
 
 message ProtoLoggingConfig {
-    mz_repr.proto.ProtoU128 granularity_ns = 1;
+    mz_proto.ProtoU128 granularity_ns = 1;
     repeated ProtoActiveLog active_logs = 2;
     bool log_logging = 3;
 }

--- a/src/dataflow-types/src/logging.rs
+++ b/src/dataflow-types/src/logging.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-use mz_repr::proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
 
 include!(concat!(env!("OUT_DIR"), "/mz_dataflow_types.logging.rs"));
@@ -388,7 +388,7 @@ impl LogVariant {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/dataflow-types/src/plan/join/delta_join.rs
+++ b/src/dataflow-types/src/plan/join/delta_join.rs
@@ -27,7 +27,7 @@ use mz_expr::permutation_for_arrangement;
 use mz_expr::JoinInputMapper;
 use mz_expr::MapFilterProject;
 use mz_expr::MirScalarExpr;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/src/dataflow-types/src/plan/join/linear_join.rs
+++ b/src/dataflow-types/src/plan/join/linear_join.rs
@@ -19,7 +19,7 @@ use mz_expr::MapFilterProject;
 use mz_expr::join_permutations;
 use mz_expr::permutation_for_arrangement;
 use mz_expr::MirScalarExpr;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::*;
 use proptest::result::Probability;
 use proptest_derive::Arbitrary;

--- a/src/dataflow-types/src/plan/join/mod.rs
+++ b/src/dataflow-types/src/plan/join/mod.rs
@@ -40,7 +40,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use mz_expr::{MapFilterProject, MirScalarExpr};
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Row, RowArena};
 
 pub use delta_join::DeltaJoinPlan;
@@ -409,7 +409,7 @@ impl JoinBuildState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]

--- a/src/dataflow-types/src/plan/mod.rs
+++ b/src/dataflow-types/src/plan/mod.rs
@@ -28,7 +28,7 @@ use mz_expr::{
     MapFilterProject, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, TableFunc,
 };
 use mz_ore::soft_panic_or_log;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Diff, GlobalId, Row};
 
 use self::join::{DeltaJoinPlan, JoinPlan, LinearJoinPlan};
@@ -1766,7 +1766,7 @@ pub fn linear_to_mfp(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(10))]

--- a/src/dataflow-types/src/plan/reduce.rs
+++ b/src/dataflow-types/src/plan/reduce.rs
@@ -68,7 +68,7 @@ use mz_expr::AggregateExpr;
 use mz_expr::AggregateFunc;
 use mz_expr::MirScalarExpr;
 use mz_ore::soft_assert_or_log;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use proptest::prelude::{any, Arbitrary, BoxedStrategy};
 use proptest::strategy::Strategy;
 use proptest_derive::Arbitrary;
@@ -880,7 +880,7 @@ fn reduction_type(func: &AggregateFunc) -> ReductionType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     // This test causes stack overflows if not run with --release,

--- a/src/dataflow-types/src/plan/threshold.rs
+++ b/src/dataflow-types/src/plan/threshold.rs
@@ -33,7 +33,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
-use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 use super::AvailableCollections;
 
@@ -182,7 +182,7 @@ impl ThresholdPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/dataflow-types/src/plan/top_k.rs
+++ b/src/dataflow-types/src/plan/top_k.rs
@@ -23,7 +23,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use mz_expr::ColumnOrder;
-use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_dataflow_types.plan.top_k.rs"));
 
@@ -231,7 +231,7 @@ impl RustType<ProtoBasicTopKPlan> for BasicTopKPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/dataflow-types/src/types.proto
+++ b/src/dataflow-types/src/types.proto
@@ -18,7 +18,7 @@ import "dataflow-types/src/types/sources.proto";
 import "expr/src/scalar.proto";
 import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
-import "repr/src/proto.proto";
+import "proto/src/proto.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 
@@ -51,7 +51,7 @@ message ProtoDataflowDescription {
     repeated ProtoSinkExport sink_exports = 5;
     optional mz_persist.gen.persist.ProtoU64Antichain as_of = 6;
     string debug_name = 7;
-    mz_repr.proto.ProtoU128 id = 8;
+    mz_proto.ProtoU128 id = 8;
 }
 
 message ProtoIndexDesc {

--- a/src/dataflow-types/src/types.rs
+++ b/src/dataflow-types/src/types.rs
@@ -26,8 +26,8 @@ use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 
 use mz_expr::{CollectionPlan, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
-use mz_repr::proto::any_uuid;
-use mz_repr::proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
+use mz_proto::any_uuid;
+use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, RelationType, Row};
 
 use crate::client::controller::storage::CollectionMetadata;
@@ -891,7 +891,7 @@ pub trait PopulateClientConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/dataflow-types/src/types/connections.rs
+++ b/src/dataflow-types/src/types/connections.rs
@@ -21,7 +21,7 @@ use url::Url;
 
 use mz_ccsr::tls::{Certificate, Identity};
 use mz_kafka_util::KafkaAddrs;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::any_url;
 use mz_repr::GlobalId;
 use mz_secrets::{SecretsReader, SecretsReaderConfig};

--- a/src/dataflow-types/src/types/connections/aws.rs
+++ b/src/dataflow-types/src/types/connections/aws.rs
@@ -14,7 +14,7 @@ use proptest::prelude::{Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::URL_PATTERN;
 use mz_repr::GlobalId;
 

--- a/src/dataflow-types/src/types/sinks.rs
+++ b/src/dataflow-types/src/types/sinks.rs
@@ -17,7 +17,7 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc};
 
 use crate::client::controller::storage::CollectionMetadata;

--- a/src/dataflow-types/src/types/sources.proto
+++ b/src/dataflow-types/src/types/sources.proto
@@ -13,7 +13,7 @@ import "google/protobuf/empty.proto";
 
 import "repr/src/chrono.proto";
 import "repr/src/global_id.proto";
-import "repr/src/proto.proto";
+import "proto/src/proto.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
 import "persist/src/persist.proto";
@@ -165,7 +165,7 @@ message ProtoKafkaSourceConnection {
     string topic = 2;
     map<int32, ProtoMzOffset> start_offsets = 3;
     optional string group_id_prefix = 4;
-    mz_repr.proto.ProtoU128 cluster_id = 5;
+    mz_proto.ProtoU128 cluster_id = 5;
     ProtoIncludedColumnPos include_timestamp = 6;
     ProtoIncludedColumnPos include_partition = 7;
     ProtoIncludedColumnPos include_topic = 8;
@@ -179,7 +179,7 @@ message ProtoSourceDesc {
     mz_dataflow_types.types.sources.encoding.ProtoSourceDataEncoding encoding = 2;
     ProtoSourceEnvelope envelope = 3;
     repeated ProtoIncludedColumnSource metadata_columns = 4;
-    mz_repr.proto.ProtoDuration ts_frequency = 5;
+    mz_proto.ProtoDuration ts_frequency = 5;
 }
 
 message ProtoSourceConnection {

--- a/src/dataflow-types/src/types/sources.rs
+++ b/src/dataflow-types/src/types/sources.rs
@@ -27,9 +27,9 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_persist_types::Codec;
+use mz_proto::{any_uuid, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType};
 use mz_repr::chrono::any_naive_datetime;
-use mz_repr::proto::{any_uuid, TryFromProtoError};
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType};
 use mz_repr::{ColumnType, GlobalId, RelationDesc, RelationType, Row, ScalarType};
 
 pub mod encoding;

--- a/src/dataflow-types/src/types/sources/encoding.rs
+++ b/src/dataflow-types/src/types/sources/encoding.rs
@@ -15,8 +15,8 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use mz_interchange::{avro, protobuf};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::regex::any_regex;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{ColumnType, RelationDesc, ScalarType};
 
 use crate::connections::CsrConnection;

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -31,6 +31,7 @@ mz-ore = { path = "../ore" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
 mz-persist-types = { path = "../persist-types" }
+mz-proto = { path = "../proto" }
 num = "0.4.0"
 num_enum = "0.5.7"
 ordered-float = { version = "3.0.0", features = ["serde"] }

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -17,7 +17,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
-use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::GlobalId;
 
 include!(concat!(env!("OUT_DIR"), "/mz_expr.id.rs"));
@@ -215,7 +215,7 @@ impl mz_persist_types::Codec for PartitionId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use proptest::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, Row};
 
 use self::proto_map_filter_project::ProtoPredicate;
@@ -1311,8 +1311,8 @@ pub mod plan {
     use proptest_derive::Arbitrary;
     use serde::{Deserialize, Serialize};
 
+    use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
     use mz_repr::adt::numeric::Numeric;
-    use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
     use mz_repr::{Datum, Diff, Row, RowArena, ScalarType};
 
     use crate::{
@@ -1777,7 +1777,7 @@ pub mod plan {
 mod tests {
     use super::plan::*;
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -15,7 +15,7 @@ use std::iter;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use dec::OrderedDecimal;
 use itertools::Itertools;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use num::{CheckedAdd, Integer, Signed};
 use ordered_float::OrderedFloat;
 use proptest::prelude::{Arbitrary, Just};
@@ -2296,7 +2296,7 @@ impl fmt::Display for TableFunc {
 #[cfg(test)]
 mod tests {
     use super::{AggregateFunc, ProtoAggregateFunc, ProtoTableFunc, TableFunc};
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -22,8 +22,8 @@ use mz_lowertest::MzReflect;
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::IdGen;
 use mz_ore::stack::RecursionLimitError;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::numeric::NumericMaxScale;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, RelationType, Row, ScalarType};
 
 use self::func::{AggregateFunc, LagLeadType, TableFunc};
@@ -2320,7 +2320,7 @@ impl RustType<proto_window_frame::ProtoWindowFrameBound> for WindowFrameBound {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -33,6 +33,7 @@ use mz_ore::cast;
 use mz_ore::fmt::FormatBuffer;
 use mz_ore::option::OptionExt;
 use mz_pgrepr::Type;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::datetime::Timezone;
 use mz_repr::adt::interval::Interval;
@@ -40,7 +41,6 @@ use mz_repr::adt::jsonb::JsonbRef;
 use mz_repr::adt::numeric::{self, DecimalLike, Numeric, NumericMaxScale};
 use mz_repr::adt::regex::any_regex;
 use mz_repr::chrono::any_naive_datetime;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{strconv, ColumnName, ColumnType, Datum, DatumType, Row, RowArena, ScalarType};
 
 use crate::scalar::func::format::DateTimeFormat;
@@ -5813,7 +5813,7 @@ mod test {
     use chrono::prelude::*;
     use proptest::prelude::*;
 
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     use super::*;
 

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::scalar::EvalError;
 use mz_lowertest::MzReflect;
 use mz_ore::fmt::FormatBuffer;
-use mz_repr::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use proto_matcher_impl::ProtoSubpatternVec;
 
 include!(concat!(env!("OUT_DIR"), "/mz_expr.scalar.like_pattern.rs"));

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::mem;
 
-use mz_repr::proto::IntoRustIfSome;
+use mz_proto::IntoRustIfSome;
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -20,11 +20,11 @@ use mz_lowertest::MzReflect;
 use mz_ore::collections::CollectionExt;
 use mz_ore::str::separated;
 use mz_pgrepr::TypeFromOidError;
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::InvalidArrayError;
 use mz_repr::adt::datetime::DateTimeUnits;
 use mz_repr::adt::regex::Regex;
 use mz_repr::arb_datum;
-use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::strconv::{ParseError, ParseHexError};
 use mz_repr::{ColumnType, Datum, RelationType, Row, RowArena, ScalarType};
 
@@ -1981,7 +1981,7 @@ impl RustType<ProtoDims> for (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mz_repr::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     #[test]
     fn test_reduce() {

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -13,8 +13,8 @@ clap = { version = "3.2.6", features = ["derive"] }
 crossbeam = "0.8.1"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
-mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore", features = ["network"] }
+mz-proto = { path = "../proto" }
 num_cpus = "1.13.1"
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }

--- a/src/kafka-util/src/addr.rs
+++ b/src/kafka-util/src/addr.rs
@@ -15,7 +15,7 @@ use std::str::FromStr;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-use mz_repr::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_kafka_util.addr.rs"));
 

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -40,6 +40,7 @@ futures-util = "0.3"
 mz-ore = { path = "../ore" }
 mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
+mz-proto = { path = "../proto" }
 prometheus = { version = "0.13.1", default-features = false }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -9,11 +9,10 @@ publish = false
 [dependencies]
 anyhow = "1.0.58"
 mz-ore = { path = "../ore", features = ["task"] }
-mz-repr = { path = "../repr" }
+mz-proto = { path = "../proto" }
 openssl = { version = "0.10.40", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git"}
 prost = "0.10.3"
 serde = { version = "1.0.137", features = ["derive"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/postgres-util/src/desc.rs
+++ b/src/postgres-util/src/desc.rs
@@ -13,7 +13,7 @@ use proptest::prelude::{any, Arbitrary};
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
 
-use mz_repr::proto::{RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_postgres_util.desc.rs"));
 

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "mz-proto"
+description = "Protocol buffer libraries for Materialize."
+version = "0.0.0"
+license = "Apache-2.0"
+edition = "2021"
+rust-version = "1.61.0"
+publish = false
+
+[dependencies]
+anyhow = "1.0.58"
+globset = "0.4.9"
+http = "0.2.8"
+mz-ore = { path = "../ore", default-features = false }
+proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
+prost = "0.10.3"
+regex = "1.5.6"
+serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
+url = { version = "2.2.2", features = ["serde"] }
+uuid = "1.1.2"
+
+[build-dependencies]
+prost-build = { version = "0.10.3", features = ["vendored"] }

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -1,0 +1,14 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+fn main() {
+    prost_build::Config::new()
+        .compile_protos(&["proto/src/proto.proto"], &[".."])
+        .unwrap();
+}

--- a/src/proto/src/proto.proto
+++ b/src/proto/src/proto.proto
@@ -9,7 +9,7 @@
 
 syntax = "proto3";
 
-package mz_repr.proto;
+package mz_proto;
 
 message ProtoU128 {
     uint64 hi = 1;

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -29,8 +29,8 @@ itertools = "0.10.3"
 once_cell = "1.12.0"
 mz-lowertest = { path = "../lowertest" }
 mz-ore = { path = "../ore", features = ["bytes", "smallvec"] }
-mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
+mz-proto = { path = "../proto" }
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 ordered-float = { version = "3.0.0", features = ["serde"] }

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -13,7 +13,6 @@ fn main() {
             &[
                 "repr/src/chrono.proto",
                 "repr/src/global_id.proto",
-                "repr/src/proto.proto",
                 "repr/src/row.proto",
                 "repr/src/strconv.proto",
                 "repr/src/relation_and_scalar.proto",

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -18,8 +18,8 @@ use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
+use mz_proto::{RustType, TryFromProtoError};
 
-use crate::proto::{RustType, TryFromProtoError};
 use crate::row::DatumList;
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.array.rs"));
@@ -220,7 +220,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #[test]

--- a/src/repr/src/adt/char.rs
+++ b/src/repr/src/adt/char.rs
@@ -16,8 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
-
-use crate::proto::{RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.char.rs"));
 
@@ -188,7 +187,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #[test]

--- a/src/repr/src/adt/datetime.rs
+++ b/src/repr/src/adt/datetime.rs
@@ -18,13 +18,13 @@ use std::str::FromStr;
 
 use chrono::{FixedOffset, NaiveDate, NaiveTime};
 use chrono_tz::Tz;
+use mz_proto::{RustType, TryFromProtoError};
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
 use crate::adt::interval::Interval;
 use crate::chrono::{any_fixed_offset, any_timezone};
-use crate::proto::{RustType, TryFromProtoError};
 
 use mz_lowertest::MzReflect;
 
@@ -2187,7 +2187,7 @@ pub(crate) fn split_timestamp_string(value: &str) -> (&str, &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     #[test]
     fn iterate_datetimefield() {

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -13,13 +13,13 @@ use std::fmt::{self, Write};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
+use mz_proto::{RustType, TryFromProtoError};
 use num_traits::CheckedMul;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::adt::datetime::DateTimeField;
 use crate::adt::numeric::{DecimalLike, Numeric};
-use crate::proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.interval.rs"));
 

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -23,8 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_ore::cast;
-
-use crate::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.numeric.rs"));
 
@@ -743,7 +742,7 @@ impl DecimalLike for Numeric {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/repr/src/adt/regex.rs
+++ b/src/repr/src/adt/regex.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 
-use crate::proto::{RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.regex.rs"));
 
@@ -87,16 +87,6 @@ impl Deref for Regex {
     }
 }
 
-impl RustType<String> for regex::Regex {
-    fn into_proto(&self) -> String {
-        self.as_str().to_string()
-    }
-
-    fn from_proto(proto: String) -> Result<Self, TryFromProtoError> {
-        Ok(regex::Regex::new(&proto)?)
-    }
-}
-
 impl RustType<ProtoRegex> for Regex {
     fn into_proto(&self) -> ProtoRegex {
         ProtoRegex {
@@ -133,7 +123,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #[test]

--- a/src/repr/src/adt/varchar.rs
+++ b/src/repr/src/adt/varchar.rs
@@ -16,8 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
-
-use crate::proto::{RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.varchar.rs"));
 
@@ -128,7 +127,7 @@ pub fn format_str(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/repr/src/chrono.rs
+++ b/src/repr/src/chrono.rs
@@ -22,7 +22,7 @@ use chrono::{
 use chrono_tz::{Tz, TZ_VARIANTS};
 use proptest::prelude::Strategy;
 
-use crate::proto::{RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.chrono.rs"));
 
@@ -160,7 +160,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(4096))]

--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 
-use crate::proto::{ProtoType, RustType, TryFromProtoError};
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.global_id.rs"));
 

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -31,7 +31,6 @@ mod scalar;
 pub mod adt;
 pub mod chrono;
 pub mod global_id;
-pub mod proto;
 pub mod strconv;
 pub mod url;
 pub mod util;

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 
 use mz_lowertest::MzReflect;
 use mz_ore::str::StrExt;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 
-use crate::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use crate::{Datum, ScalarType};
 
 use crate::relation_and_scalar::proto_relation_type::ProtoKey;

--- a/src/repr/src/row/encoding.rs
+++ b/src/repr/src/row/encoding.rs
@@ -19,11 +19,11 @@ use uuid::Uuid;
 
 use mz_ore::cast::CastFrom;
 use mz_persist_types::Codec;
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
 
 use crate::adt::array::ArrayDimension;
 use crate::adt::numeric::Numeric;
 use crate::chrono::{ProtoNaiveDate, ProtoNaiveTime};
-use crate::proto::{ProtoType, RustType, TryFromProtoError};
 use crate::row::proto_datum::DatumType;
 use crate::row::{
     ProtoArray, ProtoArrayDimension, ProtoDatum, ProtoDatumOther, ProtoDict, ProtoDictElement,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -23,6 +23,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_lowertest::MzReflect;
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 
 use crate::adt::array::{Array, ArrayDimension};
 use crate::adt::char::{Char, CharLength};
@@ -31,7 +32,6 @@ use crate::adt::jsonb::{Jsonb, JsonbRef};
 use crate::adt::numeric::{Numeric, NumericMaxScale};
 use crate::adt::system::{Oid, PgLegacyChar, RegClass, RegProc, RegType};
 use crate::adt::varchar::{VarChar, VarCharMaxLength};
-use crate::proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use crate::GlobalId;
 use crate::{ColumnName, ColumnType, DatumList, DatumMap};
 use crate::{Row, RowArena};
@@ -2296,7 +2296,7 @@ fn verify_base_eq_record_nullability() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
        #[test]

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -47,13 +47,13 @@ use uuid::Uuid;
 use mz_ore::fmt::FormatBuffer;
 use mz_ore::lex::LexBuf;
 use mz_ore::str::StrExt;
+use mz_proto::{RustType, TryFromProtoError};
 
 use crate::adt::array::ArrayDimension;
 use crate::adt::datetime::{self, DateTimeField, ParsedDateTime};
 use crate::adt::interval::Interval;
 use crate::adt::jsonb::{Jsonb, JsonbRef};
 use crate::adt::numeric::{self, Numeric, NUMERIC_DATUM_MAX_PRECISION};
-use crate::proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.strconv.rs"));
 
@@ -1588,7 +1588,7 @@ impl RustType<ProtoParseHexError> for ParseHexError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
     use proptest::prelude::*;
 
     proptest! {

--- a/src/repr/src/url.rs
+++ b/src/repr/src/url.rs
@@ -12,7 +12,7 @@
 use proptest::prelude::Strategy;
 use url::Url;
 
-use crate::proto::{RustType, TryFromProtoError};
+use mz_proto::{RustType, TryFromProtoError};
 
 include!(concat!(env!("OUT_DIR"), "/mz_repr.url.rs"));
 
@@ -42,7 +42,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::proto::protobuf_roundtrip;
+    use mz_proto::protobuf_roundtrip;
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(4096))]

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -26,6 +26,7 @@ mz-ore = { path = "../ore", features = ["task"] }
 mz-pgcopy = { path = "../pgcopy" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-postgres-util = { path = "../postgres-util" }
+mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -51,8 +51,8 @@ use mz_interchange::avro::{self, AvroSchemaGenerator};
 use mz_ore::collections::CollectionExt;
 use mz_ore::str::StrExt;
 use mz_postgres_util::desc::PostgresTableDesc;
+use mz_proto::RustType;
 use mz_repr::adt::interval::Interval;
-use mz_repr::proto::RustType;
 use mz_repr::strconv;
 use mz_repr::{ColumnName, GlobalId, RelationDesc, RelationType, ScalarType};
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -30,7 +30,7 @@ use mz_ccsr::{Client, GetBySubjectError};
 use mz_dataflow_types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
 use mz_dataflow_types::connections::{Connection, ConnectionContext};
 use mz_dataflow_types::sources::PostgresSourceDetails;
-use mz_repr::proto::RustType;
+use mz_proto::RustType;
 use mz_repr::strconv;
 
 use crate::ast::{


### PR DESCRIPTION
This is mostly for dependency reasons. We want a RustType impl for
ShardId and for rust trait coherency it need to next to either RustType
or ShardId.

Persist doesn't want to depend on repr (a) for reasons of abstraction
purity and (b) for dependency reasons. It's also not great for repr to
depend on persist because then a small change to persist causes
./bin/environmentd to recompile quite of bit of the codebase (why I'm
doing this now).

Both of these are avoided by splitting proto out into a new
low-dependency crate. It also feels correct for the proto library code
to have its own crate.

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
