### PR TITLE
stash: Apply migrations transactionally

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -12,13 +12,13 @@ use std::hash::Hash;
 use std::iter::once;
 
 use bytes::BufMut;
-use futures::future::BoxFuture;
 use itertools::max;
 use prost::{self, Message};
 use serde_json::json;
 use timely::progress::Timestamp;
 use uuid::Uuid;
 
+use crate::catalog;
 use mz_audit_log::VersionedEvent;
 use mz_compute_client::command::ReplicaId;
 use mz_compute_client::controller::ComputeInstanceId;
@@ -64,221 +64,172 @@ async fn migrate<S: Append>(
     stash: &mut S,
     version: u64,
     bootstrap_args: &BootstrapArgs,
-) -> Result<(), StashError> {
+) -> Result<(), catalog::error::Error> {
     // Initial state.
-    let migrations: &[for<'a> fn(
-        &'a mut S,
-        &'a BootstrapArgs,
-    ) -> BoxFuture<'a, Result<(), StashError>>] = &[
-        |stash, bootstrap_args| {
-            Box::pin(async {
-                // Bump uppers so peek works.
-                COLLECTION_SETTING.upsert(stash, vec![]).await?;
-                COLLECTION_SYSTEM_GID_MAPPING.upsert(stash, vec![]).await?;
-                COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX
-                    .upsert(stash, vec![])
-                    .await?;
-                COLLECTION_ITEM.upsert(stash, vec![]).await?;
-                COLLECTION_AUDIT_LOG.upsert(stash, vec![]).await?;
-
-                COLLECTION_ID_ALLOC
-                    .upsert(
-                        stash,
-                        vec![
-                            (
-                                IdAllocKey {
-                                    name: "user".into(),
-                                },
-                                IdAllocValue { next_id: 1 },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: "system".into(),
-                                },
-                                IdAllocValue { next_id: 1 },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: DATABASE_ID_ALLOC_KEY.into(),
-                                },
-                                IdAllocValue {
-                                    next_id: MATERIALIZE_DATABASE_ID + 1,
-                                },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: SCHEMA_ID_ALLOC_KEY.into(),
-                                },
-                                IdAllocValue {
-                                    next_id: max(&[
-                                        MZ_CATALOG_SCHEMA_ID,
-                                        PG_CATALOG_SCHEMA_ID,
-                                        PUBLIC_SCHEMA_ID,
-                                        MZ_INTERNAL_SCHEMA_ID,
-                                        INFORMATION_SCHEMA_ID,
-                                    ])
-                                    .unwrap()
-                                        + 1,
-                                },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: ROLE_ID_ALLOC_KEY.into(),
-                                },
-                                IdAllocValue {
-                                    next_id: MATERIALIZE_ROLE_ID + 1,
-                                },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: COMPUTE_ID_ALLOC_KEY.into(),
-                                },
-                                IdAllocValue {
-                                    next_id: DEFAULT_COMPUTE_INSTANCE_ID + 1,
-                                },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: REPLICA_ID_ALLOC_KEY.into(),
-                                },
-                                IdAllocValue {
-                                    next_id: DEFAULT_REPLICA_ID + 1,
-                                },
-                            ),
-                            (
-                                IdAllocKey {
-                                    name: AUDIT_LOG_ID_ALLOC_KEY.into(),
-                                },
-                                IdAllocValue { next_id: 1 },
-                            ),
-                        ],
-                    )
-                    .await?;
-                COLLECTION_DATABASE
-                    .upsert(
-                        stash,
-                        vec![(
-                            DatabaseKey {
-                                id: MATERIALIZE_DATABASE_ID,
-                            },
-                            DatabaseValue {
-                                name: "materialize".into(),
-                            },
-                        )],
-                    )
-                    .await?;
-                COLLECTION_SCHEMA
-                    .upsert(
-                        stash,
-                        vec![
-                            (
-                                SchemaKey {
-                                    id: MZ_CATALOG_SCHEMA_ID,
-                                },
-                                SchemaValue {
-                                    database_id: None,
-                                    name: "mz_catalog".into(),
-                                },
-                            ),
-                            (
-                                SchemaKey {
-                                    id: PG_CATALOG_SCHEMA_ID,
-                                },
-                                SchemaValue {
-                                    database_id: None,
-                                    name: "pg_catalog".into(),
-                                },
-                            ),
-                            (
-                                SchemaKey {
-                                    id: PUBLIC_SCHEMA_ID,
-                                },
-                                SchemaValue {
-                                    database_id: Some(1),
-                                    name: "public".into(),
-                                },
-                            ),
-                            (
-                                SchemaKey {
-                                    id: MZ_INTERNAL_SCHEMA_ID,
-                                },
-                                SchemaValue {
-                                    database_id: None,
-                                    name: "mz_internal".into(),
-                                },
-                            ),
-                            (
-                                SchemaKey {
-                                    id: INFORMATION_SCHEMA_ID,
-                                },
-                                SchemaValue {
-                                    database_id: None,
-                                    name: "information_schema".into(),
-                                },
-                            ),
-                        ],
-                    )
-                    .await?;
-                COLLECTION_ROLE
-                    .upsert(
-                        stash,
-                        vec![(
-                            RoleKey {
-                                id: MATERIALIZE_ROLE_ID,
-                            },
-                            RoleValue {
-                                name: "materialize".into(),
-                            },
-                        )],
-                    )
-                    .await?;
-                COLLECTION_COMPUTE_INSTANCES
-                    .upsert(
-                        stash,
-                        vec![(
-                            ComputeInstanceKey { id: DEFAULT_COMPUTE_INSTANCE_ID },
-                            ComputeInstanceValue {
-                        name: "default".into(),
-                        config: Some(
-                            "{\"debugging\":false,\"granularity\":{\"secs\":1,\"nanos\":0}}".into(),
-                        ),
-                    },
-                )],
-                    )
-                    .await?;
-                COLLECTION_COMPUTE_INSTANCE_REPLICAS
-                    .upsert(
-                        stash,
-                        vec![(
-                            ComputeInstanceReplicaKey {
-                                id: DEFAULT_REPLICA_ID,
-                            },
-                            ComputeInstanceReplicaValue {
-                                compute_instance_id: DEFAULT_COMPUTE_INSTANCE_ID,
-                                name: "default_replica".into(),
-                                config: json!({"Managed": {
-                                    "size": bootstrap_args.default_cluster_replica_size,
-                                }})
-                                .to_string(),
-                            },
-                        )],
-                    )
-                    .await?;
-                COLLECTION_TIMESTAMP
-                    .upsert(
-                        stash,
-                        vec![(
-                            TimestampKey {
-                                id: Timeline::EpochMilliseconds.to_string(),
-                            },
-                            TimestampValue {
-                                ts: mz_repr::Timestamp::minimum(),
-                            },
-                        )],
-                    )
-                    .await?;
-                Ok(())
-            })
+    let migrations: &[for<'a> fn(&mut Transaction<'a, S>, &'a BootstrapArgs) -> Result<(), ()>] = &[
+        |txn: &mut Transaction<'_, S>, bootstrap_args| {
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: "user".into(),
+                },
+                IdAllocValue { next_id: 1 },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: "system".into(),
+                },
+                IdAllocValue { next_id: 1 },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: DATABASE_ID_ALLOC_KEY.into(),
+                },
+                IdAllocValue {
+                    next_id: MATERIALIZE_DATABASE_ID + 1,
+                },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: SCHEMA_ID_ALLOC_KEY.into(),
+                },
+                IdAllocValue {
+                    next_id: max(&[
+                        MZ_CATALOG_SCHEMA_ID,
+                        PG_CATALOG_SCHEMA_ID,
+                        PUBLIC_SCHEMA_ID,
+                        MZ_INTERNAL_SCHEMA_ID,
+                        INFORMATION_SCHEMA_ID,
+                    ])
+                    .unwrap()
+                        + 1,
+                },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: ROLE_ID_ALLOC_KEY.into(),
+                },
+                IdAllocValue {
+                    next_id: MATERIALIZE_ROLE_ID + 1,
+                },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: COMPUTE_ID_ALLOC_KEY.into(),
+                },
+                IdAllocValue {
+                    next_id: DEFAULT_COMPUTE_INSTANCE_ID + 1,
+                },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: REPLICA_ID_ALLOC_KEY.into(),
+                },
+                IdAllocValue {
+                    next_id: DEFAULT_REPLICA_ID + 1,
+                },
+            )?;
+            txn.id_allocator.insert(
+                IdAllocKey {
+                    name: AUDIT_LOG_ID_ALLOC_KEY.into(),
+                },
+                IdAllocValue { next_id: 1 },
+            )?;
+            txn.databases.insert(
+                DatabaseKey {
+                    id: MATERIALIZE_DATABASE_ID,
+                },
+                DatabaseValue {
+                    name: "materialize".into(),
+                },
+            )?;
+            txn.schemas.insert(
+                SchemaKey {
+                    id: MZ_CATALOG_SCHEMA_ID,
+                },
+                SchemaValue {
+                    database_id: None,
+                    name: "mz_catalog".into(),
+                },
+            )?;
+            txn.schemas.insert(
+                SchemaKey {
+                    id: PG_CATALOG_SCHEMA_ID,
+                },
+                SchemaValue {
+                    database_id: None,
+                    name: "pg_catalog".into(),
+                },
+            )?;
+            txn.schemas.insert(
+                SchemaKey {
+                    id: PUBLIC_SCHEMA_ID,
+                },
+                SchemaValue {
+                    database_id: Some(1),
+                    name: "public".into(),
+                },
+            )?;
+            txn.schemas.insert(
+                SchemaKey {
+                    id: MZ_INTERNAL_SCHEMA_ID,
+                },
+                SchemaValue {
+                    database_id: None,
+                    name: "mz_internal".into(),
+                },
+            )?;
+            txn.schemas.insert(
+                SchemaKey {
+                    id: INFORMATION_SCHEMA_ID,
+                },
+                SchemaValue {
+                    database_id: None,
+                    name: "information_schema".into(),
+                },
+            )?;
+            txn.roles.insert(
+                RoleKey {
+                    id: MATERIALIZE_ROLE_ID,
+                },
+                RoleValue {
+                    name: "materialize".into(),
+                },
+            )?;
+            txn.compute_instances.insert(
+                ComputeInstanceKey {
+                    id: DEFAULT_COMPUTE_INSTANCE_ID,
+                },
+                ComputeInstanceValue {
+                    name: "default".into(),
+                    config: Some(
+                        "{\"debugging\":false,\"granularity\":{\"secs\":1,\"nanos\":0}}".into(),
+                    ),
+                },
+            )?;
+            txn.compute_instance_replicas.insert(
+                ComputeInstanceReplicaKey {
+                    id: DEFAULT_REPLICA_ID,
+                },
+                ComputeInstanceReplicaValue {
+                    compute_instance_id: DEFAULT_COMPUTE_INSTANCE_ID,
+                    name: "default_replica".into(),
+                    config: json!({"Managed": {
+                        "size": bootstrap_args.default_cluster_replica_size,
+                    }})
+                    .to_string(),
+                },
+            )?;
+            txn.timestamps.insert(
+                TimestampKey {
+                    id: Timeline::EpochMilliseconds.to_string(),
+                },
+                TimestampValue {
+                    ts: mz_repr::Timestamp::minimum(),
+                },
+            )?;
+            txn.configs
+                .insert(USER_VERSION.to_string(), ConfigValue { value: 0 })?;
+            Ok(())
         },
         // Add new migrations here.
         //
