### PR TITLE
WIP: Alternate approach to recording collections

### DIFF
--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -7,9 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
 use timely::dataflow::Scope;
+use timely::progress::{Antichain, Timestamp as _};
 
 use mz_repr::GlobalId;
 use mz_repr::{Diff, Row, Timestamp};
@@ -21,26 +21,15 @@ pub(crate) fn persist_sink<G>(
     target_id: GlobalId,
     target: &CollectionMetadata,
     compute_state: &mut ComputeState,
-    desired_collection: Collection<G, Row, Diff>,
+    log_collection: Collection<G, Row, Diff>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    let (_, err_collection) = desired_collection.scope().new_collection();
+    let desired_collection = log_collection.map(Ok);
+    let as_of = Antichain::from_elem(Timestamp::minimum());
 
-    // The target storage collection might still contain data written by a
-    // previous incarnation of the replica. Empty it, so we don't end up with
-    // stale data that never gets retracted.
-    // TODO(teskje,lh): Remove the truncation step once/if #13740 gets merged.
-    let truncate = true;
-
-    let token = crate::sink::persist_sink(
-        target_id,
-        target,
-        desired_collection,
-        err_collection,
-        compute_state,
-        truncate,
-    );
+    let token =
+        crate::sink::persist_sink(target_id, target, desired_collection, as_of, compute_state);
 
     // We don't allow these dataflows to be dropped, so the tokens could
     // be stored anywhere.

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -171,7 +171,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     *source_id,
                     Arc::clone(&compute_state.persist_clients),
                     source.storage_metadata.clone(),
-                    dataflow.as_of.clone().unwrap(),
+                    dataflow.as_of.clone(),
                 );
 
                 // If logging is enabled, intercept frontier advancements coming from persist to track materialization lags.

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -269,8 +269,11 @@ where
                     }
                 }
 
