### PR TITLE
sql,storage: remove default metadata from sources

### DIFF
--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -190,7 +190,6 @@ projects:
             test_materialized_view_index,1,1,
             test_materialized_view_index,1,1,
             test_source,1,1,
-            test_source,2,2,
             test_source_index,1,1,
             test_view_index,1,1,
             test_view_index,2,,pg_catalog.length(a)

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -481,6 +481,15 @@ impl RelationDesc {
         &self.names[i]
     }
 
+    /// Mutably gets the name of the `i`th column.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `i` is not a valid column index.
+    pub fn get_name_mut(&mut self, i: usize) -> &mut ColumnName {
+        &mut self.names[i]
+    }
+
     /// Gets the name of the `i`th column if that column name is unambiguous.
     ///
     /// If at least one other column has the same name as the `i`th column,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1014,9 +1014,9 @@ fn plan_query_inner(
         let (val, scope) = plan_nested_query(qcx, &cte.query)?;
         let typ = qcx.relation_type(&val);
         let mut val_desc = RelationDesc::new(typ, scope.column_names());
-        val_desc = plan_utils::maybe_rename_columns(
+        plan_utils::maybe_rename_columns(
             format!("CTE {}", cte.alias.name),
-            val_desc,
+            &mut val_desc,
             &cte.alias.columns,
         )?;
 

--- a/src/storage/src/client/sources.proto
+++ b/src/storage/src/client/sources.proto
@@ -32,12 +32,11 @@ message ProtoMzOffset {
 
 message ProtoIncludedColumnSource {
     oneof kind {
-        google.protobuf.Empty default_position = 1;
-        google.protobuf.Empty partition = 2;
-        google.protobuf.Empty offset = 3;
-        google.protobuf.Empty timestamp = 4;
-        google.protobuf.Empty topic = 5;
-        google.protobuf.Empty headers = 6;
+        google.protobuf.Empty partition = 1;
+        google.protobuf.Empty offset = 2;
+        google.protobuf.Empty timestamp = 3;
+        google.protobuf.Empty topic = 4;
+        google.protobuf.Empty headers = 5;
     }
 }
 

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -674,7 +674,7 @@ fn to_metadata_row(
             for item in metadata_items.iter() {
                 match item {
                     IncludedColumnSource::Partition => packer.push(Datum::from(partition)),
-                    IncludedColumnSource::Offset | IncludedColumnSource::DefaultPosition => {
+                    IncludedColumnSource::Offset => {
                         // note this is bitwise cast, so offsets > i64::MAX will be
                         // rendered as negative
                         // TODO: make this an native u64 when https://github.com/MaterializeInc/materialize/issues/7629
@@ -722,17 +722,8 @@ fn to_metadata_row(
             }
         }
         PartitionId::None => {
-            for item in metadata_items.iter() {
-                match item {
-                    IncludedColumnSource::DefaultPosition => {
-                        // note this is bitwise cast, so offsets > i64::MAX will be
-                        // rendered as negative
-                        // TODO: make this an native u64 when https://github.com/MaterializeInc/materialize/issues/7629
-                        // is resolved.
-                        packer.push(Datum::from(position as i64))
-                    }
-                    _ => unreachable!("Only Kafka supports non-defaultposition metadata items"),
-                }
+            if !metadata_items.is_empty() {
+                unreachable!("Only Kafka supports metadata items");
             }
         }
     }

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -179,7 +179,7 @@ A
   FORMAT BYTES
 
 > SELECT * FROM source1
-A 1
+A
 
 # Sinks
 

--- a/test/cluster/storaged/01-create-sources.td
+++ b/test/cluster/storaged/01-create-sources.td
@@ -27,6 +27,6 @@ one
   REMOTE 'storaged:2100'
 
 > SELECT * from remote1
-one  1
+one
 > SELECT * from remote2
-one  1
+one

--- a/test/cluster/storaged/02-after-environmentd-restart.td
+++ b/test/cluster/storaged/02-after-environmentd-restart.td
@@ -11,9 +11,9 @@
 # present, then try ingesting more data.
 
 > SELECT * from remote1
-one  1
+one
 > SELECT * from remote2
-one  1
+one
 
 $ kafka-ingest format=bytes topic=remote1
 two
@@ -21,8 +21,8 @@ $ kafka-ingest format=bytes topic=remote2
 two
 
 > SELECT * from remote1
-one   1
-two   2
+one
+two
 > SELECT * from remote2
-one  1
-two  2
+one
+two

--- a/test/cluster/storaged/03-while-storaged-down.td
+++ b/test/cluster/storaged/03-while-storaged-down.td
@@ -11,11 +11,11 @@
 # that newly ingested data does not appear.
 
 > SELECT * from remote1
-one   1
-two   2
+one
+two
 > SELECT * from remote2
-one  1
-two  2
+one
+two
 
 $ kafka-ingest format=bytes topic=remote1
 three
@@ -23,8 +23,8 @@ $ kafka-ingest format=bytes topic=remote2
 three
 
 > SELECT * from remote1
-one   1
-two   2
+one
+two
 > SELECT * from remote2
-one  1
-two  2
+one
+two

--- a/test/cluster/storaged/04-after-storaged-restart.td
+++ b/test/cluster/storaged/04-after-storaged-restart.td
@@ -11,13 +11,13 @@
 # then try ingesting new data.
 
 > SELECT * from remote1
-one   1
-two   2
-three 3
+one
+two
+three
 > SELECT * from remote2
-one   1
-two   2
-three 3
+one
+two
+three
 
 $ kafka-ingest format=bytes topic=remote1
 four
@@ -25,12 +25,12 @@ $ kafka-ingest format=bytes topic=remote2
 four
 
 > SELECT * from remote1
-one   1
-two   2
-three 3
-four  4
+one
+two
+three
+four
 > SELECT * from remote2
-one   1
-two   2
-three 3
-four  4
+one
+two
+three
+four

--- a/test/kafka-resumption/verify-success.td
+++ b/test/kafka-resumption/verify-success.td
@@ -13,8 +13,8 @@ Hanover,PA,17331
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
-{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "mz_offset":4}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "mz_offset":5}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "mz_offset":2}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "mz_offset":1}},"transaction":{"id":"<TIMESTAMP>"}}
-{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "mz_offset":3}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "offset":4}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "offset":5}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "offset":2}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "offset":1}},"transaction":{"id":"<TIMESTAMP>"}}
+{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "offset":3}},"transaction":{"id":"<TIMESTAMP>"}}

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -18,15 +18,16 @@ $ kafka-ingest format=bytes topic=bytes timestamp=1
 > CREATE MATERIALIZED SOURCE data
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
+  INCLUDE OFFSET
 
 > SHOW COLUMNS FROM data
 name       nullable  type
 --------------------------
 data       false     bytea
