### PR TITLE
compute: trace how long peeks spend in pending

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -39,6 +39,7 @@ use mz_storage::client::controller::CollectionMetadata;
 use mz_storage::client::errors::DataflowError;
 use mz_timely_util::activator::RcActivator;
 use mz_timely_util::operator::CollectionExt;
+use tracing::{span, Level};
 
 use crate::arrangement::manager::{TraceBundle, TraceManager};
 use crate::logging;
@@ -230,6 +231,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         if let Some(response) = peek.seek_fulfillment(&mut Antichain::new()) {
             self.send_peek_response(peek, response);
         } else {
+            peek.span = span!(parent: &peek.span, Level::DEBUG, "pending peek");
             self.compute_state.pending_peeks.push(peek);
         }
     }


### PR DESCRIPTION
This allows tracing to show how long peeks spent in pending. Example where a peek doesn't enter pending:

![without](https://user-images.githubusercontent.com/41181/179094175-9b9b45e3-9464-45e2-928e-037b1c2f0c09.png)

And with pending:

![with](https://user-images.githubusercontent.com/41181/179094508-223a58a3-c996-4d2b-a298-26c0e797679a.png)

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and threrefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