-                // Confirm that we only require updates from our lower bound onward.
-                shared_frontier.borrow_mut().clone_from(&write_lower_bound);
+                // Share that we have finished processing all times less than the persist frontier.
+                // Advancing the sink upper communicates to the storage controller that it is
+                // permitted to compact our target storage collection up to the new upper. So we
+                // must be careful to not advance the sink upper beyond our read frontier.
+                shared_frontier.borrow_mut().clone_from(&persist_frontier);
             }
         },
     );

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -86,13 +86,17 @@ pub(crate) fn persist_sink<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let scope = desired_collection.scope();
+    // There is no guarantee that `as_of` is beyond the persist shard's since. If it isn't,
+    // instantiating a `persist_source` with it would panic. So instead we leave it to
+    // `persist_source` to select an appropriate `as_of`. We only care about times beyond the
+    // current shard upper anyway.
+    let source_as_of = None;
     let (ok_stream, err_stream, token) = mz_storage::source::persist_source::persist_source(
-        &scope,
+        &desired_collection.scope(),
         sink_id.clone(),
         Arc::clone(&compute_state.persist_clients),
         target.clone(),
-        as_of.clone(),
+        source_as_of,
     );
     use differential_dataflow::AsCollection;
     let persist_collection = ok_stream

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -924,34 +924,43 @@ fn test_tail_table_rw_timestamps() -> Result<(), Box<dyn Error>> {
     client_interactive.execute("COMMIT", &[])?;
     let _ = client_interactive.query("SELECT * FROM T1", &[])?;
 
-    let rows = client_tail.query("FETCH ALL c1", &[])?;
-    client_tail.batch_execute("COMMIT;")?;
     let mut first_write_ts = None;
     let mut second_write_ts = None;
     let mut seen_first = false;
     let mut seen_second = false;
-    for row in rows.iter() {
-        let mz_timestamp = row.get::<_, MzTimestamp>("mz_timestamp");
-        let mz_progressed = row.get::<_, Option<bool>>("mz_progressed").unwrap();
-        let mz_diff = row.get::<_, Option<i64>>("mz_diff");
-        let data = row.get::<_, Option<String>>("data");
 
-        if !mz_progressed {
-            // Actual data
-            let mz_diff = mz_diff.unwrap();
-            let data = data.unwrap();
-            if !seen_first {
-                assert_eq!(data, "first");
-                seen_first = true;
-                first_write_ts = Some(mz_timestamp);
-            } else {
-                assert_eq!(data, "second");
-                seen_second = true;
-                second_write_ts = Some(mz_timestamp);
+    // TODO(aljoscha): We can wrap this with timeout logic, if we want/need to?
+    // We need to do multiple FETCH ALL calls. ALL only guarantees that all
+    // available rows will be returned, but it's up to the system to decide what
+    // is available. This means that we could still get only one row per
+    // request, and we won't know how many rows will come back otherwise.
+    while !seen_second {
+        let rows = client_tail.query("FETCH ALL c1", &[])?;
+        for row in rows.iter() {
+            let mz_timestamp = row.get::<_, MzTimestamp>("mz_timestamp");
+            let mz_progressed = row.get::<_, Option<bool>>("mz_progressed").unwrap();
+            let mz_diff = row.get::<_, Option<i64>>("mz_diff");
+            let data = row.get::<_, Option<String>>("data");
+
+            if !mz_progressed {
+                // Actual data
+                let mz_diff = mz_diff.unwrap();
+                let data = data.unwrap();
+                if !seen_first {
+                    assert_eq!(data, "first");
+                    seen_first = true;
+                    first_write_ts = Some(mz_timestamp);
+                } else {
+                    assert_eq!(data, "second");
+                    seen_second = true;
+                    second_write_ts = Some(mz_timestamp);
+                }
+                assert_eq!(mz_diff, 2);
             }
-            assert_eq!(mz_diff, 2);
         }
     }
+
+    client_tail.batch_execute("COMMIT;")?;
 
     assert!(seen_first);
     assert!(seen_second);

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -300,7 +300,7 @@ where
                                     id,
                                     persist_clients,
                                     tx_storage_metadata,
-                                    as_of,
+                                    Some(as_of),
                                 );
                             let (tx_source_ok, tx_source_err) = (
                                 tx_source_ok_stream.as_collection(),

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -93,6 +93,10 @@ where
 
         let as_of = as_of.unwrap_or_else(|| read.since().clone());
 
+        // Report initial progress so we can already downgrade our capability before potentially
+        // having to wait for the snapshot.
+        yield ListenEvent::Progress(as_of.clone());
+
         let mut subscription = read
             .subscribe(as_of)
             .await

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -50,7 +50,7 @@ pub fn persist_source<G>(
     source_id: GlobalId,
     persist_clients: Arc<Mutex<PersistClientCache>>,
     metadata: CollectionMetadata,
-    as_of: Antichain<Timestamp>,
+    as_of: Option<Antichain<Timestamp>>,
 ) -> (
     Stream<G, (Row, Timestamp, Diff)>,
     Stream<G, (DataflowError, Timestamp, Diff)>,
@@ -90,6 +90,8 @@ where
             .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(metadata.data_shard)
             .await
             .expect("could not open persist shard");
+
+        let as_of = as_of.unwrap_or_else(|| read.since().clone());
 
         let mut subscription = read
             .subscribe(as_of)

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -150,7 +150,8 @@ id price
 
 > DECLARE c CURSOR FOR TAIL data_schema_inline WITH (SNAPSHOT = FALSE, PROGRESS = TRUE);
 
-> FETCH 1 FROM c WITH (timeout = '60s')
+> FETCH 2 FROM c WITH (timeout = '60s')
+14 true <null> <null> <null>
 15 true <null> <null> <null>
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=6


### PR DESCRIPTION
Work in progress looking at an alternate way to record collections to `persist`, in which one tracks the gap between the current `persist` contents and some `desired` collection, repeatedly attempting to commit that gap to `persist`.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Testing

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

### Backward compatibility

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

### Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
