### PR TITLE
adapter: store logical cluster replica sizes in catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3597,7 +3597,7 @@ impl From<PlanContext> for SerializedPlanContext {
 /// to the catalog stash. This is a separate type to allow us to evolve the
 /// on-disk format independently from the SQL layer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-enum SerializedComputeInstanceReplicaConfig {
+pub enum SerializedComputeInstanceReplicaConfig {
     Remote {
         addrs: BTreeSet<String>,
     },

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -10,7 +10,7 @@
 //! Persistent metadata storage for the coordinator.
 
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -28,7 +28,9 @@ use mz_build_info::DUMMY_BUILD_INFO;
 use mz_compute_client::command::{ProcessId, ReplicaId};
 use mz_compute_client::controller::ComputeInstanceId;
 use mz_compute_client::logging::LoggingConfig as DataflowLoggingConfig;
-use mz_controller::{ComputeInstanceEvent, ConcreteComputeInstanceReplicaConfig};
+use mz_controller::{
+    ComputeInstanceEvent, ComputeInstanceReplicaAllocation, ConcreteComputeInstanceReplicaConfig,
+};
 use mz_expr::{ExprHumanizer, MirScalarExpr, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsRegistry;
@@ -48,9 +50,9 @@ use mz_sql::names::{
     SchemaSpecifier,
 };
 use mz_sql::plan::{
-    ComputeInstanceIntrospectionConfig, CreateConnectionPlan, CreateIndexPlan,
-    CreateRecordedViewPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan,
-    CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
+    ComputeInstanceIntrospectionConfig, ComputeInstanceReplicaConfig, CreateConnectionPlan,
+    CreateIndexPlan, CreateRecordedViewPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
+    CreateTablePlan, CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
 };
 use mz_sql::DEFAULT_SCHEMA;
 use mz_stash::{Append, Postgres, Sqlite};
@@ -63,6 +65,7 @@ use crate::catalog::builtin::{
     Builtin, BuiltinLog, BuiltinTable, BuiltinType, Fingerprint, BUILTINS, BUILTIN_ROLES,
     INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
+use crate::catalog::storage::BootstrapArgs;
 use crate::session::{PreparedStatement, Session, DEFAULT_DATABASE_NAME};
 use crate::AdapterError;
 
@@ -75,10 +78,8 @@ pub mod builtin;
 pub mod storage;
 
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
-pub use crate::catalog::config::Config;
-pub use crate::catalog::error::AmbiguousRename;
-pub use crate::catalog::error::Error;
-pub use crate::catalog::error::ErrorKind;
+pub use crate::catalog::config::{ClusterReplicaSizeMap, Config};
+pub use crate::catalog::error::{AmbiguousRename, Error, ErrorKind};
 use crate::client::ConnectionId;
 
 pub const SYSTEM_CONN_ID: ConnectionId = 0;
@@ -138,6 +139,8 @@ pub struct CatalogState {
     roles: HashMap<String, Role>,
     config: mz_sql::catalog::CatalogConfig,
     oid_counter: u32,
+    replica_sizes: ClusterReplicaSizeMap,
+    availability_zones: Vec<String>,
 }
 
 impl CatalogState {
@@ -491,10 +494,12 @@ impl CatalogState {
         on_instance: ComputeInstanceId,
         replica_name: String,
         replica_id: ReplicaId,
+        serialized_config: SerializedComputeInstanceReplicaConfig,
         config: ConcreteComputeInstanceReplicaConfig,
     ) {
         let replica = ComputeInstanceReplica {
-            config,
+            serialized_config,
+            concrete_config: config,
             process_status: HashMap::new(),
         };
         let compute_instance = self.compute_instances_by_id.get_mut(&on_instance).unwrap();
@@ -934,7 +939,8 @@ pub struct ComputeInstance {
 
 #[derive(Debug, Serialize, Clone)]
 pub struct ComputeInstanceReplica {
-    pub config: ConcreteComputeInstanceReplicaConfig,
+    pub serialized_config: SerializedComputeInstanceReplicaConfig,
+    pub concrete_config: ConcreteComputeInstanceReplicaConfig,
     pub process_status: HashMap<ProcessId, ComputeInstanceEvent>,
 }
 
@@ -1384,7 +1390,7 @@ impl<S: Append> Catalog<S> {
     /// describe the initial state of the catalog.
     pub async fn open(
         config: Config<'_, S>,
-    ) -> Result<(Catalog<S>, Vec<BuiltinTableUpdate>), Error> {
+    ) -> Result<(Catalog<S>, Vec<BuiltinTableUpdate>), AdapterError> {
         let mut catalog = Catalog {
             state: CatalogState {
                 database_by_name: BTreeMap::new(),
@@ -1408,6 +1414,8 @@ impl<S: Append> Catalog<S> {
                     now: config.now.clone(),
                 },
                 oid_counter: FIRST_USER_OID,
+                replica_sizes: config.replica_sizes,
+                availability_zones: config.availability_zones,
             },
             transient_revision: 0,
             storage: Arc::new(Mutex::new(config.storage)),
@@ -1642,10 +1650,15 @@ impl<S: Append> Catalog<S> {
             .await
             .load_compute_instance_replicas()
             .await?;
-        for (instance_id, replica_id, name, config) in replicas {
-            catalog
-                .state
-                .insert_compute_instance_replica(instance_id, name, replica_id, config);
+        for (instance_id, replica_id, name, serialized_config) in replicas {
+            let concrete_config = catalog.concretize_replica_config(serialized_config.clone())?;
+            catalog.state.insert_compute_instance_replica(
+                instance_id,
+                name,
+                replica_id,
+                serialized_config,
+                concrete_config,
+            );
         }
 
         if !config.skip_migrations {
@@ -1929,7 +1942,13 @@ impl<S: Append> Catalog<S> {
     /// instead.
     pub async fn open_debug(stash: S, now: NowFn) -> Result<Catalog<S>, anyhow::Error> {
         let metrics_registry = &MetricsRegistry::new();
-        let storage = storage::Connection::open(stash).await?;
+        let storage = storage::Connection::open(
+            stash,
+            &BootstrapArgs {
+                default_cluster_replica_size: "1".into(),
+            },
+        )
+        .await?;
         let (catalog, _) = Catalog::open(Config {
             storage,
             unsafe_mode: true,
@@ -1937,6 +1956,8 @@ impl<S: Append> Catalog<S> {
             now,
             skip_migrations: true,
             metrics_registry,
+            replica_sizes: Default::default(),
+            availability_zones: vec![],
         })
         .await?;
         Ok(catalog)
@@ -2409,6 +2430,54 @@ impl<S: Append> Catalog<S> {
         }
     }
 
+    fn concretize_replica_config(
+        &self,
+        config: SerializedComputeInstanceReplicaConfig,
+    ) -> Result<ConcreteComputeInstanceReplicaConfig, AdapterError> {
+        let replica_sizes = &self.state.replica_sizes;
+        let availability_zones = &self.state.availability_zones;
+        let config = match config {
+            SerializedComputeInstanceReplicaConfig::Remote { addrs } => {
+                ConcreteComputeInstanceReplicaConfig::Remote { addrs }
+            }
+            SerializedComputeInstanceReplicaConfig::Managed {
+                size,
+                availability_zone,
+            } => {
+                let allocation = replica_sizes.0.get(&size).ok_or_else(|| {
+                    let mut entries = replica_sizes.0.iter().collect::<Vec<_>>();
+                    entries.sort_by_key(
+                        |(
+                            _name,
+                            ComputeInstanceReplicaAllocation {
+                                scale, cpu_limit, ..
+                            },
+                        )| (scale, cpu_limit),
+                    );
+                    let expected = entries.into_iter().map(|(name, _)| name.clone()).collect();
+                    AdapterError::InvalidClusterReplicaSize {
+                        size: size.clone(),
+                        expected,
+                    }
+                })?;
+
+                if let Some(az) = &availability_zone {
+                    if !availability_zones.contains(az) {
+                        return Err(AdapterError::InvalidClusterReplicaAz {
+                            az: az.to_string(),
+                            expected: availability_zones.to_vec(),
+                        });
+                    }
+                }
+                ConcreteComputeInstanceReplicaConfig::Managed {
+                    allocation: allocation.clone(),
+                    availability_zone,
+                }
+            }
+        };
+        Ok(config)
+    }
+
     pub async fn transact<F, T>(
         &mut self,
         session: Option<&Session>,
@@ -2448,7 +2517,8 @@ impl<S: Append> Catalog<S> {
                 id: ReplicaId,
                 name: String,
                 on_cluster_name: String,
-                config: ConcreteComputeInstanceReplicaConfig,
+                serialized_config: SerializedComputeInstanceReplicaConfig,
+                concrete_config: ConcreteComputeInstanceReplicaConfig,
             },
             CreateItem {
                 id: GlobalId,
@@ -2608,20 +2678,21 @@ impl<S: Append> Catalog<S> {
                 Op::CreateComputeInstanceReplica {
                     name,
                     on_cluster_name,
-                    config,
-                    logical_size,
+                    config: serialized_config,
                 } => {
                     if is_reserved_name(&name) {
                         return Err(AdapterError::Catalog(Error::new(
                             ErrorKind::ReservedReplicaName(name),
                         )));
                     }
-                    if let Some(logical_size) = logical_size {
+                    if let SerializedComputeInstanceReplicaConfig::Managed { size, .. } =
+                        &serialized_config
+                    {
                         let details = EventDetails::CreateComputeInstanceReplicaV1(
                             mz_audit_log::CreateComputeInstanceReplicaV1 {
                                 cluster_name: on_cluster_name.clone(),
                                 replica_name: name.clone(),
-                                logical_size,
+                                logical_size: size.clone(),
                             },
                         );
                         self.add_to_audit_log(
@@ -2634,10 +2705,16 @@ impl<S: Append> Catalog<S> {
                         )?;
                     }
                     vec![Action::CreateComputeInstanceReplica {
-                        id: tx.insert_compute_instance_replica(&on_cluster_name, &name, &config)?,
+                        id: tx.insert_compute_instance_replica(
+                            &on_cluster_name,
+                            &name,
+                            &serialized_config,
+                        )?,
                         name,
                         on_cluster_name,
-                        config,
+                        concrete_config: self
+                            .concretize_replica_config(serialized_config.clone())?,
+                        serialized_config,
                     }]
                 }
                 Op::CreateItem {
@@ -3017,7 +3094,8 @@ impl<S: Append> Catalog<S> {
                     id,
                     name,
                     on_cluster_name,
-                    config,
+                    serialized_config,
+                    concrete_config,
                 } => {
                     info!("create replica {} of instance {}", name, on_cluster_name);
                     let compute_instance_id = state.compute_instances_by_name[&on_cluster_name];
@@ -3025,7 +3103,8 @@ impl<S: Append> Catalog<S> {
                         compute_instance_id,
                         name.clone(),
                         id,
-                        config,
+                        serialized_config,
+                        concrete_config,
                     );
                     builtin_table_updates.push(state.pack_compute_instance_replica_update(
                         compute_instance_id,
@@ -3441,9 +3520,8 @@ pub enum Op {
     },
     CreateComputeInstanceReplica {
         name: String,
-        config: ConcreteComputeInstanceReplicaConfig,
         on_cluster_name: String,
-        logical_size: Option<String>,
+        config: SerializedComputeInstanceReplicaConfig,
     },
     CreateItem {
         id: GlobalId,
@@ -3511,6 +3589,54 @@ impl From<PlanContext> for SerializedPlanContext {
         SerializedPlanContext {
             logical_time: None,
             wall_time: Some(cx.wall_time),
+        }
+    }
+}
+
+/// A [`ComputeInstanceReplicaConfig`] that is serialized as JSON and persisted
+/// to the catalog stash. This is a separate type to allow us to evolve the
+/// on-disk format independently from the SQL layer.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum SerializedComputeInstanceReplicaConfig {
+    Remote {
+        addrs: BTreeSet<String>,
+    },
+    Managed {
+        size: String,
+        availability_zone: Option<String>,
+    },
+}
+
+impl From<SerializedComputeInstanceReplicaConfig> for ComputeInstanceReplicaConfig {
+    fn from(config: SerializedComputeInstanceReplicaConfig) -> ComputeInstanceReplicaConfig {
+        match config {
+            SerializedComputeInstanceReplicaConfig::Remote { addrs } => {
+                ComputeInstanceReplicaConfig::Remote { addrs }
+            }
+            SerializedComputeInstanceReplicaConfig::Managed {
+                size,
+                availability_zone,
+            } => ComputeInstanceReplicaConfig::Managed {
+                size,
+                availability_zone,
+            },
+        }
+    }
+}
+
+impl From<ComputeInstanceReplicaConfig> for SerializedComputeInstanceReplicaConfig {
+    fn from(config: ComputeInstanceReplicaConfig) -> SerializedComputeInstanceReplicaConfig {
+        match config {
+            ComputeInstanceReplicaConfig::Remote { addrs } => {
+                SerializedComputeInstanceReplicaConfig::Remote { addrs }
+            }
+            ComputeInstanceReplicaConfig::Managed {
+                size,
+                availability_zone,
+            } => SerializedComputeInstanceReplicaConfig::Managed {
+                size,
+                availability_zone,
+            },
         }
     }
 }

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -7,7 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+use serde::Deserialize;
+
 use mz_build_info::BuildInfo;
+use mz_controller::ComputeInstanceReplicaAllocation;
 use mz_ore::metrics::MetricsRegistry;
 
 use crate::catalog::storage;
@@ -27,4 +33,70 @@ pub struct Config<'a, S> {
     pub skip_migrations: bool,
     /// The registry that catalog uses to report metrics.
     pub metrics_registry: &'a MetricsRegistry,
+    /// Map of strings to corresponding compute replica sizes.
+    pub replica_sizes: ClusterReplicaSizeMap,
+    /// Valid availability zones for replicas.
+    pub availability_zones: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClusterReplicaSizeMap(pub HashMap<String, ComputeInstanceReplicaAllocation>);
+
+impl Default for ClusterReplicaSizeMap {
+    fn default() -> Self {
+        // {
+        //     "1": {"scale": 1, "workers": 1},
+        //     "2": {"scale": 1, "workers": 2},
+        //     "4": {"scale": 1, "workers": 4},
+        //     /// ...
+        //     "32": {"scale": 1, "workers": 32}
+        //     /// Testing with multiple processes on a single machine is a novelty, so
+        //     /// we don't bother providing many options.
+        //     "2-1": {"scale": 2, "workers": 1},
+        //     "2-2": {"scale": 2, "workers": 2},
+        //     "2-4": {"scale": 2, "workers": 4},
+        // }
+        let mut inner = (0..=5)
+            .map(|i| {
+                let workers = 1 << i;
+                (
+                    workers.to_string(),
+                    ComputeInstanceReplicaAllocation {
+                        memory_limit: None,
+                        cpu_limit: None,
+                        scale: NonZeroUsize::new(1).unwrap(),
+                        workers: NonZeroUsize::new(workers).unwrap(),
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        inner.insert(
+            "2-1".to_string(),
+            ComputeInstanceReplicaAllocation {
+                memory_limit: None,
+                cpu_limit: None,
+                scale: NonZeroUsize::new(2).unwrap(),
+                workers: NonZeroUsize::new(1).unwrap(),
+            },
+        );
+        inner.insert(
+            "2-2".to_string(),
+            ComputeInstanceReplicaAllocation {
+                memory_limit: None,
+                cpu_limit: None,
+                scale: NonZeroUsize::new(2).unwrap(),
+                workers: NonZeroUsize::new(2).unwrap(),
+            },
+        );
+        inner.insert(
+            "2-4".to_string(),
+            ComputeInstanceReplicaAllocation {
+                memory_limit: None,
+                cpu_limit: None,
+                scale: NonZeroUsize::new(2).unwrap(),
+                workers: NonZeroUsize::new(4).unwrap(),
+            },
+        );
+        Self(inner)
+    }
 }

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -185,6 +185,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         now: config.now,
         cors_allowed_origin: AllowOrigin::list([]),
         replica_sizes: Default::default(),
+        bootstrap_default_cluster_replica_size: "1".into(),
         availability_zones: Default::default(),
         connection_context: Default::default(),
         otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -155,14 +155,14 @@ pub struct CreateRolePlan {
 pub struct CreateComputeInstancePlan {
     pub name: String,
     pub config: Option<ComputeInstanceIntrospectionConfig>,
-    pub replicas: Vec<(String, ReplicaConfig)>,
+    pub replicas: Vec<(String, ComputeInstanceReplicaConfig)>,
 }
 
 #[derive(Debug)]
 pub struct CreateComputeInstanceReplicaPlan {
     pub name: String,
     pub of_cluster: String,
-    pub config: ReplicaConfig,
+    pub config: ComputeInstanceReplicaConfig,
 }
 
 /// Configuration of introspection for a compute instance.
@@ -175,7 +175,7 @@ pub struct ComputeInstanceIntrospectionConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum ReplicaConfig {
+pub enum ComputeInstanceReplicaConfig {
     Remote {
         addrs: BTreeSet<String>,
     },

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -90,13 +90,14 @@ use crate::plan::statement::{StatementContext, StatementDesc};
 use crate::plan::with_options::{self, OptionalInterval, TryFromValue};
 use crate::plan::{
     plan_utils, query, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan, AlterItemRenamePlan,
-    AlterNoopPlan, AlterSecretPlan, ComputeInstanceIntrospectionConfig, CreateComputeInstancePlan,
-    CreateComputeInstanceReplicaPlan, CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan,
-    CreateRecordedViewPlan, CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan,
-    CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, CreateViewsPlan,
+    AlterNoopPlan, AlterSecretPlan, ComputeInstanceIntrospectionConfig,
+    ComputeInstanceReplicaConfig, CreateComputeInstancePlan, CreateComputeInstanceReplicaPlan,
+    CreateConnectionPlan, CreateDatabasePlan, CreateIndexPlan, CreateRecordedViewPlan,
+    CreateRolePlan, CreateSchemaPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
+    CreateTablePlan, CreateTypePlan, CreateViewPlan, CreateViewsPlan,
     DropComputeInstanceReplicaPlan, DropComputeInstancesPlan, DropDatabasePlan, DropItemsPlan,
-    DropRolesPlan, DropSchemaPlan, Index, Params, Plan, RecordedView, ReplicaConfig, Secret, Sink,
-    Source, Table, Type, View,
+    DropRolesPlan, DropSchemaPlan, Index, Params, Plan, RecordedView, Secret, Sink, Source, Table,
+    Type, View,
 };
 
 pub fn describe_create_database(
@@ -2703,7 +2704,7 @@ generate_extracted_config!(
 fn plan_replica_config(
     scx: &StatementContext,
     options: Vec<ReplicaOption<Aug>>,
-) -> Result<ReplicaConfig, PlanError> {
+) -> Result<ComputeInstanceReplicaConfig, PlanError> {
     let ReplicaOptionExtracted {
         availability_zone,
         size,
@@ -2725,11 +2726,11 @@ fn plan_replica_config(
             if availability_zone.is_some() {
                 sql_bail!("cannot specify AVAILABILITY ZONE and REMOTE");
             }
-            Ok(ReplicaConfig::Remote {
+            Ok(ComputeInstanceReplicaConfig::Remote {
                 addrs: remote_addrs,
             })
         }
-        (false, Some(size)) => Ok(ReplicaConfig::Managed {
+        (false, Some(size)) => Ok(ComputeInstanceReplicaConfig::Managed {
             size,
             availability_zone,
         }),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -628,6 +628,7 @@ impl Runner {
             metrics_registry,
             now: SYSTEM_TIME.clone(),
             replica_sizes: Default::default(),
+            bootstrap_default_cluster_replica_size: "1".into(),
             availability_zones: Default::default(),
             connection_context: Default::default(),
             otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -412,19 +412,19 @@ statement error unknown cluster
 CREATE CLUSTER REPLICA no_such_cluster.size_1 SIZE '1';
 
 statement error invalid SIZE
-CREATE CLUSTER foo REPLICAS (size_2 (SIZE NULL));
+CREATE CLUSTER bad REPLICAS (size_2 (SIZE NULL));
 
 statement error unknown cluster replica size
-CREATE CLUSTER foo REPLICAS (size_2 (SIZE ''));
+CREATE CLUSTER bad REPLICAS (size_2 (SIZE ''));
 
 statement error unknown cluster replica size
-CREATE CLUSTER foo REPLICAS (size_2 (SIZE 'no_such_size'));
+CREATE CLUSTER bad REPLICAS (size_2 (SIZE 'no_such_size'));
 
 statement error invalid SIZE
-CREATE CLUSTER foo REPLICAS (size_2 (SIZE 1));
+CREATE CLUSTER bad REPLICAS (size_2 (SIZE 1));
 
 statement error unknown cluster replica size a
-CREATE CLUSTER foo REPLICAS (size_2 (SIZE a));
+CREATE CLUSTER bad REPLICAS (size_2 (SIZE a));
 
 statement ok
 DROP CLUSTER foo CASCADE;
@@ -482,7 +482,7 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_32 (SIZE '32'), size_2_2 (S
 query TTT
 SELECT name, size, status FROM mz_cluster_replicas ORDER BY name
 ----
-default_replica  default  unknown
+default_replica  1        unknown
 size_1           1        unknown
 size_2_2         2-2      unknown
 size_32          32       unknown


### PR DESCRIPTION
So that if the cloud team updates the mapping from size names to
resource allocations, it will propagate to existing clusters.

Also introduce a --bootstrap-cluster-replica-default-size argument to
allow the cloud team to control the size of the default replica of the
default cluster that is created during bootstrapping.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
