### PR TITLE
sql: fix SHOW CONNECTION

### DIFF
--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -347,7 +347,7 @@ fn show_connections<'a>(
     let mut query = format!(
         "SELECT t.name, mz_internal.mz_classify_object_id(t.id) AS type
         FROM mz_catalog.mz_connections t
-        JOIN mz_catalog.mz_schemas on t.schema_id = s.id
+        JOIN mz_catalog.mz_schemas s on t.schema_id = s.id
         WHERE schema_id = {}",
         schema_spec,
     );

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -25,6 +25,12 @@ name       type
 ------------------------------
 testconn   kafka
 
+> SHOW CONNECTIONS
+testconn
+
+> SHOW FULL CONNECTIONS
+testconn user
+
 > SHOW CREATE CONNECTION testconn
 Connection   "Create Connection"
 ---------------------------------


### PR DESCRIPTION
Fixes #13630

### Motivation

  * This PR fixes a recognized bug. #13630

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a