### PR TITLE
doc/user: move min. Debezium version to integration guides

### DIFF
--- a/doc/user/content/integrations/cdc-mysql.md
+++ b/doc/user/content/integrations/cdc-mysql.md
@@ -41,10 +41,10 @@ Before deploying a Debezium connector, you need to ensure that the upstream data
 
 ### Deploy Debezium
 
+**Minimum requirements:** Debezium 1.5+
+
 Debezium is deployed as a set of Kafka Connect-compatible
 connectors, so you first need to define a MySQL connector configuration and then start the connector by adding it to Kafka Connect.
-
-{{< debezium-warning >}}
 
 {{< warning >}}
 If you deploy the MySQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html), you **must** override the default value of `After-state only` to `false`.

--- a/doc/user/content/integrations/cdc-postgres.md
+++ b/doc/user/content/integrations/cdc-postgres.md
@@ -24,7 +24,7 @@ If Kafka is not part of your stack, you can use the [Postgres source](/sql/creat
 
 ### Database setup
 
-**Minimum requirements:** Postgres 10+
+**Minimum requirements:** PostgreSQL 10+
 
 Before creating a source in Materialize, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/10/logical-replication.html).
 
@@ -129,7 +129,7 @@ If Kafka is part of your stack, you can use [Debezium](https://debezium.io/) and
 
 ### Database setup
 
-**Minimum requirements:** Postgres 10+
+**Minimum requirements:** PostgreSQL 10+
 
 Before deploying a Debezium connector, you need to ensure that the upstream database is configured to support [logical replication](https://www.postgresql.org/docs/10/logical-replication.html).
 
@@ -159,9 +159,9 @@ As a _superuser_:
 
 ### Deploy Debezium
 
-Debezium is deployed as a set of Kafka Connect-compatible connectors, so you first need to define a Postgres connector configuration and then start the connector by adding it to Kafka Connect.
+**Minimum requirements:** Debezium 1.5+
 
-{{< debezium-warning >}}
+Debezium is deployed as a set of Kafka Connect-compatible connectors, so you first need to define a Postgres connector configuration and then start the connector by adding it to Kafka Connect.
 
 {{< warning >}}
 If you deploy the PostgreSQL Debezium connector in [Confluent Cloud](https://docs.confluent.io/cloud/current/connectors/cc-mysql-source-cdc-debezium.html), you **must** override the default value of `After-state only` to `false`.

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -109,8 +109,6 @@ Primary keys are **automatically** inferred for Kafka sources using the `UPSERT`
 
 {{< debezium-json >}}
 
-{{< debezium-warning >}}
-
 Materialize provides a dedicated envelope (`ENVELOPE DEBEZIUM`) to decode Kafka messages produced by [Debezium](https://debezium.io/). To create a source that interprets Debezium messages:
 
 ```sql

--- a/doc/user/layouts/shortcodes/debezium-warning.html
+++ b/doc/user/layouts/shortcodes/debezium-warning.html
@@ -1,3 +1,0 @@
-<div class="warning">
-  <strong class="gutter">WARNING!</strong> Materialize requires Debezium v1.5+.
-</div>


### PR DESCRIPTION
The only other system we mention the minimum required version for is PostgreSQL, in the integration guides. Dropping the explicit warning about Debezium to declutter the docs and make things consistent.

Once #8262 is addressed, we can think of a better way to document this for all integrations.