### PR TITLE
storage: rehydration initial implementation

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -500,12 +500,10 @@ where
                         self.stashed_response = Some(UnderlyingControllerResponse::Compute(instance, response));
                         return Ok(());
                     }
-                    response = self.storage_controller.recv() => {
-                        if let Some(response) = response? {
-                            assert!(self.stashed_response.is_none());
-                            self.stashed_response = Some(UnderlyingControllerResponse::Storage(response));
-                            return Ok(());
-                        }
+                    Some(response) = self.storage_controller.recv() => {
+                        assert!(self.stashed_response.is_none());
+                        self.stashed_response = Some(UnderlyingControllerResponse::Storage(response));
+                        return Ok(());
                     }
                 }
             }

--- a/src/storage/src/client/controller/hosts.rs
+++ b/src/storage/src/client/controller/hosts.rs
@@ -23,20 +23,18 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::Duration;
 
-use tokio::time;
+use timely::progress::Timestamp;
 use tracing::info;
 
 use mz_orchestrator::{NamespacedOrchestrator, ServiceConfig, ServicePort};
 use mz_ore::collections::CollectionExt;
 use mz_proto::RustType;
 use mz_repr::GlobalId;
-use mz_service::client::Reconnect;
 
+use crate::client::controller::rehydration::RehydratingStorageClient;
 use crate::client::{
-    ProtoStorageCommand, ProtoStorageResponse, StorageClient, StorageCommand, StorageGrpcClient,
-    StorageResponse,
+    ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageGrpcClient, StorageResponse,
 };
 
 /// The network address of a storage host.
