### PR TITLE
.github: compress checklist in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,16 +46,10 @@ Leave some tips for your reviewer, like:
 Delete this section if no tips.
 -->
 
-### Testing
+### Checklist
 
 - [ ] This PR has adequate test coverage / QA involvement has been duly considered.
-
-### Backward compatibility
-
 - [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
-
-### Release notes
-
-This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
+- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
 
   - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->


### PR DESCRIPTION
The PR template got a bit long. Compress all the checkboxes into a
single "checklist" section. This makes it a bit more efficient to fill
out the template with no loss of content.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
