### PR TITLE
Order logging variants

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -411,7 +411,7 @@ impl CatalogState {
         let logging = match introspection {
             None => None,
             Some(introspection) => {
-                let mut active_logs = HashMap::new();
+                let mut active_logs = BTreeMap::new();
                 for (log, index_id) in introspection_sources {
                     let source_name = FullObjectName {
                         database: RawDatabaseSpecifier::Ambient,

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -9,7 +9,7 @@
 
 //! Compute layer logging configuration.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.logging.rs"));
 #[derive(Arbitrary, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggingConfig {
     pub granularity_ns: u128,
-    pub active_logs: HashMap<LogVariant, GlobalId>,
+    pub active_logs: BTreeMap<LogVariant, GlobalId>,
     // Whether we should report logs for the log-processing dataflows
     pub log_logging: bool,
 }
@@ -71,7 +71,7 @@ impl ProtoMapEntry<LogVariant, GlobalId> for ProtoActiveLog {
     }
 }
 
-#[derive(Arbitrary, Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Arbitrary, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub enum LogVariant {
     Timely(TimelyLog),
     Differential(DifferentialLog),
@@ -101,7 +101,7 @@ impl RustType<ProtoLogVariant> for LogVariant {
     }
 }
 
-#[derive(Arbitrary, Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Arbitrary, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub enum TimelyLog {
     Operates,
     Channels,
@@ -149,7 +149,7 @@ impl RustType<ProtoTimelyLog> for TimelyLog {
     }
 }
 
-#[derive(Arbitrary, Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Arbitrary, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub enum DifferentialLog {
     ArrangementBatches,
     ArrangementRecords,
@@ -181,7 +181,7 @@ impl RustType<ProtoDifferentialLog> for DifferentialLog {
     }
 }
 
-#[derive(Arbitrary, Hash, Eq, PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Arbitrary, Hash, Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Serialize, Deserialize)]
 pub enum ComputeLog {
     DataflowCurrent,
     DataflowDependency,


### PR DESCRIPTION
While doing other debugging, the non-orderedness of log variants made life hard in lining up e.g. before and after stuff, progress updates elsewhere etc. This just swaps out a `HashMap` and swaps in a `BTreeMap`, and derives `Ord` in a few places.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
