### PR TITLE
adapter: Add `EXPLAIN ... AS TEXT` support for single-output `HIR` stages

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -4592,6 +4592,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
+                    config: &config,
                     humanizer: &catalog,
                     used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
@@ -4606,6 +4607,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
+                    config: &config,
                     humanizer: &catalog,
                     used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
@@ -4621,6 +4623,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
+                    config: &config,
                     humanizer: &catalog,
                     used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
@@ -4637,6 +4640,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
+                    config: &config,
                     humanizer: &catalog,
                     used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
@@ -4653,6 +4657,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
+                    config: &config,
                     humanizer: &catalog,
                     used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,
@@ -4674,6 +4679,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
+                    config: &config,
                     humanizer: &catalog,
                     used_indexes: UsedIndexes::new(Default::default()),
                     finishing: row_set_finishing,

--- a/src/adapter/src/explain_new/hir/mod.rs
+++ b/src/adapter/src/explain_new/hir/mod.rs
@@ -11,40 +11,32 @@
 
 pub(crate) mod text;
 
-use mz_ore::id_gen::IdGen;
 use mz_repr::explain_new::{Explain, ExplainConfig, ExplainError, UnsupportedFormat};
 use mz_sql::plan::HirRelationExpr;
-use std::collections::{BTreeMap, HashMap};
-use text::HirRelationExprExplanation;
 
-use super::{ExplainContext, Explainable};
+use super::{AnnotatedPlan, ExplainContext, ExplainSinglePlan, Explainable};
 
 impl<'a> Explain<'a> for Explainable<'a, HirRelationExpr> {
     type Context = ExplainContext<'a>;
 
-    type Text = HirRelationExprExplanation<'a>;
+    type Text = ExplainSinglePlan<'a, HirRelationExpr>;
 
     type Json = UnsupportedFormat;
 
     type Dot = UnsupportedFormat;
 
+    #[allow(unused_variables)] // TODO (#13299)
     fn explain_text(
         &'a mut self,
         config: &'a ExplainConfig,
         context: &'a Self::Context,
     ) -> Result<Self::Text, ExplainError> {
-        let mut explanation = HirRelationExprExplanation::new(
-            self.0,
-            context.humanizer,
-            &mut IdGen::default(),
-            HashMap::new(),
-        );
-        if let Some(finishing) = context.finishing.clone() {
-            explanation.explain_row_set_finishing(finishing);
-        }
-        if config.types {
-            explanation.explain_types(&BTreeMap::new());
-        }
-        Ok(explanation)
+        // TODO: use config values to infer requested
+        // plan annotations
+        let plan = AnnotatedPlan {
+            plan: self.0,
+            annotations: Default::default(),
+        };
+        Ok(ExplainSinglePlan { context, plan })
     }
 }

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use mz_expr::RowSetFinishing;
-use mz_repr::explain_new::{DisplayText, ExprHumanizer};
+use mz_repr::explain_new::{DisplayText, ExplainConfig, ExprHumanizer};
 use mz_repr::GlobalId;
 use mz_storage::types::transforms::LinearOperator;
 
@@ -62,6 +62,7 @@ impl<'a, T> From<&'a T> for Displayable<'a, T> {
 #[derive(Debug)]
 #[allow(dead_code)] // TODO (#13299)
 pub(crate) struct ExplainContext<'a> {
+    pub(crate) config: &'a ExplainConfig,
     pub(crate) humanizer: &'a dyn ExprHumanizer,
     pub(crate) used_indexes: UsedIndexes,
     pub(crate) finishing: Option<RowSetFinishing>,

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -42,6 +42,21 @@ impl<'a, T> Explainable<'a, T> {
     }
 }
 
+/// Newtype struct for wrapping types that should implement one
+/// of the `Display$Format` traits.
+///
+/// While explainable wraps a mutable reference passed to the
+/// `explain*` methods in [`mz_repr::explain_new::Explain`],
+/// [`Displayable`] wraps a shared reference passed to the
+/// `fmt_$format` methods in `Display$Format`.
+pub(crate) struct Displayable<'a, T>(&'a T);
+
+impl<'a, T> From<&'a T> for Displayable<'a, T> {
+    fn from(t: &'a T) -> Self {
+        Displayable(t)
+    }
+}
+
 /// Explain context shared by all [`mz_repr::explain_new::Explain`]
 /// implementations in this crate.
 #[derive(Debug)]
@@ -53,15 +68,15 @@ pub(crate) struct ExplainContext<'a> {
     pub(crate) fast_path_plan: Option<fast_path_peek::Plan>,
 }
 
-pub struct Attributes;
+#[derive(Clone)]
+pub(crate) struct Attributes;
 
