### PR TITLE
storaged,computed,environmentd: enforce consistency on CLI flags

### DIFF
--- a/bin/cluster-dev
+++ b/bin/cluster-dev
@@ -33,7 +33,7 @@ metadata:
 data:
   schemas.sql: |
     CREATE SCHEMA consensus;
-    CREATE SCHEMA catalog;
+    CREATE SCHEMA adapter;
     CREATE SCHEMA storage;
 ---
 apiVersion: v1
@@ -138,17 +138,17 @@ spec:
       - name: environmentd
         image: $(bin/mzimage spec --dev environmentd)
         args:
+            - --unsafe-mode
+            - --orchestrator=kubernetes
+            - --orchestrator-kubernetes-service-label=materialize.cloud/example1=label1
+            - --orchestrator-kubernetes-service-label=materialize.cloud/example2=label2
+            - --orchestrator-kubernetes-image-pull-policy=never
+            - --persist-consensus-url=postgres://postgres@postgres.default?options=--search_path=consensus
+            - --persist-blob-url=file:///tmp/persist/blob
+            - --storage-stash-url=postgres://postgres@postgres.default?options=--search_path=storage
+            - --adapter-stash-url=postgres://postgres@postgres.default?options=--search_path=catalog
             - --storaged-image=$(bin/mzimage spec --dev storaged)
             - --computed-image=$(bin/mzimage spec --dev computed)
-            - --data-directory=/data
-            - --orchestrator=kubernetes
-            - --orchestrator-service-label=materialize.cloud/example1=label1
-            - --orchestrator-service-label=materialize.cloud/example2=label2
-            - --persist-consensus-url=postgres://postgres@postgres.default?options=--search_path=consensus
-            - --catalog-postgres-stash=postgres://postgres@postgres.default?options=--search_path=catalog
-            - --storage-postgres-stash=postgres://postgres@postgres.default?options=--search_path=storage
-            - --kubernetes-image-pull-policy=never
-            - --unsafe-mode
         ports:
         - containerPort: 6875
           name: sql