-mz_offset  false     bigint
+offset     false     bigint
 
 > SELECT * FROM data
-data           mz_offset
+data           offset
 ------------------------
 "\\xc2\\xa91"  1
 "\\xc2\\xa92"  2
@@ -41,15 +42,15 @@ data           mz_offset
 name       nullable  type
 --------------------------
 named_col  false     bytea
-mz_offset  false     bigint
 
 > CREATE MATERIALIZED SOURCE data_offset
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
   WITH (start_offset=1)
   FORMAT BYTES
+  INCLUDE OFFSET
 
 > SELECT * FROM data_offset
-data           mz_offset
+data           offset
 ------------------------
 "\\xc2\\xa92"  2
 
@@ -65,8 +66,9 @@ $ kafka-ingest format=bytes topic=bytes-partitions timestamp=1 partition=1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-partitions-${testdrive.seed}'
   WITH (start_offset=[0,1])
   FORMAT BYTES
+  INCLUDE OFFSET
 
 > SELECT * FROM data_offset_2
-data           mz_offset
+data           offset
 ------------------------
 "\\xc2\\xa91"  1

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -45,10 +45,10 @@ materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"te
   FORMAT CSV WITH 2 COLUMNS
 
 > SELECT * FROM connection_source
-first second mz_offset
-----------------------
-1     2      1
-2     3      2
+first second
+------------
+1     2
+2     3
 
 # Confirm we cannot drop the connection while a source depends upon it
 ! DROP CONNECTION testconn;
@@ -238,10 +238,10 @@ $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb messag
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-import-csr-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION proto_csr
 
-> SELECT importee1::text, importee2::text, mz_offset FROM import_connection_csr
-importee1  importee2            mz_offset
------------------------------------------
-(f)        "(\"(1234,5678)\")"  1
+> SELECT importee1::text, importee2::text FROM import_connection_csr
+importee1  importee2
+--------------------------------
+(f)        "(\"(1234,5678)\")"
 
 # Test invalid connection parameter combinations
 

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -55,9 +55,9 @@ contains:CSV error at record number 1: expected 2 columns, got 3.
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names where zip = '14618'
-city state zip mz_record
--------------------------
-Rochester NY 14618 1
+city state zip
+------------------
+Rochester NY 14618
 
 > CREATE MATERIALIZED SOURCE matching_column_names_alias (a, b, c)
   FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
@@ -71,9 +71,9 @@ Rochester NY 14618 1
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM matching_column_names_alias where c = '14618'
-a b c mz_record
+a b c
 ----------------
-Rochester NY 14618 1
+Rochester NY 14618
 
 > CREATE MATERIALIZED SOURCE mismatched_column_names
   FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
@@ -114,12 +114,12 @@ contains:CSV error at record number 1: expected 2 columns, got 3
   FORMAT CSV WITH 3 COLUMNS
 
 > SELECT * FROM static_csv
-column1        column2  column3  mz_record
---------------------------------------------
-city           state     zip     1
-Rochester      NY        14618   2
-"New York"     NY        10004   3
-"bad,\nplace\""  CA        92679   4
+column1        column2  column3
+---------------------------------
+city           state     zip
+Rochester      NY        14618
+"New York"     NY        10004
+"bad,\nplace\""  CA      92679
 
 ! CREATE SOURCE static_csv_nothing_demanded_src
   FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
@@ -151,11 +151,11 @@ contains:Expected a list of columns in parentheses, found EOF
   FORMAT CSV WITH HEADER (city, state, zip)
 
 > SELECT * FROM static_csv_manual_header
-city_man       state_man  zip_man  mz_record
----------------------------------------------
-Rochester      NY         14618    1
-"New York"     NY         10004    2
-"bad,\nplace\""  CA         92679    3
+city_man       state_man  zip_man
+-----------------------------------
+Rochester      NY         14618
+"New York"     NY         10004
+"bad,\nplace\""  CA       92679
 
 # Dynamic CSV with automatic headers.
 
@@ -171,18 +171,18 @@ $ kafka-ingest topic=dynamic format=bytes
 Rochester,NY,14618
 
 > SELECT * FROM dynamic_csv
-city           state     zip     mz_offset
-------------------------------------------
-Rochester      NY        14618   1
+city           state     zip
+------------------------------
+Rochester      NY        14618
 
 $ kafka-ingest topic=dynamic format=bytes
 New York,NY,10004
 
 > SELECT * FROM dynamic_csv
-city           state     zip     mz_offset
-------------------------------------------
-Rochester      NY        14618   1
-"New York"     NY        10004   2
+city           state     zip
+------------------------------
+Rochester      NY        14618
+"New York"     NY        10004
 
 # Static malformed CSV
 $ s3-put-object bucket=test key=malformed.csv
