### PR TITLE
sql: do not require CERTIFICATE AUTHORITY in CONNECTION

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2859,16 +2859,11 @@ impl KafkaConnectionOptionExtracted {
     }
     pub fn ssl_config(&self) -> HashSet<KafkaConnectionOptionName> {
         use KafkaConnectionOptionName::*;
-        HashSet::from([SslKey, SslCertificate, SslCertificateAuthority])
+        HashSet::from([SslKey, SslCertificate])
     }
     pub fn sasl_config(&self) -> HashSet<KafkaConnectionOptionName> {
         use KafkaConnectionOptionName::*;
-        HashSet::from([
-            SaslMechanisms,
-            SaslUsername,
-            SaslPassword,
-            SslCertificateAuthority,
-        ])
+        HashSet::from([SaslMechanisms, SaslUsername, SaslPassword])
     }
 }
 
@@ -2895,7 +2890,7 @@ impl From<&KafkaConnectionOptionExtracted> for Option<SaslConfig> {
                 mechanisms: k.sasl_mechanisms.clone().unwrap(),
                 username: k.sasl_username.clone().unwrap(),
                 password: k.sasl_password.unwrap().into(),
-                tls_root_cert: k.ssl_certificate_authority.clone().unwrap(),
+                tls_root_cert: k.ssl_certificate_authority.clone(),
             })
         } else {
             None

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -127,3 +127,23 @@ a
       ssl_ca_pem = '${arg.ca}'
   )
 contains:cannot set option security.protocol for SOURCE using CONNECTION materialize.public.kafka_sasl
+
+
+# Ensure that connectors do not require the certificate authority
+> CREATE CONNECTION kafka_sasl_no_ca
+  FOR KAFKA
+    BROKER 'kafka:9092',
+    SASL MECHANISMS = 'PLAIN',
+    SASL USERNAME = 'materialize',
+    SASL PASSWORD = SECRET sasl_password;
+
+# This ensures that the error is not that the CA was required, but simply that
+# not providing it prohibits connecting.
+! CREATE SOURCE connector_source
+  FROM KAFKA CONNECTION kafka_sasl_no_ca
+  TOPIC 'testdrive-data-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  WITH (
+      ssl_ca_pem = '${arg.ca}'
+  )
+contains: broker certificate could not be verified

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -219,3 +219,28 @@ a
       password = SECRET password_csr
   )
 contains:cannot set option security.protocol for SOURCE using CONNECTION materialize.public.kafka_ssl
+
+# Ensure that connectors do not require the certificate authority
+
+> CREATE CONNECTION kafka_sasl_no_ca
+  FOR KAFKA
+    BROKER 'kafka:9092',
+    SSL KEY = SECRET ssl_key_kafka,
+    SSL CERTIFICATE = '${arg.materialized-kafka-crt}';
+
+>  CREATE CONNECTION csr_ssl_no_ca
+  FOR CONFLUENT SCHEMA REGISTRY
+    URL '${testdrive.schema-registry-url}',
+    SSL KEY = SECRET ssl_key_csr,
+    SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
+    USERNAME = 'materialize',
+    PASSWORD = SECRET password_csr;
+
+# This ensures that the error is not that the CA was required, but simply that
+# not providing it prohibits connecting.
+! CREATE SOURCE kafka_ssl_no_ca
+  FROM KAFKA CONNECTION kafka_sasl_no_ca
+    TOPIC 'testdrive-data-${testdrive.seed}'
+    FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl_no_ca
+contains: broker certificate could not be verified


### PR DESCRIPTION
@sjwiesman ran into this issue

### Motivation

This PR fixes a recognized bug. Fixes #13592

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - SSL- and SASL-based `CONNECTION`s no longer require the `CERTIFICATE  AUTHORITY` option. Without the `CERTIFICATE AUTHORITY` option specified, the connection defaults to using the system certificate authority store.
