### PR TITLE
Make `Controller::ready` infallible

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1049,8 +1049,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 _ = advance_local_inputs_interval.tick() => Message::AdvanceLocalInputs,
                 // See [`mz_controller::Controller::Controller::ready`] for notes
                 // on why this is cancel-safe.
-                m = self.dataflow_client.ready() => {
-                    let () = m.unwrap();
+                () = self.dataflow_client.ready() => {
                     Message::ControllerReady
                 }
                 // `recv()` on `UnboundedReceiver` is cancellation safe:

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -491,18 +491,14 @@ where
                 .iter_mut()
                 .map(|(id, compute)| (*id, compute.client.as_stream()))
                 .collect();
-            loop {
-                tokio::select! {
-                    Some((instance, response)) = compute_stream.next() => {
-                        assert!(self.stashed_response.is_none());
-                        self.stashed_response = Some(UnderlyingControllerResponse::Compute(instance, response));
-                        return;
-                    }
-                    Some(response) = self.storage_controller.recv() => {
-                        assert!(self.stashed_response.is_none());
-                        self.stashed_response = Some(UnderlyingControllerResponse::Storage(response));
-                        return;
-                    }
+            tokio::select! {
+                Some((instance, response)) = compute_stream.next() => {
+                    assert!(self.stashed_response.is_none());
+                    self.stashed_response = Some(UnderlyingControllerResponse::Compute(instance, response));
+                }
+                Some(response) = self.storage_controller.recv() => {
+                    assert!(self.stashed_response.is_none());
+                    self.stashed_response = Some(UnderlyingControllerResponse::Storage(response));
                 }
             }
         }


### PR DESCRIPTION
It does not need to return a `Result`.


### Motivation

Fixes #13486 (or rather, proves using the type system that it is already fixed)

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
