### PR TITLE
bin/cloud-push: fix for non-x86_64 hosts

### DIFF
--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -24,7 +24,7 @@ username=$1
 
 for image in environmentd storaged computed; do
     bin/mzimage acquire --arch=x86_64 "$image"
-    docker tag "$(bin/mzimage spec "$image")" "$username/$image"
+    docker tag "$(bin/mzimage spec --arch=x86_64 "$image")" "$username/$image"
     docker push "$username/$image"
 done
 


### PR DESCRIPTION
The arch identifier is one of the inputs to the image fingerprint. Since we build the image with `--arch=x86_64`, we also need to pass the same flag when retrieving the image name afterwards, otherwise there is a mismatch.

### Motivation

  * This PR fixes a previously unreported bug.

On an M1 Mac, running `bin/cloud-push` fails due to a fingerprint mismatch:

```
...
Status: Downloaded newer image for materialize/environmentd:mzbuild-4KXOM4MUMJGSRVIOE6TOLLWLZPE55FPY
docker.io/materialize/environmentd:mzbuild-4KXOM4MUMJGSRVIOE6TOLLWLZPE55FPY
Error response from daemon: No such image: materialize/environmentd:mzbuild-XIBRLF3OMQNGYLULWHFFW5V46LZZHPCP
```

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).