-/// A somewhat hacky way to annotate the nodes of a plan with
-/// arbitrary attributes based on the pre-order of the items
-/// in the associated plan.
+/// A somewhat ad-hoc way to keep carry a plan with a set
+/// of attributes derived for each node in that plan.
 #[allow(dead_code)] // TODO (#13299)
-pub struct AnnotatedPlan<'a, T> {
-    pub(crate) plan: &'a mut T,
-    pub(crate) annotations: HashMap<usize, Attributes>,
+pub(crate) struct AnnotatedPlan<'a, T> {
+    pub(crate) plan: &'a T,
+    pub(crate) annotations: HashMap<&'a T, Attributes>,
 }
 
 /// A set of indexes that are used in the physical plan

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::fmt;
 
 use mz_expr::RowSetFinishing;
+use mz_ore::str::Indent;
 use mz_repr::explain_new::{DisplayText, ExplainConfig, ExprHumanizer};
 use mz_repr::GlobalId;
 use mz_storage::types::transforms::LinearOperator;
@@ -156,5 +157,37 @@ where
         // writeln!(f, "")?;
         // self.context.used_indexes.fmt_text(..., f)?;
         Ok(())
+    }
+}
+
+#[allow(dead_code)] // TODO (#13299)
+#[allow(missing_debug_implementations)]
+pub(crate) struct PlanRenderingContext<'a, T> {
+    pub(crate) indent: Indent,
+    pub(crate) humanizer: &'a dyn ExprHumanizer,
+    pub(crate) annotations: HashMap<&'a T, Attributes>, // TODO: can this be a ref
+    pub(crate) config: &'a ExplainConfig,
+}
+
+impl<'a, T> PlanRenderingContext<'a, T> {
+    #[allow(dead_code)] // TODO (#13299)
+    pub fn new(
+        indent: Indent,
+        humanizer: &'a dyn ExprHumanizer,
+        annotations: HashMap<&'a T, Attributes>,
+        config: &'a ExplainConfig,
+    ) -> PlanRenderingContext<'a, T> {
+        PlanRenderingContext {
+            indent,
+            humanizer,
+            annotations,
+            config,
+        }
+    }
+}
+
+impl<'a, T> AsMut<Indent> for PlanRenderingContext<'a, T> {
+    fn as_mut(&mut self) -> &mut Indent {
+        &mut self.indent
     }
 }

--- a/src/ore/src/str.rs
+++ b/src/ore/src/str.rs
@@ -179,6 +179,41 @@ impl Indent {
     }
 }
 
+/// Convenience methods for pretty-printing based on indentation
+/// that are automatically available for context objects that can
+/// be mutably referenced as an [`Indent`] instance.
+pub trait IndentLike {
+    /// Print a block of code defined in `f` one step deeper
+    /// from the current [`Indent`].
+    fn indented<F>(&mut self, f: F) -> fmt::Result
+    where
+        F: FnMut(&mut Self) -> fmt::Result;
+}
+
+impl IndentLike for Indent {
+    fn indented<F>(&mut self, mut f: F) -> fmt::Result
+    where
+        F: FnMut(&mut Self) -> fmt::Result,
+    {
+        *self += 1;
+        let result = f(self);
+        *self -= 1;
+        result
+    }
+}
+
+impl<T: AsMut<Indent>> IndentLike for T {
+    fn indented<F>(&mut self, mut f: F) -> fmt::Result
+    where
+        F: FnMut(&mut Self) -> fmt::Result,
+    {
+        *self.as_mut() += 1;
+        let result = f(self);
+        *self.as_mut() -= 1;
+        result
+    }
+}
+
 impl Default for Indent {
     fn default() -> Self {
         Indent::new(' ', 2)

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -160,11 +160,11 @@ impl<T: DisplayJson<C>, C, F: Fn() -> C> DisplayJson<()> for DisplayWithContext<
 
 impl<A, C> DisplayJson<C> for Option<A>
 where
-    A: DisplayText<C>,
+    A: DisplayJson<C>,
 {
     fn fmt_json(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
         if let Some(val) = self {
-            val.fmt_text(f, ctx)
+            val.fmt_json(f, ctx)
         } else {
             fmt::Result::Ok(())
         }

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -449,6 +449,12 @@ impl<'a> RenderingContext<'a> {
     }
 }
 
+impl<'a> AsMut<Indent> for RenderingContext<'a> {
+    fn as_mut(&mut self) -> &mut Indent {
+        &mut self.indent
+    }
+}
+
 /// A trait for humanizing components of an expression.
 ///
 /// This will be most often used as part of the rendering context

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -121,6 +121,15 @@ impl<T: DisplayText<C>, C, F: Fn() -> C> DisplayText<()> for DisplayWithContext<
     }
 }
 
+impl<A, C> DisplayText<C> for Box<A>
+where
+    A: DisplayText<C>,
+{
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
+        self.as_ref().fmt_text(f, ctx)
+    }
+}
+
 impl<A, C> DisplayText<C> for Option<A>
 where
     A: DisplayText<C>,
