### PR TITLE
sql: use enum-name options for CSR connection

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -170,7 +170,7 @@ fn test_drop_connection_race() -> Result<(), anyhow::Error> {
         let (client, _conn) = server.connect_async(postgres::NoTls).await?;
         client
             .batch_execute(&format!(
-                "CREATE CONNECTION conn FOR CONFLUENT SCHEMA REGISTRY 'http://{}'",
+                "CREATE CONNECTION conn FOR CONFLUENT SCHEMA REGISTRY URL 'http://{}'",
                 schema_registry_server.addr,
             ))
             .await?;

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -319,6 +319,7 @@ Unique
 Unknown
 Update
 Upsert
+Url
 User
 Username
 Users

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1409,11 +1409,11 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' WITH (consistency = '
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])) }, topic: "baz", key: None }), with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, materialized: false, key_constraint: None, remote: None })
 
 parse-statement
-CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username='user', password='word')
+CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word'
 ----
-CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' WITH (username = 'user', password = 'word')
+CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word'
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { url: "http://localhost:8081", with_options: [WithOption { key: Ident("username"), value: Some(Value(String("user"))) }, WithOption { key: Ident("password"), value: Some(Value(String("word"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, CsrConnectionOption { name: Username, value: Some(Value(String("user"))) }, CsrConnectionOption { name: Password, value: Some(Value(String("word"))) }] }, if_not_exists: false })
 
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2926,6 +2926,9 @@ impl KafkaConnectionOptionExtracted {
         for broker in &mut brokers {
             // Normalize Kafka addresses
             *broker = KafkaAddrs::from_str(broker)?.to_string();
+            if broker.contains(',') {
+                bail!("invalid CONNECTION: cannot specify multiple Kafka broker addresses in one string");
+            }
         }
 
         Ok(brokers)

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -28,7 +28,8 @@ use regex::Regex;
 use tracing::{debug, warn};
 
 use mz_dataflow_types::connections::{
-    Connection, KafkaConnection, SaslConfig, Security, SslConfig, StringOrSecret,
+    Connection, CsrConnectionHttpAuth, CsrConnectionTlsIdentity, KafkaConnection, SaslConfig,
+    Security, SslConfig, StringOrSecret,
 };
 use mz_dataflow_types::sinks::{
     KafkaSinkConnectionBuilder, KafkaSinkConnectionRetention, KafkaSinkFormat,
@@ -66,8 +67,9 @@ use crate::ast::{
     CreateSecretStatement, CreateSinkConnection, CreateSinkStatement, CreateSourceConnection,
     CreateSourceFormat, CreateSourceStatement, CreateTableStatement, CreateTypeAs,
     CreateTypeStatement, CreateViewStatement, CreateViewsSourceTarget, CreateViewsStatement,
-    CsrConnection, CsrConnectionAvro, CsrConnectionProto, CsrSeedCompiled, CsrSeedCompiledOrLegacy,
-    CsvColumns, DbzMode, DbzTxMetadataOption, DropClusterReplicasStatement, DropClustersStatement,
+    CsrConnection, CsrConnectionAvro, CsrConnectionOption, CsrConnectionOptionName,
+    CsrConnectionProto, CsrSeedCompiled, CsrSeedCompiledOrLegacy, CsvColumns, DbzMode,
+    DbzTxMetadataOption, DropClusterReplicasStatement, DropClustersStatement,
     DropDatabaseStatement, DropObjectsStatement, DropRolesStatement, DropSchemaStatement, Envelope,
     Expr, Format, Ident, IfExistsBehavior, IndexOption, IndexOptionName, KafkaConnectionOption,
     KafkaConnectionOptionName, KafkaConsistency, KeyConstraint, ObjectType, Op, ProtobufSchema,
@@ -3023,6 +3025,49 @@ impl TryFrom<KafkaConnectionOptionExtracted> for KafkaConnection {
     }
 }
 
+generate_extracted_config!(
+    CsrConnectionOption,
+    (Url, String),
+    (SslKey, with_options::Secret),
+    (SslCertificate, StringOrSecret),
+    (SslCertificateAuthority, StringOrSecret),
+    (Username, StringOrSecret),
+    (Password, with_options::Secret)
+);
+
+impl TryFrom<CsrConnectionOptionExtracted> for mz_dataflow_types::connections::CsrConnection {
+    type Error = anyhow::Error;
+    fn try_from(ccsr_options: CsrConnectionOptionExtracted) -> Result<Self, Self::Error> {
+        let url = match ccsr_options.url {
+            Some(url) => url.parse()?,
+            None => bail!("invalid CONNECTION: must specify URL"),
+        };
+        let root_certs = match ccsr_options.ssl_certificate_authority {
+            None => vec![],
+            Some(cert) => vec![cert],
+        };
+        let cert = ccsr_options.ssl_certificate;
+        let key = ccsr_options.ssl_key.map(|secret| secret.into());
+        let tls_identity = match (cert, key) {
+            (None, None) => None,
+            (Some(cert), Some(key)) => Some(CsrConnectionTlsIdentity { cert, key }),
+            _ => bail!(
+                "invalid CONNECTION: reading from SSL-auth Confluent Schema Registry requires both SSL KEY and SSL CERTIFICATE"
+            ),
+        };
+        let http_auth = ccsr_options.username.map(|username| CsrConnectionHttpAuth {
+            username,
+            password: ccsr_options.password.map(|secret| secret.into()),
+        });
+        Ok(mz_dataflow_types::connections::CsrConnection {
+            url,
+            root_certs,
+            tls_identity,
+            http_auth,
+        })
+    }
+}
+
 pub fn plan_create_connection(
     scx: &StatementContext,
     stmt: CreateConnectionStatement<Aug>,
@@ -3040,11 +3085,9 @@ pub fn plan_create_connection(
             let k = KafkaConnectionOptionExtracted::try_from(with_options)?;
             Connection::Kafka(KafkaConnection::try_from(k)?)
         }
-        CreateConnection::Csr { url, with_options } => {
-            let connection = kafka_util::generate_ccsr_connection(
-                url.parse()?,
-                &mut normalize::options(&with_options)?,
-            )?;
+        CreateConnection::Csr { with_options } => {
+            let c = CsrConnectionOptionExtracted::try_from(with_options)?;
+            let connection = mz_dataflow_types::connections::CsrConnection::try_from(c)?;
             Connection::Csr(connection)
         }
     };

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -184,7 +184,7 @@ contains:missing SSL KEY (ssl.key.pem)
     SSL CERTIFICATE = '${arg.materialized-kafka-crt}',
     SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}';
 
-> CREATE MATERIALIZED SOURCE connector_source
+> CREATE MATERIALIZED SOURCE kafka_connector_source
   FROM KAFKA CONNECTION kafka_ssl
   TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -197,8 +197,30 @@ contains:missing SSL KEY (ssl.key.pem)
   )
   ENVELOPE DEBEZIUM
 
+> SELECT * FROM kafka_connector_source
+a
+---
+1
+2
 
-> SELECT * FROM connector_source
+> CREATE CONNECTION csr_ssl
+  FOR CONFLUENT SCHEMA REGISTRY
+    URL '${testdrive.schema-registry-url}',
+    SSL KEY = SECRET ssl_key_csr,
+    SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
+    SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}',
+    USERNAME = 'materialize',
+    PASSWORD = SECRET password_csr;
+
+> CREATE MATERIALIZED SOURCE kafka_csr_connector_source
+  FROM KAFKA CONNECTION kafka_ssl
+    TOPIC 'testdrive-data-${testdrive.seed}'
+    FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
+  ENVELOPE DEBEZIUM
+
+
+> SELECT * FROM kafka_csr_connector_source
 a
 ---
 1

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -281,3 +281,13 @@ contains:under-specified security configuration
     BROKER 'kafka:9092',
     SASL MECHANISMS = 'PLAIN';
 contains:under-specified security configuration
+
+! CREATE CONNECTION multiple_brokers
+  FOR KAFKA
+    BROKER 'kafka:9092, kafka:9093'
+contains:cannot specify multiple Kafka broker addresses in one string
+
+! CREATE CONNECTION multiple_brokers
+  FOR KAFKA
+    BROKERS ['kafka:9092, kafka:9093']
+contains:cannot specify multiple Kafka broker addresses in one string

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -114,12 +114,14 @@ $ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema
 
 
 > CREATE CONNECTION csr_conn
-  FOR CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  FOR CONFLUENT SCHEMA REGISTRY
+    URL '${testdrive.schema-registry-url}'
 
 > CREATE MATERIALIZED SOURCE csr_source
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-csr_test-${testdrive.seed}'
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM UPSERT
+    FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-csr_test-${testdrive.seed}'
+    FORMAT AVRO
+    USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+    ENVELOPE DEBEZIUM UPSERT
 
 > SELECT * from csr_source
 id creature
@@ -229,7 +231,8 @@ $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb messag
 {"importee1": {"b": false}, "importee2": {"ts": "1970-01-01T00:20:34.000005678Z"}}
 
 > CREATE CONNECTION proto_csr
-  FOR CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+    FOR CONFLUENT SCHEMA REGISTRY
+    URL '${testdrive.schema-registry-url}'
 
 > CREATE MATERIALIZED SOURCE import_connection_csr FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-import-csr-${testdrive.seed}'
@@ -241,6 +244,8 @@ importee1  importee2            mz_offset
 (f)        "(\"(1234,5678)\")"  1
 
 # Test invalid connection parameter combinations
+
+## Kafka
 ! CREATE CONNECTION not_a_secret
   FOR KAFKA
     BROKER '',
@@ -291,3 +296,23 @@ contains:cannot specify multiple Kafka broker addresses in one string
   FOR KAFKA
     BROKERS ['kafka:9092, kafka:9093']
 contains:cannot specify multiple Kafka broker addresses in one string
+
+## CSR
+! CREATE CONNECTION missing_url
+    FOR CONFLUENT SCHEMA REGISTRY
+    USERNAME 'foo'
+contains: must specify URL
+
+> CREATE SECRET s AS '...';
+
+! CREATE CONNECTION missing_cert
+    FOR CONFLUENT SCHEMA REGISTRY
+    URL 'http://localhost',
+    SSL KEY = SECRET s
+contains: requires both SSL KEY and SSL CERTIFICATE
+
+! CREATE CONNECTION missing_key
+    FOR CONFLUENT SCHEMA REGISTRY
+     URL 'http://localhost',
+    SSL CERTIFICATE = ''
+contains: requires both SSL KEY and SSL CERTIFICATE


### PR DESCRIPTION
We're in the process of using enums as names for options; this PR does that for `CREATE CONNECTION FOR CONFLUENT SCHEMA REGISTRY`.

### Motivation

This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Refactor the syntax of  `CREATE CONNECTION FOR CONFLUENT SCHEMA REGISTRY` to use a series of keywords for its configuration.
