### PR TITLE
storage: reorganize modules in preparation for fat client

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -56,8 +56,8 @@ use mz_sql::plan::{
 };
 use mz_sql::DEFAULT_SCHEMA;
 use mz_stash::{Append, Postgres, Sqlite};
-use mz_storage::client::sinks::{SinkConnection, SinkConnectionBuilder, SinkEnvelope};
-use mz_storage::client::sources::{SourceDesc, Timeline};
+use mz_storage::types::sinks::{SinkConnection, SinkConnectionBuilder, SinkEnvelope};
+use mz_storage::types::sources::{SourceDesc, Timeline};
 use mz_transform::Optimizer;
 use uuid::Uuid;
 
@@ -1063,7 +1063,7 @@ pub struct Secret {
 #[derive(Debug, Clone, Serialize)]
 pub struct Connection {
     pub create_sql: String,
-    pub connection: mz_storage::client::connections::Connection,
+    pub connection: mz_storage::types::connections::Connection,
     pub depends_on: Vec<GlobalId>,
 }
 
@@ -1301,7 +1301,7 @@ impl CatalogEntry {
         }
     }
 
-    /// Returns the [`mz_storage::client::sources::SourceDesc`] associated with
+    /// Returns the [`mz_storage::types::sources::SourceDesc`] associated with
     /// this `CatalogEntry`.
     pub fn source_desc(&self) -> Result<&SourceDesc, SqlCatalogError> {
         self.item.source_desc(self.name())
@@ -4008,7 +4008,7 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
         Ok(self.source_desc()?)
     }
 
-    fn connection(&self) -> Result<&mz_storage::client::connections::Connection, SqlCatalogError> {
+    fn connection(&self) -> Result<&mz_storage::types::connections::Connection, SqlCatalogError> {
         Ok(&self.connection()?.connection)
     }
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -22,7 +22,7 @@ use mz_sql::ast::{CreateIndexStatement, Statement};
 use mz_sql::catalog::{CatalogDatabase, CatalogType, TypeCategory};
 use mz_sql::names::{DatabaseId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier};
 use mz_sql_parser::ast::display::AstDisplay;
-use mz_storage::client::sinks::KafkaSinkConnection;
+use mz_storage::types::sinks::KafkaSinkConnection;
 
 use crate::catalog::builtin::{
     MZ_ARRAY_TYPES, MZ_AUDIT_EVENTS, MZ_BASE_TYPES, MZ_CLUSTERS, MZ_CLUSTER_REPLICAS_BASE,
@@ -307,17 +307,17 @@ impl CatalogState {
                 Datum::Int64(u64::from(schema_id) as i64),
                 Datum::String(name),
                 Datum::String(match connection.connection {
-                    mz_storage::client::connections::Connection::Kafka { .. } => "kafka",
-                    mz_storage::client::connections::Connection::Csr { .. } => {
+                    mz_storage::types::connections::Connection::Kafka { .. } => "kafka",
+                    mz_storage::types::connections::Connection::Csr { .. } => {
                         "confluent-schema-registry"
                     }
-                    mz_storage::client::connections::Connection::Postgres { .. } => "postgres",
-                    mz_storage::client::connections::Connection::Ssh { .. } => "ssh",
+                    mz_storage::types::connections::Connection::Postgres { .. } => "postgres",
+                    mz_storage::types::connections::Connection::Ssh { .. } => "ssh",
                 }),
             ]),
             diff,
         }];
