### PR TITLE
doc/user: add new release docs and upgrade guide

### DIFF
--- a/doc/user/config.toml
+++ b/doc/user/config.toml
@@ -4,71 +4,10 @@ pygmentsCodeFences = true
 pygmentsUseClasses = true
 
 [params]
-# Keep the releases in reverse order of their release date. The first release
-# in the list is assumed to be the most recent.
-versions = [
-  { name = "v0.26.1", date = "05 May 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"], lts = true },
-  { name = "v0.26.0", date = "13 April 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.25.0", date = "31 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.24.0", date = "24 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.23.0", date = "18 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.22.0", date = "03 March 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.21.0", date = "25 February 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.20.0", date = "14 February 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.19.0", date = "02 February 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.18.0", date = "26 January 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.17.0", date = "20 January 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.16.0", date = "13 January 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.15.0", date = "05 January 2022", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.14.0", date = "29 December 2021", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.13.0", date = "21 December 2021", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.12.0", date = "16 December 2021", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.11.0", date = "8 December 2021", targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"] },
-  { name = "v0.10.0", date = "23 November 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.13", date = "17 November 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.12", date = "11 November 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.11", date = "02 November 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.10", date = "27 October 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.9", date = "21 October 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.8", date = "12 October 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.7", date = "06 October 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.6", date = "29 September 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.5", date = "23 September 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.4", date = "17 September 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.3", date = "08 September 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.2", date = "02 September 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.1", date = "23 August 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.9.0", date = "10 August 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.8.3", date = "20 July 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.8.2", date = "08 July 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.8.1", date = "29 June 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.8.0", date = "09 June 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.7.3", date = "17 May 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.7.2", date = "09 April 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.7.1", date = "25 March 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.7.0", date = "08 February 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.6.1", date = "22 January 2021", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.6.0", date = "18 December 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.5.3", date = "8 December 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.5.2", date = "18 November 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.5.1", date = "6 November 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.5.0", date = "21 October 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.4.3", date = "17 September 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.4.2", date = "3 September 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.4.1", date = "19 August 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.4.0", date = "27 July 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.3.1", date = "3 July 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.3.0", date = "1 June 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.2.2", date = "11 May 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.2.1", date = "30 April 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.2.0", date = "11 April 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.1.3", date = "17 March 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.1.2", date = "04 March 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.1.1", date = "22 February 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] },
-  { name = "v0.1.0", date = "13 February 2020", targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin"] }
-]
-
 repo = "//github.com/MaterializeInc/materialize"
