### PR TITLE
sql: make errors point to recorded view commands

### DIFF
--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -75,6 +75,9 @@ pub enum PlanError {
     InvalidTemporarySchema,
     Parser(ParserError),
     Qgm(QGMError),
+    DropViewOnRecordedView(String),
+    AlterViewOnRecordedView(String),
+    ShowCreateViewOnRecordedView(String),
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -92,7 +95,18 @@ impl PlanError {
     }
 
     pub fn hint(&self) -> Option<String> {
-        None
+        match self {
+            Self::DropViewOnRecordedView(_) => {
+                Some("Use DROP RECORDED VIEW to remove a recorded view.".into())
+            }
+            Self::AlterViewOnRecordedView(_) => {
+                Some("Use ALTER RECORDED VIEW to rename a recorded view.".into())
+            }
+            Self::ShowCreateViewOnRecordedView(_) => {
+                Some("Use SHOW CREATE RECORDED VIEW to show a recorded view.".into())
+            }
+            _ => None,
+        }
     }
 }
 
@@ -177,6 +191,9 @@ impl fmt::Display for PlanError {
             Self::InvalidTemporarySchema => {
                 write!(f, "cannot create temporary item in non-temporary schema")
             }
+            Self::DropViewOnRecordedView(name)
+            | Self::AlterViewOnRecordedView(name)
+            | Self::ShowCreateViewOnRecordedView(name) => write!(f, "{name} is not a view"),
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3562,7 +3562,7 @@ pub fn plan_alter_object_rename(
             let full_name = scx.catalog.resolve_full_name(entry.name());
             let item_type = entry.item_type();
 
-            // Return a more helpful error on `DROP VIEW <recorded-view>`.
+            // Return a more helpful error on `ALTER VIEW <recorded-view>`.
             if object_type == ObjectType::View && item_type == CatalogItemType::RecordedView {
                 return Err(PlanError::AlterViewOnRecordedView(full_name.to_string()));
             } else if object_type != item_type {

--- a/test/sqllogictest/recorded_views.slt
+++ b/test/sqllogictest/recorded_views.slt
@@ -351,6 +351,18 @@ statement error recorded view objects cannot depend on log sources
 CREATE OR REPLACE RECORDED VIEW rv AS SELECT * FROM mz_dataflow_operators;
 
 
+# Test: Attempting to use view commands on recorded views gives helpful errors.
+
+statement error materialize.public.rv is not a view\nHINT: Use DROP RECORDED VIEW to remove a recorded view.
+DROP VIEW rv
+
+statement error materialize.public.rv is not a view\nHINT: Use SHOW CREATE RECORDED VIEW to show a recorded view.
+SHOW CREATE VIEW rv
+
+statement error materialize.public.rv is not a view\nHINT: Use ALTER RECORDED VIEW to rename a recorded view.
+ALTER VIEW rv RENAME TO rv2
+
+
 # Cleanup
 
 statement ok


### PR DESCRIPTION
When a user tries to use regular view commands (`DROP VIEW`, `SHOW CREATE VIEW`, `ALTER VIEW`) on recorded views, point them to the correct RECORDED VIEW commands in the error messages.

### Motivation

  * This PR adds a known-desirable feature.

Part of #12860.

### Tips for reviewer

~~The error messages are not optimal, because we lack the ability to return `AdapterError`s inside the `sql` code (see my inline comment for more detail). If someone can think of a way to improve this without completely refactoring the crate's error handling, let me know!~~

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Improve error messages when trying to use view commands with recorded views.
