### PR TITLE
storage: use CapabilitySet instead of Capability for sources

### DIFF
--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -34,12 +34,13 @@ use async_trait::async_trait;
 use differential_dataflow::Hashable;
 use futures::stream::LocalBoxStream;
 use futures::{Stream, StreamExt as _};
+use itertools::Itertools;
 use prometheus::core::{AtomicI64, AtomicU64};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, ParallelizationContract};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::OutputHandle;
-use timely::dataflow::operators::{Capability, Event};
+use timely::dataflow::operators::{CapabilitySet, Event};
 use timely::dataflow::Scope;
 use timely::progress::{Antichain, Timestamp as _};
 use timely::scheduling::activate::SyncActivator;
@@ -828,6 +829,22 @@ where
                     }
                     // It's time to timestamp a batch
                     _ = timestamp_interval.tick() => {
+                        // Emit errors at the current upper timestamp, to make
+                        // sure that they can be emitted with the existing
+                        // capability.
+                        let current_ts_upper = timestamper
+                            .reclock_frontier(&source_upper)
+                            .expect("compacted past upper");
+                        for err in non_definite_errors.drain(..) {
+                            // TODO: make errors definite
+                            yield Event::Message(
+                                current_ts_upper
+                                    .first()
+                                    .cloned()
+                                    .expect("cannot emit errors when advanced to the empty frontier"),
+                                Err(err));
+                        }
+
                         let reclocked_msgs = match timestamper.reclock(&mut untimestamped_messages).await {
                             Ok(msgs) => msgs,
                             Err((pid, offset)) => panic!("failed to reclock {} @ {}", pid, offset),
@@ -840,10 +857,6 @@ where
 
                         timestamper.advance().await;
 
-                        for err in non_definite_errors.drain(..) {
-                            // TODO: make errors definite
-                            yield Event::Message(0, Err(err));
-                        }
                         // TODO(petrosagg): compaction should be driven by AllowCompaction commands
                         // coming from the storage controller
                         let new_ts_upper = timestamper
@@ -855,10 +868,10 @@ where
                             // is critical here: once this capability is downgraded, that timestamp
                             // is sealed forever.
                             ts_upper = new_ts_upper.clone();
-                            yield Event::Progress(new_ts_upper.into_option());
+                            yield Event::Progress(new_ts_upper);
                         }
                         if source_stream.is_done() {
-                            yield Event::Progress(None);
+                            yield Event::Progress(Antichain::new());
                             break;
                         }
                     }
@@ -867,7 +880,7 @@ where
         }));
 
         let activator = scope.activator_for(&info.address[..]);
