### PR TITLE
test/kafka-matrix: fix test

### DIFF
--- a/test/kafka-matrix/kafka-matrix.td
+++ b/test/kafka-matrix/kafka-matrix.td
@@ -22,10 +22,10 @@ $ kafka-ingest format=bytes topic=input_csv
 2,3
 
 > SELECT * from input_csv;
-first second mz_offset
-----------------------
-1     2      1
-2     3      2
+first second
+------------
+1     2
+2     3
 
 $ file-append path=input.proto
 syntax = "proto3";
@@ -47,10 +47,10 @@ $ kafka-ingest format=protobuf topic=input_proto message=Input descriptor-file=i
 {"field": "b"}
 
 > SELECT * from input_proto
-field  mz_offset
-----------------
-a      1
-b      2
+field
+-----
+a
+b
 
 $ set schema={
     "type": "record",
@@ -69,14 +69,28 @@ $ set schema={
           "null"
         ]
       },
-      { "name": "after", "type": ["row", "null"] }
+      { "name": "after", "type": ["row", "null"] },
+      { "name": "op", "type": "string" },
+      {
+        "name": "source",
+        "type": {
+          "type": "record",
+          "name": "Source",
+          "namespace": "whatever",
+          "fields": [
+            { "name": "snapshot", "type": "boolean" },
+            { "name": "lsn", "type": ["long", "null"] },
+            { "name": "sequence", "type": ["string", "null"] }
+          ]
+        }
+      }
     ]
   }
 
 $ kafka-create-topic topic=input_avro
 
 $ kafka-ingest format=avro topic=input_avro schema=${schema} publish=true timestamp=1
-{"before": null, "after": {"row": {"a": 123}}}
+{"before": null, "after": {"row": {"a": 123}}, "op": "c", "source": {"snapshot": false, "lsn": null, "sequence": null}}
 
 > CREATE MATERIALIZED SOURCE input_avro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_avro-${testdrive.seed}'


### PR DESCRIPTION
I noticed that the kafka-matrix testcase doesn't complete successfully. This PR:

* ... removes the mz_offset column from the kafka-matrix test output. This seems to have been missed in #13465.
* ... adds an "op" and "source" columns to the Debezium schema and
data, to silence these errors:
  ```
  ERROR: 'op' column missing from debezium input
  ERROR: 'source' column missing from debezium input
  ```

### Motivation

  * This PR fixes a previously unreported bug.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and threrefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).