@@ -290,7 +241,8 @@ async fn migrate<S: Append>(
         //     >
         //     > Optional additional commentary about safety or approach.
         //
-        // Please include @benesch on any code reviews that add or edit migrations.
+        // Please include @mjibson and @jkosh44 on any code reviews that add or
+        // edit migrations.
         // Migrations must preserve backwards compatibility with all past releases
         // of Materialize. Migrations can be edited up until they ship in a
         // release, after which they must never be removed, only patched by future
@@ -298,22 +250,17 @@ async fn migrate<S: Append>(
         // midway failure).
     ];
 
+    let mut txn = transaction_empty(stash).await?;
     for (i, migration) in migrations
         .iter()
         .enumerate()
         .skip(usize::cast_from(version))
     {
-        (migration)(stash, bootstrap_args).await?;
-        COLLECTION_CONFIG
-            .upsert_key(
-                stash,
-                &USER_VERSION.to_string(),
-                &ConfigValue {
-                    value: u64::cast_from(i),
-                },
-            )
-            .await?;
+        (migration)(&mut txn, bootstrap_args)
+            .map_err(|_| StashError::from("uniqueness violation"))?;
+        txn.update_user_version(u64::cast_from(i))?;
     }
+    txn.commit_empty().await?;
     Ok(())
 }
 
