### PR TITLE
test: re-enable kafka resumption tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -409,8 +409,6 @@ steps:
     label: Kafka resumption tests
     depends_on: build-x86_64
     timeout_in_minutes: 30
-    # https://github.com/MaterializeInc/materialize/issues/11992
-    soft_fail: true
     artifact_paths: junit_mzcompose_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
These have not failed once in the past 28 days [0].

Fix #11992.

[0]: https://buildkite.com/organizations/materialize/analytics/suites/mzcompose/tests/1839461?branch=main

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
