### PR TITLE
tests: Fix the kafka-matrix test

### DIFF
--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -54,10 +54,18 @@ def workflow_default(c: Composition) -> None:
             )
             c.wait_for_materialized()
             c.run("testdrive", "kafka-matrix.td", "testdrive/kafka-*.td")
+            c.kill(
+                "zookeeper",
+                "kafka",
+                "schema-registry",
+                "materialized",
+            )
             c.rm(
                 "zookeeper",
                 "kafka",
                 "schema-registry",
                 "materialized",
+                "testdrive",
                 destroy_volumes=True,
             )
+            c.rm_volumes("mzdata", "pgdata", force=True)


### PR DESCRIPTION
The kafka-matrix test was not completely wiping out pgdata and
mzdata between the sucessive parts of the test, making it susceptible
to #13726

### Motivation
  * This PR fixes a previously unreported bug.

Nightly CI was failing