### PR TITLE
S3 connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a8c971b0cb0484fc9436a291a44503b95141edc36ce7a6af6b6d7a06a02ab0"
+checksum = "c2a3ad9e793335d75b2d2faad583487efcc0df9154aff06f299a5c1fc8795698"
 dependencies = [
  "aws-http",
  "aws-sdk-sso",
@@ -296,6 +296,7 @@ dependencies = [
  "http",
  "hyper",
  "ring",
+ "time",
  "tokio",
  "tower",
  "tracing",
@@ -304,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc956f415dda77215372e5bc751a2463d1f9a1ec34edf3edc6c0ff67e5c8e43"
+checksum = "8bd4e9dad553017821ee529f186e033700e8d61dd5c4b60066b4d8fe805b8cfc"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -317,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0d98a1d606aa24554e604f220878db4aa3b525b72f88798524497cc3867fc6"
+checksum = "2ef5a579a51d352b628b76f4855ba716be686305e5e59970c476d1ae2214e90d"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -335,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e7b832ea6eecd49bda0f743b978437e2e914beb80c22ba5d2eefa4f07cdd93"
+checksum = "c9eef08115bf848c4cd63106bd70521ca709d61a35f2f0a81377b1d3cce74562"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -357,15 +358,16 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f6e22f5641db610235c0c5fb768b5925a6317b16b12e4ab5a625cfed176f8a2"
+checksum = "0d2c19b69297f16b3f18936e363f954e7504c23a4a0dc3f2833712313c09c2aa"
 dependencies = [
  "aws-endpoint",
  "aws-http",
  "aws-sig-auth",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-checksums",
  "aws-smithy-client",
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -374,17 +376,19 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
+ "bytes-utils",
  "http",
- "md-5",
+ "http-body",
  "tokio-stream",
  "tower",
+ "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sqs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7051deede78f19223122785ad0602de9b3b73ac2d876340277bac263a91143"
+checksum = "c5ca36a94eb105609766f6f46d590b0e49ad41551c2434901ecb0100b8df9a97"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -405,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baa0c66fab12976065403cf4cafacffe76afa91d0da335d195af379d4223d235"
+checksum = "f014b8ad3178b414bf732b36741325ef659fc40752f8c292400fb7c4ecb7fdd0"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -427,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048037cdfd7f42fb29b5f969c7f639b4b7eac00e8f911e4eac4f89fb7b3a0500"
+checksum = "d37e45fdce84327c69fb924b9188fd889056c6afafbd494e8dd0daa400f9c082"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -449,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8386fc0d218dbf2011f65bd8300d21ba98603fd150b962f61239be8b02d1fc6"
+checksum = "6530e72945c11439e9b3c423c95a656a233d73c3a7d4acaf9789048e1bdf7da7"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-eventstream",
@@ -463,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd866926c2c4978210bcb01d7d1b431c794f0c23ca9ee1e420204b018836b5fb"
+checksum = "6351c3ba468b04bd819f64ea53538f5f53e3d6b366b27deabee41e73c9edb3af"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -483,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb59cfdd21143006c01b9ca4dc4a9190b8c50c2ef831f9eb36f54f69efa42f1"
+checksum = "86fc23ad8d050c241bdbfa74ae360be94a844ace8e218f64a2b2de77bfa9a707"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -494,10 +498,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-client"
-version = "0.46.0"
+name = "aws-smithy-checksums"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44243329ba8618474c3b7f396de281f175ae172dd515b3d35648671a3cf51871"
+checksum = "6dd674df030b337a84eb67539db048676c691d9c88f0c54cf7748da11836cfd8"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http",
+ "http-body",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e147b157f49ce77f2a86ec693a14c84b2441fa28be58ffb2febb77d5726c934"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -517,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69ee49b9ed0ef080a6e18c08644521d3026029eb65dfc8c694315e1ae3118bc"
+checksum = "da29e67a0b90a2bc5f2bd0a06fd43e728de62e02048879c15f646a3edf8db012"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -528,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba78f69a5bbe7ac1826389304c67b789032d813574e78f9a2d450634277f833"
+checksum = "5cc1af50eac644ab6f58e5bae29328ba3092851fc2ce648ad139134699b2b66f"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -550,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8a512d68350561e901626baa08af9491cfbd54596201b84b4da846a59e4da3"
+checksum = "a1bf4c4664dff2febf91f8796505c5bc8f38a0bff0d1397d1d3fdda17bd5c5d1"
 dependencies = [
  "aws-smithy-http",
  "bytes",
@@ -565,18 +590,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b7633698853aae80bd8b26866531420138eca91ea4620735d20b0537c93c2e"
+checksum = "0e6ebc76c3c108dd2a96506bf47dc31f75420811a19f1a09907524d1451789d2"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a94b5a8cc94a85ccbff89eb7bc80dc135ede02847a73d68c04ac2a3e4cf6b7"
+checksum = "2956f1385c4daa883907a2c81d32256af8f95834c9de1bc0613fa68db63b88c4"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -584,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d230d281653de22fb0e9c7c74d18d724a39d7148e2165b1e760060064c4967c0"
+checksum = "352fb335ec1d57160a17a13e87aaa0a172ab780ddf58bfc85caedd3b7e47caed"
 dependencies = [
  "itoa",
  "num-integer",
@@ -596,18 +621,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aacaf6c0fa549ebe5d9daa96233b8635965721367ee7c69effc8d8078842df3"
+checksum = "6cf2807fa715a5a3296feffb06ce45252bd0dfd48f52838128c48fb339ddbf5c"
 dependencies = [
  "xmlparser",
 ]
 
 [[package]]
 name = "aws-types"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb54f097516352475a0159c9355f8b4737c54044538a4d9aca4d376ef2361ccc"
+checksum = "8140b89d76f67be2c136d7393e7e6d8edd65424eb58214839efbf4a2e4f7e8a3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-client",
@@ -1125,6 +1150,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dfea2db42e9927a3845fb268a10a72faed6d416065f77873f05e411457c363e"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -3561,6 +3595,7 @@ dependencies = [
  "anyhow",
  "aws-config",
  "aws-sdk-kinesis",
+ "aws-types",
  "bytes",
  "clap",
  "futures",
@@ -5654,6 +5689,17 @@ name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -316,6 +316,7 @@ impl CatalogState {
                         "confluent-schema-registry"
                     }
                     mz_storage::types::connections::Connection::Postgres { .. } => "postgres",
+                    mz_storage::types::connections::Connection::Aws(..) => "aws",
                     mz_storage::types::connections::Connection::Ssh { .. } => "ssh",
                 }),
             ]),

--- a/src/kinesis-util/Cargo.toml
+++ b/src/kinesis-util/Cargo.toml
@@ -7,4 +7,4 @@ rust-version = "1.63.0"
 publish = false
 
 [dependencies]
-aws-sdk-kinesis = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-kinesis = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }

