### PR TITLE
K8s testing framework MVP

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -16,6 +16,8 @@ flake8==4.0.1
 humanize==4.2.3
 isort==5.10.1
 junit-xml==1.9
+kubernetes==22.6.0
+kubernetes-stubs==22.6.0
 mypy==0.961
 numpy==1.22.4
 pandas==1.4.3

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -1,0 +1,184 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from kubernetes.client import (
+    AppsV1Api,
+    CoreV1Api,
+    RbacAuthorizationV1Api,
+    V1ConfigMap,
+    V1Deployment,
+    V1Pod,
+    V1RoleBinding,
+    V1Secret,
+    V1Service,
+    V1StatefulSet,
+)
+from kubernetes.client.exceptions import ApiException
+from kubernetes.config import new_client_from_config_dict  # type: ignore
+
+from materialize import ROOT, mzbuild
+
+
+class K8sResource:
+    def kube_config(self) -> Any:
+        with open(Path.home() / ".kube" / "config") as f:
+            return yaml.safe_load(f)
+
+    def api(self) -> CoreV1Api:
+        api_client = new_client_from_config_dict(self.kube_config())
+        return CoreV1Api(api_client)
+
+    def apps_api(self) -> AppsV1Api:
+        api_client = new_client_from_config_dict(self.kube_config())
+        return AppsV1Api(api_client)
+
+    def rbac_api(self) -> RbacAuthorizationV1Api:
+        api_client = new_client_from_config_dict(self.kube_config())
+        return RbacAuthorizationV1Api(api_client)
+
+    def namespace(self) -> str:
+        return "default"
+
+    def kind(self) -> str:
+        assert False
+
+    def create(self) -> None:
+        assert False
+
+    def image(self, service: str) -> str:
+        repo = mzbuild.Repository(ROOT)
+        deps = repo.resolve_dependencies([repo.images[service]])
+        rimage = deps[service]
+        return rimage.spec()
+
+
+class K8sPod(K8sResource):
+    pod: V1Pod
+
+    def kind(self) -> str:
+        return "pod"
+
+    def create(self) -> None:
+        core_v1_api = self.api()
+        core_v1_api.create_namespaced_pod(body=self.pod, namespace=self.namespace())
+
+
+class K8sService(K8sResource):
+    service: V1Service
+
+    def kind(self) -> str:
+        return "service"
+
+    def create(self) -> None:
+        core_v1_api = self.api()
+        core_v1_api.create_namespaced_service(
+            body=self.service, namespace=self.namespace()
+        )
+
+
+class K8sDeployment(K8sResource):
+    deployment: V1Deployment
+
+    def kind(self) -> str:
+        return "deployment"
+
+    def create(self) -> None:
+        apps_v1_api = self.apps_api()
+        apps_v1_api.create_namespaced_deployment(
+            body=self.deployment, namespace=self.namespace()
+        )
+
+
+class K8sStatefulSet(K8sResource):
+    stateful_set: V1StatefulSet
+
+    def kind(self) -> str:
+        return "statefulset"
+
+    def create(self) -> None:
+        apps_v1_api = self.apps_api()
+        apps_v1_api.create_namespaced_stateful_set(
+            body=self.stateful_set, namespace=self.namespace()
+        )
+
+
+class K8sConfigMap(K8sResource):
+    config_map: V1ConfigMap
+
+    def kind(self) -> str:
+        return "configmap"
+
+    def create(self) -> None:
+        core_v1_api = self.api()
+
+        # kubectl delete all -all does not clean up configmaps
+        try:
+            assert self.config_map.metadata is not None
+            assert self.config_map.metadata.name is not None
+            core_v1_api.delete_namespaced_config_map(
+                name=self.config_map.metadata.name, namespace=self.namespace()
+            )
+        except ApiException:
+            pass
+
+        core_v1_api.create_namespaced_config_map(
+            body=self.config_map, namespace=self.namespace()
+        )
+
+
+class K8sRoleBinding(K8sResource):
+    role_binding: V1RoleBinding
+
+    def kind(self) -> str:
+        return "rolebinding"
+
+    def create(self) -> None:
+        rbac_api = self.rbac_api()
+
+        # kubectl delete all -all does not clean up role bindings
+        try:
+            assert self.role_binding.metadata is not None
+            assert self.role_binding.metadata.name is not None
+            rbac_api.delete_namespaced_role_binding(
+                name=self.role_binding.metadata.name, namespace=self.namespace()
+            )
+        except ApiException:
+            pass
+
+        rbac_api.create_namespaced_role_binding(
+            body=self.role_binding,
+            namespace=self.namespace(),
+        )
+
+
+class K8sSecret(K8sResource):
+    secret = V1Secret
+
+    def kind(self) -> str:
+        return "secret"
+
+    # kubectl delete all -all does not clean up secrets
+    def create(self) -> None:
+        core_v1_api = self.api()
+
+        try:
+            assert self.secret.metadata is not None
+            assert self.secret.metadata.name is not None
+            core_v1_api.delete_namespaced_secret(
+                name=self.secret.metadata.name, namespace=self.namespace()
+            )
+        except ApiException:
+            pass
+        core_v1_api.create_namespaced_secret(
+            body=self.secret, namespace=self.namespace()  # type: ignore
+        )

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -1,0 +1,157 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import subprocess
+import urllib.parse
+from typing import Any, Tuple
+
+import pg8000
+import sqlparse
+from kubernetes.client import (
+    V1Container,
+    V1ContainerPort,
+    V1EnvVar,
+    V1EnvVarSource,
+    V1LabelSelector,
+    V1ObjectFieldSelector,
+    V1ObjectMeta,
+    V1PersistentVolumeClaim,
+    V1PersistentVolumeClaimSpec,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1ResourceRequirements,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+    V1StatefulSet,
+    V1StatefulSetSpec,
+    V1VolumeMount,
+)
+from pg8000 import Cursor
+
+from materialize.cloudtest.k8s import K8sService, K8sStatefulSet
+
+
+class EnvironmentdService(K8sService):
+    def __init__(self) -> None:
+        service_port = V1ServicePort(name="sql", port=6875)
+        self.service = V1Service(
+            api_version="v1",
+            kind="Service",
+            metadata=V1ObjectMeta(name="environmentd", labels={"app": "environmentd"}),
+            spec=V1ServiceSpec(
+                type="NodePort", ports=[service_port], selector={"app": "environmentd"}
+            ),
+        )
+
+    def host_port(self) -> Tuple[str, str]:
+        url = subprocess.check_output(
+            ["minikube", "service", "environmentd", "--url"]
+        ).decode("ascii")
+        parts = str(url).split(":")
+        host = parts[1][2:]
+        port = parts[2].strip()
+        return (host, port)
+
+    def host(self) -> str:
+        return self.host_port()[0]
+
+    def port(self) -> int:
+        return int(self.host_port()[1])
+
+    def sql_cursor(self) -> Cursor:
+        """Get a cursor to run SQL queries against the environmentd stateful set."""
+        conn = pg8000.connect(host=self.host(), port=self.port(), user="materialize")
+        conn.autocommit = True
+        return conn.cursor()
+
+    def sql(self, sql: str) -> None:
+        """Run a batch of SQL statements against the environmentd stateful set."""
+        with self.sql_cursor() as cursor:
+            for statement in sqlparse.split(sql):
+                print(f"> {statement}")
+                cursor.execute(statement)
+
+    def sql_query(self, sql: str) -> Any:
+        """Execute a SQL query against the environmentd statefule set and return results."""
+        with self.sql_cursor() as cursor:
+            print(f"> {sql}")
+            cursor.execute(sql)
+            return cursor.fetchall()
+
+
+class EnvironmentdStatefulSet(K8sStatefulSet):
+    def __init__(self) -> None:
+
+        metadata = V1ObjectMeta(name="environmentd", labels={"app": "environmentd"})
+        label_selector = V1LabelSelector(match_labels={"app": "environmentd"})
+
+        value_from = V1EnvVarSource(
+            field_ref=V1ObjectFieldSelector(field_path="metadata.name")
+        )
+
+        env = [
+            V1EnvVar(name="MZ_POD_NAME", value_from=value_from),
+            V1EnvVar(name="AWS_REGION", value="minio"),
+            V1EnvVar(name="AWS_ACCESS_KEY_ID", value="minio"),
+            V1EnvVar(name="AWS_SECRET_ACCESS_KEY", value="minio123"),
+        ]
+
+        ports = [V1ContainerPort(container_port=5432, name="sql")]
+
+        volume_mounts = [
+            V1VolumeMount(name="data", mount_path="/data"),
+        ]
+
+        s3_endpoint = urllib.parse.quote("http://minio-service.default:9000")
+
+        container = V1Container(
+            name="environmentd",
+            image=self.image("environmentd"),
+            args=[
+                "--storaged-image=" + self.image("storaged"),
+                "--computed-image=" + self.image("computed"),
+                f"--persist-blob-url=s3://minio:minio123@test/test?endpoint={s3_endpoint}&region=minio",
+                "--orchestrator=kubernetes",
+                "--orchestrator-kubernetes-image-pull-policy=never",
+                "--persist-consensus-url=postgres://postgres@postgres.default?options=--search_path=consensus",
+                "--adapter-stash-url=postgres://postgres@postgres.default?options=--search_path=catalog",
+                "--storage-stash-url=postgres://postgres@postgres.default?options=--search_path=storage",
+                "--unsafe-mode",
+            ],
+            env=env,
+            ports=ports,
+            volume_mounts=volume_mounts,
+        )
+
+        pod_spec = V1PodSpec(containers=[container])
+        template_spec = V1PodTemplateSpec(metadata=metadata, spec=pod_spec)
+        claim_templates = [
+            V1PersistentVolumeClaim(
+                metadata=V1ObjectMeta(name="data"),
+                spec=V1PersistentVolumeClaimSpec(
+                    access_modes=["ReadWriteOnce"],
+                    resources=V1ResourceRequirements(requests={"storage": "1Gi"}),
+                ),
+            )
+        ]
+
+        self.stateful_set = V1StatefulSet(
+            api_version="apps/v1",
+            kind="StatefulSet",
+            metadata=metadata,
+            spec=V1StatefulSetSpec(
+                service_name="environmentd",
+                replicas=1,
+                pod_management_policy="Parallel",
+                selector=label_selector,
+                template=template_spec,
+                volume_claim_templates=claim_templates,
+            ),
+        )

