### PR TITLE
test,limits: Increase the Tables scenario to 100 tables

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -84,7 +84,7 @@ class Connections(Generator):
 
 
 class Tables(Generator):
-    COUNT = 10  # https://github.com/MaterializeInc/materialize/issues/12773
+    COUNT = 100  # https://github.com/MaterializeInc/materialize/issues/12773
 
     @classmethod
     def body(cls) -> None:


### PR DESCRIPTION
Previously, it was not possible to create and insert into 100 tables
without loss of interactivity. Now 100 tables are doable, so set the
test to that threshold in order to preserve any scalability gains
recently made in that dimension.

1000 tables remains out of reach and continues to cause interactivity
issues.

Relates to: #12773

### Motivation

  * This PR fixes a previously unreported bug.

The Tables scenario of the Limits test in the CI was only using 10 tables, which was laughably low. 100 tables are now doable.