### PR TITLE
testing: Test storage reconciliation

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -37,6 +37,7 @@ steps:
           - { value: checks-drop-create-default-replica }
           - { value: checks-restart-computed }
           - { value: checks-restart-entire-mz }
+          - { value: checks-kill-storaged }
           - { value: secrets }
           - { value: unused-deps }
         multiple: true
@@ -285,6 +286,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartEntireMz]
+
+  - id: checks-kill-storaged
+    label: "Checks + kill storaged"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=KillStoraged]
 
   - id: secrets
     label: "Secrets"

--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -68,6 +68,12 @@ class RestartMz(Action):
         c.wait_for_materialized()
 
 
+class KillStoraged(Action):
+    def execute(self, c: Composition) -> None:
+        # Depending on the workload, storaged may not be running, hence the || true
+        c.exec("materialized", "bash", "-c", "kill -9 `pidof storaged` || true")
+
+
 class DropCreateDefaultReplica(Action):
     def execute(self, c: Composition) -> None:
         c.sql(

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -21,7 +21,9 @@ from materialize.checks.actions import Action
 from materialize.checks.actions import (
     DropCreateDefaultReplica as DropCreateDefaultReplicaAction,
 )
-from materialize.checks.actions import Initialize, KillComputed, Manipulate
+from materialize.checks.actions import Initialize, KillComputed
+from materialize.checks.actions import KillStoraged as KillStoragedAction
+from materialize.checks.actions import Manipulate
 from materialize.checks.actions import RestartMz as RestartMzAction
 from materialize.checks.actions import StartComputed, StartMz, UseComputed, Validate
 from materialize.checks.checks import Check
@@ -92,5 +94,21 @@ class RestartComputed(Scenario):
             Manipulate(self.checks, phase=2),
             KillComputed(),
             StartComputed(),
+            Validate(self.checks),
+        ]
+
+
+class KillStoraged(Scenario):
+    """Kill storaged while it is running inside the enviromentd container. The process orchestrator will (try to) start it again."""
+
+    def actions(self) -> List[Action]:
+        return [
+            StartMz(),
+            Initialize(self.checks),
+            KillStoragedAction(),
+            Manipulate(self.checks, phase=1),
+            KillStoragedAction(),
+            Manipulate(self.checks, phase=2),
+            KillStoragedAction(),
             Validate(self.checks),
         ]

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -37,3 +37,15 @@ class MzStop(Action):
 
     def removes(self) -> Set[Type[Capability]]:
         return {MzIsRunning}
+
+
+class KillStoraged(Action):
+    """Kills the storaged processes in the environmentd container. The process orchestrator will restart them."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}
+
+    def run(self, c: Composition) -> None:
+        # Depending on the workload, storaged may not be running, hence the || true
+        c.exec("materialized", "bash", "-c", "kill -9 `pidof storaged` || true")

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -11,7 +11,7 @@ from typing import Dict, Type
 
 from materialize.zippy.framework import Action, Scenario
 from materialize.zippy.kafka_actions import CreateTopic, Ingest, KafkaStart
-from materialize.zippy.mz_actions import MzStart, MzStop
+from materialize.zippy.mz_actions import KillStoraged, MzStart, MzStop
 from materialize.zippy.source_actions import CreateSource
 from materialize.zippy.table_actions import DML, CreateTable, ValidateTable
 from materialize.zippy.view_actions import CreateView, ValidateView
@@ -24,6 +24,7 @@ class KafkaSources(Scenario):
         return {
             MzStart: 1,
             MzStop: 10,
+            KillStoraged: 15,
             KafkaStart: 1,
             CreateTopic: 5,
             CreateSource: 5,


### PR DESCRIPTION
Killing of the storaged processes has been added to Zippy and
the Platform Checks framework.

### Motivation

  * This PR adds a feature that has not yet been specified.

Storage reconciliation needs to be tested in CI.

Relates to #12857