--- a/misc/python/materialize/cloudtest/k8s/minio.py
+++ b/misc/python/materialize/cloudtest/k8s/minio.py
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import subprocess
+
+from materialize.cloudtest.k8s import K8sResource
+from materialize.cloudtest.wait import wait
+
+
+class Minio(K8sResource):
+    def create(self) -> None:
+        subprocess.check_call(
+            ["kubectl", "delete", "persistentvolumeclaim", "minio-pv-claim"]
+        )
+
+        for yaml in [
+            "minio-standalone-pvc",
+            "minio-standalone-deployment",
+            "minio-standalone-service",
+        ]:
+            subprocess.check_call(
+                [
+                    "kubectl",
+                    "create",
+                    "-f",
+                    f"https://raw.githubusercontent.com/kubernetes/examples/master/staging/storage/minio/{yaml}.yaml",
+                ]
+            )
+
+        wait(
+            resource="deployment.apps/minio-deployment",
+            condition="condition=Available=True",
+        )
+
+        subprocess.check_call(
+            [
+                "kubectl",
+                "run",
+                "minio",
+                "--image=minio/mc",
+                "--restart=Never",
+                "--command",
+                "/bin/sh",
+                "--",
+                "-c",
+                ";".join(
+                    [
+                        "mc config host add myminio http://minio-service.default:9000 minio minio123",
+                        "mc rm -r --force myminio/test",
+                        "mc mb myminio/test",
+                    ]
+                ),
+            ]
+        )