--- a/doc/user/content/get-started.md
+++ b/doc/user/content/get-started.md
@@ -30,10 +30,10 @@ Select an environment and follow the instructions to get the latest stable relea
 1. Open a terminal and spin up a container running [`materialized`](https://hub.docker.com/r/materialize/materialized):
 
     ```shell
-    docker run -p 6875:6875 materialize/materialized:{{< version >}} --workers 1
+    docker run -p 6875:6875 materialize/materialized:{{< version >}}
     ```
 
-    This starts a process using one [worker thread](/cli#worker-threads) and listening on port 6875 by default.
+    This starts a process that listens for SQL connections on port 6875 by default.
 
 1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI](/integrations/sql-clients), like `psql`. If you already have `psql` installed on your machine, connect using:
 
@@ -58,7 +58,7 @@ Select an environment and follow the instructions to get the latest stable relea
     materialized --workers 1
     ```
 
-    This starts a process using one [worker thread](/cli#worker-threads) and listening on port 6875 by default.
+    This starts a process that listens for SQL connections on port 6875 by default.
 
 1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI](/integrations/sql-clients), like `psql`. If you have `psql` installed on your machine, connect using:
 
@@ -87,10 +87,10 @@ Select an environment and follow the instructions to get the latest stable relea
 1. Once the installation is complete, you can start the `materialized` process:
 
     ```shell
-    materialized --workers 1
+    materialized
     ```
 
-    This starts a process using one [worker thread](/cli#worker-threads) and listening on port 6875 by default.
+    This starts a process that listens for SQL connections on port 6875 by default.
 
 1. Using a new terminal window, you can then connect to the running instance using any [Materialize-compatible CLI](/integrations/sql-clients), like `psql`. If you have `psql` installed on your machine, connect using:
 

--- a/doc/user/content/install.md
+++ b/doc/user/content/install.md
@@ -32,16 +32,7 @@ way. For example:
 docker run -p 6875:6875 materialize/materialized:{{< version >}}
 ```
 
-### Using Docker volumes
-
-To persist Materialize metadata, you can create a Docker volume and mount it to the [`/mzdata` directory](/cli/#data-directory) in the container:
-
-```shell
-# Create a volume
-docker volume create --name mzdata
-# Create a container with the volume mounted
-docker run -v mzdata:/mzdata -p 6875:6875 materialize/materialized:{{< version >}}
-```
+Note that Materialize's state does not outlive the container.
 
 ## Build from source
 

--- a/misc/images/materialized/entrypoint.sh
+++ b/misc/images/materialized/entrypoint.sh
@@ -14,8 +14,8 @@ set -euo pipefail
 pg_ctlcluster 14 materialize start
 
 psql -Atc "CREATE SCHEMA IF NOT EXISTS consensus"
-psql -Atc "CREATE SCHEMA IF NOT EXISTS catalog"
 psql -Atc "CREATE SCHEMA IF NOT EXISTS storage"
+psql -Atc "CREATE SCHEMA IF NOT EXISTS adapter"
 
 exec environmentd \
     --sql-listen-addr=0.0.0.0:6875 \
@@ -23,6 +23,6 @@ exec environmentd \
     --internal-sql-listen-addr=0.0.0.0:6877 \
     --internal-http-listen-addr=0.0.0.0:6878 \
     "--persist-consensus-url=postgresql://materialize@$(hostname):5432?options=--search_path=consensus" \
-    "--catalog-postgres-stash=postgresql://materialize@$(hostname):5432?options=--search_path=catalog" \
-    "--storage-postgres-stash=postgresql://materialize@$(hostname):5432?options=--search_path=storage" \
+    "--storage-stash-url=postgresql://materialize@$(hostname):5432?options=--search_path=storage" \
+    "--adapter-stash-url=postgresql://materialize@$(hostname):5432?options=--search_path=adapter" \
     "$@"

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -130,15 +130,16 @@ def main() -> int:
                     continue
             if args.reset:
                 print("Removing mzdata directory...")
-                shutil.rmtree("mzdata", ignore_errors=True)
-            for schema in ["consensus", "catalog", "storage"]:
+                shutil.rmtree(ROOT / "mzdata", ignore_errors=True)
+            for schema in ["consensus", "adapter", "storage"]:
                 if args.reset:
                     _run_sql(args.postgres, f"DROP SCHEMA IF EXISTS {schema} CASCADE")
                 _run_sql(args.postgres, f"CREATE SCHEMA IF NOT EXISTS {schema}")
             command += [
                 f"--persist-consensus-url={args.postgres}?options=--search_path=consensus",
-                f"--catalog-postgres-stash={args.postgres}?options=--search_path=catalog",
-                f"--storage-postgres-stash={args.postgres}?options=--search_path=storage",
+                f"--persist-blob-url=file://{ROOT}/mzdata/persist/blob",
+                f"--adapter-stash-url={args.postgres}?options=--search_path=adapter",
+                f"--storage-stash-url={args.postgres}?options=--search_path=storage",
             ]
         elif args.program == "sqllogictest":
             command += [f"--postgres-url={args.postgres}"]

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -86,7 +86,8 @@ class Materialized(Service):
             volumes.extend(volumes_extra)
 
         command_list = [
-            f"--data-directory={data_directory}",
+            f"--persist-blob-url=file://{data_directory}/persist/blob",
+            f"--orchestrator-process-data-directory={data_directory}",
         ]
 
         config_ports: List[Union[str, int]] = (
@@ -637,7 +638,7 @@ class Testdrive(Service):
 
         if validate_postgres_stash:
             entrypoint.append(
-                "--validate-postgres-stash=postgres://materialize@materialized/materialize?options=--search_path=catalog"
+                "--validate-postgres-stash=postgres://materialize@materialized/materialize?options=--search_path=adapter"
             )
 
         if no_reset:

--- a/src/compute/ci/entrypoint.sh
+++ b/src/compute/ci/entrypoint.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-args=(--listen-addr=0.0.0.0:2100 --internal-http-listen-addr=0.0.0.0:6877)
+args=(--controller-listen-addr=0.0.0.0:2100 --internal-http-listen-addr=0.0.0.0:6877)
 if [[ "${KUBERNETES_SERVICE_HOST:-}" ]]; then
     # Hack: if running in Kubernetes, we parse the process index from the
     # hostname, if possible. At present this is the only known way to get the

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -321,7 +321,7 @@ where
                             args: &|assigned| {
                                 let mut compute_opts = vec![
                                     format!(
-                                        "--listen-addr={}:{}",
+                                        "--controller-listen-addr={}:{}",
                                         assigned.listen_host, assigned.ports["controller"]
                                     ),
                                     format!(

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -15,7 +15,6 @@
 use std::cmp;
 use std::env;
 use std::ffi::CStr;
-use std::fs;
 use std::iter;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -86,92 +85,16 @@ pub static LONG_VERSION: Lazy<String> = Lazy::new(|| {
     long_version = LONG_VERSION.as_str(),
 )]
 pub struct Args {
-    /// \[DANGEROUS\] Enable unsafe features.
+    // === Special modes. ===
+    /// Enable unsafe features.
     ///
     /// Unsafe features fall into two categories:
     ///
-    ///   * In development features that are not yet ready for production use.
+    ///   * In-development features that are not yet ready for production use.
     ///   * Features useful for development and testing that would pose a
     ///     legitimate security risk if used in Materialize Cloud.
     #[clap(long, env = "UNSAFE_MODE")]
     unsafe_mode: bool,
-
-    /// The address on which to listen for trusted SQL connections.
-    ///
-    /// Connections to this address are not subject to encryption, authentication,
-    /// or access control. Care should be taken to not expose this address to the
-    /// public internet
-    /// or other unauthorized parties.
-    #[clap(
-        long,
-        hide = true,
-        value_name = "HOST:PORT",
-        env = "MZ_INTERNAL_SQL_LISTEN_ADDR",
-        default_value = "127.0.0.1:6877"
-    )]
-    internal_sql_listen_addr: SocketAddr,
-
-    /// The address on which to listen for trusted HTTP connections.
-    ///
-    /// Connections to this address are not subject to encryption, authentication,
-    /// or access control. Care should be taken to not expose the listen address
-    /// to the public internet or other unauthorized parties.
-    #[clap(
-        long,
-        hide = true,
-        value_name = "HOST:PORT",
-        env = "MZ_INTERNAL_HTTP_LISTEN_ADDR",
-        default_value = "127.0.0.1:6878"
-    )]
-    internal_http_listen_addr: SocketAddr,
-
-    // === Platform options. ===
-    /// The service orchestrator implementation to use.
-    #[structopt(long, default_value = "process", arg_enum)]
-    orchestrator: OrchestratorKind,
-    /// Labels to apply to all services created by the orchestrator in the form
-    /// `KEY=VALUE`.
-    #[structopt(long, hide = true)]
-    orchestrator_service_label: Vec<KeyValueArg<String, String>>,
-    /// Node selector to apply to all services created by the orchestrator in
-    /// the form `KEY=VALUE`.
-    #[structopt(long, hide = true)]
-    orchestrator_service_node_selector: Vec<KeyValueArg<String, String>>,
-    #[structopt(long)]
-    kubernetes_service_account: Option<String>,
-    /// The Kubernetes context to use with the Kubernetes orchestrator.
-    ///
-    /// This defaults to `minikube` to prevent disaster (e.g., connecting to a
-    /// production cluster that happens to be the active Kubernetes context.)
-    #[structopt(long, hide = true, default_value = "minikube")]
-    kubernetes_context: String,
-    /// The storaged image reference to use.
-    #[structopt(
-        long,
-        hide = true,
-        required_if_eq("orchestrator", "kubernetes"),
-        default_value_if("orchestrator", Some("process"), Some("storaged"))
-    )]
-    storaged_image: Option<String>,
-    /// The computed image reference to use.
-    #[structopt(
-        long,
-        hide = true,
-        required_if_eq("orchestrator", "kubernetes"),
-        default_value_if("orchestrator", Some("process"), Some("computed"))
-    )]
-    computed_image: Option<String>,
-    /// The image pull policy to use for services created by the Kubernetes
-    /// orchestrator.
-    #[structopt(long, default_value = "always", arg_enum)]
-    kubernetes_image_pull_policy: KubernetesImagePullPolicy,
-    /// Base port for spawning various services
-    #[structopt(long, default_value = "2100")]
-    base_service_port: u16,
-
-    // === Tracing options. ===
-    #[clap(flatten)]
-    tracing: TracingCliArgs,
 
     // === Connection options. ===
     /// The address on which to listen for untrusted SQL connections.
