### PR TITLE
persist: Allow credentials to be specified for S3 stores

### DIFF
--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -75,7 +75,16 @@ impl BlobConfig {
                 let role_arn = query_params.remove("aws_role_arn").map(|x| x.into_owned());
                 let endpoint = query_params.remove("endpoint").map(|x| x.into_owned());
                 let region = query_params.remove("region").map(|x| x.into_owned());
-                let config = S3BlobConfig::new(bucket, prefix, role_arn, endpoint, region).await?;
+
+                let credentials = match url.password() {
+                    None => None,
+                    Some(password) => Some((url.username().to_string(), password.to_string())),
+                };
+
+                let config =
+                    S3BlobConfig::new(bucket, prefix, role_arn, endpoint, region, credentials)
+                        .await?;
+
                 Ok(BlobConfig::S3(config))
             }
             "mem" => {


### PR DESCRIPTION
Allow the access_key_id and secret_access_key to be specified for
S3 stores by repurposing the username and password portions of the
S3 URL, for example:

--persist-blob-url=s3://minio:minio123@test/test?endpoint={s3_endpoint}&region=minio

### Motivation

  * This PR fixes a previously unreported bug.

The AWS S3 sdk requires that an access_key_id and secret_access_key are provided before
any S3 requests can be made. Apparently there is no concept for unauthenticated access with
the default credentials provider. The only way to pass those to the computed is via the s3 URL.

### Tips for reviewer

This is hopefully to be the last PR around the `--persist-blob-url` that I need to get minio running . With 
this code I am able to get minio to work properly for both environmentds and spawned computeds

I am not entirely happy how I butchered the signature of the `S3BlobConfig::new` function. It now looks like a Java function that has been in some enterprise product for 10+ years. Any suggestions are welcome.