### PR TITLE
Deprecated nolimit visitor #12989 in adapter and transform

### DIFF
--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -437,8 +437,7 @@ pub fn prep_scalar_expr(
             session,
         } => expr.try_visit_mut_post(&mut |e| {
             if let MirScalarExpr::CallUnmaterializable(f) = e {
-                let evaled = eval_unmaterializable_func(state, f, logical_time, session)?;
-                *e = evaled;
+                *e = eval_unmaterializable_func(state, f, logical_time, session)?;
             }
             Ok(())
         }),

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -435,29 +435,23 @@ pub fn prep_scalar_expr(
         ExprPrepStyle::OneShot {
             logical_time,
             session,
-        } => {
-            let mut res = Ok(());
-            #[allow(deprecated)]
-            expr.visit_mut_post_nolimit(&mut |e| {
-                if let MirScalarExpr::CallUnmaterializable(f) = e {
-                    match eval_unmaterializable_func(state, f, logical_time, session) {
-                        Ok(evaled) => *e = evaled,
-                        Err(e) => res = Err(e),
-                    }
-                }
-            });
-            res
-        }
+        } => expr.try_visit_mut_post(&mut |e| {
+            if let MirScalarExpr::CallUnmaterializable(f) = e {
+                let evaled = eval_unmaterializable_func(state, f, logical_time, session)?;
+                *e = evaled;
+            }
+            Ok(())
+        }),
 
         // Reject the query if it contains any unmaterializable function calls.
         ExprPrepStyle::Index | ExprPrepStyle::AsOf => {
             let mut last_observed_unmaterializable_func = None;
-            #[allow(deprecated)]
-            expr.visit_mut_post_nolimit(&mut |e| {
+            expr.visit_mut_post(&mut |e| {
                 if let MirScalarExpr::CallUnmaterializable(f) = e {
                     last_observed_unmaterializable_func = Some(f.clone());
                 }
-            });
+            })?;
+
             if let Some(f) = last_observed_unmaterializable_func {
                 let err = match style {
                     ExprPrepStyle::Index => AdapterError::UnmaterializableFunction(f),

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -128,7 +128,6 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
                 &mut id_gen,
             )?;
             // Install the `new_local` name wherever `global_id` was used.
-            #[allow(deprecated)]
             dataflow.objects_to_build[other]
                 .plan
                 .as_inner_mut()

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -132,13 +132,13 @@ fn inline_views(dataflow: &mut DataflowDesc) -> Result<(), TransformError> {
             dataflow.objects_to_build[other]
                 .plan
                 .as_inner_mut()
-                .visit_mut_post_nolimit(&mut |expr| {
+                .visit_mut_post(&mut |expr| {
                     if let MirRelationExpr::Get { id, .. } = expr {
                         if id == &Id::Global(global_id) {
                             *id = Id::Local(new_local);
                         }
                     }
-                });
+                })?;
 
             // With identifiers rewritten, we can replace `other` with
             // a `MirRelationExpr::Let` binding, whose value is `index` and

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -266,14 +266,14 @@ where
             let projection_pushed_down = columns.iter().map(|c| *c).collect();
             // Push down the projection consisting of the entries of `columns`
             // in increasing order.
-            projection_pushdown.action(view, &projection_pushed_down, demand);
+            projection_pushdown.action(view, &projection_pushed_down, demand)?;
             applied_projection.insert(id, projection_pushed_down);
         } else if id == Id::Global(GlobalId::Explain) {
             // If we just want to explain the plan for a given view, then there
             // will be no upstream demand. Just demand all columns from views
             // that are not depended on by another view.
             let arity = view.arity();
-            projection_pushdown.action(view, &(0..arity).collect(), demand);
+            projection_pushdown.action(view, &(0..arity).collect(), demand)?;
         }
         view_refs.push(view);
     }
@@ -281,7 +281,7 @@ where
     let typ_update = crate::update_let::UpdateLet::default();
     for view in view_refs {
         // Update column references to views where projections were pushed down.
-        projection_pushdown.update_projection_around_get(view, &applied_projection);
+        projection_pushdown.update_projection_around_get(view, &applied_projection)?;
         // Types need to be updated after ProjectionPushdown
         // because the width of each view may have changed.
         typ_update.action(view, &mut HashMap::new(), &mut IdGen::default())?;

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -23,7 +23,7 @@ use mz_expr::{JoinInputMapper, MapFilterProject, MirRelationExpr, MirScalarExpr,
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
 use self::index_map::IndexMap;
-use crate::TransformArgs;
+use crate::{TransformArgs, TransformError};
 
 /// Determines the join implementation for join operators.
 #[derive(Debug)]
@@ -259,6 +259,8 @@ mod delta_queries {
 
     use mz_expr::{JoinImplementation, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 
+    use crate::TransformError;
+
     /// Creates a delta query plan, and any predicates that need to be lifted.
     ///
     /// The method returns `None` if it fails to find a sufficiently pleasing plan.
@@ -267,7 +269,7 @@ mod delta_queries {
         input_mapper: &JoinInputMapper,
         available: &[Vec<Vec<MirScalarExpr>>],
         unique_keys: &[Vec<Vec<usize>>],
-    ) -> Option<MirRelationExpr> {
+    ) -> Result<MirRelationExpr, TransformError> {
         let mut new_join = join.clone();
 
         if let MirRelationExpr::Join {
@@ -282,7 +284,9 @@ mod delta_queries {
                 // a filter gets converted into a single input join only when
                 // there are existing arrangements, without this early return,
                 // filters will always be planned as delta queries.
-                return None;
+                return Err(TransformError::Internal(String::from(
+                    "should be planned as differential plan",
+                )));
             }
 
             // Determine a viable order for each relation, or return `None` if none found.
@@ -295,7 +299,9 @@ mod delta_queries {
                 .iter()
                 .all(|o| o.iter().skip(1).all(|(c, _, _)| c.arranged))
             {
-                return None;
+                return Err(TransformError::Internal(String::from(
+                    "delta plan not viable",
+                )));
             }
 
             // Convert the order information into specific (input, keys) information.
@@ -315,12 +321,14 @@ mod delta_queries {
 
             *implementation = JoinImplementation::DeltaQuery(orders);
 
-            super::install_lifted_mfp(&mut new_join, lifted_mfp);
+            super::install_lifted_mfp(&mut new_join, lifted_mfp)?;
 
             // Hooray done!
-            Some(new_join)
+            Ok(new_join)
         } else {
-            panic!("delta_queries::plan call on non-join expression.")
+            Err(TransformError::Internal(String::from(
+                "delta_queries::plan call on non-join expression",
+            )))
         }
     }
 }
@@ -329,13 +337,15 @@ mod differential {
 
     use mz_expr::{JoinImplementation, JoinInputMapper, MirRelationExpr, MirScalarExpr};
 
+    use crate::TransformError;
+
     /// Creates a linear differential plan, and any predicates that need to be lifted.
     pub fn plan(
         join: &MirRelationExpr,
         input_mapper: &JoinInputMapper,
         available: &[Vec<Vec<MirScalarExpr>>],
         unique_keys: &[Vec<Vec<usize>>],
-    ) -> Option<MirRelationExpr> {
+    ) -> Result<MirRelationExpr, TransformError> {
         let mut new_join = join.clone();
 
         if let MirRelationExpr::Join {
@@ -366,6 +376,11 @@ mod differential {
                     .find(|o| {
                         o.iter().skip(1).map(|(c, _, _)| c).min().unwrap()
                             == &max_min_characteristics
+                    })
+                    .ok_or_else(|| {
+                        TransformError::Internal(String::from(
+                            "could not find max-min characteristics",
+                        ))
                     })?
                     .into_iter()
                     .map(|(_c, k, r)| (r, k))
@@ -404,12 +419,14 @@ mod differential {
             // Install the implementation.
             *implementation = JoinImplementation::Differential((start, start_keys), order);
 
-            super::install_lifted_mfp(&mut new_join, lifted_mfp);
+            super::install_lifted_mfp(&mut new_join, lifted_mfp)?;
 
             // Hooray done!
-            Some(new_join)
+            Ok(new_join)
         } else {
-            panic!("differential::plan call on non-join expression.")
+            Err(TransformError::Internal(String::from(
+                "differential::plan call on non-join expression.",
+            )))
         }
     }
 }
@@ -498,7 +515,10 @@ fn implement_arrangements<'a>(
         .project(combined_project)
 }
 
-fn install_lifted_mfp(new_join: &mut MirRelationExpr, mfp: MapFilterProject) {
+fn install_lifted_mfp(
+    new_join: &mut MirRelationExpr,
+    mfp: MapFilterProject,
+) -> Result<(), TransformError> {
     if !mfp.is_identity() {
         let (map, filter, project) = mfp.as_map_filter_project();
         if let MirRelationExpr::Join { equivalences, .. } = new_join {
@@ -508,8 +528,7 @@ fn install_lifted_mfp(new_join: &mut MirRelationExpr, mfp: MapFilterProject) {
                     expr.permute(&project);
                     // if column references refer to mapped expressions that have been
                     // lifted, replace the column reference with the mapped expression.
-                    #[allow(deprecated)]
-                    expr.visit_mut_pre_post_nolimit(
+                    expr.visit_mut_pre_post(
                         &mut |e| {
                             if let MirScalarExpr::Column(c) = e {
                                 if *c >= mfp.input_arity {
@@ -519,12 +538,13 @@ fn install_lifted_mfp(new_join: &mut MirRelationExpr, mfp: MapFilterProject) {
                             None
                         },
                         &mut |_| {},
-                    );
+                    )?;
                 }
             }
         }
         *new_join = new_join.clone().map(map).filter(filter).project(project);
     }
+    Ok(())
 }
 
 fn optimize_orders(

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -263,7 +263,8 @@ mod delta_queries {
 
     /// Creates a delta query plan, and any predicates that need to be lifted.
     ///
-    /// The method returns `None` if it fails to find a sufficiently pleasing plan.
+    /// The method returns `Err` if it fails to find a sufficiently pleasing plan or
+    /// if any errors occur during planning.
     pub fn plan(
         join: &MirRelationExpr,
         input_mapper: &JoinInputMapper,
@@ -289,7 +290,7 @@ mod delta_queries {
                 )));
             }
 
-            // Determine a viable order for each relation, or return `None` if none found.
+            // Determine a viable order for each relation, or return `Err` if none found.
             let orders = super::optimize_orders(equivalences, available, unique_keys, input_mapper);
 
             // A viable delta query requires that, for every order,

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -337,8 +337,7 @@ impl LiteralLifting {
                                 } else {
                                     let mut cloned_scalar = scalar.clone();
                                     // Propagate literals through expressions and remap columns.
-                                    #[allow(deprecated)]
-                                    cloned_scalar.visit_mut_post_nolimit(&mut |e| {
+                                    cloned_scalar.visit_mut_post(&mut |e| {
                                         if let MirScalarExpr::Column(old_id) = e {
                                             let new_id = projection[*old_id];
                                             if new_id >= first_literal_id {
@@ -348,7 +347,7 @@ impl LiteralLifting {
                                                 *old_id = new_id;
                                             }
                                         }
-                                    });
+                                    })?;
                                     projection.push(input_arity + new_scalars.len());
                                     new_scalars.push(cloned_scalar);
                                 }
@@ -365,14 +364,13 @@ impl LiteralLifting {
                     if !literals.is_empty() {
                         let input_arity = input.arity();
                         for expr in exprs.iter_mut() {
-                            #[allow(deprecated)]
-                            expr.visit_mut_post_nolimit(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
                                     }
                                 }
-                            });
+                            })?;
                         }
                         // Permute the literals around the columns added by FlatMap
                         let mut projection = (0..input_arity).collect::<Vec<usize>>();
@@ -392,14 +390,13 @@ impl LiteralLifting {
                         // in predicates and then lift the `map` around the filter.
                         let input_arity = input.arity();
                         for expr in predicates.iter_mut() {
-                            #[allow(deprecated)]
-                            expr.visit_mut_post_nolimit(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
                                     }
                                 }
-                            });
+                            })?;
                         }
                     }
                     Ok(literals)
@@ -446,8 +443,7 @@ impl LiteralLifting {
                         let new_input_mapper = JoinInputMapper::new(inputs);
                         for equivalence in equivalences.iter_mut() {
                             for expr in equivalence.iter_mut() {
-                                #[allow(deprecated)]
-                                expr.visit_mut_post_nolimit(&mut |e| {
+                                expr.visit_mut_post(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         let (col, input) = old_input_mapper.map_column_to_local(*c);
                                         if col >= new_input_mapper.input_arity(input) {
@@ -461,7 +457,7 @@ impl LiteralLifting {
                                             *c = new_input_mapper.map_column_to_global(col, input);
                                         }
                                     }
-                                });
+                                })?;
                             }
                         }
 
@@ -505,25 +501,23 @@ impl LiteralLifting {
                         let input_arity = input.arity();
                         // Inline literals into group key expressions.
                         for expr in group_key.iter_mut() {
-                            #[allow(deprecated)]
-                            expr.visit_mut_post_nolimit(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
                                     }
                                 }
-                            });
+                            })?;
                         }
                         // Inline literals into aggregate value selector expressions.
                         for aggr in aggregates.iter_mut() {
-                            #[allow(deprecated)]
-                            aggr.expr.visit_mut_post_nolimit(&mut |e| {
+                            aggr.expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     if *c >= input_arity {
                                         *e = literals[*c - input_arity].clone();
                                     }
                                 }
-                            });
+                            })?;
                         }
                     }
 
