### PR TITLE
adapter: forbid creating recorded views on log sources

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3316,6 +3316,22 @@ impl<S: Append + 'static> Coordinator<S> {
 
         self.validate_timeline(depends_on.clone())?;
 
+        // Recorded views are not allowed to depend on log sources, as replicas
+        // are not producing the same definite collection for these.
+        // TODO(teskje): Remove this check once arrangement-based log sources
+        // are replaced with persist-based ones.
+        let log_names = depends_on
+            .iter()
+            .flat_map(|id| self.catalog.log_dependencies(*id))
+            .map(|id| self.catalog.get_entry(&id).name().item.clone())
+            .collect::<Vec<_>>();
+        if !log_names.is_empty() {
+            return Err(AdapterError::InvalidLogDependency {
+                object_type: "recorded view".into(),
+                log_names,
+            });
+        }
+
         // Allocate IDs for the recorded view in the catalog.
         let id = self.catalog.allocate_user_id().await?;
         let oid = self.catalog.allocate_oid().await?;

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -52,6 +52,12 @@ pub enum AdapterError {
     IntrospectionDisabled {
         log_names: Vec<String>,
     },
+    /// Attempted to create an object dependent on log sources that doesn't support
+    /// log dependencies.
+    InvalidLogDependency {
+        object_type: String,
+        log_names: Vec<String>,
+    },
     /// The value for the specified parameter does not have the right type.
     InvalidParameterType(&'static (dyn Var + Send + Sync)),
     /// The value of the specified parameter is incorrect
@@ -180,6 +186,10 @@ impl AdapterError {
                 "The query references the following log sources:\n    {}",
                 log_names.join("\n    "),
             )),
+            AdapterError::InvalidLogDependency { log_names, .. } => Some(format!(
+                "The object depends on the following log sources:\n    {}",
+                log_names.join("\n    "),
+            )),
             _ => None,
         }
     }
@@ -258,6 +268,9 @@ impl fmt::Display for AdapterError {
                 f,
                 "cannot read log sources on cluster with disabled introspection"
             ),
+            AdapterError::InvalidLogDependency { object_type, .. } => {
+                write!(f, "{object_type} objects cannot depend on log sources")
+            }
             AdapterError::InvalidParameterType(p) => write!(
                 f,
                 "parameter {} requires a {} value",

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -380,6 +380,7 @@ impl ErrorResponse {
             AdapterError::IdExhaustionError => SqlState::INTERNAL_ERROR,
             AdapterError::Internal(_) => SqlState::INTERNAL_ERROR,
             AdapterError::IntrospectionDisabled { .. } => SqlState::FEATURE_NOT_SUPPORTED,
+            AdapterError::InvalidLogDependency { .. } => SqlState::FEATURE_NOT_SUPPORTED,
             AdapterError::InvalidParameterType(_) => SqlState::INVALID_PARAMETER_VALUE,
             AdapterError::InvalidParameterValue { .. } => SqlState::INVALID_PARAMETER_VALUE,
             AdapterError::InvalidClusterReplicaAz { .. } => SqlState::FEATURE_NOT_SUPPORTED,

--- a/test/sqllogictest/recorded_views.slt
+++ b/test/sqllogictest/recorded_views.slt
@@ -345,6 +345,12 @@ cluster on_name key_name       seq_in_index column_name expression nullable
 default rv      rv_primary_idx 1            ?column?    NULL       false
 
 
+# Test: Creating recorded views that depend on log sources is forbidden.
+
+statement error recorded view objects cannot depend on log sources
+CREATE OR REPLACE RECORDED VIEW rv AS SELECT * FROM mz_dataflow_operators;
+
+
 # Cleanup
 
 statement ok


### PR DESCRIPTION
The collections produced by arrangement-based log sources are different between replicas. We require that all replicas writing to the same storage collection produce the same definite collection, so we cannot allow creating recorded views that depend on log sources.

### Motivation

  * This PR adds a known-desirable feature.

Part of #12860.

### Tips for reviewer

This change will be obsolete once the introspection revamp that @lluki is working on lands, which is planned for M2. We could decide to not merge this and leave main slightly broken for a while instead. I propose we merge it so we are safe should we for some reason decide to keep the arrangement-based log sources around after all.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Disallow creating recorded views that depend on log sources.
