### PR TITLE
Remove left-over mentions of `materialized`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -5767,7 +5767,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> DataflowDescription<mz_compute_client::plan::Plan> {
         // This function must succeed because catalog_transact has generally been run
         // before calling this function. We don't have plumbing yet to rollback catalog
-        // operations if this function fails, and materialized will be in an unsafe
+        // operations if this function fails, and environmentd will be in an unsafe
         // state if we do not correctly clean up the catalog.
 
         let storage_ids = dataflow

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -560,7 +560,7 @@ fn eval_unmaterializable_func(
         UnmaterializableFunc::Version => {
             let build_info = state.config().build_info;
             let version = format!(
-                "PostgreSQL {}.{} on {} (materialized {})",
+                "PostgreSQL {}.{} on {} (Materialize {})",
                 SERVER_MAJOR_VERSION,
                 SERVER_MINOR_VERSION,
                 mz_build_info::TARGET_TRIPLE,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -9,7 +9,7 @@
 
 //! Embedded HTTP server.
 //!
-//! materialized embeds an HTTP server for introspection into the running
+//! environmentd embeds an HTTP server for introspection into the running
 //! process. At the moment, its primary exports are Prometheus metrics, heap
 //! profiles, and catalog dumps.
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -49,7 +49,7 @@ pub mod tcp_connection;
 
 pub const BUILD_INFO: BuildInfo = build_info!();
 
-/// Configuration for a `materialized` server.
+/// Configuration for an `environmentd` server.
 #[derive(Debug, Clone)]
 pub struct Config {
     // === Performance tuning options. ===
@@ -165,7 +165,7 @@ pub enum SecretsControllerConfig {
     },
 }
 
-/// Start a `materialized` server.
+/// Start an `environmentd` server.
 pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let tls = mz_postgres_util::make_tls(&tokio_postgres::config::Config::from_str(
         &config.catalog_postgres_stash,
@@ -364,7 +364,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     })
 }
 
-/// A running `materialized` server.
+/// A running `environmentd` server.
 pub struct Server {
     sql_local_addr: SocketAddr,
     http_local_addr: SocketAddr,

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -80,7 +80,7 @@
 //! REWRITE=1 cargo run --bin mz-pgtest -- test/pgtest/test.pt --addr localhost:5432 --user postgres
 //! ```
 //! This will generate the expected output for the `until` directive.
-//! Now rerun against a running materialized server:
+//! Now rerun against a running Materialize server:
 //! ```shell
 //! cargo run --bin mz-pgtest -- test/pgtest/test.pt
 //! ```

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2967,7 +2967,7 @@ pub static MZ_INTERNAL_BUILTINS: Lazy<HashMap<&'static str, Func>> = Lazy::new(|
         },
         // This ought to be exposed in `mz_catalog`, but its name is rather
         // confusing. It does not identify the SQL session, but the
-        // invocation of this `materialized` process.
+        // invocation of this `environmentd` process.
         "mz_session_id" => Scalar {
             params!() => UnmaterializableFunc::MzSessionId, oid::FUNC_MZ_SESSION_ID_OID;
         },

--- a/src/storage/src/server.rs
+++ b/src/storage/src/server.rs
@@ -53,7 +53,7 @@ pub struct Server {
     _worker_guards: WorkerGuards<()>,
 }
 
-/// Initiates a timely dataflow computation, processing materialized commands.
+/// Initiates a timely dataflow computation, processing storage commands.
 pub fn serve(
     config: Config,
 ) -> Result<

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -262,7 +262,7 @@ async fn scan_bucket_task(
     // dance.
     //
     // This isn't a meaningful performance optimization, it just makes it easy for folks to import a
-    // single object without granting materialized the ListObjects IAM permission
+    // single object without granting storaged the ListObjects IAM permission
     let is_literal_object = glob.is_some() && prefix.as_deref() == glob.map(|g| g.glob().glob());
     if is_literal_object {
         let key = glob.unwrap().glob().glob();


### PR DESCRIPTION
This PR removes mentions of `materialized` in the code that were missed when we moved from the single binary to the Platform architecture.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

This almost exclusively changes comments. The only exception is the return value of the SQL `version` function, which now looks like this:

```
                             version
-----------------------------------------------------------------
 PostgreSQL 9.5 on aarch64-apple-darwin (Materialize 0.26.1-dev)
```

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Change the output of the SQL `version` function to mention "Materialize" instead of "materialized".
