### PR TITLE
Remove user-visible persist sinks

### DIFF
--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -195,7 +195,7 @@ where
             });
             collection
         }
-        Some(SinkEnvelope::DifferentialRow) | None => keyed.map(|(key, value)| (key, Some(value))),
+        None => keyed.map(|(key, value)| (key, Some(value))),
     };
 
     collection

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -61,10 +61,6 @@ where
         let persist_location = self.storage_metadata.persist_location.clone();
         let shard_id = self.storage_metadata.data_shard;
 
-        // Log the shard ID so we know which shard to read for testing.
-        // TODO(teskje): Remove once we have a built-in way for reading back sinked data.
-        tracing::info!("persist_sink shard ID: {shard_id}");
-
         let operator_name = format!("persist_sink({})", shard_id);
         let mut persist_op = OperatorBuilder::new(operator_name, scope.clone());
 

--- a/src/coord/src/coord.rs
+++ b/src/coord/src/coord.rs
@@ -5234,24 +5234,7 @@ impl<S: Append + 'static> Coordinator<S> {
     }
 
     async fn drop_sinks(&mut self, sinks: Vec<(ComputeInstanceId, GlobalId)>) {
-        let mut by_compute_instance = HashMap::new();
-        for (compute_instance, id) in sinks {
-            by_compute_instance
-                .entry(compute_instance)
-                .or_insert(vec![])
-                .push(id);
-
-            // Persist sinks write to storage collections, which need to be
-            // dropped when their sinks are dropped.
-            // TODO(teskje): Remove this once persist sinks are replaced by recorded views.
-            if self.dataflow_client.storage_mut().collection(id).is_ok() {
-                self.dataflow_client
-                    .storage_mut()
-                    .drop_sources(vec![id])
-                    .await
-                    .unwrap();
-            }
-        }
+        let by_compute_instance = sinks.into_iter().into_group_map();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
             if let Some(mut compute) = self.dataflow_client.compute_mut(compute_instance) {

--- a/src/coord/src/sink_connection.rs
+++ b/src/coord/src/sink_connection.rs
@@ -16,8 +16,7 @@ use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, Top
 use mz_dataflow_types::connections::ConnectionContext;
 use mz_dataflow_types::sinks::{
     KafkaSinkConnection, KafkaSinkConnectionBuilder, KafkaSinkConnectionRetention,
-    KafkaSinkConsistencyConnection, PersistSinkConnection, PersistSinkConnectionBuilder,
-    PublishedSchemaInfo, SinkConnection, SinkConnectionBuilder,
+    KafkaSinkConsistencyConnection, PublishedSchemaInfo, SinkConnection, SinkConnectionBuilder,
 };
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::collections::CollectionExt;
@@ -32,7 +31,6 @@ pub async fn build(
 ) -> Result<SinkConnection, CoordError> {
     match builder {
         SinkConnectionBuilder::Kafka(k) => build_kafka(k, id, connection_context).await,
-        SinkConnectionBuilder::Persist(p) => build_persist_sink(p, id),
     }
 }
 
@@ -327,15 +325,5 @@ async fn build_kafka(
         exactly_once: builder.reuse_topic,
         transitive_source_dependencies: builder.transitive_source_dependencies,
         fuel: builder.fuel,
-    }))
-}
-
-fn build_persist_sink(
-    builder: PersistSinkConnectionBuilder,
-    _id: GlobalId,
-) -> Result<SinkConnection, CoordError> {
-    Ok(SinkConnection::Persist(PersistSinkConnection {
-        value_desc: builder.value_desc,
-        storage_metadata: (),
     }))
 }

--- a/src/dataflow-types/src/types/sinks.proto
+++ b/src/dataflow-types/src/types/sinks.proto
@@ -31,7 +31,6 @@ message ProtoSinkEnvelope {
     oneof kind {
         google.protobuf.Empty debezium = 1;
         google.protobuf.Empty upsert = 2;
-        google.protobuf.Empty differential_row = 3;
     }
 }
 

--- a/src/dataflow-types/src/types/sinks.rs
+++ b/src/dataflow-types/src/types/sinks.rs
@@ -92,9 +92,6 @@ impl RustType<ProtoSinkDesc> for SinkDesc<CollectionMetadata, mz_repr::Timestamp
 pub enum SinkEnvelope {
     Debezium,
     Upsert,
-    /// An envelope for sinks that directly write differential Rows. This is internal and
-    /// cannot be requested via SQL.
-    DifferentialRow,
 }
 
 impl RustType<ProtoSinkEnvelope> for SinkEnvelope {
@@ -104,7 +101,6 @@ impl RustType<ProtoSinkEnvelope> for SinkEnvelope {
             kind: Some(match self {
                 SinkEnvelope::Debezium => Kind::Debezium(()),
                 SinkEnvelope::Upsert => Kind::Upsert(()),
-                SinkEnvelope::DifferentialRow => Kind::DifferentialRow(()),
             }),
         }
     }
