### PR TITLE
coord: Maintain a timestamp oracle per timeline

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2057,14 +2057,14 @@ impl<S: Append> Catalog<S> {
     /// Get all global timestamps that has been persisted to disk.
     pub async fn get_all_persisted_timestamps(
         &mut self,
-    ) -> Result<BTreeMap<String, mz_repr::Timestamp>, Error> {
+    ) -> Result<BTreeMap<Timeline, mz_repr::Timestamp>, Error> {
         self.storage().await.get_all_persisted_timestamps().await
     }
 
     /// Get a global timestamp for a timeline that has been persisted to disk.
     pub async fn get_persisted_timestamp(
         &mut self,
-        timeline: &str,
+        timeline: &Timeline,
     ) -> Result<mz_repr::Timestamp, Error> {
         self.storage().await.get_persisted_timestamp(timeline).await
     }
@@ -2072,7 +2072,7 @@ impl<S: Append> Catalog<S> {
     /// Persist new global timestamp for a timeline to disk.
     pub async fn persist_timestamp(
         &mut self,
-        timeline: String,
+        timeline: &Timeline,
         timestamp: mz_repr::Timestamp,
     ) -> Result<(), Error> {
         self.storage()

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2054,14 +2054,31 @@ impl<S: Append> Catalog<S> {
         self.state.allocate_oid()
     }
 
-    /// Get the global timestamp that has been persisted to disk.
-    pub async fn get_persisted_timestamp(&mut self) -> Result<mz_repr::Timestamp, Error> {
-        self.storage().await.get_persisted_timestamp().await
+    /// Get all global timestamps that has been persisted to disk.
+    pub async fn get_all_persisted_timestamps(
+        &mut self,
+    ) -> Result<BTreeMap<String, mz_repr::Timestamp>, Error> {
+        self.storage().await.get_all_persisted_timestamps().await
     }
 
-    /// Persist new global timestamp to disk.
-    pub async fn persist_timestamp(&mut self, timestamp: mz_repr::Timestamp) -> Result<(), Error> {
-        self.storage().await.persist_timestamp(timestamp).await
+    /// Get a global timestamp for a timeline that has been persisted to disk.
+    pub async fn get_persisted_timestamp(
+        &mut self,
+        timeline: &str,
+    ) -> Result<mz_repr::Timestamp, Error> {
+        self.storage().await.get_persisted_timestamp(timeline).await
+    }
+
+    /// Persist new global timestamp for a timeline to disk.
+    pub async fn persist_timestamp(
+        &mut self,
+        timeline: String,
+        timestamp: mz_repr::Timestamp,
+    ) -> Result<(), Error> {
+        self.storage()
+            .await
+            .persist_timestamp(timeline, timestamp)
+            .await
     }
 
     pub fn resolve_database(&self, database_name: &str) -> Result<&Database, SqlCatalogError> {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -634,19 +634,19 @@ impl<S: Append> Connection<S> {
     /// Get all global timestamps that has been persisted to disk.
     pub async fn get_all_persisted_timestamps(
         &mut self,
-    ) -> Result<BTreeMap<String, mz_repr::Timestamp>, Error> {
+    ) -> Result<BTreeMap<Timeline, mz_repr::Timestamp>, Error> {
         Ok(COLLECTION_TIMESTAMP
             .peek_one(&mut self.stash)
             .await?
             .into_iter()
-            .map(|(k, v)| (k.id, v.ts))
+            .map(|(k, v)| (k.id.parse().expect("invalid timeline persisted"), v.ts))
             .collect())
     }
 
     /// Get a global timestamp for a timeline that has been persisted to disk.
     pub async fn get_persisted_timestamp(
         &mut self,
-        timeline: &str,
+        timeline: &Timeline,
     ) -> Result<mz_repr::Timestamp, Error> {
         let key = TimestampKey {
             id: timeline.to_string(),
@@ -661,7 +661,7 @@ impl<S: Append> Connection<S> {
     /// Persist new global timestamp for a timeline to disk.
     pub async fn persist_timestamp(
         &mut self,
-        timeline: String,
+        timeline: &Timeline,
         timestamp: mz_repr::Timestamp,
     ) -> Result<(), Error> {
         let key = TimestampKey {

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -35,6 +35,7 @@ use mz_sql::names::{
 };
 use mz_sql::plan::ComputeInstanceIntrospectionConfig;
 use mz_stash::{Append, AppendBatch, Stash, StashError, TableTransaction, TypedCollection};
+use mz_storage::client::sources::Timeline;
 
 use crate::catalog::builtin::BuiltinLog;
 use crate::catalog::error::{Error, ErrorKind};
@@ -57,8 +58,6 @@ const ROLE_ID_ALLOC_KEY: &str = "role";
 const COMPUTE_ID_ALLOC_KEY: &str = "compute";
 const REPLICA_ID_ALLOC_KEY: &str = "replica";
 pub(crate) const AUDIT_LOG_ID_ALLOC_KEY: &str = "auditlog";
-
-const EPOCH_MILLIS_TIMESTAMP_KEY: &str = "epoch_millis";
 
 async fn migrate<S: Append>(stash: &mut S, version: u64) -> Result<(), StashError> {
     // Initial state.
@@ -265,7 +264,7 @@ async fn migrate<S: Append>(stash: &mut S, version: u64) -> Result<(), StashErro
                         stash,
                         vec![(
                             TimestampKey {
-                                id: EPOCH_MILLIS_TIMESTAMP_KEY.into(),
+                                id: Timeline::EpochMilliseconds.to_string(),
                             },
                             TimestampValue {
                                 ts: mz_repr::Timestamp::minimum(),
@@ -632,10 +631,25 @@ impl<S: Append> Connection<S> {
         Ok((id..next.next_id).collect())
     }
 
-    /// Get the global timestamp that has been persisted to disk.
-    pub async fn get_persisted_timestamp(&mut self) -> Result<mz_repr::Timestamp, Error> {
+    /// Get all global timestamps that has been persisted to disk.
+    pub async fn get_all_persisted_timestamps(
+        &mut self,
+    ) -> Result<BTreeMap<String, mz_repr::Timestamp>, Error> {
+        Ok(COLLECTION_TIMESTAMP
+            .peek_one(&mut self.stash)
+            .await?
+            .into_iter()
+            .map(|(k, v)| (k.id, v.ts))
+            .collect())
+    }
+
+    /// Get a global timestamp for a timeline that has been persisted to disk.
+    pub async fn get_persisted_timestamp(
+        &mut self,
+        timeline: &str,
+    ) -> Result<mz_repr::Timestamp, Error> {
         let key = TimestampKey {
-            id: EPOCH_MILLIS_TIMESTAMP_KEY.to_string(),
+            id: timeline.to_string(),
         };
         Ok(COLLECTION_TIMESTAMP
             .peek_key_one(&mut self.stash, &key)
@@ -644,17 +658,21 @@ impl<S: Append> Connection<S> {
             .ts)
     }
 
-    /// Persist new global timestamp to disk.
-    pub async fn persist_timestamp(&mut self, timestamp: mz_repr::Timestamp) -> Result<(), Error> {
+    /// Persist new global timestamp for a timeline to disk.
+    pub async fn persist_timestamp(
+        &mut self,
+        timeline: String,
+        timestamp: mz_repr::Timestamp,
+    ) -> Result<(), Error> {
         let key = TimestampKey {
-            id: EPOCH_MILLIS_TIMESTAMP_KEY.to_string(),
+            id: timeline.to_string(),
         };
         let value = TimestampValue { ts: timestamp };
         let old_value = COLLECTION_TIMESTAMP
             .upsert_key(&mut self.stash, &key, &value)
             .await?;
         if let Some(old_value) = old_value {
-            assert!(value >= old_value);
+            assert!(value >= old_value, "global timestamp must always go up");
         }
         Ok(())
     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -187,7 +187,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     SinkConnectionReady(SinkConnectionReady),
     SendDiffs(SendDiffs),
     WriteLockGrant(tokio::sync::OwnedMutexGuard<()>),
-    AdvanceLocalInputs,
+    AdvanceTimelines,
     AdvanceLocalInput(AdvanceLocalInput<T>),
     GroupCommit,
     ComputeInstanceStatus(ComputeInstanceEvent),
@@ -472,7 +472,7 @@ pub struct Coordinator<S> {
 
     /// Mechanism for totally ordering write and read timestamps, so that all reads
     /// reflect exactly the set of writes that precede them, and no writes that follow.
-    global_timeline: timeline::DurableTimestampOracle<Timestamp>,
+    global_timelines: BTreeMap<Timeline, timeline::DurableTimestampOracle<Timestamp>>,
 
     /// Tracks tables needing advancement, which can be processed at a low priority
     /// in the biased select loop.
@@ -589,19 +589,42 @@ macro_rules! guard_write_critical_section {
 }
 
 impl<S: Append + 'static> Coordinator<S> {
+    /// Returns a reference to the timestamp oracle used for reads and writes
+    /// from/to a local input.
+    fn get_local_timestamp_oracle(&self) -> &timeline::DurableTimestampOracle<Timestamp> {
+        self.global_timelines
+            .get(&Timeline::EpochMilliseconds)
+            .expect("no realtime timeline")
+    }
+
+    /// Returns a mutable reference to the timestamp oracle used for reads and writes
+    /// from/to a local input.
+    fn get_local_timestamp_oracle_mut(
+        &mut self,
+    ) -> &mut timeline::DurableTimestampOracle<Timestamp> {
+        self.global_timelines
+            .get_mut(&Timeline::EpochMilliseconds)
+            .expect("no realtime timeline")
+    }
+
     /// Assign a timestamp for a read from a local input. Reads following writes
     /// must be at a time >= the write's timestamp; we choose "equal to" for
     /// simplicity's sake and to open as few new timestamps as possible.
     fn get_local_read_ts(&mut self) -> Timestamp {
-        self.global_timeline.read_ts()
+        self.get_local_timestamp_oracle_mut().read_ts()
     }
 
     /// Assign a timestamp for creating a source. Writes following reads
     /// must ensure that they are assigned a strictly larger timestamp to ensure
     /// they are not visible to any real-time earlier reads.
     async fn get_local_write_ts(&mut self) -> Timestamp {
-        self.global_timeline
-            .write_ts(|ts| self.catalog.persist_timestamp(ts))
+        self.global_timelines
+            .get_mut(&Timeline::EpochMilliseconds)
+            .expect("no realtime timeline")
+            .write_ts(|ts| {
+                self.catalog
+                    .persist_timestamp(Timeline::EpochMilliseconds.to_string(), ts)
+            })
             .await
     }
 
@@ -610,8 +633,13 @@ impl<S: Append + 'static> Coordinator<S> {
     /// timestamp to ensure they are not visible to any real-time earlier reads.
     async fn get_and_step_local_write_ts(&mut self) -> WriteTimestamp {
         let timestamp = self
-            .global_timeline
-            .write_ts(|ts| self.catalog.persist_timestamp(ts))
+            .global_timelines
+            .get_mut(&Timeline::EpochMilliseconds)
+            .expect("no realtime timeline")
+            .write_ts(|ts| {
+                self.catalog
+                    .persist_timestamp(Timeline::EpochMilliseconds.to_string(), ts)
+            })
             .await;
         /* Without an ADAPTER side durable WAL, all writes must increase the timestamp and be made
          * durable via an APPEND command to STORAGE. Calling `read_ts()` here ensures that the
@@ -621,7 +649,7 @@ impl<S: Append + 'static> Coordinator<S> {
          * If we add an ADAPTER side durable WAL, then consecutive writes could all happen at the
          * same timestamp as long as they're written to the WAL first.
          */
-        let _ = self.global_timeline.read_ts();
+        let _ = self.get_local_timestamp_oracle_mut().read_ts();
         let advance_to = timestamp.step_forward();
         WriteTimestamp {
             timestamp,
@@ -634,13 +662,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ///
     /// NOTE: This can be removed once DDL is included in group commits.
     fn peek_local_ts(&self) -> Timestamp {
-        self.global_timeline.peek_ts()
-    }
-
-    async fn local_fast_forward(&mut self, lower_bound: Timestamp) {
-        self.global_timeline
-            .fast_forward(lower_bound, |ts| self.catalog.persist_timestamp(ts))
-            .await;
+        self.get_local_timestamp_oracle().peek_ts()
     }
 
     fn now(&self) -> EpochMillis {
@@ -847,7 +869,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     let id_bundle = self
                         .index_oracle(rview.compute_instance)
                         .sufficient_collections(&rview.depends_on);
-                    let as_of = self.least_valid_read(&id_bundle, rview.compute_instance);
+                    let as_of = self.least_valid_read(&id_bundle);
                     let internal_view_id = self.allocate_transient_id()?;
                     let df = self
                         .dataflow_builder(rview.compute_instance)
@@ -1018,13 +1040,16 @@ impl<S: Append + 'static> Coordinator<S> {
         mut internal_cmd_rx: mpsc::UnboundedReceiver<Message>,
         mut cmd_rx: mpsc::UnboundedReceiver<Command>,
     ) {
-        // An explicit SELECT or INSERT on a table will bump the table's timestamps,
-        // but there are cases where timestamps are not bumped but we expect the closed
-        // timestamps to advance (`AS OF X`, TAILing views over RT sources and
-        // tables). To address these, spawn a task that forces table timestamps to
-        // close on a regular interval. This roughly tracks the behavior of realtime
-        // sources that close off timestamps on an interval.
-        let mut advance_local_inputs_interval =
+        // For the realtime timeline, an explicit SELECT or INSERT on a table will bump the
+        // table's timestamps, but there are cases where timestamps are not bumped but
+        // we expect the closed timestamps to advance (`AS OF X`, TAILing views over
+        // RT sources and tables). To address these, spawn a task that forces table
+        // timestamps to close on a regular interval. This roughly tracks the behavior
+        // of realtime sources that close off timestamps on an interval.
+        //
+        // For non-realtime timelines, noting pushes the timestamps forward, so we must do
+        // it manually.
+        let mut advance_timelines_interval =
             tokio::time::interval(self.catalog.config().timestamp_frequency);
         // Watcher that listens for and reports compute service status changes.
         let mut compute_events = self.dataflow_client.watch_compute_services();
@@ -1046,7 +1071,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 Some(event) = compute_events.next() => Message::ComputeInstanceStatus(event),
                 // `tick()` on `Interval` is cancel-safe:
                 // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
-                _ = advance_local_inputs_interval.tick() => Message::AdvanceLocalInputs,
+                _ = advance_timelines_interval.tick() => Message::AdvanceTimelines,
                 // See [`mz_controller::Controller::Controller::ready`] for notes
                 // on why this is cancel-safe.
                 m = self.dataflow_client.ready() => {
@@ -1106,21 +1131,8 @@ impl<S: Append + 'static> Coordinator<S> {
                     // here.
                 }
                 Message::SendDiffs(diffs) => self.message_send_diffs(diffs),
-                Message::AdvanceLocalInputs => {
-                    // Convince the coordinator it needs to open a new timestamp
-                    // and advance inputs.
-                    // Fast forwarding puts the `TimestampOracle` in write mode,
-                    // which means the next read will have to advance a table
-                    // after reading from it. To prevent this we explicitly put
-                    // the `TimestampOracle` in read mode. Writes will always
-                    // advance a table no matter what mode the `TimestampOracle`
-                    // is in. We step back the value of `now()` so that the
-                    // next write can happen at `now()` and not a value above
-                    // `now()`
-                    let now = self.now();
-                    self.local_fast_forward(now.step_back().unwrap_or(now))
-                        .await;
-                    let _ = self.get_local_read_ts();
+                Message::AdvanceTimelines => {
+                    self.message_advance_timelines().await;
                 }
                 Message::AdvanceLocalInput(inputs) => {
                     self.advance_local_input(inputs).await;
@@ -1139,7 +1151,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
             }
 
-            if let Some(timestamp) = self.global_timeline.should_advance_to() {
+            if let Some(timestamp) = self.get_local_timestamp_oracle_mut().should_advance_to() {
                 self.advance_local_inputs(timestamp).await;
             }
         }
@@ -1575,6 +1587,81 @@ impl<S: Append + 'static> Coordinator<S> {
                 tx.send(Err(e), session);
             }
         }
+    }
+
+    async fn message_advance_timelines(&mut self) {
+        // Convince the coordinator it needs to open a new timestamp
+        // and advance inputs.
+        // Fast forwarding puts the `TimestampOracle` in write mode,
+        // which means the next read may have to wait for table
+        // advancements. To prevent this we explicitly put
+        // the `TimestampOracle` in read mode. Writes will always
+        // advance a table no matter what mode the `TimestampOracle`
+        // is in. We step back the value of `now()` so that the
+        // next write can happen at `now()` and not a value above
+        // `now()`
+        let timelines: Vec<_> = self.global_timelines.keys().cloned().collect();
+        let nows: HashMap<_, _> = timelines
+            .into_iter()
+            .map(|timeline| {
+                let now = if timeline == Timeline::EpochMilliseconds {
+                    let now = self.now();
+                    now.step_back().unwrap_or(now)
+                } else {
+                    // For non realtime sources, we define now as the largest timestamp, not in
+                    // advance of any object's upper. This is the largest timestamp that is closed
+                    // to writes.
+                    let id_bundle = self.ids_in_timeline(&timeline);
+                    let mut now = Timestamp::minimum();
+                    let upper = self.largest_not_in_advance_of_upper(&id_bundle);
+                    now.join_assign(&upper);
+                    now
+                };
+                (timeline, now)
+            })
+            .collect();
+
+        for (timeline, timestamp_oracle) in &mut self.global_timelines {
+            let now = nows[timeline];
+            timestamp_oracle
+                .fast_forward(now, |ts| {
+                    self.catalog.persist_timestamp(timeline.to_string(), ts)
+                })
+                .await;
+            let _ = timestamp_oracle.read_ts();
+        }
+    }
+
+    fn ids_in_timeline(&self, timeline: &Timeline) -> CollectionIdBundle {
+        let mut id_bundle = CollectionIdBundle::default();
+        for entry in self.catalog.entries() {
+            if let Some(entry_timeline) = self.get_timeline(entry.id()) {
+                if timeline == &entry_timeline {
+                    match entry.item() {
+                        CatalogItem::Table(_)
+                        | CatalogItem::Source(_)
+                        | CatalogItem::RecordedView(_) => {
+                            id_bundle.storage_ids.insert(entry.id());
+                        }
+                        CatalogItem::Index(index) => {
+                            id_bundle
+                                .compute_ids
+                                .entry(index.compute_instance)
+                                .or_default()
+                                .insert(entry.id());
+                        }
+                        CatalogItem::View(_)
+                        | CatalogItem::Sink(_)
+                        | CatalogItem::Type(_)
+                        | CatalogItem::Func(_)
+                        | CatalogItem::Secret(_)
+                        | CatalogItem::Connection(_)
+                        | CatalogItem::Log(_) => {}
+                    }
+                }
+            }
+        }
+        id_bundle
     }
 
     /// Remove all pending peeks that were initiated by `conn_id`.
@@ -2237,7 +2324,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let id_bundle = self
             .index_oracle(compute_instance)
             .sufficient_collections(&[sink.from]);
-        let frontier = self.least_valid_read(&id_bundle, compute_instance);
+        let frontier = self.least_valid_read(&id_bundle);
         let as_of = SinkAsOf {
             frontier,
             strict: !sink.with_snapshot,
@@ -3370,7 +3457,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let id_bundle = self
             .index_oracle(compute_instance)
             .sufficient_collections(&depends_on);
-        let as_of = self.least_valid_read(&id_bundle, compute_instance);
+        let as_of = self.least_valid_read(&id_bundle);
 
         let mut ops = Vec::new();
         if let Some(drop_id) = replace {
@@ -3855,7 +3942,10 @@ impl<S: Append + 'static> Coordinator<S> {
             .sufficient_collections(item_ids.iter());
 
         // Filter out ids from different timelines.
-        for ids in [&mut id_bundle.storage_ids, &mut id_bundle.compute_ids] {
+        for ids in [
+            &mut id_bundle.storage_ids,
+            &mut id_bundle.compute_ids.entry(compute_instance).or_default(),
+        ] {
             ids.retain(|&id| {
                 let id_timeline = self
                     .validate_timeline(vec![id])
@@ -4009,7 +4099,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     let read_holds = read_holds::ReadHolds {
                         time: timestamp,
                         id_bundle,
-                        compute_instance,
                     };
                     self.acquire_read_holds(&read_holds).await;
                     let txn_reads = TxnReads {
@@ -4264,11 +4353,7 @@ impl<S: Append + 'static> Coordinator<S> {
     }
 
     /// The smallest common valid read frontier among the specified collections.
-    fn least_valid_read(
-        &self,
-        id_bundle: &CollectionIdBundle,
-        instance: ComputeInstanceId,
-    ) -> Antichain<mz_repr::Timestamp> {
+    fn least_valid_read(&self, id_bundle: &CollectionIdBundle) -> Antichain<mz_repr::Timestamp> {
         let mut since = Antichain::from_elem(Timestamp::minimum());
         {
             let storage = self.dataflow_client.storage();
@@ -4277,9 +4362,11 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
         {
-            let compute = self.dataflow_client.compute(instance).unwrap();
-            for id in id_bundle.compute_ids.iter() {
-                since.join_assign(&compute.collection(*id).unwrap().implied_capability)
+            for (instance, compute_ids) in &id_bundle.compute_ids {
+                let compute = self.dataflow_client.compute(*instance).unwrap();
+                for id in compute_ids.iter() {
+                    since.join_assign(&compute.collection(*id).unwrap().implied_capability)
+                }
             }
         }
         since
@@ -4289,11 +4376,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ///
     /// Times that are not greater or equal to this frontier are complete for all collections
     /// identified as arguments.
-    fn least_valid_write(
-        &self,
-        id_bundle: &CollectionIdBundle,
-        instance: ComputeInstanceId,
-    ) -> Antichain<mz_repr::Timestamp> {
+    fn least_valid_write(&self, id_bundle: &CollectionIdBundle) -> Antichain<mz_repr::Timestamp> {
         let mut since = Antichain::new();
         {
             let storage = self.dataflow_client.storage();
@@ -4310,20 +4393,47 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
         {
-            let compute = self.dataflow_client.compute(instance).unwrap();
-            for id in id_bundle.compute_ids.iter() {
-                since.extend(
-                    compute
-                        .collection(*id)
-                        .unwrap()
-                        .write_frontier
-                        .frontier()
-                        .iter()
-                        .cloned(),
-                );
+            for (instance, compute_ids) in &id_bundle.compute_ids {
+                let compute = self.dataflow_client.compute(*instance).unwrap();
+                for id in compute_ids.iter() {
+                    since.extend(
+                        compute
+                            .collection(*id)
+                            .unwrap()
+                            .write_frontier
+                            .frontier()
+                            .iter()
+                            .cloned(),
+                    );
+                }
             }
         }
         since
+    }
+
+    /// The largest element not in advance of any object in the collection.
+    ///
+    /// Times that are not greater to this frontier are complete for all collections
+    /// identified as arguments.
+    fn largest_not_in_advance_of_upper(
+        &self,
+        id_bundle: &CollectionIdBundle,
+    ) -> mz_repr::Timestamp {
+        let upper = self.least_valid_write(&id_bundle);
+
+        // We peek at the largest element not in advance of `upper`, which
+        // involves a subtraction. If `upper` contains a zero timestamp there
+        // is no "prior" answer, and we do not want to peek at it as it risks
+        // hanging awaiting the response to data that may never arrive.
+        if let Some(upper) = upper.as_option() {
+            upper.step_back().unwrap_or_else(Timestamp::minimum)
+        } else {
+            // A complete trace can be read in its final form with this time.
+            //
+            // This should only happen for literals that have no sources or sources that
+            // are known to have completed (non-tailed files for example).
+            Timestamp::MAX
+        }
     }
 
     /// Determines the timestamp for a query.
@@ -4353,7 +4463,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // what to do if it cannot be satisfied (perhaps the query should use
         // a larger timestamp and block, perhaps the user should intervene).
 
-        let since = self.least_valid_read(&id_bundle, compute_instance);
+        let since = self.least_valid_read(&id_bundle);
 
         // Initialize candidate to the minimum correct time.
         let mut candidate = Timestamp::minimum();
@@ -4394,21 +4504,7 @@ impl<S: Append + 'static> Coordinator<S> {
             candidate.join_assign(&self.get_local_read_ts());
         }
         if when.advance_to_upper(uses_tables) {
-            let upper = self.least_valid_write(&id_bundle, compute_instance);
-
-            // We peek at the largest element not in advance of `upper`, which
-            // involves a subtraction. If `upper` contains a zero timestamp there
-            // is no "prior" answer, and we do not want to peek at it as it risks
-            // hanging awaiting the response to data that may never arrive.
-            let upper = if let Some(upper) = upper.as_option() {
-                upper.step_back().unwrap_or_else(Timestamp::minimum)
-            } else {
-                // A complete trace can be read in its final form with this time.
-                //
-                // This should only happen for literals that have no sources or sources that
-                // are known to have completed (non-tailed files for example).
-                Timestamp::MAX
-            };
+            let upper = self.largest_not_in_advance_of_upper(&id_bundle);
             candidate.join_assign(&upper);
         }
 
@@ -4417,26 +4513,30 @@ impl<S: Append + 'static> Coordinator<S> {
         if since.less_equal(&candidate) {
             Ok(candidate)
         } else {
-            let invalid_indexes = id_bundle
-                .compute_ids
-                .iter()
-                .filter_map(|id| {
-                    let since = self
-                        .dataflow_client
-                        .compute(compute_instance)
-                        .unwrap()
-                        .collection(*id)
-                        .unwrap()
-                        .read_capabilities
-                        .frontier()
-                        .to_owned();
-                    if since.less_equal(&candidate) {
-                        None
-                    } else {
-                        Some(since)
-                    }
-                })
-                .collect::<Vec<_>>();
+            let invalid_indexes =
+                if let Some(compute_ids) = id_bundle.compute_ids.get(&compute_instance) {
+                    compute_ids
+                        .iter()
+                        .filter_map(|id| {
+                            let since = self
+                                .dataflow_client
+                                .compute(compute_instance)
+                                .unwrap()
+                                .collection(*id)
+                                .unwrap()
+                                .read_capabilities
+                                .frontier()
+                                .to_owned();
+                            if since.less_equal(&candidate) {
+                                None
+                            } else {
+                                Some(since)
+                            }
+                        })
+                        .collect()
+                } else {
+                    Vec::new()
+                };
             let invalid_sources = id_bundle.storage_ids.iter().filter_map(|id| {
                 let since = self
                     .dataflow_client
@@ -4759,14 +4859,8 @@ impl<S: Append + 'static> Coordinator<S> {
                     &QueryWhen::Immediately,
                     compute_instance,
                 )?;
-                let since = self
-                    .least_valid_read(&id_bundle, compute_instance)
-                    .elements()
-                    .to_vec();
-                let upper = self
-                    .least_valid_write(&id_bundle, compute_instance)
-                    .elements()
-                    .to_vec();
+                let since = self.least_valid_read(&id_bundle).elements().to_vec();
+                let upper = self.least_valid_write(&id_bundle).elements().to_vec();
                 let has_table = id_bundle.iter().any(|id| self.catalog.uses_tables(id));
                 let table_read_ts = if has_table {
                     Some(self.get_local_read_ts())
@@ -4801,29 +4895,31 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                 }
                 {
-                    let compute = self.dataflow_client.compute(compute_instance).unwrap();
-                    for id in id_bundle.compute_ids.iter() {
-                        let state = compute.collection(*id).unwrap();
-                        let name = self
-                            .catalog
-                            .try_get_entry(id)
-                            .map(|item| item.name())
-                            .map(|name| {
-                                self.catalog
-                                    .resolve_full_name(name, Some(session.conn_id()))
-                                    .to_string()
-                            })
-                            .unwrap_or_else(|| id.to_string());
-                        sources.push(TimestampSource {
-                            name: format!("{name} ({id}, compute)"),
-                            read_frontier: state.implied_capability.elements().to_vec(),
-                            write_frontier: state
-                                .write_frontier
-                                .frontier()
-                                .to_owned()
-                                .elements()
-                                .to_vec(),
-                        });
+                    if let Some(compute_ids) = id_bundle.compute_ids.get(&compute_instance) {
+                        let compute = self.dataflow_client.compute(compute_instance).unwrap();
+                        for id in compute_ids {
+                            let state = compute.collection(*id).unwrap();
+                            let name = self
+                                .catalog
+                                .try_get_entry(id)
+                                .map(|item| item.name())
+                                .map(|name| {
+                                    self.catalog
+                                        .resolve_full_name(name, Some(session.conn_id()))
+                                        .to_string()
+                                })
+                                .unwrap_or_else(|| id.to_string());
+                            sources.push(TimestampSource {
+                                name: format!("{name} ({id}, compute)"),
+                                read_frontier: state.implied_capability.elements().to_vec(),
+                                write_frontier: state
+                                    .write_frontier
+                                    .frontier()
+                                    .to_owned()
+                                    .elements()
+                                    .to_vec(),
+                            });
+                        }
                     }
                 }
                 let explanation = TimestampExplanation {
@@ -5781,13 +5877,11 @@ impl<S: Append + 'static> Coordinator<S> {
             .copied()
             .collect::<BTreeSet<_>>();
 
-        let since = self.least_valid_read(
-            &CollectionIdBundle {
-                storage_ids,
-                compute_ids,
-            },
-            compute_instance,
-        );
+        let compute_ids = vec![(compute_instance, compute_ids)].into_iter().collect();
+        let since = self.least_valid_read(&CollectionIdBundle {
+            storage_ids,
+            compute_ids,
+        });
 
         // Ensure that the dataflow's `as_of` is at least `since`.
         if let Some(as_of) = &mut dataflow.as_of {
@@ -5827,6 +5921,48 @@ impl<S: Append + 'static> Coordinator<S> {
     where
         I: IntoIterator<Item = GlobalId>,
     {
+        let timelines = self.get_timelines(ids);
+
+        // If there's more than one timeline, we will not produce meaningful
+        // data to a user. Take, for example, some realtime source and a debezium
+        // consistency topic source. The realtime source uses something close to now
+        // for its timestamps. The debezium source starts at 1 and increments per
+        // transaction. We don't want to choose some timestamp that is valid for both
+        // of these because the debezium source will never get to the same value as the
+        // realtime source's "milliseconds since Unix epoch" value. And even if it did,
+        // it's not meaningful to join just because those two numbers happen to be the
+        // same now.
+        //
+        // Another example: assume two separate debezium consistency topics. Both
+        // start counting at 1 and thus have similarish numbers that probably overlap
+        // a lot. However it's still not meaningful to join those two at a specific
+        // transaction counter number because those counters are unrelated to the
+        // other.
+        if timelines.len() > 1 {
+            return Err(AdapterError::Unsupported(
+                "multiple timelines within one dataflow",
+            ));
+        }
+        Ok(timelines.into_iter().next())
+    }
+
+    /// Return the timeline belonging to a GlobalId, if one exists.
+    fn get_timeline(&self, id: GlobalId) -> Option<Timeline> {
+        let timelines = self.get_timelines(vec![id]);
+
+        assert!(
+            timelines.len() <= 1,
+            "impossible for a single object to belong to two timelines"
+        );
+
+        timelines.into_iter().next()
+    }
+
+    /// Return the timelines belonging to a list of GlobalIds, if any exist.
+    fn get_timelines<I>(&self, ids: I) -> HashSet<Timeline>
+    where
+        I: IntoIterator<Item = GlobalId>,
+    {
         let mut timelines: HashMap<GlobalId, Timeline> = HashMap::new();
 
         // Recurse through IDs to find all sources and tables, adding new ones to
@@ -5860,32 +5996,10 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
 
-        let timelines: HashSet<Timeline> = timelines
+        timelines
             .into_iter()
             .map(|(_, timeline)| timeline)
-            .collect();
-
-        // If there's more than one timeline, we will not produce meaningful
-        // data to a user. Take, for example, some realtime source and a debezium
-        // consistency topic source. The realtime source uses something close to now
-        // for its timestamps. The debezium source starts at 1 and increments per
-        // transaction. We don't want to choose some timestamp that is valid for both
-        // of these because the debezium source will never get to the same value as the
-        // realtime source's "milliseconds since Unix epoch" value. And even if it did,
-        // it's not meaningful to join just because those two numbers happen to be the
-        // same now.
-        //
-        // Another example: assume two separate debezium consistency topics. Both
-        // start counting at 1 and thus have similarish numbers that probably overlap
-        // a lot. However it's still not meaningful to join those two at a specific
-        // transaction counter number because those counters are unrelated to the
-        // other.
-        if timelines.len() > 1 {
-            return Err(AdapterError::Unsupported(
-                "multiple timelines within one dataflow",
-            ));
-        }
-        Ok(timelines.into_iter().next())
+            .collect()
     }
 
     /// Attempts to immediately grant `session` access to the write lock or
@@ -5967,7 +6081,7 @@ pub async fn serve<S: Append + 'static>(
     let (bootstrap_tx, bootstrap_rx) = oneshot::channel();
     let handle = TokioHandle::current();
 
-    let initial_timestamp = catalog.get_persisted_timestamp().await?;
+    let initial_timestamps = catalog.get_all_persisted_timestamps().await?;
     let thread = thread::Builder::new()
         // The Coordinator thread tends to keep a lot of data on its stack. To
         // prevent a stack overflow we allocate a stack twice as big as the default
@@ -5975,12 +6089,30 @@ pub async fn serve<S: Append + 'static>(
         .stack_size(2 * stack::STACK_SIZE)
         .name("coordinator".to_string())
         .spawn(move || {
-            let timestamp_oracle = handle.block_on(timeline::DurableTimestampOracle::new(
-                initial_timestamp,
-                move || (&*now)(),
-                *timeline::TIMESTAMP_PERSIST_INTERVAL,
-                |ts| catalog.persist_timestamp(ts),
-            ));
+            let mut timestamp_oracles = BTreeMap::new();
+            for (timeline_str, initial_timestamp) in initial_timestamps {
+                let timeline = timeline_str
+                    .parse()
+                    .unwrap_or_else(|_| panic!("invalid timeline persisted {timeline_str}"));
+                let timestamp_oracle = if timeline == Timeline::EpochMilliseconds {
+                    let now = now.clone();
+                    handle.block_on(timeline::DurableTimestampOracle::new(
+                        initial_timestamp,
+                        move || (now)(),
+                        *timeline::TIMESTAMP_PERSIST_INTERVAL,
+                        |ts| catalog.persist_timestamp(timeline_str, ts),
+                    ))
+                } else {
+                    handle.block_on(timeline::DurableTimestampOracle::new(
+                        initial_timestamp,
+                        Timestamp::minimum,
+                        *timeline::TIMESTAMP_PERSIST_INTERVAL,
+                        |ts| catalog.persist_timestamp(timeline_str, ts),
+                    ))
+                };
+                timestamp_oracles.insert(timeline, timestamp_oracle);
+            }
+
             let mut coord = Coordinator {
                 dataflow_client,
                 view_optimizer: Optimizer::logical_optimizer(),
@@ -5988,7 +6120,7 @@ pub async fn serve<S: Append + 'static>(
                 logical_compaction_window_ms: logical_compaction_window
                     .map(duration_to_timestamp_millis),
                 internal_cmd_tx,
-                global_timeline: timestamp_oracle,
+                global_timelines: timestamp_oracles,
                 advance_tables: AdvanceTables::new(),
                 transient_id_counter: 1,
                 active_conns: HashMap::new(),
@@ -6493,15 +6625,12 @@ pub mod fast_path_peek {
 /// to ensure that they can continue to use collections over an open-ended series of
 /// queries. However, nothing is specific to transactions here.
 pub mod read_holds {
-    use mz_compute_client::controller::ComputeInstanceId;
-
     use crate::coord::id_bundle::CollectionIdBundle;
 
     /// Relevant information for acquiring or releasing a bundle of read holds.
     pub(super) struct ReadHolds<T> {
         pub(super) time: T,
         pub(super) id_bundle: CollectionIdBundle,
-        pub(super) compute_instance: ComputeInstanceId,
     }
 
     impl<S> crate::coord::Coordinator<S> {
@@ -6528,22 +6657,21 @@ pub mod read_holds {
             }
             storage.set_read_policy(policy_changes).await.unwrap();
             // Update COMPUTE read policies
-            let mut policy_changes = Vec::new();
-            let mut compute = self
-                .dataflow_client
-                .compute_mut(read_holds.compute_instance)
-                .unwrap();
-            for id in read_holds.id_bundle.compute_ids.iter() {
-                let collection = compute.as_ref().collection(*id).unwrap();
-                assert!(collection
-                    .read_capabilities
-                    .frontier()
-                    .less_equal(&read_holds.time));
-                let read_needs = self.read_capability.get_mut(id).unwrap();
-                read_needs.holds.update_iter(Some((read_holds.time, 1)));
-                policy_changes.push((*id, read_needs.policy()));
+            for (compute_instance, compute_ids) in read_holds.id_bundle.compute_ids.iter() {
+                let mut policy_changes = Vec::new();
+                let mut compute = self.dataflow_client.compute_mut(*compute_instance).unwrap();
+                for id in compute_ids.iter() {
+                    let collection = compute.as_ref().collection(*id).unwrap();
+                    assert!(collection
+                        .read_capabilities
+                        .frontier()
+                        .less_equal(&read_holds.time));
+                    let read_needs = self.read_capability.get_mut(id).unwrap();
+                    read_needs.holds.update_iter(Some((read_holds.time, 1)));
+                    policy_changes.push((*id, read_needs.policy()));
+                }
+                compute.set_read_policy(policy_changes).await.unwrap();
             }
-            compute.set_read_policy(policy_changes).await.unwrap();
         }
         /// Release read holds on the indicated collections at the indicated time.
         ///
@@ -6561,7 +6689,6 @@ pub mod read_holds {
                         storage_ids,
                         compute_ids,
                     },
-                compute_instance,
             } = read_holds;
 
             // Update STORAGE read policies.
@@ -6579,16 +6706,18 @@ pub mod read_holds {
                 .await
                 .unwrap();
             // Update COMPUTE read policies
-            let mut policy_changes = Vec::new();
-            for id in compute_ids.iter() {
-                // It's possible that a concurrent DDL statement has already dropped this GlobalId
-                if let Some(read_needs) = self.read_capability.get_mut(id) {
-                    read_needs.holds.update_iter(Some((time, -1)));
-                    policy_changes.push((*id, read_needs.policy()));
+            for (compute_instance, compute_ids) in compute_ids.iter() {
+                let mut policy_changes = Vec::new();
+                for id in compute_ids.iter() {
+                    // It's possible that a concurrent DDL statement has already dropped this GlobalId
+                    if let Some(read_needs) = self.read_capability.get_mut(id) {
+                        read_needs.holds.update_iter(Some((time, -1)));
+                        policy_changes.push((*id, read_needs.policy()));
+                    }
                 }
-            }
-            if let Some(mut compute) = self.dataflow_client.compute_mut(compute_instance) {
-                compute.set_read_policy(policy_changes).await.unwrap();
+                if let Some(mut compute) = self.dataflow_client.compute_mut(*compute_instance) {
+                    compute.set_read_policy(policy_changes).await.unwrap();
+                }
             }
         }
     }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1613,10 +1613,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     // advance of any object's upper. This is the largest timestamp that is closed
                     // to writes.
                     let id_bundle = self.ids_in_timeline(&timeline);
-                    let mut now = Timestamp::minimum();
-                    let upper = self.largest_not_in_advance_of_upper(&id_bundle);
-                    now.join_assign(&upper);
-                    now
+                    self.largest_not_in_advance_of_upper(&id_bundle)
                 };
                 (timeline, now)
             })

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -6059,7 +6059,7 @@ pub async fn serve<S: Append + 'static>(
                     let now = now.clone();
                     handle.block_on(timeline::DurableTimestampOracle::new(
                         initial_timestamp,
-                        move || (now)(),
+                        move || (*&(now))(),
                         *timeline::TIMESTAMP_PERSIST_INTERVAL,
                         |ts| catalog.persist_timestamp(&timeline, ts),
                     ))

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1047,7 +1047,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // timestamps to close on a regular interval. This roughly tracks the behavior
         // of realtime sources that close off timestamps on an interval.
         //
-        // For non-realtime timelines, noting pushes the timestamps forward, so we must do
+        // For non-realtime timelines, nothing pushes the timestamps forward, so we must do
         // it manually.
         let mut advance_timelines_interval =
             tokio::time::interval(self.catalog.config().timestamp_frequency);

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1600,9 +1600,10 @@ impl<S: Append + 'static> Coordinator<S> {
         // is in. We step back the value of `now()` so that the
         // next write can happen at `now()` and not a value above
         // `now()`
-        let timelines: Vec<_> = self.global_timelines.keys().cloned().collect();
-        let nows: HashMap<_, _> = timelines
-            .into_iter()
+        let nows: HashMap<_, _> = self
+            .global_timelines
+            .keys()
+            .cloned()
             .map(|timeline| {
                 let now = if timeline == Timeline::EpochMilliseconds {
                     let now = self.now();

--- a/src/adapter/src/coord/id_bundle.rs
+++ b/src/adapter/src/coord/id_bundle.rs
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::BTreeSet;
+use mz_compute_client::controller::ComputeInstanceId;
+use std::collections::{BTreeMap, BTreeSet};
 
 use mz_repr::GlobalId;
 
@@ -17,20 +18,35 @@ pub struct CollectionIdBundle {
     /// The identifiers for sources in the storage layer.
     pub storage_ids: BTreeSet<GlobalId>,
     /// The identifiers for indexes in the compute layer.
-    pub compute_ids: BTreeSet<GlobalId>,
+    pub compute_ids: BTreeMap<ComputeInstanceId, BTreeSet<GlobalId>>,
 }
 
 impl CollectionIdBundle {
     /// Reports whether the bundle contains any identifiers of any type.
     pub fn is_empty(&self) -> bool {
-        self.storage_ids.is_empty() && self.compute_ids.is_empty()
+        self.storage_ids.is_empty() && self.compute_ids.values().all(|ids| ids.is_empty())
     }
 
     /// Returns a new bundle without the identifiers from `other`.
     pub fn difference(&self, other: &CollectionIdBundle) -> CollectionIdBundle {
+        let storage_ids = &self.storage_ids - &other.storage_ids;
+        let compute_ids: BTreeMap<_, _> = self
+            .compute_ids
+            .iter()
+            .map(|(compute_instance, compute_ids)| {
+                let compute_ids =
+                    if let Some(other_compute_ids) = other.compute_ids.get(compute_instance) {
+                        compute_ids - other_compute_ids
+                    } else {
+                        compute_ids.clone()
+                    };
+                (*compute_instance, compute_ids)
+            })
+            .filter(|(_, ids)| !ids.is_empty())
+            .collect();
         CollectionIdBundle {
-            storage_ids: &self.storage_ids - &other.storage_ids,
-            compute_ids: &self.compute_ids - &other.compute_ids,
+            storage_ids,
+            compute_ids,
         }
     }
 
@@ -41,6 +57,6 @@ impl CollectionIdBundle {
         self.storage_ids
             .iter()
             .copied()
-            .chain(self.compute_ids.iter().copied())
+            .chain(self.compute_ids.values().flat_map(BTreeSet::iter).copied())
     }
 }

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -68,7 +68,11 @@ impl<T: CoordTimestamp> ComputeInstanceIndexOracle<'_, T> {
             let mut available_indexes = self.indexes_on(id).map(|(id, _)| id).peekable();
 
             if available_indexes.peek().is_some() {
-                id_bundle.compute_ids.extend(available_indexes);
+                id_bundle
+                    .compute_ids
+                    .entry(self.compute.instance_id())
+                    .or_default()
+                    .extend(available_indexes);
             } else {
                 match self.catalog.get_entry(&id).item() {
                     // Unmaterialized view. Search its dependencies.


### PR DESCRIPTION
Previously, the Coordinator only had a single timestamp oracle that
provided timestamps for user and system tables on the EpochMilliseconds
timeline. All reads to user and system tables would request a timestamp
from the global timestamp oracle. In order to provide strict
serializable reads, the Coordinator will have to consult some timestamp
oracle for all reads, not just reads to tables. Reads on objects
that are not in the EpochMilliseconds timeline need to get a timestamp
from a timestamp oracle specific to their timeline.

This commit updates the Coordinator so that it maintains a map of
timestamp oracles, so each timeline has their own timestamp oracle.
Non-realtime timestamp oracles are periodically pushed forward based
on the uppers of all objects in that timeline.

This commit may not reflect how we want timelines to look in the
future, but it does reflect how timelines look right now. The code is
also mostly plumbing. Non-realtime timestamp oracles are maintained and
kept up to date, but they're never actually used.

Works towards resolving #12309

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
* I changed the structure of `CollectionIdBundle`, so that it can hold ids from multiple compute instances which is why a lot of that code was changed. The reason is because ids from multiple compute instances can all belong to the same timeline, and it's useful to use a `CollectionIdBundle` to hold all IDs in the same timeline.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