@@ -246,6 +246,6 @@ $ kafka-create-topic topic=static-csv-pkne-sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-verify format=avro sink=materialize.public.static_csv_pkne_sink sort-messages=true
-{"zip": "10004"} {"city": "New York", "state": "NY", "zip": "10004", "mz_record": 2}
-{"zip": "14618"} {"city": "Rochester", "state": "NY", "zip": "14618", "mz_record": 1}
-{"zip": "92679"} {"city": "bad,\nplace\"", "state": "CA", "zip": "92679", "mz_record": 3}
+{"zip": "10004"} {"city": "New York", "state": "NY", "zip": "10004"}
+{"zip": "14618"} {"city": "Rochester", "state": "NY", "zip": "14618"}
+{"zip": "92679"} {"city": "bad,\nplace\"", "state": "CA", "zip": "92679"}

--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -24,7 +24,7 @@ bar
   )
   FORMAT BYTES;
 
-> SELECT data FROM posix ORDER BY mz_record;
+> SELECT data FROM posix
 foo
 bar
 
@@ -43,6 +43,6 @@ bar
   )
   FORMAT BYTES;
 
-> SELECT data FROM non_posix ORDER BY mz_record;
+> SELECT data FROM non_posix
 foo
 bar

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -20,10 +20,10 @@ $ kafka-ingest format=bytes topic=input_csv
 2,3
 
 > SELECT * from input_csv;
-first second mz_offset
-----------------------
-1     2      1
-2     3      2
+first second
+-------------
+1     2
+2     3
 
 $ kafka-ingest format=bytes topic=input_csv_partitioned partition=0
 1,2
@@ -37,6 +37,6 @@ $ kafka-ingest format=bytes topic=input_csv_partitioned partition=1
   FORMAT CSV WITH 2 COLUMNS;
 
 > SELECT * FROM input_csv_partitioned
-first second mz_offset
-----------------------
-2     3      1
+first second
+------------
+2     3

--- a/test/testdrive/kafka-envelope-none.td
+++ b/test/testdrive/kafka-envelope-none.td
@@ -21,10 +21,10 @@ $ kafka-create-topic topic=missing_keys_or_values partitions=1
 $ kafka-ingest topic=missing_keys_or_values format=bytes key-format=bytes key-terminator=:
 hello:world
 
-> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
-key   text mz_offset
----------------------------------
-hello world 1
+> SELECT * FROM missing_keys_or_values
+key   text
+-----------
+hello world
 
 
 # send a value without a key. key columns should be null
@@ -32,22 +32,22 @@ hello world 1
 $ kafka-ingest topic=missing_keys_or_values format=bytes omit-key=true
 foo
 
-> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
-key    text  mz_offset
----------------------------------
-hello  world 1
-<null> foo   2
+> SELECT * FROM missing_keys_or_values
+key    text
+-------------
+hello  world
+<null> foo
 
 
 # send an empty record with neither key nor value, should be skipped
 
 $ kafka-ingest topic=missing_keys_or_values format=bytes omit-value=true omit-key=true
 
-> SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
-key    text  mz_offset
----------------------------------
-hello  world 1
-<null> foo   2
+> SELECT * FROM missing_keys_or_values
+key    text
+-------------
+hello  world
+<null> foo
 
 
 # send a key without a value, should error
@@ -55,5 +55,5 @@ hello  world 1
 $ kafka-ingest topic=missing_keys_or_values key-format=bytes format=bytes omit-value=true
 bar
 
-! SELECT * FROM missing_keys_or_values ORDER BY mz_offset ASC
+! SELECT * FROM missing_keys_or_values
 contains: Decode error: Text: Value not present for message

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -195,12 +195,12 @@ two,2:bee,honey
   VALUE FORMAT TEXT
   INCLUDE KEY
 
-> SELECT * FROM textsrc ORDER BY mz_offset ASC
-key    text        mz_offset
----------------------------
-one,1  horse,apple 1
-two,2  bee,honey   2
-<null> cow,grass   3
+> SELECT * FROM textsrc
+key    text
+-------------------
+one,1  horse,apple
+two,2  bee,honey
+<null> cow,grass
 
 > CREATE MATERIALIZED SOURCE regexvalue
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -209,11 +209,11 @@ two,2  bee,honey   2
   INCLUDE KEY
 
 > SELECT * FROM regexvalue
-key   animal  food  mz_offset
-----------------------------
-one,1  horse  apple 1
-two,2  bee    honey 2
-<null> cow    grass 3
+key   animal  food
+--------------------
+one,1  horse  apple
+two,2  bee    honey
+<null> cow    grass
 
 > CREATE MATERIALIZED SOURCE regexboth
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textsrc-${testdrive.seed}'
@@ -221,12 +221,12 @@ two,2  bee    honey 2
   VALUE FORMAT REGEX '(?P<animal>[^,]+),(?P<food>\w+)'
   INCLUDE KEY
 
-> SELECT * FROM regexboth ORDER BY mz_offset ASC
-id_name id     animal food  mz_offset
----------------------------------
-one     1      horse  apple 1
-two     2      bee    honey 2
-<null>  <null> cow    grass 3
+> SELECT * FROM regexboth
+id_name id     animal food
+---------------------------
+one     1      horse  apple
+two     2      bee    honey
+<null>  <null> cow    grass
 
 
 > CREATE MATERIALIZED SOURCE regexbothnest
@@ -276,11 +276,11 @@ $ kafka-ingest topic=proto format=protobuf descriptor-file=test.proto message=Va
   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
   INCLUDE KEY
 
-> SELECT * FROM input_proto ORDER BY measurement ASC
-id     measurement  mz_offset
---------------------------
-a      10           1
-<null> 11           2
+> SELECT * FROM input_proto
+id     measurement
+-------------------
+a      10
+<null> 11
 
 $ kafka-create-topic topic=proto-structured partitions=1
 
@@ -295,7 +295,7 @@ $ kafka-ingest topic=proto-structured
   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA FILE '${testdrive.temp-dir}/test.proto'
   INCLUDE KEY AS key
 