@@ -117,7 +113,6 @@ impl RustType<ProtoSinkEnvelope> for SinkEnvelope {
         Ok(match kind {
             Kind::Debezium(()) => SinkEnvelope::Debezium,
             Kind::Upsert(()) => SinkEnvelope::Upsert,
-            Kind::DifferentialRow(()) => SinkEnvelope::DifferentialRow,
         })
     }
 }
@@ -468,12 +463,6 @@ pub struct TailSinkConnection {}
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum SinkConnectionBuilder {
     Kafka(KafkaSinkConnectionBuilder),
-    Persist(PersistSinkConnectionBuilder),
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PersistSinkConnectionBuilder {
-    pub value_desc: RelationDesc,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -760,7 +760,6 @@ pub enum CreateSinkConnection<T: AstInfo> {
         key: Option<KafkaSinkKey>,
         consistency: Option<KafkaConsistency<T>>,
     },
-    Persist,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
@@ -784,9 +783,6 @@ impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
                 if let Some(consistency) = consistency.as_ref() {
                     f.write_node(consistency);
                 }
-            }
-            CreateSinkConnection::Persist => {
-                f.write_str("PERSIST");
             }
         }
     }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -217,7 +217,6 @@ Outer
 Over
 Partition
 Password
-Persist
 Physical
 Plan
 Plans

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2267,45 +2267,39 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_create_sink_connection(&mut self) -> Result<CreateSinkConnection<Raw>, ParserError> {
-        match self.expect_one_of_keywords(&[KAFKA, PERSIST])? {
-            KAFKA => {
-                self.expect_keyword(BROKER)?;
-                let broker = self.parse_literal_string()?;
-                self.expect_keyword(TOPIC)?;
-                let topic = self.parse_literal_string()?;
-                // one token of lookahead:
-                // * `KEY (` means we're parsing a list of columns for the key
-                // * `KEY FORMAT` means there is no key, we'll parse a KeyValueFormat later
-                let key = if self.peek_keyword(KEY)
-                    && self.peek_nth_token(1) != Some(Token::Keyword(FORMAT))
-                {
-                    let _ = self.expect_keyword(KEY);
-                    let key_columns = self.parse_parenthesized_column_list(Mandatory)?;
+        self.expect_keyword(KAFKA)?;
+        self.expect_keyword(BROKER)?;
+        let broker = self.parse_literal_string()?;
+        self.expect_keyword(TOPIC)?;
+        let topic = self.parse_literal_string()?;
+        // one token of lookahead:
+        // * `KEY (` means we're parsing a list of columns for the key
+        // * `KEY FORMAT` means there is no key, we'll parse a KeyValueFormat later
+        let key =
+            if self.peek_keyword(KEY) && self.peek_nth_token(1) != Some(Token::Keyword(FORMAT)) {
+                let _ = self.expect_keyword(KEY);
+                let key_columns = self.parse_parenthesized_column_list(Mandatory)?;
 
-                    let not_enforced = if self.peek_keywords(&[NOT, ENFORCED]) {
-                        let _ = self.expect_keywords(&[NOT, ENFORCED])?;
-                        true
-                    } else {
-                        false
-                    };
-                    Some(KafkaSinkKey {
-                        key_columns,
-                        not_enforced,
-                    })
+                let not_enforced = if self.peek_keywords(&[NOT, ENFORCED]) {
+                    let _ = self.expect_keywords(&[NOT, ENFORCED])?;
+                    true
                 } else {
-                    None
+                    false
                 };
-                let consistency = self.parse_kafka_consistency()?;
-                Ok(CreateSinkConnection::Kafka {
-                    broker,
-                    topic,
-                    key,
-                    consistency,
+                Some(KafkaSinkKey {
+                    key_columns,
+                    not_enforced,
                 })
-            }
-            PERSIST => Ok(CreateSinkConnection::Persist),
-            _ => unreachable!(),
-        }
+            } else {
+                None
+            };
+        let consistency = self.parse_kafka_consistency()?;
+        Ok(CreateSinkConnection::Kafka {
+            broker,
+            topic,
+            key,
+            consistency,
+        })
     }
 
     fn parse_kafka_consistency(&mut self) -> Result<Option<KafkaConsistency<Raw>>, ParserError> {


### PR DESCRIPTION
This PR removes the `CREATE SINK ... INTO PERSIST` syntax, and any code exclusively required to support it. This feature is being replaced by recorded views (#13346).

### Motivation

  * This PR adds a known-desirable feature.

Part of #12860.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove support for creating persist sinks via `CREATE SINK ... INTO PERSIST`.
