### PR TITLE
persist: consistently omit "aws_" prefix from S3 params

### DIFF
--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -72,7 +72,7 @@ impl BlobConfig {
                     .strip_prefix('/')
                     .unwrap_or_else(|| url.path())
                     .to_string();
-                let role_arn = query_params.remove("aws_role_arn").map(|x| x.into_owned());
+                let role_arn = query_params.remove("role_arn").map(|x| x.into_owned());
                 let endpoint = query_params.remove("endpoint").map(|x| x.into_owned());
                 let region = query_params.remove("region").map(|x| x.into_owned());
 


### PR DESCRIPTION
The `aws_role_arn` parameter was an outlier in the S3 URL parameters in
including an `aws_` prefix. Since it's an S3 URL, it's inherently AWS
related, so let's make everything consistent in omitting the prefix.

See: https://github.com/MaterializeInc/materialize/pull/13624#discussion_r921468683

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* Addresses post merge feedback.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
