### PR TITLE
*: add some tracing to debug peek performance

### DIFF
--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -170,6 +170,7 @@ impl<T> ActiveReplicationState<T>
 where
     T: Timestamp + Lattice,
 {
+    #[tracing::instrument(level = "debug", skip(self))]
     fn handle_command(
         &mut self,
         cmd: &ComputeCommand<T>,
@@ -466,6 +467,7 @@ where
     // it returns infallible values.
 
     /// Sends a command to all replicas.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub fn send(&mut self, cmd: ComputeCommand<T>) {
         let frontiers = self
             .replicas


### PR DESCRIPTION
Add some useful debug (enabled by default) traces around, skipping fields
that could have large data (i.e., peek response rows). Instead, move
those to event logs at the trace level so they can be selectively enabled.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a