@@ -181,7 +104,7 @@ pub struct Args {
     /// options.
     #[clap(
         long,
-        env = "MZ_SQL_LISTEN_ADDR",
+        env = "SQL_LISTEN_ADDR",
         value_name = "HOST:PORT",
         default_value = "127.0.0.1:6875"
     )]
@@ -193,11 +116,40 @@ pub struct Args {
     /// options.
     #[clap(
         long,
-        env = "MZ_HTTP_LISTEN_ADDR",
+        env = "HTTP_LISTEN_ADDR",
         value_name = "HOST:PORT",
         default_value = "127.0.0.1:6876"
     )]
     http_listen_addr: SocketAddr,
+    /// The address on which to listen for trusted SQL connections.
+    ///
+    /// Connections to this address are not subject to encryption, authentication,
+    /// or access control. Care should be taken to not expose this address to the
+    /// public internet
+    /// or other unauthorized parties.
+    #[clap(
+        long,
+        value_name = "HOST:PORT",
+        env = "INTERNAL_SQL_LISTEN_ADDR",
+        default_value = "127.0.0.1:6877"
+    )]
+    internal_sql_listen_addr: SocketAddr,
+    /// The address on which to listen for trusted HTTP connections.
+    ///
+    /// Connections to this address are not subject to encryption, authentication,
+    /// or access control. Care should be taken to not expose the listen address
+    /// to the public internet or other unauthorized parties.
+    #[clap(
+        long,
+        value_name = "HOST:PORT",
+        env = "INTERNAL_HTTP_LISTEN_ADDR",
+        default_value = "127.0.0.1:6878"
+    )]
+    internal_http_listen_addr: SocketAddr,
+    /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
+    /// specified origin.
+    #[structopt(long, env = "CORS_ALLOWED_ORIGIN")]
+    cors_allowed_origin: Vec<HeaderValue>,
     /// How stringently to demand TLS authentication and encryption.
     ///
     /// If set to "disable", then environmentd rejects HTTP and PostgreSQL
