### PR TITLE
controller: don't panic if no clusters

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -185,7 +185,8 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
-          run: nightly
+          run: default
+          args: [testdrive/*.td]
 
   - id: testdrive-workers-1
     label: ":racing_car: testdrive with --workers 1"

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -442,6 +442,13 @@ where
     /// This method is cancellation safe.
     pub async fn ready(&mut self) {
         if let Readiness::NotReady = self.readiness {
+            if self.compute.is_empty() {
+                // If there are no clients, block forever. This signals that
+                // there may be more work to do (e.g., if a compute instance
+                // is created). Calling `select_all` with an empty list of
+                // futures will panic.
+                future::pending().await
+            }
             // The underlying `ready` methods are cancellation safe, so it is
             // safe to construct this `select!`.
             let computes = future::select_all(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -76,6 +76,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-cluster",
         "test-github-12251",
         "test-remote-storaged",
+        "test-drop-default-cluster",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -204,3 +205,14 @@ def workflow_test_remote_storaged(c: Composition) -> None:
 
         c.up("storaged")
         c.run("testdrive", "storaged/04-after-storaged-restart.td")
+
+
+def workflow_test_drop_default_cluster(c: Composition) -> None:
+    """Test that the default cluster can be dropped"""
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+    c.wait_for_materialized()
+
+    c.sql("DROP CLUSTER default CASCADE")
+    c.sql("CREATE CLUSTER default REPLICAS (default (SIZE '1'))")


### PR DESCRIPTION
@philip-stoev I broke this, again, recently. We had talked a while back about getting a test for this in place—any chance you've got the time?

----

This makes it possible to, once again, drop the default cluster.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
