### PR TITLE
orchestrator-kubernetes: minimize match labels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,6 +3486,7 @@ dependencies = [
  "futures",
  "k8s-openapi",
  "kube",
+ "maplit",
  "mz-orchestrator",
  "mz-repr",
  "mz-secrets",

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = "0.1.56"
 chrono = { version = "0.4.19", default_features = false }
 clap = { version = "3.2.8", features = ["derive"] }
 futures = "0.3.21"
+maplit = "1.0.2"
 mz-orchestrator = { path = "../orchestrator" }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -29,6 +29,7 @@ use kube::client::Client;
 use kube::error::Error;
 use kube::runtime::{watcher, WatchStreamExt};
 use kube::ResourceExt;
+use maplit::btreemap;
 use sha2::{Digest, Sha256};
 
 use mz_orchestrator::{
@@ -169,7 +170,16 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         }: ServiceConfig<'_>,
     ) -> Result<Box<dyn Service>, anyhow::Error> {
         let name = format!("{}-{id}", self.namespace);
-        let mut labels = BTreeMap::new();
+        // The match labels should be the minimal set of labels that uniquely
+        // identify the pods in the stateful set. Changing these after the
+        // `StatefulSet` is created is not permitted by Kubernetes, and we're
+        // not yet smart enough to handle deleting and recreating the
+        // `StatefulSet`.
+        let match_labels = btreemap! {
+            "environmentd.materialize.cloud/namespace".into() => self.namespace.clone(),
+            "environmentd.materialize.cloud/service-id".into() => id.into(),
+        };
+        let mut labels = match_labels.clone();
         for (key, value) in labels_in {
             labels.insert(
                 format!("{}.environmentd.materialize.cloud/{}", self.namespace, key),
@@ -182,14 +192,6 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                 "true".into(),
             );
         }
-        labels.insert(
-            "environmentd.materialize.cloud/namespace".into(),
-            self.namespace.clone(),
-        );
-        labels.insert(
-            "environmentd.materialize.cloud/service-id".into(),
-            id.into(),
-        );
         for (key, value) in &self.config.service_labels {
             labels.insert(key.clone(), value.clone());
         }
@@ -223,7 +225,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                         .collect(),
                 ),
                 cluster_ip: None,
-                selector: Some(labels.clone()),
+                selector: Some(match_labels.clone()),
                 ..Default::default()
             }),
             status: None,
@@ -326,7 +328,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             },
             spec: Some(StatefulSetSpec {
                 selector: LabelSelector {
-                    match_labels: Some(labels.clone()),
+                    match_labels: Some(match_labels),
                     ..Default::default()
                 },
                 service_name: name.clone(),


### PR DESCRIPTION
Kubernetes does not permit StatefulSets to change their match labels
after creation. So restrict the match labels to the minimal set, to
reduce the frequency with which they change.

We'll likely need to get smart enough to delete and recreate
StatefulSets when necessary, but this commit should stave off the
problem for now. For example, I believe PR #13578 will not be an
additional breaking change on top of this PR.

When we deploy this change to cloud, we'll need to manually delete the
StatefulSets in all existing environments.

Touches MaterializeInc/cloud#3529.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR partially fixes a recognized bug.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
