### PR TITLE
feature-benchmark: Disable the StartupLoaded scenario

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -1144,7 +1144,9 @@ class StartupEmpty(Startup):
         ]
 
 
-class StartupLoaded(Startup):
+# Scenario is not currently compatible with Platform -- the computed instances
+# also need to be taken into account, which is currently not the case
+class StartupLoaded(ScenarioDisabled):
     """Measure the time it takes to restart a populated Mz instance and have all the dataflows be ready to return something"""
 
     # Create 10^1.2 ~ 15 objects of each kind


### PR DESCRIPTION
In the absence of compute reconciliation, the computed instances
will exit along with the environmentd. However, the feature-benchmark
has no provision to restart them.

### Motivation

  * This PR fixes a previously unreported bug.

The feature benchmark is unable to go past the StartupLoaded scenario in CI