### PR TITLE
feature-benchmark: Reduce the number of "cycles" to 2

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -414,7 +414,7 @@ def workflow_mzcloud(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--max-retries",
         metavar="N",
         type=int,
-        default=3,
+        default=2,
         help="Retry any potential performance regressions up to N times.",
     )
 


### PR DESCRIPTION
The feature benchmark attempts to run each regressing benchmark
up to 3 times in the hope of weeding out false positives.

Reduce this to 2 times as the performance regressions currently
seen in the CI are unlikely to be sporadic.
### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI is slow, running the feature benchmarks one too many times.