### PR TITLE
persist: remove explicit API-level tracing events

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -567,8 +567,6 @@ where
         retry_metrics: &RetriesMetrics,
         shard_id: ShardId,
     ) -> Result<State<K, V, T, D>, CodecMismatch> {
-        debug!("Machine::maybe_init_state shard_id={}", shard_id);
-
         let path = shard_id.to_string();
         let mut current = retry_external(&retry_metrics.external.maybe_init_state_head, || async {
             consensus.head(&path).await

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::runtime::Handle;
-use tracing::{debug_span, info, instrument, trace, trace_span, warn, Instrument};
+use tracing::{debug_span, info, instrument, trace_span, warn, Instrument};
 use uuid::Uuid;
 
 use mz_persist::indexed::encoding::BlobTraceBatchPart;
@@ -159,11 +159,6 @@ where
     /// `ReadHandle::fetch_batch`.
     #[instrument(level = "debug", skip_all, fields(shard = %self.listen.handle.machine.shard_id()))]
     pub async fn next(&mut self) -> ReaderEnrichedHollowBatch<T> {
-        trace!(
-            "Subscribe::next as_of={:?}, frontier={:?}",
-            self.listen.as_of,
-            self.listen.frontier
-        );
         // This is odd, but we move our handle into a `Listen`.
         self.listen.handle.maybe_heartbeat_reader().await;
 
@@ -180,11 +175,6 @@ where
     /// `storage::source::persist_source::persist_source_sharded`.
     #[instrument(level = "debug", skip_all, fields(shard = %self.listen.handle.machine.shard_id()))]
     pub async fn next_listen_events(&mut self) -> Vec<ListenEvent<K, V, T, D>> {
-        trace!(
-            "Subscribe::next as_of={:?}, frontier={:?}",
-            self.listen.as_of,
-            self.listen.frontier
-        );
         // This is odd, but we move our handle into a `Listen`.
         self.listen.handle.maybe_heartbeat_reader().await;
 
@@ -358,7 +348,6 @@ where
     /// consolidated, come talk to us!
     #[instrument(level = "debug", name = "listen::next", skip_all, fields(shard = %self.handle.machine.shard_id()))]
     pub async fn next(&mut self) -> Vec<ListenEvent<K, V, T, D>> {
-        trace!("Listen::next");
         let batch = self.next_batch().await;
         let progress = batch.batch.desc.upper().clone();
         let updates = self
@@ -481,7 +470,6 @@ where
     /// with `new_since` equal to `self.since()`, making the call a no-op).
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn downgrade_since(&mut self, new_since: &Antichain<T>) {
-        trace!("ReadHandle::downgrade_since new_since={:?}", new_since);
         let (_seqno, current_reader_since, maintenance) = self
             .machine
             .downgrade_since(&self.reader_id, new_since, (self.cfg.now)())
@@ -511,8 +499,6 @@ where
     /// `as_of` that would have been accepted.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn listen(self, as_of: Antichain<T>) -> Result<Listen<K, V, T, D>, Since<T>> {
-        trace!("ReadHandle::listen as_of={:?}", as_of);
-
         let () = self.machine.verify_listen(&as_of).await?;
         Ok(Listen::new(self, as_of).await)
     }
@@ -580,8 +566,6 @@ where
     /// [Self::listen].
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn subscribe(self, as_of: Antichain<T>) -> Result<Subscribe<K, V, T, D>, Since<T>> {
-        trace!("ReadHandle::subscribe as_of={:?}", as_of);
-
         let snapshot_batches = self.snapshot(as_of.clone()).await?.into();
         let listen = self.listen(as_of).await?;
         Ok(Subscribe::new(snapshot_batches, listen))
@@ -594,7 +578,6 @@ where
         &mut self,
         batch: ReaderEnrichedHollowBatch<T>,
     ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, InvalidUsage<T>> {
-        trace!("ReadHandle::fetch_batch");
         if batch.shard_id != self.machine.shard_id() {
             return Err(InvalidUsage::BatchNotFromThisShard {
                 batch_shard: batch.shard_id,
@@ -668,7 +651,6 @@ where
     /// `since`.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn clone(&self) -> Self {
-        trace!("ReadHandle::clone");
         let new_reader_id = ReaderId::new();
         let mut machine = self.machine.clone();
         let read_cap = machine.clone_reader(&new_reader_id, (self.cfg.now)()).await;
@@ -735,7 +717,6 @@ where
     /// happens.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn expire(mut self) {
-        trace!("ReadHandle::expire");
         self.machine.expire_reader(&self.reader_id).await;
         self.explicitly_expired = true;
     }
@@ -813,7 +794,6 @@ where
         let _ = handle.spawn_named(
             || format!("ReadHandle::expire ({})", self.reader_id),
             async move {
-                trace!("ReadHandle::expire");
                 machine.expire_reader(&reader_id).await;
             }
             .instrument(expire_span),


### PR DESCRIPTION
It's never been clear if these were useful and with the tracing span
coverage, they're now redundant: we have tracing spans covering all the
same places now and tracing-subscriber has the ability to emit span
ENTER events as formatted logs. This also could be used to emit EXIT
events (which would correspond to the method finishing) and so is
strictly more general than this manual event start logging.

https://docs.rs/tracing-subscriber/0.3.14/tracing_subscriber/fmt/struct.SubscriberBuilder.html#method.with_span_events

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

This with_span_events stuff isn't hooked up to anything (yet?) so it's definitely no longer as easy to opt into this as setting an env var. But it seems worthwhile (to me) to remove the duplication. Thoughts? (Marking as draft until this is resolved)

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
