### PR TITLE
service: rework reconnection logic

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::{GlobalId, Row};
-use mz_service::client::GenericClient;
+use mz_service::client::{GenericClient, Reconnect};
 use mz_storage::client::controller::{ReadPolicy, StorageController, StorageError};
 use mz_storage::client::sinks::{PersistSinkConnection, SinkConnection, SinkDesc};
 
@@ -232,7 +232,10 @@ where
     }
 
     /// Adds a new instance replica, by name.
-    pub fn add_replica(&mut self, id: ReplicaId, client: Box<dyn ComputeClient<T>>) {
+    pub fn add_replica<C>(&mut self, id: ReplicaId, client: C)
+    where
+        C: ComputeClient<T> + Reconnect + 'static,
+    {
         self.compute.client.add_replica(id, client);
     }
 

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -49,7 +49,7 @@ use mz_compute_client::logging::LoggingConfig;
 use mz_compute_client::response::{
     ComputeResponse, PeekResponse, ProtoComputeResponse, TailBatch, TailResponse,
 };
-use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
+use mz_compute_client::service::ComputeGrpcClient;
 use mz_orchestrator::{
     CpuLimit, MemoryLimit, NamespacedOrchestrator, Orchestrator, ServiceConfig, ServiceEvent,
     ServicePort,
@@ -289,7 +289,6 @@ where
             ConcreteComputeInstanceReplicaConfig::Remote { replicas } => {
                 let mut compute_instance = self.compute_mut(instance_id).unwrap();
                 let client = ComputeGrpcClient::new_partitioned(replicas.into_iter().collect());
-                let client: Box<dyn ComputeClient<T>> = Box::new(client);
                 compute_instance.add_replica(replica_id, client);
             }
             ConcreteComputeInstanceReplicaConfig::Managed {
@@ -362,7 +361,6 @@ where
                     )
                     .await?;
                 let client = ComputeGrpcClient::new_partitioned(service.addresses("controller"));
-                let client: Box<dyn ComputeClient<T>> = Box::new(client);
                 self.compute_mut(instance_id)
                     .unwrap()
                     .add_replica(replica_id, client);

--- a/src/service/src/local.rs
+++ b/src/service/src/local.rs
@@ -17,7 +17,7 @@ use crossbeam_channel::Sender;
 use itertools::Itertools;
 use tokio::sync::mpsc::UnboundedReceiver;
 
-use crate::client::{GenericClient, Partitionable, Partitioned, Reconnect};
+use crate::client::{GenericClient, Partitionable, Partitioned};
 
 /// A client to a thread in the same process.
 ///
@@ -28,17 +28,6 @@ pub struct LocalClient<C, R> {
     rx: UnboundedReceiver<R>,
     tx: Sender<C>,
     thread: Thread,
-}
-
-#[async_trait]
-impl<C: Send, R: Send> Reconnect for LocalClient<C, R> {
-    fn disconnect(&mut self) {
-        panic!("Disconnecting and reconnecting local clients is currently impossible");
-    }
-
-    async fn reconnect(&mut self) {
-        panic!("Disconnecting and reconnecting local clients is currently impossible");
-    }
 }
 
 #[async_trait]

--- a/src/storage/src/client/controller.rs
+++ b/src/storage/src/client/controller.rs
@@ -25,6 +25,7 @@ use std::fmt::Debug;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::BufMut;
@@ -52,6 +53,7 @@ use mz_persist_client::{
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
+use mz_service::client::Reconnect;
 use mz_stash::{self, StashError, TypedCollection};
 
 use crate::client::errors::DataflowError;
@@ -584,8 +586,11 @@ where
                 // TODO: don't block waiting for a connection. Put a queue in the
                 // middle instead.
                 let mut client: Box<dyn StorageClient<T>> = Box::new({
-                    let mut client = StorageGrpcClient::new(addr);
-                    client.connect().await;
+                    let mut client = StorageGrpcClient::new(addr.clone());
+                    while let Err(e) = client.reconnect().await {
+                        tracing::info!("connecting to storage {addr} failed (retrying in 1s): {e}");
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
                     client
                 });
 


### PR DESCRIPTION
Rework how reconnection works in the client stack. Rather than a
complicated interplay of error returns and cancel safe reconnection
logic that was split between GrpcClient, Partitioned, and
ActiveReplication, make ActiveReplication the sole place where
reconnections are attempted. ActiveReplication is the only place where
failed connections can be properly handled, so this cleans up the logic
substantially, and in particular makes it possible to guarantee that all
communication with a compute cluster will actually begin with a
CreateInstance command.

It's still a complicated protocol between ActiveReplication and each
replica task, but at least the complexity is isolated to the single
module, and the `reconnect` logic in Partitioned and GrpcClient becomes
dead simple.

Fix https://github.com/MaterializeInc/materialize/issues/12233.
Fix #12396.
Fix https://github.com/MaterializeInc/materialize/issues/12645.
Fix https://github.com/MaterializeInc/materialize/issues/12843.
Fix https://github.com/MaterializeInc/materialize/issues/12993.

Touches https://github.com/MaterializeInc/materialize/issues/12946.

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

View with whitespace suppressed: https://github.com/MaterializeInc/materialize/pull/13388/files?w=1

I haven't actually tested this much. It just _seems_ like it would fix all those bugs. 🤪 

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
