### PR TITLE
persist: fix format_push_string clippy lint error

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -612,6 +612,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::fmt::Write;
 
     use differential_dataflow::trace::Description;
     use mz_ore::cast::CastFrom;
@@ -719,7 +720,7 @@ mod tests {
 
                             let mut s = String::new();
                             for (idx, key) in batch.keys.iter().enumerate() {
-                                s.push_str(&format!("<part {}>\n", idx));
+                                let _ = write!(&mut s, "<part {}>\n", idx);
                                 fetch_batch_part(
                                     &shard_id,
                                     client.blob.as_ref(),
@@ -728,7 +729,7 @@ mod tests {
                                     &batch.desc,
                                     |k, _v, t, d| {
                                         let (k, d) = (String::decode(k).unwrap(), i64::decode(d));
-                                        s.push_str(&format!("{} {} {}\n", k, t, d));
+                                        let _ = write!(&mut s, "{} {} {}\n", k, t, d);
                                     },
                                 )
                                 .await
@@ -828,12 +829,13 @@ mod tests {
                                     match event {
                                         ListenEvent::Updates(x) => {
                                             for ((k, _v), t, d) in x.iter() {
-                                                s.push_str(&format!(
+                                                let _ = write!(
+                                                    &mut s,
                                                     "{} {} {}\n",
                                                     k.as_ref().unwrap(),
                                                     t,
                                                     d
-                                                ));
+                                                );
                                             }
                                         }
                                         ListenEvent::Progress(x) => {

--- a/src/persist-client/src/impl/trace.rs
+++ b/src/persist-client/src/impl/trace.rs
@@ -1015,6 +1015,8 @@ impl<T: Timestamp + Lattice> MergeVariant<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write;
+
     use super::*;
 
     #[test]
@@ -1105,7 +1107,8 @@ mod tests {
                         assert!(tc.input.is_empty());
                         let mut s = String::new();
                         for merge_req in trace.take_merge_reqs() {
-                            s.push_str(&format!(
+                            let _ = write!(
+                                &mut s,
                                 "{:?}{:?}{:?} {}\n",
                                 merge_req.desc.lower().elements(),
                                 merge_req.desc.upper().elements(),
@@ -1117,7 +1120,7 @@ mod tests {
                                     .cloned()
                                     .collect::<Vec<_>>()
                                     .join(" ")
-                            ));
+                            );
                         }
                         if s.is_empty() {
                             s.push_str("<empty>\n");


### PR DESCRIPTION
Dunno why this wasn't happening in CI but it triggers for me locally.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
