### PR TITLE
sql: disable/remove FORMAT ... USING SCHEMA FILE

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -382,8 +382,7 @@ CREATE MATERIALIZED VIEW jsonified_kafka_source AS
 CREATE SOURCE proto_source
   FROM KAFKA BROKER 'localhost:9092' TOPIC 'billing'
   WITH (cache = true)
-  FORMAT PROTOBUF MESSAGE '.billing.Batch'
-  USING SCHEMA FILE '[path to schema]';
+  FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY 'https://schema-registry:8081';
 ```
 
 {{< /tab >}}
@@ -393,7 +392,6 @@ CREATE SOURCE proto_source
 CREATE SOURCE text_source
   FROM KAFKA BROKER 'localhost:9092' TOPIC 'data'
   FORMAT TEXT
-  USING SCHEMA FILE '/scratch/data.json'
   ENVELOPE UPSERT;
 ```
 

--- a/doc/user/content/sql/create-source/kinesis.md
+++ b/doc/user/content/sql/create-source/kinesis.md
@@ -99,18 +99,6 @@ CREATE MATERIALIZED VIEW jsonified_kinesis_source AS
 ```
 
 {{< /tab >}}
-{{< tab "Protobuf">}}
-
-```sql
-CREATE SOURCE proto_source
-  FROM KINESIS ARN 'arn:aws:kinesis:aws-region::stream/fake-stream'
-  WITH ( access_key_id = 'access_key_id',
-         secret_access_key = 'secret_access_key' )
-  FORMAT PROTOBUF MESSAGE 'billing.Batch'
-    USING SCHEMA FILE '[path to schema]';
-```
-
-{{< /tab >}}
 {{< tab "Text/bytes">}}
 
 ```sql

--- a/doc/user/layouts/partials/sql-grammar/format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/format-spec.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1009" height="465">
+<svg xmlns="http://www.w3.org/2000/svg" width="969" height="377">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="51" y="3" width="110" height="32" rx="10"/>
@@ -9,175 +9,142 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="59" y="21">AVRO USING</text>
-   <rect x="201" y="3" width="246" height="32" rx="10"/>
-   <rect x="199"
+   <rect x="181" y="3" width="246" height="32" rx="10"/>
+   <rect x="179"
          y="1"
          width="246"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="209" y="21">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="467" y="3" width="36" height="32"/>
-   <rect x="465" y="1" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="475" y="21">url</text>
-   <rect x="543" y="35" width="80" height="32"/>
-   <rect x="541" y="33" width="80" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="551" y="53">key_strat</text>
-   <rect x="683" y="35" width="76" height="32"/>
-   <rect x="681" y="33" width="76" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="691" y="53">val_strat</text>
-   <rect x="819" y="35" width="102" height="32"/>
-   <rect x="817" y="33" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="827" y="53">with_options</text>
-   <rect x="201" y="79" width="114" height="32" rx="10"/>
-   <rect x="199"
-         y="77"
-         width="114"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="209" y="97">SCHEMA FILE</text>
-   <rect x="335" y="79" width="50" height="32"/>
-   <rect x="333" y="77" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="343" y="97">path</text>
-   <rect x="51" y="123" width="96" height="32" rx="10"/>
+   <text class="terminal" x="189" y="21">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="447" y="3" width="36" height="32"/>
+   <rect x="445" y="1" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="455" y="21">url</text>
+   <rect x="523" y="35" width="80" height="32"/>
+   <rect x="521" y="33" width="80" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="531" y="53">key_strat</text>
+   <rect x="663" y="35" width="76" height="32"/>
+   <rect x="661" y="33" width="76" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="671" y="53">val_strat</text>
+   <rect x="799" y="35" width="102" height="32"/>
+   <rect x="797" y="33" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="807" y="53">with_options</text>
+   <rect x="51" y="79" width="96" height="32" rx="10"/>
    <rect x="49"
