### PR TITLE
optimization: move to MIR the decision to use an index to speed up <expr>=literal

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -331,13 +331,19 @@ impl CatalogState {
         let index_matches =
             move |idx: &Index| idx.on == id && idx.compute_instance == compute_instance;
 
-        self.get_entry(&id)
-            .used_by()
-            .iter()
-            .filter_map(move |uses_id| match self.get_entry(uses_id).item() {
-                CatalogItem::Index(index) if index_matches(index) => Some((*uses_id, index)),
-                _ => None,
+        self.try_get_entry(&id)
+            .into_iter()
+            .map(move |e| {
+                e.used_by()
+                    .iter()
+                    .filter_map(move |uses_id| match self.get_entry(uses_id).item() {
+                        CatalogItem::Index(index) if index_matches(index) => {
+                            Some((*uses_id, index))
+                        }
+                        _ => None,
+                    })
             })
+            .flatten()
     }
 
     fn insert_item(

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use mz_expr::RowSetFinishing;
+use mz_expr::{OptimizedMirRelationExpr, RowSetFinishing};
 use mz_ore::str::{Indent, IndentLike};
 use mz_repr::explain_new::{DisplayText, ExplainConfig, ExprHumanizer};
 use mz_repr::GlobalId;
@@ -67,7 +67,7 @@ pub(crate) struct ExplainContext<'a> {
     pub(crate) humanizer: &'a dyn ExprHumanizer,
     pub(crate) used_indexes: UsedIndexes,
     pub(crate) finishing: Option<RowSetFinishing>,
-    pub(crate) fast_path_plan: Option<peek::Plan>,
+    pub(crate) fast_path_plan: Option<peek::Plan<OptimizedMirRelationExpr>>,
 }
 
 #[derive(Clone)]

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -411,6 +411,18 @@ impl<'a> ViewExplanation<'a> {
                 }
                 Ok(())
             }
+            JoinImplementation::PredicateIndex(_, key, val) => {
+                writeln!(
+                    f,
+                    "IndexedFilter {}",
+                    separated(
+                        " AND ",
+                        key.iter()
+                            .zip(val.unpack().into_iter())
+                            .map(|(k, v)| format!("{} = {}", k, v))
+                    )
+                )
+            }
             JoinImplementation::Unimplemented => writeln!(f, "Unimplemented"),
         }
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1935,6 +1935,10 @@ pub enum JoinImplementation {
     /// Each plan starts from the corresponding index, and then in sequence joins
     /// against collections identified by index and with the specified arrangement key.
     DeltaQuery(Vec<Vec<(usize, Vec<MirScalarExpr>)>>),
+    /// Join a constant to a user-created index to speed up evaluation of a predicate
+    ///
+    /// Consists of (<view id>, <keys of index>, <constant>)
+    PredicateIndex(GlobalId, Vec<MirScalarExpr>, #[mzreflect(ignore)] Row),
     /// No implementation yet selected.
     Unimplemented,
 }

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -7,10 +7,12 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Canonicalizes MFPs and performs common sub-expression elimination.
+//! Canonicalizes MFPs, performs CSEs, and speeds up certain filters.
 //!
 //! This transform takes a sequence of Maps, Filters, and Projects and
 //! canonicalizes it to a sequence like this:
+//! | Index
+//! | Predicates sped up by the index
 //! | Map
 //! | Filter
 //! | Project
@@ -25,10 +27,14 @@
 //! It may be worth considering relations of this if it results in more
 //! busywork and less efficiency, but the wins can be substantial when
 //! expressions re-use complex subexpressions.
+//!
+//! Right now, predicates sped up by an index are still present in the "Filter"
+//! that comes after the Map. Issue #13774 has been filed to track removing
+//! said predicates from "Filter".
 
-use crate::{TransformArgs, TransformError};
+use crate::{IndexOracle, TransformArgs};
 use mz_expr::visit::VisitChildren;
-use mz_expr::MirRelationExpr;
+use mz_expr::{Id, MirRelationExpr};
 
 /// Canonicalizes MFPs and performs common sub-expression elimination.
 #[derive(Debug)]
@@ -38,17 +44,49 @@ impl crate::Transform for CanonicalizeMfp {
     fn transform(
         &self,
         relation: &mut MirRelationExpr,
-        _: TransformArgs,
-    ) -> Result<(), TransformError> {
-        self.action(relation)
+        args: TransformArgs,
+    ) -> Result<(), crate::TransformError> {
+        self.action(relation, args.indexes)
     }
 }
 
 impl CanonicalizeMfp {
-    fn action(&self, relation: &mut MirRelationExpr) -> Result<(), TransformError> {
+    fn action(
+        &self,
+        relation: &mut MirRelationExpr,
+        indexes: &dyn IndexOracle,
+    ) -> Result<(), crate::TransformError> {
         let mut mfp = mz_expr::MapFilterProject::extract_non_errors_from_expr_mut(relation);
-        relation.try_visit_mut_children(|e| self.action(e))?;
+        relation.try_visit_mut_children(|e| self.action(e, indexes))?;
+        // perform CSE
         mfp.optimize();
+        // See if there are predicates of the form <expr>=literal that can be
+        // sped up using an index.
+        if let MirRelationExpr::Get {
+            id: Id::Global(id), ..
+        } = relation
+        {
+            let key_val = indexes
+                .indexes_on(*id)
+                .filter_map(|key| {
+                    mfp.literal_constraints(key)
+                        .map(|val| (key.to_owned(), val))
+                })
+                // Maximize number of predicates that are sped using a single index.
+                .max_by_key(|(key, _val)| key.len());
+            if let Some((key, val)) = key_val {
+                *relation = MirRelationExpr::Join {
+                    implementation: mz_expr::JoinImplementation::PredicateIndex(
+                        *id,
+                        key.clone(),
+                        val,
+                    ),
+                    inputs: vec![relation.take_dangerous().arrange_by(&[key])],
+                    equivalences: Vec::new(),
+                };
+            }
+        }
+        // Canonicalize the MapFilterProject to Map-Filter-Project, in that order.
         if !mfp.is_identity() {
             let (map, filter, project) = mfp.as_map_filter_project();
             let total_arity = mfp.input_arity + map.len();

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -65,34 +65,44 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 AS a1 , t1 AS a2 WHERE a1.f1 = 1 AND a2.f1 = 1;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | ArrangeBy ()
 
-%2 =
-| Join %1 %0
-| | implementation = Differential %0 %1.()
+%3 =
+| Join %2 %1
+| | implementation = Differential %1 %2.()
 
 EOF
 
 query T multiline
 EXPLAIN SELECT * FROM t1 AS a1 , t1 AS a2, t1 AS a3 WHERE a1.f1 = 1 AND a2.f1 = 1 AND a3.f1 = 1;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 = Let l1 =
-| Get %0 (l0)
+%2 = Let l1 =
+| Get %1 (l0)
 | ArrangeBy ()
 
-%2 =
-| Join %1 %1 %0
-| | implementation = Differential %0 %1.() %1.()
+%3 =
+| Join %2 %2 %1
+| | implementation = Differential %1 %2.() %2.()
 
 EOF
 
@@ -103,21 +113,26 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1) WHERE a1.f1 = 1 AND a2.f1 = 1;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | ArrangeBy ()
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l0)
 | Project (#1)
 
-%3 =
-| Join %1 %2
-| | implementation = Differential %2 %1.()
+%4 =
+| Join %2 %3
+| | implementation = Differential %3 %2.()
 
 EOF
 
@@ -164,16 +179,21 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1) AND f2 = (SELECT f1 FROM t1 WHERE f1 = 1);
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | Project (#0)
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -181,21 +201,21 @@ EXPLAIN SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1) AND f2 = (S
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%3 = Let l1 =
-| Union %1 %2
+%4 = Let l1 =
+| Union %2 %3
 
-%4 =
+%5 =
 | Get materialize.public.t1 (u1)
 | Filter (#0) IS NOT NULL, (#1) IS NOT NULL
 | ArrangeBy (#1)
 
-%5 =
-| Get %3 (l1)
+%6 =
+| Get %4 (l1)
 | ArrangeBy (#0)
 
-%6 =
-| Join %4 %5 %3 (= #0 #2) (= #1 #3)
-| | implementation = Differential %3 %4.(#1) %5.(#0)
+%7 =
+| Join %5 %6 %4 (= #0 #2) (= #1 #3)
+| | implementation = Differential %4 %5.(#1) %6.(#0)
 | Project (#0, #1)
 
 EOF
@@ -292,17 +312,22 @@ FROM (SELECT * FROM t1 WHERE f1 = 1) AS a1
 JOIN (SELECT * FROM t1 WHERE f1 = 1) AS a2
 ON TRUE
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | ArrangeBy ()
 
-%2 =
-| Join %1 %0
-| | implementation = Differential %0 %1.()
+%3 =
+| Join %2 %1
+| | implementation = Differential %1 %2.()
 
 EOF
 
@@ -313,17 +338,22 @@ FROM (SELECT * FROM t1 WHERE f1 = 1) AS a1
 WHERE a1.f2 = 2
 AND a2.f2 = 2
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1), (#1 = 2)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | ArrangeBy ()
 
-%2 =
-| Join %1 %0
-| | implementation = Differential %0 %1.()
+%3 =
+| Join %2 %1
+| | implementation = Differential %1 %2.()
 
 EOF
 
@@ -337,16 +367,24 @@ AND a2.f2 = 3
 ----
 %0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+
+%2 =
+| Get %1 (l0)
 | Filter (#0 = 1), (#1 = 2)
 | ArrangeBy ()
 
-%1 =
-| Get materialize.public.t1 (u1)
+%3 =
+| Get %1 (l0)
 | Filter (#0 = 1), (#1 = 3)
 
-%2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
+%4 =
+| Join %2 %3
+| | implementation = Differential %3 %2.()
 
 EOF
 
@@ -357,25 +395,35 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Union %0 %0 %0
+%2 =
+| Union %1 %1 %1
 
 EOF
 
 query T multiline
 EXPLAIN SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1 UNION SELECT * FROM t1 WHERE f1 = 1;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | Project (#1)
 
-%1 =
-| Union %0 %0 %0
+%2 =
+| Union %1 %1 %1
 | Distinct group=(#0)
 | Map 1
 | Project (#1, #0)
@@ -389,16 +437,21 @@ EOF
 query T multiline
 EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1;
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | Project (#0)
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -406,16 +459,67 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%3 = Let l1 =
-| Union %1 %2
+%4 = Let l1 =
+| Union %2 %3
 
-%4 =
+%5 =
 | Get materialize.public.t1 (u1)
 | Project ()
 | ArrangeBy ()
 
+%6 =
+| Get %4 (l1)
+| Project ()
+| Distinct group=()
+| Negate
+
+%7 =
+| Constant ()
+
+%8 =
+| Union %6 %7
+| Map null
+
+%9 =
+| Union %4 %8
+
+%10 =
+| Join %5 %9
+| | implementation = Differential %9 %5.()
+| Project (#0, #0)
+
+EOF
+
+query T multiline
+EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHERE f1 = 1)) FROM t1;
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
+
+%2 =
+| Get %1 (l0)
+| Project (#0)
+
+%3 =
+| Get %1 (l0)
+| Project ()
+| Reduce group=()
+| | agg count(true)
+| Filter (#0 > 1)
+| Project ()
+| Map (err: more than one record produced in subquery)
+
+%4 = Let l1 =
+| Union %2 %3
+
 %5 =
-| Get %3 (l1)
+| Get %4 (l1)
 | Project ()
 | Distinct group=()
 | Negate
@@ -427,85 +531,39 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 
 | Union %5 %6
 | Map null
 
-%8 =
-| Union %3 %7
+%8 = Let l2 =
+| Union %4 %7
 
 %9 =
-| Join %4 %8
-| | implementation = Differential %8 %4.()
-| Project (#0, #0)
-
-EOF
-
-query T multiline
-EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHERE f1 = 1)) FROM t1;
-----
-%0 = Let l0 =
-| Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
-
-%1 =
-| Get %0 (l0)
-| Project (#0)
-
-%2 =
-| Get %0 (l0)
-| Project ()
-| Reduce group=()
-| | agg count(true)
-| Filter (#0 > 1)
-| Project ()
-| Map (err: more than one record produced in subquery)
-
-%3 = Let l1 =
-| Union %1 %2
-
-%4 =
-| Get %3 (l1)
-| Project ()
-| Distinct group=()
-| Negate
-
-%5 =
-| Constant ()
-
-%6 =
-| Union %4 %5
-| Map null
-
-%7 = Let l2 =
-| Union %3 %6
-
-%8 =
 | Get materialize.public.t1 (u1)
 | Project ()
 | ArrangeBy ()
 
-%9 =
-| Get %7 (l2)
+%10 =
+| Get %8 (l2)
 | ArrangeBy ()
 
-%10 = Let l3 =
-| Join %8 %9 %7
-| | implementation = Differential %7 %8.() %9.()
+%11 = Let l3 =
+| Join %9 %10 %8
+| | implementation = Differential %8 %9.() %10.()
 | Reduce group=()
 | | agg min(#0)
 | | agg max(#1)
 
-%11 =
-| Get %10 (l3)
+%12 =
+| Get %11 (l3)
 | Project ()
 | Negate
 
-%12 =
+%13 =
 | Constant ()
 
-%13 =
-| Union %11 %12
+%14 =
+| Union %12 %13
 | Map null, null
 
-%14 =
-| Union %10 %13
+%15 =
+| Union %11 %14
 
 EOF
 
@@ -516,20 +574,87 @@ EOF
 query T multiline
 EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1 WHERE EXISTS (SELECT f1 FROM t1 WHERE f1 = 1);
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 = Let l1 =
-| Get %0 (l0)
+%2 = Let l1 =
+| Get %1 (l0)
 | Project ()
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l0)
+| Project (#0)
+
+%4 =
+| Get %2 (l1)
+| Reduce group=()
+| | agg count(true)
+| Filter (#0 > 1)
+| Project ()
+| Map (err: more than one record produced in subquery)
+
+%5 = Let l2 =
+| Union %3 %4
+
+%6 =
+| Get materialize.public.t1 (u1)
+| Project ()
+| ArrangeBy ()
+
+%7 =
+| Get %2 (l1)
+| Distinct group=()
+| ArrangeBy ()
+
+%8 =
+| Get %5 (l2)
+| Project ()
+| Distinct group=()
+| Negate
+
+%9 =
+| Constant ()
+
+%10 =
+| Union %8 %9
+| Map null
+
+%11 =
+| Union %5 %10
+
+%12 =
+| Join %6 %7 %11
+| | implementation = Differential %11 %7.() %6.()
+
+EOF
+
+query T multiline
+EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1
+UNION ALL
+SELECT f1 FROM t1 WHERE f1 = 1
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
+
+%2 = Let l1 =
+| Get %1 (l0)
 | Project (#0)
 
 %3 =
-| Get %1 (l1)
+| Get %1 (l0)
+| Project ()
 | Reduce group=()
 | | agg count(true)
 | Filter (#0 > 1)
@@ -545,84 +670,27 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1 WHERE EXISTS (SELECT f1 
 | ArrangeBy ()
 
 %6 =
-| Get %1 (l1)
-| Distinct group=()
-| ArrangeBy ()
-
-%7 =
 | Get %4 (l2)
 | Project ()
 | Distinct group=()
 | Negate
 
-%8 =
+%7 =
 | Constant ()
 
-%9 =
-| Union %7 %8
+%8 =
+| Union %6 %7
 | Map null
 
+%9 =
+| Union %4 %8
+
 %10 =
-| Union %4 %9
+| Join %5 %9
+| | implementation = Differential %9 %5.()
 
 %11 =
-| Join %5 %6 %10
-| | implementation = Differential %10 %6.() %5.()
-
-EOF
-
-query T multiline
-EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1
-UNION ALL
-SELECT f1 FROM t1 WHERE f1 = 1
-----
-%0 = Let l0 =
-| Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
-
-%1 = Let l1 =
-| Get %0 (l0)
-| Project (#0)
-
-%2 =
-| Get %0 (l0)
-| Project ()
-| Reduce group=()
-| | agg count(true)
-| Filter (#0 > 1)
-| Project ()
-| Map (err: more than one record produced in subquery)
-
-%3 = Let l2 =
-| Union %1 %2
-
-%4 =
-| Get materialize.public.t1 (u1)
-| Project ()
-| ArrangeBy ()
-
-%5 =
-| Get %3 (l2)
-| Project ()
-| Distinct group=()
-| Negate
-
-%6 =
-| Constant ()
-
-%7 =
-| Union %5 %6
-| Map null
-
-%8 =
-| Union %3 %7
-
-%9 =
-| Join %4 %8
-| | implementation = Differential %8 %4.()
-
-%10 =
-| Union %9 %1
+| Union %10 %2
 
 EOF
 
@@ -710,40 +778,46 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)) W
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
+| ArrangeBy (#0)
 
 %1 = Let l1 =
-| Get materialize.public.t1 (u1)
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
+
+%2 = Let l2 =
+| Join %0
+| | implementation = IndexedFilter #0 = 2
 | Filter (#0 = 2)
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l1)
 | Project ()
 | ArrangeBy ()
-
-%3 =
-| Get %0 (l0)
-| Project (#0)
 
 %4 =
-| Join %2 %3
-| | implementation = Differential %3 %2.()
-
-%5 =
-| Get %1 (l1)
-| Project ()
-| ArrangeBy ()
-
-%6 =
 | Get %1 (l1)
 | Project (#0)
 
+%5 =
+| Join %3 %4
+| | implementation = Differential %4 %3.()
+
+%6 =
+| Get %2 (l2)
+| Project ()
+| ArrangeBy ()
+
 %7 =
-| Join %5 %6
-| | implementation = Differential %6 %5.()
+| Get %2 (l2)
+| Project (#0)
 
 %8 =
-| Union %4 %7
+| Join %6 %7
+| | implementation = Differential %7 %6.()
+
+%9 =
+| Union %5 %8
 
 EOF
 
@@ -754,26 +828,31 @@ SELECT * FROM
 (SELECT a2.f1 AS f1 FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)) AS s2
 WHERE s1.f1 = 1 AND s2.f1 = 1
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 = Let l1 =
-| Get %0 (l0)
+%2 = Let l1 =
+| Get %1 (l0)
 | Project (#0)
 | ArrangeBy ()
 
-%2 = Let l2 =
-| Get %0 (l0)
+%3 = Let l2 =
+| Get %1 (l0)
 | Project ()
 
-%3 =
-| Get %2 (l2)
+%4 =
+| Get %3 (l2)
 | ArrangeBy ()
 
-%4 =
-| Join %1 %3 %1 %2
-| | implementation = Differential %2 %1.() %3.() %1.()
+%5 =
+| Join %2 %4 %2 %3
+| | implementation = Differential %3 %2.() %4.() %2.()
 
 EOF
 
@@ -786,34 +865,40 @@ WHERE s1.f1 = 1 AND s2.f1 = 2
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
+| ArrangeBy (#0)
 
 %1 = Let l1 =
-| Get materialize.public.t1 (u1)
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
+
+%2 = Let l2 =
+| Join %0
+| | implementation = IndexedFilter #0 = 2
 | Filter (#0 = 2)
 
-%2 =
-| Get %0 (l0)
-| Project (#0)
-| ArrangeBy ()
-
 %3 =
-| Get %0 (l0)
-| Project ()
+| Get %1 (l1)
+| Project (#0)
 | ArrangeBy ()
 
 %4 =
 | Get %1 (l1)
-| Project (#0)
+| Project ()
 | ArrangeBy ()
 
 %5 =
-| Get %1 (l1)
-| Project ()
+| Get %2 (l2)
+| Project (#0)
+| ArrangeBy ()
 
 %6 =
-| Join %2 %3 %4 %5
-| | implementation = Differential %5 %2.() %3.() %4.()
+| Get %2 (l2)
+| Project ()
+
+%7 =
+| Join %3 %4 %5 %6
+| | implementation = Differential %6 %3.() %4.() %5.()
 
 EOF
 
@@ -827,12 +912,17 @@ SELECT * FROM t1 WHERE f1 = 1 AND f2 = 2
 UNION ALL
 SELECT * FROM t1 WHERE f1 = 1 AND f2 = 2
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1), (#1 = 2)
 
-%1 =
-| Union %0 %0
+%2 =
+| Union %1 %1
 
 EOF
 
@@ -870,17 +960,22 @@ SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1)
 
 %1 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%2 =
+| Join %1
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%2 = Let l0 =
-| Join %0 %1
-| | implementation = Differential %0 %1.()
+%3 = Let l0 =
+| Join %0 %2
+| | implementation = Differential %0 %2.()
 
-%3 =
-| Union %2 %2
+%4 =
+| Union %3 %3
 
 EOF
 
@@ -892,18 +987,19 @@ SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1)
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
-
-%1 =
-| Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
+%1 = Let l1 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
+
 %2 =
-| Get %0 (l0)
+| Get %1 (l1)
 | Project (#0)
 
 %3 =
-| Get %0 (l0)
+| Get %1 (l1)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -914,9 +1010,9 @@ SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1)
 %4 =
 | Union %2 %3
 
-%5 = Let l1 =
-| Join %1 %4 (= #0 #2)
-| | implementation = Differential %4 %1.(#0)
+%5 = Let l2 =
+| Join %0 %4 (= #0 #2)
+| | implementation = Differential %4 %0.(#0)
 | Project (#0, #1)
 
 %6 =
@@ -1055,12 +1151,17 @@ EXPLAIN
 UNION ALL
 (SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1)
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Union %0 %0 %0 %0
+%2 =
+| Union %1 %1 %1 %1
 
 EOF
 
@@ -1075,17 +1176,22 @@ UNION ALL
 
 %1 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%2 =
+| Join %1
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%2 = Let l0 =
-| Join %0 %1
-| | implementation = Differential %0 %1.()
+%3 = Let l0 =
+| Join %0 %2
+| | implementation = Differential %0 %2.()
 
-%3 =
-| Union %2 %2
+%4 =
+| Union %3 %3
 
 EOF
 
@@ -1104,25 +1210,30 @@ UNION ALL
 
 %1 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%2 =
+| Join %1
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%2 = Let l0 =
-| Join %0 %1
-| | implementation = Differential %0 %1.()
-
-%3 =
-| Get %2 (l0)
-| Project (#0)
+%3 = Let l0 =
+| Join %0 %2
+| | implementation = Differential %0 %2.()
 
 %4 =
-| Get %2 (l0)
-| Project (#1)
+| Get %3 (l0)
+| Project (#0)
 
 %5 =
-| Union %3 %4
+| Get %3 (l0)
+| Project (#1)
+
+%6 =
+| Union %4 %5
 
 EOF
 
@@ -1136,29 +1247,34 @@ Source materialize.public.t2 (u3):
 | Project (#0, #1)
 
 Query:
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%1 =
+%2 =
 | Get materialize.public.t1 (u1)
 
-%2 =
-| Join %1 %0
-| | implementation = Differential %1 %0.()
-
 %3 =
-| Get materialize.public.t2 (u3)
+| Join %2 %1
+| | implementation = Differential %2 %1.()
 
 %4 =
-| Join %3 %0
-| | implementation = Differential %3 %0.()
+| Get materialize.public.t2 (u3)
 
 %5 =
-| Union %2 %4
+| Join %4 %1
+| | implementation = Differential %4 %1.()
+
+%6 =
+| Union %3 %5
 
 EOF
 
@@ -1171,29 +1287,34 @@ Source materialize.public.t2 (u3):
 | Project (#0, #1)
 
 Query:
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | Project (#0)
 
-%1 =
+%2 =
 | Get materialize.public.t2 (u3)
 | Project (#0)
 
-%2 =
-| Union %1 %0
+%3 =
+| Union %2 %1
 | ArrangeBy ()
 
-%3 =
+%4 =
 | Get materialize.public.t2 (u3)
 | Project (#1)
 
-%4 =
-| Union %3 %0
-
 %5 =
-| Join %2 %4
-| | implementation = Differential %4 %2.()
+| Union %4 %1
+
+%6 =
+| Join %3 %5
+| | implementation = Differential %5 %3.()
 
 EOF
 
@@ -1204,20 +1325,25 @@ SELECT f1 FROM t1 WHERE f1 = 1
 UNION ALL
 SELECT f2 FROM t1 WHERE f1 = 1
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 
-%1 =
-| Get %0 (l0)
+%2 =
+| Get %1 (l0)
 | Project (#0)
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l0)
 | Project (#1)
 
-%3 =
-| Union %1 %2
+%4 =
+| Union %2 %3
 
 EOF
 
@@ -1229,18 +1355,24 @@ EOF
 query T multiline
 EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 = 1 AND a2.f1 = 2
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 =
+| Join %0
+| | implementation = IndexedFilter #0 = 1
 | Filter (#0 = 1)
 | ArrangeBy ()
 
-%1 =
-| Get materialize.public.t1 (u1)
+%2 =
+| Join %0
+| | implementation = IndexedFilter #0 = 2
 | Filter (#0 = 2)
 
-%2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
+%3 =
+| Join %1 %2
+| | implementation = Differential %2 %1.()
 
 EOF
 
@@ -1252,40 +1384,46 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 JOIN t1 AS a2 USING (f1)) WHERE 
 ----
 %0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
+| ArrangeBy (#0)
 
 %1 = Let l1 =
-| Get materialize.public.t1 (u1)
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
+
+%2 = Let l2 =
+| Join %0
+| | implementation = IndexedFilter #0 = 2
 | Filter (#0 = 2)
 
-%2 =
-| Get %0 (l0)
+%3 =
+| Get %1 (l1)
 | Project ()
 | ArrangeBy ()
-
-%3 =
-| Get %0 (l0)
-| Project (#0)
 
 %4 =
-| Join %2 %3
-| | implementation = Differential %3 %2.()
-
-%5 =
-| Get %1 (l1)
-| Project ()
-| ArrangeBy ()
-
-%6 =
 | Get %1 (l1)
 | Project (#0)
 
+%5 =
+| Join %3 %4
+| | implementation = Differential %4 %3.()
+
+%6 =
+| Get %2 (l2)
+| Project ()
+| ArrangeBy ()
+
 %7 =
-| Join %5 %6
-| | implementation = Differential %6 %5.()
+| Get %2 (l2)
+| Project (#0)
 
 %8 =
-| Union %4 %7
+| Join %6 %7
+| | implementation = Differential %7 %6.()
+
+%9 =
+| Union %5 %8
 
 EOF
 
@@ -1295,16 +1433,22 @@ SELECT * FROM t1 WHERE f1 = 1
 UNION ALL
 SELECT * FROM t1 WHERE f1 = 2
 ----
-%0 =
+%0 = Let l0 =
 | Get materialize.public.t1 (u1)
-| Filter (#0 = 1)
+| ArrangeBy (#0)
 
 %1 =
-| Get materialize.public.t1 (u1)
-| Filter (#0 = 2)
+| Join %0
+| | implementation = IndexedFilter #0 = 1
+| Filter (#0 = 1)
 
 %2 =
-| Union %0 %1
+| Join %0
+| | implementation = IndexedFilter #0 = 2
+| Filter (#0 = 2)
+
+%3 =
+| Union %1 %2
 
 EOF
 

--- a/test/sqllogictest/transform/dataflow.slt
+++ b/test/sqllogictest/transform/dataflow.slt
@@ -59,6 +59,11 @@ EXPLAIN PLAN FOR VIEW foo3
 ----
 %0 =
 | Get materialize.public.foo2 (u2)
+| ArrangeBy (#0)
+
+%1 =
+| Join %0
+| | implementation = IndexedFilter #0 = 6
 | Filter (#0 = 6)
 
 EOF
@@ -68,6 +73,11 @@ EXPLAIN PLAN FOR SELECT * from foo3
 ----
 %0 =
 | Get materialize.public.foo2 (u2)
+| ArrangeBy (#0)
+
+%1 =
+| Join %0
+| | implementation = IndexedFilter #0 = 6
 | Filter (#0 = 6)
 
 EOF

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -149,26 +149,31 @@ EXPLAIN SELECT  MIN( o_orderkey  )
   AND o_orderdate  = l_commitDATE  + ' 7 MONTHS '
   AND o_orderkey  = (  SELECT l_orderkey  FROM lineitem  WHERE l_orderkey  =  38  )
 ----
-%0 = Let l0 =
+%0 =
 | Get materialize.public.lineitem (u10)
+| ArrangeBy (#0)
+
+%1 = Let l0 =
+| Join %0
+| | implementation = IndexedFilter #0 = 38
 | Filter (#0 = 38)
 
-%1 =
+%2 =
 | Get materialize.public.lineitem (u10)
 | Filter (#6 = 1997-01-25)
 | Project (#4)
 | ArrangeBy (#0)
 
-%2 =
+%3 =
 | Get materialize.public.orders (u7)
 | ArrangeBy (#0)
 
-%3 =
-| Get %0 (l0)
+%4 =
+| Get %1 (l0)
 | Project (#0)
 
-%4 =
-| Get %0 (l0)
+%5 =
+| Get %1 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -176,31 +181,31 @@ EXPLAIN SELECT  MIN( o_orderkey  )
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%5 =
-| Union %3 %4
+%6 =
+| Union %4 %5
 
-%6 = Let l1 =
-| Join %1 %2 %5 (= #0 #3) (= #1 #5)
-| | implementation = Differential %5 %2.(#0) %1.(#0)
+%7 = Let l1 =
+| Join %2 %3 %6 (= #0 #3) (= #1 #5)
+| | implementation = Differential %6 %3.(#0) %2.(#0)
 | Filter (#1 <= 195), (#1 >= 38), (1997-08-25 00:00:00 = date_to_timestamp(#4))
 | Project (#1)
 | Reduce group=()
 | | agg min(#0)
 
-%7 =
-| Get %6 (l1)
+%8 =
+| Get %7 (l1)
 | Project ()
 | Negate
 
-%8 =
+%9 =
 | Constant ()
 
-%9 =
-| Union %7 %8
+%10 =
+| Union %8 %9
 | Map null
 
-%10 =
-| Union %6 %9
+%11 =
+| Union %7 %10
 
 EOF
 
@@ -220,18 +225,28 @@ EXPLAIN SELECT l_partkey AS col24843 , l_orderkey AS col24844 , l_partkey AS col
 
 %1 =
 | Get materialize.public.orders (u7)
+| ArrangeBy (#1)
+
+%2 =
+| Join %1
+| | implementation = IndexedFilter #1 = 134
 | Filter (#1 = 134), (#2 = (#2 % 5))
 | Project (#2, #3)
 | ArrangeBy (#0, #1)
 
-%2 =
+%3 =
 | Get materialize.public.customer (u4)
+| ArrangeBy (#0)
+
+%4 =
+| Join %3
+| | implementation = IndexedFilter #0 = 134
 | Filter (#0 = 134)
 | Project ()
 
-%3 =
-| Join %0 %1 %2 (= #2 #4) (= #3 #5)
-| | implementation = Differential %2 %0.() %1.(#0, #1)
+%5 =
+| Join %0 %2 %4 (= #2 #4) (= #3 #5)
+| | implementation = Differential %4 %0.() %2.(#0, #1)
 | Project (#1, #0, #1)
 
 EOF
@@ -251,16 +266,26 @@ EXPLAIN SELECT *
 
 %1 =
 | Get materialize.public.orders (u7)
+| ArrangeBy (#1)
+
+%2 =
+| Join %1
+| | implementation = IndexedFilter #1 = 229
 | Filter (#1 = 229)
 | ArrangeBy (#2, #3)
 
-%2 =
+%3 =
 | Get materialize.public.customer (u4)
+| ArrangeBy (#0)
+
+%4 =
+| Join %3
+| | implementation = IndexedFilter #0 = 229
 | Filter (#0 = 229)
 
-%3 =
-| Join %0 %1 %2 (= #4 #10) (= #5 #11)
-| | implementation = Differential %2 %0.() %1.(#2, #3)
+%5 =
+| Join %0 %2 %4 (= #4 #10) (= #5 #11)
+| | implementation = Differential %4 %0.() %2.(#2, #3)
 | Project (#0..=#9, #4, #5, #12..=#14)
 
 EOF

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -28,11 +28,11 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 "%0 =| Get t1| Filter (#0) IS NULL, (#1 = 5)"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
-"%0 =| Get t1| Filter (#0 = 5), (#1 = 1)"
+"%0 =| Get t1| ArrangeBy (#0, #1)%1 =| Join %0| | implementation = IndexedFilter #0 = 5 AND #1 = 1| Filter (#0 = 5), (#1 = 1)"
 
 # NULL-able expressions are dedupped
 > EXPLAIN SELECT * FROM t1 WHERE col_null = 1 AND (col_null = 1 AND col_not_null = 5);
-"%0 =| Get t1| Filter (#0 = 1), (#1 = 5)"
+"%0 =| Get t1| ArrangeBy (#0, #1)%1 =| Join %0| | implementation = IndexedFilter #0 = 1 AND #1 = 5| Filter (#0 = 1), (#1 = 5)"
 
 # OR/disjunction at the top level
 


### PR DESCRIPTION
The following are things we have been doing on main this whole time, so fixing it is considered out of scope for this PR.
* When we use an index to speed up a predicate of the form `<expr>=literal`, we haven't been removing that predicate from the `MapFilterProject` that comes after. Issue filed at #13774.
* We only use user-created indexes to speed up a predicate of the form `<expr>=literal`. We don't use other arrangements, such as ones created as part of a reduce. Upon thinking about it, speeding up a predicate of the form `<expr>=literal` using other kinds of arrangements is an inferior optimization to pushing the predicate down past whatever is creating the arrangement, so no issue has been filed.
* Our aggressive CSE slash deficiencies in our `<expr>=literal` detection code means that we do not speed up `<expr>=literal` predicates if the `<expr>` is also an output column.




### Motivation

  * (First commit) This PR fixes a previously unreported bug.

The doc comment of `IndexOracle::indexes_on` reads:
```
    /// Each index is described by the list of key expressions. If no indexes
    /// exist for the identified collection, or if the identified collection
    /// is unknown, the returned iterator will be empty.
```
However, the implementation of `IndexOracle` for the catalog crashes if the identified collection is unknown. Fixed the implementation to conform with the doc comment.

  * (Second and third commit) This PR fixes a recognized bug.

This PR fixes #4887 by moving index decisions to the physical planner (third commit) and then doing a scan of the MIR for which indexes are actually used (second commit).

The use of an index to speed up `<expr>=literal` now looks like this:
```
%0 =
| Get materialize.public.foo2 (u2)
| ArrangeBy (#0)

%1 =
| Join %0
| | implementation = IndexedFilter #0 = 6
| Filter (#0 = 6)
```

The `ArrangeBy{ Get{ ..} }` is so that the index usage can be detected and added to index_imports. The join implementation enum is
```
/// Join a constant to a user-created index to speed up evaluation of a predicate
PredicateIndex(GlobalId, Vec<MirScalarExpr>, #[mzreflect(ignore)] Row),
```
so that the MIR => LIR code can translate the subtree to the correct LIR::Get plan without looking at the join input. 

The use of the join is because 
1) it is the closest existing flavor of MIR to using an index to speed up evaluation of a predicate.
2) Creating a new JoinImplementation variant does not involve changing a bunch of other transforms. Other transforms do not look at the JoinImplementation, so I don't risk inadvertently changing plans.

 * (Fourth commit) This PR adds a desired feature.

This PR moves detecting whether or not we can use fast path to before the MIR => LIR conversion. This allows the future ability to print out fast path information as part of `EXPLAIN OPTIMIZED PLAN`. 

### Tips for reviewer

Hide whitespace.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Release notes

Explain output is not part of the backwards compatible interface.