### PR TITLE
sql: switch all errors to PlanError

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -190,6 +190,7 @@ impl AdapterError {
                 "The object depends on the following log sources:\n    {}",
                 log_names.join("\n    "),
             )),
+            AdapterError::PlanError(e) => e.detail(),
             _ => None,
         }
     }
@@ -234,6 +235,7 @@ impl AdapterError {
                  selection, use `RESET cluster_replica`."
                     .into(),
             ),
+            AdapterError::PlanError(e) => e.hint(),
             _ => None,
         }
     }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -1050,7 +1050,7 @@ where
             }
             (FuncSpec::Op(_), [..]) => unreachable!("non-unary non-binary operator"),
         };
-        PlanError::Unstructured(format!("{}: {}", context, e))
+        sql_err!("{}: {}", context, e)
     })
 }
 
@@ -2857,7 +2857,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(||
             params!(String, String) => Operation::binary(move |_ecx, regex, haystack| {
                 let regex = match regex.into_literal_string() {
                     None => sql_bail!("regex_extract requires a string literal as its first argument"),
-                    Some(regex) => mz_expr::AnalyzedRegex::new(&regex).map_err(|e| PlanError::Unstructured(format!("analyzing regex: {}", e)))?,
+                    Some(regex) => mz_expr::AnalyzedRegex::new(&regex).map_err(|e| sql_err!("analyzing regex: {}", e))?,
                 };
                 let column_names = regex
                     .capture_groups_iter()

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -82,10 +82,15 @@ macro_rules! bail_unsupported {
     };
 }
 
-// TODO(benesch): delete this once we use structured errors everywhere.
+// TODO(benesch): delete these macros once we use structured errors everywhere.
 macro_rules! sql_bail {
     ($($e:expr),* $(,)?) => {
-        return Err(crate::plan::error::PlanError::Unstructured(format!($($e),*)))
+        return Err(sql_err!($($e),*))
+    }
+}
+macro_rules! sql_err {
+    ($($e:expr),* $(,)?) => {
+        crate::plan::error::PlanError::Unstructured(format!($($e),*))
     }
 }
 

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -38,7 +38,6 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use anyhow::bail;
 use itertools::Itertools;
 
 use mz_ore::collections::CollectionExt;
@@ -49,7 +48,7 @@ use mz_repr::*;
 use crate::plan::expr::{
     AggregateExpr, ColumnOrder, ColumnRef, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType,
 };
-use crate::plan::transform_expr;
+use crate::plan::{transform_expr, PlanError};
 
 /// Maps a leveled column reference to a specific column.
 ///
@@ -1365,7 +1364,7 @@ impl HirScalarExpr {
     }
 
     /// Rewrites `self` into a `mz_expr::ScalarExpr`.
-    pub fn lower_uncorrelated(self) -> Result<mz_expr::MirScalarExpr, anyhow::Error> {
+    pub fn lower_uncorrelated(self) -> Result<mz_expr::MirScalarExpr, PlanError> {
         use self::HirScalarExpr::*;
         use mz_expr::MirScalarExpr as SS;
 
@@ -1395,7 +1394,7 @@ impl HirScalarExpr {
                 els: Box::new(els.lower_uncorrelated()?),
             },
             Select { .. } | Exists { .. } | Parameter(..) | Column(..) | Windowing(..) => {
-                bail!("unexpected ScalarExpr in uncorrelated plan: {:?}", self);
+                sql_bail!("unexpected ScalarExpr in uncorrelated plan: {:?}", self);
             }
         })
     }

--- a/src/sql/src/plan/plan_utils.rs
+++ b/src/sql/src/plan/plan_utils.rs
@@ -11,12 +11,11 @@
 
 use std::fmt;
 
-use anyhow::bail;
-
 use mz_repr::RelationDesc;
 
 use crate::ast::Ident;
 use crate::normalize;
+use crate::plan::PlanError;
 
 /// Renames the columns in `desc` with the names in `column_names` if
 /// `column_names` is non-empty.
@@ -27,13 +26,13 @@ pub fn maybe_rename_columns(
     context: impl fmt::Display,
     desc: RelationDesc,
     column_names: &[Ident],
-) -> Result<RelationDesc, anyhow::Error> {
+) -> Result<RelationDesc, PlanError> {
     if column_names.is_empty() {
         return Ok(desc);
     }
 
     if column_names.len() != desc.typ().column_types.len() {
-        bail!(
+        sql_bail!(
             "{0} definition names {1} column{2}, but {0} has {3} column{4}",
             context,
             column_names.len(),

--- a/src/sql/src/plan/scope.rs
+++ b/src/sql/src/plan/scope.rs
@@ -44,8 +44,6 @@
 use std::collections::HashSet;
 use std::iter;
 
-use anyhow::bail;
-
 use mz_ore::iter::IteratorExt;
 use mz_repr::ColumnName;
 
@@ -405,7 +403,7 @@ impl Scope {
             })
     }
 
-    pub fn product(self, right: Self) -> Result<Self, anyhow::Error> {
+    pub fn product(self, right: Self) -> Result<Self, PlanError> {
         let mut l_tables = self.table_names().into_iter().collect::<Vec<_>>();
         // Make ordering deterministic for testing
         l_tables.sort_by(|l, r| l.item.cmp(&r.item));
@@ -413,7 +411,7 @@ impl Scope {
         for l in l_tables {
             for r in &r_tables {
                 if l.matches(r) {
-                    bail!("table name \"{}\" specified more than once", l.item)
+                    sql_bail!("table name \"{}\" specified more than once", l.item)
                 }
             }
         }

--- a/src/sql/src/plan/statement/raise.rs
+++ b/src/sql/src/plan/statement/raise.rs
@@ -14,16 +14,13 @@
 
 use crate::ast::RaiseStatement;
 use crate::plan::statement::{StatementContext, StatementDesc};
-use crate::plan::{Plan, RaisePlan};
+use crate::plan::{Plan, PlanError, RaisePlan};
 
-pub fn describe_raise(
-    _: &StatementContext,
-    _: RaiseStatement,
-) -> Result<StatementDesc, anyhow::Error> {
+pub fn describe_raise(_: &StatementContext, _: RaiseStatement) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(None))
 }
 
-pub fn plan_raise(scx: &StatementContext, r: RaiseStatement) -> Result<Plan, anyhow::Error> {
+pub fn plan_raise(scx: &StatementContext, r: RaiseStatement) -> Result<Plan, PlanError> {
     scx.require_unsafe_mode("RAISE statement")?;
     Ok(Plan::Raise(RaisePlan {
         severity: r.severity,

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -15,8 +15,6 @@
 
 use std::fmt::Write;
 
-use anyhow::bail;
-
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Datum, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -35,12 +33,12 @@ use crate::names::{
 };
 use crate::parse;
 use crate::plan::statement::{dml, StatementContext, StatementDesc};
-use crate::plan::{Params, Plan, SendRowsPlan};
+use crate::plan::{Params, Plan, PlanError, SendRowsPlan};
 
 pub fn describe_show_create_view(
     _: &StatementContext,
     _: ShowCreateViewStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("View", ScalarType::String.nullable(false))
@@ -51,7 +49,7 @@ pub fn describe_show_create_view(
 pub fn plan_show_create_view(
     scx: &mut StatementContext,
     ShowCreateViewStatement { view_name }: ShowCreateViewStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let view = scx.get_item_by_resolved_name(&view_name)?;
     if let CatalogItemType::View = view.item_type() {
         let name = view_name.full_name_str();
@@ -71,14 +69,14 @@ pub fn plan_show_create_view(
             ])],
         }))
     } else {
-        bail!("{} is not a view", view_name.full_name_str());
+        sql_bail!("{} is not a view", view_name.full_name_str());
     }
 }
 
 pub fn describe_show_create_recorded_view(
     _: &StatementContext,
     _: ShowCreateRecordedViewStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("Recorded View", ScalarType::String.nullable(false))
@@ -89,7 +87,7 @@ pub fn describe_show_create_recorded_view(
 pub fn plan_show_create_recorded_view(
     scx: &mut StatementContext,
     stmt: ShowCreateRecordedViewStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let name = stmt.recorded_view_name;
     let rview = scx.get_item_by_resolved_name(&name)?;
     if let CatalogItemType::RecordedView = rview.item_type() {
@@ -110,14 +108,14 @@ pub fn plan_show_create_recorded_view(
             ])],
         }))
     } else {
-        bail!("{} is not a recorded view", name.full_name_str());
+        sql_bail!("{} is not a recorded view", name.full_name_str());
     }
 }
 
 pub fn describe_show_create_table(
     _: &StatementContext,
     _: ShowCreateTableStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("Table", ScalarType::String.nullable(false))
@@ -128,7 +126,7 @@ pub fn describe_show_create_table(
 pub fn plan_show_create_table(
     scx: &mut StatementContext,
     ShowCreateTableStatement { table_name }: ShowCreateTableStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let table = scx.get_item_by_resolved_name(&table_name)?;
     if let CatalogItemType::Table = table.item_type() {
         let name = table_name.full_name_str();
@@ -145,14 +143,14 @@ pub fn plan_show_create_table(
             ])],
         }))
     } else {
-        bail!("{} is not a table", table_name.full_name_str());
+        sql_bail!("{} is not a table", table_name.full_name_str());
     }
 }
 
 pub fn describe_show_create_source(
     _: &StatementContext,
     _: ShowCreateSourceStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("Source", ScalarType::String.nullable(false))
@@ -163,7 +161,7 @@ pub fn describe_show_create_source(
 pub fn plan_show_create_source(
     scx: &StatementContext,
     ShowCreateSourceStatement { source_name }: ShowCreateSourceStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let source = scx.get_item_by_resolved_name(&source_name)?;
     if let CatalogItemType::Source = source.item_type() {
         let name = source_name.full_name_str();
@@ -174,14 +172,14 @@ pub fn plan_show_create_source(
             ])],
         }))
     } else {
-        bail!("{} is not a source", source_name.full_name_str());
+        sql_bail!("{} is not a source", source_name.full_name_str());
     }
 }
 
 pub fn describe_show_create_sink(
     _: &StatementContext,
     _: ShowCreateSinkStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("Sink", ScalarType::String.nullable(false))
@@ -192,7 +190,7 @@ pub fn describe_show_create_sink(
 pub fn plan_show_create_sink(
     scx: &StatementContext,
     ShowCreateSinkStatement { sink_name }: ShowCreateSinkStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let sink = scx.get_item_by_resolved_name(&sink_name)?;
     if let CatalogItemType::Sink = sink.item_type() {
         let name = sink_name.full_name_str();
@@ -203,14 +201,14 @@ pub fn plan_show_create_sink(
             ])],
         }))
     } else {
-        bail!("'{}' is not a sink", sink_name.full_name_str());
+        sql_bail!("'{}' is not a sink", sink_name.full_name_str());
     }
 }
 
 pub fn describe_show_create_index(
     _: &StatementContext,
     _: ShowCreateIndexStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("Index", ScalarType::String.nullable(false))
@@ -221,7 +219,7 @@ pub fn describe_show_create_index(
 pub fn plan_show_create_index(
     scx: &StatementContext,
     ShowCreateIndexStatement { index_name }: ShowCreateIndexStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let index = scx.get_item_by_resolved_name(&index_name)?;
     if let CatalogItemType::Index = index.item_type() {
         let name = index_name.full_name_str();
@@ -232,14 +230,14 @@ pub fn plan_show_create_index(
             ])],
         }))
     } else {
-        bail!("'{}' is not an index", index_name.full_name_str());
+        sql_bail!("'{}' is not an index", index_name.full_name_str());
     }
 }
 
 pub fn describe_show_create_connection(
     _: &StatementContext,
     _: ShowCreateConnectionStatement<Aug>,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
             .with_column("Connection", ScalarType::String.nullable(false))
@@ -250,7 +248,7 @@ pub fn describe_show_create_connection(
 pub fn plan_show_create_connection(
     scx: &StatementContext,
     ShowCreateConnectionStatement { connection_name }: ShowCreateConnectionStatement<Aug>,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let connection = scx.get_item_by_resolved_name(&connection_name)?;
     if let CatalogItemType::Connection = connection.item_type() {
         let name = connection_name.full_name_str();
@@ -261,14 +259,14 @@ pub fn plan_show_create_connection(
             ])],
         }))
     } else {
-        bail!("'{}' is not a connection", connection_name.full_name_str());
+        sql_bail!("'{}' is not a connection", connection_name.full_name_str());
     }
 }
 
 pub fn show_databases<'a>(
     scx: &'a StatementContext<'a>,
     ShowDatabasesStatement { filter }: ShowDatabasesStatement<Aug>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT name FROM mz_catalog.mz_databases".to_string();
     ShowSelect::new(scx, query, filter, None, None)
 }