@@ -690,44 +637,114 @@ impl<S: Append> Connection<S> {
     }
 
     pub async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a, S>, Error> {
-        let databases = COLLECTION_DATABASE.peek_one(&mut self.stash).await?;
-        let schemas = COLLECTION_SCHEMA.peek_one(&mut self.stash).await?;
-        let roles = COLLECTION_ROLE.peek_one(&mut self.stash).await?;
-        let items = COLLECTION_ITEM.peek_one(&mut self.stash).await?;
-        let compute_instances = COLLECTION_COMPUTE_INSTANCES
-            .peek_one(&mut self.stash)
-            .await?;
-        let compute_instance_replicas = COLLECTION_COMPUTE_INSTANCE_REPLICAS
-            .peek_one(&mut self.stash)
-            .await?;
-        let introspection_sources = COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX
-            .peek_one(&mut self.stash)
-            .await?;
-        let id_allocator = COLLECTION_ID_ALLOC.peek_one(&mut self.stash).await?;
-
-        Ok(Transaction {
-            stash: &mut self.stash,
-            databases: TableTransaction::new(databases, |a, b| a.name == b.name),
-            schemas: TableTransaction::new(schemas, |a, b| {
-                a.database_id == b.database_id && a.name == b.name
-            }),
-            items: TableTransaction::new(items, |a, b| {
-                a.schema_id == b.schema_id && a.name == b.name
-            }),
-            roles: TableTransaction::new(roles, |a, b| a.name == b.name),
-            compute_instances: TableTransaction::new(compute_instances, |a, b| a.name == b.name),
-            compute_instance_replicas: TableTransaction::new(compute_instance_replicas, |a, b| {
-                a.compute_instance_id == b.compute_instance_id && a.name == b.name
-            }),
-            introspection_sources: TableTransaction::new(introspection_sources, |_a, _b| false),
-            id_allocator: TableTransaction::new(id_allocator, |_a, _b| false),
-            audit_log_updates: Vec::new(),
-        })
+        transaction(&mut self.stash).await
     }
 
     pub fn cluster_id(&self) -> Uuid {
         self.cluster_id
     }
