### PR TITLE
persist: disable aggressive debug assert in ColumnarRecordsBuilder::push

### DIFF
--- a/src/persist/src/indexed/columnar.rs
+++ b/src/persist/src/indexed/columnar.rs
@@ -473,7 +473,7 @@ impl ColumnarRecordsBuilder {
         self.timestamps.push(i64::from_le_bytes(ts));
         self.diffs.push(i64::from_le_bytes(diff));
         self.len += 1;
-        debug_assert_eq!(self.borrow().validate(), Ok(()));
+
         true
     }
 


### PR DESCRIPTION
Leaving this enabled makes large appends in debug mode take unreasonably
long. This has potentially led people down the wrong path/caused some
wasted developer time.

Fixes #13395

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.