-         y="121"
+         y="77"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="141">PROTOBUF</text>
-   <rect x="187" y="123" width="90" height="32" rx="10"/>
-   <rect x="185"
-         y="121"
-         width="90"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="195" y="141">MESSAGE</text>
-   <rect x="297" y="123" width="122" height="32"/>
-   <rect x="295" y="121" width="122" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="305" y="141">message_name</text>
-   <rect x="439" y="123" width="162" height="32" rx="10"/>
-   <rect x="437"
-         y="121"
-         width="162"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="447" y="141">USING SCHEMA FILE</text>
-   <rect x="621" y="123" width="50" height="32"/>
-   <rect x="619" y="121" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="629" y="141">path</text>
-   <rect x="187" y="167" width="296" height="32" rx="10"/>
-   <rect x="185"
-         y="165"
+   <text class="terminal" x="59" y="97">PROTOBUF</text>
+   <rect x="167" y="79" width="296" height="32" rx="10"/>
+   <rect x="165"
+         y="77"
          width="296"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="195" y="185">USING CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="503" y="167" width="36" height="32"/>
-   <rect x="501" y="165" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="511" y="185">url</text>
-   <rect x="559" y="167" width="102" height="32"/>
-   <rect x="557" y="165" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="567" y="185">with_options</text>
-   <rect x="51" y="211" width="66" height="32" rx="10"/>
+   <text class="terminal" x="175" y="97">USING CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="483" y="79" width="36" height="32"/>
+   <rect x="481" y="77" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="491" y="97">url</text>
+   <rect x="539" y="79" width="102" height="32"/>
+   <rect x="537" y="77" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="547" y="97">with_options</text>
+   <rect x="51" y="123" width="66" height="32" rx="10"/>
    <rect x="49"
-         y="209"
+         y="121"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="229">REGEX</text>
-   <rect x="137" y="211" width="56" height="32"/>
-   <rect x="135" y="209" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="145" y="229">regex</text>
-   <rect x="51" y="299" width="92" height="32" rx="10"/>
+   <text class="terminal" x="59" y="141">REGEX</text>
+   <rect x="137" y="123" width="56" height="32"/>
+   <rect x="135" y="121" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="145" y="141">regex</text>
+   <rect x="51" y="211" width="92" height="32" rx="10"/>
    <rect x="49"
-         y="297"
+         y="209"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="317">CSV WITH</text>
-   <rect x="183" y="299" width="78" height="32" rx="10"/>
+   <text class="terminal" x="59" y="229">CSV WITH</text>
+   <rect x="183" y="211" width="78" height="32" rx="10"/>
    <rect x="181"
-         y="297"
+         y="209"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="191" y="317">HEADER</text>
-   <rect x="281" y="299" width="26" height="32" rx="10"/>
+   <text class="terminal" x="191" y="229">HEADER</text>
+   <rect x="281" y="211" width="26" height="32" rx="10"/>
    <rect x="279"
-         y="297"
+         y="209"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="289" y="317">(</text>
-   <rect x="347" y="299" width="82" height="32"/>
-   <rect x="345" y="297" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="355" y="317">col_name</text>
-   <rect x="347" y="255" width="24" height="32" rx="10"/>
+   <text class="terminal" x="289" y="229">(</text>
+   <rect x="347" y="211" width="82" height="32"/>
+   <rect x="345" y="209" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="355" y="229">col_name</text>
+   <rect x="347" y="167" width="24" height="32" rx="10"/>
    <rect x="345"
-         y="253"
+         y="165"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="273">,</text>
-   <rect x="469" y="299" width="26" height="32" rx="10"/>
+   <text class="terminal" x="355" y="185">,</text>
+   <rect x="469" y="211" width="26" height="32" rx="10"/>
    <rect x="467"
-         y="297"
+         y="209"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="477" y="317">)</text>
-   <rect x="183" y="343" width="28" height="32"/>
-   <rect x="181" y="341" width="28" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="191" y="361">n</text>
-   <rect x="231" y="343" width="92" height="32" rx="10"/>
+   <text class="terminal" x="477" y="229">)</text>
+   <rect x="183" y="255" width="28" height="32"/>
+   <rect x="181" y="253" width="28" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="191" y="273">n</text>
+   <rect x="231" y="255" width="92" height="32" rx="10"/>
    <rect x="229"
