### PR TITLE
*: consistently use 6878 as the internal HTTP port

### DIFF
--- a/src/compute/ci/entrypoint.sh
+++ b/src/compute/ci/entrypoint.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-args=(--controller-listen-addr=0.0.0.0:2100 --internal-http-listen-addr=0.0.0.0:6877)
+args=(--controller-listen-addr=0.0.0.0:2100 --internal-http-listen-addr=0.0.0.0:6878)
 if [[ "${KUBERNETES_SERVICE_HOST:-}" ]]; then
     # Hack: if running in Kubernetes, we parse the process index from the
     # hostname, if possible. At present this is the only known way to get the

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -62,7 +62,7 @@ struct Args {
         long,
         env = "INTERNAL_HTTP_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "127.0.0.1:6877"
+        default_value = "127.0.0.1:6878"
     )]
     internal_http_listen_addr: SocketAddr,
 

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -297,7 +297,7 @@ where
                                 },
                                 ServicePort {
                                     name: "internal-http".into(),
-                                    port_hint: 6877,
+                                    port_hint: 6878,
                                 },
                             ],
                             cpu_limit: allocation.cpu_limit,

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -88,7 +88,7 @@ pub struct Args {
     shard_id: Option<String>,
 
     /// The address of the internal HTTP server.
-    #[clap(long, value_name = "HOST:PORT", default_value = "127.0.0.1:6877")]
+    #[clap(long, value_name = "HOST:PORT", default_value = "127.0.0.1:6878")]
     internal_http_listen_addr: SocketAddr,
 
     /// Path of a file to write metrics at the end of the run.

--- a/src/storage/ci/Dockerfile
+++ b/src/storage/ci/Dockerfile
@@ -18,4 +18,4 @@ COPY storaged /usr/local/bin/
 
 USER materialize
 
-ENTRYPOINT ["tini", "--", "storaged", "--controller-listen-addr=0.0.0.0:2100", "--internal-http-listen-addr=0.0.0.0:6877"]
+ENTRYPOINT ["tini", "--", "storaged", "--controller-listen-addr=0.0.0.0:2100", "--internal-http-listen-addr=0.0.0.0:6878"]

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -62,7 +62,7 @@ struct Args {
         long,
         env = "INTERNAL_HTTP_LISTEN_ADDR",
         value_name = "HOST:PORT",
-        default_value = "127.0.0.1:6877"
+        default_value = "127.0.0.1:6878"
     )]
     internal_http_listen_addr: SocketAddr,
 


### PR DESCRIPTION
The internal HTTP port should be 6878. Various services were
semi-incorrectly using 6877 as the internal HTTP port.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
