### PR TITLE
persist: add missing hardcoded-credentials feature on aws-types

### DIFF
--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1.56"
 aws-config = { version = "0.15.0", default-features = false, features = ["native-tls"] }
 aws-sdk-s3 = { version = "0.15.0", default-features = false, features = ["native-tls", "rt-tokio"]  }
 aws-smithy-http = "0.45.0"
-aws-types = "0.15.0"
+aws-types = { version = "0.15.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
 bytes = "1.1.0"
 crossbeam-channel = "0.5.5"


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.