@@ -281,12 +279,12 @@ pub fn show_schemas<'a>(
         full,
         filter,
     }: ShowSchemasStatement<Aug>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let database_id = match from {
         Some(ResolvedDatabaseName::Database { id, .. }) => id.0,
         None => match scx.active_database() {
             Some(id) => id.0,
-            None => bail!("no database specified and no active database"),
+            None => sql_bail!("no database specified and no active database"),
         },
         Some(ResolvedDatabaseName::Error) => {
             unreachable!("should have been handled in name resolution")
@@ -333,7 +331,7 @@ pub fn show_objects<'a>(
         in_cluster,
         filter,
     }: ShowObjectsStatement<Aug>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     match object_type {
         ObjectType::Table => show_tables(scx, extended, full, from, filter),
         ObjectType::Source => show_sources(scx, full, materialized, from, filter),
@@ -357,7 +355,7 @@ fn show_connections<'a>(
     full: bool,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let mut query = format!(
         "SELECT t.name, mz_internal.mz_classify_object_id(t.id) AS type
@@ -381,7 +379,7 @@ fn show_tables<'a>(
     full: bool,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let mut query = format!(
@@ -407,7 +405,7 @@ fn show_sources<'a>(
     materialized: bool,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let query = match (full, materialized) {
@@ -463,7 +461,7 @@ fn show_views<'a>(
     materialized: bool,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let query = if !full & !materialized {
@@ -505,12 +503,13 @@ fn show_recorded_views<'a>(
     from: Option<ResolvedSchemaName>,
     in_cluster: Option<ResolvedClusterName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let mut where_clause = format!("schema_id = {schema_spec}");
 
     if let Some(cluster) = in_cluster {
-        write!(where_clause, " AND cluster_id = {}", cluster.0)?;
+        write!(where_clause, " AND cluster_id = {}", cluster.0)
+            .expect("write on string cannot fail");
     }
 
     let query = if full {
@@ -541,7 +540,7 @@ fn show_sinks<'a>(
     from: Option<ResolvedSchemaName>,
     in_cluster: Option<ResolvedClusterName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let mut query_filters = vec![];
 
     if let Some(ResolvedSchemaName::Schema { schema_spec, .. }) = from {
@@ -590,7 +589,7 @@ fn show_types<'a>(
     full: bool,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let mut query = format!(
@@ -616,7 +615,7 @@ fn show_all_objects<'a>(
     full: bool,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let mut query = format!(
@@ -644,7 +643,7 @@ pub fn show_indexes<'a>(
         table_name,
         filter,
     }: ShowIndexesStatement<Aug>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     // Exclude system indexes unless `EXTENDED` is requested.
     let mut query_filter = if extended {
         vec!["TRUE".into()]
@@ -659,7 +658,7 @@ pub fn show_indexes<'a>(
             && from.item_type() != CatalogItemType::Source
             && from.item_type() != CatalogItemType::Table
         {
-            bail!(
+            sql_bail!(
                 "cannot show indexes on {} because it is a {}",
                 table_name.full_name_str(),
                 from.item_type(),
@@ -704,7 +703,7 @@ pub fn show_columns<'a>(
         table_name,
         filter,
     }: ShowColumnsStatement<Aug>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     if extended {
         bail_unsupported!("SHOW EXTENDED COLUMNS");
     }
@@ -736,7 +735,7 @@ pub fn show_columns<'a>(
 pub fn show_clusters<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let query = "SELECT mz_clusters.name FROM mz_catalog.mz_clusters".to_string();
 
     ShowSelect::new(scx, query, filter, None, None)
@@ -745,7 +744,7 @@ pub fn show_clusters<'a>(
 pub fn show_cluster_replicas<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let query = r#"
     SELECT
         mz_catalog.mz_clusters.name AS cluster,
@@ -765,7 +764,7 @@ pub fn show_secrets<'a>(
     scx: &'a StatementContext<'a>,
     from: Option<ResolvedSchemaName>,
     filter: Option<ShowStatementFilter<Aug>>,
-) -> Result<ShowSelect<'a>, anyhow::Error> {
+) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
 
     let query = format!(
@@ -801,7 +800,7 @@ impl<'a> ShowSelect<'a> {
         filter: Option<ShowStatementFilter<Aug>>,
         order: Option<&str>,
         projection: Option<&[&str]>,
-    ) -> Result<ShowSelect<'a>, anyhow::Error> {
+    ) -> Result<ShowSelect<'a>, PlanError> {
         let filter = match filter {
             Some(ShowStatementFilter::Like(like)) => format!("name LIKE {}", Value::String(like)),
             Some(ShowStatementFilter::Where(expr)) => expr.to_string(),
@@ -826,12 +825,12 @@ impl<'a> ShowSelect<'a> {
     }
 
     /// Computes the shape of this `ShowSelect`.
-    pub fn describe(self) -> Result<StatementDesc, anyhow::Error> {
+    pub fn describe(self) -> Result<StatementDesc, PlanError> {
         dml::describe_select(self.scx, self.stmt)
     }
 
     /// Converts this `ShowSelect` into a [`Plan`].
-    pub fn plan(self) -> Result<Plan, anyhow::Error> {
+    pub fn plan(self) -> Result<Plan, PlanError> {
         dml::plan_select(self.scx, self.stmt, &Params::empty(), None)
     }
 }

--- a/src/sql/src/plan/statement/tcl.rs
+++ b/src/sql/src/plan/statement/tcl.rs
@@ -17,19 +17,19 @@ use crate::ast::{
     TransactionAccessMode, TransactionMode,
 };
 use crate::plan::statement::{StatementContext, StatementDesc};
-use crate::plan::{Plan, StartTransactionPlan};
+use crate::plan::{Plan, PlanError, StartTransactionPlan};
 
 pub fn describe_start_transaction(
     _: &StatementContext,
     _: StartTransactionStatement,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_start_transaction(
     _: &StatementContext,
     StartTransactionStatement { modes }: StartTransactionStatement,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     let access = verify_transaction_modes(modes)?;
     Ok(Plan::StartTransaction(StartTransactionPlan { access }))
 }
@@ -37,20 +37,20 @@ pub fn plan_start_transaction(
 pub fn describe_set_transaction(
     _: &StatementContext,
     _: SetTransactionStatement,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     bail_unsupported!("SET TRANSACTION")
 }
 
 pub fn plan_set_transaction(
     _: &StatementContext,
     _: SetTransactionStatement,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     bail_unsupported!("SET TRANSACTION")
 }
 
 fn verify_transaction_modes(
     modes: Vec<TransactionMode>,
-) -> Result<Option<TransactionAccessMode>, anyhow::Error> {
+) -> Result<Option<TransactionAccessMode>, PlanError> {
     let mut access = None;
     for mode in modes {
         match mode {
@@ -68,14 +68,14 @@ fn verify_transaction_modes(
 pub fn describe_rollback(
     _: &StatementContext,
     _: RollbackStatement,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_rollback(
     _: &StatementContext,
     RollbackStatement { chain }: RollbackStatement,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     verify_chain(chain)?;
     Ok(Plan::AbortTransaction)
 }
@@ -83,19 +83,19 @@ pub fn plan_rollback(
 pub fn describe_commit(
     _: &StatementContext,
     _: CommitStatement,
-) -> Result<StatementDesc, anyhow::Error> {
+) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(None))
 }
 
 pub fn plan_commit(
     _: &StatementContext,
     CommitStatement { chain }: CommitStatement,
-) -> Result<Plan, anyhow::Error> {
+) -> Result<Plan, PlanError> {
     verify_chain(chain)?;
     Ok(Plan::CommitTransaction)
 }
 
-fn verify_chain(chain: bool) -> Result<(), anyhow::Error> {
+fn verify_chain(chain: bool) -> Result<(), PlanError> {
     if chain {
         bail_unsupported!("CHAIN");
     }


### PR DESCRIPTION
Most of the functions still produce only PlanError::Unstructured, but
this will allow us to incrementally move each error to a structured
error type.

This allows the error structure to be propagated upwards to the
coordinator when it exists, which will allow the structured SQL errors
to return hints and long form descriptions.

In particular, after this change, the error messages under construction
in #13445 will be able to properly emit hints.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
