### PR TITLE
coord: Add strict serializable isolation level

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4524,7 +4524,7 @@ impl<S: Append + 'static> Coordinator<S> {
             candidate.join_assign(&upper);
         }
 
-        if use_timestamp_oracle {
+        if use_timestamp_oracle && when == &QueryWhen::Immediately {
             assert!(
                 since.less_equal(&candidate),
                 "the strict serializable isolation level guarantees that the timestamp chosen \

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4501,10 +4501,8 @@ impl<S: Append + 'static> Coordinator<S> {
 
         let isolation_level = session.vars().transaction_isolation();
         let timeline = self.validate_timeline(id_bundle.iter())?;
-        let uses_tables = id_bundle.iter().any(|id| self.catalog.uses_tables(id));
-        let use_timestamp_oracle = (isolation_level == &vars::IsolationLevel::StrictSerializable
-            || uses_tables)
-            && timeline.is_some();
+        let use_timestamp_oracle =
+            isolation_level == &vars::IsolationLevel::StrictSerializable && timeline.is_some();
 
         if !use_timestamp_oracle && when.advance_to_since() {
             candidate.advance_by(since.borrow());

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -6077,6 +6077,9 @@ impl<S: Append + 'static> Coordinator<S> {
                     CatalogItem::Table(table) => {
                         timelines.insert(id, table.timeline());
                     }
+                    CatalogItem::Log(_) => {
+                        timelines.insert(id, Timeline::EpochMilliseconds);
+                    }
                     _ => {}
                 }
             }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1858,7 +1858,7 @@ impl<S: Append + 'static> Coordinator<S> {
             } => {
                 let now = self.now_datetime();
                 let session = match implicit {
-                    None => session.start_transaction(now, None),
+                    None => session.start_transaction(now, None, None),
                     Some(stmts) => session.start_transaction_implicit(now, stmts),
                 };
                 let _ = tx.send(Response {
@@ -2513,7 +2513,11 @@ impl<S: Append + 'static> Coordinator<S> {
             Plan::StartTransaction(plan) => {
                 let duplicated =
                     matches!(session.transaction(), TransactionStatus::InTransaction(_));
-                let session = session.start_transaction(self.now_datetime(), plan.access);
+                let session = session.start_transaction(
+                    self.now_datetime(),
+                    plan.access,
+                    plan.isolation_level,
+                );
                 tx.send(
                     Ok(ExecuteResponse::StartedTransaction { duplicated }),
                     session,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4521,11 +4521,12 @@ impl<S: Append + 'static> Coordinator<S> {
             candidate.join_assign(&upper);
         }
 
-        if strict_serializable {
+        if strict_serializable && matches!(when, QueryWhen::Immediately) {
             assert!(
                 since.less_equal(&candidate),
-                "the strict serializable isolation level guarantees that the timestamp chosen is \
-                greater than or equal to since via read holds"
+                "the strict serializable isolation level guarantees that the timestamp chosen \
+                ({candidate}) is greater than or equal to since ({:?}) via read holds",
+                since
             )
         }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -25,10 +25,12 @@ use mz_pgrepr::Format;
 use mz_repr::{Datum, Diff, GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
 use mz_sql::plan::{Params, PlanContext, StatementDesc};
+use mz_sql_parser::ast::TransactionIsolationLevel;
 
 use crate::client::ConnectionId;
 use crate::coord::{CoordTimestamp, PeekResponseUnary};
 use crate::error::AdapterError;
+use crate::session::vars::IsolationLevel;
 
 pub(crate) mod vars;
 
@@ -97,6 +99,7 @@ impl<T: CoordTimestamp> Session<T> {
         mut self,
         wall_time: DateTime<Utc>,
         access: Option<TransactionAccessMode>,
+        isolation_level: Option<TransactionIsolationLevel>,
     ) -> Self {
         match self.transaction {
             TransactionStatus::Default | TransactionStatus::Started(_) => {
@@ -113,6 +116,11 @@ impl<T: CoordTimestamp> Session<T> {
             TransactionStatus::InTransaction(_) => {}
             TransactionStatus::Failed(_) => unreachable!(),
         };
+        if let Some(isolation_level) = isolation_level {
+            self.vars
+                .set("transaction_isolation", IsolationLevel::from(isolation_level).as_str(), true)
+                .expect("transaction_isolation should be a valid var and isolation level is a valid value");
+        }
         self
     }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -30,7 +30,7 @@ use crate::client::ConnectionId;
 use crate::coord::{CoordTimestamp, PeekResponseUnary};
 use crate::error::AdapterError;
 
-mod vars;
+pub(crate) mod vars;
 
 pub use self::vars::{
     ClientSeverity, Var, Vars, DEFAULT_DATABASE_NAME, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION,

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -168,7 +168,7 @@ const TIMEZONE: ServerVar<TimeZone> = ServerVar {
 
 const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
     name: UncasedStr::new("transaction_isolation"),
-    value: &IsolationLevel::Serializable,
+    value: &IsolationLevel::StrictSerializable,
     description: "Sets the current transaction's isolation level (PostgreSQL).",
 };
 

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -1222,13 +1222,13 @@ impl Value for IsolationLevel {
     fn parse(s: &str) -> Result<Self::Owned, ()> {
         let s = UncasedStr::new(s);
 
-        if s == Self::ReadUncommitted.as_str() {
-            Ok(Self::ReadUncommitted)
-        } else if s == Self::ReadCommitted.as_str() {
-            Ok(Self::ReadCommitted)
-        } else if s == Self::RepeatableRead.as_str() {
-            Ok(Self::RepeatableRead)
-        } else if s == Self::Serializable.as_str() {
+        // We don't have any optimizations for levels below Serializable,
+        // so we upgrade them all to Serializable.
+        if s == Self::ReadUncommitted.as_str()
+            || s == Self::ReadCommitted.as_str()
+            || s == Self::RepeatableRead.as_str()
+            || s == Self::Serializable.as_str()
+        {
             Ok(Self::Serializable)
         } else if s == Self::StrictSerializable.as_str() {
             Ok(Self::StrictSerializable)

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1524,10 +1524,6 @@ fn create_postgres_source_with_table(
         runtime.block_on(pg_client.execute(&format!("DROP TABLE IF EXISTS {table_name};"), &[]))?;
     let _ = runtime
         .block_on(pg_client.execute(&format!("DROP PUBLICATION IF EXISTS {source_name};"), &[]))?;
-    let _ = runtime.block_on(pg_client.execute(
-        &format!("SELECT pg_drop_replication_slot(slot_name) from pg_replication_slots;"),
-        &[],
-    ))?;
     let _ = runtime
         .block_on(pg_client.execute(&format!("CREATE TABLE {table_name} {table_schema};"), &[]))?;
     let _ = runtime.block_on(pg_client.execute(
@@ -1572,10 +1568,6 @@ fn create_postgres_source_with_table(
                 .block_on(pg_client.execute(&format!("DROP PUBLICATION {source_name};"), &[]))?;
             let _ =
                 runtime.block_on(pg_client.execute(&format!("DROP TABLE {table_name};"), &[]))?;
-            let _ = runtime.block_on(pg_client.execute(
-                &format!("SELECT pg_drop_replication_slot(slot_name) from pg_replication_slots;"),
-                &[],
-            ))?;
             Ok(())
         },
     ))

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2090,6 +2090,7 @@ pub enum TransactionIsolationLevel {
     ReadCommitted,
     RepeatableRead,
     Serializable,
+    StrictSerializable,
 }
 
 impl AstDisplay for TransactionIsolationLevel {
@@ -2100,6 +2101,7 @@ impl AstDisplay for TransactionIsolationLevel {
             ReadCommitted => "READ COMMITTED",
             RepeatableRead => "REPEATABLE READ",
             Serializable => "SERIALIZABLE",
+            StrictSerializable => "STRICT SERIALIZABLE",
         })
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -582,8 +582,8 @@ impl QueryWhen {
     /// Returns whether the candidate must be advanced to the global timestamp.
     pub fn advance_to_global_ts(&self) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => true,
-            QueryWhen::AtTimestamp(_) => false,
+            QueryWhen::Immediately => true,
+            QueryWhen::AtLeastTimestamp(_) | QueryWhen::AtTimestamp(_) => false,
         }
     }
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -564,23 +564,27 @@ impl QueryWhen {
         }
     }
     /// Returns whether the candidate must be advanced to the since.
-    pub fn advance_to_since(&self) -> bool {
+    pub fn advance_to_since(&self, strict_serializable: bool) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => true,
+            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => !strict_serializable,
             QueryWhen::AtTimestamp(_) => false,
         }
     }
     /// Returns whether the candidate must be advanced to the upper.
-    pub fn advance_to_upper(&self, uses_tables: bool) -> bool {
+    pub fn advance_to_upper(&self, uses_tables: bool, strict_serializable: bool) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => !uses_tables,
+            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => {
+                !uses_tables && !strict_serializable
+            }
             QueryWhen::AtTimestamp(_) => false,
         }
     }
-    /// Returns whether the candidate must be advanced to the global table timestamp.
-    pub fn advance_to_table_ts(&self, uses_tables: bool) -> bool {
+    /// Returns whether the candidate must be advanced to the global timestamp.
+    pub fn advance_to_global_ts(&self, uses_tables: bool, strict_serializable: bool) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => uses_tables,
+            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => {
+                uses_tables || strict_serializable
+            }
             QueryWhen::AtTimestamp(_) => false,
         }
     }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -566,27 +566,23 @@ impl QueryWhen {
         }
     }
     /// Returns whether the candidate must be advanced to the since.
-    pub fn advance_to_since(&self, strict_serializable: bool) -> bool {
+    pub fn advance_to_since(&self) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => !strict_serializable,
+            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => true,
             QueryWhen::AtTimestamp(_) => false,
         }
     }
     /// Returns whether the candidate must be advanced to the upper.
-    pub fn advance_to_upper(&self, uses_tables: bool, strict_serializable: bool) -> bool {
+    pub fn advance_to_upper(&self) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => {
-                !uses_tables && !strict_serializable
-            }
+            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => true,
             QueryWhen::AtTimestamp(_) => false,
         }
     }
     /// Returns whether the candidate must be advanced to the global timestamp.
-    pub fn advance_to_global_ts(&self, uses_tables: bool, strict_serializable: bool) -> bool {
+    pub fn advance_to_global_ts(&self) -> bool {
         match self {
-            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => {
-                uses_tables || strict_serializable
-            }
+            QueryWhen::Immediately | QueryWhen::AtLeastTimestamp(_) => true,
             QueryWhen::AtTimestamp(_) => false,
         }
     }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -68,6 +68,7 @@ pub(crate) mod with_options;
 pub use self::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
 pub use error::PlanError;
 pub use explain::Explanation;
+use mz_sql_parser::ast::TransactionIsolationLevel;
 pub use optimize::OptimizerConfig;
 pub use query::{QueryContext, QueryLifetime};
 pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
@@ -131,6 +132,7 @@ pub enum Plan {
 #[derive(Debug)]
 pub struct StartTransactionPlan {
     pub access: Option<TransactionAccessMode>,
+    pub isolation_level: Option<TransactionIsolationLevel>,
 }
 
 #[derive(Debug)]

--- a/test/cluster/storaged/03-while-storaged-down.td
+++ b/test/cluster/storaged/03-while-storaged-down.td
@@ -10,6 +10,8 @@
 # Verify that the data ingested before `storaged` crashed is still present but
 # that newly ingested data does not appear.
 
+> SET transaction_isolation = SERIALIZABLE
+
 > SELECT * from remote1
 one
 two
@@ -28,3 +30,5 @@ two
 > SELECT * from remote2
 one
 two
+
+> SET transaction_isolation = STRICT_SERIALIZABLE

--- a/test/sqllogictest/cursor.slt
+++ b/test/sqllogictest/cursor.slt
@@ -44,10 +44,10 @@ CREATE VIEW v AS VALUES ('a', 'b'), ('c', 'd'), ('e', 'f'), ('g', 'h')
 query IITT
 TAIL v
 ----
-0  1  a  b
-0  1  c  d
-0  1  e  f
-0  1  g  h
+18446744073709551615  1  a  b
+18446744073709551615  1  c  d
+18446744073709551615  1  e  f
+18446744073709551615  1  g  h
 
 statement ok
 BEGIN
@@ -58,18 +58,18 @@ DECLARE c CURSOR FOR TAIL v
 query IITT
 FETCH c
 ----
-0  1  a  b
+18446744073709551615  1  a  b
 
 query IITT
 FETCH 2 c WITH (TIMEOUT = '10s')
 ----
-0  1  c  d
-0  1  e  f
+18446744073709551615  1  c  d
+18446744073709551615  1  e  f
 
 query IITT
 FETCH 2 c WITH (TIMEOUT = '1s')
 ----
-0  1  g  h
+18446744073709551615  1  g  h
 
 query IITT
 FETCH c WITH (TIMEOUT = '1s')

--- a/test/sqllogictest/cursor.slt
+++ b/test/sqllogictest/cursor.slt
@@ -44,10 +44,10 @@ CREATE VIEW v AS VALUES ('a', 'b'), ('c', 'd'), ('e', 'f'), ('g', 'h')
 query IITT
 TAIL v
 ----
-18446744073709551615  1  a  b
-18446744073709551615  1  c  d
-18446744073709551615  1  e  f
-18446744073709551615  1  g  h
+0  1  a  b
+0  1  c  d
+0  1  e  f
+0  1  g  h
 
 statement ok
 BEGIN
@@ -58,18 +58,18 @@ DECLARE c CURSOR FOR TAIL v
 query IITT
 FETCH c
 ----
-18446744073709551615  1  a  b
+0  1  a  b
 
 query IITT
 FETCH 2 c WITH (TIMEOUT = '10s')
 ----
-18446744073709551615  1  c  d
-18446744073709551615  1  e  f
+0  1  c  d
+0  1  e  f
 
 query IITT
 FETCH 2 c WITH (TIMEOUT = '1s')
 ----
-18446744073709551615  1  g  h
+0  1  g  h
 
 query IITT
 FETCH c WITH (TIMEOUT = '1s')

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -47,7 +47,7 @@ SELECT * FROM mz_materializations
 # We sleep between checks to give dataflow logging time to catch up.
 
 statement ok
-SELECT mz_internal.mz_sleep(0.1)
+SELECT mz_internal.mz_sleep(1.1)
 
 query I
 SELECT sum(count) FROM mz_peek_durations
@@ -55,7 +55,7 @@ SELECT sum(count) FROM mz_peek_durations
 2
 
 statement ok
-SELECT mz_internal.mz_sleep(0.1)
+SELECT mz_internal.mz_sleep(1.1)
 
 query I
 SELECT sum(count) FROM mz_peek_durations
@@ -63,7 +63,7 @@ SELECT sum(count) FROM mz_peek_durations
 3
 
 statement ok
-SELECT mz_internal.mz_sleep(0.1)
+SELECT mz_internal.mz_sleep(1.1)
 
 query I
 SELECT sum(count) FROM mz_peek_durations

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -137,18 +137,21 @@ RESET does_not_exist
 query T
 SHOW transaction_isolation
 ----
-SERIALIZABLE
+STRICT_SERIALIZABLE
 
 statement ok
-SET transaction_isolation = STRICT_SERIALIZABLE
+SET transaction_isolation = SERIALIZABLE
 
 query T
 SHOW transaction_isolation
 ----
-STRICT_SERIALIZABLE
+SERIALIZABLE
 
 statement error invalid value for parameter "transaction_isolation": "snapshot_isolation"
 SET transaction_isolation = SNAPSHOT_ISOLATION
+
+statement ok
+SET transaction_isolation = STRICT_SERIALIZABLE
 
 # Test that a failed transaction will not commit var changes.
 

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -132,6 +132,24 @@ SET does_not_exist = DEFAULT
 statement error unrecognized configuration parameter
 RESET does_not_exist
 
+# Test transaction isolation
+
+query T
+SHOW transaction_isolation
+----
+SERIALIZABLE
+
+statement ok
+SET transaction_isolation = STRICT_SERIALIZABLE
+
+query T
+SHOW transaction_isolation
+----
+STRICT_SERIALIZABLE
+
+statement error invalid value for parameter "transaction_isolation": "read_committed"
+SET transaction_isolation = READ_COMMITTED
+
 # Test that a failed transaction will not commit var changes.
 
 statement ok

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -147,6 +147,14 @@ SHOW transaction_isolation
 ----
 SERIALIZABLE
 
+statement ok
+SET transaction_isolation = READ_COMMITTED
+
+query T
+SHOW transaction_isolation
+----
+SERIALIZABLE
+
 statement error invalid value for parameter "transaction_isolation": "snapshot_isolation"
 SET transaction_isolation = SNAPSHOT_ISOLATION
 

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -147,8 +147,8 @@ SHOW transaction_isolation
 ----
 STRICT_SERIALIZABLE
 
-statement error invalid value for parameter "transaction_isolation": "read_committed"
-SET transaction_isolation = READ_COMMITTED
+statement error invalid value for parameter "transaction_isolation": "snapshot_isolation"
+SET transaction_isolation = SNAPSHOT_ISOLATION
 
 # Test that a failed transaction will not commit var changes.
 

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -133,10 +133,11 @@ Rochester      NY        14618
   FORMAT CSV WITH HEADER
 contains:Expected a list of columns in parentheses, found EOF
 
-# The timestamp chosen when reading from a static CSV should be the end of time,
+# The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-4  18446744073709551615
+"     timestamp: <TIMESTAMP>\n         since:[<TIMESTAMP>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv_primary_idx (u37, compute):\n read frontier:[<TIMESTAMP>]\nwrite frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE MATERIALIZED SOURCE static_csv_manual_header (city_man, state_man, zip_man)

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -135,7 +135,7 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The timestamp chosen when reading from a static CSV should be the end of time,
 # since the definition of "static" means "will never change again".
-> SELECT count(*), mz_logical_timestamp() FROM static_csv
+> EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
 4  18446744073709551615
 
 # Static CSV with manual headers.

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -28,7 +28,7 @@ sql_safe_updates            off             "Prohibits SQL statements that may b
 standard_conforming_strings on              "Causes '...' strings to treat backslashes literally (PostgreSQL)."
 statement_timeout           "10 s"          "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
 TimeZone                    UTC             "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
-transaction_isolation       serializable    "Sets the current transaction's isolation level (PostgreSQL)."
+transaction_isolation       SERIALIZABLE    "Sets the current transaction's isolation level (PostgreSQL)."
 
 > SET application_name = 'foo'
 
@@ -99,10 +99,10 @@ contains:invalid value for parameter "TimeZone": "nope"
 # The `transaction_isolation` variable has dedicated syntax as mandated by the
 # SQL standard.
 > SHOW TRANSACTION ISOLATION LEVEL
-serializable
+SERIALIZABLE
 
 ! SET transaction_isolation = 'read committed'
-contains:parameter "transaction_isolation" cannot be changed
+contains:invalid value for parameter "transaction_isolation": "read committed"
 
 ! SET integer_datetimes = false
 contains:parameter "integer_datetimes" cannot be changed

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -28,7 +28,7 @@ sql_safe_updates            off             "Prohibits SQL statements that may b
 standard_conforming_strings on              "Causes '...' strings to treat backslashes literally (PostgreSQL)."
 statement_timeout           "10 s"          "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
 TimeZone                    UTC             "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
-transaction_isolation       SERIALIZABLE    "Sets the current transaction's isolation level (PostgreSQL)."
+transaction_isolation       STRICT_SERIALIZABLE    "Sets the current transaction's isolation level (PostgreSQL)."
 
 > SET application_name = 'foo'
 
@@ -99,7 +99,7 @@ contains:invalid value for parameter "TimeZone": "nope"
 # The `transaction_isolation` variable has dedicated syntax as mandated by the
 # SQL standard.
 > SHOW TRANSACTION ISOLATION LEVEL
-SERIALIZABLE
+STRICT_SERIALIZABLE
 
 ! SET transaction_isolation = 'read committed'
 contains:invalid value for parameter "transaction_isolation": "read committed"

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -155,6 +155,11 @@ b  sum
 1  1
 2  2
 
+> SELECT * FROM data_bar;
+a   b
+-----
+10  1
+
 > SELECT * FROM bar;
 b  sum
 ------
@@ -183,7 +188,17 @@ b  sum
 b  sum
 ------
 1  10
+
+# Under weaker isolation levels we can see the row at time 2 before all objects have closed time 2.
+> SET transaction_isolation = SERIALIZABLE
+
+> SELECT * FROM bar;
+b  sum
+------
+1  10
 3  30
+
+> SET transaction_isolation = STRICT_SERIALIZABLE
 
 > SELECT * FROM join;
 b foo_sum bar_sum
@@ -200,6 +215,12 @@ b  sum
 2  2
 3  3
 4  4
+
+> SELECT * FROM bar;
+b  sum
+------
+1  10
+3  30
 
 > SELECT * FROM join;
 b foo_sum bar_sum


### PR DESCRIPTION
Previously, Materialize only exposed a single isolation level of
serializable. Materialize could create a total order of all operations
using the timestamp of that operation. However, there was no guarantee
that a read was performed at an equal to or higher timestamp than all
previous reads.

This commit adds the strict serializable isolation level. To learn more
about isolation levels see: https://jepsen.io/consistency. All reads
within a single timeline is performed at a timestamp equal to or higher
than all previous reads.

We accomplish this by using a TimestampOracle to get timestamps for
all reads. The TimestampOracle is guaranteed to always provide
increasing timestamps. We know that the timestamp will be valid to use
for reads, because the Coordinator maintains read holds on these times.

This commit does not prevent strict serializability violations if there
are multiple Coordinators active at the same time. This is a known
issue and a fix is being designed/worked on.

Fixes #12309

### Motivation
This PR adds a known-desirable feature.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds a strict serializable transaction isolation level and makes it the default level.