-         y="341"
+         y="253"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="239" y="361">COLUMNS</text>
-   <rect x="555" y="331" width="118" height="32" rx="10"/>
+   <text class="terminal" x="239" y="273">COLUMNS</text>
+   <rect x="555" y="243" width="118" height="32" rx="10"/>
    <rect x="553"
-         y="329"
+         y="241"
          width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="563" y="349">DELIMITED BY</text>
-   <rect x="693" y="331" width="48" height="32"/>
-   <rect x="691" y="329" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="701" y="349">char</text>
-   <rect x="51" y="387" width="56" height="32" rx="10"/>
+   <text class="terminal" x="563" y="261">DELIMITED BY</text>
+   <rect x="693" y="243" width="48" height="32"/>
+   <rect x="691" y="241" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="701" y="261">char</text>
+   <rect x="51" y="299" width="56" height="32" rx="10"/>
    <rect x="49"
-         y="385"
+         y="297"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="405">TEXT</text>
-   <rect x="51" y="431" width="66" height="32" rx="10"/>
+   <text class="terminal" x="59" y="317">TEXT</text>
+   <rect x="51" y="343" width="66" height="32" rx="10"/>
    <rect x="49"
-         y="429"
+         y="341"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="449">BYTES</text>
+   <text class="terminal" x="59" y="361">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m110 0 h10 m20 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -32 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m40 -32 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-760 -32 h20 m760 0 h20 m-800 0 q10 0 10 10 m780 0 q0 -10 10 -10 m-790 10 v56 m780 0 v-56 m-780 56 q0 10 10 10 m760 0 q10 0 10 -10 m-770 10 h10 m114 0 h10 m0 0 h10 m50 0 h10 m0 0 h556 m-930 -76 h20 m930 0 h20 m-970 0 q10 0 10 10 m950 0 q0 -10 10 -10 m-960 10 v100 m950 0 v-100 m-950 100 q0 10 10 10 m930 0 q10 0 10 -10 m-940 10 h10 m96 0 h10 m20 0 h10 m90 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h10 m50 0 h10 m-524 0 h20 m504 0 h20 m-544 0 q10 0 10 10 m524 0 q0 -10 10 -10 m-534 10 v24 m524 0 v-24 m-524 24 q0 10 10 10 m504 0 q10 0 10 -10 m-514 10 h10 m296 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m20 -44 h270 m-940 -10 v20 m950 0 v-20 m-950 20 v68 m950 0 v-68 m-950 68 q0 10 10 10 m930 0 q10 0 10 -10 m-940 10 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h768 m-940 -10 v20 m950 0 v-20 m-950 20 v68 m950 0 v-68 m-950 68 q0 10 10 10 m930 0 q10 0 10 -10 m-940 10 h10 m92 0 h10 m20 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v24 m352 0 v-24 m-352 24 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m28 0 h10 m0 0 h10 m92 0 h10 m0 0 h172 m40 -44 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m118 0 h10 m0 0 h10 m48 0 h10 m20 -32 h200 m-940 -10 v20 m950 0 v-20 m-950 20 v68 m950 0 v-68 m-950 68 q0 10 10 10 m930 0 q10 0 10 -10 m-940 10 h10 m56 0 h10 m0 0 h854 m-940 -10 v20 m950 0 v-20 m-950 20 v24 m950 0 v-24 m-950 24 q0 10 10 10 m930 0 q10 0 10 -10 m-940 10 h10 m66 0 h10 m0 0 h844 m23 -428 h-3"/>
-   <polygon points="999 17 1007 13 1007 21"/>
-   <polygon points="999 17 991 13 991 21"/>
+         d="m17 17 h2 m20 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h90 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v12 m120 0 v-12 m-120 12 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m40 -32 h10 m0 0 h86 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v12 m116 0 v-12 m-116 12 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m40 -32 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-890 -32 h20 m890 0 h20 m-930 0 q10 0 10 10 m910 0 q0 -10 10 -10 m-920 10 v56 m910 0 v-56 m-910 56 q0 10 10 10 m890 0 q10 0 10 -10 m-900 10 h10 m96 0 h10 m0 0 h10 m296 0 h10 m0 0 h10 m36 0 h10 m0 0 h10 m102 0 h10 m0 0 h280 m-900 -10 v20 m910 0 v-20 m-910 20 v24 m910 0 v-24 m-910 24 q0 10 10 10 m890 0 q10 0 10 -10 m-900 10 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h728 m-900 -10 v20 m910 0 v-20 m-910 20 v68 m910 0 v-68 m-910 68 q0 10 10 10 m890 0 q10 0 10 -10 m-900 10 h10 m92 0 h10 m20 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v24 m352 0 v-24 m-352 24 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m28 0 h10 m0 0 h10 m92 0 h10 m0 0 h172 m40 -44 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m118 0 h10 m0 0 h10 m48 0 h10 m20 -32 h160 m-900 -10 v20 m910 0 v-20 m-910 20 v68 m910 0 v-68 m-910 68 q0 10 10 10 m890 0 q10 0 10 -10 m-900 10 h10 m56 0 h10 m0 0 h814 m-900 -10 v20 m910 0 v-20 m-910 20 v24 m910 0 v-24 m-910 24 q0 10 10 10 m890 0 q10 0 10 -10 m-900 10 h10 m66 0 h10 m0 0 h804 m23 -340 h-3"/>
+   <polygon points="959 17 967 13 967 21"/>
+   <polygon points="959 17 951 13 951 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/kinesis-format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/kinesis-format-spec.svg
@@ -1,122 +1,100 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="809" height="301">
+<svg xmlns="http://www.w3.org/2000/svg" width="809" height="257">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
-   <rect x="51" y="3" width="170" height="32" rx="10"/>
+   <rect x="51" y="3" width="66" height="32" rx="10"/>
    <rect x="49"
          y="1"
