### PR TITLE
adapter: add recorded views to mz_relations

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1190,7 +1190,8 @@ pub const MZ_RELATIONS: BuiltinView = BuiltinView {
     sql: "CREATE VIEW mz_catalog.mz_relations (id, oid, schema_id, name, type) AS
       SELECT id, oid, schema_id, name, 'table' FROM mz_catalog.mz_tables
 UNION SELECT id, oid, schema_id, name, 'source' FROM mz_catalog.mz_sources
-UNION SELECT id, oid, schema_id, name, 'view' FROM mz_catalog.mz_views",
+UNION SELECT id, oid, schema_id, name, 'view' FROM mz_catalog.mz_views
+UNION SELECT id, oid, schema_id, name, 'recorded view' FROM mz_catalog.mz_recorded_views",
 };
 
 pub const MZ_OBJECTS: BuiltinView = BuiltinView {

--- a/test/sqllogictest/recorded_views.slt
+++ b/test/sqllogictest/recorded_views.slt
@@ -291,6 +291,31 @@ SELECT count(*) FROM mz_recorded_views
 0
 
 
+# Test: Recorded views show in `SHOW OBJECTS`.
+
+statement ok
+CREATE RECORDED VIEW rv AS SELECT 1
+
+query T colnames,rowsort
+SHOW OBJECTS
+----
+name
+rv
+t
+
+
+# Test: Indexes on recorded views show in `SHOW INDEXES`.
+
+statement ok
+CREATE DEFAULT INDEX ON rv
+
+query TTTITTT colnames
+SHOW INDEXES ON rv
+----
+cluster on_name key_name       seq_in_index column_name expression nullable
+default rv      rv_primary_idx 1            ?column?    NULL       false
+
+
 # Cleanup
 
 statement ok


### PR DESCRIPTION
This makes both `SHOW OBJECTS` and `SHOW INDEXES ON ...` work for recorded views.

### Motivation

  * This PR adds a known-desirable feature.

Part of #12860.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).

  - Make `SHOW OBJECTS` and `SHOW INDEXES ON...` work with recorded views.