--- a/misc/python/materialize/cloudtest/k8s/postgres.py
+++ b/misc/python/materialize/cloudtest/k8s/postgres.py
@@ -1,0 +1,126 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from kubernetes.client import (
+    V1ConfigMap,
+    V1ConfigMapVolumeSource,
+    V1Container,
+    V1ContainerPort,
+    V1EnvVar,
+    V1LabelSelector,
+    V1ObjectMeta,
+    V1PersistentVolumeClaim,
+    V1PersistentVolumeClaimSpec,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1ResourceRequirements,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+    V1StatefulSet,
+    V1StatefulSetSpec,
+    V1Volume,
+    V1VolumeMount,
+)
+
+from materialize.cloudtest.k8s import K8sConfigMap, K8sService, K8sStatefulSet
+
+
+class PostgresConfigMap(K8sConfigMap):
+    def __init__(self) -> None:
+        self.config_map = V1ConfigMap(
+            metadata=V1ObjectMeta(
+                name="postgres-init",
+            ),
+            data={
+                "schemas.sql": dedent(
+                    """
+                CREATE SCHEMA consensus;
+                CREATE SCHEMA catalog;
+                CREATE SCHEMA storage;
+            """
+                )
+            },
+        )
+
+
+class PostgresService(K8sService):
+    def __init__(self) -> None:
+        service_port = V1ServicePort(name="sql", port=5432)
+
+        self.service = V1Service(
+            api_version="v1",
+            kind="Service",
+            metadata=V1ObjectMeta(name="postgres", labels={"app": "postgres"}),
+            spec=V1ServiceSpec(
+                type="NodePort", ports=[service_port], selector={"app": "postgres"}
+            ),
+        )
+
+
+class PostgresStatefulSet(K8sStatefulSet):
+    def __init__(self) -> None:
+        metadata = V1ObjectMeta(name="postgres", labels={"app": "postgres"})
+        label_selector = V1LabelSelector(match_labels={"app": "postgres"})
+        env = [V1EnvVar(name="POSTGRES_HOST_AUTH_METHOD", value="trust")]
+        ports = [V1ContainerPort(container_port=5432, name="sql")]
+        volume_mounts = [
+            V1VolumeMount(name="data", mount_path="/data"),
+            V1VolumeMount(
+                name="postgres-init", mount_path="/docker-entrypoint-initdb.d"
+            ),
+        ]
+
+        volume_config = V1ConfigMapVolumeSource(
+            name="postgres-init",
+        )
+
+        volumes = [V1Volume(name="postgres-init", config_map=volume_config)]
+
+        container = V1Container(
+            name="postgres",
+            image="postgres:14.3",
+            env=env,
+            ports=ports,
+            volume_mounts=volume_mounts,
+        )
+
+        pod_spec = V1PodSpec(containers=[container], volumes=volumes)
+        template_spec = V1PodTemplateSpec(metadata=metadata, spec=pod_spec)
+        claim_templates = [
+            V1PersistentVolumeClaim(
+                metadata=V1ObjectMeta(name="data"),
+                spec=V1PersistentVolumeClaimSpec(
+                    access_modes=["ReadWriteOnce"],
+                    resources=V1ResourceRequirements(requests={"storage": "1Gi"}),
+                ),
+            )
+        ]
+
+        self.stateful_set = V1StatefulSet(
+            api_version="apps/v1",
+            kind="StatefulSet",
+            metadata=metadata,
+            spec=V1StatefulSetSpec(
+                service_name="postgres",
+                replicas=1,
+                selector=label_selector,
+                template=template_spec,
+                volume_claim_templates=claim_templates,
+            ),
+        )
+
+
+POSTGRES_RESOURCES = [
+    PostgresConfigMap(),
+    PostgresService(),
+    PostgresStatefulSet(),
+]

