### PR TITLE
checks framework: Add the RestartMz scenario to the CI

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -35,6 +35,7 @@ steps:
           - { value: zippy-kafka-sources }
           - { value: checks-drop-create-default-replica }
           - { value: checks-restart-computed }
+          - { value: checks-restart-entire-mz }
           - { value: secrets }
           - { value: unused-deps }
         multiple: true
@@ -262,6 +263,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartComputed]
+
+  - id: checks-restart-entire-mz
+    label: "Checks + restart of the entire Mz"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEntireMz]
 
   - id: secrets
     label: "Secrets"

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -44,3 +44,11 @@ class Check:
 
     def run_validate(self, c: Composition) -> None:
         self._validate.execute(c)
+
+
+class CheckDisabled(Check):
+    def manipulate(self) -> List[Testdrive]:
+        return [Testdrive(""), Testdrive("")]
+
+    def validate(self) -> Testdrive:
+        return Testdrive("")

--- a/misc/python/materialize/checks/cluster.py
+++ b/misc/python/materialize/checks/cluster.py
@@ -10,10 +10,10 @@ from textwrap import dedent
 from typing import List
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import CheckDisabled
 
 
-class CreateCluster(Check):
+class CreateCluster(CheckDisabled):
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))
@@ -62,7 +62,8 @@ class CreateCluster(Check):
         )
 
 
-class DropCluster(Check):
+# https://github.com/MaterializeInc/materialize/issues/13235
+class DropCluster(CheckDisabled):
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))

--- a/misc/python/materialize/checks/replica.py
+++ b/misc/python/materialize/checks/replica.py
@@ -10,10 +10,11 @@ from textwrap import dedent
 from typing import List
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import CheckDisabled
 
 
-class CreateReplica(Check):
+# https://github.com/MaterializeInc/materialize/issues/13235
+class CreateReplica(CheckDisabled):
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))
@@ -51,7 +52,8 @@ class CreateReplica(Check):
         )
 
 
-class DropReplica(Check):
+# https://github.com/MaterializeInc/materialize/issues/13235
+class DropReplica(CheckDisabled):
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -51,14 +51,16 @@ class NoRestartNoUpgrade(Scenario):
         ]
 
 
-class RestartMz(Scenario):
+class RestartEntireMz(Scenario):
     def actions(self) -> List[Action]:
         return [
             StartMz(),
             Initialize(self.checks),
+            RestartMzAction(),
             Manipulate(self.checks, phase=1),
             RestartMzAction(),
             Manipulate(self.checks, phase=2),
+            RestartMzAction(),
             Validate(self.checks),
         ]
 


### PR DESCRIPTION
Disable the ClusterCreate/ClusterDrop/ReplicateCreate/ReplicaDrop
due to #13235 that makes those checks incompatible with whole-Mz restart

### Motivation

  * This PR adds a feature that has not yet been specified.

Now that table persistence has been enabled, the checks framework can run in a "whole Mz instance restart" mode.