### PR TITLE
persist: add shard and writer id to blob keys

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -28,12 +28,12 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::task::JoinHandle;
 use tracing::{debug_span, instrument, trace_span, warn, Instrument};
-use uuid::Uuid;
 
 use crate::error::InvalidUsage;
 use crate::r#impl::machine::retry_external;
 use crate::r#impl::metrics::{BatchWriteMetrics, Metrics};
-use crate::{PersistConfig, ShardId};
+use crate::r#impl::paths::{PartId, PartialBlobKey};
+use crate::{PersistConfig, ShardId, WriterId};
 
 /// A handle to a batch of updates that has been written to blob storage but
 /// which has not yet been appended to a shard.
@@ -51,7 +51,7 @@ where
     shard_id: ShardId,
 
     /// Keys to blobs that make up this batch of updates.
-    pub(crate) blob_keys: Vec<String>,
+    pub(crate) blob_keys: Vec<PartialBlobKey>,
 
     /// The number of updates in this batch.
     pub(crate) num_updates: usize,
@@ -90,7 +90,7 @@ where
         blob: Arc<dyn Blob + Send + Sync>,
         shard_id: ShardId,
         desc: Description<T>,
-        blob_keys: Vec<String>,
+        blob_keys: Vec<PartialBlobKey>,
         num_updates: usize,
     ) -> Self {
         Self {
@@ -198,11 +198,13 @@ where
         lower: Antichain<T>,
         blob: Arc<dyn Blob + Send + Sync>,
         shard_id: ShardId,
+        writer_id: WriterId,
     ) -> Self {
         let parts = BatchParts::new(
             cfg.batch_builder_max_outstanding_parts,
             Arc::clone(&metrics),
             shard_id,
+            writer_id,
             lower.clone(),
             Arc::clone(&blob),
             &metrics.user,
@@ -333,10 +335,11 @@ pub(crate) struct BatchParts<T> {
     max_outstanding: usize,
     metrics: Arc<Metrics>,
     shard_id: ShardId,
+    writer_id: WriterId,
     lower: Antichain<T>,
     blob: Arc<dyn Blob + Send + Sync>,
-    writing_parts: VecDeque<(String, JoinHandle<()>)>,
-    finished_parts: Vec<String>,
+    writing_parts: VecDeque<(PartialBlobKey, JoinHandle<()>)>,
+    finished_parts: Vec<PartialBlobKey>,
     batch_metrics: BatchWriteMetrics,
 }
 
@@ -345,6 +348,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         max_outstanding: usize,
         metrics: Arc<Metrics>,
         shard_id: ShardId,
+        writer_id: WriterId,
         lower: Antichain<T>,
         blob: Arc<dyn Blob + Send + Sync>,
         batch_metrics: &BatchWriteMetrics,
@@ -353,6 +357,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
             max_outstanding,
             metrics,
             shard_id,
+            writer_id,
             lower,
             blob,
             writing_parts: VecDeque::new(),
@@ -371,8 +376,8 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         let metrics = Arc::clone(&self.metrics);
         let blob = Arc::clone(&self.blob);
         let batch_metrics = self.batch_metrics.clone();
-        let key = Uuid::new_v4().to_string();
-        let blob_key = key.clone();
+        let partial_key = PartialBlobKey::new(&self.writer_id, &PartId::new());
+        let key = partial_key.complete(&self.shard_id);
         let index = u64::cast_from(self.finished_parts.len() + self.writing_parts.len());
 
         let write_span = debug_span!("batch::write_part", shard = %self.shard_id).or_current();
@@ -436,7 +441,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
 
                 let payload_len = buf.len();
                 let () = retry_external(&metrics.retries.external.batch_set, || async {
-                    blob.set(&blob_key, Bytes::clone(&buf), Atomicity::RequireAtomic)
+                    blob.set(&key, Bytes::clone(&buf), Atomicity::RequireAtomic)
                         .await
                 })
                 .instrument(trace_span!("batch::set", payload_len))
@@ -446,7 +451,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
             }
             .instrument(write_span),
         );
-        self.writing_parts.push_back((key, handle));
+        self.writing_parts.push_back((partial_key, handle));
 
         while self.writing_parts.len() > self.max_outstanding {
             let (key, handle) = self
@@ -466,7 +471,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
     }
 
     #[instrument(level = "debug", name = "batch::finish_upload", skip_all, fields(shard = %self.shard_id))]
-    pub(crate) async fn finish(self) -> Vec<String> {
+    pub(crate) async fn finish(self) -> Vec<PartialBlobKey> {
         let mut keys = self.finished_parts;
         for (key, handle) in self.writing_parts {
             let () = match handle.await {
@@ -500,6 +505,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
 #[cfg(test)]
 mod tests {
     use crate::cache::PersistClientCache;
+    use crate::r#impl::paths::BlobKey;
     use crate::tests::all_ok;
     use crate::PersistLocation;
 
@@ -579,5 +585,48 @@ mod tests {
             read.expect_snapshot(3).await.read_all().await,
             all_ok(&data, 3)
         );
+    }
+
+    #[tokio::test]
+    async fn batch_builder_keys() {
+        mz_ore::test::init_logging();
+
+        let mut cache = PersistClientCache::new_no_metrics();
+        // Set blob_target_size to 0 so that each row gets forced into its own batch part
+        cache.cfg.blob_target_size = 0;
+        let client = cache
+            .open(PersistLocation {
+                blob_uri: "mem://".to_owned(),
+                consensus_uri: "mem://".to_owned(),
+            })
+            .await
+            .expect("client construction failed");
+        let shard_id = ShardId::new();
+        let (mut write, _) = client
+            .expect_open::<String, String, u64, i64>(shard_id)
+            .await;
+
+        let batch = write
+            .expect_batch(
+                &[
+                    (("1".into(), "one".into()), 1, 1),
+                    (("2".into(), "two".into()), 2, 1),
+                    (("3".into(), "three".into()), 3, 1),
+                ],
+                0,
+                4,
+            )
+            .await;
+
+        assert_eq!(batch.blob_keys.len(), 3);
+        for key in &batch.blob_keys {
+            match BlobKey::parse_ids(&key.complete(&shard_id)) {
+                Ok((Some((shard, writer)), _)) => {
+                    assert_eq!(shard.to_string(), shard_id.to_string());
+                    assert_eq!(writer.to_string(), write.writer_id.to_string());
+                }
+                _ => panic!("unparseable blob key"),
+            }
+        }
     }
 }

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -14,6 +14,7 @@ use std::fmt::Debug;
 use mz_persist::location::{Determinate, ExternalError, Indeterminate};
 use timely::progress::Antichain;
 
+use crate::r#impl::paths::PartialBlobKey;
 use crate::{ShardId, WriterId};
 
 /// An indication of whether the given error type indicates an operation
@@ -65,7 +66,7 @@ pub enum InvalidUsage<T> {
         /// The given upper bound
         upper: Antichain<T>,
         /// Set of keys containing updates.
-        keys: Vec<String>,
+        keys: Vec<PartialBlobKey>,
     },
     /// Bounds of a [crate::batch::Batch] are not valid for the attempted append call
     InvalidBatchBounds {

--- a/src/persist-client/src/impl/encoding.rs
+++ b/src/persist-client/src/impl/encoding.rs
@@ -21,6 +21,7 @@ use timely::PartialOrder;
 use uuid::Uuid;
 
 use crate::error::CodecMismatch;
+use crate::r#impl::paths::PartialBlobKey;
 use crate::r#impl::state::{
     HollowBatch, ProtoHollowBatch, ProtoHollowBatchPart, ProtoReader, ProtoSnapshotSplit,
     ProtoStateRollup, ProtoTrace, ProtoU64Antichain, ProtoU64Description, ProtoWriter,
@@ -76,6 +77,16 @@ impl RustType<String> for WriterId {
             Ok(x) => Ok(WriterId(x)),
             Err(_) => Err(TryFromProtoError::InvalidShardId(proto)),
         }
+    }
+}
+
+impl RustType<String> for PartialBlobKey {
+    fn into_proto(&self) -> String {
+        self.0.clone()
+    }
+
+    fn from_proto(proto: String) -> Result<Self, TryFromProtoError> {
+        Ok(PartialBlobKey(proto))
     }
 }
 
@@ -365,7 +376,7 @@ impl<T: Timestamp + Codec64> RustType<ProtoSnapshotSplit> for SnapshotSplit<T> {
         let mut batches = Vec::new();
         for batch in proto.batches.into_iter() {
             let desc = batch.desc.into_rust_if_some("desc")?;
-            batches.push((batch.key, desc));
+            batches.push((PartialBlobKey(batch.key), desc));
         }
         Ok(SnapshotSplit {
             shard_id: proto.shard_id.into_rust()?,

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -727,6 +727,7 @@ mod tests {
                                 Antichain::from_elem(lower),
                                 Arc::clone(&client.blob),
                                 shard_id.clone(),
+                                WriterId::new(),
                             );
                             for (k, t, d) in updates {
                                 builder.add(&k, &(), &t, &d).await.expect("invalid batch");
@@ -819,6 +820,7 @@ mod tests {
                                 Arc::clone(&client.blob),
                                 Arc::clone(&client.metrics),
                                 req,
+                                WriterId::new(),
                             )
                             .await;
                             match res {

--- a/src/persist-client/src/impl/paths.rs
+++ b/src/persist-client/src/impl/paths.rs
@@ -1,0 +1,201 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::ops::Deref;
+use std::str::FromStr;
+use uuid::Uuid;
+
+use crate::r#impl::encoding::parse_id;
+use crate::{ShardId, WriterId};
+
+/// An opaque identifier for an individual blob of a persist durable TVC (aka shard).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct PartId(pub(crate) [u8; 16]);
+
+impl std::fmt::Display for PartId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "p{}", Uuid::from_bytes(self.0))
+    }
+}
+
+impl std::fmt::Debug for PartId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PartId({})", Uuid::from_bytes(self.0))
+    }
+}
+
+impl FromStr for PartId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_id('p', "PartId", s).map(PartId)
+    }
+}
+
+impl PartId {
+    pub(crate) fn new() -> Self {
+        PartId(*Uuid::new_v4().as_bytes())
+    }
+}
+
+/// Partially encoded path used in [mz_persist::location::Blob] storage.
+/// Composed of a [crate::write::WriterId] and [crate::impl::paths::PartId]. Can
+/// be completed with a [crate::ShardId] to form a full [crate::impl::paths::BlobKey].
+///
+/// Used to reduce the bytes needed to refer to a blob key in memory and
+/// in persistent state, all access to blobs are always within the context
+/// of an individual shard.
+#[derive(Clone, Debug, PartialEq)]
+pub struct PartialBlobKey(pub(crate) String);
+
+impl PartialBlobKey {
+    pub fn new(writer_id: &WriterId, part_id: &PartId) -> PartialBlobKey {
+        PartialBlobKey(format!("{}/{}", writer_id, part_id))
+    }
+
+    pub fn complete(&self, shard_id: &ShardId) -> BlobKey {
+        if self.starts_with('w') {
+            BlobKey(format!("{}/{}", shard_id, self))
+        } else {
+            // the legacy key format is a plain UUID (which cannot start with 'w')
+            // so it should not be prepended with the shard id.
+            //
+            // TODO: this can be removed when there are no more legacy keys.
+            //       see [crate::impl::paths::BlobKey::parse_ids] for more details
+            BlobKey(self.0.to_owned())
+        }
+    }
+}
+
+impl std::fmt::Display for PartialBlobKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Deref for PartialBlobKey {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Fully encoded path used in [mz_persist::location::Blob] storage.
+/// Composed of a [crate::ShardId], [crate::write::WriterId] and
+/// [crate::impl::paths::PartId].
+///
+/// Use when directly interacting with a [mz_persist::location::Blob],
+/// otherwise use [crate::impl::paths::PartialBlobKey] to refer to
+/// a blob without needing to copy the [crate::ShardId].
+#[derive(Clone, Debug, PartialEq)]
+pub struct BlobKey(String);
+
+impl std::fmt::Display for BlobKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Deref for BlobKey {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl BlobKey {
+    pub fn parse_ids(key: &str) -> Result<(Option<(ShardId, WriterId)>, PartId), String> {
+        let ids = key.split('/').collect::<Vec<_>>();
+
+        match ids[..] {
+            [shard, writer, part] => Ok((
+                Some((ShardId::from_str(shard)?, WriterId::from_str(writer)?)),
+                PartId::from_str(part)?,
+            )),
+            // TODO: this blob key format can be removed (and return type updated to not include
+            //       Option) once all deployed environments have been wiped clean after
+            //       https://github.com/MaterializeInc/materialize/pull/13617 has been merged
+            [part] => Ok((None, PartId::from_str(part)?)),
+            _ => Err(format!("invalid blob key format. expected either <shard_id>/<writer_id>/<part_id> or legacy <part_id> format. got: {}", key)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::r#impl::paths::BlobKey;
+
+    use super::*;
+
+    #[test]
+    fn partial_blob_key_completion() {
+        let (shard_id, writer_id, part_id) = (ShardId::new(), WriterId::new(), PartId::new());
+        let partial_key = PartialBlobKey::new(&writer_id, &part_id);
+        assert_eq!(
+            partial_key.complete(&shard_id),
+            BlobKey(format!("{}/{}/{}", shard_id, writer_id, part_id))
+        );
+
+        let partial_key = PartialBlobKey("random-legacy-key".to_string());
+        assert_eq!(
+            partial_key.complete(&shard_id),
+            BlobKey("random-legacy-key".to_string())
+        );
+    }
+
+    #[test]
+    fn blob_key_parse() -> Result<(), String> {
+        let (shard_id, writer_id, part_id) = (ShardId::new(), WriterId::new(), PartId::new());
+
+        // can parse full blob key
+        assert_eq!(
+            BlobKey::parse_ids(&format!("{}/{}/{}", shard_id, writer_id, part_id)),
+            Ok((Some((shard_id, writer_id)), part_id.clone()))
+        );
+
+        // can parse legacy blob key
+        assert_eq!(
+            BlobKey::parse_ids(&format!("{}", part_id)),
+            Ok((None, part_id))
+        );
+
+        // fails on invalid blob key formats
+        assert!(matches!(
+            BlobKey::parse_ids(&format!("{}/{}", WriterId::new(), PartId::new())),
+            Err(_)
+        ));
+        assert!(matches!(
+            BlobKey::parse_ids(&format!(
+                "{}/{}/{}/{}",
+                ShardId::new(),
+                WriterId::new(),
+                PartId::new(),
+                PartId::new()
+            )),
+            Err(_)
+        ));
+        assert!(matches!(BlobKey::parse_ids("abc/def/ghi"), Err(_)));
+        assert!(matches!(BlobKey::parse_ids(""), Err(_)));
+
+        // fails if shard/writer/part id are in the wrong spots
+        assert!(matches!(
+            BlobKey::parse_ids(&format!(
+                "{}/{}/{}",
+                PartId::new(),
+                ShardId::new(),
+                WriterId::new()
+            )),
+            Err(_)
+        ));
+
+        Ok(())
+    }
+}

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -20,6 +20,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 use crate::error::{Determinacy, InvalidUsage};
+use crate::r#impl::paths::PartialBlobKey;
 use crate::r#impl::trace::{FueledMergeReq, FueledMergeRes, Trace};
 use crate::read::ReaderId;
 use crate::write::WriterId;
@@ -50,7 +51,7 @@ pub struct HollowBatch<T> {
     /// Describes the times of the updates in the batch.
     pub desc: Description<T>,
     /// Pointers usable to retrieve the updates.
-    pub keys: Vec<String>,
+    pub keys: Vec<PartialBlobKey>,
     /// The number of updates in the batch.
     pub len: usize,
 }
@@ -391,7 +392,10 @@ mod tests {
                 Antichain::from_elem(upper),
                 Antichain::from_elem(T::minimum()),
             ),
-            keys: keys.iter().map(|x| (*x).to_owned()).collect(),
+            keys: keys
+                .iter()
+                .map(|x| PartialBlobKey((*x).to_owned()))
+                .collect(),
             len,
         }
     }
@@ -520,7 +524,7 @@ mod tests {
             Break(Err(InvalidEmptyTimeInterval {
                 lower: Antichain::from_elem(5),
                 upper: Antichain::from_elem(5),
-                keys: vec!["key1".to_owned()],
+                keys: vec![PartialBlobKey("key1".to_owned())],
             }))
         );
 

--- a/src/persist-client/src/impl/trace.rs
+++ b/src/persist-client/src/impl/trace.rs
@@ -1019,6 +1019,7 @@ impl<T: Timestamp + Lattice> MergeVariant<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::r#impl::paths::PartialBlobKey;
 
     #[test]
     fn trace_datadriven() {
@@ -1041,7 +1042,10 @@ mod tests {
                     Antichain::from_elem(since),
                 ),
                 len,
-                keys: keys.iter().map(|x| (*x).to_owned()).collect(),
+                keys: keys
+                    .iter()
+                    .map(|x| PartialBlobKey((*x).to_owned()))
+                    .collect(),
             }
         }
 
@@ -1119,6 +1123,7 @@ mod tests {
                                     .iter()
                                     .flat_map(|x| x.keys.iter())
                                     .cloned()
+                                    .map(|x| x.0)
                                     .collect::<Vec<_>>()
                                     .join(" ")
                             );

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -33,7 +33,7 @@ use crate::r#impl::compact::{CompactReq, Compactor};
 use crate::r#impl::machine::{Machine, INFO_MIN_ATTEMPTS};
 use crate::r#impl::metrics::Metrics;
 use crate::r#impl::state::{HollowBatch, Upper};
-use crate::PersistConfig;
+use crate::{parse_id, PersistConfig};
 
 /// An opaque identifier for a writer of a persist durable TVC (aka shard).
 #[derive(Clone, PartialEq, Eq, Hash)]
@@ -48,6 +48,14 @@ impl std::fmt::Display for WriterId {
 impl std::fmt::Debug for WriterId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "WriterId({})", Uuid::from_bytes(self.0))
+    }
+}
+
+impl std::str::FromStr for WriterId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_id('w', "WriterId", s).map(WriterId)
     }
 }
 
