### PR TITLE
adapter,storage: update controller to support work on source errors

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -769,6 +769,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 desc: source.desc.clone(),
                                 ingestion: Some(ingestion),
                                 remote_addr: source.remote_addr.clone(),
+                                shard_id: None,
                             },
                         )])
                         .await
@@ -785,6 +786,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 desc: table.desc.clone(),
                                 ingestion: None,
                                 remote_addr: None,
+                                shard_id: None,
                             },
                         )])
                         .await
@@ -829,6 +831,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 desc: rview.desc.clone(),
                                 ingestion: None,
                                 remote_addr: None,
+                                shard_id: None,
                             },
                         )])
                         .await
@@ -2862,6 +2865,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             desc: table.desc.clone(),
                             ingestion: None,
                             remote_addr: None,
+                            shard_id: None,
                         },
                     )])
                     .await
@@ -2987,6 +2991,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             desc: source.desc.clone(),
                             ingestion: Some(ingestion),
                             remote_addr: source.remote_addr,
+                            shard_id: None,
                         },
                     )])
                     .await
@@ -3402,6 +3407,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             desc,
                             ingestion: None,
                             remote_addr: None,
+                            shard_id: None,
                         },
                     )])
                     .await

--- a/src/storage/src/client/controller.proto
+++ b/src/storage/src/client/controller.proto
@@ -18,4 +18,5 @@ message ProtoCollectionMetadata {
     string consensus_uri = 2;
     string data_shard = 3;
     string remap_shard = 4;
+    string status_shard = 5;
 }

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -511,6 +511,7 @@ mod tests {
             },
             remap_shard: shard,
             data_shard: ShardId::new(),
+            status_shard: ShardId::new(),
         };
 
         ReclockOperator::new(


### PR DESCRIPTION
This is the first part of the work on exposing source errors, and it includes the necessary changes in the communication between the coordinator and the storage controller to support the rest of the work.

There are two changes being made here:
- Adding `shard_id` as an optional field in `CollectionDescription`, as a way to allow the Adapter to create tables based on pre-existing storage collection (in this case, the motivation is `mz_connector_errors`).
- Adding `status_shard` as a new field `CollectionMetadata`. It is going to store the ShardId of the collection used to persist errors and other status information for each source. In the initial proposal, a single shared collection will be used for all sources, but having this exposed in `CollectionMetadata` (similarly to `remap_shard` for reclocking) allows us to change this in the future without breaking the stored state for the storage controller (and it makes the code cleaner overall).

I wanted to get this change merged first, as the rest of work should not involve any breaking changes and can be done/reviewed in smaller pieces at a calmer pace without impacting users.

For more context on this change, please feel free to check the [design doc on Notion](https://www.notion.so/materialize/Exposing-source-errors-via-SQL-1c83b2070b5a48db967b829b7ccd88dc) or the [WIP branch](https://github.com/andrioni/materialize/tree/andrioni/test-storage-v2) (warning, WIP code there!) from where the next PRs will come from as it stabilizes.

### Motivation

  * This PR makes progress towards a known-desirable feature: #12864

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
