### PR TITLE
adapter: pick a better time for recording restarts

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -857,7 +857,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
                     // Select a time as of which to restart the sink dataflow.
                     let collection = self.controller.storage().collection(entry.id()).unwrap();
-                    let upper_ts = collection.write_frontier.frontier()[0];
+                    let upper_ts = collection.write_frontier()[0];
                     let as_of = if upper_ts == Timestamp::minimum() {
                         // The sink has never produced any updates, so we select `as_of` based on
                         // the input `since`s, as we do when creating a new recorded view.
@@ -1212,7 +1212,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     || !storage
                         .collection(id)
                         .unwrap()
-                        .write_frontier
+                        .write_frontier()
                         .less_than(&inputs.advance_to)
                 {
                     // Filter out tables that were dropped while waiting for advancement.
@@ -4360,8 +4360,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     storage
                         .collection(*id)
                         .unwrap()
-                        .write_frontier
-                        .frontier()
+                        .write_frontier()
                         .iter()
                         .cloned(),
                 );
@@ -4860,12 +4859,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         sources.push(TimestampSource {
                             name: format!("{name} ({id}, storage)"),
                             read_frontier: state.implied_capability.elements().to_vec(),
-                            write_frontier: state
-                                .write_frontier
-                                .frontier()
-                                .to_owned()
-                                .elements()
-                                .to_vec(),
+                            write_frontier: state.write_frontier().to_owned().elements().to_vec(),
                         });
                     }
                 }


### PR DESCRIPTION
Previously, when bootstrapping an existing recorded view, the `as_of` we picked for the sink dataflow was the upper bound of the `since`s of the dataflow inputs. This assumed that `since`s of inputs would never move backwards, which turned out to not always be true on restarts. It was possible for a recorded view dataflow to resume at an `as_of` prior to the `as_of` it was originally created with, leading to missed updates in the target storage collection.

This PR fixes the above issue by picking the `as_of` of a resumed recorded view based on the target collection's `upper` instead, making it independent of the `since`s of the dataflow inputs. There is one exception: If we restart a recording that has never seen any writes to its storage collection, we treat it like a freshly created recording and still base its `as_of` on the input `since`s.

Implementing this fix also required extending the storage controller to immediately report a useful upper for newly created collections. See the second commit for details.

### Motivation

  * This PR fixes a recognized bug.

Fixes #13496 

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).