### PR TITLE
repr: Add `Self::Context` to `Display$Format` types

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4586,7 +4586,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: Default::default(),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut raw_plan).explain(&format, &config, &context)?
@@ -4598,7 +4600,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: Default::default(),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut model).explain(&format, &config, &context)?
@@ -4611,7 +4615,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: Default::default(),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut model).explain(&format, &config, &context)?
@@ -4625,7 +4631,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: Default::default(),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut dataflow).explain(&format, &config, &context)?
@@ -4639,7 +4647,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: Default::default(),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut dataflow).explain(&format, &config, &context)?
@@ -4658,7 +4668,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: Default::default(),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut dataflow_plan).explain(&format, &config, &context)?

--- a/src/adapter/src/explain_new/common.rs
+++ b/src/adapter/src/explain_new/common.rs
@@ -34,7 +34,6 @@ use mz_expr::explain::{Indices, ViewExplanation};
 use mz_expr::{ExprHumanizer, OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
-use mz_repr::explain_new::{DisplayJson, DisplayText, Explain, UnsupportedFormat};
 use mz_repr::GlobalId;
 use mz_storage::client::transforms::LinearOperator;
 
@@ -233,100 +232,6 @@ impl<'a> ViewFormatter<OptimizedMirRelationExpr> for DataflowGraphFormatter<'a> 
         }
         fmt::Display::fmt(&explain, f)
     }
