### PR TITLE
doc/user: patch language-specific integration guides

### DIFF
--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -164,7 +164,7 @@ Client libraries and ORM frameworks tend to run complex introspection queries th
 
 | Language | Support level | Tested drivers | Notes |
 | --- | --- | --- | --- |
-| Golang | {{< supportLevel production >}} | [`pgx`](https://github.com/jackc/pgx) | See the [Golang cheatsheet](/integrations/golang/). |
+| Go | {{< supportLevel production >}} | [`pgx`](https://github.com/jackc/pgx) | See the [Go cheatsheet](/integrations/golang/). |
 | Java | {{< supportLevel production >}} | [PostgreSQL JDBC driver](https://jdbc.postgresql.org/) | See the [Java cheatsheet](/integrations/java-jdbc/). |
 | Node.js | {{< supportLevel production >}} | [`node-postgres`](https://node-postgres.com/) | See the [Node.js cheatsheet](/integrations/node-js/). |
 | PHP | {{< supportLevel production >}} | [`pdo_pgsql`](https://www.php.net/manual/en/ref.pgsql.php) | See the [PHP cheatsheet](/integrations/php/). |

--- a/doc/user/content/integrations/aws-msk.md
+++ b/doc/user/content/integrations/aws-msk.md
@@ -1,6 +1,6 @@
 ---
 title: "How to connect AWS MSK to Materialize"
-description: "Instructions for securely connecting an AWS Managed Streaming for Kafka (MSK) cluster to Materialize."
+description: "How to securely connect an AWS Managed Streaming for Kafka (MSK) cluster as a source to Materialize."
 menu:
   main:
     parent: "integration-guides"

--- a/doc/user/content/integrations/java-jdbc.md
+++ b/doc/user/content/integrations/java-jdbc.md
@@ -1,5 +1,5 @@
 ---
-title: "Java Cheatsheet"
+title: "Java cheatsheet"
 description: "Use the PostgreSQL JDBC Driver to connect, insert, manage, query and stream from Materialize."
 aliases:
   - /guides/java-jdbc/
@@ -9,15 +9,11 @@ menu:
     name: "Java"
 ---
 
-Materialize is **PostgreSQL-compatible**, which means that Java applications can use any existing PostgreSQL client to interact with Materialize as if it were a PostgreSQL database. In this guide, we'll use the [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/download.html) to connect to Materialize and issue PostgreSQL commands.
+Materialize is **wire-compatible** with PostgreSQL, which means that Java applications can use common PostgreSQL clients to interact with Materialize. In this guide, we'll use the [PostgreSQL JDBC Driver](https://jdbc.postgresql.org/download.html) to connect to Materialize and issue SQL commands.
 
 ## Connect
 
-You connect to Materialize the same way you [connect to PostgreSQL with the JDBC driver](https://jdbc.postgresql.org/documentation/head/connect.html).
-
-### Local Instance
-
-You can connect to a local Materialize instance just as you would connect to a PostgreSQL instance:
+To [connect](https://jdbc.postgresql.org/documentation/head/connect.html) to a local Materialize instance using the PostgreSQL JDBC Driver:
 
 ```java
 import java.sql.Connection;
@@ -59,13 +55,13 @@ public class App {
 }
 ```
 
-To establish the connection to Materialize, just as with PostgreSQL, you can call the `getConnection()` method on the `DriverManager` class.
+To establish the connection to Materialize, call the `getConnection()` method on the `DriverManager` class.
 
 ## Stream
 
-To take full advantage of incrementally updated materialized views from a Java application, instead of [querying](#query) Materialize for the state of a view at a point in time, use [a `TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
+To take full advantage of incrementally updated materialized views from a Java application, instead of [querying](#query) Materialize for the state of a view at a point in time, use a [`TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
 
-To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query.
+To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query:
 
 ```java
 import java.sql.Connection;
@@ -120,7 +116,7 @@ public class App {
 }
 ```
 
-The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view update objects. When a row of a tailed view is **updated,** two objects will show up in the `rows` array:
+The [TAIL output format](/sql/tail/#output) of `rs` is a `ResultSet` of view updates. When a row of a tailed view is **updated,** two objects will show up in the `rows` array:
 
 ```java
     ...
@@ -130,15 +126,15 @@ The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view up
     ...
 ```
 
-The first column is the timestamp of the update. The second column is the `mz_diff` value. A `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a deletion (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same `mz_timestamp`.
+A `mz_diff` value of `-1` indicates that Materialize is deleting one row with the included values.  An update is just a retraction (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same timestamp.
 
 ## Query
 
-Querying Materialize is identical to querying a traditional PostgreSQL database: Java executes the query, and Materialize returns the state of the view, source, or table at that point in time.
+Querying Materialize is identical to querying a PostgreSQL database: Java executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
 Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
-Query a view `my_view` with a select statement:
+To query a view `my_view` using a `SELECT` statement:
 
 ```java
 import java.sql.Connection;
@@ -195,9 +191,9 @@ For more details, see the [JDBC](https://jdbc.postgresql.org/documentation/head/
 
 ## Insert data into tables
 
-Most data in Materialize will stream in via a `SOURCE`, but a [`TABLE` in Materialize](https://materialize.com/docs/sql/create-table/) can be helpful for supplementary data. For example, use a table to join slower-moving reference or lookup data with a stream.
+Most data in Materialize will stream in via an external system, but a [table](/sql/create-table/) can be helpful for supplementary data. For example, you can use a table to join slower-moving reference or lookup data with a stream.
 
-**Basic Example:** [Insert a row](https://materialize.com/docs/sql/insert/) of data into a table named `countries` in Materialize.
+**Basic Example:** [Insert a row](https://materialize.com/docs/sql/insert/) of data into a table named `countries` in Materialize:
 
 ```java
 import java.sql.Connection;
@@ -339,4 +335,6 @@ For more information, see [`CREATE VIEW`](/sql/create-view/).
 
 ## Java ORMs
 
-Materialize doesn't currently support the full catalog of PostgreSQL system metadata API endpoints, including the system calls that object relational mapping systems (ORMs) like **Hibernate** use to introspect databases and do extra work behind the scenes. This means that some ORM system attempts to interact with Materialize will currently fail. Once [full `pg_catalog` support](https://github.com/MaterializeInc/materialize/issues/2157) is implemented, the features that depend on `pg_catalog` may work properly.
+ORM frameworks like **Hibernate** tend to run complex introspection queries that may use configuration settings, system tables or features not yet implemented in Materialize. This means that even if a tool is compatible with PostgreSQL, it’s not guaranteed that the same integration will work out-of-the-box.
+
+The level of support for these tools will improve as we extend the coverage of `pg_catalog` in Materialize {{% gh 2157 %}} and join efforts with each community to make the integrations Just Work™️.

--- a/doc/user/content/integrations/python.md
+++ b/doc/user/content/integrations/python.md
@@ -1,5 +1,5 @@
 ---
-title: "Python Cheatsheet"
+title: "Python cheatsheet"
 description: "Use Python to connect, insert, manage, query and stream from Materialize."
 aliases:
   - /guides/python/
@@ -9,15 +9,11 @@ menu:
     name: "Python"
 ---
 
-Materialize is **PostgreSQL-compatible**, which means that Python applications can use any existing PostgreSQL client to interact with Materialize as if it were a PostgreSQL database. In this guide, we'll use [psycopg2 PostgreSQL database adapter](https://pypi.org/project/psycopg2/) to connect to Materialize and issue PostgreSQL commands.
+MMaterialize is **wire-compatible** with PostgreSQL, which means that Python applications can use common PostgreSQL clients to interact with Materialize. In this guide, we'll use the [`psycopg2`](https://pypi.org/project/psycopg2/) adapter to connect to Materialize and issue SQL commands.
 
 ## Connect
 
-You connect to Materialize the same way you [connect to PostgreSQL with `psycopg2`](https://www.psycopg.org/docs/usage.html).
-
-### Local Instance
-
-You can connect to a local Materialize instance just as you would connect to a PostgreSQL instance:
+To [connect](https://www.psycopg.org/docs/usage.html) to a local Materialize instance using `psycopg2`:
 
 ```python
 #!/usr/bin/env python3
@@ -31,9 +27,9 @@ conn = psycopg2.connect(dsn)
 
 ## Stream
 
-To take full advantage of incrementally updated materialized views from a Python application, instead of [querying](#query) Materialize for the state of a view at a point in time, use [a `TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
+To take full advantage of incrementally updated materialized views from a Python application, instead of [querying](#query) Materialize for the state of a view at a point in time, use a [`TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
 
-To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query.
+To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query:
 
 ```python
 #!/usr/bin/env python3
@@ -52,7 +48,7 @@ with conn.cursor() as cur:
             print(row)
 ```
 
-The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view update objects. When a row of a tailed view is **updated,** two objects will show up in the `rows` array:
+The [TAIL output format](/sql/tail/#output) of `cur` is a data access object that can be used to iterate over the set of rows. When a row of a tailed view is **updated,** two objects will show up in the `rows` array:
 
 ```python
     ...
@@ -64,17 +60,16 @@ The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view up
     ...
 ```
 
-A `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a deletion (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same `mz_timestamp`.
+A `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a retraction (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same timestamp.
 
-### Streaming with psycopg3
+### Streaming with `psycopg3`
 
 {{< warning >}}
-psycopg3 is not yet stable.
-The example here could break if their API changes.
+`psycopg3` is **not yet stable**. The following example may break if its API changes.
 {{< /warning >}}
 
-Although psycopg3 can function identically as the psycopg2 example above,
-it also has a `stream` feature where rows are not buffered and we can thus use `TAIL` directly.
+Although `psycopg3` can function identically as the `psycopg2` example above,
+it provides has a `stream` feature where rows are not buffered, which allows you to use `TAIL` directly:
 
 ```python
 #!/usr/bin/env python3
@@ -90,13 +85,14 @@ with conn.cursor() as cur:
     for row in cur.stream("TAIL t"):
         print(row)
 ```
+
 ## Query
 
-Querying Materialize is identical to querying a traditional PostgreSQL database: Python executes the query, and Materialize returns the state of the view, source, or table at that point in time.
+Querying Materialize is identical to querying a PostgreSQL database: Python executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
 Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
-Query a view `my_view` with a select statement:
+To query a view `my_view` with a `SELECT` statement:
 
 ```python
 #!/usr/bin/env python3
@@ -117,7 +113,7 @@ For more details, see the [Psycopg](https://www.psycopg.org/docs/usage.html) doc
 
 ## Insert data into tables
 
-Most data in Materialize will stream in via a `SOURCE`, but a [`TABLE` in Materialize](/sql/create-table/) can be helpful for supplementary data. For example, use a table to join slower-moving reference or lookup data with a stream.
+Most data in Materialize will stream in via an external system, but a [table](/sql/create-table/) can be helpful for supplementary data. For example, use a table to join slower-moving reference or lookup data with a stream.
 
 **Basic Example:** [Insert a row](/sql/insert/) of data into a table named `countries` in Materialize.
 
@@ -205,4 +201,6 @@ For more information, see [`CREATE VIEW`](/sql/create-view/).
 
 ## Python ORMs
 
-Materialize doesn't currently support the full catalog of PostgreSQL system metadata API endpoints, including the system calls that object relational mapping systems (ORMs) like **SQLAlchemy** use to introspect databases and do extra work behind the scenes. This means that some ORM system attempts to interact with Materialize will currently fail. Once [full `pg_catalog` support](https://github.com/MaterializeInc/materialize/issues/2157) is implemented, the features that depend on `pg_catalog` may work properly.
+ORM frameworks like **SQLAlchemy** tend to run complex introspection queries that may use configuration settings, system tables or features not yet implemented in Materialize. This means that even if a tool is compatible with PostgreSQL, it’s not guaranteed that the same integration will work out-of-the-box.
+
+The level of support for these tools will improve as we extend the coverage of `pg_catalog` in Materialize {{% gh 2157 %}} and join efforts with each community to make the integrations Just Work™️.

--- a/doc/user/content/integrations/ruby.md
+++ b/doc/user/content/integrations/ruby.md
@@ -1,5 +1,5 @@
 ---
-title: "Ruby Cheatsheet"
+title: "Ruby cheatsheet"
 description: "Use Ruby to connect, insert, manage, query and stream from Materialize."
 aliases:
   - /guides/ruby/
@@ -9,19 +9,11 @@ menu:
     name: 'Ruby'
 ---
 
-Materialize is **PostgreSQL-compatible**, which means that Ruby applications can use any existing PostgreSQL client to interact with Materialize as if it were a PostgreSQL database. In this guide, we'll use the  [`pg` gem](https://rubygems.org/gems/pg/) to connect to Materialize and issue PostgreSQL commands.
+Materialize is **wire-compatible** with PostgreSQL, which means that Ruby applications can use common PostgreSQL clients to interact with Materialize. In this guide, we'll use the  [`pg` gem](https://rubygems.org/gems/pg/) to connect to Materialize and issue SQL commands.
 
 ## Connect
 
-You connect to Materialize the same way you [connect to PostgreSQL with `pg`](https://github.com/ged/ruby-pg). If you don't have a `pg` gem, you can install it with:
-
-```bash
-gem install pg
-```
-
-### Local Instance
-
-You can connect to a local Materialize instance just as you would connect to a PostgreSQL instance:
+To connect to a local instance of Materialize using `pg`:
 
 ```ruby
 require 'pg'
@@ -29,11 +21,17 @@ require 'pg'
 conn = PG.connect(host:"127.0.0.1", port: 6875, user: "materialize")
 ```
 
+If you don't have a `pg` gem, you can install it with:
+
+```bash
+gem install pg
+```
+
 ## Stream
 
-To take full advantage of incrementally updated materialized views from a Ruby application, instead of [querying](#query) Materialize for the state of a view at a point in time, use [a `TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
+To take full advantage of incrementally updated materialized views from a Ruby application, instead of [querying](#query) Materialize for the state of a view at a point in time, use a [`TAIL` statement](/sql/tail/) to request a stream of updates as the view changes.
 
-To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query.
+To read a stream of updates from an existing materialized view, open a long-lived transaction with `BEGIN` and use [`TAIL` with `FETCH`](/sql/tail/#tailing-with-fetch) to repeatedly fetch all changes to the view since the last query:
 
 ```ruby
 require 'pg'
@@ -52,7 +50,7 @@ while true
 end
 ```
 
-The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view update objects. When a row of a tailed view is **updated,** two objects will show up in the `rows` array:
+Each `result` of the [TAIL output format](/sql/tail/#output) has exactly object. When a row of a tailed view is **updated,** two objects will show up:
 
 ```json
 ...
@@ -63,16 +61,16 @@ The [TAIL Output format](/sql/tail/#output) of `res.rows` is an array of view up
 ...
 ```
 
-An `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a deletion (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same `mz_timestamp`.
+An `mz_diff` value of `-1` indicates Materialize is deleting one row with the included values.  An update is just a retraction (`mz_diff: '-1'`) and an insertion (`mz_diff: '1'`) with the same `mz_timestamp`.
 
 
 ## Query
 
-Querying Materialize is identical to querying a traditional PostgreSQL database: Ruby executes the query, and Materialize returns the state of the view, source, or table at that point in time.
+Querying Materialize is identical to querying a PostgreSQL database: Ruby executes the query, and Materialize returns the state of the view, source, or table at that point in time.
 
 Because Materialize maintains materialized views in memory, response times are much faster than traditional database queries, and polling (repeatedly querying) a view doesn't impact performance.
 
-Query a view `my_view` with a select statement:
+To query a view `my_view` using a `SELECT` statement:
 
 ```ruby
 require 'pg'
@@ -90,9 +88,9 @@ For more details, see the  [`exec` instance method](https://rubydoc.info/gems/pg
 
 ## Insert data into tables
 
-Most data in Materialize will stream in via a `SOURCE`, but a [`TABLE` in Materialize](https://materialize.com/docs/sql/create-table/) can be helpful for supplementary data. For example, use a table to join slower-moving reference or lookup data with a stream.
+Most data in Materialize will stream in via an external system, but a [table](/sql/create-table/) can be helpful for supplementary data. For example, you can use a table to join slower-moving reference or lookup data with a stream.
 
-**Basic Example:** [Insert a row](https://materialize.com/docs/sql/insert/) of data into a table named `countries` in Materialize.
+**Basic Example:** [Insert a row](https://materialize.com/docs/sql/insert/) of data into a table named `countries` in Materialize:
 
 ```ruby
 require 'pg'
@@ -110,7 +108,7 @@ end
 
 ## Manage sources, views, and indexes
 
-Typically, you create sources, views, and indexes when deploying Materialize, although it is possible to use a Ruby app to execute common DDL statements.
+Typically, you create sources, views, and indexes when deploying Materialize, but it's also possible to use a Ruby app to execute common DDL statements.
 
 ### Create a source from Ruby
 
@@ -165,4 +163,6 @@ For more information, see [`CREATE VIEW`](/sql/create-view/).
 
 ## Ruby ORMs
 
-Materialize doesn't currently support the full catalog of PostgreSQL system metadata API endpoints, including the system calls that object relational mapping systems (ORMs) like **Active Record** use to introspect databases and do extra work behind the scenes. This means that ORM system attempts to interact with Materialize will currently fail. Once [full `pg_catalog` support](https://github.com/MaterializeInc/materialize/issues/2157) is implemented, the features that depend on  `pg_catalog` may work properly.
+ORM frameworks like **Active Record** tend to run complex introspection queries that may use configuration settings, system tables or features not yet implemented in Materialize. This means that even if a tool is compatible with PostgreSQL, it’s not guaranteed that the same integration will work out-of-the-box.
+
+The level of support for these tools will improve as we extend the coverage of `pg_catalog` in Materialize {{% gh 2157 %}} and join efforts with each community to make the integrations Just Work™️.

--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -175,7 +175,7 @@ quickly.
 
 Creating additional indexes on materialized views lets you store some subset of a query's data in memory using a different structure, which can be useful if you want to perform a join over a view's data using non-primary keys (e.g. foreign keys).
 
-For a deeper dive into arrangments, see [Arrangments](/overview/arrangements/).
+For a deeper dive into arrangments, see [Arrangements](/overview/arrangements/).
 
 ## Clusters
 


### PR DESCRIPTION
Make integration guides consistent, and patch a few lingering incorrections. All guides will be updated for cloud in `M2-DevEx`.