### PR TITLE
Choose least-popular AZ for a cluster by default

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -54,8 +54,8 @@ use mz_sql::names::{
 };
 use mz_sql::plan::{
     ComputeInstanceIntrospectionConfig, CreateConnectionPlan, CreateIndexPlan,
-    CreateMaterializedViewPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan,
-    CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
+    CreateMaterializedViewPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan,
+    CreateTablePlan, CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
 };
 use mz_sql::DEFAULT_SCHEMA;
 use mz_stash::{Append, Postgres, Sqlite};

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -53,10 +53,9 @@ use mz_sql::names::{
     SchemaSpecifier,
 };
 use mz_sql::plan::{
-    ComputeInstanceIntrospectionConfig, ComputeInstanceReplicaConfig, CreateConnectionPlan,
-    CreateIndexPlan, CreateMaterializedViewPlan, CreateSecretPlan, CreateSinkPlan,
-    CreateSourcePlan, CreateTablePlan, CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext,
-    StatementDesc,
+    ComputeInstanceIntrospectionConfig, CreateConnectionPlan, CreateIndexPlan,
+    CreateMaterializedViewPlan, CreateSecretPlan, CreateSinkPlan, CreateSourcePlan, CreateTablePlan,
+    CreateTypePlan, CreateViewPlan, Params, Plan, PlanContext, StatementDesc,
 };
 use mz_sql::DEFAULT_SCHEMA;
 use mz_stash::{Append, Postgres, Sqlite};
@@ -864,6 +863,10 @@ impl CatalogState {
     /// identically.
     pub fn dump(&self) -> String {
         serde_json::to_string(&self.database_by_id).expect("serialization cannot fail")
+    }
+
+    pub fn availability_zones(&self) -> &[String] {
+        &self.availability_zones
     }
 }
 
@@ -1716,8 +1719,10 @@ impl<S: Append> Catalog<S> {
                 }
             };
 
-            let config =
-                catalog.concretize_replica_config(serialized_config.into(), persisted_logs)?;
+            let config = ConcreteComputeInstanceReplicaConfig {
+                location: catalog.concretize_replica_location(serialized_config.location)?,
+                persisted_logs,
+            };
 
             // And write the allocated sources back to storage
             catalog
@@ -2016,6 +2021,7 @@ impl<S: Append> Catalog<S> {
             stash,
             &BootstrapArgs {
                 default_cluster_replica_size: "1".into(),
+                default_availability_zone: "".into(),
             },
         )
         .await?;
@@ -2508,20 +2514,19 @@ impl<S: Append> Catalog<S> {
         }
     }
 
