### PR TITLE
bump openssl version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4500,9 +4500,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.18.0+1.1.1n"
+version = "111.22.0+1.1.1q"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
fixes https://buildkite.com/materialize/security/builds/712 (non-issue in practice, but no reason not to bump the package version anyway)