@@ -232,6 +184,7 @@ pub struct Args {
         value_name = "MODE",
     )]
     tls_mode: String,
+    /// The certificate authority for TLS connections.
     #[clap(
         long,
         env = "TLS_CA",
@@ -258,81 +211,130 @@ pub struct Args {
         value_name = "PATH"
     )]
     tls_key: Option<PathBuf>,
-    /// Specifies the tenant id when authenticating users. Must be a valid UUID.
+    /// Enables Frontegg authentication for the specified tenant ID.
     #[clap(
         long,
         env = "FRONTEGG_TENANT",
         requires_all = &["frontegg-jwk", "frontegg-api-token-url"],
-        hide = true
+        value_name = "UUID",
     )]
     frontegg_tenant: Option<Uuid>,
-    /// JWK used to validate JWTs during user authentication as a PEM public
+    /// JWK used to validate JWTs during Frontegg authentication as a PEM public
     /// key. Can optionally be base64 encoded with the URL-safe alphabet.
-    #[clap(long, env = "FRONTEGG_JWK", requires = "frontegg-tenant", hide = true)]
+    #[clap(long, env = "FRONTEGG_JWK", requires = "frontegg-tenant")]
     frontegg_jwk: Option<String>,
-    /// The full URL (including path) to the api-token endpoint.
-    #[clap(
-        long,
-        env = "FRONTEGG_API_TOKEN_URL",
-        requires = "frontegg-tenant",
-        hide = true
-    )]
+    /// The full URL (including path) to the Frontegg api-token endpoint.
+    #[clap(long, env = "FRONTEGG_API_TOKEN_URL", requires = "frontegg-tenant")]
     frontegg_api_token_url: Option<String>,
-    /// A common string prefix that is expected to be present at the beginning of passwords.
-    #[clap(
-        long,
-        env = "FRONTEGG_PASSWORD_PREFIX",
-        requires = "frontegg-tenant",
-        hide = true
-    )]
+    /// A common string prefix that is expected to be present at the beginning
+    /// of all Frontegg passwords.
+    #[clap(long, env = "FRONTEGG_PASSWORD_PREFIX", requires = "frontegg-tenant")]
     frontegg_password_prefix: Option<String>,
-    /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
-    /// specified origin.
-    #[structopt(long, env = "CORS_ALLOWED_ORIGIN", hide = true)]
-    cors_allowed_origin: Vec<HeaderValue>,
 
