### PR TITLE
tracing-orchestrator: pass through current otel status

### DIFF
--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -116,7 +116,7 @@ fn create_communication_config(args: &Args) -> Result<CommunicationConfig, anyho
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let otel_collector_enabler = mz_ore::tracing::configure("computed", &args.tracing).await?;
+    let otel_enable_callback = mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -154,7 +154,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_enable_otel(otel_collector_enabler, payload).await
+                            mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
                         }),
                     )
                     .into_make_service(),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -420,7 +420,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     } else {
         None
     };
-    let otel_collector_enabler =
+    let otel_enable_callback =
         runtime.block_on(mz_ore::tracing::configure("environmentd", &args.tracing))?;
 
     // Initialize fail crate for failpoint support
@@ -554,7 +554,11 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     };
     let persist_clients = PersistClientCache::new(&metrics_registry);
     let persist_clients = Arc::new(Mutex::new(persist_clients));
-    let orchestrator = Arc::new(TracingOrchestrator::new(orchestrator, args.tracing.clone()));
+    let orchestrator = Arc::new(TracingOrchestrator::new(
+        orchestrator,
+        args.tracing.clone(),
+        otel_enable_callback.clone(),
+    ));
     let controller = ControllerConfig {
         orchestrator,
         persist_location: PersistLocation {
@@ -692,7 +696,7 @@ max log level: {max_log_level}",
             args.aws_external_id_prefix,
             secrets_path,
         ),
-        otel_collector_enabler,
+        otel_enable_callback,
     }))?;
 
     println!(

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -322,17 +322,17 @@ async fn auth<B>(
 #[derive(Clone)]
 pub struct InternalServer {
     metrics_registry: MetricsRegistry,
-    otel_collector_enabler: OpenTelemetryEnableCallback,
+    otel_enable_callback: OpenTelemetryEnableCallback,
 }
 
 impl InternalServer {
     pub fn new(
         metrics_registry: MetricsRegistry,
-        otel_collector_enabler: OpenTelemetryEnableCallback,
+        otel_enable_callback: OpenTelemetryEnableCallback,
     ) -> Self {
         Self {
             metrics_registry,
-            otel_collector_enabler,
+            otel_enable_callback,
         }
     }
 
@@ -352,7 +352,7 @@ impl InternalServer {
             .route(
                 "/api/opentelemetry/config",
                 routing::put(move |payload| async move {
-                    mz_http_util::handle_enable_otel(self.otel_collector_enabler, payload).await
+                    mz_http_util::handle_enable_otel(self.otel_enable_callback, payload).await
                 }),
             );
         axum::Server::bind(&addr).serve(router.into_make_service())

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -115,7 +115,7 @@ pub struct Config {
     pub availability_zones: Vec<String>,
 
     /// A callback used to enable or disable the OpenTelemetry tracing collector.
-    pub otel_collector_enabler: OpenTelemetryEnableCallback,
+    pub otel_enable_callback: OpenTelemetryEnableCallback,
 }
 
 /// Configures TLS encryption for connections.
@@ -275,7 +275,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Listen on the internal HTTP API port.
     let internal_http_local_addr = {
         let metrics_registry = config.metrics_registry.clone();
-        let server = http::InternalServer::new(metrics_registry, config.otel_collector_enabler);
+        let server = http::InternalServer::new(metrics_registry, config.otel_enable_callback);
         let bound_server = server.bind(config.internal_http_listen_addr);
         let internal_http_local_addr = bound_server.local_addr();
         task::spawn(|| "internal_http_server", {

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -202,7 +202,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         replica_sizes: Default::default(),
         availability_zones: Default::default(),
         connection_context: Default::default(),
-        otel_collector_enabler: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
+        otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
     }))?;
     let server = Server {
         inner,

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -119,7 +119,7 @@ pub async fn handle_enable_otel(
     callback: mz_ore::tracing::OpenTelemetryEnableCallback,
     Json(cfg): Json<DynamicOtelConfig>,
 ) -> impl IntoResponse {
-    match callback.0(cfg.enabled) {
+    match callback.call(cfg.enabled) {
         Ok(()) => (
             StatusCode::OK,
             format!(

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -632,7 +632,7 @@ impl Runner {
             replica_sizes: Default::default(),
             availability_zones: Default::default(),
             connection_context: Default::default(),
-            otel_collector_enabler: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
+            otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -113,7 +113,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let otel_collector_enabler = mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let otel_enable_callback = mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -151,7 +151,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_enable_otel(otel_collector_enabler, payload).await
+                            mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
                         }),
                     )
                     .into_make_service(),


### PR DESCRIPTION
@mjibson made a good point when I was merging https://github.com/MaterializeInc/materialize/pull/13361 about whether or not NEW clusters come up with the same status as the envd they are orchestrated by. This pr passes through an atomic so that NEW clusters that envd starts come up with the same otel-status as the envd. This is useful to watch envd boostrap storageds/computeds in real-time

@antifuchs I dont think that this complicates the script proposed in https://github.com/MaterializeInc/cloud/issues/3431, but its possible new clusters being started at the same time as _disabling_ otel could leave some processes with otel enabled, but I doubt that will be a problem

### Motivation

  * This PR adds a feature that has not yet been specified.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

None
