### PR TITLE
zippy: Add support for ENVELOPE NONE

### DIFF
--- a/misc/python/materialize/zippy/kafka_capabilities.py
+++ b/misc/python/materialize/zippy/kafka_capabilities.py
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from enum import Enum
+from typing import Optional
+
 from materialize.zippy.framework import Capability
 from materialize.zippy.watermarks import Watermarks
 
@@ -15,7 +18,13 @@ class KafkaRunning(Capability):
     pass
 
 
+class Envelope(Enum):
+    NONE = 1
+    UPSERT = 2
+
+
 class TopicExists(Capability):
     def __init__(self, name: str) -> None:
         self.name = name
+        self.envelope: Optional[Envelope] = None
         self.watermarks = Watermarks()

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -47,13 +47,14 @@ class CreateSource(Action):
 
     def run(self, c: Composition) -> None:
         if self.new_source:
+            envelope = str(self.topic.envelope).split(".")[1]
             c.testdrive(
                 f"""
 > CREATE MATERIALIZED SOURCE {self.source.name}
   FROM KAFKA BROKER '${{testdrive.kafka-addr}}'
   TOPIC 'testdrive-{self.topic.name}-${{testdrive.seed}}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
-  ENVELOPE UPSERT
+  ENVELOPE {envelope}
 """
             )
 


### PR DESCRIPTION
50% of the sources created will have ENVELOPE NONE

### Motivation

  * This PR adds a feature that has not yet been specified.

Zippy needs envelope `NONE` support, especially since this is the only envelope that is truly persistent at this time.