@@ -70,7 +68,7 @@ pub struct StorageHosts<T> {
 #[derive(Debug)]
 struct StorageHost<T> {
     /// The client to the storage host.
-    client: Box<dyn StorageClient<T>>,
+    client: RehydratingStorageClient<T>,
     /// The IDs of the storage objects installed on the storage host.
     objects: HashSet<GlobalId>,
     /// Whether the storage host is orchestrated.
@@ -107,9 +105,9 @@ impl<T> StorageHosts<T> {
         &mut self,
         id: GlobalId,
         host_addr: Option<StorageHostAddr>,
-    ) -> Result<&mut dyn StorageClient<T>, anyhow::Error>
+    ) -> Result<&mut RehydratingStorageClient<T>, anyhow::Error>
     where
-        T: Send + Sync + 'static,
+        T: Timestamp,
         StorageCommand<T>: RustType<ProtoStorageCommand>,
         StorageResponse<T>: RustType<ProtoStorageResponse>,
     {
@@ -125,24 +123,14 @@ impl<T> StorageHosts<T> {
         info!("assigned storage object {id} to storage host {host_addr}");
         match self.hosts.entry(host_addr.clone()) {
             Entry::Vacant(entry) => {
-                // TODO: don't block waiting for a connection. Put a queue in the
-                // middle instead.
-                let client: Box<dyn StorageClient<T>> = Box::new({
-                    let mut client = StorageGrpcClient::new(host_addr.clone());
-                    while let Err(e) = client.reconnect().await {
-                        info!(
-                            "connecting to storage host {host_addr} failed (retrying in 1s): {e}"
-                        );
-                        time::sleep(Duration::from_secs(1)).await;
-                    }
-                    client
-                });
+                let client =
+                    RehydratingStorageClient::new(StorageGrpcClient::new(host_addr.clone()));
                 let host = entry.insert(StorageHost {
                     client,
                     objects: HashSet::from_iter([id]),
                     orchestrated,
                 });
-                Ok(&mut *host.client)
+                Ok(&mut host.client)
             }
             Entry::Occupied(entry) => {
                 let host = entry.into_mut();
@@ -151,7 +139,7 @@ impl<T> StorageHosts<T> {
                     inserted,
                     "StorageHosts internally inconsistent: ID {id} partially tracked"
                 );
-                Ok(&mut *host.client)
+                Ok(&mut host.client)
             }
         }
     }
@@ -192,20 +180,20 @@ impl<T> StorageHosts<T> {
 
     /// Retrives the client for the storage host for the given ID, if the
     /// ID is currently provisioned.
-    pub fn client(&mut self, id: GlobalId) -> Option<&mut dyn StorageClient<T>> {
+    pub fn client(&mut self, id: GlobalId) -> Option<&mut RehydratingStorageClient<T>> {
         let host_addr = self.objects.get(&id)?;
         match self.hosts.get_mut(host_addr) {
             None => panic!(
                 "StorageHosts internally inconsistent: \
                  ingestion {id} referenced missing storage host {host_addr:?}"
             ),
-            Some(host) => Some(&mut *host.client),
+            Some(host) => Some(&mut host.client),
         }
     }
 
     /// Returns an iterator over clients for all known storage hosts.
-    pub fn clients(&mut self) -> impl Iterator<Item = &mut (dyn StorageClient<T> + 'static)> {
-        self.hosts.values_mut().map(|h| &mut *h.client)
+    pub fn clients(&mut self) -> impl Iterator<Item = &mut RehydratingStorageClient<T>> {
+        self.hosts.values_mut().map(|h| &mut h.client)
     }
 
     /// Starts a orchestrated storage host for the specified ID.

--- a/src/storage/src/client/controller/rehydration.rs
+++ b/src/storage/src/client/controller/rehydration.rs
@@ -1,0 +1,213 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Rehydration of storage hosts.
+//!
+//! Rehydration is the process of bringing a crashed `storaged` process back
+//! up to date. The [`RehydratingStorageClient`] records all commands it
+//! observes in a minimal form. If it observes a send or receive failure while
+//! communicating with the underlying client, it will reconnect the client and
+//! replay the command stream.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use futures::{Stream, StreamExt};
+use timely::progress::Timestamp;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+use tokio::{pin, select};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tracing::warn;
+
+use mz_ore::retry::Retry;
+use mz_repr::GlobalId;
+use mz_service::client::Reconnect;
+
+use crate::client::{IngestSourceCommand, StorageClient, StorageCommand, StorageResponse};
+
+/// A storage client that replays the command stream on failure.
+///
+/// See the [module documentation](self) for details.
+#[derive(Debug)]
+pub struct RehydratingStorageClient<T> {
+    command_tx: UnboundedSender<StorageCommand<T>>,
+    response_rx: UnboundedReceiverStream<StorageResponse<T>>,
+}
+
+impl<T> RehydratingStorageClient<T>
+where
+    T: Timestamp,
+{
+    /// Creates a `RehydratingStorageClient` that wraps a reconnectable
+    /// [`StorageClient`].
+    pub fn new<C>(client: C) -> RehydratingStorageClient<T>
+    where
+        C: StorageClient<T> + Reconnect + 'static,
+    {
+        let (command_tx, command_rx) = unbounded_channel();
+        let (response_tx, response_rx) = unbounded_channel();
+        let mut task = RehydrationTask {
+            command_rx,
+            response_tx,
+            ingestions: BTreeMap::new(),
+            client,
+        };
+        mz_ore::task::spawn(|| "rehydration", async move { task.run().await });
+        RehydratingStorageClient {
+            command_tx,
+            response_rx: UnboundedReceiverStream::new(response_rx),
+        }
+    }
+
+    /// Sends a command to the underlying client.
+    pub fn send(&mut self, cmd: StorageCommand<T>) {
+        self.command_tx
+            .send(cmd)
+            .expect("rehydration task should not drop first");
+    }
+
+    /// Returns a stream that produces responses from the underlying client.
+    pub fn response_stream(&mut self) -> impl Stream<Item = StorageResponse<T>> + '_ {
+        &mut self.response_rx
+    }
+}
+
+/// A task that manages rehydration.
+struct RehydrationTask<C, T> {
+    /// A channel upon which commands intended for the storage host are delivered.
+    command_rx: UnboundedReceiver<StorageCommand<T>>,
+    /// A channel upon which responses from the storage host are delivered.
+    response_tx: UnboundedSender<StorageResponse<T>>,
+    /// The ingestions that have been observed.
+    ingestions: BTreeMap<GlobalId, IngestSourceCommand<T>>,
+    /// The underlying client that communicates with the storage host.
+    client: C,
+}
+
+enum RehydrationTaskState {
+    /// The storage host should be (re)hydrated.
+    Rehydrate,
+    /// Communication with the storage host is live. Commands and responses should
+    /// be forwarded until an error occurs.
+    Pump,
+    /// The caller has asked us to shut down communication with this storage
+    /// host.
+    Done,
+}
+
+impl<C, T> RehydrationTask<C, T>
+where
+    C: StorageClient<T> + Reconnect + 'static,
+    T: Timestamp,
+{
+    async fn run(&mut self) {
+        let mut state = RehydrationTaskState::Rehydrate;
+        loop {
+            state = match state {
+                RehydrationTaskState::Rehydrate => self.step_rehydrate().await,
+                RehydrationTaskState::Pump => self.step_pump().await,
+                RehydrationTaskState::Done => break,
+            }
+        }
+    }
+
+    async fn step_rehydrate(&mut self) -> RehydrationTaskState {
+        // Reconnect to the storage host.
+        let retry = Retry::default()
+            .clamp_backoff(Duration::from_secs(32))
+            .into_retry_stream();
+        pin!(retry);
+        loop {
+            match self.client.reconnect().await {
+                Ok(()) => break,
+                Err(e) => {
+                    warn!("error connecting to storage host, retrying: {e}");
+                    retry.next().await;
+                }
+            }
+        }
+
+        // Rehydrate all commands.
+        self.send_command(StorageCommand::IngestSources(
+            self.ingestions.values().cloned().collect(),
+        ))
+        .await
+    }
+
+    async fn step_pump(&mut self) -> RehydrationTaskState {
+        select! {
+            // Command from controller to forward to storage host.
+            command = self.command_rx.recv() => match command {
+                None => RehydrationTaskState::Done,
+                Some(command) => {
+                    self.absorb_command(&command);
+                    self.send_command(command).await
+                }
+            },
+            // Response from storage host to forward to controller.
+            response = self.client.recv() => {
+                let response = match response.transpose() {
+                    None => {
+                        // In the future, if a storage host politely hangs up,
+                        // we might want to take it as a signal that a new
+                        // controller has taken over. For now we just try to
+                        // reconnect.
+                        Err(anyhow!("storage host unexpectedly gracefully terminated connection"))
+                    }
+                    Some(response) => response,
+                };
+                self.send_response(response).await
+            }
+        }
+    }
+
+    async fn send_command(&mut self, command: StorageCommand<T>) -> RehydrationTaskState {
+        match self.client.send(command).await {
+            Ok(()) => RehydrationTaskState::Pump,
+            Err(e) => self.send_response(Err(e)).await,
+        }
+    }
+
+    async fn send_response(
+        &mut self,
+        response: Result<StorageResponse<T>, anyhow::Error>,
+    ) -> RehydrationTaskState {
+        match response {
+            Ok(response) => {
+                if self.response_tx.send(response).is_err() {
+                    RehydrationTaskState::Done
+                } else {
+                    RehydrationTaskState::Pump
+                }
+            }
+            Err(e) => {
+                warn!("storage host produced error, reconnecting: {e}");
+                RehydrationTaskState::Rehydrate
+            }
+        }
+    }
+
+    fn absorb_command(&mut self, command: &StorageCommand<T>) {
+        match command {
+            StorageCommand::IngestSources(ingestions) => {
+                for ingestion in ingestions {
+                    self.ingestions.insert(ingestion.id, ingestion.clone());
+                }
+            }
+            StorageCommand::AllowCompaction(frontiers) => {
+                for (id, frontier) in frontiers {
+                    if frontier.is_empty() {
+                        self.ingestions.remove(id);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -189,7 +189,15 @@ def test_remote_storaged(c: Composition, redpanda: bool) -> None:
         c.start_and_wait_for_tcp(
             services=dependencies,
         )
+
         c.run("testdrive", "storaged/01-create-sources.td")
+
         c.kill("materialized")
         c.up("materialized")
         c.run("testdrive", "storaged/02-after-environmentd-restart.td")
+
+        c.kill("storaged")
+        c.run("testdrive", "storaged/03-while-storaged-down.td")
+
+        c.up("storaged")
+        c.run("testdrive", "storaged/04-after-storaged-restart.td")

--- a/test/cluster/storaged/03-while-storaged-down.td
+++ b/test/cluster/storaged/03-while-storaged-down.td
@@ -7,18 +7,20 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Verify that the data ingested before `environmentd` was killed is still
-# present, then try ingesting more data.
+# Verify that the data ingested before `storaged` crashed is still present but
+# that newly ingested data does not appear.
 
 > SELECT * from remote1
-one  1
+one   1
+two   2
 > SELECT * from remote2
 one  1
+two  2
 
 $ kafka-ingest format=bytes topic=remote1
-two
+three
 $ kafka-ingest format=bytes topic=remote2
-two
+three
 
 > SELECT * from remote1
 one   1

--- a/test/cluster/storaged/04-after-storaged-restart.td
+++ b/test/cluster/storaged/04-after-storaged-restart.td
@@ -7,22 +7,30 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Verify that the data ingested before `environmentd` was killed is still
-# present, then try ingesting more data.
-
-> SELECT * from remote1
-one  1
-> SELECT * from remote2
-one  1
-
-$ kafka-ingest format=bytes topic=remote1
-two
-$ kafka-ingest format=bytes topic=remote2
-two
+# Verify that the data ingested while `storaged` was down eventually appears,
+# then try ingesting new data.
 
 > SELECT * from remote1
 one   1
 two   2
+three 3
 > SELECT * from remote2
-one  1
-two  2
+one   1
+two   2
+three 3
+
+$ kafka-ingest format=bytes topic=remote1
+four
+$ kafka-ingest format=bytes topic=remote2
+four
+
+> SELECT * from remote1
+one   1
+two   2
+three 3
+four  4
+> SELECT * from remote2
+one   1
+two   2
+three 3
+four  4


### PR DESCRIPTION
This branch implements a "first viable pass" at rehydration of storaged instances. The primary design is documented here: https://www.notion.so/materialize/Storage-reconciliation-eede18c75d9249fca2726acbb856ece7

Here are some important details about the implementation:
- The `ReconciledStoragedClient` offers a `mpsc::Sender<StoragedCommand>` + `impl Stream<Item = StorageResponse` interface, allowing safe selection. It does this by communicating with a tokio task that implements the main functionality
- `ReconciledStoragedClient` is not generic over `GenericClient<StorageCommand, StorageResponse>`. It accepts only a `StorageRemoteClient`, as it can semi-reasonably gaurantee that `StorageRemoteClient::recv` is cancel-safe. This should and likely will change to be a tokio-task of its own, connected with channels/streams in the future
- I am no expect of the `FrontierReconciliation` logic, which was factored out the compute reconciliation code. @antiguru will need to review this code closely, I expect
- The branch leaves one key piece of functionality missing: **reconnect+rehydrate on `send` errors**. This is primarily a control flow change, but does have some subtleties as it requires we handle `send` errors that happen WHEN already in the process of rehydration. This can be done in a followup pr.
- This branch does not implement anything necessary for `environmentd` restarting, only `storaged`

### Motivation
  * This PR adds a known-desirable feature.
https://github.com/MaterializeInc/materialize/issues/12857

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
