### PR TITLE
controller: use correct internal HTTP port for compute

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -297,7 +297,7 @@ where
                                 },
                                 ServicePort {
                                     name: "internal-http".into(),
-                                    port_hint: 6875,
+                                    port_hint: 6877,
                                 },
                             ],
                             cpu_limit: allocation.cpu_limit,


### PR DESCRIPTION
We use 6877 for the internal HTTP port everywhere else; just missed
this one port.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
