### PR TITLE
persist: thread the shared NowFn down through PersistConfig

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -14,6 +14,7 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use crossbeam_channel::TryRecvError;
+use mz_persist_client::PersistConfig;
 use timely::communication::initialize::WorkerGuards;
 use timely::communication::Allocate;
 use timely::execute::execute_from;
@@ -110,7 +111,10 @@ pub fn serve(
     let (builders, other) =
         initialize_networking(config.comm_config).map_err(|e| anyhow!("{e}"))?;
 
-    let persist_clients = PersistClientCache::new(&config.metrics_registry);
+    let persist_clients = PersistClientCache::new(
+        PersistConfig::new(config.now.clone()),
+        &config.metrics_registry,
+    );
     let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_clients));
 
     let worker_guards = execute_from(

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -52,7 +52,7 @@ use mz_ore::id_gen::PortAllocator;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::PersistLocation;
+use mz_persist_client::{PersistConfig, PersistLocation};
 use mz_secrets::SecretsController;
 use mz_storage::types::connections::ConnectionContext;
 
@@ -538,7 +538,9 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         }
     };
     let secrets_reader = secrets_controller.reader();
-    let persist_clients = PersistClientCache::new(&metrics_registry);
+    let now = SYSTEM_TIME.clone();
+    let persist_clients =
+        PersistClientCache::new(PersistConfig::new(now.clone()), &metrics_registry);
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let orchestrator = Arc::new(TracingOrchestrator::new(
         orchestrator,
@@ -655,7 +657,7 @@ max log level: {max_log_level}",
         secrets_controller,
         unsafe_mode: args.unsafe_mode,
         metrics_registry,
-        now: SYSTEM_TIME.clone(),
+        now,
         replica_sizes,
         bootstrap_default_cluster_replica_size: args.bootstrap_default_cluster_replica_size,
         availability_zones: args.availability_zone,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -34,7 +34,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NowFn, SYSTEM_TIME};
 use mz_ore::task;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::PersistLocation;
+use mz_persist_client::{PersistConfig, PersistLocation};
 use mz_secrets::SecretsController;
 use mz_storage::types::connections::ConnectionContext;
 
@@ -159,7 +159,8 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             command_wrapper: vec![],
         }))?,
     );
-    let persist_clients = PersistClientCache::new(&metrics_registry);
+    let persist_clients =
+        PersistClientCache::new(PersistConfig::new(config.now.clone()), &metrics_registry);
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let inner = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         adapter_stash_url,

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -50,7 +50,7 @@ impl fmt::Debug for NowFn {
 }
 
 impl Deref for NowFn {
-    type Target = dyn Fn() -> EpochMillis;
+    type Target = dyn Fn() -> EpochMillis + Send + Sync;
 
     fn deref(&self) -> &Self::Target {
         &(*self.0)

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use criterion::measurement::WallTime;
 use criterion::{criterion_group, criterion_main, Bencher, BenchmarkGroup, BenchmarkId, Criterion};
 use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
 use tempfile::TempDir;
 use timely::progress::{Antichain, Timestamp};
 use tokio::runtime::Runtime;
@@ -98,7 +99,13 @@ async fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
     let blob = Arc::new(MemBlob::open(MemBlobConfig::default()));
     let consensus = Arc::new(MemConsensus::default());
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-    PersistClient::new(PersistConfig::default(), blob, consensus, metrics).await
+    PersistClient::new(
+        PersistConfig::new(SYSTEM_TIME.clone()),
+        blob,
+        consensus,
+        metrics,
+    )
+    .await
 }
 
 async fn create_file_pg_client(
@@ -114,7 +121,13 @@ async fn create_file_pg_client(
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus) as Arc<dyn Consensus + Send + Sync>;
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-    let client = PersistClient::new(PersistConfig::default(), blob, consensus, metrics).await?;
+    let client = PersistClient::new(
+        PersistConfig::new(SYSTEM_TIME.clone()),
+        blob,
+        consensus,
+        metrics,
+    )
+    .await?;
     Ok(Some((postgres_consensus, client, dir)))
 }
 
@@ -133,7 +146,13 @@ async fn create_s3_pg_client(
     let postgres_consensus = Arc::new(PostgresConsensus::open(pg).await?);
     let consensus = Arc::clone(&postgres_consensus) as Arc<dyn Consensus + Send + Sync>;
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-    let client = PersistClient::new(PersistConfig::default(), blob, consensus, metrics).await?;
+    let client = PersistClient::new(
+        PersistConfig::new(SYSTEM_TIME.clone()),
+        blob,
+        consensus,
+        metrics,
+    )
+    .await?;
     Ok(Some((postgres_consensus, client)))
 }
 

--- a/src/persist-client/examples/open_loop.rs
+++ b/src/persist-client/examples/open_loop.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::bail;
 use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
 use prometheus::Encoder;
 use tokio::sync::mpsc::error::SendError;
@@ -26,7 +27,7 @@ use tracing::{debug, error, info, info_span, trace, Instrument};
 
 use mz_ore::cast::CastFrom;
 use mz_persist::workload::DataGenerator;
-use mz_persist_client::{Metrics, PersistLocation, ShardId};
+use mz_persist_client::{Metrics, PersistConfig, PersistLocation, ShardId};
 
 use crate::open_loop::api::{BenchmarkReader, BenchmarkWriter};
 
@@ -125,9 +126,10 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         blob_uri: args.blob_uri.clone(),
         consensus_uri: args.consensus_uri.clone(),
     };