+}
+
+/// Same as [`transaction`], except it will read an empty collection if it fails to read an initial
+/// collection state. This is because a collection is not readable until it is written to for the
+/// first time.
+///
+/// This method should only be used during migrations, when Stash may have never been written to.
+pub async fn transaction_empty<'a, S: Append>(
+    stash: &'a mut S,
+) -> Result<Transaction<'a, S>, Error> {
+    let databases = COLLECTION_DATABASE
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+    let schemas = COLLECTION_SCHEMA.peek_one(stash).await.unwrap_or_default();
+    let roles = COLLECTION_ROLE.peek_one(stash).await.unwrap_or_default();
+    let items = COLLECTION_ITEM.peek_one(stash).await.unwrap_or_default();
+    let compute_instances = COLLECTION_COMPUTE_INSTANCES
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+    let compute_instance_replicas = COLLECTION_COMPUTE_INSTANCE_REPLICAS
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+    let introspection_sources = COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+    let id_allocator = COLLECTION_ID_ALLOC
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+    let collection_config = COLLECTION_CONFIG.peek_one(stash).await.unwrap_or_default();
+    let collection_setting = COLLECTION_SETTING.peek_one(stash).await.unwrap_or_default();
+    let collection_timestamps = COLLECTION_TIMESTAMP
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+    let collection_system_gid_mapping = COLLECTION_SYSTEM_GID_MAPPING
+        .peek_one(stash)
+        .await
+        .unwrap_or_default();
+
+    Ok(Transaction {
+        stash,
+        databases: TableTransaction::new(databases, |a, b| a.name == b.name),
+        schemas: TableTransaction::new(schemas, |a, b| {
+            a.database_id == b.database_id && a.name == b.name
+        }),
+        items: TableTransaction::new(items, |a, b| a.schema_id == b.schema_id && a.name == b.name),
+        roles: TableTransaction::new(roles, |a, b| a.name == b.name),
+        compute_instances: TableTransaction::new(compute_instances, |a, b| a.name == b.name),
+        compute_instance_replicas: TableTransaction::new(compute_instance_replicas, |a, b| {
+            a.compute_instance_id == b.compute_instance_id && a.name == b.name
+        }),
+        introspection_sources: TableTransaction::new(introspection_sources, |_a, _b| false),
+        id_allocator: TableTransaction::new(id_allocator, |_a, _b| false),
+        configs: TableTransaction::new(collection_config, |_a, _b| false),
+        settings: TableTransaction::new(collection_setting, |_a, _b| false),
+        timestamps: TableTransaction::new(collection_timestamps, |_a, _b| false),
+        system_gid_mapping: TableTransaction::new(collection_system_gid_mapping, |_a, _b| false),
+        audit_log_updates: Vec::new(),
+    })
+}
+
+pub async fn transaction<'a, S: Append>(stash: &'a mut S) -> Result<Transaction<'a, S>, Error> {
+    let databases = COLLECTION_DATABASE.peek_one(stash).await?;
+    let schemas = COLLECTION_SCHEMA.peek_one(stash).await?;
+    let roles = COLLECTION_ROLE.peek_one(stash).await?;
+    let items = COLLECTION_ITEM.peek_one(stash).await?;
+    let compute_instances = COLLECTION_COMPUTE_INSTANCES.peek_one(stash).await?;
+    let compute_instance_replicas = COLLECTION_COMPUTE_INSTANCE_REPLICAS.peek_one(stash).await?;
+    let introspection_sources = COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX
+        .peek_one(stash)
+        .await?;
+    let id_allocator = COLLECTION_ID_ALLOC.peek_one(stash).await?;
+    let collection_config = COLLECTION_CONFIG.peek_one(stash).await?;
+    let collection_setting = COLLECTION_SETTING.peek_one(stash).await?;
+    let collection_timestamps = COLLECTION_TIMESTAMP.peek_one(stash).await?;
+    let collection_system_gid_mapping = COLLECTION_SYSTEM_GID_MAPPING.peek_one(stash).await?;
+
+    Ok(Transaction {
+        stash,
+        databases: TableTransaction::new(databases, |a, b| a.name == b.name),
+        schemas: TableTransaction::new(schemas, |a, b| {
+            a.database_id == b.database_id && a.name == b.name
+        }),
+        items: TableTransaction::new(items, |a, b| a.schema_id == b.schema_id && a.name == b.name),
+        roles: TableTransaction::new(roles, |a, b| a.name == b.name),
+        compute_instances: TableTransaction::new(compute_instances, |a, b| a.name == b.name),
+        compute_instance_replicas: TableTransaction::new(compute_instance_replicas, |a, b| {
+            a.compute_instance_id == b.compute_instance_id && a.name == b.name
+        }),
+        introspection_sources: TableTransaction::new(introspection_sources, |_a, _b| false),
+        id_allocator: TableTransaction::new(id_allocator, |_a, _b| false),
+        configs: TableTransaction::new(collection_config, |_a, _b| false),
+        settings: TableTransaction::new(collection_setting, |_a, _b| false),
+        timestamps: TableTransaction::new(collection_timestamps, |_a, _b| false),
+        system_gid_mapping: TableTransaction::new(collection_system_gid_mapping, |_a, _b| false),
+        audit_log_updates: Vec::new(),
+    })
 }
 
 pub struct Transaction<'a, S> {
