### PR TITLE
persist: accept multiple Batches in compare_and_append_batch

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -169,7 +169,11 @@ pub fn render<G>(
                             .expect("invalid usage");
 
                         write
-                            .compare_and_append_batch(&mut batch, expected_upper, new_upper.clone())
+                            .compare_and_append_batch(
+                                &mut [&mut batch],
+                                expected_upper,
+                                new_upper.clone(),
+                            )
                             .await
                             .expect("cannot append updates")
                             .expect("cannot append updates")


### PR DESCRIPTION
This unlocks a pattern where multiple workers can each concurrently
create a Batch using the BatchBuilder API, then forward the metadata to
a single worker, which collects them all into a single
compare_and_append_batch call to link them all in at once. The times of
the Batches involved are allowed to overlap.

Making Batch impl ExchangeData is left for a followup.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Definitely wants testing and should probably go ahead and make an ExchangeData version of Batch in this initial PR so we can immediately wire it up.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