-    pub fn concretize_replica_config(
+    pub fn concretize_replica_location(
         &self,
-        config: ComputeInstanceReplicaConfig,
-        persisted_logs: ConcreteComputeInstanceReplicaLogging,
-    ) -> Result<ConcreteComputeInstanceReplicaConfig, AdapterError> {
+        location: SerializedComputeInstanceReplicaLocation,
+    ) -> Result<ConcreteComputeInstanceReplicaLocation, AdapterError> {
         let replica_sizes = &self.state.replica_sizes;
-        let availability_zones = &self.state.availability_zones;
-        let location = match config {
-            ComputeInstanceReplicaConfig::Remote { addrs } => {
+        let location = match location {
+            SerializedComputeInstanceReplicaLocation::Remote { addrs } => {
                 ConcreteComputeInstanceReplicaLocation::Remote { addrs }
             }
-            ComputeInstanceReplicaConfig::Managed {
+            SerializedComputeInstanceReplicaLocation::Managed {
                 size,
                 availability_zone,
+                az_user_specified,
             } => {
                 let allocation = replica_sizes.0.get(&size).ok_or_else(|| {
                     let mut entries = replica_sizes.0.iter().collect::<Vec<_>>();
@@ -2539,26 +2544,15 @@ impl<S: Append> Catalog<S> {
                         expected,
                     }
                 })?;
-
-                if let Some(az) = &availability_zone {
-                    if !availability_zones.contains(az) {
-                        return Err(AdapterError::InvalidClusterReplicaAz {
-                            az: az.to_string(),
-                            expected: availability_zones.to_vec(),
-                        });
-                    }
-                }
                 ConcreteComputeInstanceReplicaLocation::Managed {
-                    size,
                     allocation: allocation.clone(),
                     availability_zone,
+                    size,
+                    az_user_specified,
                 }
             }
         };
-        Ok(ConcreteComputeInstanceReplicaConfig {
-            location,
-            persisted_logs,
-        })
+        Ok(location)
     }
 
     pub async fn transact<F, T>(
@@ -3717,7 +3711,16 @@ pub enum SerializedComputeInstanceReplicaLogging {
     Concrete(Vec<(LogVariant, GlobalId)>),
 }
 
-/// A [`ComputeInstanceReplicaConfig`] that is serialized as JSON and persisted
+impl From<ConcreteComputeInstanceReplicaLogging> for SerializedComputeInstanceReplicaLogging {
+    fn from(conc: ConcreteComputeInstanceReplicaLogging) -> Self {
+        match conc {
+            ConcreteComputeInstanceReplicaLogging::Default => Self::Default,
+            ConcreteComputeInstanceReplicaLogging::Concrete(vars) => Self::Concrete(vars),
+        }
+    }
+}
+
+/// A [`mz_sql::plan::ComputeInstanceReplicaConfig`] that is serialized as JSON and persisted
 /// to the catalog stash. This is a separate type to allow us to evolve the
 /// on-disk format independently from the SQL layer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -3726,53 +3729,16 @@ pub struct SerializedComputeInstanceReplicaConfig {
     pub location: SerializedComputeInstanceReplicaLocation,
 }
 
-impl SerializedComputeInstanceReplicaConfig {
-    pub fn from(
-        location: ConcreteComputeInstanceReplicaLocation,
-        persisted_logs: ConcreteComputeInstanceReplicaLogging,
+impl From<ConcreteComputeInstanceReplicaConfig> for SerializedComputeInstanceReplicaConfig {
+    fn from(
+        ConcreteComputeInstanceReplicaConfig {
+            location,
+            persisted_logs,
+        }: ConcreteComputeInstanceReplicaConfig,
     ) -> Self {
-        Self {
+        SerializedComputeInstanceReplicaConfig {
             persisted_logs: persisted_logs.into(),
             location: location.into(),
-        }
-    }
-}
-
-impl From<ConcreteComputeInstanceReplicaLogging> for SerializedComputeInstanceReplicaLogging {
-    fn from(conc: ConcreteComputeInstanceReplicaLogging) -> Self {
-        match conc {
-            ConcreteComputeInstanceReplicaLogging::Default => {
-                SerializedComputeInstanceReplicaLogging::Default
-            }
-            ConcreteComputeInstanceReplicaLogging::Concrete(x) => {
-                SerializedComputeInstanceReplicaLogging::Concrete(x)
-            }
-        }
-    }
-}
-
-impl From<SerializedComputeInstanceReplicaConfig> for ComputeInstanceReplicaConfig {
-    fn from(x: SerializedComputeInstanceReplicaConfig) -> Self {
-        match x.location {
-            SerializedComputeInstanceReplicaLocation::Remote { addrs } => {
-                ComputeInstanceReplicaConfig::Remote { addrs }
-            }
-            SerializedComputeInstanceReplicaLocation::Managed {
-                size,
-                availability_zone,
-            } => ComputeInstanceReplicaConfig::Managed {
-                size,
-                availability_zone,
-            },
-        }
-    }
-}
-
-impl From<ConcreteComputeInstanceReplicaConfig> for SerializedComputeInstanceReplicaConfig {
-    fn from(conf: ConcreteComputeInstanceReplicaConfig) -> Self {
-        Self {
-            persisted_logs: conf.persisted_logs.into(),
-            location: conf.location.into(),
         }
     }
 }
@@ -3784,25 +3750,26 @@ pub enum SerializedComputeInstanceReplicaLocation {
     },
     Managed {
         size: String,
-        availability_zone: Option<String>,
+        availability_zone: String,
+        /// `true` if the AZ was specified by the user and must be respected;
+        /// `false` if it was picked arbitrarily by Materialize.
+        az_user_specified: bool,
     },
 }
 
 impl From<ConcreteComputeInstanceReplicaLocation> for SerializedComputeInstanceReplicaLocation {
-    fn from(
-        config: ConcreteComputeInstanceReplicaLocation,
-    ) -> SerializedComputeInstanceReplicaLocation {
-        match config {
-            ConcreteComputeInstanceReplicaLocation::Remote { addrs } => {
-                SerializedComputeInstanceReplicaLocation::Remote { addrs }
-            }
+    fn from(loc: ConcreteComputeInstanceReplicaLocation) -> Self {
+        match loc {
+            ConcreteComputeInstanceReplicaLocation::Remote { addrs } => Self::Remote { addrs },
             ConcreteComputeInstanceReplicaLocation::Managed {
-                availability_zone,
-                size,
-                ..
-            } => SerializedComputeInstanceReplicaLocation::Managed {
+                allocation: _,
                 size,
                 availability_zone,
+                az_user_specified,
+            } => Self::Managed {
+                size,
+                availability_zone,
+                az_user_specified,
             },
         }
     }

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -132,8 +132,9 @@ impl CatalogState {
             ConcreteComputeInstanceReplicaLocation::Managed {
                 size,
                 availability_zone,
-                ..
-            } => (Some(&**size), availability_zone.as_deref()),
+                az_user_specified: _,
+                allocation: _,
+            } => (Some(&**size), Some(availability_zone.as_str())),
             ConcreteComputeInstanceReplicaLocation::Remote { .. } => (None, None),
         };
 

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -55,6 +55,7 @@ openssl-sys = { version = "0.9.75", features = ["vendored"] }
 os_info = "3.4.0"
 prometheus = { version = "0.13.1", default-features = false, features = ["process"] }
 rdkafka-sys = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rand = "0.8.5"
 reqwest = { version = "0.11.11", features = ["json"] }
 rlimit = "0.8.3"
 serde = { version = "1.0.139", features = ["derive"] }
@@ -98,7 +99,6 @@ postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres_array = { git = "https://github.com/MaterializeInc/rust-postgres-array" }
 predicates = "2.1.1"
-rand = "0.8.5"
 regex = "1.6.0"
 reqwest = { version = "0.11.11", features = ["blocking"] }
 serde_json = "1.0.82"

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -644,6 +644,10 @@ max log level: {max_log_level}",
         bail!("--availability-zone values must be unique");
     }
 
+    // Make later logic for choosing AZs unbiased
+    use rand::seq::SliceRandom;
+    args.availability_zone.shuffle(&mut rand::thread_rng());
+
     let server = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         sql_listen_addr: args.sql_listen_addr,
         http_listen_addr: args.http_listen_addr,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -187,6 +187,18 @@ pub enum ComputeInstanceReplicaConfig {
     },
 }
 
+impl ComputeInstanceReplicaConfig {
+    pub fn get_az(&self) -> Option<&str> {
+        match self {
+            ComputeInstanceReplicaConfig::Remote { addrs: _ } => None,
+            ComputeInstanceReplicaConfig::Managed {
+                size: _,
+                availability_zone,
+            } => availability_zone.as_deref(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct CreateSourcePlan {
     pub name: QualifiedObjectName,


### PR DESCRIPTION
This PR has two main effects:

1. Forces all replicas to specify an AZ, which will prevent cross-AZ replicas from existing (since any process within a replica failing is a replica-global failure, spreading them across several AZs _decreases_ reliability).
2. For a replica whose AZ is not specified at creation time, chooses the least-popular replica among the available choices. If several are tied, choose one arbitrarily.