### PR TITLE
limits: Increase timeout to 120s

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1034,7 +1034,7 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     Materialized(memory="8G"),
-    Testdrive(default_timeout="60s"),
+    Testdrive(default_timeout="120s"),
 ]
 
 


### PR DESCRIPTION
Further slow-downs in the product mean that scenarios such
as KafkaRecordsEnvelopeNone time out with the previous default of 60s

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

CI failures in Nightly