### PR TITLE
rename `Coordinator::dataflow_client` to `compute_controller`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -453,14 +453,15 @@ pub struct ReplicaMetadata {
 
 /// Glues the external world to the Timely workers.
 pub struct Coordinator<S> {
-    /// A client to a running dataflow cluster.
+    /// A client to COMPUTE, encompassing all compute clusters and
+    /// all their replicas.
     ///
     /// This component offers:
     /// - Sufficient isolation from COMPUTE, so long as communication with
     ///   COMPUTE replicas is non-blocking.
     /// - Insufficient isolation from STORAGE. The ADAPTER cannot tolerate
     ///   failure of STORAGE services.
-    dataflow_client: mz_controller::Controller,
+    compute_controller: mz_controller::Controller,
     /// Optimizer instance for logical optimization of views.
     view_optimizer: Optimizer,
     catalog: Catalog<S>,
@@ -670,7 +671,7 @@ impl<S: Append + 'static> Coordinator<S> {
             self.read_capability.insert(id, policy.clone().into());
             policy_updates.push((id, self.read_capability[&id].policy()));
         }
-        self.dataflow_client
+        self.compute_controller
             .storage_mut()
             .set_read_policy(policy_updates)
             .await
@@ -697,7 +698,7 @@ impl<S: Append + 'static> Coordinator<S> {
             self.read_capability.insert(id, policy.clone().into());
             policy_updates.push((id, self.read_capability[&id].policy()));
         }
-        self.dataflow_client
+        self.compute_controller
             .compute_mut(instance)
             .unwrap()
             .set_read_policy(policy_updates)
