### PR TITLE
python: skip inspecting processes without names or pids

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -115,16 +115,19 @@ def main() -> int:
             command += ["--tokio-console-listen-addr=127.0.0.1:6669"]
         if args.program == "environmentd":
             for proc in psutil.process_iter():
-                if proc.name() in ["storaged", "computed"]:
-                    if args.reset:
-                        print(
-                            f"Killing orphaned {proc.name()} process (PID {proc.pid})"
-                        )
-                        proc.kill()
-                    else:
-                        ui.warn(
-                            f"Existing {proc.name()} process (PID {proc.pid}) will be reused"
-                        )
+                try:
+                    if proc.name() in ["storaged", "computed"]:
+                        if args.reset:
+                            print(
+                                f"Killing orphaned {proc.name()} process (PID {proc.pid})"
+                            )
+                            proc.kill()
+                        else:
+                            ui.warn(
+                                f"Existing {proc.name()} process (PID {proc.pid}) will be reused"
+                            )
+                except psutil.NoSuchProcess:
+                    continue
             if args.reset:
                 print("Removing mzdata directory...")
                 shutil.rmtree("mzdata", ignore_errors=True)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The latest build can break on macOS. During `environmentd` startup, we check for all processes to see if there are orphaned `computed` and `storaged` processes. However if _any_ process on the machine (not just Materialize related!) is in a terminated state, this fails because the returned `proc` object has no name or pid.

### Motivation

This PR fixes a previously unreported bug.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