@@ -679,13 +673,13 @@ impl LiteralLifting {
                         for key in keys.iter_mut() {
                             for expr in key.iter_mut() {
                                 #[allow(deprecated)]
-                                expr.visit_mut_post_nolimit(&mut |e| {
+                                expr.visit_mut_post(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         if *c >= input_arity {
                                             *e = literals[*c - input_arity].clone();
                                         }
                                     }
-                                });
+                                })?;
                             }
                         }
                     }

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -672,7 +672,6 @@ impl LiteralLifting {
                         let input_arity = input.arity();
                         for key in keys.iter_mut() {
                             for expr in key.iter_mut() {
-                                #[allow(deprecated)]
                                 expr.visit_mut_post(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         if *c >= input_arity {

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -14,7 +14,8 @@
 
 // TODO(frank): evaluate for redundancy with `column_knowledge`, or vice-versa.
 
-use crate::TransformArgs;
+use crate::{TransformArgs, TransformError};
+use itertools::Itertools;
 use mz_expr::visit::Visit;
 use mz_expr::{func, AggregateExpr, AggregateFunc, MirRelationExpr, MirScalarExpr, UnaryFunc};
 use mz_repr::{Datum, RelationType, ScalarType};
@@ -28,17 +29,21 @@ impl crate::Transform for NonNullable {
         &self,
         relation: &mut MirRelationExpr,
         _: TransformArgs,
-    ) -> Result<(), crate::TransformError> {
+    ) -> Result<(), TransformError> {
         relation.try_visit_mut_pre(&mut |e| self.action(e))
     }
 }
 
 impl NonNullable {
     /// Harvests information about non-nullability of columns from sources.
-    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), crate::TransformError> {
+    pub fn action(&self, relation: &mut MirRelationExpr) -> Result<(), TransformError> {
         match relation {
             MirRelationExpr::Map { input, scalars } => {
-                if scalars.iter().any(scalar_contains_isnull) {
+                let contains_isnull = scalars
+                    .iter()
+                    .map(scalar_contains_isnull)
+                    .fold_ok(false, |b1, b2| b1 || b2)?;
+                if contains_isnull {
                     let mut metadata = input.typ();
                     for scalar in scalars.iter_mut() {
                         scalar_nonnullable(scalar, &metadata);
@@ -48,7 +53,11 @@ impl NonNullable {
                 }
             }
             MirRelationExpr::Filter { input, predicates } => {
-                if predicates.iter().any(scalar_contains_isnull) {
+                let contains_isnull = predicates
+                    .iter()
+                    .map(scalar_contains_isnull)
+                    .fold_ok(false, |b1, b2| b1 || b2)?;
+                if contains_isnull {
                     let metadata = input.typ();
                     for predicate in predicates.iter_mut() {
                         scalar_nonnullable(predicate, &metadata);
@@ -62,9 +71,15 @@ impl NonNullable {
                 monotonic: _,
                 expected_group_size: _,
             } => {
-                if aggregates.iter().any(|a| {
-                    scalar_contains_isnull(&(a).expr) || matches!(&(a).func, AggregateFunc::Count)
-                }) {
+                let contains_isnull_or_count = aggregates
+                    .iter()
+                    .map::<Result<_, TransformError>, _>(|a| {
+                        let contains_null = scalar_contains_isnull(&(a).expr)?;
+                        let matches_count = matches!(&(a).func, AggregateFunc::Count);
+                        Ok(contains_null || matches_count)
+                    })
+                    .fold_ok(false, |b1, b2| b1 || b2)?;
+                if contains_isnull_or_count {
                     let metadata = input.typ();
                     for aggregate in aggregates.iter_mut() {
                         scalar_nonnullable(&mut aggregate.expr, &metadata);
@@ -79,10 +94,9 @@ impl NonNullable {
 }
 
 /// True if the expression contains a "is null" test.
-fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
+fn scalar_contains_isnull(expr: &MirScalarExpr) -> Result<bool, TransformError> {
     let mut result = false;
-    #[allow(deprecated)]
-    expr.visit_post_nolimit(&mut |e| {
+    expr.visit_post(&mut |e| {
         if let MirScalarExpr::CallUnary {
             func: UnaryFunc::IsNull(func::IsNull),
             ..
@@ -90,8 +104,8 @@ fn scalar_contains_isnull(expr: &MirScalarExpr) -> bool {
         {
             result = true;
         }
-    });
-    result
+    })?;
+    Ok(result)
 }
 
 /// Transformations to scalar functions, based on nonnullability of columns.

--- a/src/transform/src/reduction_pushdown.rs
+++ b/src/transform/src/reduction_pushdown.rs
@@ -98,34 +98,31 @@ impl ReductionPushdown {
                 let mut scalars = scalars.clone();
                 for index in 0..scalars.len() {
                     let (lower, upper) = scalars.split_at_mut(index);
-                    #[allow(deprecated)]
-                    upper[0].visit_mut_post_nolimit(&mut |e| {
+                    upper[0].visit_mut_post(&mut |e| {
                         if let mz_expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = lower[*c - arity].clone();
                             }
                         }
-                    });
+                    })?;
                 }
                 for key in group_key.iter_mut() {
-                    #[allow(deprecated)]
-                    key.visit_mut_post_nolimit(&mut |e| {
+                    key.visit_mut_post(&mut |e| {
                         if let mz_expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = scalars[*c - arity].clone();
                             }
                         }
-                    });
+                    })?;
                 }
                 for agg in aggregates.iter_mut() {
-                    #[allow(deprecated)]
-                    agg.expr.visit_mut_post_nolimit(&mut |e| {
+                    agg.expr.visit_mut_post(&mut |e| {
                         if let mz_expr::MirScalarExpr::Column(c) = e {
                             if *c >= arity {
                                 *e = scalars[*c - arity].clone();
                             }
                         }
-                    });
+                    })?;
                 }
 
                 **input = inner.take_dangerous()

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -148,8 +148,7 @@ impl RedundantJoin {
                         // Update the column offsets in the binding expressions to catch
                         // up with the removal of `remove_input_idx`.
                         for expr in bindings.iter_mut() {
-                            #[allow(deprecated)]
-                            expr.visit_mut_post_nolimit(&mut |e| {
+                            expr.visit_mut_post(&mut |e| {
                                 if let MirScalarExpr::Column(c) = e {
                                     let (_local_col, input_relation) =
                                         old_input_mapper.map_column_to_local(*c);
@@ -157,7 +156,7 @@ impl RedundantJoin {
                                         *c -= old_input_mapper.input_arity(remove_input_idx);
                                     }
                                 }
-                            });
+                            })?;
                         }
 
                         // Replace column references from `remove_input_idx` with the corresponding
@@ -165,8 +164,7 @@ impl RedundantJoin {
                         // from inputs after `remove_input_idx`.
                         for equivalence in equivalences.iter_mut() {
                             for expr in equivalence.iter_mut() {
-                                #[allow(deprecated)]
-                                expr.visit_mut_post_nolimit(&mut |e| {
+                                expr.visit_mut_post(&mut |e| {
                                     if let MirScalarExpr::Column(c) = e {
                                         let (local_col, input_relation) =
                                             old_input_mapper.map_column_to_local(*c);
@@ -176,7 +174,7 @@ impl RedundantJoin {
                                             *c -= old_input_mapper.input_arity(remove_input_idx);
                                         }
                                     }
-                                });
+                                })?;
                             }
                         }
 


### PR DESCRIPTION
This PR advances issue #12989  by eliminating calls to the deprecated `*_nolimit` variants of visit traversal functions in `mz_adapter` and `mz_transform`. As a consequence, Materialize's codebase can make less use of `#[allow(deprecated)]` annotations.

- Eliminates calls to `*_nolimit` variants of visit traversal functions as well as `#[allow(deprecated)]` annotations.
- Introduces error propagation so that higher level components can become aware of recursion limit errors.
- Makes minor changes to simplify code, in particular by using a `try_visit*` variant in `src/adapter/src/coord/dataflow_builder.rs`.
 
### Motivation

   * This PR refactors existing code. By advancing issue #12989  we move the codebase towards working with bounded recursion limit in traversals, allowing for controlled error handling.

### Tips for reviewer

I am still new to Rust, so code style comments are much appreciated!

### Testing

- [ X ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

N/A
