### PR TITLE
persist: remove deadline arguments in Blob and Consensus

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -426,7 +426,6 @@ mod tests {
     use std::pin::Pin;
     use std::str::FromStr;
     use std::task::Context;
-    use std::time::{Duration, Instant};
 
     use differential_dataflow::consolidation::consolidate_updates;
     use futures_task::noop_waker;
@@ -502,9 +501,8 @@ mod tests {
         T: Codec64,
         D: Codec64,
     {
-        let deadline = Instant::now() + Duration::from_secs(1_000_000_000);
         let value = blob
-            .get(deadline, key)
+            .get(key)
             .await
             .expect("failed to fetch part")
             .expect("missing part");

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -13,7 +13,7 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::{Instant, SystemTime};
+use std::time::SystemTime;
 
 use anyhow::anyhow;
 use differential_dataflow::difference::Semigroup;
@@ -35,7 +35,7 @@ use mz_persist_types::{Codec, Codec64};
 
 use crate::error::InvalidUsage;
 use crate::r#impl::encoding::SerdeSnapshotSplit;
-use crate::r#impl::machine::{retry_external, Machine, FOREVER};
+use crate::r#impl::machine::{retry_external, Machine};
 use crate::r#impl::metrics::Metrics;
 use crate::r#impl::state::Since;
 use crate::ShardId;
@@ -625,7 +625,7 @@ pub(crate) async fn fetch_batch_part<T, UpdateFn>(
     let get_span = debug_span!("fetch_batch::get");
     let value = loop {
         let value = retry_external(&metrics.retries.external.fetch_batch_get, || async {
-            blob.get(Instant::now() + FOREVER, key).await
+            blob.get(key).await
         })
         .instrument(get_span.clone())
         .await;
@@ -633,8 +633,7 @@ pub(crate) async fn fetch_batch_part<T, UpdateFn>(
             Some(x) => break x,
             // If the underlying impl of blob isn't linearizable, then we
             // might get a key reference that that blob isn't returning yet.
-            // Keep trying, it'll show up. The deadline will eventually bail
-            // us out of this loop if something has gone wrong internally.
+            // Keep trying, it'll show up.
             None => {
                 // This is quite unexpected given that our initial blobs _are_
                 // linearizable, so always log at info.

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -547,9 +547,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Instant;
-
-    use crate::r#impl::machine::FOREVER;
     use crate::tests::new_test_client;
     use crate::ShardId;
 
@@ -576,21 +573,14 @@ mod tests {
         write.expect_append(&data[..2], vec![0], vec![upper]).await;
 
         // Write a bunch of empty batches. This shouldn't write blobs, so the count should stay the same.
-        let blob_count_before = blob
-            .list_keys(Instant::now() + FOREVER)
-            .await
-            .expect("list_keys failed")
-            .len();
+        let blob_count_before = blob.list_keys().await.expect("list_keys failed").len();
         for _ in 0..5 {
             let new_upper = upper + 1;
             write.expect_compare_and_append(&[], upper, new_upper).await;
             upper = new_upper;
         }
         assert_eq!(
-            blob.list_keys(Instant::now() + FOREVER)
-                .await
-                .expect("list_keys failed")
-                .len(),
+            blob.list_keys().await.expect("list_keys failed").len(),
             blob_count_before
         );
     }

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -11,7 +11,6 @@
 
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -59,7 +58,7 @@ impl FileBlob {
 
 #[async_trait]
 impl Blob for FileBlob {
-    async fn get(&self, _deadline: Instant, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError> {
         let file_path = self.blob_path(key);
         let mut file = match File::open(file_path).await {
             Ok(file) => file,
@@ -71,7 +70,7 @@ impl Blob for FileBlob {
         Ok(Some(buf))
     }
 
-    async fn list_keys(&self, _deadline: Instant) -> Result<Vec<String>, ExternalError> {
+    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
         let base_dir = self.base_dir.canonicalize()?;
         let mut ret = vec![];
 
@@ -108,13 +107,7 @@ impl Blob for FileBlob {
         Ok(ret)
     }
 
-    async fn set(
-        &self,
-        _deadline: Instant,
-        key: &str,
-        value: Bytes,
-        atomic: Atomicity,
-    ) -> Result<(), ExternalError> {
+    async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {
         let file_path = self.blob_path(key);
         match atomic {
             Atomicity::RequireAtomic => {
@@ -163,7 +156,7 @@ impl Blob for FileBlob {
         Ok(())
     }
 
-    async fn delete(&self, _deadline: Instant, key: &str) -> Result<(), ExternalError> {
+    async fn delete(&self, key: &str) -> Result<(), ExternalError> {
         let file_path = self.blob_path(key);
         // TODO: strict correctness requires that we fsync the parent directory
         // as well after file removal.


### PR DESCRIPTION
They're vestigial at this point. We long ago realized that this code
structure doesn't line up with what external services give us. In
particular neither of the drivers for our production impls of S3 nor
Aurora/CockroachDB offer a good way to hook this up. Also note that not
a single usage did anything other than an "infinite" timeout.

Instead we'll move to the standard "cancel-safe" aka "drop-is-cancel"
idiom of rust Futures. Propagating these cancellations to
S3/Aurora/CockroachDB is left for a followup. Similarly, nothing tests
cancel-safety at the persist API level (yet) and this commit also kicks
the can down the road on figuring out a way to test this (yet).

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