-        if let mz_storage::client::connections::Connection::Ssh(ssh) = &connection.connection {
+        if let mz_storage::types::connections::Connection::Ssh(ssh) = &connection.connection {
             updates.extend(self.pack_ssh_tunnel_connection_update(id, name, &ssh.public_key, diff));
         }
         updates

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -35,7 +35,7 @@ use mz_sql::names::{
 };
 use mz_sql::plan::ComputeInstanceIntrospectionConfig;
 use mz_stash::{Append, AppendBatch, Stash, StashError, TableTransaction, TypedCollection};
-use mz_storage::client::sources::Timeline;
+use mz_storage::types::sources::Timeline;
 
 use crate::catalog::builtin::BuiltinLog;
 use crate::catalog::error::{Error, ErrorKind};

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -145,13 +145,13 @@ use mz_sql::plan::{
     StatementDesc, TailFrom, TailPlan, View,
 };
 use mz_stash::Append;
-use mz_storage::client::connections::ConnectionContext;
-use mz_storage::client::controller::{CollectionDescription, ReadPolicy};
-use mz_storage::client::sinks::{SinkAsOf, SinkConnection, SinkDesc, TailSinkConnection};
-use mz_storage::client::sources::{
+use mz_storage::controller::{CollectionDescription, ReadPolicy};
+use mz_storage::protocol::client::Update;
+use mz_storage::types::connections::ConnectionContext;
+use mz_storage::types::sinks::{SinkAsOf, SinkConnection, SinkDesc, TailSinkConnection};
+use mz_storage::types::sources::{
     IngestionDescription, PostgresSourceConnection, SourceConnection, Timeline,
 };
-use mz_storage::client::Update;
 use mz_transform::Optimizer;
 
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
@@ -2276,7 +2276,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .catalog_transact(session, ops, |txn| {
                 let mut builder = txn.dataflow_builder(compute_instance);
                 let from_entry = builder.catalog.get_entry(&sink.from);
-                let sink_description = mz_storage::client::sinks::SinkDesc {
+                let sink_description = mz_storage::types::sinks::SinkDesc {
                     from: sink.from,
                     from_desc: from_entry
                         .desc(
@@ -3082,7 +3082,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         .build_sink_dataflow(
                             "dummy".into(),
                             id,
-                            mz_storage::client::sinks::SinkDesc {
+                            mz_storage::types::sinks::SinkDesc {
                                 from: sink.from,
                                 from_desc: from_entry
                                     .desc(

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -28,7 +28,7 @@ use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::numeric::Numeric;
 use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_stash::Append;
-use mz_storage::client::sinks::{PersistSinkConnection, SinkAsOf, SinkConnection, SinkDesc};
+use mz_storage::types::sinks::{PersistSinkConnection, SinkAsOf, SinkConnection, SinkDesc};
 use std::collections::{HashMap, HashSet};
 use tracing::warn;
 

--- a/src/adapter/src/explain_new/common.rs
+++ b/src/adapter/src/explain_new/common.rs
@@ -37,7 +37,7 @@ use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
 use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::GlobalId;
-use mz_storage::client::transforms::LinearOperator;
+use mz_storage::types::transforms::LinearOperator;
 
 pub trait ViewFormatter<ViewExpr> {
     fn fmt_source_body(&self, f: &mut fmt::Formatter, operator: &LinearOperator) -> fmt::Result;

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -22,7 +22,7 @@ use std::fmt;
 use mz_expr::RowSetFinishing;
 use mz_repr::explain_new::{DisplayText, ExprHumanizer};
 use mz_repr::GlobalId;
-use mz_storage::client::transforms::LinearOperator;
+use mz_storage::types::transforms::LinearOperator;
 
 use crate::coord::fast_path_peek;
 

--- a/src/adapter/src/sink_connection.rs
+++ b/src/adapter/src/sink_connection.rs
@@ -15,8 +15,8 @@ use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, Top
 use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::collections::CollectionExt;
 use mz_repr::GlobalId;
-use mz_storage::client::connections::{ConnectionContext, PopulateClientConfig};
-use mz_storage::client::sinks::{
+use mz_storage::types::connections::{ConnectionContext, PopulateClientConfig};
+use mz_storage::types::sinks::{
     KafkaSinkConnection, KafkaSinkConnectionBuilder, KafkaSinkConnectionRetention,
     KafkaSinkConsistencyConnection, PublishedSchemaInfo, SinkConnection, SinkConnectionBuilder,
 };
@@ -237,7 +237,7 @@ async fn build_kafka(
     .await
     .context("error registering kafka topic for sink")?;
     let published_schema_info = match builder.format {
-        mz_storage::client::sinks::KafkaSinkFormat::Avro {
+        mz_storage::types::sinks::KafkaSinkFormat::Avro {
             key_schema,
             value_schema,
             csr_connection,
@@ -261,11 +261,11 @@ async fn build_kafka(
                 value_schema_id,
             })
         }
-        mz_storage::client::sinks::KafkaSinkFormat::Json => None,
+        mz_storage::types::sinks::KafkaSinkFormat::Json => None,
     };
 
     let consistency = match builder.consistency_format {
-        Some(mz_storage::client::sinks::KafkaSinkFormat::Avro {
+        Some(mz_storage::types::sinks::KafkaSinkFormat::Avro {
             value_schema,
             csr_connection,
             ..

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -19,10 +19,10 @@ import "proto/src/proto.proto";
 import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
-import "storage/src/client.proto";
-import "storage/src/client/controller.proto";
-import "storage/src/client/sinks.proto";
-import "storage/src/client/transforms.proto";
+import "storage/src/protocol/client.proto";
+import "storage/src/controller.proto";
+import "storage/src/types/sinks.proto";
+import "storage/src/types/transforms.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -41,7 +41,7 @@ message ProtoComputeCommand {
         ProtoInstanceConfig create_instance = 1;
         google.protobuf.Empty drop_instance = 2;
         ProtoCreateDataflows create_dataflows = 3;
-        mz_storage.client.ProtoAllowCompaction allow_compaction = 4;
+        mz_storage.protocol.client.ProtoAllowCompaction allow_compaction = 4;
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
     }
@@ -74,7 +74,7 @@ message ProtoDataflowDescription {
 
     message ProtoSinkExport {
         mz_repr.global_id.ProtoGlobalId id = 1;
-        mz_storage.client.sinks.ProtoSinkDesc sink_desc = 2;
+        mz_storage.types.sinks.ProtoSinkDesc sink_desc = 2;
     }
 
     repeated ProtoSourceImport source_imports = 1;
@@ -99,12 +99,12 @@ message ProtoBuildDesc {
 
 message ProtoSourceInstanceDesc {
     ProtoSourceInstanceArguments arguments = 1;
-    mz_storage.client.controller.ProtoCollectionMetadata storage_metadata = 2;
+    mz_storage.controller.ProtoCollectionMetadata storage_metadata = 2;
     mz_repr.relation_and_scalar.ProtoRelationType typ = 3;
 }
 
 message ProtoSourceInstanceArguments {
-    optional mz_storage.client.transforms.ProtoLinearOperator operators = 1;
+    optional mz_storage.types.transforms.ProtoLinearOperator operators = 1;
 }
 
 message ProtoPeek {

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -29,10 +29,10 @@ use mz_expr::{
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_proto::{any_uuid, IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationType, Row};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::sinks::SinkDesc;
-use mz_storage::client::transforms::LinearOperator;
-use mz_storage::client::ProtoAllowCompaction;
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::protocol::client::ProtoAllowCompaction;
+use mz_storage::types::sinks::SinkDesc;
+use mz_storage::types::transforms::LinearOperator;
 
 use crate::command::proto_dataflow_description::{
     ProtoIndexExport, ProtoIndexImport, ProtoSinkExport, ProtoSourceImport,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -37,8 +37,8 @@ use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_types::Codec64;
 use mz_repr::{GlobalId, Row};
-use mz_storage::client::controller::{ReadPolicy, StorageController, StorageError};
-use mz_storage::client::sinks::{PersistSinkConnection, SinkConnection, SinkDesc};
+use mz_storage::controller::{ReadPolicy, StorageController, StorageError};
+use mz_storage::types::sinks::{PersistSinkConnection, SinkConnection, SinkDesc};
 
 use crate::command::{
     ComputeCommand, DataflowDescription, InstanceConfig, Peek, ReplicaId, SourceInstanceDesc,

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -36,7 +36,7 @@ use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
 use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::GlobalId;
-use mz_storage::client::transforms::LinearOperator;
+use mz_storage::types::transforms::LinearOperator;
 
 use crate::command::DataflowDescription;
 

--- a/src/compute-client/src/response.proto
+++ b/src/compute-client/src/response.proto
@@ -13,7 +13,7 @@ import "persist/src/persist.proto";
 import "proto/src/proto.proto";
 import "repr/src/global_id.proto";
 import "repr/src/row.proto";
-import "storage/src/client.proto";
+import "storage/src/protocol/client.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -32,7 +32,7 @@ message ProtoComputeResponse {
     }
 
     oneof kind {
-        mz_storage.client.ProtoFrontierUppersKind frontier_uppers = 1;
+        mz_storage.protocol.client.ProtoFrontierUppersKind frontier_uppers = 1;
         ProtoPeekResponseKind peek_response = 2;
         ProtoTailResponseKind tail_response = 3;
     }

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -26,7 +26,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_pid_file::PidFile;
 use mz_service::grpc::GrpcServer;
-use mz_storage::client::connections::ConnectionContext;
+use mz_storage::types::connections::ConnectionContext;
 
 // Disable jemalloc on macOS, as it is not well supported [0][1][2].
 // The issues present as runaway latency on load test workloads that are

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -34,9 +34,9 @@ use mz_compute_client::plan::Plan;
 use mz_compute_client::response::{ComputeResponse, PeekResponse, TailResponse};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
-use mz_storage::client::connections::ConnectionContext;
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::connections::ConnectionContext;
+use mz_storage::types::errors::DataflowError;
 use mz_timely_util::activator::RcActivator;
 use mz_timely_util::operator::CollectionExt;
 

--- a/src/compute/src/reconciliation.rs
+++ b/src/compute/src/reconciliation.rs
@@ -39,7 +39,7 @@ use mz_repr::GlobalId;
 use mz_service::client::GenericClient;
 use mz_service::frontiers::FrontierReconcile;
 use mz_service::grpc::GrpcServerCommand;
-use mz_storage::client::controller::CollectionMetadata;
+use mz_storage::controller::CollectionMetadata;
 
 /// Reconcile commands targeted at a COMPUTE instance.
 ///

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -31,8 +31,8 @@ use timely::progress::{Antichain, Timestamp};
 use mz_compute_client::command::DataflowDescription;
 use mz_expr::{Id, MapFilterProject, MirScalarExpr};
 use mz_repr::{DatumVec, Diff, GlobalId, Row, RowArena};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 
 use crate::typedefs::{ErrSpine, RowSpine, TraceErrHandle, TraceRowHandle};

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -21,7 +21,7 @@ use mz_compute_client::plan::join::delta_join::{DeltaJoinPlan, DeltaPathPlan, De
 use mz_compute_client::plan::join::JoinClosure;
 use mz_expr::MirScalarExpr;
 use mz_repr::{DatumVec, Diff, Row, RowArena};
-use mz_storage::client::errors::DataflowError;
+use mz_storage::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 
 use crate::render::context::{ArrangementFlavor, CollectionBundle, Context};

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -23,7 +23,7 @@ use timely::progress::{timestamp::Refines, Timestamp};
 use mz_compute_client::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan};
 use mz_compute_client::plan::join::JoinClosure;
 use mz_repr::{DatumVec, Diff, Row, RowArena};
-use mz_storage::client::errors::DataflowError;
+use mz_storage::types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
 
 use crate::render::context::{

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -117,9 +117,9 @@ use mz_compute_client::plan::Plan;
 use mz_expr::Id;
 use mz_ore::collections::CollectionExt as IteratorExt;
 use mz_repr::{GlobalId, Row};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
+use mz_storage::controller::CollectionMetadata;
 use mz_storage::source::persist_source;
+use mz_storage::types::errors::DataflowError;
 
 use crate::arrangement::manager::TraceBundle;
 use crate::compute_state::ComputeState;

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -36,7 +36,7 @@ use mz_expr::{AggregateExpr, AggregateFunc};
 use mz_ore::soft_assert_or_log;
 use mz_repr::adt::numeric::{self, Numeric, NumericAgg};
 use mz_repr::{Datum, DatumList, DatumVec, Diff, Row, RowArena};
-use mz_storage::client::errors::DataflowError;
+use mz_storage::types::errors::DataflowError;
 
 use crate::render::context::{Arrangement, CollectionBundle, Context};
 use crate::render::ArrangementFlavor;

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -21,9 +21,9 @@ use timely::dataflow::Scope;
 use mz_expr::{permutation_for_arrangement, MapFilterProject};
 use mz_interchange::envelopes::{combine_at_timestamp, dbz_format, upsert_format};
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
-use mz_storage::client::sinks::{SinkConnection, SinkDesc, SinkEnvelope};
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::errors::DataflowError;
+use mz_storage::types::sinks::{SinkConnection, SinkDesc, SinkEnvelope};
 
 use crate::render::context::Context;
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -29,7 +29,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_service::client::GenericClient;
 use mz_service::grpc::GrpcServerCommand;
 use mz_service::local::LocalClient;
-use mz_storage::client::connections::ConnectionContext;
+use mz_storage::types::connections::ConnectionContext;
 
 use crate::communication::initialize_networking;
 use crate::compute_state::ActiveComputeState;

--- a/src/compute/src/sink/kafka.rs
+++ b/src/compute/src/sink/kafka.rs
@@ -55,10 +55,10 @@ use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, Gau
 use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
-use mz_storage::client::connections::{ConnectionContext, PopulateClientConfig};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
-use mz_storage::client::sinks::{
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::connections::{ConnectionContext, PopulateClientConfig};
+use mz_storage::types::errors::DataflowError;
+use mz_storage::types::sinks::{
     KafkaSinkConnection, KafkaSinkConsistencyConnection, PublishedSchemaInfo, SinkAsOf, SinkDesc,
     SinkEnvelope,
 };

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -22,10 +22,10 @@ use timely::progress::Timestamp as TimelyTimestamp;
 use timely::PartialOrder;
 
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
-use mz_storage::client::sinks::{PersistSinkConnection, SinkDesc};
-use mz_storage::client::sources::SourceData;
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::errors::DataflowError;
+use mz_storage::types::sinks::{PersistSinkConnection, SinkDesc};
+use mz_storage::types::sources::SourceData;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::render::sinks::SinkRender;

--- a/src/compute/src/sink/tail.rs
+++ b/src/compute/src/sink/tail.rs
@@ -22,9 +22,9 @@ use timely::progress::Antichain;
 
 use mz_compute_client::response::{TailBatch, TailResponse};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
-use mz_storage::client::controller::CollectionMetadata;
-use mz_storage::client::errors::DataflowError;
-use mz_storage::client::sinks::{SinkAsOf, SinkDesc, TailSinkConnection};
+use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::errors::DataflowError;
+use mz_storage::types::sinks::{SinkAsOf, SinkDesc, TailSinkConnection};
 
 use crate::render::sinks::SinkRender;
 

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -15,7 +15,7 @@ use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::ord::{OrdKeySpine, OrdValSpine};
 
 use mz_repr::{Diff, Row, Timestamp};
-use mz_storage::client::errors::DataflowError;
+use mz_storage::types::errors::DataflowError;
 
 pub type RowSpine<K, V, T, R, O = usize> = OrdValSpine<K, V, T, R, O>;
 pub type ErrSpine<K, T, R, O = usize> = OrdKeySpine<K, T, R, O>;

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -61,8 +61,8 @@ use mz_persist_client::PersistLocation;
 use mz_persist_types::Codec64;
 use mz_proto::RustType;
 use mz_repr::GlobalId;
-use mz_storage::client::controller::StorageController;
-use mz_storage::client::{
+use mz_storage::controller::StorageController;
+use mz_storage::protocol::client::{
     ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageResponse,
 };
 
@@ -503,7 +503,7 @@ where
 {
     /// Creates a new controller.
     pub async fn new(config: ControllerConfig) -> Self {
-        let storage_controller = mz_storage::client::controller::Controller::new(
+        let storage_controller = mz_storage::controller::Controller::new(
             config.build_info,
             config.storage_stash_url,
             config.persist_location,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -54,7 +54,7 @@ use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use mz_secrets::SecretsController;
-use mz_storage::client::connections::ConnectionContext;
+use mz_storage::types::connections::ConnectionContext;
 
 mod sys;
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -36,7 +36,7 @@ use mz_ore::now::NowFn;
 use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryEnableCallback;
 use mz_secrets::SecretsController;
-use mz_storage::client::connections::ConnectionContext;
+use mz_storage::types::connections::ConnectionContext;
 use tracing::error;
 
 use crate::tcp_connection::ConnectionHandler;

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -36,7 +36,7 @@ use mz_ore::task;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::PersistLocation;
 use mz_secrets::SecretsController;
-use mz_storage::client::connections::ConnectionContext;
+use mz_storage::types::connections::ConnectionContext;
 
 pub static KAFKA_ADDRS: Lazy<mz_kafka_util::KafkaAddrs> =
     Lazy::new(|| match env::var("KAFKA_ADDRS") {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -28,8 +28,8 @@ use mz_ore::now::{EpochMillis, NowFn, NOW_ZERO};
 use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, ScalarType};
 use mz_sql_parser::ast::Expr;
-use mz_storage::client::connections::Connection;
-use mz_storage::client::sources::SourceDesc;
+use mz_storage::types::connections::Connection;
+use mz_storage::types::sources::SourceDesc;
 use uuid::Uuid;
 
 use crate::func::Func;

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -23,7 +23,7 @@ use mz_kafka_util::client::{create_new_client_config, MzClientContext};
 use mz_ore::task;
 use mz_secrets::SecretsReader;
 use mz_sql_parser::ast::Value;
-use mz_storage::client::connections::{
+use mz_storage::types::connections::{
     CsrConnection, CsrConnectionHttpAuth, KafkaConnection, StringOrSecret, TlsIdentity,
 };
 
@@ -224,7 +224,7 @@ pub async fn create_consumer(
     secrets_reader: &dyn SecretsReader,
 ) -> Result<Arc<BaseConsumer<KafkaErrCheckContext>>, PlanError> {
     let mut config = create_new_client_config(librdkafka_log_level);
-    mz_storage::client::connections::populate_client_config(
+    mz_storage::types::connections::populate_client_config(
         kafka_connection.clone(),
         options,
         std::collections::HashSet::new(),

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -29,7 +29,7 @@ use mz_sql_parser::ast::{
     IfExistsBehavior, Op, Query, Statement, TableFactor, TableFunction, UnresolvedObjectName,
     UnresolvedSchemaName, Value, ViewDefinition, WithOption, WithOptionValue,
 };
-use mz_storage::client::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
+use mz_storage::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials, SerdeUri};
 
 use crate::names::{
     Aug, FullObjectName, PartialObjectName, PartialSchemaName, RawDatabaseSpecifier,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -39,8 +39,8 @@ use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
-use mz_storage::client::sinks::{SinkConnectionBuilder, SinkEnvelope};
-use mz_storage::client::sources::{SourceDesc, Timeline};
+use mz_storage::types::sinks::{SinkConnectionBuilder, SinkEnvelope};
+use mz_storage::types::sources::{SourceDesc, Timeline};
 
 use crate::ast::{
     ExplainOptions, ExplainStageNew, ExplainStageOld, Expr, FetchDirection, IndexOptionName,
@@ -491,7 +491,7 @@ pub struct Source {
 #[derive(Clone, Debug)]
 pub struct Connection {
     pub create_sql: String,
-    pub connection: mz_storage::client::connections::Connection,
+    pub connection: mz_storage::types::connections::Connection,
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use mz_repr::adt::interval::Interval;
 use mz_repr::strconv;
 use mz_repr::GlobalId;
-use mz_storage::client::connections::StringOrSecret;
+use mz_storage::types::connections::StringOrSecret;
 
 use crate::ast::{AstInfo, IntervalValue, Value, WithOptionValue};
 use crate::names::ResolvedObjectName;

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -34,9 +34,9 @@ use mz_ccsr::Schema as CcsrSchema;
 use mz_ccsr::{Client, GetByIdError, GetBySubjectError};
 use mz_proto::RustType;
 use mz_repr::strconv;
-use mz_storage::client::connections::aws::{AwsConfig, AwsExternalIdPrefix};
-use mz_storage::client::connections::{Connection, ConnectionContext};
-use mz_storage::client::sources::PostgresSourceDetails;
+use mz_storage::types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
+use mz_storage::types::connections::{Connection, ConnectionContext};
+use mz_storage::types::sources::PostgresSourceDetails;
 
 use crate::ast::{
     AvroSchema, CreateSourceConnection, CreateSourceFormat, CreateSourceStatement,
@@ -101,7 +101,7 @@ pub async fn purify_create_source(
                         KafkaAddrs::from_str(&broker)?.to_string().into(),
                     );
 
-                    mz_storage::client::connections::KafkaConnection::try_from(
+                    mz_storage::types::connections::KafkaConnection::try_from(
                         &mut connection_options,
                     )?
                 }

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -23,8 +23,8 @@ use mz_lowertest::*;
 use mz_ore::now::{EpochMillis, NOW_ZERO};
 use mz_repr::explain_new::{DummyHumanizer, ExprHumanizer};
 use mz_repr::{GlobalId, RelationDesc, ScalarType};
-use mz_storage::client::connections::Connection;
-use mz_storage::client::sources::SourceDesc;
+use mz_storage::types::connections::Connection;
+use mz_storage::types::sources::SourceDesc;
 
 use crate::ast::Expr;
 use crate::catalog::{

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -72,7 +72,7 @@ use mz_repr::adt::numeric;
 use mz_repr::ColumnName;
 use mz_secrets::SecretsController;
 use mz_sql::ast::Statement;
-use mz_storage::client::connections::ConnectionContext;
+use mz_storage::types::connections::ConnectionContext;
 
 use crate::ast::{Location, Mode, Output, QueryOutput, Record, Sort, Type};
 use crate::util;

--- a/src/storage/build.rs
+++ b/src/storage/build.rs
@@ -26,14 +26,14 @@ fn main() {
         .extern_path(".mz_repr.url", "::mz_repr::url")
         .compile(
             &[
-                "storage/src/client.proto",
-                "storage/src/client/controller.proto",
-                "storage/src/client/errors.proto",
-                "storage/src/client/connections/aws.proto",
-                "storage/src/client/sinks.proto",
-                "storage/src/client/sources.proto",
-                "storage/src/client/sources/encoding.proto",
-                "storage/src/client/transforms.proto",
+                "storage/src/protocol/client.proto",
+                "storage/src/controller.proto",
+                "storage/src/types/errors.proto",
+                "storage/src/types/connections/aws.proto",
+                "storage/src/types/sinks.proto",
+                "storage/src/types/sources.proto",
+                "storage/src/types/sources/encoding.proto",
+                "storage/src/types/transforms.proto",
             ],
             &[".."],
         )

--- a/src/storage/src/controller.proto
+++ b/src/storage/src/controller.proto
@@ -11,7 +11,7 @@
 
 syntax = "proto3";
 
-package mz_storage.client.controller;
+package mz_storage.controller;
 
 message ProtoCollectionMetadata {
     string blob_uri = 1;

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+#![allow(missing_docs)]
+
 //! A controller that provides an interface to the storage layer.
 //!
 //! The storage controller curates the creation of sources, the progress of readers through these collections,
@@ -53,18 +55,18 @@ use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_stash::{self, StashError, TypedCollection};
 
-use crate::client::controller::hosts::{StorageHosts, StorageHostsConfig};
-use crate::client::errors::DataflowError;
-use crate::client::sources::{IngestionDescription, MzOffset, SourceData, SourceEnvelope};
-use crate::client::{
+use crate::controller::hosts::{StorageHosts, StorageHostsConfig};
+use crate::protocol::client::{
     IngestSourceCommand, ProtoStorageCommand, ProtoStorageResponse, StorageCommand,
     StorageResponse, Update,
 };
+use crate::types::errors::DataflowError;
+use crate::types::sources::{IngestionDescription, MzOffset, SourceData, SourceEnvelope};
 
 mod hosts;
 mod rehydration;
 
-include!(concat!(env!("OUT_DIR"), "/mz_storage.client.controller.rs"));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.controller.rs"));
 
 static METADATA_COLLECTION: TypedCollection<GlobalId, CollectionMetadata> =
     TypedCollection::new("storage-collection-metadata");

--- a/src/storage/src/controller/hosts.rs
+++ b/src/storage/src/controller/hosts.rs
@@ -34,8 +34,10 @@ use mz_ore::collections::CollectionExt;
 use mz_proto::RustType;
 use mz_repr::GlobalId;
 
-use crate::client::controller::rehydration::RehydratingStorageClient;
-use crate::client::{ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageResponse};
+use crate::controller::rehydration::RehydratingStorageClient;
+use crate::protocol::client::{
+    ProtoStorageCommand, ProtoStorageResponse, StorageCommand, StorageResponse,
+};
 
 /// The network address of a storage host.
 pub type StorageHostAddr = String;

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -33,7 +33,7 @@ use mz_ore::retry::Retry;
 use mz_repr::GlobalId;
 use mz_service::client::GenericClient;
 
-use crate::client::{
+use crate::protocol::client::{
     IngestSourceCommand, StorageClient, StorageCommand, StorageGrpcClient, StorageResponse,
 };
 

--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -12,7 +12,7 @@ use futures::executor::block_on;
 use mz_interchange::avro::Decoder;
 use mz_repr::Row;
 
-use crate::client::errors::DecodeError;
+use crate::types::errors::DecodeError;
 
 #[derive(Debug)]
 pub struct AvroDecoderState {

--- a/src/storage/src/decode/csv.rs
+++ b/src/storage/src/decode/csv.rs
@@ -9,9 +9,9 @@
 
 use mz_repr::{Datum, Row};
 
-use crate::client::errors::DecodeError;
-use crate::client::sources::encoding::CsvEncoding;
-use crate::client::transforms::LinearOperator;
+use crate::types::errors::DecodeError;
+use crate::types::sources::encoding::CsvEncoding;
+use crate::types::transforms::LinearOperator;
 
 #[derive(Debug)]
 pub struct CsvDecoderState {

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -44,14 +44,14 @@ use self::avro::AvroDecoderState;
 use self::csv::CsvDecoderState;
 use self::metrics::DecodeMetrics;
 use self::protobuf::ProtobufDecoderState;
-use crate::client::connections::ConnectionContext;
-use crate::client::errors::DecodeError;
-use crate::client::sources::encoding::{
+use crate::source::{DecodeResult, SourceOutput};
+use crate::types::connections::ConnectionContext;
+use crate::types::errors::DecodeError;
+use crate::types::sources::encoding::{
     AvroEncoding, DataEncoding, DataEncodingInner, RegexEncoding,
 };
-use crate::client::sources::{IncludedColumnSource, MzOffset};
-use crate::client::transforms::LinearOperator;
-use crate::source::{DecodeResult, SourceOutput};
+use crate::types::sources::{IncludedColumnSource, MzOffset};
+use crate::types::transforms::LinearOperator;
 
 mod avro;
 mod csv;

--- a/src/storage/src/decode/protobuf.rs
+++ b/src/storage/src/decode/protobuf.rs
@@ -10,8 +10,8 @@
 use mz_interchange::protobuf::{DecodedDescriptors, Decoder};
 use mz_repr::Row;
 
-use crate::client::errors::DecodeError;
-use crate::client::sources::encoding::ProtobufEncoding;
+use crate::types::errors::DecodeError;
+use crate::types::sources::encoding::ProtobufEncoding;
 
 #[derive(Debug)]
 pub struct ProtobufDecoderState {

--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -12,11 +12,11 @@ syntax = "proto3";
 import "persist/src/persist.proto";
 import "proto/src/proto.proto";
 import "repr/src/global_id.proto";
-import "storage/src/client/sources.proto";
+import "storage/src/types/sources.proto";
 
 import "google/protobuf/empty.proto";
 
-package mz_storage.client;
+package mz_storage.protocol.client;
 
 service ProtoStorage {
     rpc CommandResponseStream (stream ProtoStorageCommand) returns (stream ProtoStorageResponse);
@@ -33,7 +33,7 @@ message ProtoAllowCompaction {
 
 message ProtoIngestSourceCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
-    sources.ProtoIngestionDescription description = 2;
+    mz_storage.types.sources.ProtoIngestionDescription description = 2;
     mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
 }
 

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -36,19 +36,12 @@ use mz_service::grpc::{
 };
 use mz_timely_util::progress::any_change_batch;
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::proto_storage_client::ProtoStorageClient;
-use crate::client::proto_storage_server::ProtoStorage;
-use crate::client::sources::IngestionDescription;
+use crate::controller::CollectionMetadata;
+use crate::protocol::client::proto_storage_client::ProtoStorageClient;
+use crate::protocol::client::proto_storage_server::ProtoStorage;
+use crate::types::sources::IngestionDescription;
 
-pub mod connections;
-pub mod controller;
-pub mod errors;
-pub mod sinks;
-pub mod sources;
-pub mod transforms;
-
-include!(concat!(env!("OUT_DIR"), "/mz_storage.client.rs"));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.protocol.client.rs"));
 
 /// A client to a storage server.
 pub trait StorageClient<T = mz_repr::Timestamp>:

--- a/src/storage/src/protocol/mod.rs
+++ b/src/storage/src/protocol/mod.rs
@@ -7,17 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![warn(missing_docs)]
+//! The communication protocol between the storaged server and the storage controller
 
-//! Materialize's storage layer.
-
-pub mod controller;
-pub mod decode;
-pub mod protocol;
-pub mod render;
-pub mod source;
-pub mod storage_state;
-pub mod types;
-
-pub use decode::metrics::DecodeMetrics;
-pub use protocol::server::{serve, Config, Server};
+pub mod client;
+pub(crate) mod server;

--- a/src/storage/src/protocol/server.rs
+++ b/src/storage/src/protocol/server.rs
@@ -23,11 +23,11 @@ use mz_service::client::GenericClient;
 use mz_service::grpc::GrpcServerCommand;
 use mz_service::local::LocalClient;
 
-use crate::client::connections::ConnectionContext;
-use crate::client::{StorageCommand, StorageResponse};
-use crate::server::reconciliation::StorageCommandReconcile;
+use crate::protocol::client::{StorageCommand, StorageResponse};
+use crate::protocol::server::reconciliation::StorageCommandReconcile;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::storage_state::{StorageState, Worker};
+use crate::types::connections::ConnectionContext;
 use crate::DecodeMetrics;
 
 mod reconciliation;

--- a/src/storage/src/protocol/server/reconciliation.rs
+++ b/src/storage/src/protocol/server/reconciliation.rs
@@ -34,9 +34,9 @@ use mz_service::client::GenericClient;
 use mz_service::frontiers::FrontierReconcile;
 use mz_service::grpc::GrpcServerCommand;
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::sources::IngestionDescription;
-use crate::client::{StorageClient, StorageCommand, StorageResponse};
+use crate::controller::CollectionMetadata;
+use crate::protocol::client::{StorageClient, StorageCommand, StorageResponse};
+use crate::types::sources::IngestionDescription;
 
 /// Reconcile commands targeted at a storage host.
 ///

--- a/src/storage/src/render/debezium.rs
+++ b/src/storage/src/render/debezium.rs
@@ -19,12 +19,12 @@ use timely::dataflow::{Scope, ScopeParent, Stream};
 use mz_expr::EvalError;
 use mz_repr::{Datum, Diff, Row, Timestamp};
 
-use crate::client::errors::{DataflowError, DecodeError};
-use crate::client::sources::{
+use crate::source::DecodeResult;
+use crate::types::errors::{DataflowError, DecodeError};
+use crate::types::sources::{
     DebeziumDedupProjection, DebeziumEnvelope, DebeziumSourceProjection,
     DebeziumTransactionMetadata, MzOffset,
 };
-use crate::source::DecodeResult;
 
 pub(crate) fn render<G: Scope>(
     envelope: &DebeziumEnvelope,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -109,9 +109,9 @@ use timely::worker::Worker as TimelyWorker;
 
 use mz_repr::GlobalId;
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::sources::IngestionDescription;
+use crate::controller::CollectionMetadata;
 use crate::storage_state::StorageState;
+use crate::types::sources::IngestionDescription;
 
 mod debezium;
 mod persist_sink;

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -24,9 +24,9 @@ use timely::PartialOrder;
 
 use crate::storage_state::StorageState;
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::errors::DataflowError;
-use crate::client::sources::SourceData;
+use crate::controller::CollectionMetadata;
+use crate::types::errors::DataflowError;
+use crate::types::sources::SourceData;
 
 pub fn render<G>(
     scope: &mut G,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -26,10 +26,7 @@ use mz_expr::PartitionId;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_timely_util::operator::{CollectionExt, StreamExt};
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::errors::{DataflowError, DecodeError};
-use crate::client::sources::{encoding::*, *};
-use crate::client::transforms::LinearOperator;
+use crate::controller::CollectionMetadata;
 use crate::decode::{render_decode, render_decode_cdcv2, render_decode_delimited};
 use crate::source::persist_source;
 use crate::source::{
@@ -37,6 +34,9 @@ use crate::source::{
     PostgresSourceReader, PubNubSourceReader, RawSourceCreationConfig, S3SourceReader,
     SourceOutput,
 };
+use crate::types::errors::{DataflowError, DecodeError};
+use crate::types::sources::{encoding::*, *};
+use crate::types::transforms::LinearOperator;
 
 /// A type-level enum that holds one of two types of sources depending on their message type
 ///

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -23,10 +23,10 @@ use mz_ore::result::ResultExt;
 use mz_repr::{Datum, DatumVec, DatumVecBorrow, Diff, Row, RowArena, Timestamp};
 use mz_timely_util::operator::StreamExt;
 
-use crate::client::errors::{DataflowError, DecodeError};
-use crate::client::sources::{MzOffset, UpsertEnvelope, UpsertStyle};
-use crate::client::transforms::LinearOperator;
 use crate::source::DecodeResult;
+use crate::types::errors::{DataflowError, DecodeError};
+use crate::types::sources::{MzOffset, UpsertEnvelope, UpsertStyle};
+use crate::types::transforms::LinearOperator;
 
 #[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 struct UpsertSourceData {

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -28,12 +28,12 @@ use mz_kafka_util::{client::create_new_client_config, client::MzClientContext};
 use mz_ore::thread::{JoinHandleExt, UnparkOnDropHandle};
 use mz_repr::{adt::jsonb::Jsonb, GlobalId};
 
-use crate::client::connections::{ConnectionContext, KafkaConnection, StringOrSecret};
-use crate::client::sources::encoding::SourceDataEncoding;
-use crate::client::sources::{KafkaOffset, KafkaSourceConnection, MzOffset, SourceConnection};
 use crate::source::{
     NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
 };
+use crate::types::connections::{ConnectionContext, KafkaConnection, StringOrSecret};
+use crate::types::sources::encoding::SourceDataEncoding;
+use crate::types::sources::{KafkaOffset, KafkaSourceConnection, MzOffset, SourceConnection};
 
 use self::metrics::KafkaPartitionMetrics;
 
@@ -527,7 +527,7 @@ fn create_kafka_config(
 ) -> ClientConfig {
     let mut kafka_config = create_new_client_config(connection_context.librdkafka_log_level);
 
-    crate::client::connections::populate_client_config(
+    crate::types::connections::populate_client_config(
         kafka_connection.clone(),
         options,
         std::collections::HashSet::new(),

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -25,15 +25,15 @@ use mz_expr::PartitionId;
 use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 use mz_repr::GlobalId;
 
-use crate::client::connections::aws::AwsExternalIdPrefix;
-use crate::client::connections::ConnectionContext;
-use crate::client::errors::SourceErrorDetails;
-use crate::client::sources::encoding::SourceDataEncoding;
-use crate::client::sources::{KinesisSourceConnection, MzOffset, SourceConnection};
 use crate::source::metrics::KinesisMetrics;
 use crate::source::{
     NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
 };
+use crate::types::connections::aws::AwsExternalIdPrefix;
+use crate::types::connections::ConnectionContext;
+use crate::types::errors::SourceErrorDetails;
+use crate::types::sources::encoding::SourceDataEncoding;
+use crate::types::sources::{KinesisSourceConnection, MzOffset, SourceConnection};
 
 /// To read all data from a Kinesis stream, we need to continually update
 /// our knowledge of the stream's shards by calling the ListShards API.

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -57,14 +57,14 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_timely_util::operator::StreamExt as _;
 
-use crate::client::connections::ConnectionContext;
-use crate::client::controller::CollectionMetadata;
-use crate::client::errors::{DecodeError, SourceError, SourceErrorDetails};
-use crate::client::sources::encoding::SourceDataEncoding;
-use crate::client::sources::{MzOffset, SourceConnection};
+use crate::controller::CollectionMetadata;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::ReclockOperator;
 use crate::source::util::source;
+use crate::types::connections::ConnectionContext;
+use crate::types::errors::{DecodeError, SourceError, SourceErrorDetails};
+use crate::types::sources::encoding::SourceDataEncoding;
+use crate::types::sources::{MzOffset, SourceConnection};
 
 mod kafka;
 mod kinesis;

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -27,10 +27,10 @@ use mz_persist::location::ExternalError;
 use mz_persist_client::read::ListenEvent;
 use mz_repr::{Diff, Row, Timestamp};
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::errors::DataflowError;
-use crate::client::sources::SourceData;
+use crate::controller::CollectionMetadata;
 use crate::source::{SourceStatus, YIELD_INTERVAL};
+use crate::types::errors::DataflowError;
+use crate::types::sources::SourceData;
 
 /// Creates a new source that reads from a persist shard.
 ///

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -33,12 +33,12 @@ use mz_repr::{Datum, Diff, GlobalId, Row};
 
 use self::metrics::PgSourceMetrics;
 use super::metrics::SourceBaseMetrics;
-use crate::client::connections::ConnectionContext;
-use crate::client::errors::SourceErrorDetails;
-use crate::client::sources::{encoding::SourceDataEncoding, MzOffset, SourceConnection};
 use crate::source::{
     NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
 };
+use crate::types::connections::ConnectionContext;
+use crate::types::errors::SourceErrorDetails;
+use crate::types::sources::{encoding::SourceDataEncoding, MzOffset, SourceConnection};
 
 mod metrics;
 

--- a/src/storage/src/source/pubnub.rs
+++ b/src/storage/src/source/pubnub.rs
@@ -20,9 +20,9 @@ use tracing::info;
 use mz_expr::PartitionId;
 use mz_repr::{Datum, GlobalId, Row};
 
-use crate::client::connections::ConnectionContext;
-use crate::client::sources::{encoding::SourceDataEncoding, MzOffset, SourceConnection};
 use crate::source::{SourceMessage, SourceMessageType, SourceReader, SourceReaderError};
+use crate::types::connections::ConnectionContext;
+use crate::types::sources::{encoding::SourceDataEncoding, MzOffset, SourceConnection};
 
 /// Information required to sync data from PubNub
 pub struct PubNubSourceReader {

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -31,8 +31,8 @@ use mz_persist_client::write::WriteHandle;
 use mz_persist_client::Upper;
 use mz_repr::Timestamp;
 
-use crate::client::controller::CollectionMetadata;
-use crate::client::sources::MzOffset;
+use crate::controller::CollectionMetadata;
+use crate::types::sources::MzOffset;
 
 /// The reclock operator reclocks a stream that is timestamped with some timestamp `SourceTime`
 /// into another time domain that is timestamped with some timestamp `DestTime`.

--- a/src/storage/src/source/s3.rs
+++ b/src/storage/src/source/s3.rs
@@ -54,13 +54,13 @@ use mz_repr::GlobalId;
 
 use self::metrics::{BucketMetrics, ScanBucketMetrics};
 use self::notifications::{Event, EventType, TestEvent};
-use crate::client::connections::aws::{AwsConfig, AwsExternalIdPrefix};
-use crate::client::connections::ConnectionContext;
-use crate::client::sources::encoding::SourceDataEncoding;
-use crate::client::sources::{Compression, MzOffset, S3KeySource, SourceConnection};
 use crate::source::{
     NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
 };
+use crate::types::connections::aws::{AwsConfig, AwsExternalIdPrefix};
+use crate::types::connections::ConnectionContext;
+use crate::types::sources::encoding::SourceDataEncoding;
+use crate::types::sources::{Compression, MzOffset, S3KeySource, SourceConnection};
 
 use super::metrics::SourceBaseMetrics;
 

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -24,8 +24,8 @@ use tokio::sync::{mpsc, Mutex};
 use mz_ore::now::NowFn;
 use mz_repr::{GlobalId, Timestamp};
 
-use crate::client::connections::ConnectionContext;
-use crate::client::{StorageCommand, StorageResponse};
+use crate::protocol::client::{StorageCommand, StorageResponse};
+use crate::types::connections::ConnectionContext;
 
 use crate::decode::metrics::DecodeMetrics;
 use crate::source::metrics::SourceBaseMetrics;

--- a/src/storage/src/types/connections.proto
+++ b/src/storage/src/types/connections.proto
@@ -13,9 +13,9 @@ import "kafka-util/src/addr.proto";
 import "repr/src/global_id.proto";
 import "repr/src/url.proto";
 import "proto/src/tokio_postgres.proto";
-import "storage/src/client/errors.proto";
+import "storage/src/types/errors.proto";
 
-package mz_storage.client.connections;
+package mz_storage.types.connections;
 
 message ProtoStringOrSecret {
     oneof kind {

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -30,14 +30,11 @@ use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 use mz_sql_parser::ast::KafkaConnectionOptionName;
 
-use crate::client::connections::aws::AwsExternalIdPrefix;
+use crate::types::connections::aws::AwsExternalIdPrefix;
 
 pub mod aws;
 
-include!(concat!(
-    env!("OUT_DIR"),
-    "/mz_storage.client.connections.rs"
-));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.types.connections.rs"));
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum StringOrSecret {

--- a/src/storage/src/types/connections/aws.proto
+++ b/src/storage/src/types/connections/aws.proto
@@ -11,7 +11,7 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
-package mz_storage.client.connections.aws;
+package mz_storage.types.connections.aws;
 
 message ProtoSerdeUri {
     string uri = 1;

--- a/src/storage/src/types/connections/aws.rs
+++ b/src/storage/src/types/connections/aws.rs
@@ -20,7 +20,7 @@ use mz_repr::GlobalId;
 
 include!(concat!(
     env!("OUT_DIR"),
-    "/mz_storage.client.connections.aws.rs"
+    "/mz_storage.types.connections.aws.rs"
 ));
 
 /// A wrapper for [`Uri`] that implements [`Serialize`] and `Deserialize`.
@@ -67,7 +67,7 @@ impl RustType<ProtoSerdeUri> for SerdeUri {
 /// `AwsExternalIdPrefix`. The only approved way to construct an `AwsExternalIdPrefix`
 /// is via [`ConnectionContext::from_cli_args`].
 ///
-/// [`ConnectionContext::from_cli_args`]: crate::client::connections::ConnectionContext::from_cli_args
+/// [`ConnectionContext::from_cli_args`]: crate::types::connections::ConnectionContext::from_cli_args
 /// [external ID]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AwsExternalIdPrefix(pub(super) String);

--- a/src/storage/src/types/errors.proto
+++ b/src/storage/src/types/errors.proto
@@ -12,7 +12,7 @@ syntax = "proto3";
 import "expr/src/scalar.proto";
 import "repr/src/global_id.proto";
 
-package mz_storage.client.errors;
+package mz_storage.types.errors;
 
 message ProtoDecodeError {
     oneof kind {

--- a/src/storage/src/types/errors.rs
+++ b/src/storage/src/types/errors.rs
@@ -19,7 +19,7 @@ use mz_persist_types::Codec;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::GlobalId;
 
-include!(concat!(env!("OUT_DIR"), "/mz_storage.client.errors.rs"));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.types.errors.rs"));
 
 #[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub enum DecodeError {

--- a/src/storage/src/types/mod.rs
+++ b/src/storage/src/types/mod.rs
@@ -7,17 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![warn(missing_docs)]
+#![allow(missing_docs)]
 
-//! Materialize's storage layer.
-
-pub mod controller;
-pub mod decode;
-pub mod protocol;
-pub mod render;
-pub mod source;
-pub mod storage_state;
-pub mod types;
-
-pub use decode::metrics::DecodeMetrics;
-pub use protocol::server::{serve, Config, Server};
+pub mod connections;
+pub mod errors;
+pub mod sinks;
+pub mod sources;
+pub mod transforms;

--- a/src/storage/src/types/sinks.proto
+++ b/src/storage/src/types/sinks.proto
@@ -14,10 +14,10 @@ import "google/protobuf/empty.proto";
 import "persist/src/persist.proto";
 import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
-import "storage/src/client/controller.proto";
-import "storage/src/client/connections.proto";
+import "storage/src/controller.proto";
+import "storage/src/types/connections.proto";
 
-package mz_storage.client.sinks;
+package mz_storage.types.sinks;
 
 message ProtoSinkDesc {
     mz_repr.global_id.ProtoGlobalId from = 1;
@@ -62,7 +62,7 @@ message ProtoKafkaSinkConnection {
         repeated uint64 relation_key_indices = 1;
     }
 
-    mz_storage.client.connections.ProtoKafkaConnection connection = 1;
+    mz_storage.types.connections.ProtoKafkaConnection connection = 1;
     string topic = 2;
     string topic_prefix = 3;
     optional ProtoKeyDescAndIndices key_desc_and_indices = 4;
@@ -73,7 +73,7 @@ message ProtoKafkaSinkConnection {
     bool exactly_once = 9;
     repeated mz_repr.global_id.ProtoGlobalId transitive_source_dependencies = 10;
     uint64 fuel = 11;
-    map<string, mz_storage.client.connections.ProtoStringOrSecret> options = 12;
+    map<string, mz_storage.types.connections.ProtoStringOrSecret> options = 12;
 }
 
 message ProtoPublishedSchemaInfo {
@@ -83,5 +83,5 @@ message ProtoPublishedSchemaInfo {
 
 message ProtoPersistSinkConnection {
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 1;
-    mz_storage.client.controller.ProtoCollectionMetadata storage_metadata = 2;
+    mz_storage.controller.ProtoCollectionMetadata storage_metadata = 2;
 }

--- a/src/storage/src/types/sinks.rs
+++ b/src/storage/src/types/sinks.rs
@@ -20,12 +20,12 @@ use timely::progress::frontier::Antichain;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc};
 
-use crate::client::connections::{
+use crate::controller::CollectionMetadata;
+use crate::types::connections::{
     CsrConnection, KafkaConnection, PopulateClientConfig, StringOrSecret,
 };
-use crate::client::controller::CollectionMetadata;
 
-include!(concat!(env!("OUT_DIR"), "/mz_storage.client.sinks.rs"));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.types.sinks.rs"));
 
 /// A sink for updates to a relational collection.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -17,13 +17,13 @@ import "repr/src/chrono.proto";
 import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
 import "repr/src/row.proto";
-import "storage/src/client/controller.proto";
-import "storage/src/client/connections.proto";
-import "storage/src/client/connections/aws.proto";
-import "storage/src/client/errors.proto";
-import "storage/src/client/sources/encoding.proto";
+import "storage/src/controller.proto";
+import "storage/src/types/connections.proto";
+import "storage/src/types/connections/aws.proto";
+import "storage/src/types/errors.proto";
+import "storage/src/types/sources/encoding.proto";
 
-package mz_storage.client.sources;
+package mz_storage.types.sources;
 
 message ProtoMzOffset {
   uint64 offset = 1;
@@ -142,7 +142,7 @@ message ProtoDebeziumSourceProjection {
 }
 
 message ProtoKafkaSourceConnection {
-    mz_storage.client.connections.ProtoKafkaConnection connection = 1;
+    mz_storage.types.connections.ProtoKafkaConnection connection = 1;
     string topic = 2;
     map<int32, ProtoMzOffset> start_offsets = 3;
     optional string group_id_prefix = 4;
@@ -152,12 +152,12 @@ message ProtoKafkaSourceConnection {
     ProtoIncludedColumnPos include_topic = 8;
     ProtoIncludedColumnPos include_offset = 9;
     ProtoIncludedColumnPos include_headers = 10;
-    map<string, mz_storage.client.connections.ProtoStringOrSecret> options = 11;
+    map<string, mz_storage.types.connections.ProtoStringOrSecret> options = 11;
 }
 
 message ProtoSourceDesc {
     ProtoSourceConnection connection = 1;
-    mz_storage.client.sources.encoding.ProtoSourceDataEncoding encoding = 2;
+    mz_storage.types.sources.encoding.ProtoSourceDataEncoding encoding = 2;
     ProtoSourceEnvelope envelope = 3;
     repeated ProtoIncludedColumnSource metadata_columns = 4;
     mz_proto.ProtoDuration ts_frequency = 5;
@@ -182,11 +182,11 @@ message ProtoSourceData {
 
 message ProtoKinesisSourceConnection {
     string stream_name = 1;
-    mz_storage.client.connections.aws.ProtoAwsConfig aws = 2;
+    mz_storage.types.connections.aws.ProtoAwsConfig aws = 2;
 }
 
 message ProtoPostgresSourceConnection {
-    mz_storage.client.connections.ProtoPostgresConnection connection = 1;
+    mz_storage.types.connections.ProtoPostgresConnection connection = 1;
     string publication = 2;
     ProtoPostgresSourceDetails details = 4;
 }
@@ -204,7 +204,7 @@ message ProtoPubNubSourceConnection {
 message ProtoS3SourceConnection {
     repeated ProtoS3KeySource key_sources = 1;
     optional string pattern = 2;
-    mz_storage.client.connections.aws.ProtoAwsConfig aws = 3;
+    mz_storage.types.connections.aws.ProtoAwsConfig aws = 3;
     ProtoCompression compression = 4;
 }
 
@@ -226,10 +226,10 @@ message ProtoIngestionDescription {
     // ProtoSourceImport is taken by ProtoDataflowDescription
     message ProtoSourceMetadataImport {
         mz_repr.global_id.ProtoGlobalId id = 1;
-        mz_storage.client.controller.ProtoCollectionMetadata storage_metadata = 2;
+        mz_storage.controller.ProtoCollectionMetadata storage_metadata = 2;
     }
     repeated ProtoSourceMetadataImport source_imports = 1;
     ProtoSourceDesc desc = 2;
-    mz_storage.client.controller.ProtoCollectionMetadata storage_metadata = 3;
+    mz_storage.controller.ProtoCollectionMetadata storage_metadata = 3;
     mz_repr.relation_and_scalar.ProtoRelationType typ = 4;
 }

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -32,12 +32,12 @@ use mz_repr::{ColumnType, GlobalId, RelationDesc, RelationType, Row, ScalarType}
 
 pub mod encoding;
 
-use crate::client::connections::aws::AwsConfig;
-use crate::client::connections::{KafkaConnection, PostgresConnection, StringOrSecret};
-use crate::client::controller::CollectionMetadata;
-use crate::client::errors::DataflowError;
+use crate::controller::CollectionMetadata;
+use crate::types::connections::aws::AwsConfig;
+use crate::types::connections::{KafkaConnection, PostgresConnection, StringOrSecret};
+use crate::types::errors::DataflowError;
 
-include!(concat!(env!("OUT_DIR"), "/mz_storage.client.sources.rs"));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.types.sources.rs"));
 
 /// A description of a source ingestion
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]

--- a/src/storage/src/types/sources/encoding.proto
+++ b/src/storage/src/types/sources/encoding.proto
@@ -13,9 +13,9 @@ import "google/protobuf/empty.proto";
 
 import "repr/src/adt/regex.proto";
 import "repr/src/relation_and_scalar.proto";
-import "storage/src/client/connections.proto";
+import "storage/src/types/connections.proto";
 
-package mz_storage.client.sources.encoding;
+package mz_storage.types.sources.encoding;
 
 message ProtoSourceDataEncoding {
     message ProtoKeyValue {
@@ -49,7 +49,7 @@ message ProtoDataEncoding {
 
 message ProtoAvroEncoding {
     string schema = 1;
-    mz_storage.client.connections.ProtoCsrConnection csr_connection = 2;
+    mz_storage.types.connections.ProtoCsrConnection csr_connection = 2;
     bool confluent_wire_format = 3;
 }
 

--- a/src/storage/src/types/sources/encoding.rs
+++ b/src/storage/src/types/sources/encoding.rs
@@ -19,11 +19,11 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::regex::any_regex;
 use mz_repr::{ColumnType, RelationDesc, ScalarType};
 
-use crate::client::connections::CsrConnection;
+use crate::types::connections::CsrConnection;
 
 include!(concat!(
     env!("OUT_DIR"),
-    "/mz_storage.client.sources.encoding.rs"
+    "/mz_storage.types.sources.encoding.rs"
 ));
 
 pub enum SourceDataEncodingInner {

--- a/src/storage/src/types/transforms.proto
+++ b/src/storage/src/types/transforms.proto
@@ -11,7 +11,7 @@ syntax = "proto3";
 
 import "expr/src/scalar.proto";
 
-package mz_storage.client.transforms;
+package mz_storage.types.transforms;
 
 message ProtoLinearOperator {
     repeated mz_expr.scalar.ProtoMirScalarExpr predicates = 1;

--- a/src/storage/src/types/transforms.rs
+++ b/src/storage/src/types/transforms.rs
@@ -15,7 +15,7 @@ use mz_expr::{MapFilterProject, MirScalarExpr};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Datum, RelationType};
 
-include!(concat!(env!("OUT_DIR"), "/mz_storage.client.transforms.rs"));
+include!(concat!(env!("OUT_DIR"), "/mz_storage.types.transforms.rs"));
 
 // TODO: change contract to ensure that the operator is always applied to
 // streams of rows

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -25,8 +25,8 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_pid_file::PidFile;
 use mz_service::grpc::GrpcServer;
-use mz_storage::client::connections::ConnectionContext;
-use mz_storage::client::proto_storage_server::ProtoStorageServer;
+use mz_storage::protocol::client::proto_storage_server::ProtoStorageServer;
+use mz_storage::types::connections::ConnectionContext;
 
 // Disable jemalloc on macOS, as it is not well supported [0][1][2].
 // The issues present as runaway latency on load test workloads that are

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -21,7 +21,7 @@ use mz_expr::visit::Visit;
 use mz_expr::{CollectionPlan, Id, LocalId, MirRelationExpr};
 use mz_ore::id_gen::IdGen;
 use mz_repr::GlobalId;
-use mz_storage::client::transforms::LinearOperator;
+use mz_storage::types::transforms::LinearOperator;
 
 use crate::{monotonic::MonotonicFlag, IndexOracle, Optimizer, TransformError};
 


### PR DESCRIPTION
This PR changes the modules in the storage crate as follows:

* All types that were previously in `mz_dataflow_types` are moved to
  `mz_storage::types`
* The `client` and `server` modules that define the protocol of
  communication between the `storaged` instances and the storage
  controller have been moved to `mz_storage::protocol`
* The controller has been moved to the root.

This is both a clean up and preparation for adding a top level `client`
module in a subsequent PR that will host the fat client code that other
components of Materialize will use to interact with storage collections