-> SELECT key::text, (key).id1, (key).id2, measurement, mz_offset FROM input_proto_structured
-key    id1  id2  measurement  mz_offset
----------------------------------------
-(1,2)  1    2    10           1
+> SELECT key::text, (key).id1, (key).id2, measurement FROM input_proto_structured
+key    id1  id2  measurement
+----------------------------
+(1,2)  1    2    10

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -20,18 +20,21 @@ $ kafka-create-topic topic=t0
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'missing_topic'
   WITH (kafka_time_offset=1)
   FORMAT TEXT
+  INCLUDE OFFSET
 contains:topic missing_topic does not exist
 
 ! CREATE MATERIALIZED SOURCE pick_one
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
   WITH (kafka_time_offset=1, start_offset=1)
   FORMAT TEXT
+  INCLUDE OFFSET
 contains:`start_offset` and `kafka_time_offset` cannot be set at the same time.
 
 ! CREATE MATERIALIZED SOURCE not_a_number
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t0-${testdrive.seed}'
   WITH (kafka_time_offset="not_a_number")
   FORMAT TEXT
+  INCLUDE OFFSET
 contains:`kafka_time_offset` must be a number
 
 #
@@ -59,34 +62,40 @@ grape:grape
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t1-${testdrive.seed}'
   WITH (kafka_time_offset=0)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > CREATE MATERIALIZED SOURCE append_time_offset_1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t1-${testdrive.seed}'
   WITH (kafka_time_offset=1, topic_metadata_refresh_interval_ms=10)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > CREATE MATERIALIZED SOURCE append_time_offset_2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t1-${testdrive.seed}'
   WITH (kafka_time_offset=2, topic_metadata_refresh_interval_ms=10)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > CREATE MATERIALIZED SOURCE append_time_offset_3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t1-${testdrive.seed}'
   WITH (kafka_time_offset=3, topic_metadata_refresh_interval_ms=10)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > CREATE MATERIALIZED SOURCE append_time_offset_4
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t1-${testdrive.seed}'
   WITH (kafka_time_offset=4, topic_metadata_refresh_interval_ms=10)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > CREATE MATERIALIZED SOURCE append_time_offset_5
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t1-${testdrive.seed}'
   WITH (kafka_time_offset=5, topic_metadata_refresh_interval_ms=10)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > SELECT * FROM append_time_offset_0
-text      mz_offset
+text      offset
 -------------------
 apple     1
 banana    2
@@ -97,7 +106,7 @@ fig       4
 grape     1
 
 > SELECT * FROM append_time_offset_1
-text      mz_offset
+text      offset
 -------------------
 apple     1
 banana    2
@@ -108,7 +117,7 @@ fig       4
 grape     1
 
 > SELECT * FROM append_time_offset_2
-text      mz_offset
+text      offset
 -------------------
 cherry    1
 date      2
@@ -117,18 +126,18 @@ fig       4
 grape     1
 
 > SELECT * FROM append_time_offset_3
-text      mz_offset
+text      offset
 -------------------
 fig       4
 grape     1
 
 > SELECT * FROM append_time_offset_4
-text      mz_offset
+text      offset
 -------------------
 grape     1
 
 > SELECT * FROM append_time_offset_5
-text      mz_offset
+text      offset
 -------------------
 
 $ kafka-add-partitions topic=t1 total-partitions=4
@@ -139,7 +148,7 @@ hazelnut:hazelnut
 $ set-sql-timeout duration=60s
 
 > SELECT * FROM append_time_offset_5
-text      mz_offset
+text      offset
 -------------------
 hazelnut  1
 
@@ -172,40 +181,46 @@ grape:grape
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t2-${testdrive.seed}'
   WITH (kafka_time_offset=0)
   KEY FORMAT TEXT VALUE FORMAT TEXT
+  INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE upsert_time_offset_1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t2-${testdrive.seed}'
   WITH (kafka_time_offset=1)
   KEY FORMAT TEXT VALUE FORMAT TEXT
+  INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE upsert_time_offset_2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t2-${testdrive.seed}'
   WITH (kafka_time_offset=2)
   KEY FORMAT TEXT VALUE FORMAT TEXT
+  INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE upsert_time_offset_3
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t2-${testdrive.seed}'
   WITH (kafka_time_offset=3)
   KEY FORMAT TEXT VALUE FORMAT TEXT
+  INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE upsert_time_offset_4
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t2-${testdrive.seed}'
   WITH (kafka_time_offset=4)
   KEY FORMAT TEXT VALUE FORMAT TEXT
+  INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE MATERIALIZED SOURCE upsert_time_offset_5
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t2-${testdrive.seed}'
   WITH (kafka_time_offset=5, topic_metadata_refresh_interval_ms=10)
   KEY FORMAT TEXT VALUE FORMAT TEXT
+  INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > SELECT * FROM upsert_time_offset_0
-key       text      mz_offset
+key       text      offset
 -----------------------------
 banana    banana    2
 date      date      2
@@ -214,7 +229,7 @@ fig       fig       5
 grape     grape     1
 
 > SELECT * FROM upsert_time_offset_1
-key       text      mz_offset
+key       text      offset
 -----------------------------
 banana    banana    2
 date      date      2
@@ -223,7 +238,7 @@ fig       fig       5
 grape     grape     1
 
 > SELECT * FROM upsert_time_offset_2
-key       text      mz_offset
+key       text      offset
 -----------------------------
 date      date      2
 eggfruit  eggfruit  3
@@ -231,18 +246,18 @@ fig       fig       5
 grape     grape     1
 
 > SELECT * FROM upsert_time_offset_3
-key       text      mz_offset
+key       text      offset
 -----------------------------
 fig       fig       5
 grape     grape     1
 
 > SELECT * FROM upsert_time_offset_4
