### PR TITLE
mzcompose: Add secrets-related options to Computed and Storaged

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -147,6 +147,8 @@ class Computed(Service):
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
         workers: Optional[int] = None,
+        secrets_reader: str = "process",
+        secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:
         if environment is None:
             environment = [
@@ -183,6 +185,11 @@ class Computed(Service):
             command_list.append(f"--process {peers.index(name)}")
             command_list.append(" ".join(f"{peer}:2102" for peer in peers))
 
+        command_list.append(f"--secrets-reader {secrets_reader}")
+        command_list.append(
+            f"--secrets-reader-process-dir {secrets_reader_process_dir}"
+        )
+
         config.update(
             {
                 "command": " ".join(command_list),
@@ -207,6 +214,8 @@ class Storaged(Service):
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
         workers: Optional[int] = None,
+        secrets_reader: str = "process",
+        secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:
         if environment is None:
             environment = [
@@ -238,6 +247,11 @@ class Storaged(Service):
 
         if workers:
             command_list.append(f"--workers {workers}")
+
+        command_list.append(f"--secrets-reader {secrets_reader}")
+        command_list.append(
+            f"--secrets-reader-process-dir {secrets_reader_process_dir}"
+        )
 
         config.update(
             {

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -204,22 +204,18 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         Computed(
             name="computed_1_1",
             peers=["computed_1_1", "computed_1_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
         Computed(
             name="computed_1_2",
             peers=["computed_1_1", "computed_1_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
         Computed(
             name="computed_2_1",
             peers=["computed_2_1", "computed_2_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
         Computed(
             name="computed_2_2",
             peers=["computed_2_1", "computed_2_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
     ]
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -32,26 +32,22 @@ SERVICES = [
     Localstack(),
     Computed(
         name="computed_1",
-        options="--workers 2 --process 0 --secrets-reader process --secrets-reader-process-dir mzdata/secrets "
-        "computed_1:2102 computed_2:2102 ",
+        options="--workers 2 --process 0 computed_1:2102 computed_2:2102 ",
         ports=[2100, 2102],
     ),
     Computed(
         name="computed_2",
-        options="--workers 2 --process 1 --secrets-reader process --secrets-reader-process-dir mzdata/secrets "
-        "computed_1:2102 computed_2:2102",
+        options="--workers 2 --process 1 computed_1:2102 computed_2:2102",
         ports=[2100, 2102],
     ),
     Computed(
         name="computed_3",
-        options="--workers 2 --process 0 --secrets-reader process --secrets-reader-process-dir mzdata/secrets "
-        "computed_3:2102 computed_4:2102",
+        options="--workers 2 --process 0 computed_3:2102 computed_4:2102",
         ports=[2100, 2102],
     ),
     Computed(
         name="computed_4",
-        options="--workers 2 --process 1 --secrets-reader process --secrets-reader-process-dir mzdata/secrets "
-        "computed_3:2102 computed_4:2102",
+        options="--workers 2 --process 1 computed_3:2102 computed_4:2102",
         ports=[2100, 2102],
     ),
     Materialized(),
@@ -65,9 +61,7 @@ SERVICES = [
         ],
         materialize_params={"cluster": "cluster1"},
     ),
-    Storaged(
-        options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets"
-    ),
+    Storaged(),
 ]
 
 

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -186,22 +186,18 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         Computed(
             name="computed_1_1",
             peers=["computed_1_1", "computed_1_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
         Computed(
             name="computed_1_2",
             peers=["computed_1_1", "computed_1_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
         Computed(
             name="computed_2_1",
             peers=["computed_2_1", "computed_2_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
         Computed(
             name="computed_2_2",
             peers=["computed_2_1", "computed_2_2"],
-            options="--secrets-reader process --secrets-reader-process-dir mzdata/secrets",
         ),
     ]
 


### PR DESCRIPTION
Now that --secrets-reader and --secrets-reader-process-dir are required
for Computed and Storaged, set those in the constructors in services.py
rather than on a per-test basis.

This way all existing and future tests will be able to boot up properly.

### Motivation

  * This PR fixes a previously unreported bug.
Jobs in Nightly CI were failing because the required secrets options were not in force in all tests.


@jkosh44 FYI