### PR TITLE
test: Fix csv-source.td

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -135,10 +135,9 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=\d{13} replacement=<TIMESTAMP>
-$ set-regex match=u\d{2} replacement=<GID>
+$ set-regex match=(\d{13}|u\d{1,2}) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-"     timestamp: <TIMESTAMP>\n         since:[<TIMESTAMP>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv (<GID>, storage):\n read frontier:[<TIMESTAMP>]\nwrite frontier:[]\n"
+"     timestamp: <>\n         since:[<>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<>]\nwrite frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -136,8 +136,9 @@ contains:Expected a list of columns in parentheses, found EOF
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
+$ set-regex match=u\d{2} replacement=<GID>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-"     timestamp: <TIMESTAMP>\n         since:[<TIMESTAMP>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv_primary_idx (u37, compute):\n read frontier:[<TIMESTAMP>]\nwrite frontier:[]\n"
+"     timestamp: <TIMESTAMP>\n         since:[<TIMESTAMP>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv (<GID>, storage):\n read frontier:[<TIMESTAMP>]\nwrite frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)


### PR DESCRIPTION
### Motivation
This PR fixes a broken test.

### Testing

- [X] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