-         width="170"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="59" y="21">PROTOBUF MESSAGE</text>
-   <rect x="241" y="3" width="122" height="32"/>
-   <rect x="239" y="1" width="122" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="249" y="21">message_name</text>
-   <rect x="383" y="3" width="162" height="32" rx="10"/>
-   <rect x="381"
-         y="1"
-         width="162"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="391" y="21">USING SCHEMA FILE</text>
-   <rect x="565" y="3" width="50" height="32"/>
-   <rect x="563" y="1" width="50" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="573" y="21">path</text>
-   <rect x="51" y="47" width="66" height="32" rx="10"/>
-   <rect x="49"
-         y="45"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="65">REGEX</text>
-   <rect x="137" y="47" width="56" height="32"/>
-   <rect x="135" y="45" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="145" y="65">regex</text>
-   <rect x="51" y="135" width="92" height="32" rx="10"/>
+   <text class="terminal" x="59" y="21">REGEX</text>
+   <rect x="137" y="3" width="56" height="32"/>
+   <rect x="135" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="145" y="21">regex</text>
+   <rect x="51" y="91" width="92" height="32" rx="10"/>
    <rect x="49"
-         y="133"
+         y="89"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="153">CSV WITH</text>
-   <rect x="183" y="135" width="78" height="32" rx="10"/>
+   <text class="terminal" x="59" y="109">CSV WITH</text>
+   <rect x="183" y="91" width="78" height="32" rx="10"/>
    <rect x="181"
-         y="133"
+         y="89"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="191" y="153">HEADER</text>
-   <rect x="281" y="135" width="26" height="32" rx="10"/>
+   <text class="terminal" x="191" y="109">HEADER</text>
+   <rect x="281" y="91" width="26" height="32" rx="10"/>
    <rect x="279"