-key       text      mz_offset
+key       text      offset
 -----------------------------
 grape     grape     1
 
 > SELECT * FROM upsert_time_offset_5
-key       text      mz_offset
+key       text      offset
 -----------------------------
 
 $ kafka-add-partitions topic=t2 total-partitions=4
@@ -254,7 +269,7 @@ hazelnut:hazelnut
 $ set-sql-timeout duration=60s
 
 > SELECT * FROM upsert_time_offset_5
-key       text      mz_offset
+key       text      offset
 -----------------------------
 hazelnut  hazelnut  1
 
@@ -282,20 +297,22 @@ cherry
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t3-${testdrive.seed}'
   WITH (kafka_time_offset=-946100000000)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > CREATE MATERIALIZED SOURCE relative_time_offset_today
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t3-${testdrive.seed}'
   WITH (kafka_time_offset=-1)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 > SELECT * FROM relative_time_offset_30_years_ago
-text      mz_offset
+text      offset
 -------------------
 banana    2
 cherry    3
 
 > SELECT * FROM relative_time_offset_today
-text      mz_offset
+text      offset
 -------------------
 cherry    3
 
@@ -313,6 +330,7 @@ pie
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-t4-${testdrive.seed}'
   WITH (kafka_time_offset = -1)
   FORMAT TEXT
+  INCLUDE OFFSET
 
 
 #

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -128,11 +128,11 @@ bìrd1:
   ENVELOPE UPSERT
 
 > select * from texttext
-key           text  mz_offset
------------------------------
-fish          fish  1
-bírdmore      geese 3
-mammal1       moose 4
+key           text
+-------------------
+fish          fish
+bírdmore      geese
+mammal1       moose
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 bírdmore:géese
@@ -141,34 +141,34 @@ mammal1:
 mammal1:mouse
 
 > select * from textbytes
-key           data             mz_offset
-----------------------------------------
-fish          fish             1
-bírdmore      g\xc3\xa9ese     6
-mammal1       mouse            9
-mammalmore    moose            7
+key           data
+---------------------------
+fish          fish
+bírdmore      g\xc3\xa9ese
+mammal1       mouse
+mammalmore    moose
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 mammalmore:herd
 
 > select * from bytesbytes
-key              data             mz_offset
-----------------------------------------
-fish             fish             1
-b\xc3\xadrdmore  g\xc3\xa9ese     6
-mammal1          mouse            9
-mammalmore       herd             10
+key              data
+------------------------------
+fish             fish
+b\xc3\xadrdmore  g\xc3\xa9ese
+mammal1          mouse
+mammalmore       herd
 
 $ kafka-ingest format=bytes topic=textbytes key-format=bytes key-terminator=:
 bìrd1:
 fish:
 
 > select * from bytestext
-key              text             mz_offset
-----------------------------------------
-b\xc3\xadrdmore  géese            6
-mammal1          mouse            9
-mammalmore       herd             10
+key              text
+-----------------------
+b\xc3\xadrdmore  géese
+mammal1          mouse
+mammalmore       herd
 
 $ file-append path=test.proto
 syntax = "proto3";
@@ -201,14 +201,14 @@ bìrd1:{"f": "two"}
 birdmore: {}
 
 > SELECT * FROM bytesproto
-fish         one 1
-b\xc3\xacrd1 two 2
-birdmore     "" 3
+fish         one
+b\xc3\xacrd1 two
+birdmore     ""
 
 > SELECT * FROM textproto
-fish      one  1
-bìrd1     two  2
-birdmore  ""   3
+fish      one
+bìrd1     two
+birdmore  ""
 
 $ kafka-ingest topic=textproto
   format=protobuf descriptor-file=test.pb message=Test
@@ -222,18 +222,18 @@ mammal1:
 mammalmore: {"f": "seven"}
 
 > SELECT * FROM bytesproto
-fish              one    1
-birdmore          four   6
-m\xc3\xa4mmalmore five   7
-b\xc3\xacrd1      six    8
-mammalmore        seven  10
+fish              one
+birdmore          four
+m\xc3\xa4mmalmore five
+b\xc3\xacrd1      six
+mammalmore        seven
 
 > SELECT * FROM textproto
-fish        one    1
-birdmore    four   6
-mämmalmore  five   7
-bìrd1       six    8
-mammalmore  seven  10
+fish        one
+birdmore    four
+mämmalmore  five
+bìrd1       six
+mammalmore  seven
 
 $ kafka-create-topic topic=nullkey partitions=1
 
@@ -254,10 +254,10 @@ mammal1:
   ENVELOPE UPSERT
 
 > select * from nullkey
-key           text  mz_offset
------------------------------
-birdmore      geese 5
-mammalmore    moose 6
+key           text
+-------------------
+birdmore      geese
+mammalmore    moose
 
 $ kafka-create-topic topic=realtimeavroavro partitions=1
 

--- a/test/testdrive/protobuf-basic.td
+++ b/test/testdrive/protobuf-basic.td
@@ -67,11 +67,10 @@ bytes      false     bytea
 string     false     text
 enum       false     text
 message    true      record
-mz_offset  false     bigint
 
-> SELECT bool, int32, int64, float, double, bytes, string, enum, message::text, mz_offset FROM basic
-bool  int32  int64  float  double  bytes  string enum  message                             mz_offset
+> SELECT bool, int32, int64, float, double, bytes, string, enum, message::text FROM basic
+bool  int32  int64  float  double  bytes  string enum  message
 ----