--- a/src/kinesis-util/src/lib.rs
+++ b/src/kinesis-util/src/lib.rs
@@ -24,7 +24,7 @@ use aws_sdk_kinesis::Client;
 /// Any errors from the underlying `GetShardIterator` API call are surfaced
 /// directly.
 pub async fn list_shards(
-    client: &Client,
+    client: &aws_sdk_kinesis::Client,
     stream_name: &str,
 ) -> Result<Vec<Shard>, SdkError<ListShardsError>> {
     let mut next_token = None;

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -22,10 +22,10 @@ bench = false
 anyhow = { version = "1.0.58", features = ["backtrace"] }
 arrow2 = { version = "0.12.0", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.56"
-aws-config = { version = "0.46.0", default-features = false, features = ["native-tls"] }
-aws-sdk-s3 = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"]  }
-aws-smithy-http = "0.46.0"
-aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.47.0", default-features = false, features = ["native-tls"] }
+aws-sdk-s3 = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"]  }
+aws-smithy-http = "0.47.0"
+aws-types = { version = "0.47.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
 bytes = "1.2.0"
 crossbeam-channel = "0.5.6"

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.58"
-aws-config = { version = "0.46.0", default-features = false, features = ["native-tls"] }
-aws-sdk-s3 = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-config = { version = "0.47.0", default-features = false, features = ["native-tls"] }
+aws-sdk-s3 = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 bytefmt = "0.1.7"
 clap = { version = "3.2.14", features = ["derive"] }
 futures = "0.3.21"

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -23,6 +23,7 @@
 #
 # For details on the code that is generated, see keywords.rs.
 
+Access
 All
 Alter
 And
@@ -37,6 +38,7 @@ Auction
 Authority
 Availability
 Avro
+Aws
 Begin
 Between
 Bigint
@@ -312,6 +314,7 @@ Timeout
 Timestamp
 Timing
 To
+Token
 Topic
 Trace
 Trailing

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.58"
 aws-arn = "0.3.1"
-aws-sdk-sts = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sts = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 chrono = { version = "0.4.0", default-features = false, features = ["clock", "std"] }
 enum-kinds = "0.5.1"
 globset = "0.4.9"

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -623,7 +623,7 @@ pub(crate) fn ensure_empty_options<V>(
 pub fn aws_config(
     options: &mut BTreeMap<String, SqlValueOrSecret>,
     region: Option<String>,
-    connection: Option<AwsCredentials>,
+    credentials: AwsCredentials,
 ) -> Result<AwsConfig, PlanError> {
     let mut extract = |key| match options.remove(key) {
         // TODO: support secrets in S3
@@ -636,19 +636,6 @@ pub fn aws_config(
         }
         Some(_) => sql_bail!("{} must be a string", key),
         _ => Ok(None),
-    };
-
-    let credentials = match extract("profile")? {
-        Some(profile_name) => {
-            if connection.is_some() {
-                sql_bail!("AWS profile cannot be set in combination with CONNECTION");
-            }
-            AwsCredentials::Profile { profile_name }
-        }
-        None => match connection {
-            Some(connection) => connection,
-            None => sql_bail!("Must specify an S3 CONNECTION"),
-        },
     };
 
     let region = match region {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -560,7 +560,7 @@ pub fn plan_create_source(
             let aws = normalize::aws_config(
                 &mut legacy_with_options,
                 Some(region.into()),
-                Some(aws_connection),
+                aws_connection,
             )?;
             let encoding = get_encoding(scx, format, &envelope, &connection)?;
             let connection =
@@ -581,7 +581,7 @@ pub fn plan_create_source(
                 _ => sql_bail!("{} is not an AWS connection", item.name()),
             };
 
-            let aws = normalize::aws_config(&mut legacy_with_options, None, Some(aws_connection))?;
+            let aws = normalize::aws_config(&mut legacy_with_options, None, aws_connection)?;
             let mut converted_sources = Vec::new();
             for ks in key_sources {
                 let dtks = match ks {
@@ -3114,7 +3114,7 @@ impl TryFrom<AwsConnectionOptionExtracted> for AwsCredentials {
     type Error = PlanError;
 
     fn try_from(options: AwsConnectionOptionExtracted) -> Result<Self, Self::Error> {
-        Ok(AwsCredentials::Static {
+        Ok(AwsCredentials {
             access_key_id: options
                 .access_key_id
                 .ok_or_else(|| sql_err!("ACCESS KEY ID option is required"))?,

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -156,7 +156,7 @@ pub async fn purify_create_source(
                 }
             };
 
-            let aws_config = normalize::aws_config(&mut with_options_map, None, Some(connection))?;
+            let aws_config = normalize::aws_config(&mut with_options_map, None, connection)?;
             validate_aws_credentials(
                 &aws_config,
                 connection_context.aws_external_id_prefix.as_ref(),
@@ -180,11 +180,8 @@ pub async fn purify_create_source(
                 }
             };
 
-            let aws_config = normalize::aws_config(
-                &mut with_options_map,
-                Some(region.into()),
-                Some(connection),
-            )?;
+            let aws_config =
+                normalize::aws_config(&mut with_options_map, Some(region.into()), connection)?;
             validate_aws_credentials(
                 &aws_config,
                 connection_context.aws_external_id_prefix.as_ref(),

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -11,12 +11,12 @@ anyhow = "1.0.58"
 async-compression = { version = "0.3.14", features = ["tokio", "gzip"] }
 async-stream = "0.3.3"
 async-trait = "0.1.56"
-aws-config = { version = "0.46.0", default-features = false, features = ["native-tls"] }
-aws-sdk-kinesis = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-s3 = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-sqs = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-smithy-http = "0.46.0"
-aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.47.0", default-features = false, features = ["native-tls"] }
+aws-sdk-kinesis = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-s3 = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sqs = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-smithy-http = "0.47.0"
+aws-types = { version = "0.47.0", features = ["hardcoded-credentials"] }
 bincode = { version = "1.3.3" }
 bytes = "1.2.0"
 bytesize = "1.1.0"

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -297,6 +297,7 @@ async fn create_state(
         .aws
         .load(aws_external_id_prefix, Some(&source_id), secrets_reader)
         .await;
+
     let kinesis_client = aws_sdk_kinesis::Client::new(&config);
 
     let shard_set = mz_kinesis_util::get_shard_ids(&kinesis_client, &c.stream_name).await?;

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -32,6 +32,8 @@ use mz_sql_parser::ast::KafkaConnectionOptionName;
 
 use crate::types::connections::aws::AwsExternalIdPrefix;
 
+use self::aws::AwsCredentials;
+
 pub mod aws;
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage.types.connections.rs"));
@@ -148,6 +150,7 @@ pub enum Connection {
     Csr(CsrConnection),
     Postgres(PostgresConnection),
     Ssh(SshConnection),
+    Aws(AwsCredentials),
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/src/storage/src/types/connections/aws.proto
+++ b/src/storage/src/types/connections/aws.proto
@@ -28,16 +28,9 @@ message ProtoAwsConfig {
 }
 
 message ProtoAwsCredentials {
-    message ProtoStatic {
-        mz_storage.types.connections.ProtoStringOrSecret access_key_id = 1;
-        mz_repr.global_id.ProtoGlobalId secret_access_key = 2;
-        optional mz_storage.types.connections.ProtoStringOrSecret session_token = 3;
-    }
-    oneof kind {
-        google.protobuf.Empty default = 1;
-        string profile = 2;
-        ProtoStatic static = 3;
-    }
+    mz_storage.types.connections.ProtoStringOrSecret access_key_id = 1;
+    mz_repr.global_id.ProtoGlobalId secret_access_key = 2;
+    optional mz_storage.types.connections.ProtoStringOrSecret session_token = 3;
 }
 
 message ProtoAwsAssumeRole {

--- a/src/storage/src/types/connections/aws.proto
+++ b/src/storage/src/types/connections/aws.proto
@@ -11,6 +11,9 @@ syntax = "proto3";
 
 import "google/protobuf/empty.proto";
 
+import "repr/src/global_id.proto";
+import "storage/src/types/connections.proto";
+
 package mz_storage.types.connections.aws;
 
 message ProtoSerdeUri {
@@ -26,9 +29,9 @@ message ProtoAwsConfig {
 
 message ProtoAwsCredentials {
     message ProtoStatic {
-        string access_key_id = 1;
-        string secret_access_key = 2;
-        optional string session_token = 3;
+        mz_storage.types.connections.ProtoStringOrSecret access_key_id = 1;
+        mz_repr.global_id.ProtoGlobalId secret_access_key = 2;
+        optional mz_storage.types.connections.ProtoStringOrSecret session_token = 3;
     }
     oneof kind {
         google.protobuf.Empty default = 1;

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -11,13 +11,13 @@ anyhow = "1.0.58"
 async-compression = { version = "0.3.14", features = ["tokio", "gzip"] }
 async-trait = "0.1.56"
 atty = "0.2.0"
-aws-config = { version = "0.46.0", default-features = false, features = ["native-tls"] }
-aws-sdk-kinesis = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-s3 = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-sqs = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-sdk-sts = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
-aws-smithy-http = "0.46.0"
-aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.47.0", default-features = false, features = ["native-tls"] }
+aws-sdk-kinesis = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-s3 = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sqs = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-sdk-sts = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-smithy-http = "0.47.0"
+aws-types = { version = "0.47.0", features = ["hardcoded-credentials"] }
 byteorder = "1.4.3"
 bytes = "1.2.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }

--- a/test/perf-kinesis/Cargo.toml
+++ b/test/perf-kinesis/Cargo.toml
@@ -8,8 +8,9 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.58"
-aws-config = { version = "0.46.0", default-features = false, features = ["native-tls"] }
-aws-sdk-kinesis = { version = "0.16.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-config = { version = "0.47.0", default-features = false, features = ["native-tls"] }
+aws-sdk-kinesis = { version = "0.17.0", default-features = false, features = ["native-tls", "rt-tokio"] }
+aws-types = "0.47.0"
 bytes = "1.2.0"
 clap = { version = "3.2.14", features = ["derive"] }
 futures = "0.3.21"

--- a/test/perf-kinesis/src/bin/perf-kinesis/kinesis.rs
+++ b/test/perf-kinesis/src/bin/perf-kinesis/kinesis.rs
@@ -69,7 +69,7 @@ pub async fn create_stream(
 /// This function will log if it's falling behind the expected put rate and once
 /// at the end to indicate total amount of time spent generating and putting records.
 pub async fn generate_and_put_records(
-    kinesis_client: &aws_sdk_kinesis::Client,
+    kinesis_client: aws_sdk_kinesis::Client,
     stream_name: &str,
     total_records: u64,
     records_per_second: u64,
@@ -94,7 +94,7 @@ pub async fn generate_and_put_records(
 
         let target_shard = shard_starting_hash_keys.pop_front().unwrap();
         put_record_count += put_records_one_second(
-            kinesis_client,
+            &kinesis_client,
             stream_name,
             &target_shard,
             records_per_second,

--- a/test/perf-kinesis/src/bin/perf-kinesis/main.rs
+++ b/test/perf-kinesis/src/bin/perf-kinesis/main.rs
@@ -81,7 +81,7 @@ async fn run() -> Result<(), anyhow::Error> {
         let records_per_second = args.records_per_second;
         async move {
             kinesis::generate_and_put_records(
-                &kinesis_client_clone,
+                kinesis_client_clone,
                 &stream_name_clone,
                 total_records,
                 records_per_second,
@@ -96,7 +96,7 @@ async fn run() -> Result<(), anyhow::Error> {
         .context("creating postgres client")?;
 
     // Create Kinesis source and materialized view.
-    mz::create_source_and_views(&client, stream_arn).await?;
+    mz::create_source_and_views(&client, &config, stream_arn).await?;
     info!("Created source and materialized views");
 
     // Query materialized view for all pushed Kinesis records.

--- a/test/s3-resumption/configure-materialize.td
+++ b/test/s3-resumption/configure-materialize.td
@@ -7,29 +7,30 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+> CREATE SECRET IF NOT EXISTS s3_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION IF NOT EXISTS s3_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 > CREATE SOURCE s3_text
-  FROM S3
+  FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 's3/*.text'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 
 > CREATE SOURCE s3_gzip
-  FROM S3
+  FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 's3/*.gzip'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
   COMPRESSION GZIP
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -16,41 +16,42 @@ New York,NY,10004
 "bad,
 place""",CA,92679
 
+> CREATE SECRET s3_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION s3_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 # We should refuse to create a source with invalid WITH options
 ! CREATE SOURCE invalid_with_option
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}',
     badoption = true
   )
   FORMAT CSV WITH 3 COLUMNS
 contains:unexpected parameters for CREATE SOURCE: badoption
 
 > CREATE SOURCE mismatched_column_count
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH 2 COLUMNS
 ! SELECT * FROM mismatched_column_count
 contains:CSV error at record number 1: expected 2 columns, got 3.
 
 > CREATE SOURCE matching_column_names
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (city, state, zip)
 
@@ -60,13 +61,11 @@ city state zip
 Rochester NY 14618
 
 > CREATE SOURCE matching_column_names_alias (a, b, c)
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (city, state, zip)
 
@@ -76,26 +75,22 @@ a b c
 Rochester NY 14618
 
 > CREATE SOURCE mismatched_column_names
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (cities, country, zip)
 ! SELECT * FROM mismatched_column_names
 contains:first mismatched column at index 1 expected=cities actual="city"
 
 > CREATE SOURCE mismatched_column_names_count
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (cities, state)
 ! SELECT * FROM mismatched_column_names_count
@@ -103,13 +98,11 @@ contains:CSV error at record number 1: expected 2 columns, got 3
 
 # Static CSV without headers.
 > CREATE SOURCE static_csv
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH 3 COLUMNS
 
@@ -122,13 +115,11 @@ Rochester      NY        14618
 "bad,\nplace\""  CA      92679
 
 ! CREATE SOURCE static_csv_nothing_demanded_src
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER
 contains:Expected a list of columns in parentheses, found EOF
@@ -141,13 +132,11 @@ $ set-regex match=(\d{13}|u\d{1,3}) replacement=<>
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (city, state, zip)
 
@@ -194,13 +183,11 @@ dollars,category
 badint,
 
 > CREATE SOURCE malformed_csv
-  FROM S3 DISCOVER OBJECTS MATCHING 'malformed.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'malformed.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (dollars, category)
 
@@ -213,13 +200,11 @@ dollars,category
 5161669,\x80
 
 > CREATE SOURCE bad_text_csv
-  FROM S3 DISCOVER OBJECTS MATCHING 'bad-text.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'bad-text.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (dollars, category)
 
@@ -231,13 +216,11 @@ contains:Decode error: Text: CSV error at record number 2: invalid UTF-8
 $ kafka-create-topic topic=static-csv-pkne-sink
 
 > CREATE SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (city, state, zip)
 

--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -13,14 +13,19 @@ $ s3-put-object bucket=test key=posix
 foo
 bar
 
+> CREATE SECRET s3_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION s3_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 > CREATE SOURCE posix
-  FROM S3 DISCOVER OBJECTS MATCHING 'posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT BYTES;
 
@@ -33,13 +38,11 @@ foo
 bar
 
 > CREATE SOURCE non_posix
-  FROM S3 DISCOVER OBJECTS MATCHING 'non-posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'non-posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT BYTES;
 

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -53,14 +53,19 @@ contains:INCLUDE HEADERS requires ENVELOPE UPSERT or no ENVELOPE
 $ s3-create-bucket bucket=test
 $ s3-put-object bucket=test key=static.csv
 
+> CREATE SECRET s3_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION s3_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 ! CREATE SOURCE headers_src
-  FROM S3 DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (city, state, zip)
   INCLUDE HEADERS

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -22,19 +22,29 @@ $ kinesis-verify stream=test
 here is a test string
 here is a second test string
 
+> CREATE SECRET kinesis_bad_conn_secret AS 'fake_secret_access_key';
+
+> CREATE CONNECTION kinesis_bad_conn FOR AWS
+  ACCESS KEY ID = 'fake_access_key_id',
+  SECRET ACCESS KEY = SECRET kinesis_bad_conn_secret;
+
 ! CREATE SOURCE custom_source
-  FROM KINESIS ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
-  WITH (access_key_id = 'fake_access_key_id',
-        secret_access_key = 'fake_secret_access_key')
+  FROM KINESIS CONNECTION kinesis_bad_conn
+  ARN 'arn:aws:kinesis:custom-region::stream/fake-stream'
   FORMAT BYTES;
 contains:dns error: failed to lookup address information: Name or service not known
 
+> CREATE SECRET kinesis_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION kinesis_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET kinesis_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 > CREATE SOURCE f
-  FROM KINESIS ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
-  WITH (access_key_id = '${testdrive.aws-access-key-id}',
-        secret_access_key = '${testdrive.aws-secret-access-key}',
-        token = '${testdrive.aws-token}',
-        endpoint = '${testdrive.aws-endpoint}')
+  FROM KINESIS CONNECTION kinesis_conn
+  ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
+  WITH (endpoint = '${testdrive.aws-endpoint}')
   FORMAT BYTES;
 
 > CREATE MATERIALIZED VIEW f_view

--- a/test/testdrive/s3-gzip.td
+++ b/test/testdrive/s3-gzip.td
@@ -21,15 +21,20 @@ b1
 b2
 b3
 
+> CREATE SECRET s3_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION s3_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 > CREATE SOURCE s3_all_none
-  FROM S3 DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-no-compression-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-no-compression-${testdrive.seed}'
   COMPRESSION NONE
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 
@@ -59,14 +64,12 @@ b2
 b3
 
 > CREATE SOURCE s3_all_gzip
-  FROM S3 DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-gzip-compression-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-gzip-compression-${testdrive.seed}'
   COMPRESSION GZIP
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 

--- a/test/testdrive/s3.td
+++ b/test/testdrive/s3.td
@@ -19,14 +19,19 @@ b1
 b2
 b3
 
+> CREATE SECRET s3_conn_secret_access_key AS '${testdrive.aws-secret-access-key}';
+
+> CREATE CONNECTION s3_conn FOR AWS
+  ACCESS KEY ID = '${testdrive.aws-access-key-id}',
+  SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
+  TOKEN = '${testdrive.aws-token}';
+
 > CREATE SOURCE s3_all
-  FROM S3 DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 
@@ -39,13 +44,11 @@ b2
 b3
 
 > CREATE SOURCE s3_glob_a
-  FROM S3 DISCOVER OBJECTS MATCHING '**/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING '**/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 
@@ -55,13 +58,11 @@ a2
 a3
 
 > CREATE SOURCE s3_just_a
-  FROM S3 DISCOVER OBJECTS MATCHING 'short/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'short/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 
@@ -76,13 +77,11 @@ c,8
 c,9
 
 > CREATE SOURCE csv_example (name, counts)
-  FROM S3 DISCOVER OBJECTS MATCHING '*.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING '*.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH 2 COLUMNS;
 
@@ -117,13 +116,11 @@ $ s3-put-object bucket=test key=logs/2021/01/01/frontend.log
 173.203.139.108 - - [01/01/2021:00:00:39] "GET /downloads/materialized HTTP/1.1" 404 335 "-" "Python/Requests_22"
 
 > CREATE SOURCE frontend_logs
-  FROM S3 DISCOVER OBJECTS MATCHING 'logs/**/*.log' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'logs/**/*.log' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT REGEX '(?P<ip>[^ ]+) - - \[(?P<dt>[^]]+)\] "(?P<method>\w+) (?P<path>[^ ]+)[^"]+" (?P<status>\d+) (?P<content_length>\d+) "-" "(?P<user_agent>[^"]+)"';
 
@@ -144,14 +141,12 @@ c2
 c3
 
 > CREATE SOURCE s3_multi
-  FROM S3 DISCOVER OBJECTS MATCHING 'short/*'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'short/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}', BUCKET SCAN 'testdrive-other-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT TEXT;
 
@@ -184,14 +179,12 @@ id,value
 5,c
 
 > CREATE SOURCE s3_csv_headers
-  FROM S3 DISCOVER OBJECTS MATCHING 'csv/*'
+  FROM S3 CONNECTION s3_conn
+  DISCOVER OBJECTS MATCHING 'csv/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
   WITH (
     region = '${testdrive.aws-region}',
-    endpoint = '${testdrive.aws-endpoint}',
-    access_key_id = '${testdrive.aws-access-key-id}',
-    secret_access_key = '${testdrive.aws-secret-access-key}',
-    token = '${testdrive.aws-token}'
+    endpoint = '${testdrive.aws-endpoint}'
   )
   FORMAT CSV WITH HEADER (id, value);
 


### PR DESCRIPTION
We ultimately want to rely on `CONNECTION`s for all external systems; this PR does that for AWS-backed systems, i.e. Kinesis and S3.

### Motivation

This PR adds a known-desirable feature. Part of #13374

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Connecting to S3 and Kinesis sources now requires an AWS connection.