--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -1,0 +1,88 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from kubernetes.client import (
+    V1Container,
+    V1Deployment,
+    V1DeploymentSpec,
+    V1LabelSelector,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Service,
+    V1ServicePort,
+    V1ServiceSpec,
+)
+
+from materialize.cloudtest.k8s import K8sDeployment, K8sService
+
+
+class RedpandaDeployment(K8sDeployment):
+    def __init__(self) -> None:
+        container = V1Container(
+            name="redpanda",
+            image="vectorized/redpanda:v21.11.13",
+            command=[
+                "/usr/bin/rpk",
+                "redpanda",
+                "start",
+                "--overprovisioned",
+                "--smp",
+                "1",
+                "--memory",
+                "1G",
+                "--reserve-memory",
+                "0M",
+                "--node-id",
+                "0",
+                "--check=false",
+                "--set",
+                "redpanda.enable_transactions=true",
+                "--set",
+                "redpanda.enable_idempotence=true",
+                "--set",
+                "redpanda.auto_create_topics_enabled=false",
+                "--advertise-kafka-addr",
+                "redpanda:9092",
+            ],
+        )
+
+        template = V1PodTemplateSpec(
+            metadata=V1ObjectMeta(labels={"app": "redpanda"}),
+            spec=V1PodSpec(containers=[container]),
+        )
+
+        selector = V1LabelSelector(match_labels={"app": "redpanda"})
+
+        spec = V1DeploymentSpec(replicas=1, template=template, selector=selector)
+
+        self.deployment = V1Deployment(
+            api_version="apps/v1",
+            kind="Deployment",
+            metadata=V1ObjectMeta(name="redpanda"),
+            spec=spec,
+        )
+
+
+class RedpandaService(K8sService):
+    def __init__(self) -> None:
+        ports = [
+            V1ServicePort(name="kafka", port=9092),
+            V1ServicePort(name="schema-registry", port=8081),
+        ]
+
+        self.service = V1Service(
+            metadata=V1ObjectMeta(name="redpanda", labels={"app": "redpanda"}),
+            spec=V1ServiceSpec(
+                type="NodePort", ports=ports, selector={"app": "redpanda"}
+            ),
+        )
+
+
+REDPANDA_RESOURCES = [RedpandaDeployment(), RedpandaService()]