-    // === Storage options. ===
-    /// Where to store data.
-    #[clap(
-        short = 'D',
+    // === Orchestrator options. ===
+    /// The service orchestrator implementation to use.
+    #[structopt(long, default_value = "process", arg_enum)]
+    orchestrator: OrchestratorKind,
+    /// Labels to apply to all services created by the Kubernetes orchestrator
+    /// in the form `KEY=VALUE`.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_LABEL")]
+    orchestrator_kubernetes_service_label: Vec<KeyValueArg<String, String>>,
+    /// Node selector to apply to all services created by the Kubernetes
+    /// orchestrator in the form `KEY=VALUE`.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_NODE_SELECTOR")]
+    orchestrator_kubernetes_service_node_selector: Vec<KeyValueArg<String, String>>,
+    /// The name of a service account to apply to all services created by the
+    /// Kubernetes orchestrator.
+    #[structopt(long, env = "ORCHESTRATOR_KUBERNETES_SERVICE_ACCOUNT")]
+    orchestrator_kubernetes_service_account: Option<String>,
+    /// The Kubernetes context to use with the Kubernetes orchestrator.
+    ///
+    /// This defaults to `minikube` to prevent disaster (e.g., connecting to a
+    /// production cluster that happens to be the active Kubernetes context.)
+    #[structopt(
         long,
-        env = "DATA_DIRECTORY",
+        env = "ORCHESTRATOR_KUBERNETES_CONTEXT",
+        default_value = "minikube"
+    )]
+    orchestrator_kubernetes_context: String,
+    /// The image pull policy to use for services created by the Kubernetes
+    /// orchestrator.
+    #[structopt(
+        long,
+        env = "ORCHESTRATOR_KUBERNETES_IMAGE_PULL_POLICY",
+        default_value = "always",
+        arg_enum
+    )]
+    orchestrator_kubernetes_image_pull_policy: KubernetesImagePullPolicy,
+    /// Prefix commands issued by the process orchestrator with the supplied
+    /// value.
+    #[clap(long, env = "ORCHESTRATOR_PROCESS_WRAPPER")]
+    orchestrator_process_wrapper: Option<String>,
+    /// Base port for services spawned by the process orchestrator.
+    #[structopt(
+        long,
+        env = "ORCHESTRATOR_PROCESS_BASE_SERVICE_PORT",
+        default_value = "2100"
+    )]
+    orchestrator_process_base_service_port: u16,
+    /// Where the process orchestrator should store its metadata.
+    #[clap(
+        long,
+        env = "ORCHESTRATOR_PROCESSDATA_DIRECTORY",
         value_name = "PATH",
         default_value = "mzdata"
     )]
-    data_directory: PathBuf,
+    orchestrator_process_data_directory: PathBuf,
+
+    // === Storage options. ===
     /// Where the persist library should store its blob data.
-    ///
-    /// Defaults to the `persist/blob` in the data directory.
     #[clap(long, env = "PERSIST_BLOB_URL")]
-    persist_blob_url: Option<Url>,
+    persist_blob_url: Url,
     /// Where the persist library should perform consensus.
     #[clap(long, env = "PERSIST_CONSENSUS_URL")]
     persist_consensus_url: Url,
-    /// Postgres catalog stash connection string.
-    #[clap(long, env = "CATALOG_POSTGRES_STASH", value_name = "POSTGRES_URL")]
-    catalog_postgres_stash: String,
-    /// Postgres storage stash connection string.
-    #[clap(long, env = "STORAGE_POSTGRES_STASH", value_name = "POSTGRES_URL")]
-    storage_postgres_stash: String,
+    /// The PostgreSQL URL for the storage stash.
+    #[clap(long, env = "STORAGE_STASH_URL", value_name = "POSTGRES_URL")]
+    storage_stash_url: String,
+    /// The storaged image reference to use.
+    #[structopt(
+        long,
+        required_if_eq("orchestrator", "kubernetes"),
+        default_value_if("orchestrator", Some("process"), Some("storaged"))
+    )]
+    storaged_image: Option<String>,
 
-    // === AWS options. ===
+    // === Compute options. ===
+    /// The computed image reference to use.
+    #[structopt(
+        long,
+        required_if_eq("orchestrator", "kubernetes"),
+        default_value_if("orchestrator", Some("process"), Some("computed"))
+    )]
+    computed_image: Option<String>,
+
+    // === Adapter options. ===
+    /// The PostgreSQL URL for the adapter stash.
+    #[clap(long, env = "ADAPTER_STASH_URL", value_name = "POSTGRES_URL")]
+    adapter_stash_url: String,
+
+    // === Cloud options. ===
     /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
-    #[clap(long, value_name = "ID")]
+    #[clap(long, env = "AWS_EXTERNAL_ID_PREFIX", value_name = "ID")]
     aws_external_id_prefix: Option<String>,
