### PR TITLE
sql: convert cluster IDs to names in SHOW CREATE

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3773,6 +3773,13 @@ impl SessionCatalog for ConnCatalog<'_> {
         self.state.item_exists(name, self.conn_id)
     }
 
+    fn get_compute_instance(
+        &self,
+        id: ComputeInstanceId,
+    ) -> &dyn mz_sql::catalog::CatalogComputeInstance {
+        &self.state.compute_instances_by_id[&id]
+    }
+
     fn find_available_name(&self, name: QualifiedObjectName) -> QualifiedObjectName {
         self.state.find_available_name(name, self.conn_id)
     }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -172,6 +172,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Reports whether the specified type exists in the catalog.
     fn item_exists(&self, name: &QualifiedObjectName) -> bool;
 
+    /// Gets a compute instance by ID.
+    fn get_compute_instance(&self, id: ComputeInstanceId) -> &dyn CatalogComputeInstance;
+
     /// Finds a name like `name` that is not already in use.
     ///
     /// If `name` itself is available, it is returned unchanged.
@@ -673,6 +676,10 @@ impl SessionCatalog for DummyCatalog {
 
     fn item_exists(&self, _: &QualifiedObjectName) -> bool {
         false
+    }
+
+    fn get_compute_instance(&self, _: ComputeInstanceId) -> &dyn CatalogComputeInstance {
+        unimplemented!();
     }
 
     fn resolve_full_name(&self, _: &QualifiedObjectName) -> FullObjectName {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1780,9 +1780,12 @@ pub fn plan_create_recorded_view(
 ) -> Result<Plan, PlanError> {
     let compute_instance = match &stmt.in_cluster {
         None => scx.resolve_compute_instance(None)?.id(),
-        Some(in_cluster) => in_cluster.0,
+        Some(in_cluster) => in_cluster.id,
     };
-    stmt.in_cluster = Some(ResolvedClusterName(compute_instance));
+    stmt.in_cluster = Some(ResolvedClusterName {
+        id: compute_instance,
+        print_name: None,
+    });
 
     let create_sql = normalize::create_statement(scx, Statement::CreateRecordedView(stmt.clone()))?;
 
@@ -2181,9 +2184,12 @@ pub fn plan_create_sink(
     scx.require_unsafe_mode("CREATE SINK")?;
     let compute_instance = match &stmt.in_cluster {
         None => scx.resolve_compute_instance(None)?.id(),
-        Some(in_cluster) => in_cluster.0,
+        Some(in_cluster) => in_cluster.id,
     };
-    stmt.in_cluster = Some(ResolvedClusterName(compute_instance));
+    stmt.in_cluster = Some(ResolvedClusterName {
+        id: compute_instance,
+        print_name: None,
+    });
 
     let create_sql = normalize::create_statement(scx, Statement::CreateSink(stmt.clone()))?;
     let CreateSinkStatement {
@@ -2508,9 +2514,12 @@ pub fn plan_create_index(
     let options = plan_index_options(with_options.clone())?;
     let compute_instance = match in_cluster {
         None => scx.resolve_compute_instance(None)?.id(),
-        Some(in_cluster) => in_cluster.0,
+        Some(in_cluster) => in_cluster.id,
     };
-    *in_cluster = Some(ResolvedClusterName(compute_instance));
+    *in_cluster = Some(ResolvedClusterName {
+        id: compute_instance,
+        print_name: None,
+    });
 
     // Normalize `stmt`.
     *name = Some(Ident::new(index_name.item.clone()));

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use mz_build_info::DUMMY_BUILD_INFO;
+use mz_compute_client::controller::ComputeInstanceId;
 use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
@@ -280,6 +281,10 @@ impl SessionCatalog for TestCatalog {
 
     fn try_get_item(&self, _: &GlobalId) -> Option<&dyn CatalogItem> {
         unimplemented!();
+    }
+
+    fn get_compute_instance(&self, _: ComputeInstanceId) -> &dyn CatalogComputeInstance {
+        unimplemented!()
     }
 
     fn config(&self) -> &CatalogConfig {

--- a/test/sqllogictest/recorded_views.slt
+++ b/test/sqllogictest/recorded_views.slt
@@ -254,7 +254,7 @@ query TT colnames
 SHOW CREATE RECORDED VIEW rv
 ----
 Recorded␠View         Create␠Recorded␠View
-materialize.public.rv CREATE␠RECORDED␠VIEW␠"materialize"."public"."rv"␠IN␠CLUSTER␠[1]␠AS␠SELECT␠1
+materialize.public.rv CREATE␠RECORDED␠VIEW␠"materialize"."public"."rv"␠IN␠CLUSTER␠"default"␠AS␠SELECT␠1
 
 
 # Test: SHOW RECORDED VIEWS

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default|\[\d\] replacement=<VARIABLE_OUTPUT>
+$ set-regex match=cluster1|default replacement=<VARIABLE_OUTPUT>
 
 $ set writer-schema={
     "name": "row",
@@ -196,7 +196,7 @@ cluster on_name    key_name                seq_in_index  column_name  expression
 > SHOW CREATE INDEX data_view_primary_idx
 Index                                    "Create Index"
 --------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\" IN CLUSTER <VARIABLE_OUTPUT> ON \"materialize\".\"public\".\"data_view\" (\"b\" - \"a\", \"a\")"
+materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\" IN CLUSTER \"<VARIABLE_OUTPUT>\" ON \"materialize\".\"public\".\"data_view\" (\"b\" - \"a\", \"a\")"
 
 > CREATE TABLE foo (
     a int NOT NULL,

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -180,7 +180,7 @@ cluster on_name          key_name       seq_in_index  column_name expression nul
 > SHOW CREATE INDEX renamed_index
 Index               "Create Index"
 ---------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_index "CREATE INDEX \"renamed_index\" IN CLUSTER [1] ON \"materialize\".\"public\".\"renamed_mz_view\" (\"a\", \"b\")"
+materialize.public.renamed_index "CREATE INDEX \"renamed_index\" IN CLUSTER \"<VARIABLE_OUTPUT>\" ON \"materialize\".\"public\".\"renamed_mz_view\" (\"a\", \"b\")"
 
 # Simple dependencies are renamed
 > SHOW CREATE VIEW dependent_view
@@ -191,7 +191,7 @@ materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"de
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER [1] FROM [<VARIABLE_OUTPUT> AS \"materialize\".\"public\".\"renamed_mz_data\"] INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" IN CLUSTER \"<VARIABLE_OUTPUT>\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' WITH SNAPSHOT"
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -7,9 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=u\d+ replacement=UID
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER [1] FROM [UID AS \"materialize\".\"public\".\"static_view\"] INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER \"default\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
 
 $ kafka-verify format=avro sink=materialize.public.upgrade_kafka_sink sort-messages=true
 {"before": null, "after": {"row": {"f1": 1}}}


### PR DESCRIPTION
Teach SHOW CREATE INDEX and SHOW CREATE SINK to convert cluster IDs back
to names.

Fix #11130.
Fix #11131.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