-         y="133"
+         y="89"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="289" y="153">(</text>
-   <rect x="347" y="135" width="82" height="32"/>
-   <rect x="345" y="133" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="355" y="153">col_name</text>
-   <rect x="347" y="91" width="24" height="32" rx="10"/>
+   <text class="terminal" x="289" y="109">(</text>
+   <rect x="347" y="91" width="82" height="32"/>
+   <rect x="345" y="89" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="355" y="109">col_name</text>
+   <rect x="347" y="47" width="24" height="32" rx="10"/>
    <rect x="345"
-         y="89"
+         y="45"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="355" y="109">,</text>
-   <rect x="469" y="135" width="26" height="32" rx="10"/>
+   <text class="terminal" x="355" y="65">,</text>
+   <rect x="469" y="91" width="26" height="32" rx="10"/>
    <rect x="467"
-         y="133"
+         y="89"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="477" y="153">)</text>
-   <rect x="183" y="179" width="28" height="32"/>
-   <rect x="181" y="177" width="28" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="191" y="197">n</text>
-   <rect x="231" y="179" width="92" height="32" rx="10"/>
+   <text class="terminal" x="477" y="109">)</text>
+   <rect x="183" y="135" width="28" height="32"/>
+   <rect x="181" y="133" width="28" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="191" y="153">n</text>
+   <rect x="231" y="135" width="92" height="32" rx="10"/>
    <rect x="229"
-         y="177"
+         y="133"
          width="92"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="239" y="197">COLUMNS</text>
-   <rect x="555" y="167" width="118" height="32" rx="10"/>
+   <text class="terminal" x="239" y="153">COLUMNS</text>
+   <rect x="555" y="123" width="118" height="32" rx="10"/>
    <rect x="553"
-         y="165"
+         y="121"
          width="118"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="563" y="185">DELIMITED BY</text>
-   <rect x="693" y="167" width="48" height="32"/>
-   <rect x="691" y="165" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="701" y="185">char</text>
-   <rect x="51" y="223" width="56" height="32" rx="10"/>
+   <text class="terminal" x="563" y="141">DELIMITED BY</text>
+   <rect x="693" y="123" width="48" height="32"/>
+   <rect x="691" y="121" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="701" y="141">char</text>
+   <rect x="51" y="179" width="56" height="32" rx="10"/>
    <rect x="49"
-         y="221"
+         y="177"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="241">TEXT</text>
-   <rect x="51" y="267" width="66" height="32" rx="10"/>
+   <text class="terminal" x="59" y="197">TEXT</text>
+   <rect x="51" y="223" width="66" height="32" rx="10"/>
    <rect x="49"
-         y="265"
+         y="221"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="285">BYTES</text>
+   <text class="terminal" x="59" y="241">BYTES</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m170 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m162 0 h10 m0 0 h10 m50 0 h10 m0 0 h146 m-750 0 h20 m730 0 h20 m-770 0 q10 0 10 10 m750 0 q0 -10 10 -10 m-760 10 v24 m750 0 v-24 m-750 24 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h568 m-740 -10 v20 m750 0 v-20 m-750 20 v68 m750 0 v-68 m-750 68 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m92 0 h10 m20 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v24 m352 0 v-24 m-352 24 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m28 0 h10 m0 0 h10 m92 0 h10 m0 0 h172 m40 -44 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m118 0 h10 m0 0 h10 m48 0 h10 m-720 -42 v20 m750 0 v-20 m-750 20 v68 m750 0 v-68 m-750 68 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m56 0 h10 m0 0 h654 m-740 -10 v20 m750 0 v-20 m-750 20 v24 m750 0 v-24 m-750 24 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m66 0 h10 m0 0 h644 m23 -264 h-3"/>
+         d="m17 17 h2 m20 0 h10 m66 0 h10 m0 0 h10 m56 0 h10 m0 0 h568 m-750 0 h20 m730 0 h20 m-770 0 q10 0 10 10 m750 0 q0 -10 10 -10 m-760 10 v68 m750 0 v-68 m-750 68 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m92 0 h10 m20 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-352 0 h20 m332 0 h20 m-372 0 q10 0 10 10 m352 0 q0 -10 10 -10 m-362 10 v24 m352 0 v-24 m-352 24 q0 10 10 10 m332 0 q10 0 10 -10 m-342 10 h10 m28 0 h10 m0 0 h10 m92 0 h10 m0 0 h172 m40 -44 h10 m0 0 h196 m-226 0 h20 m206 0 h20 m-246 0 q10 0 10 10 m226 0 q0 -10 10 -10 m-236 10 v12 m226 0 v-12 m-226 12 q0 10 10 10 m206 0 q10 0 10 -10 m-216 10 h10 m118 0 h10 m0 0 h10 m48 0 h10 m-720 -42 v20 m750 0 v-20 m-750 20 v68 m750 0 v-68 m-750 68 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m56 0 h10 m0 0 h654 m-740 -10 v20 m750 0 v-20 m-750 20 v24 m750 0 v-24 m-750 24 q0 10 10 10 m730 0 q10 0 10 -10 m-740 10 h10 m66 0 h10 m0 0 h644 m23 -220 h-3"/>
    <polygon points="799 17 807 13 807 21"/>
    <polygon points="799 17 791 13 791 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
