### PR TITLE
dbt-materialize: add macro for `CREATE VIEWS` step in the Postgres source

### DIFF
--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -35,6 +35,16 @@
     {{ sql }}
 {%- endmacro %}
 
+{% macro materialize__create_views(relation, upstream_tables_list) -%}
+  {% set upstream_tables = upstream_tables_list | join(", ") %}
+  {%- call statement('create_views') -%}
+    create views if not exists from source {{ relation }}
+    {% if upstream_tables -%}
+      ({{ upstream_tables }})
+    {%- endif -%}
+  {%- endcall -%}
+{%- endmacro %}
+
 {% macro materialize__rename_relation(from_relation, to_relation) -%}
   {% set target_name = adapter.quote_as_configured(to_relation.identifier, 'identifier') %}
   {% call statement('rename_relation') -%}

--- a/misc/dbt-materialize/test/configure-postgres.td
+++ b/misc/dbt-materialize/test/configure-postgres.td
@@ -1,0 +1,42 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# IMPORTANT: The Postgres server has a custom pg_hba.conf that only
+# accepts connections from specific users. You will have to update
+# pg_hba.conf if you modify the existing user names or add new ones.
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+
+DROP SCHEMA IF EXISTS jaffle CASCADE;
+CREATE SCHEMA jaffle;
+
+CREATE TABLE pg_t1 (pk INTEGER PRIMARY KEY, f2 TEXT);
+ALTER TABLE pg_t1 REPLICA IDENTITY FULL;
+
+INSERT INTO pg_t1 VALUES (1, 'one');
+INSERT INTO pg_t1 VALUES (2, 'two');
+INSERT INTO pg_t1 VALUES (3, 'three');
+
+CREATE TABLE jaffle.pg_t2 (pk INTEGER PRIMARY KEY, f2 TEXT);
+ALTER TABLE jaffle.pg_t2 REPLICA IDENTITY FULL;
+
+INSERT INTO jaffle.pg_t2 VALUES (1, 'one');
+INSERT INTO jaffle.pg_t2 VALUES (2, 'two');
+INSERT INTO jaffle.pg_t2 VALUES (3, 'three');
+
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> DROP SCHEMA IF EXISTS jaffle
+
+> CREATE SCHEMA jaffle

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -93,6 +93,8 @@ sequences:
         relations: [test_materialized_view, test_view_index]
       - type: relations_equal
         relations: [actual_indexes, expected_indexes]
+      - type: relations_equal
+        relations: [actual_views, expected_views]
       # TODO(benesch): figure out how to test that the source/sink emit the
       # correct data. Ideally we'd just ingest the sink back into Materialize
       # with the source and then use `relations_equal` with
@@ -163,6 +165,29 @@ projects:
             CREATE SOURCE {{ mz_generate_name('test_source_index') }}
             FROM KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-source-index'
             FORMAT BYTES
+
+        models/test_source_views.sql: |
+            {{ config(
+                materialized='source',
+                post_hook=materialize__create_views({{ this }},['pg_t1','jaffle.pg_t2'])
+            ) }}
+
+            CREATE SOURCE {{ mz_generate_name('test_source_index') }}
+            FROM POSTGRES
+            CONNECTION 'host=postgres port=5432 user=materialize password=materialize dbname=postgres'
+            PUBLICATION 'mz_source'
+
+        models/actual_views.sql: |
+            SELECT
+                v.name AS view_name, s.name AS schema_name
+            FROM mz_views v
+            JOIN mz_schemas s ON v.schema_id = s.id
+            WHERE v.name LIKE 'pg%'
+
+        seeds/expected_views.csv: |
+            view_name,schema_name
+            pg_t1,public
+            pg_t2,jaffle
 
         models/test_sink.sql: |
             {{ config(materialized='sink') }}


### PR DESCRIPTION
🚧 **WIP**

Fixes #12781.

Right now, this adds a pretty basic macro to natively support the `CREATE VIEWS` step using a `post-hook` on Postgres source models.

@benesch, I fiddled around with `mz_compose.py` to use the Postgres service, but can't tell if it's sleep creeping in or if it's actually kind of hard to add a test for this. Is there a way to reuse some existing step from the test suite to boot Postgres for logical replication?

<hr>

## Open questions

@ahelium, you'll probably have some better ideas here.

### Referencing multiplexed views

The problem with `CREATE VIEWS` is that it creates multiple views in Materialize, but there is no easy way to pull these into the dbt context. The current workflow is to manually create a bunch of `.yml` and `.sql` files manually to piece things together (see the example in [`gouda-vibes-dbt`](https://github.com/MaterializeInc/materialize-training/tree/main/exercises/gouda-vibes-dbt)).

Some approaches I was hopeful about, but that don't seem doable:

* https://github.com/dbt-labs/dbt-core/discussions/5100
* https://github.com/dbt-labs/dbt-core/discussions/5101
* https://github.com/dbt-labs/dbt-core/issues/2716
* It isn't possible to hack the DAG using the [graph](https://docs.getdbt.com/reference/dbt-jinja-functions/graph) context variable, either.

### Automatic schema creation
One annoyance that could be worked around with dbt is automatically creating schemas that don't exist in Materialize (unless explicitly renamed, Materialize will attempt to create the views in the same schema as upstream, and fail if the schema doesn't exist). I'm not sure this is desired behavior, though; it's just kind of annoying when replicating from schemas other than `target_schema`. ~AFAIK there also isn't a way to know which schemas are contained in the publication upfront (in a way that is tractable to dbt)~ -> this should be possible after #10121.