### PR TITLE
coord: Fix recorded views read policy

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -3409,9 +3409,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
 
-                self.initialize_storage_read_policies(vec![id], self.logical_compaction_window_ms)
-                    .await;
-
                 self.ship_dataflow(df, compute_instance).await;
 
                 Ok(ExecuteResponse::CreatedRecordedView { existed: false })


### PR DESCRIPTION
Previously, when creating a recorded view we were accidently setting
its read policy twice. Once explicitly in
`sequence_create_recorded_view` and once inside of the call to
`ship_dataflow`.

### Motivation
This PR fixes a previously unreported bug.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