+++ b/doc/user/layouts/partials/sql-grammar/sink-format-spec.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="733" height="157">
+<svg xmlns="http://www.w3.org/2000/svg" width="693" height="113">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="51" y="3" width="110" height="32" rx="10"/>
@@ -9,49 +9,30 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="59" y="21">AVRO USING</text>
-   <rect x="201" y="3" width="246" height="32" rx="10"/>
-   <rect x="199"
+   <rect x="181" y="3" width="246" height="32" rx="10"/>
+   <rect x="179"
          y="1"
          width="246"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="209" y="21">CONFLUENT SCHEMA REGISTRY</text>
-   <rect x="467" y="3" width="36" height="32"/>
-   <rect x="465" y="1" width="36" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="475" y="21">url</text>
-   <rect x="543" y="35" width="102" height="32"/>
-   <rect x="541" y="33" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="551" y="53">with_options</text>
-   <rect x="201" y="79" width="82" height="32" rx="10"/>
-   <rect x="199"
-         y="77"
-         width="82"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="209" y="97">SCHEMA</text>
-   <rect x="303" y="79" width="48" height="32" rx="10"/>
-   <rect x="301"
-         y="77"
-         width="48"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="311" y="97">FILE</text>
-   <rect x="371" y="79" width="132" height="32"/>
-   <rect x="369" y="77" width="132" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="379" y="97">schema_file_path</text>
-   <rect x="51" y="123" width="58" height="32" rx="10"/>
+   <text class="terminal" x="189" y="21">CONFLUENT SCHEMA REGISTRY</text>
+   <rect x="447" y="3" width="36" height="32"/>
+   <rect x="445" y="1" width="36" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="455" y="21">url</text>
+   <rect x="523" y="35" width="102" height="32"/>
+   <rect x="521" y="33" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="531" y="53">with_options</text>
+   <rect x="51" y="79" width="58" height="32" rx="10"/>
    <rect x="49"