@@ -714,11 +715,11 @@ impl<S: Append + 'static> Coordinator<S> {
         mut builtin_table_updates: Vec<BuiltinTableUpdate>,
     ) -> Result<(), AdapterError> {
         for instance in self.catalog.compute_instances() {
-            self.dataflow_client
+            self.compute_controller
                 .create_instance(instance.id, instance.logging.clone())
                 .await;
             for (replica_id, replica) in instance.replicas_by_id.clone() {
-                self.dataflow_client
+                self.compute_controller
                     .add_replica_to_instance(instance.id, replica_id, replica.config)
                     .await
                     .unwrap();
@@ -768,7 +769,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         }
                     }
 
-                    self.dataflow_client
+                    self.compute_controller
                         .storage_mut()
                         .create_collections(vec![(
                             entry.id(),
@@ -784,7 +785,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     storage_policies_to_set.push(entry.id());
                 }
                 CatalogItem::Table(table) => {
-                    self.dataflow_client
+                    self.compute_controller
                         .storage_mut()
                         .create_collections(vec![(
                             entry.id(),
@@ -817,7 +818,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             .extend(dataflow.export_ids());
                         let dataflow_plan =
                             vec![self.finalize_dataflow(dataflow, idx.compute_instance)];
-                        self.dataflow_client
+                        self.compute_controller
                             .compute_mut(idx.compute_instance)
                             .unwrap()
                             .create_dataflows(dataflow_plan)
@@ -828,7 +829,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 CatalogItem::View(_) => (),
                 CatalogItem::RecordedView(rview) => {
                     // Re-create the storage collection.
-                    self.dataflow_client
+                    self.compute_controller
                         .storage_mut()
                         .create_collections(vec![(
                             entry.id(),
@@ -976,7 +977,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .filter(|entry| entry.is_table())
             .map(|entry| (entry.id(), Vec::new(), advance_to))
             .collect();
-        self.dataflow_client
+        self.compute_controller
             .storage_mut()
             .append(appends)
             .await
@@ -989,7 +990,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .filter(|entry| entry.is_table() && entry.id().is_system())
         {
             let current_contents = self
-                .dataflow_client
+                .compute_controller
                 .storage_mut()
                 .snapshot(system_table.id(), read_ts)
                 .await
@@ -1027,7 +1028,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut advance_local_inputs_interval =
             tokio::time::interval(self.catalog.config().timestamp_frequency);
         // Watcher that listens for and reports compute service status changes.
-        let mut compute_events = self.dataflow_client.watch_compute_services();
+        let mut compute_events = self.compute_controller.watch_compute_services();
 
         loop {
             // Before adding a branch to this select loop, please ensure that the branch is
@@ -1049,7 +1050,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 _ = advance_local_inputs_interval.tick() => Message::AdvanceLocalInputs,
                 // See [`mz_controller::Controller::Controller::ready`] for notes
                 // on why this is cancel-safe.
-                () = self.dataflow_client.ready() => {
+                () = self.compute_controller.ready() => {
                     Message::ControllerReady
                 }
                 // `recv()` on `UnboundedReceiver` is cancellation safe:
@@ -1075,7 +1076,7 @@ impl<S: Append + 'static> Coordinator<S> {
             match msg {
                 Message::Command(cmd) => self.message_command(cmd).await,
                 Message::ControllerReady => {
-                    if let Some(m) = self.dataflow_client.process().await.unwrap() {
+                    if let Some(m) = self.compute_controller.process().await.unwrap() {
                         self.message_controller(m).await
                     }
                 }
@@ -1185,7 +1186,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // change the batch size.
         const WINDOW: Duration = Duration::from_millis(10);
         let start = Instant::now();
-        let storage = self.dataflow_client.storage();
+        let storage = self.compute_controller.storage();
         let appends = inputs
             .ids
             .into_iter()
@@ -1208,7 +1209,7 @@ impl<S: Append + 'static> Coordinator<S> {
             })
             .collect::<Vec<_>>();
         let num_updates = appends.len();
-        self.dataflow_client
+        self.compute_controller
             .storage_mut()
             .append(appends)
             .await
@@ -1338,7 +1339,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .into_iter()
             .map(|(id, updates)| (id, updates, advance_to))
             .collect();
-        self.dataflow_client
+        self.compute_controller
             .storage_mut()
             .append(appends)
             .await
@@ -1580,7 +1581,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 inverse.entry(*compute_instance).or_default().insert(*uuid);
             }
             for (compute_instance, uuids) in inverse {
-                self.dataflow_client
+                self.compute_controller
                     .compute_mut(compute_instance)
                     .unwrap()
                     .cancel_peeks(&uuids)
@@ -2713,11 +2714,11 @@ impl<S: Append + 'static> Coordinator<S> {
             .catalog
             .resolve_compute_instance(&name)
             .expect("compute instance must exist after creation");
-        self.dataflow_client
+        self.compute_controller
             .create_instance(instance.id, instance.logging.clone())
             .await;
         for (replica_id, replica) in instance.replicas_by_id.clone() {
-            self.dataflow_client
+            self.compute_controller
                 .add_replica_to_instance(instance.id, replica_id, replica.config)
                 .await
                 .unwrap();
@@ -2752,7 +2753,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
         let instance = self.catalog.resolve_compute_instance(&of_cluster)?;
         let replica_id = instance.replica_id_by_name[&name];
-        self.dataflow_client
+        self.compute_controller
             .add_replica_to_instance(instance.id, replica_id, config)
             .await
             .unwrap();
@@ -2855,7 +2856,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // Determine the initial validity for the table.
                 let since_ts = self.get_local_write_ts().await;
 
-                self.dataflow_client
+                self.compute_controller
                     .storage_mut()
                     .create_collections(vec![(
                         table_id,
@@ -2869,7 +2870,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .unwrap();
 
                 let policy = ReadPolicy::ValidFrom(Antichain::from_elem(since_ts));
-                self.dataflow_client
+                self.compute_controller
                     .storage_mut()
                     .set_read_policy(vec![(table_id, policy)])
                     .await
@@ -2980,7 +2981,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                 }
 
-                self.dataflow_client
+                self.compute_controller
                     .storage_mut()
                     .create_collections(vec![(
                         source_id,
@@ -3395,7 +3396,7 @@ impl<S: Append + 'static> Coordinator<S> {
         {
             Ok(df) => {
                 // Announce the creation of the recorded view source.
-                self.dataflow_client
+                self.compute_controller
                     .storage_mut()
                     .create_collections(vec![(
                         id,
@@ -3559,7 +3560,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .pack_replica_heartbeat_update(replica_id, metadata, -1);
             self.send_builtin_table_updates(vec![retraction]).await;
         }
-        self.dataflow_client
+        self.compute_controller
             .drop_replica(instance_id, replica_id, replica_config)
             .await
     }
@@ -3593,7 +3594,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
             }
-            self.dataflow_client
+            self.compute_controller
                 .drop_instance(instance_id)
                 .await
                 .unwrap();
@@ -4264,13 +4265,13 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Antichain<mz_repr::Timestamp> {
         let mut since = Antichain::from_elem(Timestamp::minimum());
         {
-            let storage = self.dataflow_client.storage();
+            let storage = self.compute_controller.storage();
             for id in id_bundle.storage_ids.iter() {
                 since.join_assign(&storage.collection(*id).unwrap().implied_capability)
             }
         }
         {
-            let compute = self.dataflow_client.compute(instance).unwrap();
+            let compute = self.compute_controller.compute(instance).unwrap();
             for id in id_bundle.compute_ids.iter() {
                 since.join_assign(&compute.collection(*id).unwrap().implied_capability)
             }
@@ -4289,7 +4290,7 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Antichain<mz_repr::Timestamp> {
         let mut since = Antichain::new();
         {
-            let storage = self.dataflow_client.storage();
+            let storage = self.compute_controller.storage();
             for id in id_bundle.storage_ids.iter() {
                 since.extend(
                     storage
@@ -4303,7 +4304,7 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
         {
-            let compute = self.dataflow_client.compute(instance).unwrap();
+            let compute = self.compute_controller.compute(instance).unwrap();
             for id in id_bundle.compute_ids.iter() {
                 since.extend(
                     compute
@@ -4415,7 +4416,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .iter()
                 .filter_map(|id| {
                     let since = self
-                        .dataflow_client
+                        .compute_controller
                         .compute(compute_instance)
                         .unwrap()
                         .collection(*id)
@@ -4432,7 +4433,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .collect::<Vec<_>>();
             let invalid_sources = id_bundle.storage_ids.iter().filter_map(|id| {
                 let since = self
-                    .dataflow_client
+                    .compute_controller
                     .storage()
                     .collection(*id)
                     .unwrap()
@@ -4768,7 +4769,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 };
                 let mut sources = Vec::new();
                 {
-                    let storage = self.dataflow_client.storage();
+                    let storage = self.compute_controller.storage();
                     for id in id_bundle.storage_ids.iter() {
                         let state = storage.collection(*id).unwrap();
                         let name = self
@@ -4794,7 +4795,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                 }
                 {
-                    let compute = self.dataflow_client.compute(compute_instance).unwrap();
+                    let compute = self.compute_controller.compute(compute_instance).unwrap();
                     for id in id_bundle.compute_ids.iter() {
                         let state = compute.collection(*id).unwrap();
                         let name = self
@@ -5481,7 +5482,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .catalog
             .transact(session, ops, |catalog| {
                 f(CatalogTxn {
-                    dataflow_client: &self.dataflow_client,
+                    dataflow_client: &self.compute_controller,
                     catalog,
                 })
             })
@@ -5496,7 +5497,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 for id in &sources_to_drop {
                     self.read_capability.remove(id);
                 }
-                self.dataflow_client
+                self.compute_controller
                     .storage_mut()
                     .drop_sources(sources_to_drop)
                     .await
@@ -5506,7 +5507,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 for id in &tables_to_drop {
                     self.read_capability.remove(id);
                 }
-                self.dataflow_client
+                self.compute_controller
                     .storage_mut()
                     .drop_sources(tables_to_drop)
                     .await
@@ -5588,7 +5589,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 (id, updates, advance_to)
             })
             .collect();
-        self.dataflow_client
+        self.compute_controller
             .storage_mut()
             .append(appends)
             .await
@@ -5599,7 +5600,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let by_compute_instance = sinks.into_iter().into_group_map();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Some(mut compute) = self.dataflow_client.compute_mut(compute_instance) {
+            if let Some(mut compute) = self.compute_controller.compute_mut(compute_instance) {
                 compute.drop_sinks(ids).await.unwrap();
             }
         }
@@ -5618,7 +5619,7 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
         for (compute_instance, ids) in by_compute_instance {
-            self.dataflow_client
+            self.compute_controller
                 .compute_mut(compute_instance)
                 .unwrap()
                 .drop_indexes(ids)
@@ -5645,13 +5646,13 @@ impl<S: Append + 'static> Coordinator<S> {
         // Drop compute sinks.
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Some(mut compute) = self.dataflow_client.compute_mut(compute_instance) {
+            if let Some(mut compute) = self.compute_controller.compute_mut(compute_instance) {
                 compute.drop_sinks(ids).await.unwrap();
             }
         }
 
         // Drop storage sources.
-        self.dataflow_client
+        self.compute_controller
             .storage_mut()
             .drop_sources(source_ids)
             .await
@@ -5684,7 +5685,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         None => ReadPolicy::ValidFrom(Antichain::from_elem(Timestamp::minimum())),
                     };
                     needs.base_policy = policy;
-                    self.dataflow_client
+                    self.compute_controller
                         .compute_mut(compute_instance)
                         .unwrap()
                         .set_read_policy(vec![(id, needs.policy())])
@@ -5724,7 +5725,7 @@ impl<S: Append + 'static> Coordinator<S> {
             output_ids.extend(dataflow.export_ids());
             dataflow_plans.push(self.finalize_dataflow(dataflow, instance));
         }
-        self.dataflow_client
+        self.compute_controller
             .compute_mut(instance)
             .unwrap()
             .create_dataflows(dataflow_plans)
@@ -5975,7 +5976,7 @@ pub async fn serve<S: Append + 'static>(
                 |ts| catalog.persist_timestamp(ts),
             ));
             let mut coord = Coordinator {
-                dataflow_client,
+                compute_controller: dataflow_client,
                 view_optimizer: Optimizer::logical_optimizer(),
                 catalog,
                 logical_compaction_window_ms: logical_compaction_window
@@ -6357,7 +6358,7 @@ pub mod fast_path_peek {
                     let output_ids = dataflow.export_ids().collect();
 
                     // Very important: actually create the dataflow (here, so we can destructure).
-                    self.dataflow_client
+                    self.compute_controller
                         .compute_mut(compute_instance)
                         .unwrap()
                         .create_dataflows(vec![dataflow])
@@ -6426,7 +6427,7 @@ pub mod fast_path_peek {
                 .insert(uuid, compute_instance);
             let (id, key, timestamp, _finishing, map_filter_project) = peek_command;
 
-            self.dataflow_client
+            self.compute_controller
                 .compute_mut(compute_instance)
                 .unwrap()
                 .peek(
@@ -6508,7 +6509,7 @@ pub mod read_holds {
         ) {
             // Update STORAGE read policies.
             let mut policy_changes = Vec::new();
-            let storage = self.dataflow_client.storage_mut();
+            let storage = self.compute_controller.storage_mut();
             for id in read_holds.id_bundle.storage_ids.iter() {
                 let collection = storage.collection(*id).unwrap();
                 assert!(collection
@@ -6523,7 +6524,7 @@ pub mod read_holds {
             // Update COMPUTE read policies
             let mut policy_changes = Vec::new();
             let mut compute = self
-                .dataflow_client
+                .compute_controller
                 .compute_mut(read_holds.compute_instance)
                 .unwrap();
             for id in read_holds.id_bundle.compute_ids.iter() {
@@ -6566,7 +6567,7 @@ pub mod read_holds {
                     policy_changes.push((*id, read_needs.policy()));
                 }
             }
-            self.dataflow_client
+            self.compute_controller
                 .storage_mut()
                 .set_read_policy(policy_changes)
                 .await
@@ -6580,7 +6581,7 @@ pub mod read_holds {
                     policy_changes.push((*id, read_needs.policy()));
                 }
             }
-            if let Some(mut compute) = self.dataflow_client.compute_mut(compute_instance) {
+            if let Some(mut compute) = self.compute_controller.compute_mut(compute_instance) {
                 compute.set_read_policy(policy_changes).await.unwrap();
             }
         }

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -69,7 +69,7 @@ impl<S: Append> Coordinator<S> {
         &self,
         instance: ComputeInstanceId,
     ) -> DataflowBuilder<mz_repr::Timestamp> {
-        let compute = self.dataflow_client.compute(instance).unwrap();
+        let compute = self.compute_controller.compute(instance).unwrap();
         DataflowBuilder {
             catalog: self.catalog.state(),
             compute,

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -35,7 +35,7 @@ impl<S: Append> Coordinator<S> {
     ) -> ComputeInstanceIndexOracle<mz_repr::Timestamp> {
         ComputeInstanceIndexOracle {
             catalog: self.catalog.state(),
-            compute: self.dataflow_client.compute(instance).unwrap(),
+            compute: self.compute_controller.compute(instance).unwrap(),
         }
     }
 }


### PR DESCRIPTION


### Motivation

`dataflow_client` is not what this thing is called anywhere else, and probably dates to some older naming philosophy reflecting pre-platform (or at least early platform) architecture.

Rename it to match what we actually call it.