+
+[frontmatter]
+publishDate = ["publishDate"]
 
 [[menu.main]]
 identifier = "overview"

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -1,0 +1,85 @@
+---
+title: "Releases"
+description: "How Materialize is released"
+disable_list: true
+menu:
+  main:
+    parent: 'about'
+    weight: 10
+---
+
+We are continually improving Materialize with new features and bug fixes. We
+periodically release these improvements to your Materialize account. This page
+describes the changes in each release and the process by which they are
+deployed.
+
+## Release notes
+
+{{< warning >}}
+The v0.27.0 release notes describe the coalesced changes between v0.26 LTS
+and the currently released version of Materialize. We will begin publishing
+weekly release notes after general availability.
+{{< /warning >}}
+
+{{< version-list >}}
+
+For versions that predate cloud-native Materialize, see our
+[historical release notes](https://materialize.com/docs/release-notes/).
+
+## Schedule
+
+We release a new version of Materialize approximately every week. Each
+version includes both new features and bug fixes.
+
+On weeks with a scheduled release, we deploy the release to Materialize accounts
+during the scheduled maintenance window on Wednesday from 4-6pm ET.
+
+We may occasionally deploy unscheduled releases to fix urgent bugs during
+unplanned maintenance windows. Due to the unexpected nature of these bugs, we
+cannot provide advance notice of these releases.
+
+The deployment of a new release of Materialize causes an interruption in
+service. The length of the service interruption is proportional to the size of
+your sources, sinks, and indexes. We plan to support zero-downtime deployments
+in a future release of Materialize.
+
+We announce both planned and unplanned maintenance windows on our [status
+page](https://status.materialize.com).
+
+## Versioning
+
+Each release is associated with an internal version number. You can determine
+what release your Materialize region is running by executing:
+
+```
+SELECT mz_version();
+```
+
+Scheduled weekly releases increase the middle component of the version number
+(e.g., v0.27.0). Unscheduled releases increase the final component of the
+version number (e.g., v0.27.1).
+
+## Backwards compatibility
+
+Materialize maintains backwards compatibility whenever possible. Applications
+that work with the current version of Materialize can expect to work with all
+future versions of Materialize with only minor changes to the application's
+code.
+
+Very occasionally, a bug fix may require breaking backwards compatibility. These
+changes are approved only after weighing the severity of the bug against the
+number of users that will be affected by the backwards-incompatible change.
+Backwards-incompatible changes are always clearly marked as such in the [release
+notes](#release-notes).
+
+There are several aspects of the product that are not considered part of
+Materialize's stable interface:
+
+  * Features that are in beta (labeled as such in the documentation)
+  * Objects in the [system catalog](/sql/system-tables)
+  * Any undocumented features or behavior
+
+These unstable interfaces are not subject to the backwards-compatibility policy.
+If you choose to use these unstable interfaces, you should be aware of the risk
+of backwards-incompatible changes. Backwards-incompatible changes may be made to
+these unstable interfaces at any time and without mention in the release notes.

--- a/doc/user/content/releases/v0.27.0.md
+++ b/doc/user/content/releases/v0.27.0.md
@@ -1,0 +1,115 @@
+---
+title: "Materialize v0.27.0"
+date: 2022-11-01
+---
+
+v0.27.0 is the first cloud-native release of Materialize. It contains
+substantial breaking changes from [v0.26 LTS].
+
+## Changes
+
+* Add [clusters](/sql/create-cluster) and [cluster
+  replicas](/sql/create-cluster-replica/).
+
+* Require associating indexes with a cluster.
+
+* Remove the `MATERIALIZED` keyword as shorthand for `CREATE DEFAULT INDEX`.
+
+  * Remove `CREATE MATERIALIZED SOURCE` syntax.
+  * Remove the `materialized` column from the output of `SHOW FULL SOURCES`.
+
+* Add recorded views (which will be conflated with materialized views in an
+  upcoming release {{% gh 13663 %}}).
+
+* Add secrets.
+
+* Add connections.
+
+* Ingest and persist sources. This removes the single-materialization limitation
+  for sources. Sources can always be queried directly.
+
+* Require the use of connections with sources and sinks.
+
+* Allow provisioning the size of a source or sink.
+
+* Change sinks to have exactly-once behavior by default.
+
+## Upgrade guide
+
+Following are several examples of how to adapt source and view definitions
+from Materialize v0.26 LTS for Materialize v0.27:
+
+### Authenticated Kafka source
+
+Change from:
+
+```sql
+CREATE SOURCE kafka_sasl
+  FROM KAFKA BROKER 'broker.tld:9092' TOPIC 'top-secret' WITH (
+      security_protocol = 'SASL_SSL',
+      sasl_mechanisms = 'PLAIN',
+      sasl_username = '<BROKER_USERNAME>',
+      sasl_password = '<BROKER_PASSWORD>'
+  )
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'https://schema-registry.tld' WITH (
+      username = '<SCHEMA_REGISTRY_USERNAME>',
+      password = '<SCHEMA_REGISTRY_PASSWORD>'
+  );
+```
+
+to:
+
+```sql
+CREATE SECRET kafka_password AS '<BROKER_PASSWORD>';
+CREATE SECRET csr_password AS '<SCHEMA_REGISTRY_PASSWORD>';
+CREATE CONNECTION kafka FOR KAFKA
+    BROKER 'broker.tld:9092',
+    SASL MECHANISMS 'PLAIN',
+    SASL USERNAME 'materialize',
+    SASL PASSWORD SECRET kafka_password;
+CREATE CONNECTION csr
+  FOR CONFLUENT SCHEMA REGISTRY
+    USERNAME = '<SCHEMA_REGISTRY_USERNAME>',
+    PASSWORD = SECRET csr_password;
+CREATE SOURCE kafka_top_secret FROM
+    KAFKA CONNECTION kafka
+    FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr;
+```
+
+### Materialized view
+
+Change from:
+
+```sql
+CREATE MATERIALIZED VIEW v AS SELECT ...
+```
+
+to:
+
+```sql
+CREATE VIEW v AS SELECT ...
+CREATE DEFAULT INDEX ON v
+```
+
+## Materialized source
+
+Change from:
+
+```sql
+CREATE MATERIALIZED SOURCE src ...
+```
+
+to:
+
+```sql
+CREATE SOURCE src ...
+```
+
+If you are performing point lookups on `src` directly, consider building an
+index on `src` directly:
+
+```
+CREATE INDEX on src (lookup_col1, lookup_col2)
+```
+
+[v0.26 LTS]: https://materialize.com/docs/release-notes/#v0.26.4

--- a/doc/user/layouts/shortcodes/version-list.html
+++ b/doc/user/layouts/shortcodes/version-list.html
@@ -1,0 +1,23 @@
+<div class="table-scrollable" {{/* style="height: 300px;" */}}>
+  <table>
+    <thead>
+      <th>Version</th>
+      <th>Release date</th>
+    </thead>
+
+    <tbody>
+      {{range $i, $page := .Page.Pages.ByDate.Reverse }}
+        <tr>
+          <td>
+            <strong>
+              <a href="{{.Page.RelPermalink}}">
+                {{$page.File.ContentBaseName}}
+              </a>
+            </strong>
+          </td>
+          <td>{{$page.Date.Format "January 2, 2006"}}</td>
+        </tr>
+      {{end}}
+    </tbody>
+  </table>
+</div>

--- a/doc/user/layouts/shortcodes/version.html
+++ b/doc/user/layouts/shortcodes/version.html
@@ -1,1 +1,1 @@
-{{ (index $.Site.Params.versions 0).name -}}
+{{ (index (index (where $.Site.Sections "Title" "Releases") 0).Pages.ByDate.Reverse 0).File.ContentBaseName -}}

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -14,7 +14,6 @@ import random
 from pathlib import Path
 from typing import List
 
-import toml
 from semver import Version
 
 ROOT = Path(os.environ["MZ_ROOT"])
@@ -29,5 +28,5 @@ def known_materialize_versions() -> List[Version]:
 
     The list is returned in version order with newest versions first.
     """
-    config = toml.load(ROOT / "doc" / "user" / "config.toml")
-    return [Version.parse(v["name"].lstrip("v")) for v in config["params"]["versions"]]
+    files = Path(ROOT / "doc" / "user" / "content" / "releases").glob("*.md")
+    return [Version.parse(f.stem.lstrip("v")) for f in files if f.stem.startswith("v")]


### PR DESCRIPTION
Add a page that describes our new cloud-native release process, with
structure for weekly release notes. The v0.27.0 release notes can serve
as the home for an upgrade guide for v0.26 => v0.27.0.

I've filled in the change highlights at a *very* high level. We'll want
to incrementally improve this upgrade guide over the next few months.

Touches MaterializeInc/developer-experience#128.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