-}
-
-pub struct ExplainContext<'a> {
-    used_indexes: Vec<GlobalId>,
-    // TODO: uncomment when fast_path_peek has been moved outside of coord.rs
-    //fast_path_plan: Option<fast_path_peek::Plan>,
-    row_set_finishing: Option<RowSetFinishing>,
-    humanizer: &'a dyn ExprHumanizer,
-}
-
-impl<'a> Explain<'a> for ExplainContext<'a> {
-    type Context = ();
-
-    type Text = ContextExplanation;
-
-    type Json = ContextExplanation;
-
-    type Dot = UnsupportedFormat;
-
-    fn explain_text(
-        & mut self,
-        _config: & mz_repr::explain_new::ExplainConfig,
-        _context: & Self::Context,
-    ) -> Result<Self::Text, mz_repr::explain_new::ExplainError> {
-        self.generate_context_explanation()
-    }
-
-    fn explain_json(
-        & mut self,
-        _config: & mz_repr::explain_new::ExplainConfig,
-        _context: & Self::Context,
-    ) -> Result<Self::Json, mz_repr::explain_new::ExplainError> {
-        self.generate_context_explanation()
-    }
-}
-
-impl ExplainContext<'_> {
-    fn generate_context_explanation(
-        &mut self,
-    ) -> Result<ContextExplanation, mz_repr::explain_new::ExplainError> {
-        let used_indexes_names = self
-            .used_indexes
-            .iter()
-            .map(|id| {
-                self.humanizer
-                    .humanize_id(*id)
-                    .unwrap_or_else(|| id.to_string())
-            })
-            .collect();
-        Ok(ContextExplanation {
-            used_indexes_names,
-            row_set_finishing: self.row_set_finishing.clone(),
-        })
-    }
-}
-
-pub struct ContextExplanation {
-    used_indexes_names: Vec<String>,
-    row_set_finishing: Option<RowSetFinishing>,
-}
-
-impl DisplayText for ContextExplanation {
-    fn fmt_text(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-    }
-}
-
-impl DisplayJson for ContextExplanation {
-    fn fmt_json(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!()
-    }
-}
-
-pub struct SinglePlan<T> {
-    plan: T,
-    // TODO: uncomment this when we want to restore support for typed
-    // somewhat hacky, based on pre-order of the items in the plans
-    // annotations: HashMap<usize, Attributes>
-}
-
-pub struct ExplainSinglePlan<T> {
-    context: ContextExplanation,
-    single_plan: SinglePlan<T>,
-}
-
-pub struct ExplainMultiPlan<T> {
-    context: ContextExplanation,
-    // Maps the names of the sources to the linear operators that will be
-    // on them.
-    // TODO: implement DisplayText and DisplayJson for LinearOperator
-    // there are plans to replace LinearOperator with MFP struct (#6657)
-    sources: Vec<(String, LinearOperator)>,
-    // elements of the vector are in topological order
-    plans: Vec<SinglePlan<T>>,
 }
 
 /// Information used when determining the timestamp for a query.

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -510,7 +510,8 @@ impl<'a> HirRelationExprExplanation<'a> {
 }
 
 impl<'a> DisplayText for HirRelationExprExplanation<'a> {
-    fn fmt_text(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    type Context = ();
+    fn fmt_text(&self, _ctx: &mut Self::Context, f: &mut fmt::Formatter) -> fmt::Result {
         let mut prev_chain = u64::max_value();
         for node in &self.nodes {
             if node.chain != prev_chain {

--- a/src/adapter/src/explain_new/lir/json.rs
+++ b/src/adapter/src/explain_new/lir/json.rs
@@ -9,6 +9,7 @@
 
 //! JSON format `EXPLAIN` support for `Lir~` structures.
 
+use std::fmt;
 use std::fmt::Display;
 
 use mz_compute_client::plan::Plan;
@@ -17,7 +18,8 @@ use mz_repr::explain_new::DisplayJson;
 use crate::explain_new::common::{Explanation, JsonViewFormatter};
 
 impl<'a> DisplayJson for Explanation<'a, JsonViewFormatter, Plan> {
-    fn fmt_json(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    type Context = ();
+    fn fmt_json(&self, _ctx: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt(f)
     }
 }

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -9,6 +9,7 @@
 
 //! `EXPLAIN` support for `Mir` structures.
 
+use std::fmt;
 use std::fmt::Display;
 
 use mz_expr::OptimizedMirRelationExpr;
@@ -17,7 +18,8 @@ use mz_repr::explain_new::DisplayText;
 use crate::explain_new::common::{DataflowGraphFormatter, Explanation};
 
 impl<'a> DisplayText for Explanation<'a, DataflowGraphFormatter<'a>, OptimizedMirRelationExpr> {
-    fn fmt_text(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    type Context = ();
+    fn fmt_text(&self, _ctx: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt(f)
     }
 }

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -16,7 +16,17 @@
 //! the various IRs live, this is not possible. Consequencly, we
 //! currently resort to using a wrapper type.
 
+use std::collections::HashMap;
+use std::fmt;
+
 use mz_expr::{ExprHumanizer, RowSetFinishing};
+use mz_repr::{
+    explain_new::{DisplayText, Explain, Indent, UnsupportedFormat},
+    GlobalId,
+};
+use mz_storage::client::transforms::LinearOperator;
+
+use crate::coord::fast_path_peek;
 
 pub(crate) mod common;
 pub(crate) mod hir;
@@ -39,5 +49,66 @@ impl<'a, T> Explainable<'a, T> {
 #[derive(Debug)]
 pub struct ExplainContext<'a> {
     pub humanizer: &'a dyn ExprHumanizer,
+    pub used_indexes: Vec<GlobalId>,
     pub finishing: Option<RowSetFinishing>,
+    pub fast_path_plan: Option<fast_path_peek::Plan>,
+}
+
+pub struct Attributes;
+
+/// A somewhat hacky way to annotate the nodes of a plan with
+/// arbitrary attributes based on the pre-order of the items
+/// in the associated plan.
+pub struct AnnotatedPlan<T> {
+    pub plan: T,
+    pub annotations: HashMap<usize, Attributes>,
+}
+
+pub struct ExplainSinglePlan<'a, T> {
+    pub context: ExplainContext<'a>,
+    pub plan: AnnotatedPlan<T>,
+}
+
+impl<'a, T> DisplayText for ExplainSinglePlan<'a, T>
+where
+    T: DisplayText,
+{
+    type Context = ();
+
+    fn fmt_text(&self, _: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut indent = Indent::default();
+
+        self.context.finishing.fmt_text(&mut indent, f)?;
+        // self.plans.fmt_text(..., f)?;
+        // self.context.used_indexes.fmt_text(..., f)?;
+        Ok(())
+    }
+}
+
+pub struct ExplainMultiPlan<'a, T> {
+    pub context: ExplainContext<'a>,
+    // Maps the names of the sources to the linear operators that will be
+    // on them.
+    // TODO: implement DisplayText and DisplayJson for LinearOperator
+    // there are plans to replace LinearOperator with MFP struct (#6657)
+    pub sources: Vec<(String, LinearOperator)>,
+    // elements of the vector are in topological order
+    pub plans: Vec<AnnotatedPlan<T>>,
+}
+
+impl<'a, T> DisplayText for ExplainMultiPlan<'a, T>
+where
+    T: DisplayText,
+{
+    type Context = ();
+
+    fn fmt_text(&self, _: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut indent = Indent::default();
+
+        self.context.finishing.fmt_text(&mut indent, f)?;
+        // self.plans.fmt_text(..., f)?;
+        // self.sources.used_indexes.fmt_text(..., f)?;
+        // self.context.used_indexes.fmt_text(..., f)?;
+        Ok(())
+    }
 }

--- a/src/adapter/src/explain_new/qgm/dot.rs
+++ b/src/adapter/src/explain_new/qgm/dot.rs
@@ -9,6 +9,8 @@
 
 //! DOT format `EXPLAIN` support for `QGM` structures.
 
+use std::fmt;
+
 use mz_repr::explain_new::DisplayDot;
 
 /// A very naive way of representing a
@@ -38,7 +40,8 @@ impl From<String> for ModelDotExplanation {
 }
 
 impl DisplayDot for ModelDotExplanation {
-    fn fmt_dot(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    type Context = ();
+    fn fmt_dot(&self, _ctx: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0)
     }
 }

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -105,6 +105,21 @@ where
     }
 }
 
+impl<A> DisplayText for Option<A>
+where
+    A: DisplayText,
+{
+    type Context = A::Context;
+
+    fn fmt_text(&self, ctx: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(val) = self {
+            val.fmt_text(ctx, f)
+        } else {
+            fmt::Result::Ok(())
+        }
+    }
+}
+
 /// A trait implemented by explanation types that can be rendered as
 /// [`ExplainFormat::Json`].
 pub trait DisplayJson
@@ -118,6 +133,21 @@ where
 
     fn str_json(&self) -> String {
         Explanation::<'_, UnsupportedFormat, Self, UnsupportedFormat>::Json(self).to_string()
+    }
+}
+
+impl<A> DisplayJson for Option<A>
+where
+    A: DisplayText,
+{
+    type Context = A::Context;
+
+    fn fmt_json(&self, ctx: &mut Self::Context, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(val) = self {
+            val.fmt_text(ctx, f)
+        } else {
+            fmt::Result::Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
The `fmt_$format` might need to share and modify some context that asserts that a sub-part (such as a field) is rendered correctly within the enclosing parent.

To achieve that, I propose to add an associated type called `Context` which implements `Default` to each `Display$Format` trait.

Generic implementations of the form

```rust
impl<T, U> Explain$Format for T<U> where U: Explain$Format`
```

might use additional bounds such as

```rust
T::Context: AsRef<U::Context>
```

in order to pass along the context from `T` to `U`.

### Motivation

  * This PR adds a feature that has not yet been specified.

We will need to do this as part of the migration to new top-level `Explain` structs with generic implementations.

### Tips for reviewer

I'm happy to keep this open for now and merge it once we actually need it (which should be quite soon). We can even use this as a basis for discussion and then cherry-pick as part of a bigger PR if we agree on the approach.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A