### PR TITLE
compute,storage: add optional dataflow execution spans

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -168,6 +168,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     Arc::clone(&compute_state.persist_clients),
                     source.storage_metadata.clone(),
                     dataflow.as_of.clone().unwrap(),
+                    context.tracing_execution_span.clone(),
                 );
 
                 // TODO(petrosagg): this is just wrapping an Arc<T> into an Rc<Arc<T>> to make the

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -21,6 +21,7 @@ use timely::dataflow::Scope;
 use timely::progress::frontier::Antichain;
 use timely::progress::Timestamp as _;
 use timely::PartialOrder;
+use tracing::{info_span, Instrument, Span};
 
 use crate::storage_state::StorageState;
 
@@ -35,6 +36,7 @@ pub fn render<G>(
     source_data: Collection<G, Result<Row, DataflowError>, Diff>,
     storage_state: &mut StorageState,
     token: Rc<dyn Any>,
+    tracing_execution_span: Span,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -61,130 +63,140 @@ pub fn render<G>(
     let persist_clients = Arc::clone(&storage_state.persist_clients);
     persist_op.build_async(
         scope.clone(),
-        move |mut capabilities, frontiers, scheduler| async move {
-            capabilities.clear();
-            let mut buffer = Vec::new();
-            let mut stashed_batches = HashMap::new();
+        move |mut capabilities, frontiers, scheduler| {
+            async move {
+                capabilities.clear();
+                let mut buffer = Vec::new();
+                let mut stashed_batches = HashMap::new();
 
-            let mut write = persist_clients
-                .lock()
-                .await
-                .open(metadata.persist_location)
-                .await
-                .expect("could not open persist client")
-                .open_writer::<SourceData, (), Timestamp, Diff>(metadata.data_shard)
-                .await
-                .expect("could not open persist shard");
+                let mut write = persist_clients
+                    .lock()
+                    .await
+                    .open(metadata.persist_location)
+                    .await
+                    .expect("could not open persist client")
+                    .open_writer::<SourceData, (), Timestamp, Diff>(metadata.data_shard)
+                    .await
+                    .expect("could not open persist shard");
 
-            // Initialize this sink's `upper` to the `upper` of the persist shard we are writing
-            // to. Data from the source not beyond this time will be dropped, as it has already
-            // been persisted.
-            // In the future, sources will avoid passing through data not beyond this upper
-            *current_upper.borrow_mut() = write.upper().clone();
+                // Initialize this sink's `upper` to the `upper` of the persist shard we are writing
+                // to. Data from the source not beyond this time will be dropped, as it has already
+                // been persisted.
+                // In the future, sources will avoid passing through data not beyond this upper
+                *current_upper.borrow_mut() = write.upper().clone();
 
-            while scheduler.notified().await {
-                let input_upper = frontiers.borrow()[0].clone();
+                while scheduler.notified().await {
+                    let input_upper = frontiers.borrow()[0].clone();
 
-                if !active_write_worker
-                    || weak_token.upgrade().is_none()
-                    || current_upper.borrow().is_empty()
-                {
-                    return;
-                }
+                    if !active_write_worker
+                        || weak_token.upgrade().is_none()
+                        || current_upper.borrow().is_empty()
+                    {
+                        return;
+                    }
 
-                while let Some((_cap, data)) = input.next() {
-                    data.swap(&mut buffer);
+                    while let Some((_cap, data)) = input.next() {
+                        data.swap(&mut buffer);
 
-                    // TODO: come up with a better default batch size here
-                    // (100 was chosen arbitrarily), and avoid having to make a batch
-                    // per-timestamp.
-                    for (row, ts, diff) in buffer.drain(..) {
-                        if write.upper().less_equal(&ts) {
-                            stashed_batches
-                                .entry(ts)
-                                .or_insert_with(|| {
-                                    // TODO: the lower has to be the min because we don't know
-                                    // what the minimum ts of data we will see is. In the future,
-                                    // this lower should be declared in `finish` instead.
-                                    write.builder(100, Antichain::from_elem(Timestamp::minimum()))
-                                })
-                                .add(&SourceData(row), &(), &ts, &diff)
-                                .await
-                                .expect("invalid usage");
+                        // TODO: come up with a better default batch size here
+                        // (100 was chosen arbitrarily), and avoid having to make a batch
+                        // per-timestamp.
+                        for (row, ts, diff) in buffer.drain(..) {
+                            if write.upper().less_equal(&ts) {
+                                stashed_batches
+                                    .entry(ts)
+                                    .or_insert_with(|| {
+                                        // TODO: the lower has to be the min because we don't know
+                                        // what the minimum ts of data we will see is. In the future,
+                                        // this lower should be declared in `finish` instead.
+                                        write.builder(
+                                            100,
+                                            Antichain::from_elem(Timestamp::minimum()),
+                                        )
+                                    })
+                                    .add(&SourceData(row), &(), &ts, &diff)
+                                    .await
+                                    .expect("invalid usage");
+                            }
                         }
                     }
-                }
 
-                // See if any timestamps are done!
-                // TODO(guswynn/petrosagg): remove this additional allocation
-                let mut finalized_timestamps: Vec<_> = stashed_batches
-                    .keys()
-                    .filter(|ts| !input_upper.less_equal(ts))
-                    .copied()
-                    .collect();
-                finalized_timestamps.sort_unstable();
+                    // See if any timestamps are done!
+                    // TODO(guswynn/petrosagg): remove this additional allocation
+                    let mut finalized_timestamps: Vec<_> = stashed_batches
+                        .keys()
+                        .filter(|ts| !input_upper.less_equal(ts))
+                        .copied()
+                        .collect();
+                    finalized_timestamps.sort_unstable();
 
-                // If the frontier has advanced, we need to finalize data being written to persist
-                if PartialOrder::less_than(&*current_upper.borrow(), &input_upper) {
-                    // We always append, even in case we don't have any updates, because appending
-                    // also advances the frontier.
-                    if finalized_timestamps.is_empty() {
-                        let expected_upper = current_upper.borrow().clone();
-                        write
-                            .append(
-                                Vec::<((SourceData, ()), Timestamp, Diff)>::new(),
-                                expected_upper,
-                                input_upper.clone(),
-                            )
-                            .await
-                            .expect("cannot append updates")
-                            .expect("invalid/outdated upper");
+                    // If the frontier has advanced, we need to finalize data being written to persist
+                    if PartialOrder::less_than(&*current_upper.borrow(), &input_upper) {
+                        // We always append, even in case we don't have any updates, because appending
+                        // also advances the frontier.
+                        if finalized_timestamps.is_empty() {
+                            let expected_upper = current_upper.borrow().clone();
+                            write
+                                .append(
+                                    Vec::<((SourceData, ()), Timestamp, Diff)>::new(),
+                                    expected_upper,
+                                    input_upper.clone(),
+                                )
+                                .await
+                                .expect("cannot append updates")
+                                .expect("invalid/outdated upper");
 
+                            // advance our stashed frontier
+                            *current_upper.borrow_mut() = input_upper.clone();
+                            // wait for more data or a new input frontier
+                            continue;
+                        }
+
+                        // `current_upper` tracks the last known upper
+                        let mut expected_upper = current_upper.borrow().clone();
+                        let finalized_batch_count = finalized_timestamps.len();
+
+                        for (i, ts) in finalized_timestamps.into_iter().enumerate() {
+                            // TODO(aljoscha): Figure out how errors from this should be reported.
+
+                            // Set the upper to the upper of the batch (which is 1 past the ts it
+                            // manages) OR the new frontier if we are appending the final batch
+                            let new_upper = if i == finalized_batch_count - 1 {
+                                input_upper.clone()
+                            } else {
+                                Antichain::from_elem(ts + 1)
+                            };
+
+                            let mut batch = stashed_batches
+                                .remove(&ts)
+                                .expect("batch for timestamp to still be there")
+                                .finish(new_upper.clone())
+                                .await
+                                .expect("invalid usage");
+
+                            write
+                                .compare_and_append_batch(
+                                    &mut batch,
+                                    expected_upper,
+                                    new_upper.clone(),
+                                )
+                                .await
+                                .expect("cannot append updates")
+                                .expect("cannot append updates")
+                                .expect("invalid/outdated upper");
+
+                            // next `expected_upper` is the one we just successfully appended
+                            expected_upper = new_upper;
+                        }
                         // advance our stashed frontier
                         *current_upper.borrow_mut() = input_upper.clone();
-                        // wait for more data or a new input frontier
-                        continue;
+                    } else {
+                        // We cannot have updates without the frontier advancing
+                        assert!(finalized_timestamps.is_empty());
                     }
-
-                    // `current_upper` tracks the last known upper
-                    let mut expected_upper = current_upper.borrow().clone();
-                    let finalized_batch_count = finalized_timestamps.len();
-
-                    for (i, ts) in finalized_timestamps.into_iter().enumerate() {
-                        // TODO(aljoscha): Figure out how errors from this should be reported.
-
-                        // Set the upper to the upper of the batch (which is 1 past the ts it
-                        // manages) OR the new frontier if we are appending the final batch
-                        let new_upper = if i == finalized_batch_count - 1 {
-                            input_upper.clone()
-                        } else {
-                            Antichain::from_elem(ts + 1)
-                        };
-
-                        let mut batch = stashed_batches
-                            .remove(&ts)
-                            .expect("batch for timestamp to still be there")
-                            .finish(new_upper.clone())
-                            .await
-                            .expect("invalid usage");
-
-                        write
-                            .compare_and_append_batch(&mut batch, expected_upper, new_upper.clone())
-                            .await
-                            .expect("cannot append updates")
-                            .expect("cannot append updates")
-                            .expect("invalid/outdated upper");
-
-                        // next `expected_upper` is the one we just successfully appended
-                        expected_upper = new_upper;
-                    }
-                    // advance our stashed frontier
-                    *current_upper.borrow_mut() = input_upper.clone();
-                } else {
-                    // We cannot have updates without the frontier advancing
-                    assert!(finalized_timestamps.is_empty());
                 }
             }
+            .instrument(info_span!(parent: tracing_execution_span, "persist_sink"))
         },
     )
 }

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -21,7 +21,7 @@ use timely::dataflow::operators::OkErr;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
 use tokio::sync::Mutex;
-use tracing::trace;
+use tracing::{info_span, trace, Span};
 
 use mz_persist::location::ExternalError;
 use mz_persist_client::read::ListenEvent;
@@ -48,6 +48,7 @@ pub fn persist_source<G>(
     persist_clients: Arc<Mutex<PersistClientCache>>,
     metadata: CollectionMetadata,
     as_of: Antichain<Timestamp>,
+    tracing_execution_span: Span,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
     Stream<G, (DataflowError, Timestamp, Diff)>,
@@ -130,6 +131,7 @@ where
             let waker_activator = Arc::new(scope.sync_activator_for(&info.address[..]));
             let waker = futures_util::task::waker(waker_activator);
             let activator = scope.activator_for(&info.address[..]);
+            let span = info_span!(parent: tracing_execution_span, "persist_source");
 
             // There is a bit of a mismatch: listening on a ReadHandle will give us an Antichain<T>
             // as a frontier in `Progress` messages while a timely source usually only has a single
@@ -141,6 +143,8 @@ where
             let mut current_ts = 0;
 
             move |cap, output| {
+                let _span_guard = span.enter();
+
                 let mut context = Context::from_waker(&waker);
                 // Bound execution of operator to prevent a single operator from hogging
                 // the CPU if there are many messages to process


### PR DESCRIPTION
Create a root tracing span for the execution of each dataflow in storage
and compute. Each operator can, at its option, enter this span when it
is scheduled, and exit the span when it yields. This is intended for
operators which call into code that is instrumented with the `tracing`
crate, so that the spans created by that instrumented code get parented
to the span for dataflow that created them.

This commit has the same effect as #13634--see that pull request for a
screenshot of the resulting traces. I made the following tweaks to that
PR:

  * The execution span is explicitly plumbed through to the relevant
    operators, rather than being passed through thread-local state. I
    find this easier to reason about than thread-local state in
    timely-related code. For me, at least, the timely idiom of
    short-lived functions creating long-lived closures makes reasoning
    about TLS state quite difficult.

  * The execution span is created unconditionally. It seems harmless to
    create this span even for long-lived dataflows. If it *is* a
    problem, it's easy to add back the logic that only creates the span
    for transient dataflows.

  * The execution span "follows from" the render span, rather than being
    a direct child. I think this better aligns with the tracing model.
    Dataflow execution can be thought of as an asynchronous background
    task that is *triggered* by dataflow rendering, rather than work
    that is done *during* dataflow rendering.

  * The timely operator closure enters the span, rather than each future
    involved in the operator. This should be a bit more robust against
    future refactorings of the code losing calls to `.instrument`.

Alternative to #13634.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Be sure to suppress whitespace.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