@@ -742,6 +759,10 @@ pub struct Transaction<'a, S> {
     introspection_sources:
         TableTransaction<ComputeIntrospectionSourceIndexKey, ComputeIntrospectionSourceIndexValue>,
     id_allocator: TableTransaction<IdAllocKey, IdAllocValue>,
+    configs: TableTransaction<String, ConfigValue>,
+    settings: TableTransaction<SettingKey, SettingValue>,
+    timestamps: TableTransaction<TimestampKey, TimestampValue>,
+    system_gid_mapping: TableTransaction<GidMappingKey, GidMappingValue>,
     // Don't make this a table transaction so that it's not read into the stash
     // memory cache.
     audit_log_updates: Vec<(AuditLogKey, (), i64)>,
@@ -1065,13 +1086,35 @@ impl<'a, S: Append> Transaction<'a, S> {
         }
     }
 
+    pub fn update_user_version(&mut self, version: u64) -> Result<(), Error> {
+        let n = self.configs.update(|k, _v| {
+            if k == USER_VERSION {
+                Some(ConfigValue { value: version })
+            } else {
+                None
+            }
+        })?;
+        assert_eq!(n, 1);
+        Ok(())
+    }
+
+    /// Same as [`Self::commit`], but includes empty batches.
+    pub async fn commit_empty(self) -> Result<(), Error> {
+        self.commit_inner(true).await
+    }
+
     pub async fn commit(self) -> Result<(), Error> {
+        self.commit_inner(false).await
+    }
+
+    async fn commit_inner(self, include_empty: bool) -> Result<(), Error> {
         let mut batches = Vec::new();
         async fn add_batch<K, V, S, I>(
             stash: &mut S,
             batches: &mut Vec<AppendBatch>,
             collection: &TypedCollection<K, V>,
             changes: I,
+            include_empty: bool,
         ) -> Result<(), Error>
         where
             K: mz_stash::Data,
@@ -1080,7 +1123,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             I: IntoIterator<Item = (K, V, mz_stash::Diff)>,
         {
             let mut changes = changes.into_iter().peekable();
-            if changes.peek().is_none() {
+            if !include_empty && changes.peek().is_none() {
                 return Ok(());
             }
             let collection = collection.get(stash).await?;
@@ -1096,6 +1139,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_DATABASE,
             self.databases.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1103,6 +1147,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_SCHEMA,
             self.schemas.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1110,6 +1155,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_ITEM,
             self.items.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1117,6 +1163,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_ROLE,
             self.roles.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1124,6 +1171,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_COMPUTE_INSTANCES,
             self.compute_instances.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1131,6 +1179,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_COMPUTE_INSTANCE_REPLICAS,
             self.compute_instance_replicas.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1138,6 +1187,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_COMPUTE_INTROSPECTION_SOURCE_INDEX,
             self.introspection_sources.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1145,6 +1195,39 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_ID_ALLOC,
             self.id_allocator.pending(),
+            include_empty,
+        )
+        .await?;
+        add_batch(
+            self.stash,
+            &mut batches,
+            &COLLECTION_CONFIG,
+            self.configs.pending(),
+            include_empty,
+        )
+        .await?;
+        add_batch(
+            self.stash,
+            &mut batches,
+            &COLLECTION_SETTING,
+            self.settings.pending(),
+            include_empty,
+        )
+        .await?;
+        add_batch(
+            self.stash,
+            &mut batches,
+            &COLLECTION_TIMESTAMP,
+            self.timestamps.pending(),
+            include_empty,
+        )
+        .await?;
+        add_batch(
+            self.stash,
+            &mut batches,
+            &COLLECTION_SYSTEM_GID_MAPPING,
+            self.system_gid_mapping.pending(),
+            include_empty,
         )
         .await?;
         add_batch(
@@ -1152,9 +1235,10 @@ impl<'a, S: Append> Transaction<'a, S> {
             &mut batches,
             &COLLECTION_AUDIT_LOG,
             self.audit_log_updates,
+            include_empty,
         )
         .await?;
-        if batches.is_empty() {
+        if !include_empty && batches.is_empty() {
             return Ok(());
         }
         self.stash.append(batches).await.map_err(|e| e.into())


### PR DESCRIPTION
Previously, all migrations were applied as a single stash statement at
a time. Therefore, multiple concurrent Coordinators would interleave
their transactions leading to an inconsistent state.

This commit applies all migrations as a single commit to avoid
interleaving migrations.

Fixes #13632

### Motivation
This PR fixes a recognized bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
