### PR TITLE
stash: Return non-empty error from insert

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -862,7 +862,7 @@ where
     /// Inserts a new k,v pair.
     ///
     /// Returns an error if the uniqueness check failed or the key already exists.
-    pub fn insert(&mut self, k: K, v: V) -> Result<(), ()> {
+    pub fn insert(&mut self, k: K, v: V) -> Result<(), StashError> {
         let mut violation = false;
         self.for_values(|for_k, for_v| {
             if &k == for_k || (self.uniqueness_violation)(for_v, &v) {
@@ -870,7 +870,7 @@ where
             }
         });
         if violation {
-            return Err(());
+            return Err(StashError::from("insert violation"));
         }
         self.pending.insert(k, Some(v));
         soft_assert!(self.verify().is_ok());


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
