### PR TITLE
prost: no recursion limit for compute connection

### DIFF
--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -38,7 +38,7 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
 mz-storage = { path = "../storage"}
 mz-transform = { path = "../transform" }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.5.6"

--- a/src/billing-demo/Cargo.toml
+++ b/src/billing-demo/Cargo.toml
@@ -13,7 +13,7 @@ clap = { version = "3.2.8", features = ["derive"] }
 hex = "0.4.3"
 mz-ore = { path = "../../src/ore", features = ["task"] }
 mz-test-util = { path = "../../test/test-util" }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 prost-types = "0.10.0"
 rand = "0.8.5"
 rand_distr = "0.4.3"

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -23,7 +23,7 @@ mz-storage = { path = "../storage" }
 mz-timely-util = { path = "../timely-util" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git"}
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.82"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -22,7 +22,7 @@ mz-repr = { path = "../repr" }
 mz-service = { path = "../service" }
 mz-storage = { path = "../storage" }
 once_cell = "1.12.0"
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 regex = "1.5.6"
 serde = { version = "1.0.138", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -36,7 +36,7 @@ num = "0.4.0"
 num_enum = "0.5.7"
 ordered-float = { version = "3.0.0", features = ["serde"] }
 paste = "1.0.7"
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 regex = "1.5.6"
 regex-syntax = "0.6.25"
 serde = { version = "1.0.138", features = ["derive"] }

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -26,7 +26,7 @@ mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 ordered-float = { version = "3.0.0", features = ["serde"] }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 prost-reflect = "0.8.1"
 serde_json = "1.0.82"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -18,7 +18,7 @@ mz-proto = { path = "../proto" }
 num_cpus = "1.13.1"
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
-prost = "0.10.1"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.138", features = ["derive"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -38,7 +38,7 @@ mz-persist-types = { path = "../persist-types" }
 openssl = { version = "0.10.40", features = ["vendored"] }
 openssl-sys = { version = "0.9.74", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.138", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -13,7 +13,7 @@ mz-proto = { path = "../proto" }
 openssl = { version = "0.10.40", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 serde = { version = "1.0.138", features = ["derive"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 

--- a/src/proto/Cargo.toml
+++ b/src/proto/Cargo.toml
@@ -13,7 +13,7 @@ globset = "0.4.9"
 http = "0.2.8"
 mz-ore = { path = "../ore", default-features = false }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 regex = "1.5.6"
 serde_json = { version = "1.0.82", features = ["arbitrary_precision"] }
 url = { version = "2.2.2", features = ["serde"] }

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -34,7 +34,7 @@ mz-proto = { path = "../proto" }
 num-traits = "0.2.15"
 num_enum = "0.5.7"
 ordered-float = { version = "3.0.0", features = ["serde"] }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 regex = "1.5.6"
 ryu = "1.0.10"
 serde = { version = "1.0.138", features = ["derive"] }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -33,7 +33,7 @@ mz-sql-parser = { path = "../sql-parser" }
 mz-storage = { path = "../storage" }
 paste = "1.0"
 protobuf-native = "0.2.1"
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.5.6"
 reqwest = "0.11.11"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -57,7 +57,7 @@ postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 prometheus = { version = "0.13.1", default-features = false }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git"}
-prost = { version = "0.10.3" }
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 pubnub-hyper = { git = "https://github.com/MaterializeInc/pubnub-rust", default-features = false }
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.5.6" }

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -47,7 +47,7 @@ mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-stash = { path = "../stash" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
-prost = "0.10.3"
+prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 prost-reflect = { version = "0.8.1", features = ["serde"] }
 protobuf-src = "1.0.4"
 rand = "0.8.5"


### PR DESCRIPTION
Prost has a default recursion limit of 100, meaning that it fails to decode
any message that has a nesting level of more than 100. In most scenarios
this should be a reasonable default, but the way the dataflow plan is
encoded, we can easily exceed this limit when creating large join plans.

This change disables the recusion limit for prost for the `compute-client`
crate. While this is not a great fix, it avoids the problem for the moment.

In the future, we should think about a different representation of plans,
which use a flat and/or stack-based representation. Both could help limit
the depth of the message structure.

Fixes #13431.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