@@ -484,6 +492,7 @@ where
             lower,
             Arc::clone(&self.blob),
             self.machine.shard_id().clone(),
+            self.writer_id.clone(),
         )
     }
 

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -403,9 +403,11 @@ pub mod tests {
         // We can open two blobs to the same place, even.
         let blob1 = new_fn("path0").await?;
 
+        let k0 = "foo/bar/k0";
+
         // Empty key is empty.
-        assert_eq!(blob0.get("k0").await?, None);
-        assert_eq!(blob1.get("k0").await?, None);
+        assert_eq!(blob0.get(&k0).await?, None);
+        assert_eq!(blob1.get(&k0).await?, None);
 
         // Empty list keys is empty.
         let empty_keys = blob0.list_keys().await?;
@@ -415,10 +417,10 @@ pub mod tests {
 
         // Set a key with AllowNonAtomic and get it back.
         blob0
-            .set("k0", values[0].clone().into(), AllowNonAtomic)
+            .set(&k0, values[0].clone().into(), AllowNonAtomic)
             .await?;
-        assert_eq!(blob0.get("k0").await?, Some(values[0].clone()));
-        assert_eq!(blob1.get("k0").await?, Some(values[0].clone()));
+        assert_eq!(blob0.get(&k0).await?, Some(values[0].clone()));
+        assert_eq!(blob1.get(&k0).await?, Some(values[0].clone()));
 
         // Set a key with RequireAtomic and get it back.
         blob0
@@ -430,17 +432,17 @@ pub mod tests {
         // Blob contains the key we just inserted.
         let mut blob_keys = blob0.list_keys().await?;
         blob_keys.sort();
-        assert_eq!(blob_keys, keys(&empty_keys, &["k0", "k0a"]));
+        assert_eq!(blob_keys, keys(&empty_keys, &[&k0, "k0a"]));
         let mut blob_keys = blob1.list_keys().await?;
         blob_keys.sort();
-        assert_eq!(blob_keys, keys(&empty_keys, &["k0", "k0a"]));
+        assert_eq!(blob_keys, keys(&empty_keys, &[&k0, "k0a"]));
 
         // Can overwrite a key with AllowNonAtomic.
         blob0
-            .set("k0", values[1].clone().into(), AllowNonAtomic)
+            .set(&k0, values[1].clone().into(), AllowNonAtomic)
             .await?;
-        assert_eq!(blob0.get("k0").await?, Some(values[1].clone()));
-        assert_eq!(blob1.get("k0").await?, Some(values[1].clone()));
+        assert_eq!(blob0.get(&k0).await?, Some(values[1].clone()));
+        assert_eq!(blob1.get(&k0).await?, Some(values[1].clone()));
         // Can overwrite a key with RequireAtomic.
         blob0
             .set("k0a", values[1].clone().into(), RequireAtomic)
@@ -449,12 +451,12 @@ pub mod tests {
         assert_eq!(blob1.get("k0a").await?, Some(values[1].clone()));
 
         // Can delete a key.
-        blob0.delete("k0").await?;
+        blob0.delete(&k0).await?;
         // Can no longer get a deleted key.
-        assert_eq!(blob0.get("k0").await?, None);
-        assert_eq!(blob1.get("k0").await?, None);
+        assert_eq!(blob0.get(&k0).await?, None);
+        assert_eq!(blob1.get(&k0).await?, None);
         // Double deleting a key succeeds.
-        assert_eq!(blob0.delete("k0").await, Ok(()));
+        assert_eq!(blob0.delete(&k0).await, Ok(()));
         // Deleting a key that does not exist succeeds.
         assert_eq!(blob0.delete("nope").await, Ok(()));
 
@@ -468,10 +470,10 @@ pub mod tests {
         assert_eq!(blob_keys, empty_keys);
         // Can reset a deleted key to some other value.
         blob0
-            .set("k0", values[1].clone().into(), AllowNonAtomic)
+            .set(&k0, values[1].clone().into(), AllowNonAtomic)
             .await?;
-        assert_eq!(blob1.get("k0").await?, Some(values[1].clone()));
-        assert_eq!(blob0.get("k0").await?, Some(values[1].clone()));
+        assert_eq!(blob1.get(&k0).await?, Some(values[1].clone()));
+        assert_eq!(blob0.get(&k0).await?, Some(values[1].clone()));
 
         // Insert multiple keys back to back and validate that we can list
         // them all out.
@@ -487,14 +489,14 @@ pub mod tests {
         // Blob contains the key we just inserted.
         let mut blob_keys = blob0.list_keys().await?;
         blob_keys.sort();
-        assert_eq!(blob_keys, keys(&expected_keys, &["k0"]));
+        assert_eq!(blob_keys, keys(&expected_keys, &[&k0]));
         let mut blob_keys = blob1.list_keys().await?;
         blob_keys.sort();
-        assert_eq!(blob_keys, keys(&expected_keys, &["k0"]));
+        assert_eq!(blob_keys, keys(&expected_keys, &[&k0]));
 
         // We can open a new blob to the same path and use it.
         let blob3 = new_fn("path0").await?;
-        assert_eq!(blob3.get("k0").await?, Some(values[1].clone()));
+        assert_eq!(blob3.get(&k0).await?, Some(values[1].clone()));
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

(This PR builds on https://github.com/MaterializeInc/materialize/pull/13577 so it will be more readable once that merges)

This PR adds the simplest possible way of structuring our blob keys as `shard_id/writer_id/uuid`. This will let us do S3 prefix scans over `shard_id` for usage/billing, and the `writer_id` will be used to identify orphaned blobs. 

Forthcoming either in this PR or a future change will be more structured types, and avoiding the `shard_id` component when linking into consensus. (Though as I think about this, since we're trying to avoid breaking changes now, maybe this PR _does_ need to strip the `shard_id` when linking in, otherwise we could have keys of multiple structures in consensus)



### Motivation

* This PR adds a known-desirable feature.

One piece of https://github.com/MaterializeInc/materialize/issues/13576

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
