### PR TITLE
sql-parser: avoid execution of `unreachable!`

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1926,12 +1926,12 @@ impl<'a> Parser<'a> {
         let name = self.parse_object_name()?;
         self.expect_keyword(FOR)?;
         let connection = match self.expect_one_of_keywords(&[KAFKA, CONFLUENT])? {
-            Keyword::Kafka => {
+            KAFKA => {
                 let with_options =
                     self.parse_comma_separated(Parser::parse_kafka_connection_options)?;
                 CreateConnection::Kafka { with_options }
             }
-            Keyword::Confluent => {
+            CONFLUENT => {
                 self.expect_keywords(&[SCHEMA, REGISTRY])?;
                 let registry = self.parse_literal_string()?;
                 let with_options = self.parse_opt_with_options()?;
@@ -2154,7 +2154,7 @@ impl<'a> Parser<'a> {
     fn parse_create_source_connection(
         &mut self,
     ) -> Result<CreateSourceConnection<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[KAFKA, KINESIS, AVRO, S3, POSTGRES, PUBNUB])? {
+        match self.expect_one_of_keywords(&[KAFKA, KINESIS, S3, POSTGRES, PUBNUB])? {
             PUBNUB => {
                 self.expect_keywords(&[SUBSCRIBE, KEY])?;
                 let subscribe_key = self.parse_literal_string()?;
@@ -2267,7 +2267,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_sink_connection(&mut self) -> Result<CreateSinkConnection<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[KAFKA, AVRO, PERSIST])? {
+        match self.expect_one_of_keywords(&[KAFKA, PERSIST])? {
             KAFKA => {
                 self.expect_keyword(BROKER)?;
                 let broker = self.parse_literal_string()?;

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -651,20 +651,6 @@ CREATE SOURCE remote_fail_in_planning FROM PUBNUB SUBSCRIBE KEY 'subscribe_key' 
                                                                                                          ^
 
 parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES
-                              ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' WITH SNAPSHOT FORMAT BYTES
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' WITH SNAPSHOT FORMAT BYTES
-                              ^
-
-parse-statement
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES
 ----
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' WITH (replication_factor = 7, retention_ms = 10000, retention_bytes = 10000000000) FORMAT BYTES WITH SNAPSHOT
@@ -726,55 +712,6 @@ CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
 error: Expected end of statement, found KEY
 CREATE SINK foo FROM bar INTO KAFKA BROKER 'baz' TOPIC 'topic' KEY FORMAT BYTES
                                                                ^
-
-parse-statement
-CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK IF NOT EXISTS foo FROM bar INTO FILE 'baz' FORMAT BYTES
-                                            ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF 123
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF 123
-                              ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITHOUT SNAPSHOT AS OF 123
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES WITHOUT SNAPSHOT AS OF 123
-                              ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF now()
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT BYTES AS OF now()
-                              ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH SNAPSHOT
-                              ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
-                              ^
-
-parse-statement
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
-----
-error: Expected one of KAFKA or AVRO or PERSIST, found FILE
-CREATE SINK foo FROM bar INTO FILE 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (a = 'b') WITH SNAPSHOT
-                              ^
 
 parse-statement
 CREATE SINK IF EXISTS foo FROM bar INTO 'baz'


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

Executing any of the following statements:

```sql
CREATE SOURCE a FROM AVRO;
CREATE SINK a FROM a INTO AVRO;
```

... makes environmentd crash by invoking an `unreachable!()`, because `AVRO` is neither a valid source nor sink type.

Fixing that made a bunch of parser tests involving `CREATE SINK ... INTO FILE` fail, because the error message changed. We don't support file sinks anymore, so I simply removed those tests.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).