### PR TITLE
Add common explanation structures

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -31,12 +31,12 @@ use mz_compute_client::logging::LoggingConfig as DataflowLoggingConfig;
 use mz_controller::{
     ComputeInstanceEvent, ComputeInstanceReplicaAllocation, ConcreteComputeInstanceReplicaConfig,
 };
-use mz_expr::{ExprHumanizer, MirScalarExpr, OptimizedMirRelationExpr};
+use mz_expr::{MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{to_datetime, EpochMillis, NowFn};
 use mz_pgrepr::oid::FIRST_USER_OID;
-use mz_repr::{Diff, GlobalId, RelationDesc, ScalarType};
+use mz_repr::{explain_new::ExprHumanizer, Diff, GlobalId, RelationDesc, ScalarType};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Expr;
 use mz_sql::catalog::{

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -105,7 +105,7 @@ use mz_controller::{
     ComputeInstanceEvent, ConcreteComputeInstanceReplicaConfig, ControllerResponse,
 };
 use mz_expr::{
-    permutation_for_arrangement, CollectionPlan, ExprHumanizer, MirRelationExpr, MirScalarExpr,
+    permutation_for_arrangement, CollectionPlan, MirRelationExpr, MirScalarExpr,
     OptimizedMirRelationExpr, RowSetFinishing,
 };
 use mz_ore::metrics::MetricsRegistry;
@@ -115,6 +115,7 @@ use mz_ore::thread::JoinHandleExt;
 use mz_ore::{stack, task};
 use mz_repr::adt::interval::Interval;
 use mz_repr::adt::numeric::{Numeric, NumericMaxScale};
+use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::{
     Datum, Diff, GlobalId, RelationDesc, RelationType, Row, RowArena, ScalarType, Timestamp,
 };

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -165,7 +165,7 @@ use crate::command::{
 use crate::coord::dataflow_builder::{prep_relation_expr, prep_scalar_expr, ExprPrepStyle};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::error::AdapterError;
-use crate::explain_new::{ExplainContext, Explainable};
+use crate::explain_new::{ExplainContext, Explainable, UsedIndexes};
 use crate::session::{
     EndTransactionAction, PreparedStatement, Session, TransactionOps, TransactionStatus, WriteOp,
 };
@@ -4531,7 +4531,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut raw_plan).explain(&format, &config, &context)?
@@ -4543,7 +4545,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut model).explain(&format, &config, &context)?
@@ -4556,7 +4560,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut model).explain(&format, &config, &context)?
@@ -4570,7 +4576,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut dataflow).explain(&format, &config, &context)?
@@ -4584,7 +4592,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut dataflow).explain(&format, &config, &context)?
@@ -4603,7 +4613,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
                     humanizer: &catalog,
+                    used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
+                    fast_path_plan: Default::default(),
                 };
                 // explain plan
                 Explainable::new(&mut dataflow_plan).explain(&format, &config, &context)?

--- a/src/adapter/src/explain_new/common.rs
+++ b/src/adapter/src/explain_new/common.rs
@@ -30,14 +30,14 @@
 
 use std::fmt;
 
+use mz_compute_client::command::DataflowDescription;
 use mz_expr::explain::{Indices, ViewExplanation};
