### PR TITLE
sql: fix logic error in cluster drop check

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1144,7 +1144,7 @@ fn test_github_12951() {
         client2
             .batch_execute("BEGIN; DECLARE c CURSOR FOR TAIL (SELECT count(*) FROM t1); FETCH 1 c")
             .unwrap();
-        client1.batch_execute("DROP CLUSTER foo").unwrap();
+        client1.batch_execute("DROP CLUSTER foo CASCADE").unwrap();
         client2_cancel.cancel_query(postgres::NoTls).unwrap();
         client2
             .batch_execute("ROLLBACK; SET CLUSTER = default")
@@ -1168,7 +1168,7 @@ fn test_github_12951() {
             .unwrap();
         client2.batch_execute("SET CLUSTER = foo").unwrap();
         client2.batch_execute("BEGIN; SELECT * FROM t1").unwrap();
-        client1.batch_execute("DROP CLUSTER foo").unwrap();
+        client1.batch_execute("DROP CLUSTER foo CASCADE").unwrap();
         client2
             .batch_execute("COMMIT; SET CLUSTER = default")
             .unwrap();
@@ -1202,7 +1202,7 @@ fn test_tail_outlive_cluster() {
     client2
         .batch_execute("BEGIN; DECLARE c CURSOR FOR TAIL (SELECT count(*) FROM t1); FETCH 1 c")
         .unwrap();
-    client1.batch_execute("DROP CLUSTER foo").unwrap();
+    client1.batch_execute("DROP CLUSTER foo CASCADE").unwrap();
     client1
         .batch_execute("CREATE CLUSTER newcluster REPLICAS (r1 (size '1'))")
         .unwrap();

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3260,7 +3260,7 @@ pub fn plan_drop_cluster(
         };
         match scx.catalog.resolve_compute_instance(Some(name.as_str())) {
             Ok(instance) => {
-                if !(instance.indexes().is_empty() || instance.replica_names().is_empty())
+                if !(instance.indexes().is_empty() && instance.replica_names().is_empty())
                     && !cascade
                 {
                     bail!("cannot drop cluster with active indexes, sinks, or replicas");

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -62,7 +62,7 @@ disruptions = [
         name="drop-cluster",
         disruption=lambda c: c.testdrive(
             """
-> DROP CLUSTER cluster1
+> DROP CLUSTER cluster1 CASCADE
 """,
         ),
     ),

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -232,6 +232,12 @@ DROP INDEX v_primary_idx
 statement ok
 DROP INDEX v_primary_idx1
 
+statement ok
+DROP CLUSTER REPLICA bar.r1
+
+statement ok
+DROP CLUSTER REPLICA bar.r2
+
 # Test valid DROPs
 
 statement ok
@@ -261,13 +267,13 @@ statement ok
 CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION GRANULARITY '1s'
 
 statement ok
-DROP CLUSTER foo
+DROP CLUSTER foo CASCADE
 
 statement ok
 CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION GRANULARITY '1s'
 
 statement ok
-DROP CLUSTER foo
+DROP CLUSTER foo CASCADE
 
 # Test that bad cluster sizes don't cause a crash
 
@@ -308,7 +314,7 @@ SELECT COUNT(name) FROM mz_indexes;
 34
 
 statement ok
-DROP CLUSTER test;
+DROP CLUSTER test CASCADE
 
 query T
 SELECT COUNT(name) FROM mz_indexes;

--- a/test/sqllogictest/id_reuse.slt
+++ b/test/sqllogictest/id_reuse.slt
@@ -94,7 +94,7 @@ SELECT id, name FROM mz_clusters
 2 foo
 
 statement ok
-DROP CLUSTER foo
+DROP CLUSTER foo CASCADE
 
 statement ok
 CREATE CLUSTER bar REPLICAS (r1 (size '1'))

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -131,4 +131,4 @@ SELECT * FROM mz_materializations
 # Clean up.
 
 statement ok
-DROP CLUSTER test
+DROP CLUSTER test CASCADE


### PR DESCRIPTION
This PR fixes a bug in the logic that decides whether a cluster has active items. Prior to this change, as cluster could be dropped when it had no exports (even if it had replicas) or when it had no replicas (even if it had exports), leaving catalog items that referred to a non-existing cluster.

### Motivation

  * This PR fixes a previously unreported bug.

TODO

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fix a bug in the cluster drop checking that made it possible to drop clusters that still had active indexes, sinks, or replicas.
