### PR TITLE
zippy: Test compute reconciliation

### DIFF
--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -12,6 +12,7 @@ from typing import List, Set, Type
 from materialize.mzcompose import Composition
 from materialize.zippy.framework import Action, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.view_capabilities import ViewExists
 
 
 class MzStart(Action):
@@ -49,3 +50,15 @@ class KillStoraged(Action):
     def run(self, c: Composition) -> None:
         # Depending on the workload, storaged may not be running, hence the || true
         c.exec("materialized", "bash", "-c", "kill -9 `pidof storaged` || true")
+
+
+class KillComputed(Action):
+    """Kills the computed processes in the environmentd container. The process orchestrator will restart them."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, ViewExists}
+
+    def run(self, c: Composition) -> None:
+        # Depending on the workload, computed may not be running, hence the || true
+        c.exec("materialized", "bash", "-c", "kill -9 `pidof computed` || true")

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -11,7 +11,7 @@ from typing import Dict, Type
 
 from materialize.zippy.framework import Action, Scenario
 from materialize.zippy.kafka_actions import CreateTopic, Ingest, KafkaStart
-from materialize.zippy.mz_actions import KillStoraged, MzStart, MzStop
+from materialize.zippy.mz_actions import KillComputed, KillStoraged, MzStart, MzStop
 from materialize.zippy.source_actions import CreateSource
 from materialize.zippy.table_actions import DML, CreateTable, ValidateTable
 from materialize.zippy.view_actions import CreateView, ValidateView
@@ -25,6 +25,7 @@ class KafkaSources(Scenario):
             MzStart: 1,
             MzStop: 10,
             KillStoraged: 15,
+            KillComputed: 15,
             KafkaStart: 1,
             CreateTopic: 5,
             CreateSource: 5,
@@ -42,6 +43,7 @@ class UserTables(Scenario):
             MzStart: 1,
             MzStop: 15,
             KafkaStart: 1,
+            KillComputed: 15,
             CreateTable: 10,
             CreateView: 10,
             ValidateTable: 20,


### PR DESCRIPTION
Add killing of computed to the workloads

### Motivation

  * This PR adds a feature that has not yet been specified.

Testing computed reconciliation via Zippy is a prerequisite to considering compute reconciliation QA-complete.