-use mz_expr::{ExprHumanizer, OptimizedMirRelationExpr, RowSetFinishing};
+use mz_expr::{OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
+use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::GlobalId;
 use mz_storage::client::transforms::LinearOperator;
-
-use mz_compute_client::command::DataflowDescription;
 
 pub trait ViewFormatter<ViewExpr> {
     fn fmt_source_body(&self, f: &mut fmt::Formatter, operator: &LinearOperator) -> fmt::Result;

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -13,11 +13,11 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use mz_expr::explain::Indices;
-use mz_expr::{ExprHumanizer, Id, LocalId, RowSetFinishing};
+use mz_expr::{Id, LocalId, RowSetFinishing};
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::IdGen;
 use mz_ore::str::{bracketed, separated};
-use mz_repr::explain_new::{text_string, DisplayText};
+use mz_repr::explain_new::{text_string, DisplayText, ExprHumanizer};
 use mz_repr::{RelationType, ScalarType};
 use mz_sql::plan::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
 

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -17,7 +17,7 @@ use mz_expr::{ExprHumanizer, Id, LocalId, RowSetFinishing};
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::IdGen;
 use mz_ore::str::{bracketed, separated};
-use mz_repr::explain_new::DisplayText;
+use mz_repr::explain_new::{text_string, DisplayText};
 use mz_repr::{RelationType, ScalarType};
 use mz_sql::plan::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
 
@@ -389,7 +389,7 @@ impl<'a> HirRelationExprExplanation<'a> {
         }
 
         for subquery in &node.subqueries {
-            for line in subquery.str_text().split('\n') {
+            for line in text_string(subquery).split('\n') {
                 if line.is_empty() {
                     writeln!(f, "| |")?;
                 } else {
@@ -510,7 +510,7 @@ impl<'a> HirRelationExprExplanation<'a> {
 }
 
 impl<'a> DisplayText for HirRelationExprExplanation<'a> {
-    fn fmt_text(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt_text(&self, f: &mut fmt::Formatter, _ctx: &mut ()) -> fmt::Result {
         let mut prev_chain = u64::max_value();
         for node in &self.nodes {
             if node.chain != prev_chain {

--- a/src/adapter/src/explain_new/lir/json.rs
+++ b/src/adapter/src/explain_new/lir/json.rs
@@ -9,6 +9,7 @@
 
 //! JSON format `EXPLAIN` support for `Lir~` structures.
 
+use std::fmt;
 use std::fmt::Display;
 
 use mz_compute_client::plan::Plan;
@@ -16,8 +17,8 @@ use mz_repr::explain_new::DisplayJson;
 
 use crate::explain_new::common::{Explanation, JsonViewFormatter};
 
-impl<'a> DisplayJson for Explanation<'a, JsonViewFormatter, Plan> {
-    fn fmt_json(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<'a> DisplayJson<()> for Explanation<'a, JsonViewFormatter, Plan> {
+    fn fmt_json(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         self.fmt(f)
     }
 }

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -9,6 +9,7 @@
 
 //! `EXPLAIN` support for `Mir` structures.
 
+use std::fmt;
 use std::fmt::Display;
 
 use mz_expr::OptimizedMirRelationExpr;
@@ -17,7 +18,7 @@ use mz_repr::explain_new::DisplayText;
 use crate::explain_new::common::{DataflowGraphFormatter, Explanation};
 
 impl<'a> DisplayText for Explanation<'a, DataflowGraphFormatter<'a>, OptimizedMirRelationExpr> {
-    fn fmt_text(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         self.fmt(f)
     }
 }

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -97,10 +97,10 @@ impl<'a, T: 'a> DisplayText<()> for ExplainSinglePlan<'a, T>
 where
     Explainable<'a, T>: DisplayText,
 {
-    fn fmt_text(&self, _f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         // TODO (#13472)
-        // let mut context = ...
-        // self.context.finishing.fmt_text(&mut context, f)?;
+        let mut context = Default::default();
+        self.context.finishing.fmt_text(f, &mut context)?;
         // writeln!(f, "")?;
         // self.plan.fmt_text(..., f)?;
         // writeln!(f, "")?;
@@ -129,10 +129,10 @@ impl<'a, T: 'a> DisplayText<()> for ExplainMultiPlan<'a, T>
 where
     Explainable<'a, T>: DisplayText,
 {
-    fn fmt_text(&self, _f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         // TODO (#13472)
-        // let mut context = ...
-        // self.context.finishing.fmt_text(..., f)?;
+        let mut context = Default::default();
+        self.context.finishing.fmt_text(f, &mut context)?;
         // writeln!(f, "")?;
         // self.plans.fmt_text(..., f)?;
         // writeln!(f, "")?;

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -19,8 +19,9 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use mz_expr::{ExprHumanizer, RowSetFinishing};
-use mz_repr::{explain_new::DisplayText, GlobalId};
+use mz_expr::RowSetFinishing;
+use mz_repr::explain_new::{DisplayText, ExprHumanizer};
+use mz_repr::GlobalId;
 use mz_storage::client::transforms::LinearOperator;
 
 use crate::coord::fast_path_peek;

--- a/src/adapter/src/explain_new/qgm/dot.rs
+++ b/src/adapter/src/explain_new/qgm/dot.rs
@@ -9,6 +9,8 @@
 
 //! DOT format `EXPLAIN` support for `QGM` structures.
 
+use std::fmt;
+
 use mz_repr::explain_new::DisplayDot;
 
 /// A very naive way of representing a
@@ -37,8 +39,8 @@ impl From<String> for ModelDotExplanation {
     }
 }
 
-impl DisplayDot for ModelDotExplanation {
-    fn fmt_dot(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl DisplayDot<()> for ModelDotExplanation {
+    fn fmt_dot(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         f.write_str(&self.0)
     }
 }

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -31,9 +31,10 @@
 use std::fmt;
 
 use mz_expr::explain::{Indices, ViewExplanation};
-use mz_expr::{ExprHumanizer, OptimizedMirRelationExpr, RowSetFinishing};
+use mz_expr::{OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
+use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::GlobalId;
 use mz_storage::client::transforms::LinearOperator;
 

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -14,12 +14,11 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use mz_expr::explain::ViewExplanation;
-use mz_expr::{
-    DummyHumanizer, EvalError, ExprHumanizer, Id, LocalId, MirRelationExpr, MirScalarExpr,
-};
+use mz_expr::{EvalError, Id, LocalId, MirRelationExpr, MirScalarExpr};
 use mz_lowertest::*;
 use mz_ore::result::ResultExt;
 use mz_ore::str::separated;
+use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{ColumnType, GlobalId, RelationType, Row, ScalarType};
 use mz_repr_test_util::*;
 

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -29,9 +29,10 @@ use std::fmt;
 use std::iter;
 
 use mz_ore::str::{bracketed, separated, StrExt};
+use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::RelationType;
 
-use crate::{ExprHumanizer, Id, JoinImplementation, LocalId, MirRelationExpr};
+use crate::{Id, JoinImplementation, LocalId, MirRelationExpr};
 
 /// An `ViewExplanation` facilitates pretty-printing of a [`MirRelationExpr`].
 ///

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -12,12 +12,11 @@
 #![warn(missing_debug_implementations)]
 
 use std::collections::BTreeSet;
-use std::fmt;
 use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 
-use mz_repr::{ColumnType, GlobalId, ScalarType};
+use mz_repr::GlobalId;
 
 mod id;
 mod linear;
@@ -88,45 +87,5 @@ impl Deref for OptimizedMirRelationExpr {
 impl CollectionPlan for OptimizedMirRelationExpr {
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         self.0.depends_on_into(out)
-    }
-}
-
-/// A trait for humanizing components of an expression.
-pub trait ExprHumanizer: fmt::Debug {
-    /// Attempts to return the a human-readable string for the relation
-    /// identified by `id`.
-    fn humanize_id(&self, id: GlobalId) -> Option<String>;
-
-    /// Returns a human-readable name for the specified scalar type.
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String;
-
-    /// Returns a human-readable name for the specified scalar type.
-    fn humanize_column_type(&self, typ: &ColumnType) -> String {
-        format!(
-            "{}{}",
-            self.humanize_scalar_type(&typ.scalar_type),
-            if typ.nullable { "?" } else { "" }
-        )
-    }
-}
-
-/// A bare-minimum implementation of [`ExprHumanizer`].
-///
-/// The `DummyHumanizer` does a poor job of humanizing expressions. It is
-/// intended for use in contexts where polish is not required, like in tests or
-/// while debugging.
-#[derive(Debug)]
-pub struct DummyHumanizer;
-
-impl ExprHumanizer for DummyHumanizer {
-    fn humanize_id(&self, _: GlobalId) -> Option<String> {
-        // Returning `None` allows the caller to fall back to displaying the
-        // ID, if they so desire.
-        None
-    }
-
-    fn humanize_scalar_type(&self, ty: &ScalarType) -> String {
-        // The debug implementation is better than nothing.
-        format!("{:?}", ty)
     }
 }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -15,6 +15,8 @@ use std::fmt;
 use std::num::NonZeroUsize;
 
 use itertools::Itertools;
+use mz_ore::str::{bracketed, separated, Indent};
+use mz_repr::explain_new::DisplayText;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -1960,6 +1962,34 @@ pub struct RowSetFinishing {
     pub project: Vec<usize>,
 }
 
+impl DisplayText<Indent> for RowSetFinishing {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut Indent) -> fmt::Result {
+        writeln!(f, "{}row_set_finishing:", ctx)?;
+        *ctx += 1;
+        // order by
+        if !self.order_by.is_empty() {
+            let order_by = bracketed("[", "]", separated(",", &self.order_by));
+            writeln!(f, "{}order_by: {}", ctx, order_by)?;
+        }
+        // limit
+        if let Some(limit) = self.limit {
+            writeln!(f, "{}limit: {}", ctx, limit)?;
+        }
+        // offset
+        if self.offset > 0 {
+            writeln!(f, "{}offset: {}", ctx, self.offset)?;
+        }
+        // project
+        {
+            // TODO: add an option for column ranges?
+            let project = bracketed("[", "]", separated(",", &self.project));
+            writeln!(f, "{}output: {}", ctx, project)?;
+        }
+        *ctx -= 1;
+        Ok(())
+    }
+}
+
 impl RustType<ProtoRowSetFinishing> for RowSetFinishing {
     fn into_proto(&self) -> ProtoRowSetFinishing {
         ProtoRowSetFinishing {
@@ -2319,6 +2349,7 @@ impl RustType<proto_window_frame::ProtoWindowFrameBound> for WindowFrameBound {
 mod tests {
     use super::*;
     use mz_proto::protobuf_roundtrip;
+    use mz_repr::explain_new::text_string_at;
     use proptest::prelude::*;
 
     proptest! {
@@ -2364,5 +2395,33 @@ mod tests {
             assert!(actual.is_ok());
             assert_eq!(actual.unwrap(), expect);
         }
+    }
+
+    #[test]
+    fn test_row_set_finishing_as_text() {
+        let finishing = RowSetFinishing {
+            order_by: vec![ColumnOrder {
+                column: 4,
+                desc: true,
+                nulls_last: true,
+            }],
+            limit: Some(7),
+            offset: Default::default(),
+            project: vec![1, 3, 5],
+        };
+
+        let act = text_string_at(&finishing, Indent::default);
+
+        let exp = {
+            use mz_ore::fmt::FormatBuffer;
+            let mut s = String::new();
+            writeln!(&mut s, "row_set_finishing:");
+            writeln!(&mut s, "  order_by: [#4 desc nulls_last]");
+            writeln!(&mut s, "  limit: 7");
+            writeln!(&mut s, "  output: [1,3,5]");
+            s
+        };
+
+        assert_eq!(act, exp);
     }
 }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -24,15 +24,13 @@ use mz_ore::id_gen::IdGen;
 use mz_ore::stack::RecursionLimitError;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::numeric::NumericMaxScale;
+use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, RelationType, Row, ScalarType};
 
 use self::func::{AggregateFunc, LagLeadType, TableFunc};
 use crate::explain::ViewExplanation;
 use crate::visit::{Visit, VisitChildren};
-use crate::{
-    func as scalar_func, DummyHumanizer, EvalError, ExprHumanizer, Id, LocalId, MirScalarExpr,
-    UnaryFunc, VariadicFunc,
-};
+use crate::{func as scalar_func, EvalError, Id, LocalId, MirScalarExpr, UnaryFunc, VariadicFunc};
 
 pub mod canonicalize;
 pub mod func;

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -32,6 +32,8 @@
 
 use std::{collections::HashSet, fmt};
 
+use mz_ore::str::Indent;
+
 use crate::{ColumnType, GlobalId, ScalarType};
 
 /// Wraps a reference to a type that implements `Display$Format` for a specific
@@ -405,60 +407,18 @@ pub trait Explain<'a>: 'a {
     }
 }
 
-<<<<<<< HEAD
-=======
-/// A helper struct to keep track of indentation levels.
-///
-/// This will be most often used as part of the rendering context
-/// type for various `Display$Format` implementation.
+/// A helper struct which will most commonly be used as the generic
+/// rendering context type `C` for various `Explain$Format`
+/// implementations.
 #[derive(Debug)]
-pub struct Indent {
-    unit: String,
-    buff: String,
+pub struct RenderingContext<'a> {
+    pub indent: Indent,
+    pub humanizer: &'a dyn ExprHumanizer,
 }
 
-impl Indent {
-    pub fn new(unit: char, step: usize) -> Indent {
-        Indent {
-            unit: std::iter::repeat(unit).take(step).collect::<String>(),
-            buff: String::with_capacity(unit.len_utf8()),
-        }
-    }
-
-    fn inc(&mut self, rhs: usize) {
-        for _ in 0..rhs {
-            self.buff += &self.unit;
-        }
-    }
-
-    fn dec(&mut self, rhs: usize) {
-        let tail = rhs.saturating_mul(self.unit.len());
-        let head = self.buff.len().saturating_sub(tail);
-        self.buff.truncate(head);
-    }
-}
-
-impl Default for Indent {
-    fn default() -> Self {
-        Indent::new(' ', 2)
-    }
-}
-
-impl std::ops::AddAssign<usize> for Indent {
-    fn add_assign(&mut self, rhs: usize) {
-        self.inc(rhs)
-    }
-}
-
-impl std::ops::SubAssign<usize> for Indent {
-    fn sub_assign(&mut self, rhs: usize) {
-        self.dec(rhs)
-    }
-}
-
-impl fmt::Display for Indent {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.buff)
+impl<'a> RenderingContext<'a> {
+    pub fn new(indent: Indent, humanizer: &'a dyn ExprHumanizer) -> RenderingContext {
+        RenderingContext { indent, humanizer }
     }
 }
 
@@ -505,7 +465,6 @@ impl ExprHumanizer for DummyHumanizer {
     }
 }
 
->>>>>>> 00f828a47... repr: move `ExprHumanizer` to the `explain-new` module
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -117,6 +117,19 @@ impl<T: DisplayText<C>, C, F: Fn() -> C> DisplayText<()> for DisplayWithContext<
     }
 }
 
+impl<A, C> DisplayText<C> for Option<A>
+where
+    A: DisplayText<C>,
+{
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
+        if let Some(val) = self {
+            val.fmt_text(f, ctx)
+        } else {
+            fmt::Result::Ok(())
+        }
+    }
+}
+
 /// A trait implemented by explanation types that can be rendered as
 /// [`ExplainFormat::Json`].
 pub trait DisplayJson<C = ()>
@@ -141,6 +154,19 @@ impl<T: DisplayJson<C>, C, F: Fn() -> C> DisplayJson<()> for DisplayWithContext<
     }
 }
 
+impl<A, C> DisplayJson<C> for Option<A>
+where
+    A: DisplayText<C>,
+{
+    fn fmt_json(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
+        if let Some(val) = self {
+            val.fmt_text(f, ctx)
+        } else {
+            fmt::Result::Ok(())
+        }
+    }
+}
+
 /// A trait implemented by explanation types that can be rendered as
 /// [`ExplainFormat::Dot`].
 pub trait DisplayDot<C = ()>
@@ -162,6 +188,19 @@ impl<T: DisplayDot<C>, C, F: Fn() -> C> DisplayDot<()> for DisplayWithContext<'_
     fn fmt_dot(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         let mut ctx = (self.f)();
         self.t.fmt_dot(f, &mut ctx)
+    }
+}
+
+impl<A, C> DisplayDot<C> for Option<A>
+where
+    A: DisplayDot<C>,
+{
+    fn fmt_dot(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
+        if let Some(val) = self {
+            val.fmt_dot(f, ctx)
+        } else {
+            fmt::Result::Ok(())
+        }
     }
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -23,8 +23,9 @@ use once_cell::sync::Lazy;
 
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
 use mz_compute_client::controller::ComputeInstanceId;
-use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
+use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
+use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
 use mz_sql_parser::ast::Expr;
 use mz_storage::client::connections::Connection;

--- a/src/sql/src/plan/explain.rs
+++ b/src/sql/src/plan/explain.rs
@@ -22,11 +22,11 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 
 use mz_expr::explain::Indices;
-use mz_expr::{ExprHumanizer, Id, LocalId, RowSetFinishing};
+use mz_expr::{Id, LocalId, RowSetFinishing};
 use mz_ore::collections::CollectionExt;
 use mz_ore::id_gen::IdGen;
 use mz_ore::str::{bracketed, separated};
-use mz_repr::{RelationType, ScalarType};
+use mz_repr::{explain_new::ExprHumanizer, RelationType, ScalarType};
 
 use crate::plan::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
 

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -19,12 +19,11 @@ use std::mem;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use mz_expr::DummyHumanizer;
-
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::numeric::NumericMaxScale;
+use mz_repr::explain_new::DummyHumanizer;
 use mz_repr::*;
 
 use crate::plan::error::PlanError;

--- a/src/sql/src/query_model/dot.rs
+++ b/src/sql/src/query_model/dot.rs
@@ -16,8 +16,8 @@ use crate::query_model::model::{
 };
 use crate::query_model::Model;
 use itertools::Itertools;
-use mz_expr::ExprHumanizer;
 use mz_ore::str::separated;
+use mz_repr::explain_new::ExprHumanizer;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::{self, Write};
 

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -18,9 +18,10 @@ use uuid::Uuid;
 
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_compute_client::controller::ComputeInstanceId;
-use mz_expr::{DummyHumanizer, ExprHumanizer, MirScalarExpr};
+use mz_expr::MirScalarExpr;
 use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
+use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
 use mz_storage::client::connections::Connection;
 use mz_storage::client::sources::SourceDesc;


### PR DESCRIPTION
Posting what I have so far.

### Motivation

This is a major step towards closing #13472.

- Adds common structures that from which different formats of explanations will be generated from: 41c70b5b1.
- Reworks the `Explain` API so `Display$Format` can have their own mutable rendering context type `C`: 0c1b3252e, 6408fe261. This defaults to `()` for formats that don't need a rendering context. 
- Common utilities that can be part of the rendering context are added added and consolidated as part of `mz_repr::explain_new`: 6279a3902, bbc1ae4d2, 2d52a62a1.
- As an example, this PR also implements `ExplainText` for `RowSetFinishing`: 540c618a7.

### Tips for reviewer

- 0c1b3252e adds `C` parameter to `Display$Format` types.
- 6408fe261 adds blanket `Display$Format` implementations for `Option<A>`.
- 6279a3902 adds `Indent` utility for rendering contexts.
- 41c70b5b1 adds common explanation structs.
- bbc1ae4d2 moves `ExprHumanizer` to the `explain_new` module.
- 2d52a62a1 adds `RenderingContext` helper struct.
- 540c618a7 implements `ExplainText` for `RowSetFinishing`.

### Testing

Tested manually for now. We will move to the new format and rewrite the `*.slt` tests in `test/sqllogictest/explain` in the next commits, which will rework the legacy code in `adapter::explain_new::{hir, lir, mir, qgm}`.

### Release notes

No user facing behavior changes. New features will be documented as part of the wrap-up phase of the enclosing epic.
