### PR TITLE
environmentd: implement dyanmic enabling of the otel collector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,12 +3331,14 @@ dependencies = [
 name = "mz-http-util"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "askama",
  "axum",
  "headers",
  "include_dir",
  "mz-ore",
  "prometheus",
+ "serde",
 ]
 
 [[package]]

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -118,7 +118,7 @@ fn create_communication_config(args: &Args) -> Result<CommunicationConfig, anyho
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    mz_ore::tracing::configure("computed", &args.tracing).await?;
+    let otel_collector_enabler = mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -151,6 +151,12 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                         "/metrics",
                         routing::get(move || async move {
                             mz_http_util::handle_prometheus(&metrics_registry).await
+                        }),
+                    )
+                    .route(
+                        "/api/opentelemetry/config",
+                        routing::put(move |payload| async move {
+                            mz_http_util::handle_enable_otel(otel_collector_enabler, payload).await
                         }),
                     )
                     .into_make_service(),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -420,7 +420,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     } else {
         None
     };
-    runtime.block_on(mz_ore::tracing::configure("environmentd", &args.tracing))?;
+    let otel_collector_enabler =
+        runtime.block_on(mz_ore::tracing::configure("environmentd", &args.tracing))?;
 
     // Initialize fail crate for failpoint support
     let _failpoint_scenario = FailScenario::setup();
@@ -691,6 +692,7 @@ max log level: {max_log_level}",
             args.aws_external_id_prefix,
             secrets_path,
         ),
+        otel_collector_enabler,
     }))?;
 
     println!(

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -202,6 +202,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         replica_sizes: Default::default(),
         availability_zones: Default::default(),
         connection_context: Default::default(),
+        otel_collector_enabler: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
     }))?;
     let server = Server {
         inner,

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -7,11 +7,13 @@ rust-version = "1.62.0"
 publish = false
 
 [dependencies]
+anyhow = "1.0.57"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 axum = { version = "0.5.11", features = ["headers"] }
 headers = "0.3.7"
+serde = "1.0.137"
 include_dir = "0.7.2"
-mz-ore = { path = "../ore", default-features = false, features = ["metrics"] }
+mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
 prometheus = { version = "0.13.1", default-features = false, features = ["process"] }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/ore/src/cli.rs
+++ b/src/ore/src/cli.rs
@@ -16,7 +16,7 @@
 //! Command-line parsing utilities.
 
 use std::ffi::OsString;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 use std::str::FromStr;
 
 use clap::Parser;
@@ -109,5 +109,34 @@ where
             key: key.parse().map_err(|e| format!("parsing key: {}", e))?,
             value: value.parse().map_err(|e| format!("parsing value: {}", e))?,
         })
+    }
+}
+
+/// A command-line argument that defaults to `true`
+/// that can be falsified with `--flag=false`
+// TODO: replace with `SetTrue` when available in clap.
+#[derive(Debug, Clone)]
+pub struct DefaultTrue {
+    /// The value for this flag
+    pub value: bool,
+}
+
+impl Default for DefaultTrue {
+    fn default() -> Self {
+        Self { value: true }
+    }
+}
+
+impl fmt::Display for DefaultTrue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl FromStr for DefaultTrue {
+    type Err = std::str::ParseBoolError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self { value: s.parse()? })
     }
 }

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -55,7 +55,7 @@ fn main() {
         .build()
         .expect("Failed building the Runtime");
 
-    runtime
+    let _ = runtime
         .block_on(mz_ore::tracing::configure(
             "persist-open-loop",
             TracingConfig::from(&args.tracing),

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = "1.12.0"
 md-5 = "0.10.1"
 mz-controller = { path = "../controller" }
 mz-environmentd = { path = "../environmentd", default-features = false }
-mz-ore = { path = "../ore", features = ["task"] }
+mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -632,6 +632,7 @@ impl Runner {
             replica_sizes: Default::default(),
             availability_zones: Default::default(),
             connection_context: Default::default(),
+            otel_collector_enabler: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -114,7 +114,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let otel_collector_enabler = mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -147,6 +147,12 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                         "/metrics",
                         routing::get(move || async move {
                             mz_http_util::handle_prometheus(&metrics_registry).await
+                        }),
+                    )
+                    .route(
+                        "/api/opentelemetry/config",
+                        routing::put(move |payload| async move {
+                            mz_http_util::handle_enable_otel(otel_collector_enabler, payload).await
                         }),
                     )
                     .into_make_service(),


### PR DESCRIPTION
This pr allows us to dynamically enable and disable the otel collector, with some caveats:
- the http api to do so must be called on all services separately
- When the otel subscriber is on (as in, we provide and endpoint, disabled or not), there is a fixed cost to the `RwLock` the `reload` layer uses, for all events. Currently, this causes a regression in the fast-path filter for `TRACE` events, but this will be fixed in https://github.com/tokio-rs/tracing/pull/2204

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer
@benesch this pr adds `DefaultTrue` to `mz_ore::cli`, let me know if you dont like that

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