-         y="121"
+         y="77"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="59" y="141">JSON</text>
+   <text class="terminal" x="59" y="97">JSON</text>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m110 0 h10 m20 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-484 -32 h20 m484 0 h20 m-524 0 q10 0 10 10 m504 0 q0 -10 10 -10 m-514 10 v56 m504 0 v-56 m-504 56 q0 10 10 10 m484 0 q10 0 10 -10 m-494 10 h10 m82 0 h10 m0 0 h10 m48 0 h10 m0 0 h10 m132 0 h10 m0 0 h162 m-654 -76 h20 m654 0 h20 m-694 0 q10 0 10 10 m674 0 q0 -10 10 -10 m-684 10 v100 m674 0 v-100 m-674 100 q0 10 10 10 m654 0 q10 0 10 -10 m-664 10 h10 m58 0 h10 m0 0 h576 m23 -120 h-3"/>
-   <polygon points="723 17 731 13 731 21"/>
-   <polygon points="723 17 715 13 715 21"/>
+         d="m17 17 h2 m20 0 h10 m110 0 h10 m0 0 h10 m246 0 h10 m0 0 h10 m36 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m-614 -32 h20 m614 0 h20 m-654 0 q10 0 10 10 m634 0 q0 -10 10 -10 m-644 10 v56 m634 0 v-56 m-634 56 q0 10 10 10 m614 0 q10 0 10 -10 m-624 10 h10 m58 0 h10 m0 0 h536 m23 -76 h-3"/>
+   <polygon points="683 17 691 13 691 21"/>
+   <polygon points="683 17 675 13 675 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -179,14 +179,8 @@ fetch ::=
   'FETCH' 'FORWARD'? ('ALL' | count)? 'FROM'? cursor_name
   ( 'WITH'? '(' (option_name ('=' option_value)?) ( ',' (option_name ('=' option_value)?) )* ')' )?
 format_spec ::=
-  'AVRO USING' (
-        'CONFLUENT SCHEMA REGISTRY' url key_strat? val_strat? with_options? |
-        'SCHEMA FILE' path
-        ) |
-  'PROTOBUF' (
-        'MESSAGE' message_name 'USING SCHEMA FILE' path |
-        'USING CONFLUENT SCHEMA REGISTRY' url with_options
-        ) |
+  'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url key_strat? val_strat? with_options? |
+  'PROTOBUF' 'USING CONFLUENT SCHEMA REGISTRY' url with_options |
   'REGEX' regex |
   'CSV WITH' ('HEADER' ( '(' col_name (',' col_name)* ')' ) | n 'COLUMNS') ('DELIMITED BY' char)? |
   'TEXT' |
@@ -200,7 +194,6 @@ strat ::=
   'ID' schema_registry_id |
   'LATEST'
 kinesis_format_spec ::=
-  'PROTOBUF MESSAGE' message_name 'USING SCHEMA FILE' path |
   'REGEX' regex |
   'CSV WITH' ('HEADER' ( '(' col_name (',' col_name)* ')' ) | n 'COLUMNS') ('DELIMITED BY' char)? |
   'TEXT' |
@@ -211,10 +204,7 @@ s3_format_spec ::=
   'TEXT' |
   'BYTES'
 sink_format_spec ::=
-  'AVRO USING' (
-        'CONFLUENT SCHEMA REGISTRY' url with_options? |
-        'SCHEMA' 'FILE' schema_file_path
-        ) |
+  'AVRO USING' 'CONFLUENT SCHEMA REGISTRY' url with_options?|
   'JSON'
 consistency_format_spec ::=
   'AVRO USING' (

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -479,40 +479,6 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USIN
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(InlineSchema { schema: Inline("string"), with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] })), envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
-parse-statement
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-----
-error: Expected end of statement, found FORMAT
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-                                                                                                                     ^
-
-parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-----
-error: Expected end of statement, found FORMAT
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=2) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-                                                                                                                                         ^
-
-parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-----
-error: Expected end of statement, found FORMAT
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-                                                                                                                                          ^
-
-parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-----
-error: Expected end of statement, found FORMAT
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-                                                                                                                                           ^
-
-parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-----
-error: Expected end of statement, found FORMAT
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (start_offset=[2, 40000000]) FORMAT AVRO USING SCHEMA FILE 'path' ENVELOPE UPSERT FORMAT TEXT
-                                                                                                                                                     ^
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SEKRET)

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -260,9 +260,10 @@ async fn purify_source_format_single(
                 .await?
             }
             AvroSchema::InlineSchema { schema, .. } => {
-                if let mz_sql_parser::ast::Schema::File(path) = schema {
-                    let file_schema = tokio::fs::read_to_string(path).await?;
-                    *schema = mz_sql_parser::ast::Schema::Inline(file_schema);
+                if let mz_sql_parser::ast::Schema::File(_) = schema {
+                    // See comment below about this branch for the protobuf
+                    // format.
+                    bail_unsupported!("FORMAT AVRO USING SCHEMA FILE");
                 }
             }
         },