-true  1      2      1.2    3.2     aaa    bbb    ENUM1 (t,1,2,1.2,3.2,\x616161,bbb,ENUM1)  1
-false 0      0      0      0       ""     ""     ENUM0 <null>                              2
-false 0      0      0      0       ""     ""     ENUM0 "(f,0,0,0,0,\\x,\"\",ENUM0)"        3
+true  1      2      1.2    3.2     aaa    bbb    ENUM1 (t,1,2,1.2,3.2,\x616161,bbb,ENUM1)
+false 0      0      0      0       ""     ""     ENUM0 <null>
+false 0      0      0      0       ""     ""     ENUM0 "(f,0,0,0,0,\\x,\"\",ENUM0)"

--- a/test/testdrive/protobuf-defaults.td
+++ b/test/testdrive/protobuf-defaults.td
@@ -40,6 +40,6 @@ $ kafka-ingest topic=defaults format=protobuf descriptor-file=defaults.pb messag
   FORMAT PROTOBUF MESSAGE '.Defaults' USING SCHEMA FILE '${testdrive.temp-dir}/defaults.pb'
 
 > SELECT * FROM defaults
-bool  int32  int64  float  double  bytes  string enum  mz_offset
+bool  int32  int64  float  double  bytes  string enum
 ----
-true  42     42     42     42      aaa    bbb    ENUM1 1
+true  42     42     42     42      aaa    bbb    ENUM1

--- a/test/testdrive/protobuf-evolution.td
+++ b/test/testdrive/protobuf-evolution.td
@@ -36,9 +36,9 @@ $ kafka-ingest topic=evolution format=protobuf descriptor-file=evolution.pb mess
 {"i": 1}
 
 > SELECT * FROM evolution
-i  mz_offset
-------------
-1  1
+i
+---
+1
 
 # Adding new fields and renaming existing fields is safe. New fields won't be
 # reflected in the source, though.
@@ -64,10 +64,10 @@ $ kafka-ingest topic=evolution format=protobuf descriptor-file=evolution.pb mess
 {"i_renamed": 2, "extra": false}
 
 > SELECT * FROM evolution
-i  mz_offset
-------------
-1  1
-2  2
+i
+---
+1
+2
 
 # Changing the size of an integer type is allowed; values are truncated/promoted
 # as in C.
@@ -92,11 +92,11 @@ $ kafka-ingest topic=evolution format=protobuf descriptor-file=evolution.pb mess
 {"i_demoted": false}
 
 > SELECT * FROM evolution
-i  mz_offset
-------------
-1  1
-2  2
-0  3
+i
+---
+1
+2
+0
 
 # Expect that ingesting an incompatible message will brick the topic. We have to
 # explicitly disable the schema registry's protection against this.

--- a/test/testdrive/protobuf-import.td
+++ b/test/testdrive/protobuf-import.td
@@ -60,10 +60,10 @@ $ kafka-ingest topic=import format=protobuf descriptor-file=import.pb message=Im
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-import-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Importer' USING SCHEMA FILE '${testdrive.temp-dir}/import.pb'
 
-> SELECT importee1::text, importee2::text, mz_offset FROM import
-importee1  importee2            mz_offset
------------------------------------------
-(f)        "(\"(1234,5678)\")"  1
+> SELECT importee1::text, importee2::text FROM import
+importee1  importee2
+------------------------------
+(f)        "(\"(1234,5678)\")"
 
 
 # Then, test again with the Confluent Schema Registry. Publishing Protobuf
@@ -103,14 +103,14 @@ $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb messag
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-import-csr-${testdrive.seed}'
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-> SELECT importee1::text, importee2::text, mz_offset FROM import_csr
-importee1  importee2            mz_offset
------------------------------------------
-(f)        "(\"(1234,5678)\")"  1
+> SELECT importee1::text, importee2::text FROM import_csr
+importee1  importee2
+-------------------------------
+(f)        "(\"(1234,5678)\")"
 
 # Test that non-zero message IDs in the Confluent wire format are rejected.
 $ kafka-ingest topic=import-csr format=protobuf descriptor-file=import.pb message=Importer confluent-wire-format=true schema-message-id=123
 {"importee1": {"b": false}, "importee2": {"ts": "1970-01-01T00:20:34.000005678Z"}}
 
-! SELECT importee1::text, importee2::text, mz_offset FROM import_csr
+! SELECT importee1::text, importee2::text FROM import_csr
 contains:Decode error: Text: protobuf deserialization error: unsupported Confluent-style protobuf message descriptor id: expected 0, but found: 123. See https://github.com/MaterializeInc/materialize/issues/9250

--- a/test/testdrive/protobuf-name.td
+++ b/test/testdrive/protobuf-name.td
@@ -29,19 +29,19 @@ $ kafka-ingest topic=name format=protobuf descriptor-file=name.pb message=some.w
 > CREATE MATERIALIZED SOURCE qualified_absolute_path FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.some.where.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
-> SELECT i, mz_offset FROM qualified_absolute_path
-i   mz_offset
--------------
-42  1
+> SELECT i FROM qualified_absolute_path
+i
+---
+42
 
 # Ingesting with the absolute path should work without the leading dot.
 > CREATE MATERIALIZED SOURCE absolute_path FROM
   KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-name-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE 'some.where.Name' USING SCHEMA FILE '${testdrive.temp-dir}/name.pb'
-> SELECT i, mz_offset FROM absolute_path
-i   mz_offset
--------------
-42  1
+> SELECT i FROM absolute_path
+i
+---
+42
 
 # Ingesting without the package prefix should fail.
 ! CREATE MATERIALIZED SOURCE absolute_path FROM

--- a/test/testdrive/protobuf-repeated.td
+++ b/test/testdrive/protobuf-repeated.td
@@ -58,10 +58,9 @@ bytes      false     list
 string     false     list
 enum       false     list
 message    false     list
-mz_offset  false     bigint
 
-> SELECT bool::text, int32::text, int64::text, float::text, double::text, string::text, bytes::text, enum::text, message::text, mz_offset FROM repeated
-bool    int32  int64  float   double   string     bytes                enum           message                  mz_offset
+> SELECT bool::text, int32::text, int64::text, float::text, double::text, string::text, bytes::text, enum::text, message::text FROM repeated
+bool    int32  int64  float   double   string     bytes                enum           message
 ----
