### PR TITLE
adapter,stash,storage: add some tracing

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -573,6 +573,7 @@ impl<S: Append> Connection<S> {
         Ok(GlobalId::User(id))
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, Error> {
         let key = IdAllocKey {
             name: id_type.to_string(),
@@ -1035,6 +1036,7 @@ impl<'a, S: Append> Transaction<'a, S> {
         Ok(())
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn commit(self) -> Result<(), Error> {
         let mut batches = Vec::new();
         async fn add_batch<K, V, S, I>(

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -680,6 +680,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// This should be called only after a collection is created, and
     /// ideally very soon afterwards. The collection is otherwise initialized
     /// with a read policy that allows no compaction.
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn initialize_read_policies(
         &mut self,
         id_bundle: CollectionIdBundle,
@@ -1260,7 +1261,7 @@ impl<S: Append + 'static> Coordinator<S> {
     /// chosen for the writes is not ahead of `now()`, then we can execute and commit the writes
     /// immediately. Otherwise we must wait for `now()` to advance past the timestamp chosen for the
     /// writes.
-    #[tracing::instrument(level = "trace", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn try_group_commit(&mut self) {
         if self.pending_writes.is_empty() {
             return;
@@ -2906,6 +2907,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sequence_create_table(
         &mut self,
         session: &Session,
@@ -5505,6 +5507,8 @@ impl<S: Append + 'static> Coordinator<S> {
     where
         F: FnOnce(CatalogTxn<Timestamp>) -> Result<R, AdapterError>,
     {
+        event!(Level::TRACE, ops = format!("{:?}", ops));
+
         let mut sources_to_drop = vec![];
         let mut tables_to_drop = vec![];
         let mut sinks_to_drop = vec![];

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -679,6 +679,7 @@ where
     /// Sets the given k,v pair.
     ///
     /// Returns the old value if one existed.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn upsert_key<S>(
         &self,
         stash: &mut S,
@@ -712,6 +713,7 @@ where
     }
 
     /// Sets the given key value pairs, removing existing entries match any key.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn upsert<S, I>(&self, stash: &mut S, entries: I) -> Result<(), StashError>
     where
         S: Append,

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -178,6 +178,7 @@ impl Postgres {
     ///     .await
     //  }
     /// ```
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn transact<F, T>(&mut self, f: F) -> Result<T, StashError>
     where
         F: for<'a> Fn(&'a mut Transaction) -> BoxFuture<'a, Result<T, StashError>>,
@@ -714,6 +715,7 @@ impl From<tokio_postgres::Error> for StashError {
 
 #[async_trait]
 impl Append for Postgres {
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn append<I>(&mut self, batches: I) -> Result<(), StashError>
     where
         I: IntoIterator<Item = AppendBatch> + Send + 'static,

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -488,6 +488,7 @@ where
             .ok_or(StorageError::IdentifierMissing(id))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn create_collections(
         &mut self,
         mut collections: Vec<(GlobalId, CollectionDescription<T>)>,
@@ -707,6 +708,7 @@ where
             .unwrap()
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn set_read_policy(
         &mut self,
         policies: Vec<(GlobalId, ReadPolicy<T>)>,


### PR DESCRIPTION
This greatly improves visibility into DDL commands.

### Motivation

  * This PR adds a known-desirable feature.

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a