-    let persist = PersistClientCache::new(&metrics_registry)
-        .open(location)
-        .await?;
+    let persist =
+        PersistClientCache::new(PersistConfig::new(SYSTEM_TIME.clone()), &metrics_registry)
+            .open(location)
+            .await?;
 
     let shard_id = match args.shard_id.clone() {
         Some(shard_id) => ShardId::from_str(&shard_id).map_err(anyhow::Error::msg)?,

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -195,7 +195,13 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         Arc::new(UnreliableBlob::new(blob, unreliable.clone())) as Arc<dyn Blob + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
-    PersistClient::new(PersistConfig::default(), blob, consensus, metrics).await
+    PersistClient::new(
+        PersistConfig::new(SYSTEM_TIME.clone()),
+        blob,
+        consensus,
+        metrics,
+    )
+    .await
 }
 
 mod api {

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -40,9 +40,9 @@ pub struct PersistClientCache {
 
 impl PersistClientCache {
     /// Returns a new [PersistClientCache].
-    pub fn new(registry: &MetricsRegistry) -> Self {
+    pub fn new(cfg: PersistConfig, registry: &MetricsRegistry) -> Self {
         PersistClientCache {
-            cfg: PersistConfig::default(),
+            cfg,
             metrics: Arc::new(Metrics::new(registry)),
             blob_by_uri: HashMap::new(),
             consensus_by_uri: HashMap::new(),
@@ -53,7 +53,10 @@ impl PersistClientCache {
     /// metrics.
     #[cfg(test)]
     pub fn new_no_metrics() -> Self {
-        Self::new(&MetricsRegistry::new())
+        use mz_ore::now::SYSTEM_TIME;
+
+        let cfg = PersistConfig::new(SYSTEM_TIME.clone());
+        Self::new(cfg, &MetricsRegistry::new())
     }
 
     /// Returns a new [PersistClient] for interfacing with persist shards made
@@ -105,11 +108,16 @@ impl PersistClientCache {
 
 #[cfg(test)]
 mod tests {
+    use mz_ore::now::SYSTEM_TIME;
+
     use super::*;
 
     #[tokio::test]
     async fn client_cache() {
-        let mut cache = PersistClientCache::new(&MetricsRegistry::new());
+        let mut cache = PersistClientCache::new(
+            PersistConfig::new(SYSTEM_TIME.clone()),
+            &MetricsRegistry::new(),
+        );
         assert_eq!(cache.blob_by_uri.len(), 0);
         assert_eq!(cache.consensus_by_uri.len(), 0);
 

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -623,15 +623,6 @@ where
     }
 }
 
-pub fn system_time() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .expect("failed to get millis since epoch")
-        .as_millis()
-        .try_into()
-        .expect("current time did not fit into u64")
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -678,7 +669,8 @@ mod tests {
             let mut client = new_test_client().await;
             // Reset blob_target_size. Individual batch writes and compactions
             // can override it with an arg.
-            client.cfg.blob_target_size = PersistConfig::default().blob_target_size;
+            client.cfg.blob_target_size =
+                PersistConfig::new(client.cfg.now.clone()).blob_target_size;
 
             let state = Arc::new(Mutex::new(DatadrivenState::default()));
 

--- a/src/storage/src/protocol/server.rs
+++ b/src/storage/src/protocol/server.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
+use mz_persist_client::PersistConfig;
 use timely::communication::initialize::WorkerGuards;
 use tokio::sync::mpsc;
 
@@ -90,7 +91,8 @@ pub fn serve(
 
     let tokio_executor = tokio::runtime::Handle::current();
     let now = config.now;
-    let persist_clients = PersistClientCache::new(&config.metrics_registry);
+    let persist_clients =
+        PersistClientCache::new(PersistConfig::new(now.clone()), &config.metrics_registry);
     let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_clients));
 
     let worker_guards = timely::execute::execute(config.timely_config, move |timely_worker| {

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -492,13 +492,18 @@ mod tests {
     use std::time::Duration;
 
     use itertools::Itertools;
+    use mz_ore::now::SYSTEM_TIME;
     use once_cell::sync::Lazy;
 
     use mz_ore::metrics::MetricsRegistry;
-    use mz_persist_client::{PersistLocation, ShardId};
+    use mz_persist_client::{PersistConfig, PersistLocation, ShardId};
 
-    static PERSIST_CACHE: Lazy<Arc<Mutex<PersistClientCache>>> =
-        Lazy::new(|| Arc::new(Mutex::new(PersistClientCache::new(&MetricsRegistry::new()))));
+    static PERSIST_CACHE: Lazy<Arc<Mutex<PersistClientCache>>> = Lazy::new(|| {
+        Arc::new(Mutex::new(PersistClientCache::new(
+            PersistConfig::new(SYSTEM_TIME.clone()),
+            &MetricsRegistry::new(),
+        )))
+    });
 
     async fn make_test_operator(shard: ShardId, as_of: Antichain<Timestamp>) -> ReclockOperator {
         let start = tokio::time::Instant::now();


### PR DESCRIPTION
We intend to have one place in the codebase where we call
SystemTime::now, so be a good citizen and plumb the one per
environmentd/storaged/computed down into persist.

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