--- a/misc/python/materialize/cloudtest/k8s/role_binding.py
+++ b/misc/python/materialize/cloudtest/k8s/role_binding.py
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from kubernetes.client import V1ObjectMeta, V1RoleBinding, V1RoleRef, V1Subject
+
+from materialize.cloudtest.k8s import K8sRoleBinding
+
+
+class AdminRoleBinding(K8sRoleBinding):
+    def __init__(self) -> None:
+        metadata = V1ObjectMeta(name="admin-binding")
+        role_ref = V1RoleRef(
+            api_group="rbac.authorization.k8s.io", kind="ClusterRole", name="admin"
+        )
+        subjects = [V1Subject(kind="ServiceAccount", name="default")]
+        self.role_binding = V1RoleBinding(
+            api_version="rbac.authorization.k8s.io/v1",
+            kind="RoleBinding",
+            metadata=metadata,
+            role_ref=role_ref,
+            subjects=subjects,
+        )

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import subprocess
+
+from kubernetes.client import V1Container, V1ObjectMeta, V1Pod, V1PodSpec
+
+from materialize.cloudtest.k8s import K8sPod
+
+
+class Testdrive(K8sPod):
+    def __init__(self) -> None:
+        metadata = V1ObjectMeta(name="testdrive")
+
+        container = V1Container(
+            name="testdrive",
+            image=self.image("testdrive"),
+            command=["sleep", "infinity"],
+        )
+
+        pod_spec = V1PodSpec(containers=[container])
+        self.pod = V1Pod(metadata=metadata, spec=pod_spec)
+
+    def run_string(self, input: str) -> None:
+        subprocess.run(
+            [
+                "kubectl",
+                "exec",
+                "-it",
+                "testdrive",
+                "--",
+                "testdrive",
+                "--materialize-url=postgres://materialize:materialize@environmentd:6875/materialize",
+                "--kafka-addr=redpanda:9092",
+                "--schema-registry-url=http://redpanda:8081",
+                "--default-timeout=300s",
+            ],
+            check=True,
+            input=input,
+            text=True,
+        )

