### PR TITLE
storage: resume ingestion from last ingested offsets

### DIFF
--- a/src/storage/src/client.proto
+++ b/src/storage/src/client.proto
@@ -32,6 +32,7 @@ message ProtoAllowCompaction {
 message ProtoIngestSourceCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     sources.ProtoIngestionDescription description = 2;
+    mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
 }
 
 message ProtoIngestSources {

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -127,7 +127,7 @@ pub fn build_storage_dataflow<A: Allocate>(
     storage_state: &mut StorageState,
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
-    as_of: Antichain<mz_repr::Timestamp>,
+    resume_upper: Antichain<mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();
@@ -145,7 +145,7 @@ pub fn build_storage_dataflow<A: Allocate>(
                 &debug_name,
                 id,
                 description.clone(),
-                as_of,
+                resume_upper,
                 // NOTE: For now sources never have LinearOperators but might have in the future
                 None,
                 storage_state,

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -225,6 +225,21 @@ impl ReclockOperator {
         }
     }
 
+    /// Calculates the source upper frontier at a particular timestamp
+    pub fn source_upper_at(&self, target: Timestamp) -> HashMap<PartitionId, MzOffset> {
+        let mut source_upper = HashMap::new();
+        for pid in self.remap_trace.keys() {
+            let binding = self
+                .partition_bindings(pid)
+                .take_while(|(ts, _)| ts <= &target)
+                .last();
+            if let Some((_, part_upper)) = binding {
+                source_upper.insert(pid.clone(), part_upper);
+            }
+        }
+        source_upper
+    }
+
     /// Syncs the state of this operator to match that of the persist shard until the provided
     /// frontier
     async fn sync(&mut self, target_upper: &Antichain<Timestamp>) {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -125,7 +125,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         &mut self.storage_state,
                         ingestion.id,
                         ingestion.description,
-                        Antichain::from_elem(Timestamp::minimum()),
+                        ingestion.resume_upper,
                     );
 
                     self.storage_state.reported_frontiers.insert(


### PR DESCRIPTION
Currently source ingestion is fault tolerant but on failure it
unconditionally restarts ingestion from the very beginning.
This PR makes STORAGE restart ingestion from the last point it left of
for the supported ingestion configurations.

Any ingestion that has a NONE envelope specified will benefit from fast
restarts. Other envelopes will be added in future PRs once we change
them to write down their in-memory state in persist shards.

This PR also brings Postgres sources into the fold of fault tolerant and
fast-restartable sources.