-
+    /// A map from size name to resource allocations for cluster replicas.
     #[clap(long, env = "CLUSTER_REPLICA_SIZES")]
     cluster_replica_sizes: Option<String>,
-
-    /// Availability zones compute resources may be deployed in.
+    /// Availability zones in which storage and compute resources may be
+    /// deployed.
     #[clap(long, env = "AVAILABILITY_ZONE", use_value_delimiter = true)]
     availability_zone: Vec<String>,
 
-    /// Prefix commands issued by the process orchestrator with the supplied value.
-    #[clap(long, env = "PROCESS_ORCHESTRATOR_WRAPPER")]
-    process_orchestrator_wrapper: Option<String>,
+    // === Tracing options. ===
+    #[clap(flatten)]
+    tracing: TracingCliArgs,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -465,31 +467,25 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         ])
     };
 
-    // Configure storage.
-    fs::create_dir_all(&args.data_directory)
-        .with_context(|| format!("creating data directory: {}", args.data_directory.display()))?;
-    let catalog_postgres_stash = args.catalog_postgres_stash;
-
     // Configure controller.
-    let cwd = env::current_dir().context("retrieving current working directory")?;
     let (orchestrator, secrets_controller) = match args.orchestrator {
         OrchestratorKind::Kubernetes => {
             let orchestrator = Arc::new(
                 runtime
                     .block_on(KubernetesOrchestrator::new(KubernetesOrchestratorConfig {
-                        context: args.kubernetes_context.clone(),
+                        context: args.orchestrator_kubernetes_context.clone(),
                         service_labels: args
-                            .orchestrator_service_label
+                            .orchestrator_kubernetes_service_label
                             .into_iter()
                             .map(|l| (l.key, l.value))
                             .collect(),
                         service_node_selector: args
-                            .orchestrator_service_node_selector
+                            .orchestrator_kubernetes_service_node_selector
                             .into_iter()
                             .map(|l| (l.key, l.value))
                             .collect(),
-                        service_account: args.kubernetes_service_account,
-                        image_pull_policy: args.kubernetes_image_pull_policy,
+                        service_account: args.orchestrator_kubernetes_service_account,
+                        image_pull_policy: args.orchestrator_kubernetes_image_pull_policy,
                     }))
                     .context("creating kubernetes orchestrator")?,
             );
@@ -509,15 +505,15 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                         // binaries.
                         image_dir: env::current_exe()?.parent().unwrap().to_path_buf(),
                         port_allocator: Arc::new(PortAllocator::new(
-                            args.base_service_port,
-                            args.base_service_port
+                            args.orchestrator_process_base_service_port,
+                            args.orchestrator_process_base_service_port
                                 .checked_add(1000)
                                 .expect("Port number overflow, base-service-port too large."),
                         )),
                         suppress_output: false,
-                        data_dir: args.data_directory.clone(),
+                        data_dir: args.orchestrator_process_data_directory.clone(),
                         command_wrapper: args
-                            .process_orchestrator_wrapper
+                            .orchestrator_process_wrapper
                             .map_or(Ok(vec![]), |s| shell_words::split(&s))?,
                     }))
                     .context("creating process orchestrator")?,
@@ -540,19 +536,11 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         build_info: &mz_environmentd::BUILD_INFO,
         orchestrator,
         persist_location: PersistLocation {
-            blob_uri: match args.persist_blob_url {
-                // TODO: need to handle non-UTF-8 paths here.
-                None => format!(
-                    "file://{}/{}/persist/blob",
-                    cwd.display(),
-                    args.data_directory.display()
-                ),
-                Some(blob_url) => blob_url.to_string(),
-            },
+            blob_uri: args.persist_blob_url.to_string(),
             consensus_uri: args.persist_consensus_url.to_string(),
         },
         persist_clients,
-        storage_stash_url: args.storage_postgres_stash,
+        storage_stash_url: args.storage_stash_url,
         storaged_image: args.storaged_image.expect("clap enforced"),
         computed_image: args.computed_image.expect("clap enforced"),
     };
@@ -643,7 +631,7 @@ max log level: {max_log_level}",
         tls,
         frontegg,
         cors_allowed_origin,