--- a/misc/python/materialize/cloudtest/testcase.py
+++ b/misc/python/materialize/cloudtest/testcase.py
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from materialize import ROOT, mzbuild
+
+
+class CloudTestCase(unittest.TestCase):
+    def acquire_images(self) -> None:
+        images = ["environmentd", "computed", "storaged", "testdrive"]
+
+        # Direct mzbuild to push the images into minikube's container registry
+        # while preserving the original values for use inside the ci-builder
+        minikube_env = {
+            "MZ_DEV_CI_BUILDER_DOCKER_HOST": os.environ.get("DOCKER_HOST", ""),
+            "MZ_DEV_CI_BUILDER_DOCKER_TLS_VERIFY": os.environ.get(
+                "DOCKER_TLS_VERIFY", ""
+            ),
+            "MZ_DEV_CI_BUILDER_DOCKER_CERT_PATH": os.environ.get(
+                "DOCKER_CERT_PATH", ""
+            ),
+        }
+
+        minikube_env_str = subprocess.check_output(["minikube", "docker-env"]).decode(
+            "ascii"
+        )
+        prefix = "export "
+        for minikube_env_line in minikube_env_str.splitlines():
+            if minikube_env_line.startswith(prefix):
+                parts = minikube_env_line[len(prefix) :].split("=")
+                minikube_env[parts[0]] = parts[1].strip('"')
+
+        repo = mzbuild.Repository(ROOT)
+        with patch.dict("os.environ", minikube_env):
+            for image in images:
+                deps = repo.resolve_dependencies([repo.images[image]])
+                deps.acquire()

--- a/misc/python/materialize/cloudtest/wait.py
+++ b/misc/python/materialize/cloudtest/wait.py
@@ -1,0 +1,40 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import subprocess
+
+from materialize import ui
+from materialize.ui import UIError
+
+
+def wait(condition: str, resource: str, timeout_secs: int = 300) -> None:
+    cmd = [
+        "kubectl",
+        "wait",
+        "--for",
+        condition,
+        resource,
+        "--timeout",
+        f"{timeout_secs}s",
+    ]
+    ui.progress(f'waiting for {" ".join(cmd)} ... ')
+
+    error = None
+    for remaining in ui.timeout_loop(timeout_secs, tick=0.1):
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+            if "condition met" in output.decode("ascii"):
+                ui.progress("success!", finish=True)
+                return
+        except subprocess.CalledProcessError as e:
+            error = e
+
+    ui.progress(finish=True)
+    raise UIError(f"kubectl wait never returned 'condition met': {error}")

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -956,7 +956,7 @@ def _wait_for_pg(
                     f"host={host} port={port} did not return rows matching {expected} got: {result}"
                 )
         except Exception as e:
-            ui.progress(" " + str(int(remaining)))
+            ui.progress(f"{e} " + str(int(remaining)))
             error = e
     ui.progress(finish=True)
     raise UIError(f"never got correct result for {args}: {error}")