-{t,f}  {2,1}   {2,1}  {3.2,1} {3.2,1}  {bbb,aaa}  {\x626262,\x616161}  {ENUM1,ENUM0}  "{\"(4,2)\",\"(2,4)\"}"  1
-{}     {}      {}     {}      {}       {}         {}                   {}             {}                       2
+{t,f}  {2,1}   {2,1}  {3.2,1} {3.2,1}  {bbb,aaa}  {\x626262,\x616161}  {ENUM1,ENUM0}  "{\"(4,2)\",\"(2,4)\"}"
+{}     {}      {}     {}      {}       {}         {}                   {}             {}

--- a/test/testdrive/protobuf-required.td
+++ b/test/testdrive/protobuf-required.td
@@ -28,9 +28,9 @@ $ kafka-ingest topic=required format=protobuf descriptor-file=required.pb messag
   FORMAT PROTOBUF MESSAGE '.Required' USING SCHEMA FILE '${testdrive.temp-dir}/required.pb'
 
 > SELECT * FROM required
-f   mz_offset
--------------
-42  1
+f
+----
+42
 
 $ kafka-ingest topic=required format=protobuf descriptor-file=required.pb message=Required
 {}

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -27,14 +27,13 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-mz_offset          false     bigint
 
 > SELECT * FROM regex_source
-ip            ts                      path                                           search_kw           product_detail_id  code  mz_offset
--------------------------------------------------------------------------------------------------------------------------------------------
-123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
-8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
-96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
+ip            ts                      path                                           search_kw           product_detail_id  code
+---------------------------------------------------------------------------------------------------------------------------------
+123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200
+8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200
 
 > SELECT search_kw FROM regex_source WHERE search_kw IS NOT NULL
 search_kw
@@ -54,12 +53,12 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-mz_offset          false     bigint
 
 # verify metadata column renaming
 > CREATE MATERIALIZED SOURCE regex_source_renamed_cols (ip, ts, path, search_kw, product_detail_id, code, lineno)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-request-log-${testdrive.seed}'
   FORMAT REGEX '(?P<foo1>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<foo2>[^]]+)\] "(?P<foo3>(?:GET /search/\?kw=(?P<foo4>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<foo5>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<foo6>\d{3}) -'
+  INCLUDE OFFSET
 
 > SHOW COLUMNS FROM regex_source_renamed_cols
 name               nullable  type
@@ -73,11 +72,11 @@ code               true      text
 lineno             false     bigint
 
 > SELECT * FROM regex_source_named_cols
-ip            ts                      path                                           search_kw           product_detail_id  code  mz_offset
--------------------------------------------------------------------------------------------------------------------------------------------
-123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200   1
-8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200   2
-96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200   3
+ip            ts                      path                                           search_kw           product_detail_id  code
+---------------------------------------------------------------------------------------------------------------------------------
+123.17.127.5  "22/Jan/2020 18:59:52"  "GET / HTTP/1.1"                               <null>              <null>             200
+8.15.119.56   "22/Jan/2020 18:59:52"  "GET /detail/nNZpqxzR HTTP/1.1"                <null>              nNZpqxzR           200
+96.12.83.72   "22/Jan/2020 18:59:52"  "GET /search/?kw=helper+ins+hennaed HTTP/1.1"  helper+ins+hennaed  <null>             200
 
 # Malformed regex with non-utf-8 characters
 $ kafka-create-topic topic=malformed-request-log

--- a/test/testdrive/s3-gzip.td
+++ b/test/testdrive/s3-gzip.td
@@ -33,13 +33,13 @@ b3
   )
   FORMAT TEXT;
 
-> SELECT * FROM s3_all_none ORDER BY mz_record;
-a1 1
-a2 2
-a3 3
-b1 4
-b2 5
-b3 6
+> SELECT * FROM s3_all_none
+a1
+a2
+a3
+b1
+b2
+b3
 
 # Test explicit lack of compression
 
@@ -70,13 +70,13 @@ b3
   )
   FORMAT TEXT;
 
-> SELECT * FROM s3_all_gzip ORDER BY mz_record;
-a1 1
-a2 2
-a3 3
-b1 4
-b2 5
-b3 6
+> SELECT * FROM s3_all_gzip
+a1
+a2
+a3
+b1
+b2
+b3
 
 # Test automatic decompression handling
 # $ set bucket=materialize-ci-testdrive-auto-${testdrive.seed}
@@ -105,10 +105,10 @@ b3 6
 #   )
 #   FORMAT TEXT;
 #
-# > SELECT * FROM s3_all ORDER BY mz_record;
-# a1 1
-# a2 2
-# a3 3
-# b1 4
-# b2 5
-# b3 6
+# > SELECT * FROM s3_all
+# a1
+# a2
+# a3
+# b1
+# b2
+# b3

--- a/test/testdrive/s3.td
+++ b/test/testdrive/s3.td
@@ -30,13 +30,13 @@ b3
   )
   FORMAT TEXT;
 
-> SELECT * FROM s3_all ORDER BY mz_record;
-a1 1
-a2 2
-a3 3
-b1 4
-b2 5
-b3 6
+> SELECT * FROM s3_all
+a1
+a2
+a3
+b1
+b2
+b3
 
 > CREATE MATERIALIZED SOURCE s3_glob_a
   FROM S3 DISCOVER OBJECTS MATCHING '**/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
@@ -49,10 +49,10 @@ b3 6
   )
   FORMAT TEXT;
 
-> SELECT * FROM s3_glob_a ORDER BY mz_record;
-a1 1
-a2 2
-a3 3
+> SELECT * FROM s3_glob_a
+a1
+a2
+a3
 
 > CREATE MATERIALIZED SOURCE s3_just_a
   FROM S3 DISCOVER OBJECTS MATCHING 'short/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
