### PR TITLE
storage: panic when failing to start the source timestamper or reader

### DIFF
--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -47,7 +47,6 @@ use timely::scheduling::ActivateOnDrop;
 use timely::{Data, PartialOrder};
 use tokio::sync::Mutex;
 use tokio::time::MissedTickBehavior;
-use tracing::error;
 
 use mz_avro::types::Value;
 use mz_expr::PartitionId;
@@ -759,8 +758,7 @@ where
             {
                 Ok(t) => t,
                 Err(e) => {
-                    error!("Failed to create source {} timestamper: {:#}", name, e);
-                    return;
+                    panic!("Failed to create source {} timestamper: {:#}", name, e);
                 }
             };
 
@@ -782,13 +780,10 @@ where
                 base_metrics,
                 connection_context.clone(),
             );
-            let source_stream = match source_reader {
-                Ok(s) => s.into_stream(timestamp_frequency).fuse(),
-                Err(e) => {
-                    error!("Failed to create source: {}", e);
-                    return;
-                }
-            };
+            let source_stream = source_reader
+                .expect("Failed to create source")
+                .into_stream(timestamp_frequency)
+                .fuse();
 
             tokio::pin!(source_stream);
 


### PR DESCRIPTION
Panic instead of just logging an error message whenever we fail to initialize either the source timestamper (reclock operator) or the source reader itself. Without this panic, `storaged` would just idle without consuming data from the source, but also not clearly signalling any kind of failure.

### Motivation

  * This PR fixes a previously unreported bug: `storaged` idling if initializing the source reader or timestamp fails.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