--- a/test/cloudtest/cloudtest
+++ b/test/cloudtest/cloudtest
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../bin/pyactivate -m unittest ./*.py "$@"

--- a/test/cloudtest/cloudtest.py
+++ b/test/cloudtest/cloudtest.py
@@ -1,0 +1,81 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.cloudtest.k8s.environmentd import (
+    EnvironmentdService,
+    EnvironmentdStatefulSet,
+)
+from materialize.cloudtest.k8s.minio import Minio
+from materialize.cloudtest.k8s.postgres import POSTGRES_RESOURCES
+from materialize.cloudtest.k8s.redpanda import REDPANDA_RESOURCES
+from materialize.cloudtest.k8s.role_binding import AdminRoleBinding
+from materialize.cloudtest.k8s.testdrive import Testdrive
+from materialize.cloudtest.testcase import CloudTestCase
+from materialize.cloudtest.wait import wait
+
+
+class SimpleCloudTest(CloudTestCase):
+    def test_simple(self) -> None:
+        self.acquire_images()
+
+        ed_service = EnvironmentdService()
+        testdrive = Testdrive()
+
+        for resource in [
+            *POSTGRES_RESOURCES,
+            *REDPANDA_RESOURCES,
+            Minio(),
+            AdminRoleBinding(),
+            EnvironmentdStatefulSet(),
+            ed_service,
+            testdrive,
+        ]:
+            print(resource)
+            resource.create()
+
+        wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+
+        ed_service.sql("SELECT 1")
+
+        wait(condition="condition=Ready", resource="pod/testdrive")
+        testdrive.run_string(
+            input=dedent(
+                """
+                $ kafka-create-topic topic=test
+
+                $ kafka-ingest format=bytes topic=test
+                ABC
+
+                > CREATE TABLE t1 (f1 INTEGER);
+                > CREATE DEFAULT INDEX ON t1;
+                > INSERT INTO t1 VALUES (1);
+
+                > CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '2-2'));
+                > SET cluster=c1
+
+                > CREATE CONNECTION kafka FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+                > CREATE SOURCE s1
+                  FROM KAFKA CONNECTION kafka
+                  TOPIC'testdrive-test-${testdrive.seed}'
+                  FORMAT BYTES
+                  ENVELOPE NONE;
+
+                > CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) FROM t1;
+                > SELECT * FROM v1;
+                1
+
+                > CREATE MATERIALIZED VIEW v2 AS SELECT COUNT(*) FROM s1;
+                > SELECT * FROM v2;
+                1
+                """
+            )
+        )


### PR DESCRIPTION
This is the basic skeleton of the K8s testing framework. In some situations, a more concise syntax is possible so I will do some work on that in follow-up PRs in order to avoid too much of a boilerplate per test.
To run:

```
bin/ci-builder build stable
cd test/cloudtest
kubectl delete all --all
./cloudtest
```

What works:
- starting a Mz instance in the cloud
- running stand-alone SQL
- running in-line testdrive scripts
- minio blob store
- postgres as a stash database
- redpanda's kafka implementation
- CREATE CLUSTER ... without REMOTE works as advertised
- kafka FORMAT BYTES sources work
- integration with mzimage to build and upload containers from the local tree

What does not work:

- Due to some weirdness where Redpanda's own schema registry is unable to contact Redpanda's kafka implementation that runs inside the same container. So:
-- schema registry can not be used
-- FORMAT AVRO sources does not work
* If the ci-builder needs to be rebuilt (which is the case because this PR modifies requirements.txt), this will not happen automatically (same problem occurs in mzcompose-based tests)

What is not implemented:
- cleanup without having to call `kubectl` manually
- use of a separate namespace per test. However, the groundwork has been laid a bit as `namespace="default"` is not peppered throughout the code.
### Tips for reviewer

If you have the patience, please reconsider before rewriting the code from scratch. Instead, feel free to savage it in the PR.