### PR TITLE
python/checks: add missing license header

### DIFF
--- a/misc/python/materialize/checks/__init__.py
+++ b/misc/python/materialize/checks/__init__.py
@@ -1,0 +1,8 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.


### PR DESCRIPTION
The lack of this header was breaking the CI deploy job.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
