### PR TITLE
zippy: Add partitions to kafka topics

### DIFF
--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -66,14 +66,17 @@ class CreateTopic(Action):
         return {MzIsRunning, KafkaRunning}
 
     def __init__(self, capabilities: Capabilities) -> None:
-        this_topic = TopicExists(name="topic" + str(random.randint(1, 10)))
+        this_topic = TopicExists(
+            name="topic" + str(random.randint(1, 10)),
+            envelope=random.choice([Envelope.NONE, Envelope.UPSERT]),
+            partitions=random.randint(1, 10),
+        )
         existing_topics = [
             t for t in capabilities.get(TopicExists) if t.name == this_topic.name
         ]
 
         if len(existing_topics) == 0:
             self.new_topic = True
-            this_topic.envelope = random.choice([Envelope.NONE, Envelope.UPSERT])
             self.topic = this_topic
         elif len(existing_topics) == 1:
             self.new_topic = False
@@ -88,7 +91,7 @@ class CreateTopic(Action):
         if self.new_topic:
             c.testdrive(
                 f"""
-$ kafka-create-topic topic={self.topic.name}
+$ kafka-create-topic topic={self.topic.name} partitions={self.topic.partitions}
 
 {SCHEMA}
 

--- a/misc/python/materialize/zippy/kafka_capabilities.py
+++ b/misc/python/materialize/zippy/kafka_capabilities.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 from enum import Enum
-from typing import Optional
 
 from materialize.zippy.framework import Capability
 from materialize.zippy.watermarks import Watermarks
@@ -33,7 +32,8 @@ class Envelope(Enum):
 class TopicExists(Capability):
     """A Topic exists on the Kafka instance."""
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, partitions: int, envelope: Envelope) -> None:
         self.name = name
-        self.envelope: Optional[Envelope] = None
+        self.partitions = partitions
+        self.envelope = envelope
         self.watermarks = Watermarks()


### PR DESCRIPTION
Create each Kafka topic with between 1 and 10 partitions. This
is needed to make sure any parallelism further down the pipeline
has had the chance to be exercised.

### Motivation

  * This PR fixes a previously unreported bug.

Zippy was not testing partitioned topics.