@@ -65,10 +65,10 @@ a3 3
   )
   FORMAT TEXT;
 
-> SELECT * FROM s3_just_a ORDER BY mz_record;
-a1 1
-a2 2
-a3 3
+> SELECT * FROM s3_just_a
+a1
+a2
+a3
 
 $ s3-put-object bucket=test key=csv.csv
 c,7
@@ -86,13 +86,13 @@ c,9
   )
   FORMAT CSV WITH 2 COLUMNS;
 
-> SELECT * FROM csv_example ORDER BY mz_record;
-c 7 1
-c 8 2
-c 9 3
+> SELECT * FROM csv_example
+c 7
+c 8
+c 9
 
 > SELECT * FROM csv_example WHERE counts = '8';
-c 8 2
+c 8
 
 $ s3-put-object bucket=test key=logs/2020/12/31/frontend.log
 99.99.44.44 - - [12/31/2020:23:55:59] "GET /updates HTTP/1.1" 200 10020 "-" "Python/Requests_22"

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -115,12 +115,12 @@ cluster        name   type
 <CLUSTER_NAME> snk5   user
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_offset": 1}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk2 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_offset": 1}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
@@ -163,12 +163,12 @@ $ kafka-ingest topic=test format=bytes
 extra,row
 
 $ kafka-verify format=avro sink=materialize.public.snk7
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_offset": 3}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 3}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "mz_offset": 3}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "mz_offset": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "mz_offset": 1}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 3}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}}
 
 # Test that we are correctly handling WITH/WITHOUT SNAPSHOT on views with
 # empty upper frontier

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -147,11 +147,11 @@ contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 
 > CREATE MATERIALIZED VIEW input_values_mview AS VALUES (1), (2), (3);
 
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_cdcv2;
+! CREATE MATERIALIZED VIEW must_fail (a, b, c) AS SELECT * FROM source_system, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
 
 # Verify that user timelines don't allow things to be joinable with their non-user versions.
-! CREATE MATERIALIZED VIEW must_fail (a, b, c, d) AS SELECT * FROM source_system, source_system_user;
+! CREATE MATERIALIZED VIEW must_fail (a, b) AS SELECT * FROM source_system, source_system_user;
 contains:multiple timelines within one dataflow are not supported
 
 # Can join static view with anything.
@@ -168,7 +168,7 @@ contains:multiple timelines within one dataflow are not supported
 # System things should be joinable only with system sources.
 ! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
-> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_system;
+> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, source_system;
 > CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k) AS SELECT * FROM mz_catalog_names, mz_views, mz_dataflow_operators, input_table;
 
 # EXPLAIN should complain too.
@@ -176,7 +176,7 @@ contains:multiple timelines within one dataflow are not supported
 contains:multiple timelines within one dataflow are not supported
 
 # Can join user-specified timelines.
-> CREATE MATERIALIZED VIEW source_system_cdcv2_user (a, b, c, d) AS SELECT * FROM source_system_user, source_cdcv2_user;
+> CREATE MATERIALIZED VIEW source_system_cdcv2_user (a, b, c) AS SELECT * FROM source_system_user, source_cdcv2_user;
 
 # CDCv2 can only be joined with system time stuff if specified
 > CREATE MATERIALIZED VIEW source_cdcv2_table_system AS SELECT * FROM source_cdcv2_system, input_table;

--- a/test/upgrade/check-from-current_source-compile-proto-sources.td
+++ b/test/upgrade/check-from-current_source-compile-proto-sources.td
@@ -8,21 +8,21 @@
 # by the Apache License, Version 2.0.
 
 > SELECT * FROM kafka_proto_source;
-id mz_offset
-------------
-c  1
-h  2
+id
+---
+c
+h
 
 $ kafka-ingest topic=upgrade-proto-source-${arg.upgrade-from-version} format=protobuf descriptor-file=message.pb message=Message confluent-wire-format=true
 {"id": "a"}
 {"id": "e"}
 
 > SELECT * FROM kafka_proto_source;
-id mz_offset
-------------
-c  1
-h  2
-a  3
-e  4
+id
+---
+c
+h
+a
+e
 
 > DROP SOURCE kafka_proto_source;

--- a/test/upgrade/check-from-current_source-csv-basic.td
+++ b/test/upgrade/check-from-current_source-csv-basic.td
@@ -8,17 +8,17 @@
 # by the Apache License, Version 2.0.
 
 > select * from csv
-al  sia     mz_offset
----------------------
-id  value   1
-1   person  2
+al  sia
+------------
+id  value
+1   person
 
 $ kafka-ingest topic=csv-basic format=bytes
 2,animal
 
 > select * from csv
-al  sia     mz_offset
----------------------
-id  value   1
-1   person  2
-2   animal  3
+al  sia
+------------
+id  value
+1   person
+2   animal

--- a/test/upgrade/check-from-current_source-csv.td
+++ b/test/upgrade/check-from-current_source-csv.td
@@ -8,13 +8,13 @@
 # by the Apache License, Version 2.0.
 
 > select * from csv_upgrade_no_header
-column1  column2  mz_offset
----------------------------
-id       value    1
-1        person   2
+column1  column2
+------------------
+id       value
+1        person
 
 > select * from csv_upgrade_no_header_alias
-al  sia     mz_offset
----------------------
-id  value   1
-1   person  2
+al  sia
+------------
+id  value
+1   person


### PR DESCRIPTION
Remove the notion of default metadata from sources (e.g., the mz_offset
column on a Kafka source). Instead, users will be able to opt-in to
metadata on a per source basis, via e.g. `INCLUDE OFFSET`.

This resolves a long standing TODO.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR resolves a TODO.

### Tips for reviewer

~Ignore the first commit; that's #13464.~

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