@@ -282,6 +283,11 @@ async fn purify_source_format_single(
                 schema,
             } => {
                 if let mz_sql_parser::ast::Schema::File(path) = schema {
+                    // We want to remove this feature, as it doesn't work in
+                    // cloud, but there are many tests that rely on this
+                    // feature that need to be updated first.
+                    let scx = StatementContext::new(None, &*catalog);
+                    scx.require_unsafe_mode("FORMAT PROTOBUF USING SCHEMA FILE")?;
                     let descriptors = tokio::fs::read(path).await?;
                     let mut buf = String::new();
                     strconv::format_bytes(&mut buf, &descriptors);

--- a/test/testdrive/disabled/kafka-avro-debezium-transaction.td
+++ b/test/testdrive/disabled/kafka-avro-debezium-transaction.td
@@ -245,28 +245,6 @@ a    b
 ---------
 101  101
 
-
-#
-# Create a source using a file schema
-#
-$ file-append path=data-schema.json
-\${schema}
-
-> CREATE SOURCE data_schema_file
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA FILE '${testdrive.temp-dir}/data-schema.json'
-    ENVELOPE DEBEZIUM (
-      TRANSACTION METADATA (SOURCE data_txdata, COLLECTION 'testdrive-data-${testdrive.seed}')
-  )
-
-> SELECT a, b FROM data_schema_file
-a  b
-----
-1  1
-2  3
-4  5
-8  9
-
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 $ kafka-verify format=avro sink=materialize.public.data_sink sort-messages=true

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -163,36 +163,6 @@ a  b  json                     c            d             e                   f
 -1  7 "[1,2,3]"                FileNotFound True          <null>              <null>
 42 19 "[4,5,6]"                FileNotFound True          <null>              <null>
 
-# Create a source using a file schema. This should fail if the named schema file
-# does not exist.
-
-! CREATE SOURCE data_schema_file
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA FILE 'data-schema.json'
-  ENVELOPE DEBEZIUM
-contains:No such file or directory
-
-$ file-append path=data-schema.json
-\${schema}
-
-> CREATE SOURCE data_schema_file
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  FORMAT AVRO USING SCHEMA FILE '${testdrive.temp-dir}/data-schema.json'
-  ENVELOPE DEBEZIUM
-
-> SHOW CREATE SOURCE data_schema_file
-Source   "Create Source"
-------------------------
-materialize.public.data_schema_file "CREATE SOURCE \"materialize\".\"public\".\"data_schema_file\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}\n' ENVELOPE DEBEZIUM"
-
-> SELECT a, b, json, c, d FROM data_schema_file
-a  b  json                     c            d
---------------------------------------------------------
-1  1  null                     True         False
-2  3  "{\"hello\":\"world\"}"  False        FileNotFound
--1  7 "[1,2,3]"                FileNotFound True
-42 19 "[4,5,6]"                FileNotFound True
-
 # Test an Avro source without a Debezium envelope.
 
 $ set non-dbz-schema={

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -65,13 +65,10 @@ mammal1: {"f1": "moose", "f2": 1}
   VALUE FORMAT AVRO USING SCHEMA  '${schema}'
   ENVELOPE UPSERT
 
-$ file-append path=data-schema.json
-\${schema}
-
 > CREATE SOURCE textavro
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
   KEY FORMAT TEXT
-  VALUE FORMAT AVRO USING SCHEMA FILE '${testdrive.temp-dir}/data-schema.json'
+  VALUE FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE UPSERT
 
 > select * from bytesavro


### PR DESCRIPTION
Cloud-native Materialize does not have access to files. So
remove/disable support for specifying Protobuf and Avro schemas in
files.

There are a few too many protobuf-based tests that use this right now,
so `FORMAT PROTOBUF USING SCHEMA FILE` remains as an unsafe mode feature
until we have time to update the tests.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR removes code that is no longer relevant in cloud-native Materialize.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a