### PR TITLE
coord: disable compaction of peek dataflows

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -6257,7 +6257,7 @@ pub mod fast_path_peek {
     use mz_stash::Append;
 
     use crate::client::ConnectionId;
-    use crate::coord::{PeekResponseUnary, PendingPeek, DEFAULT_LOGICAL_COMPACTION_WINDOW_MS};
+    use crate::coord::{PeekResponseUnary, PendingPeek};
     use crate::AdapterError;
 
     #[derive(Debug)]
@@ -6464,7 +6464,9 @@ pub mod fast_path_peek {
                     self.initialize_compute_read_policies(
                         output_ids,
                         compute_instance,
-                        DEFAULT_LOGICAL_COMPACTION_WINDOW_MS,
+                        // Disable compaction by using None as the compaction window so that nothing
+                        // can compact before the peek occurs below.
+                        None,
                     )
                     .await;
 


### PR DESCRIPTION
For peeks that must create a dataflow, ensure they are not compacted
before peek is called by disabling compaction on them. Although this
seems like a latent race condition, because the compute controller is
not its own thread, no compaction was able to take place.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
