### PR TITLE
service: improve documentation of GenericClient::recv

### DIFF
--- a/src/service/src/client.rs
+++ b/src/service/src/client.rs
@@ -31,8 +31,23 @@ pub trait GenericClient<C, R>: fmt::Debug + Send {
 
     /// Receives the next response from the dataflow server.
     ///
-    /// This method blocks until the next response is available, or, if the
-    /// dataflow server has been shut down, returns `None`.
+    /// This method blocks until the next response is available.
+    ///
+    /// A return value of `Ok(Some(_))` transmits a response.
+    ///
+    /// A return value of `Ok(None)` indicates graceful termination of the
+    /// connection. The owner of the client should not call `recv` again.
+    ///
+    /// A return value of `Err(_)` indicates an unrecoverable error. After
+    /// observing an error, the owner of the client must either drop the client,
+    /// or, if the client supports reconnection, call the
+    /// [`Reconnect::reconnect`] method.
+    ///
+    /// Implementations of this method **must** be [cancellation safe]. That
+    /// means that work must not be lost if the future returned by this method
+    /// is dropped.
+    ///
+    /// [cancellation safe]: https://docs.rs/tokio/latest/tokio/macro.select.html#cancellation-safety
     async fn recv(&mut self) -> Result<Option<R>, anyhow::Error>;
 
     /// Returns an adapter that treats the client as a stream.


### PR DESCRIPTION
As requested by @lluki in the code review for #13388.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR improves internal documentation.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
