### PR TITLE
storage,compute: rethink reconciliation

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -955,6 +955,9 @@ impl<S: Append + 'static> Coordinator<S> {
         self.initialize_read_policies(policies_to_set, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS)
             .await;
 
+        // Announce the completion of initialization.
+        self.controller.initialization_complete();
+
         // Announce primary and foreign key relationships.
         let mz_view_keys = self.catalog.resolve_builtin_table(&MZ_VIEW_KEYS);
         for log in BUILTINS::logs() {

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -44,6 +44,7 @@ message ProtoComputeCommand {
         mz_storage.protocol.client.ProtoAllowCompaction allow_compaction = 4;
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
+        google.protobuf.Empty initialization_complete = 7;
     }
 }
 

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -50,6 +50,10 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// Indicates the termination of an instance, and is the last command for its compute instance.
     DropInstance,
 
+    /// Indicates that the controller has sent all commands reflecting its
+    /// initial state.
+    InitializationComplete,
+
     /// Create a sequence of dataflows.
     ///
     /// Each of the dataflows must contain `as_of` members that are valid
@@ -83,6 +87,7 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
             kind: Some(match self {
                 ComputeCommand::CreateInstance(config) => CreateInstance(config.into_proto()),
                 ComputeCommand::DropInstance => DropInstance(()),
+                ComputeCommand::InitializationComplete => InitializationComplete(()),
                 ComputeCommand::CreateDataflows(dataflows) => {
                     CreateDataflows(ProtoCreateDataflows {
                         dataflows: dataflows.into_proto(),
@@ -107,6 +112,7 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
         match proto.kind {
             Some(CreateInstance(config)) => Ok(ComputeCommand::CreateInstance(config.into_rust()?)),
             Some(DropInstance(())) => Ok(ComputeCommand::DropInstance),
+            Some(InitializationComplete(())) => Ok(ComputeCommand::InitializationComplete),
             Some(CreateDataflows(ProtoCreateDataflows { dataflows })) => {
                 Ok(ComputeCommand::CreateDataflows(dataflows.into_rust()?))
             }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -48,7 +48,7 @@ use crate::logging::LoggingConfig;
 use crate::response::{ComputeResponse, PeekResponse, TailBatch, TailResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
-mod replicated;
+pub mod replicated;
 
 /// An abstraction allowing us to name different compute instances.
 pub type ComputeInstanceId = u64;
@@ -646,6 +646,15 @@ where
     T: Timestamp + Lattice + Codec64,
     ComputeGrpcClient: ComputeClient<T>,
 {
+    /// Marks the end of any initialization commands.
+    ///
+    /// Intended to be called by `Controller`, rather than by other code (to avoid repeated calls).
+    pub fn initialization_complete(&mut self) {
+        self.compute
+            .replicas
+            .send(ComputeCommand::InitializationComplete);
+    }
+
     /// Acquire a mutable reference to the collection state, should it exist.
     pub fn collection_mut(
         &mut self,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -558,10 +558,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
             // Read the upper frontier and compare to what we've reported.
             traces.oks_mut().read_upper(&mut new_frontier);
             if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&id) {
-                assert!(<_ as PartialOrder>::less_equal(
-                    prev_frontier,
-                    &new_frontier
-                ));
+                assert!(PartialOrder::less_equal(prev_frontier, &new_frontier));
                 if prev_frontier != &new_frontier {
                     add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
                     prev_frontier.clone_from(&new_frontier);

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -29,6 +29,7 @@ use tokio::sync::{mpsc, Mutex};
 use mz_compute_client::command::{
     ComputeCommand, DataflowDescription, InstanceConfig, Peek, ReplicaId,
 };
+use mz_compute_client::controller::replicated::ComputeCommandHistory;
 use mz_compute_client::logging::LoggingConfig;
 use mz_compute_client::plan::Plan;
 use mz_compute_client::response::{ComputeResponse, PeekResponse, TailResponse};
@@ -80,8 +81,8 @@ pub struct ComputeState {
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers.
     pub persist_clients: Arc<Mutex<PersistClientCache>>,
-    /// Descriptions for installed dataflows.
-    pub dataflow_descriptions: HashMap<GlobalId, DataflowDescription<Plan, CollectionMetadata>>,
+    /// History of commands received by this workers and all its peers.
+    pub command_history: ComputeCommandHistory,
 }
 
 /// A wrapper around [ComputeState] with a live timely worker and response channel.
@@ -107,10 +108,11 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         use ComputeCommand::*;
-
+        self.compute_state.command_history.push(cmd.clone());
         match cmd {
             CreateInstance(config) => self.handle_create_instance(config),
             DropInstance => (),
+            InitializationComplete => (),
             CreateDataflows(dataflows) => self.handle_create_dataflows(dataflows),
             AllowCompaction(list) => self.handle_allow_compaction(list),
             Peek(peek) => {
@@ -132,25 +134,6 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         dataflows: Vec<DataflowDescription<Plan, CollectionMetadata>>,
     ) {
         for dataflow in dataflows.into_iter() {
-            let existed = if let Some(existing) = self
-                .compute_state
-                .dataflow_descriptions
-                .get(&dataflow.global_id().unwrap())
-            {
-                assert!(
-                    existing.compatible_with(&dataflow),
-                    "New dataflow with same ID {:?}",
-                    dataflow.id
-                );
-                true
-            } else {
-                false
-            };
-
-            self.compute_state
-                .dataflow_descriptions
-                .insert(dataflow.global_id().unwrap(), dataflow.clone());
-
             // Collect the exported object identifiers, paired with their associated "collection" identifier.
             // The latter is used to extract dependency information, which is in terms of collections ids.
             let sink_ids = dataflow
@@ -170,27 +153,23 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                     .insert(object_id, Antichain::from_elem(0));
 
                 // Log dataflow construction, frontier construction, and any dependencies.
-                if !existed {
-                    if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-                        logger.log(ComputeEvent::Dataflow(object_id, true));
-                        logger.log(ComputeEvent::Frontier(object_id, 0, 1));
-                        for import_id in dataflow.depends_on(collection_id) {
-                            logger.log(ComputeEvent::DataflowDependency {
-                                dataflow: object_id,
-                                source: import_id,
-                            })
-                        }
+                if let Some(logger) = self.compute_state.compute_logger.as_mut() {
+                    logger.log(ComputeEvent::Dataflow(object_id, true));
+                    logger.log(ComputeEvent::Frontier(object_id, 0, 1));
+                    for import_id in dataflow.depends_on(collection_id) {
+                        logger.log(ComputeEvent::DataflowDependency {
+                            dataflow: object_id,
+                            source: import_id,
+                        })
                     }
                 }
             }
 
-            if !existed {
-                crate::render::build_compute_dataflow(
-                    self.timely_worker,
-                    &mut self.compute_state,
-                    dataflow,
-                );
-            }
+            crate::render::build_compute_dataflow(
+                self.timely_worker,
+                &mut self.compute_state,
+                dataflow,
+            );
         }
     }
 
@@ -578,20 +557,17 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         for (id, traces) in self.compute_state.traces.traces.iter_mut() {
             // Read the upper frontier and compare to what we've reported.
             traces.oks_mut().read_upper(&mut new_frontier);
-            let prev_frontier = match self.compute_state.reported_frontiers.get_mut(&id) {
-                None => {
-                    // The current client has not expressed interest in this
-                    // collection. Move on.
-                    //
-                    // TODO(benesch): reconciliation should prevent
-                    // this situation.
-                    continue;
+            if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&id) {
+                assert!(<_ as PartialOrder>::less_equal(
+                    prev_frontier,
+                    &new_frontier
+                ));
+                if prev_frontier != &new_frontier {
+                    add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
+                    prev_frontier.clone_from(&new_frontier);
                 }
-                Some(reported_frontier) => reported_frontier,
-            };
-            if prev_frontier != &new_frontier {
-                add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
-                prev_frontier.clone_from(&new_frontier);
+            } else {
+                panic!("Frontier update for untracked identifier: {:?}", id);
             }
         }
 
@@ -606,24 +582,17 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
         for (id, frontier) in self.compute_state.sink_write_frontiers.iter() {
             new_frontier.clone_from(&frontier.borrow());
-            let prev_frontier = match self.compute_state.reported_frontiers.get_mut(&id) {
-                None => {
-                    // The current client has not expressed interest in this
-                    // collection. Move on.
-                    //
-                    // TODO(benesch): reconciliation should prevent
-                    // this situation.
-                    continue;
+            if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&id) {
+                assert!(<_ as PartialOrder>::less_equal(
+                    prev_frontier,
+                    &new_frontier
+                ));
+                if prev_frontier != &new_frontier {
+                    add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
+                    prev_frontier.clone_from(&new_frontier);
                 }
-                Some(reported_frontier) => reported_frontier,
-            };
-            assert!(<_ as PartialOrder>::less_equal(
-                prev_frontier,
-                &new_frontier
-            ));
-            if prev_frontier != &new_frontier {
-                add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
-                prev_frontier.clone_from(&new_frontier);
+            } else {
+                panic!("Frontier update for untracked identifier: {:?}", id);
             }
         }
 

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -454,7 +454,7 @@ where
             }
             .initialization_complete();
         }
-        // TODO(benesch): Initialize STORAGE controller.
+        self.storage_mut().initialization_complete();
     }
 
     /// Waits until the controller is ready to process a response.

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -432,6 +432,22 @@ where
     T: Timestamp + Lattice + Codec64 + Copy,
     ComputeGrpcClient: ComputeClient<T>,
 {
+    /// Marks the end of any initialization commands.
+    ///
+    /// The implementor may wait for this method to be called before implementing prior commands,
+    /// and so it is important for a user to invoke this method as soon as it is comfortable.
+    /// This method can be invoked immediately, at the potential expense of performance.
+    pub fn initialization_complete(&mut self) {
+        for (instance, compute) in self.compute.iter_mut() {
+            ComputeControllerMut {
+                instance: *instance,
+                compute,
+                storage_controller: &mut *self.storage_controller,
+            }
+            .initialization_complete();
+        }
+    }
+
     /// Waits until the controller is ready to process a response.
     ///
     /// This method may block for an arbitrarily long time.

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -102,6 +102,13 @@ impl<T> From<RelationDesc> for CollectionDescription<T> {
 pub trait StorageController: Debug + Send {
     type Timestamp;
 
+    /// Marks the end of any initialization commands.
+    ///
+    /// The implementor may wait for this method to be called before implementing prior commands,
+    /// and so it is important for a user to invoke this method as soon as it is comfortable.
+    /// This method can be invoked immediately, at the potential expense of performance.
+    fn initialization_complete(&mut self);
+
     /// Acquire an immutable reference to the collection state, should it exist.
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<Self::Timestamp>, StorageError>;
 
@@ -452,6 +459,10 @@ where
     StorageResponse<T>: RustType<ProtoStorageResponse>,
 {
     type Timestamp = T;
+
+    fn initialization_complete(&mut self) {
+        // TODO(benesch)
+    }
 
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, StorageError> {
         self.state

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -197,7 +197,7 @@ where
     async fn send_commands(
         &mut self,
         mut client: StorageGrpcClient,
-        commands: Vec<StorageCommand<T>>,
+        commands: impl IntoIterator<Item = StorageCommand<T>>,
     ) -> RehydrationTaskState {
         for command in commands {
             if let Err(e) = client.send(command).await {

--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -59,6 +59,7 @@ message ProtoStorageCommand {
     oneof kind {
         ProtoIngestSources ingest_sources = 1;
         ProtoAllowCompaction allow_compaction = 2;
+        google.protobuf.Empty initialization_complete = 3;
     }
 }
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -7,7 +7,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -95,12 +95,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
     /// Draws commands from a single client until disconnected.
     fn run_client(&mut self, command_rx: CommandReceiver, response_tx: ResponseSender) {
-        // A new client has connected. Reset state about what we have reported.
-        //
-        // TODO(benesch,mcsherry): introduce a `InitializationComplete` command
-        // and only clear the state that is missing after initialization
-        // completes.
-        self.storage_state.reported_frontiers.clear();
+        self.reconcile(&command_rx);
 
         let mut disconnected = false;
         while !disconnected {
@@ -137,21 +132,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
             StorageCommand::InitializationComplete => (),
             StorageCommand::IngestSources(ingestions) => {
                 for ingestion in ingestions {
-                    if let Some(existing) = self.storage_state.ingestions.get(&ingestion.id) {
-                        // If we've been asked to create an ingestion that is
-                        // already installed, the descriptions must match
-                        // exactly.
-                        assert_eq!(
-                            *existing, ingestion.description,
-                            "New ingestion with same ID {:?}",
-                            ingestion.id,
-                        );
-                        self.storage_state.reported_frontiers.insert(
-                            ingestion.id,
-                            Antichain::from_elem(mz_repr::Timestamp::minimum()),
-                        );
-                        continue;
-                    }
+                    // Remember the ingestion description to facilitate possible
+                    // reconciliation later.
+                    self.storage_state
+                        .ingestions
+                        .insert(ingestion.id, ingestion.description.clone());
 
                     // Initialize shared frontier tracking.
                     self.storage_state.source_uppers.insert(
@@ -204,17 +189,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
         // Check if any observed frontier should advance the reported frontiers.
         for (id, frontier) in self.storage_state.source_uppers.iter() {
-            let reported_frontier = match self.storage_state.reported_frontiers.get_mut(&id) {
-                None => {
-                    // The current client has not expressed interest in this
-                    // collection. Move on.
-                    //
-                    // TODO(benesch): reconciliation should prevent
-                    // this situation.
-                    continue;
-                }
-                Some(reported_frontier) => reported_frontier,
-            };
+            let reported_frontier = self
+                .storage_state
+                .reported_frontiers
+                .get_mut(&id)
+                .expect("Reported frontier missing!");
 
             let observed_frontier = frontier.borrow();
 
@@ -245,5 +224,88 @@ impl<'w, A: Allocate> Worker<'w, A> {
         // Ignore send errors because the coordinator is free to ignore our
         // responses. This happens during shutdown.
         let _ = response_tx.send(response);
+    }
+
+    /// Extract commands until `InitializationComplete`, and make the worker
+    /// reflect those commands. If the worker can not be made to reflect the
+    /// commands, exit the process.
+    ///
+    /// This method is meant to be a function of the commands received thus far
+    /// (as recorded in the compute state command history) and the new commands
+    /// from `command_rx`. It should not be a function of other characteristics,
+    /// like whether the worker has managed to respond to a peek or not. Some
+    /// effort goes in to narrowing our view to only the existing commands we
+    /// can be sure are live at all other workers.
+    ///
+    /// The methodology here is to drain `command_rx` until an
+    /// `InitializationComplete`, at which point the prior commands are
+    /// "reconciled" in. Reconciliation takes each goal dataflow and looks for
+    /// an existing "compatible" dataflow (per `compatible()`) it can repurpose,
+    /// with some additional tests to be sure that we can cut over from one to
+    /// the other (no additional compaction, no tails/sinks). With any
+    /// connections established, old orphaned dataflows are allow to compact
+    /// away, and any new dataflows are created from scratch. "Kept" dataflows
+    /// are allowed to compact up to any new `as_of`.
+    ///
+    /// Some additional tidying happens, e.g. cleaning up reported frontiers.
+    /// tail response buffer. We will need to be vigilant with future
+    /// modifications to `StorageState` to line up changes there with clean
+    /// resets here.
+    fn reconcile(&mut self, command_rx: &CommandReceiver) {
+        // To initialize the connection, we want to drain all commands until we
+        // receive a `StorageCommand::InitializationComplete` command to form a
+        // target command state.
+        let mut commands = vec![];
+        while let Ok(command) = command_rx.recv() {
+            match command {
+                StorageCommand::InitializationComplete => break,
+                _ => commands.push(command),
+            }
+        }
+
+        // Elide any ingestions we're already aware of while determining what
+        // ingestions no longer exist.
+        let mut stale_ingestions = self.storage_state.ingestions.keys().collect::<HashSet<_>>();
+        for command in &mut commands {
+            match command {
+                StorageCommand::IngestSources(ingestions) => {
+                    ingestions.retain_mut(|ingestion| {
+                        if let Some(existing) = self.storage_state.ingestions.get(&ingestion.id) {
+                            stale_ingestions.remove(&ingestion.id);
+                            // If we've been asked to create an ingestion that is
+                            // already installed, the descriptions must match
+                            // exactly.
+                            assert_eq!(
+                                *existing, ingestion.description,
+                                "New ingestion with same ID {:?}",
+                                ingestion.id,
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                }
+                _ => (),
+            }
+        }
+
+        // Synthesize a drop command to remove stale ingestions.
+        commands.push(StorageCommand::AllowCompaction(
+            stale_ingestions
+                .into_iter()
+                .map(|id| (*id, Antichain::new()))
+                .collect(),
+        ));
+
+        // Reset the reported frontiers.
+        for (_, frontier) in &mut self.storage_state.reported_frontiers {
+            *frontier = Antichain::from_elem(<_>::minimum());
+        }
+
+        // Execute the modified commands.
+        for command in commands {
+            self.handle_storage_command(command);
+        }
     }
 }

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -134,6 +134,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
     /// Entry point for applying a storage command.
     pub fn handle_storage_command(&mut self, cmd: StorageCommand) {
         match cmd {
+            StorageCommand::InitializationComplete => (),
             StorageCommand::IngestSources(ingestions) => {
                 for ingestion in ingestions {
                     if let Some(existing) = self.storage_state.ingestions.get(&ingestion.id) {


### PR DESCRIPTION
Ignore the first commit. That's #13525.

Previously, reconciliation sat on *top* of storage/compute servers, and
attempted to paper over commands and responses so that clients believed
they were talking to a fresh server, while servers always believed they
were talking to the originally-connected client. This introduced a lot
of complicated logic and double bookkeeping.

This commit pushes reconciliation logic into the storaged and computed
servers. The servers are now aware of when a new client connects, and
they simply ditch any state that was related to the old client.

This tees us up for the last reconciliation task: garbage collecting
sources and dataflows that newly-connected clients are not interested
in.

Touches https://github.com/MaterializeInc/materialize/issues/10549.
Touches https://github.com/MaterializeInc/materialize/issues/12857.

### Motivation

   * This PR refactors existing code.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
