### PR TITLE
persist: allow the region to be specified in the S3 URL

### DIFF
--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -74,7 +74,8 @@ impl BlobConfig {
                     .to_string();
                 let role_arn = query_params.remove("aws_role_arn").map(|x| x.into_owned());
                 let endpoint = query_params.remove("endpoint").map(|x| x.into_owned());
-                let config = S3BlobConfig::new(bucket, prefix, role_arn, endpoint).await?;
+                let region = query_params.remove("region").map(|x| x.into_owned());
+                let config = S3BlobConfig::new(bucket, prefix, role_arn, endpoint, region).await?;
                 Ok(BlobConfig::S3(config))
             }
             "mem" => {


### PR DESCRIPTION
If a region is not specified, the rust AWS SDK will perform
an HTTP request to an internal AWS service to determine the region
to use. This call will fail in non-AWS environments, such as
local minikube clusters and environmentd and/or computed will
fail to start properly.

To allow Mz to run in non-AWS environments, allow the region
to be specified as part of the S3 URL. Then, 'region' can be used
in conjunction with 'entrypoint' to send all the traffic to the
desired blob storage, avoiding any calls to AWS services:

--persist-blob-url=s3://test_bucket?region=minio&endpoint=http%3A%2F%2Flocalhost%3A9000

Fixes: #13622


### Motivation

  * This PR fixes a recognized bug.
