### PR TITLE
bin/run: add `--rewrite-results` flag to `sqllogictest`

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -91,6 +91,11 @@ def main() -> int:
         help="Only build, don't run",
         action="store_true",
     )
+    parser.add_argument(
+        "--rewrite-results",
+        help="Rewrite results when running sqllogictest",
+        action="store_true",
+    )
     args = parser.parse_intermixed_args()
 
     # Handle `+toolchain` like rustup.
@@ -126,6 +131,8 @@ def main() -> int:
             ]
         elif args.program == "sqllogictest":
             command += [f"--postgres-url={args.postgres}"]
+            if args.rewrite_results:
+                command += ["--rewrite-results"]
     elif args.program == "test":
         build_retcode = _build(args)
         if args.build_only:


### PR DESCRIPTION
Sometimes we want to write 

```bash
bin/sqllogictest $SQLLT_PATH --rewrite-results
```

to update the test results in a specific path. This PR adds and threads through the `--rewrite-results` boolean flag to the `sqllogictest` call.

### Motivation

   * This PR refactors existing code.

See description above.

### Tips for reviewer

N/A

### Testing

I used the new syntax to update the tests for #13370

### Release notes

N/A