### PR TITLE
storage: track dependencies of storage collections/acquire read holds

### DIFF
--- a/src/storage/src/client.proto
+++ b/src/storage/src/client.proto
@@ -35,6 +35,7 @@ message ProtoIngestSourceCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     sources.ProtoIngestionDescription description = 2;
     mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
+    mz_persist.gen.persist.ProtoU64Antichain dependency_since = 4;
 }
 
 message ProtoIngestSources {

--- a/src/storage/src/client/controller.rs
+++ b/src/storage/src/client/controller.rs
@@ -480,8 +480,30 @@ where
                 .await
                 .expect("invalid persist usage");
 
-            let collection_state =
-                CollectionState::new(description.clone(), read.since().clone(), metadata);
+            let mut collection_since = read.since().to_owned();
+
+            let mut storage_dependencies = self.get_storage_dependencies(&description);
+            // Canonicalize dependencies.
+            // Probably redundant based on key structure, but doing for sanity.
+            storage_dependencies.sort();
+            storage_dependencies.dedup();
+
+            // Install read holds for our dependencies, if any, and get the
+            // frontier at which we can read from all dependencies.
+            let dependency_since = self
+                .install_read_capabilities(&storage_dependencies)
+                .await?;
+
+            // Advance the collection since to the since of dependencies, if
+            // any.
+            collection_since.join_assign(&dependency_since);
+
+            let collection_state = CollectionState::new(
+                description.clone(),
+                collection_since.clone(),
+                storage_dependencies,
+                metadata,
+            );
 
             self.state
                 .persist_handles
@@ -539,6 +561,7 @@ where
                         typ: description.desc.typ().clone(),
                     },
                     resume_upper,
+                    dependency_since,
                 };
 
                 // Provision a storage host for the ingestion.
@@ -743,6 +766,13 @@ where
                 let changes = collection.read_capabilities.update_iter(update.drain());
                 update.extend(changes);
 
+                for id in collection.storage_dependencies.iter() {
+                    updates
+                        .entry(*id)
+                        .or_insert_with(ChangeBatch::new)
+                        .extend(update.iter().cloned());
+                }
+
                 let (changes, frontier) = storage_net
                     .entry(key)
                     .or_insert_with(|| (ChangeBatch::new(), Antichain::new()));
@@ -880,6 +910,66 @@ where
         }
         Ok(())
     }
