### PR TITLE
sql: move CREATE CONNECTION out of unsafe mode

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3043,8 +3043,6 @@ pub fn plan_create_connection(
     scx: &StatementContext,
     stmt: CreateConnectionStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    scx.require_unsafe_mode("CREATE CONNECTION")?;
-
     let create_sql = normalize::create_statement(&scx, Statement::CreateConnection(stmt.clone()))?;
     let CreateConnectionStatement {
         name,


### PR DESCRIPTION
Connections are mandatory for sources now, so they better not be unsafe.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