-        catalog_postgres_stash,
+        adapter_stash_url: args.adapter_stash_url,
         controller,
         secrets_controller,
         unsafe_mode: args.unsafe_mode,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -66,8 +66,8 @@ pub struct Config {
     pub cors_allowed_origin: AllowOrigin,
 
     // === Storage options. ===
-    /// Postgres connection string for catalog's stash.
-    pub catalog_postgres_stash: String,
+    /// Postgres connection string for adapter's stash.
+    pub adapter_stash_url: String,
 
     // === Connection options. ===
     /// Configuration for source and sink connections created by the storage
@@ -132,9 +132,9 @@ pub enum TlsMode {
 /// Start an `environmentd` server.
 pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let tls = mz_postgres_util::make_tls(&tokio_postgres::config::Config::from_str(
-        &config.catalog_postgres_stash,
+        &config.adapter_stash_url,
     )?)?;
-    let stash = mz_stash::Postgres::new(config.catalog_postgres_stash.clone(), None, tls).await?;
+    let stash = mz_stash::Postgres::new(config.adapter_stash_url.clone(), None, tls).await?;
     let stash = mz_stash::Memory::new(stash);
 
     // Validate TLS configuration, if present.

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -124,19 +124,19 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         }
         Some(data_directory) => (data_directory, None),
     };
-    let (consensus_uri, catalog_postgres_stash, storage_postgres_stash) = {
+    let (consensus_uri, adapter_stash_url, storage_stash_url) = {
         let seed = config.seed;
         let postgres_url = env::var("POSTGRES_URL")
             .map_err(|_| anyhow!("POSTGRES_URL environment variable is not set"))?;
         let mut conn = postgres::Client::connect(&postgres_url, NoTls)?;
         conn.batch_execute(&format!(
             "CREATE SCHEMA IF NOT EXISTS consensus_{seed};
-             CREATE SCHEMA IF NOT EXISTS catalog_{seed};
+             CREATE SCHEMA IF NOT EXISTS adapter_{seed};
              CREATE SCHEMA IF NOT EXISTS storage_{seed};",
         ))?;
         (
             format!("{postgres_url}?options=--search_path=consensus_{seed}"),
-            format!("{postgres_url}?options=--search_path=catalog_{seed}"),
+            format!("{postgres_url}?options=--search_path=adapter_{seed}"),
             format!("{postgres_url}?options=--search_path=storage_{seed}"),
         )
     };
@@ -160,7 +160,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
     let persist_clients = PersistClientCache::new(&metrics_registry);
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let inner = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
-        catalog_postgres_stash,
+        adapter_stash_url,
         controller: ControllerConfig {
             build_info: &mz_environmentd::BUILD_INFO,
             orchestrator: Arc::clone(&orchestrator) as Arc<dyn Orchestrator>,
@@ -171,7 +171,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
                 consensus_uri,
             },
             persist_clients,
-            storage_stash_url: storage_postgres_stash,
+            storage_stash_url,
         },
         secrets_controller: orchestrator,
         sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -88,7 +88,6 @@ impl ProcessOrchestrator {
             command_wrapper,
         }: ProcessOrchestratorConfig,
     ) -> Result<ProcessOrchestrator, anyhow::Error> {
-        let data_dir = fs::canonicalize(data_dir).await?;
         let secrets_dir = data_dir.join("secrets");
         fs::create_dir_all(&secrets_dir)
             .await
@@ -98,8 +97,8 @@ impl ProcessOrchestrator {
             port_allocator,
             suppress_output,
             namespaces: Mutex::new(HashMap::new()),
-            data_dir,
-            secrets_dir,
+            data_dir: fs::canonicalize(data_dir).await?,
+            secrets_dir: fs::canonicalize(secrets_dir).await?,
             command_wrapper,
         })
     }

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -84,7 +84,20 @@ pub struct TracingCliArgs {
     /// An optional prefix for each stderr log line.
     #[clap(long, env = "LOG_INCLUDE_SERVICE_NAME")]
     pub log_prefix: Option<String>,
-    /// Export tracing events to the provided observability backend.
+    /// Whether OpenTelemetry tracing is enabled by default.
+    ///
+    /// OpenTelemetry tracing can be dynamically toggled during runtime via the
+    /// internal HTTP server.
+    ///
+    /// Requires that the `--opentelemetry-endpoint` option is specified.
+    #[clap(
+        long,
+        env = "OPENTELEMETRY_ENABLED",
+        default_value_t = DefaultTrue::default(),
+        requires = "opentelemetry-endpoint"
+    )]
+    pub opentelemetry_enabled: DefaultTrue,
+    /// Export OpenTelemetry tracing events to the provided endpoint.
     ///
     /// The specified endpoint should speak the OTLP/HTTP protocol. If the
     /// backend requires authentication, you can pass authentication metadata
