### PR TITLE
controller: push `ready`/`process` methods into each controller

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -151,7 +151,7 @@ use mz_storage::client::sinks::{SinkAsOf, SinkConnection, SinkDesc, TailSinkConn
 use mz_storage::client::sources::{
     IngestionDescription, PostgresSourceConnection, SourceConnection, Timeline,
 };
-use mz_storage::client::{LinearizedTimestampBindingFeedback, Update};
+use mz_storage::client::Update;
 use mz_transform::Optimizer;
 
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
@@ -1392,12 +1392,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         self.pending_tails.remove(&sink_id);
                     }
                 }
-            }
-            ControllerResponse::LinearizedTimestamps(LinearizedTimestampBindingFeedback {
-                timestamp: _,
-                peek_id: _,
-            }) => {
-                // TODO(guswynn): communicate `bindings` to `sequence_peek`
             }
             ControllerResponse::ComputeReplicaHeartbeat(replica_id, when) => {
                 let replica_status_granularity = chrono::Duration::seconds(60);

--- a/src/storage/src/client.proto
+++ b/src/storage/src/client.proto
@@ -63,12 +63,7 @@ message ProtoStorageCommand {
 }
 
 message ProtoStorageResponse {
-    message ProtoLinearizedTimestampBindingFeedback {
-        uint64 timestamp = 1;
-        mz_proto.ProtoU128 peek_id = 3;
-    }
     oneof kind {
         ProtoFrontierUppersKind frontier_uppers = 1;
-        ProtoLinearizedTimestampBindingFeedback linearized_timestamps = 2;
     }
 }

--- a/src/storage/src/client/controller/rehydration.rs
+++ b/src/storage/src/client/controller/rehydration.rs
@@ -267,7 +267,6 @@ where
                     None
                 }
             }
-            other => Some(other),
         }
     }
 }

--- a/src/storage/src/server/reconciliation.rs
+++ b/src/storage/src/server/reconciliation.rs
@@ -125,9 +125,6 @@ where
                 self.responses
                     .push_back(StorageResponse::FrontierUppers(list));
             }
-            StorageResponse::LinearizedTimestamps(_) => {
-                unreachable!("storaged processes never produce this response type");
-            }
         }
     }
 


### PR DESCRIPTION
The `Controller::ready` and `Controller::process` methods have proven to
be a useful tool to work around cancellation safety issues. The idea is
that `ready` is cancellation safe, waits for work to become available,
then stashes it away for later; when readiness is observed, the
cancellation-unsafe `Controller:process` method must be driven to
completion.

This commit pushes the pattern into `StorageController` and
`ComputeController`. The top-level `Controller`'s `process` and
`ready` methods now delegate to the underlying controllers.

This change avoids leaking implementation details to the `Controller`.
For example, previously, the top-level `Controller` was responsible for
processing `FrontierUppers` responses by calling
`update_write_frontiers`. After this commit, frontier handling occurs
locally to each controller.

The unused `LinearizedTimestamps` response was frustrating this effort,
so I removed it. It would have needed a refactoring anyway, since our
latest thinking did not involve sending the command all the way down to
the storage hosts themselves.

With this change, I am quite comfortable with our cancellation safety
story. There are only a few `GenericClient::recv` and
`Controller::ready` methods that need to be audited for cancellation
safety issues, and they are now all quite simple.

h/t to @brennanvincent for inventing the `ready`/`process` technique.

Touches #12946.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
