### PR TITLE
adapter: properly pass timestamp in ns, not ms

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent};
 use mz_compute_client::command::{ProcessId, ReplicaId};
@@ -702,10 +702,7 @@ impl CatalogState {
             })?
             .into_row();
         let event_details = event_details.iter().next().unwrap();
-        let dt = NaiveDateTime::from_timestamp(
-            (occurred_at / 1_000).try_into().expect("must fit"),
-            (occurred_at % 1_000).try_into().expect("must fit"),
-        );
+        let dt = mz_ore::now::to_datetime(occurred_at).naive_utc();
         let id = i64::try_from(event.sortable_id()).map_err(|e| {
             Error::new(ErrorKind::Unstructured(format!(
                 "exceeded event id space: {}",

--- a/src/ore/src/now.rs
+++ b/src/ore/src/now.rs
@@ -85,3 +85,31 @@ pub static SYSTEM_TIME: Lazy<NowFn> = Lazy::new(|| NowFn::from(system_time));
 ///
 /// For use in tests.
 pub static NOW_ZERO: Lazy<NowFn> = Lazy::new(|| NowFn::from(now_zero));
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDate;
+
+    use super::to_datetime;
+
+    #[test]
+    fn test_to_datetime() {
+        let test_cases = [
+            (0, NaiveDate::from_ymd(1970, 1, 1).and_hms_nano(0, 0, 0, 0)),
+            (
+                1600000000000,
+                NaiveDate::from_ymd(2020, 9, 13).and_hms_nano(12, 26, 40, 0),
+            ),
+            (
+                1658323270293,
+                NaiveDate::from_ymd(2022, 7, 20).and_hms_nano(13, 21, 10, 293_000_000),
+            ),
+        ];
+        // to_datetime works properly and roundtrips
+        for (millis, datetime) in test_cases.into_iter() {
+            let converted_datetime = to_datetime(millis).naive_utc();
+            assert_eq!(datetime, converted_datetime);
+            assert_eq!(millis, converted_datetime.timestamp_millis() as u64)
+        }
+    }
+}


### PR DESCRIPTION
`pack_audit_log_update` was accidentally passing milliseconds instead of nanoseconds when building a timestamp.

### Motivation
  * This PR fixes a previously unreported bug: `pack_audit_log_update` was accidentally passing milliseconds instead of nanoseconds when building a timestamp, which meant the timestamps in the audit log would be wrong.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