@@ -131,17 +144,6 @@ pub struct TracingCliArgs {
         use_value_delimiter = true
     )]
     pub opentelemetry_resource: Vec<KeyValueArg<String, String>>,
-    /// Default the OpenTelemetry tracing collector to off, but allow it to be
-    /// dynamically turned on.
-    ///
-    /// Requires that the `--opentelemetry-endpoint` option is specified.
-    #[clap(
-        long,
-        env = "OPENTELEMETRY_ENABLED",
-        default_value_t = DefaultTrue::default(),
-        requires = "opentelemetry-endpoint"
-    )]
-    pub opentelemetry_enabled: DefaultTrue,
     /// The address on which to listen for Tokio console connections.
     ///
     /// For details about Tokio console, see: <https://github.com/tokio-rs/console>

--- a/src/service/src/grpc.rs
+++ b/src/service/src/grpc.rs
@@ -10,7 +10,7 @@
 //! gRPC transport for the [client](crate::client) module.
 
 use std::fmt::{self, Debug};
-use std::net::ToSocketAddrs;
+use std::net::{SocketAddr, ToSocketAddrs};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -188,7 +188,7 @@ where
     /// by the tonic-generated `ProtoServer::new` method for a specific Protobuf
     /// service.
     pub async fn serve<S, F>(
-        listen_addr: String,
+        listen_addr: SocketAddr,
         version: Version,
         client: G,
         f: F,

--- a/src/storage/ci/Dockerfile
+++ b/src/storage/ci/Dockerfile
@@ -18,4 +18,4 @@ COPY storaged /usr/local/bin/
 
 USER materialize
 
-ENTRYPOINT ["tini", "--", "storaged", "--listen-addr=0.0.0.0:2100", "--internal-http-listen-addr=0.0.0.0:6877"]
+ENTRYPOINT ["tini", "--", "storaged", "--controller-listen-addr=0.0.0.0:2100", "--internal-http-listen-addr=0.0.0.0:6877"]

--- a/src/storage/src/client/controller/hosts.rs
+++ b/src/storage/src/client/controller/hosts.rs
@@ -212,7 +212,7 @@ impl<T> StorageHosts<T> {
                         vec![
                             format!("--workers=1"),
                             format!(
-                                "--listen-addr={}:{}",
+                                "--controller-listen-addr={}:{}",
                                 assigned.listen_host, assigned.ports["controller"]
                             ),
                             format!(

--- a/test/stash/mzcompose.py
+++ b/test/stash/mzcompose.py
@@ -19,7 +19,7 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     materialized = Materialized(
-        options=["--catalog-postgres-stash", "postgres://postgres:postgres@postgres"],
+        options=["--adapter-postgres-stash", "postgres://postgres:postgres@postgres"],
     )
     postgres = Postgres(image="postgres:13.6")
     testdrive = Testdrive()


### PR DESCRIPTION
Enforce consistency on the CLI flags across our three production
binaries (storaged, computed, and environmentd). The rules are:

  * Only long options; never short options. Now that these binaries are
    never invoked by hand, better to prefer the long options, as they're
    self documenting.

  * Err on the side of long but clear rather than short but unclear.

  * Name related parameters with a consistent prefix.

  * Always expose an environment variable whose name is the SNAKE_CASE
    version of the flag.

  * Set `use_value_delimiter` for any options whose value is a `Vec`, so
    that multiple values can be set via the environment variable.

  * Never set `hide`.

This changes are largely code movement and additional documentation, but
with a few changes, listed below.

In environmentd:

  * --orchestrator-service-label => --orchestrator-kubernetes-service-label
  * --orchestrator-service-node-selector => --orchestrator-kubernetes-service-node-selector
  * --kubernetes-service-account => --orchestrator-kubernetes-service-account
  * --kubernetes-context => --orchestrator-kubernetes-context
  * --kubernetes-image-pull-policy => --orchestrator-kubernetes-image-pull-policy
  * --data-directory => --orchestrator-process-data-directory
  * --persist-blob-url is now required
  * --storage-postgres-stash => --storage-stash-url
  * --catalog-postgres-stash => --adapter-stash-url

In storaged and computed:

  * --listen-addr => --controller-listen-addr
  * --{controller,internal-http}-listen-addr require IP hosts, not domain hosts
  * -w removed (use long form --workers instead)

Fix #12143.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