@@ -158,6 +167,15 @@ impl<T: DisplayJson<C>, C, F: Fn() -> C> DisplayJson<()> for DisplayWithContext<
     }
 }
 
+impl<A, C> DisplayJson<C> for Box<A>
+where
+    A: DisplayJson<C>,
+{
+    fn fmt_json(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
+        self.as_ref().fmt_json(f, ctx)
+    }
+}
+
 impl<A, C> DisplayJson<C> for Option<A>
 where
     A: DisplayJson<C>,
@@ -192,6 +210,15 @@ impl<T: DisplayDot<C>, C, F: Fn() -> C> DisplayDot<()> for DisplayWithContext<'_
     fn fmt_dot(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         let mut ctx = (self.f)();
         self.t.fmt_dot(f, &mut ctx)
+    }
+}
+
+impl<A, C> DisplayDot<C> for Box<A>
+where
+    A: DisplayDot<C>,
+{
+    fn fmt_dot(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
+        self.as_ref().fmt_dot(f, ctx)
     }
 }
 

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -14,7 +14,7 @@ CREATE TABLE t (
 )
 
 statement ok
-CREATE MATERIALIZED VIEW v AS
+CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
 
 statement ok
@@ -25,51 +25,316 @@ mode cockroach
 
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a + 1, b, 4 FROM mv WHERE a > 0 LIMIT 1
+----
+Finish limit=1 output=[#0..=#2]
+  Project #2, #1, #3
+    Map (#0 + 1), 4
+      Filter (#0 > 0)
+        Get materialize.public.mv
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT * FROM generate_series(1, 7)
+----
+CallTable generate_series(1, 7, 1)
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a FROM t EXCEPT SELECT b FROM mv
+----
+Threshold
+  Union
+    Distinct
+      Project #1
+        Map #0
+          Project #0
+            Get materialize.public.t
+    Negate
+      Distinct
+        Project #1
+          Map #0
+            Project #1
+              Get materialize.public.mv
+
+EOF
+
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
+----
+%0 = Let x (l0) =
+| Get materialize.public.t (u1)
+| Map (#0 * #1)
+| Project (#2)
+
+%1 =
+| Get x (l0) (%0)
+| Map (#0 + 5)
+| Project (#1)
+
+EOF
+
+# Directly nested 'Let' variants are rendered in a flattened way
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+WITH A AS (SELECT 1 AS a), B as (SELECT a as b FROM A WHERE a > 0) SELECT * FROM A, B;
+----
+Let
+  InnerJoin true
+    Get l0
+    Get l1
+  Where
+    l1 =
+      Filter (#0 > 0)
+        Get l0
+    l0 =
+      Map 1
+        Constant
+          - ()
+
+EOF
+
+statement ok
+CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+VIEW ov
+----
+Project #0, #1
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+----
+Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
+  Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t GROUP BY b
+----
+Project #3
+  Map abs((#1 - #2))
+    Reduce group_by=[#2]  aggregates=[min(#0), max(#0)]
+      Map #1
+        Get materialize.public.t
+
+EOF
+
+# This should be something like
+#
+# Filter exists(%1)
+# | Get materialize.public.t
+# |
+# | Subquery %1
+# |   Filter (#^0 = #0)
+# |     Get materialize.public.t
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT * FROM t WHERE EXISTS(SELECT * FROM t as t1 WHERE t.a = t1.a)
+----
+Filter ???
+  Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1, t as t2
+----
+Project #0, #2
+  InnerJoin true
+    Get materialize.public.t
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1, t as t2 WHERE t1.b = t2.b
+----
+Project #0, #2
+  Filter (#1 = #3)
+    InnerJoin true
+      Get materialize.public.t
+      Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1 JOIN t as t2 ON t1.b = t2.b
+----
+Project #0, #2
+  InnerJoin (#1 = #3)
+    Get materialize.public.t
+    Get materialize.public.t
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1 JOIN t as t2 ON t1.b = t2.b
+----
+Project #0, #2
+  InnerJoin (#1 = #3)
+    Get materialize.public.t
+    Get materialize.public.t
+
+EOF
+
+
+# A case where we cannot pull the let statement up through teh join,
+# because the local l0 is correlated against the lhs of the enclosing join
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
 SELECT
   *
 FROM
-  T as X
-WHERE
-  NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
-LIMIT 10
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r2 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r2 WHERE r2.m != r1.a
+  ) as r3
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
+  ) as r5;
 ----
-%0 =
-| Get materialize.public.t (u1)
-| Filter NOT(exists(%1))
-| |
-| | %1 =
-| | | Get materialize.public.t (u1)
-| | | Filter (#^0 = #1)
-| |
-
-Finish order_by=() limit=10 offset=0 project=(#0, #1)
+InnerJoin true
+  InnerJoin true
+    Get materialize.public.t
+    Let
+      Filter (#0 != #^0)
+        Get l0
+      Where
+        l0 =
+          Reduce aggregates=[max((#^0 * #0))]
+            Get materialize.public.t
+  Let
+    Filter ((#0 != #^0) || ((#0) IS NOT NULL && (#^0) IS NULL))
+      Get l0
+    Where
+      l0 =
+        Reduce aggregates=[max((#^0 * #0))]
+          Get materialize.public.t
 
 EOF
 
+
+# A case where we cannot pull the let statement up through teh join,
+# because the local l0 is correlated against the lhs of the enclosing join
 query T multiline
-EXPLAIN RAW PLAN WITH (TYPES) AS TEXT FOR
-VIEW v
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT
+  *
+FROM
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT *
+    FROM
+      r4
+      CROSS JOIN LATERAL (
+        WITH r2 as (
+          SELECT MAX(r1.a * t.a) AS m FROM t
+        )
+        SELECT * FROM r2 WHERE r1.a = r4.m AND r2.m > 5
+      ) as r3
+    WHERE a != r1.a
+  ) as r5;
 ----
-%0 =
-| Get materialize.public.t (u1)
-| | types = (integer?, integer?)
-| | keys = ()
-| Filter NOT(isnull(#0))
-| | types = (integer?, integer?)
-| | keys = ()
+InnerJoin true
+  Get materialize.public.t
+  Let
+    Filter (#^0 != #^0)
+      InnerJoin true
+        Get l0
+        Let
+          Filter ((#^^0 = #^0) && (#0 > 5))
+            Get l1
+          Where
+            l1 =
+              Reduce aggregates=[max((#^^0 * #0))]
+                Get materialize.public.t
+    Where
+      l0 =
+        Reduce aggregates=[max((#^0 * #0))]
+          Get materialize.public.t
 
 EOF
 
-query T multiline
-EXPLAIN RAW PLAN WITH (TYPES) AS TEXT FOR
-RECORDED VIEW rv
-----
-%0 =
-| Get materialize.public.t (u1)
-| | types = (integer?, integer?)
-| | keys = ()
-| Filter NOT(isnull(#0))
-| | types = (integer?, integer?)
-| | keys = ()
 
-EOF
+# query T multiline
+# EXPLAIN RAW PLAN AS TEXT FOR
+# SELECT
+#   *
+# FROM
+#   T as X
+# WHERE
+#   NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
+# LIMIT 10
+# ----
+# %0 =
+# | Get materialize.public.t (u1)
+# | Filter NOT(exists(%1))
+# | |
+# | | %1 =
+# | | | Get materialize.public.t (u1)
+# | | | Filter (#^0 = #1)
+# | |
+
+# Finish order_by=() limit=10 offset=0 project=(#0, #1)
+
+# EOF
+
+# query T multiline
+# EXPLAIN RAW PLAN WITH (TYPES) AS TEXT FOR
+# VIEW v
+# ----
+# %0 =
+# | Get materialize.public.t (u1)
+# | | types = (integer?, integer?)
+# | | keys = ()
+# | Filter NOT(isnull(#0))
+# | | types = (integer?, integer?)
+# | | keys = ()
+
+# EOF
+
+# query T multiline
+# EXPLAIN RAW PLAN WITH (TYPES) AS TEXT FOR
+# RECORDED VIEW rv
+# ----
+# %0 =
+# | Get materialize.public.t (u1)
+# | | types = (integer?, integer?)
+# | | keys = ()
+# | Filter NOT(isnull(#0))
+# | | types = (integer?, integer?)
+# | | keys = ()
+
+# EOF


### PR DESCRIPTION
This is the bulk of resolving #13472 for HIR.

### Motivation

  * This PR adds a known-desirable feature. #13472

### Tips for reviewer

- The bulk of the work is in the last commit, which reworks `explain/hir/mod.rs` and `explain/hir/text.rs` in adapter.
- Examples of the proposed format can be found in the new `raw_plan_as_text.slt` tests.
- There are some leftovers for follow-up PRs, for which I will open separate PRs:
    - Support for printing types (depends on generalizing the `Attributes` code from QGM).
    - Support for subqueries.
    - Let-normalization for better text output.

### Testing

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