+
+    /// Returns IDs for all storage collections that the given
+    /// `collection_description` depends on.
+    fn get_storage_dependencies(
+        &self,
+        collection_description: &CollectionDescription,
+    ) -> Vec<GlobalId> {
+        let mut result = Vec::new();
+
+        if let Some(ingestion) = &collection_description.ingestion {
+            match &ingestion.desc.envelope {
+                SourceEnvelope::Debezium(envelope_debezium) => {
+                    let tx_metadata_topic = envelope_debezium.mode.tx_metadata();
+                    if let Some(tx_input) = tx_metadata_topic {
+                        result.push(tx_input.tx_metadata_global_id);
+                    }
+                }
+                // NOTE: We explicitly list envelopes instead of using a catch all to
+                // make sure that we change this when adding/removing and envelope.
+                SourceEnvelope::None(_) | SourceEnvelope::Upsert(_) | SourceEnvelope::CdcV2 => {
+                    // No storage dependencies.
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Install read capabilities on the given `storage_dependencies` and return
+    /// the frontier at which we are guaranteed to be able to read from all
+    /// dependencies.
+    async fn install_read_capabilities(
+        &mut self,
+        storage_dependencies: &[GlobalId],
+    ) -> Result<Antichain<T>, StorageError> {
+        // First, determine the since frontier at which we can read from all
+        // dependencies.
+        let mut dependency_since = Antichain::from_elem(T::minimum());
+        for id in storage_dependencies {
+            let collection = self.collection(*id)?;
+            let since = collection.implied_capability.clone();
+            dependency_since.join_assign(&since);
+        }
+
+        let mut changes = ChangeBatch::new();
+        for time in dependency_since.iter() {
+            changes.update(time.clone(), 1);
+        }
+
+        // Then install holds for all dependencies at the determined since.
+        let mut storage_read_updates = storage_dependencies
+            .iter()
+            .map(|id| (*id, changes.clone()))
+            .collect();
+
+        self.update_read_capabilities(&mut storage_read_updates)
+            .await?;
+
+        Ok(dependency_since)
+    }
 }
 
 /// State maintained about individual collections.
@@ -897,6 +987,9 @@ pub struct CollectionState<T> {
     pub implied_capability: Antichain<T>,
     /// The policy to use to downgrade `self.implied_capability`.
     pub read_policy: ReadPolicy<T>,
+
+    /// Storage identifiers on which this collection depends.
+    pub storage_dependencies: Vec<GlobalId>,
 
     /// Reported progress in the write capabilities.
     ///
@@ -921,6 +1014,7 @@ impl<T: Timestamp> CollectionState<T> {
     pub fn new(
         description: CollectionDescription,
         since: Antichain<T>,
+        storage_dependencies: Vec<GlobalId>,
         metadata: CollectionMetadata,
     ) -> Self {
         let mut read_capabilities = MutableAntichain::new();
@@ -929,6 +1023,7 @@ impl<T: Timestamp> CollectionState<T> {
             description,
             read_capabilities,
             implied_capability: since.clone(),
+            storage_dependencies,
             read_policy: ReadPolicy::ValidFrom(since),
             write_frontier: MutableAntichain::new_bottom(Timestamp::minimum()),
             collection_metadata: metadata,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -128,6 +128,7 @@ pub fn build_storage_dataflow<A: Allocate>(
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<mz_repr::Timestamp>,
+    dependency_since: Antichain<mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();
@@ -146,6 +147,7 @@ pub fn build_storage_dataflow<A: Allocate>(
                 id,
                 description.clone(),
                 resume_upper,
+                dependency_since,
                 // NOTE: For now sources never have LinearOperators but might have in the future
                 None,
                 storage_state,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -62,6 +62,9 @@ enum SourceType<Delimited, ByteStream, RowSource, AppendRowSource> {
 /// as requested by the original `CREATE SOURCE` statement,
 /// encapsulated in the passed `SourceInstanceDesc`.
 ///
+/// The given `dependency_since` is the frontier at which we are guaranteed to
+/// be able to read from storage dependencies, if any.
+///
 /// The first element in the returned tuple is the pair of [`Collection`]s,
 /// the second is a type-erased token that will keep the source
 /// alive as long as it is not dropped.
@@ -75,6 +78,7 @@ pub fn render_source<G>(
     id: GlobalId,
     description: IngestionDescription<CollectionMetadata>,
     resume_upper: Antichain<G::Timestamp>,
+    dependency_since: Antichain<G::Timestamp>,
     mut linear_operators: Option<LinearOperator>,
     storage_state: &mut crate::storage_state::StorageState,
 ) -> (
@@ -318,14 +322,12 @@ where
                                 .expect("dependent source missing from ingestion description")
                                 .clone();
                             let persist_clients = Arc::clone(&storage_state.persist_clients);
-                            let upper_ts = resume_upper.as_option().copied().unwrap();
-                            let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
                             let (tx_source_ok_stream, tx_source_err_stream, tx_token) =
                                 persist_source::persist_source(
                                     scope,
                                     persist_clients,
                                     tx_storage_metadata,
-                                    as_of,
+                                    dependency_since,
                                 );
                             let (tx_source_ok, tx_source_err) = (
                                 tx_source_ok_stream.as_collection(),

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -126,6 +126,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         ingestion.id,
                         ingestion.description,
                         ingestion.resume_upper,
+                        ingestion.dependency_since,
                     );
 
                     self.storage_state.reported_frontiers.insert(


### PR DESCRIPTION
Before, the storage controller didn't track dependencies that storage
collections might have on other storage collections. The only case where
we have this right now is Debezium sources with a transaction source
(which is gated behind the "unsafe" flag). In this case it is a bug,
because rendering the debezium source can fail when the transaction
source has been compacted (since has advanced).

The bug in Debezium sources did not surface because we currently don't
correctly downgrade the since of persist shards because we do not
properly expire all `ReadHandle`s. The bug will surface in multiple
failed tests on #13347, which removes per-reader sinces and therefore
makes us downgrade persist sinces correctly.

In the future, we will also need this for external sinks, which depend
on the storage collection that they are sinking from.

Closes #13490

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- #13347 (without this fix) shows multiple test failures which go away with this PR. (I pushed the change in this PR to #13347 to verify)