-        move |cap, output| {
+        move |cap_set, output| {
             if !active {
                 return SourceStatus::Done;
             }
@@ -887,15 +900,16 @@ where
             while let Poll::Ready(Some(event)) = source_reader.as_mut().poll_next(&mut context) {
                 match event {
                     Event::Progress(upper) => {
-                        let ts = upper.unwrap_or(Timestamp::MAX);
+                        let ts = upper.as_option().cloned().unwrap_or(Timestamp::MAX);
                         for partition_metrics in source_metrics.partition_metrics.values_mut() {
                             partition_metrics.closed_ts.set(ts);
                         }
-                        // TODO(petrosagg): `cap` should become a CapabilitySet to allow
-                        // downgrading it to the empty frontier. For now setting SourceStatus to
-                        // Done achieves the same effect
-                        cap.downgrade(&ts);
-                        if upper.is_none() {
+
+                        cap_set.downgrade(upper.iter());
+
+                        // WIP: Can we remove the bit about SourceStatus::Done
+                        // now?
+                        if upper.is_empty() {
                             source_status = SourceStatus::Done;
                         }
                     }
@@ -903,14 +917,14 @@ where
                         Ok(message) => handle_message::<S>(
                             message,
                             &mut bytes_read,
-                            &cap,
+                            &cap_set,
                             output,
                             &mut metric_updates,
                             ts,
                         ),
                         // TODO: make errors definite
                         Err(e) => {
-                            output.session(&cap).give(Err(SourceError {
+                            output.session(&cap_set.delayed(&ts)).give(Err(SourceError {
                                 source_id: id,
                                 error: e.inner,
                             }));
@@ -925,7 +939,19 @@ where
 
             bytes_read_counter.inc_by(bytes_read as u64);
             source_metrics.record_partition_offsets(metric_updates);
-            source_metrics.capability.set(*cap.time());
+            // This is correct for totally ordered times because there can be at
+            // most one entry in the `CapabilitySet`. If this ever changes we
+            // need to rethink how we surface this in metrics. We will notice
+            // when that happens because the `expect()` will fail.
+            source_metrics.capability.set(
+                cap_set
+                    .iter()
+                    .at_most_one()
+                    .expect("there can be at most one element for totally ordered times")
+                    .map(|c| c.time())
+                    .cloned()
+                    .unwrap_or(Timestamp::MAX),
+            );
 
             source_status
         }
@@ -947,7 +973,7 @@ where
 fn handle_message<S: SourceReader>(
     message: SourceMessage<S::Key, S::Value, S::Diff>,
     bytes_read: &mut usize,
-    cap: &Capability<Timestamp>,
+    cap_set: &CapabilitySet<Timestamp>,
     output: &mut OutputHandle<
         Timestamp,
         Result<SourceOutput<S::Key, S::Value, S::Diff>, SourceError>,
@@ -972,7 +998,7 @@ fn handle_message<S: SourceReader>(
     if let Some(len) = out.len() {
         *bytes_read += len;
     }
-    let ts_cap = cap.delayed(&ts);
+    let ts_cap = cap_set.delayed(&ts);
     output.session(&ts_cap).give(Ok(SourceOutput::new(
         key,
         out,

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -20,6 +20,7 @@ use mz_persist_client::cache::PersistClientCache;
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
+use timely::PartialOrder;
 use tokio::sync::Mutex;
 use tracing::trace;
 
@@ -118,16 +119,7 @@ where
             let waker = futures_util::task::waker(waker_activator);
             let activator = scope.activator_for(&info.address[..]);
 
-            // There is a bit of a mismatch: listening on a ReadHandle will give us an Antichain<T>
-            // as a frontier in `Progress` messages while a timely source usually only has a single
-            // `Capability` that it can downgrade. We can work around that by using a
-            // `CapabilitySet`, which allows downgrading the contained capabilities to a frontier
-            // but `util::source` gives us both a vanilla `Capability` and a `CapabilitySet` that
-            // we have to keep downgrading because we cannot simply drop the one that we don't
-            // need.
-            let mut current_ts = 0;
-
-            move |cap, output| {
+            move |cap_set, output| {
                 let mut context = Context::from_waker(&waker);
                 // Bound execution of operator to prevent a single operator from hogging
                 // the CPU if there are many messages to process
@@ -135,20 +127,50 @@ where
 
                 while let Poll::Ready(item) = pinned_stream.as_mut().poll_next(&mut context) {
                     match item {
-                        Some(Ok(ListenEvent::Progress(upper))) => match upper.into_option() {
-                            Some(ts) => {
-                                current_ts = ts;
-                                cap.downgrade(&ts);
+                        Some(Ok(ListenEvent::Progress(upper))) => {
+                            cap_set.downgrade(upper.iter());
+
+                            if upper.is_empty() {
+                                return SourceStatus::Done;
                             }
-                            None => return SourceStatus::Done,
-                        },
+                        }
                         Some(Ok(ListenEvent::Updates(mut updates))) => {
                             // This operator guarantees that its output has been advanced by `as_of.
                             // The persist SnapshotIter already has this contract, so nothing to do
                             // here.
-                            let cap = cap.delayed(&current_ts);
-                            let mut session = output.session(&cap);
-                            session.give_vec(&mut updates);
+
+                            if updates.is_empty() {
+                                continue;
+                            }
+
+                            // Swing through all the capabilities we have and
+                            // peel off updates that we can emit with it. For
+                            // the case of totally ordered times, we have at
+                            // most on capability and will peel off all updates
+                            // in one go.
+                            //
+                            // NOTE: We use this seemingly complicated approach
+                            // such that the code is ready to deal with
+                            // partially ordered times.
+                            for cap in cap_set.iter() {
+                                // NOTE: The nightly `drain_filter()` would use
+                                // less allocations than this. Should switch to
+                                // it once it's available in stable rust.
+                                let (mut to_emit, remaining_updates) =
+                                    updates.into_iter().partition(|(_update, ts, _diff)| {
+                                        PartialOrder::less_equal(cap.time(), ts)
+                                    });
+                                updates = remaining_updates;
+
+                                let mut session = output.session(&cap);
+                                session.give_vec(&mut to_emit);
+                            }
+
+                            assert!(
+                                updates.is_empty(),
+                                "did not have matching Capability for updates: {:?}",
+                                updates
+                            );
                         }
                         Some(Err::<_, ExternalError>(e)) => {
                             // TODO(petrosagg): error handling

--- a/src/storage/src/source/util.rs
+++ b/src/storage/src/source/util.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{OperatorInfo, OutputHandle};
-use timely::dataflow::operators::Capability;
+use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::{Scope, Stream};
 use timely::scheduling::ActivateOnDrop;
 use timely::Data;
@@ -56,7 +56,7 @@ where
     D: Data,
     B: FnOnce(OperatorInfo) -> L,
     L: FnMut(
-            &mut Capability<Timestamp>,
+            &mut CapabilitySet<Timestamp>,
             &mut OutputHandle<G::Timestamp, D, Tee<G::Timestamp, D>>,
         ) -> SourceStatus
         + 'static,
@@ -70,7 +70,8 @@ where
     builder.set_notify(false);
 
     builder.build(|capabilities| {
-        let mut capability = Some(capabilities.into_element());
+        let cap_set = CapabilitySet::from_elem(capabilities.into_element());
+        let mut capability = Some(cap_set);
 
         let drop_activator = Rc::new(ActivateOnDrop::new(
             (),


### PR DESCRIPTION
The `CapabilitySet` makes it easier to interface with systems that
report an `Antichain` as their progress frontier.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.