### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,6 +50,10 @@ Delete this section if no tips.
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
 
+### Backward compatibility
+
+- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and threrefore is tagged with a `T-protobuf` label.
+
 ### Release notes
 
 This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):


### PR DESCRIPTION
Add a checklist item to track PRs that change the `$T ⇔ Proto$T` mappings.

### Motivation

This will help me track PRs that change the existing `$T ⇔ Proto$T` mapping so I can write a more structured manual for introducing changes in a backwards compatible way when we have to do that. 


### Tips for reviewer

The new item template requires from developers to add a label "T-proto" to such PRs which change the `$T ⇔ Proto$T` mappings, but this label does not exists yet. You'll need to create it before you approve this, or we can revisit the tracking strategy.

### Testing

N/A

### Release notes

N/A
