### PR TITLE
compute,service: split FrontierReconcile from ComputeCommandReconcile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3912,6 +3912,7 @@ dependencies = [
  "mz-proto",
  "mz-repr",
  "serde",
+ "timely",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -18,6 +18,7 @@ mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr" }
 mz-ore = { path = "../ore" }
 serde = { version = "1.0.138", features = ["derive"] }
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.19.2"
 tokio-stream = "0.1.9"
 tonic = "0.7.2"

--- a/src/service/src/frontiers.rs
+++ b/src/service/src/frontiers.rs
@@ -1,0 +1,82 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Reconciliation of timely frontiers.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+use timely::progress::frontier::MutableAntichain;
+use timely::progress::{ChangeBatch, Timestamp};
+
+use mz_repr::GlobalId;
+
+/// Reconciles a set of frontiers that are each associated with a [`GlobalId`].
+#[derive(Debug)]
+pub struct FrontierReconcile<T> {
+    frontiers: HashMap<GlobalId, MutableAntichain<T>>,
+}
+
+impl<T> Default for FrontierReconcile<T> {
+    fn default() -> FrontierReconcile<T> {
+        FrontierReconcile {
+            frontiers: HashMap::default(),
+        }
+    }
+}
+
+impl<T> FrontierReconcile<T>
+where
+    T: Timestamp + Copy,
+{
+    /// Starts tracking the frontier for an ID.
+    ///
+    /// If the ID is already tracked, returns a change batch that describes
+    /// how to update the minimum frontier to the currently tracked frontier.
+    pub fn start_tracking(&mut self, id: GlobalId) -> ChangeBatch<T> {
+        match self.frontiers.entry(id) {
+            Entry::Occupied(entry) => {
+                let mut change_batch = ChangeBatch::new_from(T::minimum(), -1);
+                change_batch.extend(entry.get().frontier().iter().map(|t| (*t, 1)));
+                change_batch
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(MutableAntichain::new_bottom(T::minimum()));
+                ChangeBatch::new()
+            }
+        }
+    }
+
+    /// Stops tracking the frontier for an ID.
+    ///
+    /// Returns the tracked frontier for the ID, if the ID was tracked.
+    pub fn stop_tracking(&mut self, id: GlobalId) -> Option<MutableAntichain<T>> {
+        self.frontiers.remove(&id)
+    }
+
+    /// Reports whether the ID is currently tracked.
+    pub fn is_tracked(&self, id: GlobalId) -> bool {
+        self.frontiers.contains_key(&id)
+    }
+
+    /// Absorbs new frontiers and mutates the provided frontiers to reflect the
+    /// tracked state.
+    pub fn absorb(&mut self, frontiers: &mut Vec<(GlobalId, ChangeBatch<T>)>) {
+        frontiers.retain_mut(|(id, changes)| {
+            if let Some(frontier) = self.frontiers.get_mut(id) {
+                let iter = frontier.update_iter(changes.drain());
+                changes.extend(iter);
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// Removes all tracked frontiers.
+    pub fn clear(&mut self) {
+        self.frontiers.clear();
+    }
+}

--- a/src/service/src/lib.rs
+++ b/src/service/src/lib.rs
@@ -19,5 +19,6 @@
 //! gRPC utilities that are presently in the `grpc` module.
 
 pub mod client;
+pub mod frontiers;
 pub mod grpc;
 pub mod local;


### PR DESCRIPTION
@antiguru could you take a close look at this? It should be exactly equivalent to the old code, except that `FrontierReconcile::absorb` now drops untracked IDs entirely (via `retain_mut`) instead of just clearing out the change batch.

----

So that it can be reused by storage reconcilation. Split out from
PR #13360 to get a closer review.

Part of #12857.

Co-authored-by: Gus Wynn <gus@materialize.com>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
