### PR TITLE
adapter,storage: update controller to support work on source errors

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -996,6 +996,8 @@ pub struct Table {
     pub defaults: Vec<Expr<Aug>>,
     pub conn_id: Option<ConnectionId>,
     pub depends_on: Vec<GlobalId>,
+    /// Flag for tables whose collections are managed externally, outside of the coordinator
+    pub externally_managed: bool,
 }
 
 impl Table {
@@ -1332,6 +1334,16 @@ impl CatalogEntry {
         matches!(self.item(), CatalogItem::Table(_))
     }
 
+    /// Indicates whether this catalog entry is an externally managed table
+    pub fn is_externally_managed_table(&self) -> bool {
+        match self.item() {
+            CatalogItem::Table(Table {
+                externally_managed, ..
+            }) => *externally_managed,
+            _ => false,
+        }
+    }
+
     /// Collects the identifiers of the dataflows that this dataflow depends
     /// upon.
     pub fn uses(&self) -> &[GlobalId] {
@@ -1563,6 +1575,7 @@ impl<S: Append> Catalog<S> {
                             defaults: vec![Expr::null(); table.desc.arity()],
                             conn_id: None,
                             depends_on: vec![],
+                            externally_managed: table.externally_managed,
                         }),
                     );
                 }
@@ -3406,6 +3419,7 @@ impl<S: Append> Catalog<S> {
                 defaults: table.defaults,
                 conn_id: None,
                 depends_on,
+                externally_managed: false,
             }),
             Plan::CreateSource(CreateSourcePlan {
                 source,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1010,8 +1010,6 @@ pub struct Table {
     pub defaults: Vec<Expr<Aug>>,
     pub conn_id: Option<ConnectionId>,
     pub depends_on: Vec<GlobalId>,
-    /// Flag for tables whose collections are managed externally, outside of the coordinator
-    pub externally_managed: bool,
 }
 
 impl Table {
@@ -1354,16 +1352,6 @@ impl CatalogEntry {
         matches!(self.item(), CatalogItem::Table(_))
     }
 
-    /// Indicates whether this catalog entry is an externally managed table
-    pub fn is_externally_managed_table(&self) -> bool {
-        match self.item() {
-            CatalogItem::Table(Table {
-                externally_managed, ..
-            }) => *externally_managed,
-            _ => false,
-        }
-    }
-
     /// Collects the identifiers of the dataflows that this dataflow depends
     /// upon.
     pub fn uses(&self) -> &[GlobalId] {
@@ -1595,7 +1583,6 @@ impl<S: Append> Catalog<S> {
                             defaults: vec![Expr::null(); table.desc.arity()],
                             conn_id: None,
                             depends_on: vec![],
-                            externally_managed: table.externally_managed,
                         }),
                     );
                 }
@@ -3460,7 +3447,6 @@ impl<S: Append> Catalog<S> {
                 defaults: table.defaults,
                 conn_id: None,
                 depends_on,
-                externally_managed: false,
             }),
             Plan::CreateSource(CreateSourcePlan {
                 source,

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -80,6 +80,7 @@ pub struct BuiltinTable {
     pub name: &'static str,
     pub schema: &'static str,
     pub desc: RelationDesc,
+    pub externally_managed: bool,
 }
 
 #[derive(Hash)]
@@ -925,6 +926,7 @@ pub const MZ_ARRANGEMENT_RECORDS_INTERNAL: BuiltinLog = BuiltinLog {
 pub static MZ_VIEW_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_view_keys",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("global_id", ScalarType::String.nullable(false))
         .with_column("column", ScalarType::Int64.nullable(false))
@@ -934,6 +936,7 @@ pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
     BuiltinTable {
         name: "mz_view_foreign_keys",
         schema: MZ_CATALOG_SCHEMA,
+        externally_managed: false,
         desc: RelationDesc::empty()
             .with_column("child_id", ScalarType::String.nullable(false))
             .with_column("child_column", ScalarType::Int64.nullable(false))
@@ -946,6 +949,7 @@ pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
 pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_kafka_sinks",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("sink_id", ScalarType::String.nullable(false))
         .with_column("topic", ScalarType::String.nullable(false))
@@ -955,6 +959,7 @@ pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_databases",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -963,6 +968,7 @@ pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_schemas",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -972,6 +978,7 @@ pub static MZ_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_columns",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -984,6 +991,7 @@ pub static MZ_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_indexes",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -994,6 +1002,7 @@ pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_index_columns",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("index_id", ScalarType::String.nullable(false))
         .with_column("index_position", ScalarType::Int64.nullable(false))
@@ -1004,6 +1013,7 @@ pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_tables",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1013,6 +1023,7 @@ pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_connections",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1023,6 +1034,7 @@ pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SSH_TUNNEL_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_ssh_tunnel_connections",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -1031,6 +1043,7 @@ pub static MZ_SSH_TUNNEL_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinT
 pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sources",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1041,6 +1054,7 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sinks",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1052,6 +1066,7 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_views",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1062,6 +1077,7 @@ pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_RECORDED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_recorded_views",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1073,6 +1089,7 @@ pub static MZ_RECORDED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_types",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1083,6 +1100,7 @@ pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_array_types",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("type_id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false)),
@@ -1090,11 +1108,13 @@ pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_BASE_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_base_types",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty().with_column("type_id", ScalarType::String.nullable(false)),
 });
 pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_list_types",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("type_id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false)),
@@ -1102,6 +1122,7 @@ pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_map_types",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("type_id", ScalarType::String.nullable(false))
         .with_column("key_id", ScalarType::String.nullable(false))
@@ -1110,6 +1131,7 @@ pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_roles",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1118,11 +1140,13 @@ pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_PSEUDO_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_pseudo_types",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty().with_column("type_id", ScalarType::String.nullable(false)),
 });
 pub static MZ_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_functions",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1139,6 +1163,7 @@ pub static MZ_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_clusters",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false)),
@@ -1146,6 +1171,7 @@ pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_secrets",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
@@ -1154,6 +1180,7 @@ pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_CLUSTER_REPLICAS_BASE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas_base",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("cluster_id", ScalarType::Int64.nullable(false))
         .with_column("id", ScalarType::Int64.nullable(false))
@@ -1165,6 +1192,7 @@ pub static MZ_CLUSTER_REPLICAS_BASE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
 pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_statuses",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::Int64.nullable(false))
         .with_column("process_id", ScalarType::Int64.nullable(false))
@@ -1175,6 +1203,7 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
 pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_heartbeats",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::Int64.nullable(false))
         .with_column("last_heartbeat", ScalarType::TimestampTz.nullable(false)),
@@ -1183,6 +1212,7 @@ pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| Buil
 pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_audit_events",
     schema: MZ_CATALOG_SCHEMA,
+    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("event_type", ScalarType::String.nullable(false))
@@ -1190,6 +1220,23 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("event_details", ScalarType::Jsonb.nullable(false))
         .with_column("user", ScalarType::String.nullable(false))
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
+});
+
+pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_source_status_history",
+    schema: MZ_CATALOG_SCHEMA,
+    externally_managed: true,
+    desc: RelationDesc::empty()
+        .with_column("timestamp", ScalarType::Timestamp.nullable(false))
+        .with_column("source_name", ScalarType::String.nullable(false))
+        .with_column("source_id", ScalarType::String.nullable(false))
+        .with_column("source_type", ScalarType::String.nullable(false))
+        .with_column("upstream_name", ScalarType::String.nullable(true))
+        .with_column("worker_id", ScalarType::Int64.nullable(false))
+        .with_column("worker_count", ScalarType::Int64.nullable(false))
+        .with_column("status", ScalarType::String.nullable(false))
+        .with_column("error", ScalarType::String.nullable(true))
+        .with_column("metadata", ScalarType::Jsonb.nullable(true)),
 });
 
 pub const MZ_RELATIONS: BuiltinView = BuiltinView {
@@ -2126,6 +2173,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_CLUSTER_REPLICA_STATUSES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
         Builtin::Table(&MZ_AUDIT_EVENTS),
+        Builtin::Table(&MZ_SOURCE_STATUS_HISTORY),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_CATALOG_NAMES),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -83,7 +83,6 @@ pub struct BuiltinTable {
     pub name: &'static str,
     pub schema: &'static str,
     pub desc: RelationDesc,
-    pub externally_managed: bool,
 }
 
 #[derive(Clone, Debug, Hash, Serialize)]
@@ -937,7 +936,6 @@ pub const MZ_ARRANGEMENT_RECORDS_INTERNAL: BuiltinLog = BuiltinLog {
 pub static MZ_VIEW_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_view_keys",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("global_id", ScalarType::String.nullable(false))
         .with_column("column", ScalarType::Int64.nullable(false))
@@ -947,7 +945,6 @@ pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
     BuiltinTable {
         name: "mz_view_foreign_keys",
         schema: MZ_CATALOG_SCHEMA,
-        externally_managed: false,
         desc: RelationDesc::empty()
             .with_column("child_id", ScalarType::String.nullable(false))
             .with_column("child_column", ScalarType::Int64.nullable(false))
@@ -960,7 +957,6 @@ pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
 pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_kafka_sinks",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("sink_id", ScalarType::String.nullable(false))
         .with_column("topic", ScalarType::String.nullable(false))
@@ -970,7 +966,6 @@ pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_databases",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -979,7 +974,6 @@ pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_schemas",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -989,7 +983,6 @@ pub static MZ_SCHEMAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_columns",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -1002,7 +995,6 @@ pub static MZ_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_indexes",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1013,7 +1005,6 @@ pub static MZ_INDEXES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_index_columns",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("index_id", ScalarType::String.nullable(false))
         .with_column("index_position", ScalarType::Int64.nullable(false))
@@ -1024,7 +1015,6 @@ pub static MZ_INDEX_COLUMNS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_tables",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1034,7 +1024,6 @@ pub static MZ_TABLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_connections",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1045,7 +1034,6 @@ pub static MZ_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SSH_TUNNEL_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_ssh_tunnel_connections",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
@@ -1054,7 +1042,6 @@ pub static MZ_SSH_TUNNEL_CONNECTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinT
 pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sources",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1065,7 +1052,6 @@ pub static MZ_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_sinks",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1077,7 +1063,6 @@ pub static MZ_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_views",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1088,7 +1073,6 @@ pub static MZ_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_RECORDED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_recorded_views",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1100,7 +1084,6 @@ pub static MZ_RECORDED_VIEWS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_types",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1111,7 +1094,6 @@ pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_array_types",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("type_id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false)),
@@ -1119,13 +1101,11 @@ pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_BASE_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_base_types",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty().with_column("type_id", ScalarType::String.nullable(false)),
 });
 pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_list_types",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("type_id", ScalarType::String.nullable(false))
         .with_column("element_id", ScalarType::String.nullable(false)),
@@ -1133,7 +1113,6 @@ pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_map_types",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("type_id", ScalarType::String.nullable(false))
         .with_column("key_id", ScalarType::String.nullable(false))
@@ -1142,7 +1121,6 @@ pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_roles",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1151,13 +1129,11 @@ pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_PSEUDO_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_pseudo_types",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty().with_column("type_id", ScalarType::String.nullable(false)),
 });
 pub static MZ_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_functions",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("oid", ScalarType::Oid.nullable(false))
@@ -1174,7 +1150,6 @@ pub static MZ_FUNCTIONS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_clusters",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("name", ScalarType::String.nullable(false)),
@@ -1182,7 +1157,6 @@ pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_secrets",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("schema_id", ScalarType::Int64.nullable(false))
@@ -1191,7 +1165,6 @@ pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
 pub static MZ_CLUSTER_REPLICAS_BASE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas_base",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("cluster_id", ScalarType::Int64.nullable(false))
         .with_column("id", ScalarType::Int64.nullable(false))
@@ -1203,7 +1176,6 @@ pub static MZ_CLUSTER_REPLICAS_BASE: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTa
 pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_statuses",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::Int64.nullable(false))
         .with_column("process_id", ScalarType::Int64.nullable(false))
@@ -1214,7 +1186,6 @@ pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| Builti
 pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replica_heartbeats",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("replica_id", ScalarType::Int64.nullable(false))
         .with_column("last_heartbeat", ScalarType::TimestampTz.nullable(false)),
@@ -1223,7 +1194,6 @@ pub static MZ_CLUSTER_REPLICA_HEARTBEATS: Lazy<BuiltinTable> = Lazy::new(|| Buil
 pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_audit_events",
     schema: MZ_CATALOG_SCHEMA,
-    externally_managed: false,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::Int64.nullable(false))
         .with_column("event_type", ScalarType::String.nullable(false))

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -44,6 +44,7 @@ pub enum Builtin<T: 'static + TypeReference> {
     View(&'static BuiltinView),
     Type(&'static BuiltinType<T>),
     Func(BuiltinFunc),
+    StorageCollection(&'static BuiltinStorageCollection),
 }
 
 impl<T: TypeReference> Builtin<T> {
@@ -54,6 +55,7 @@ impl<T: TypeReference> Builtin<T> {
             Builtin::View(view) => view.name,
             Builtin::Type(typ) => typ.name,
             Builtin::Func(func) => func.name,
+            Builtin::StorageCollection(coll) => coll.name,
         }
     }
 
@@ -64,6 +66,7 @@ impl<T: TypeReference> Builtin<T> {
             Builtin::View(view) => view.schema,
             Builtin::Type(typ) => typ.schema,
             Builtin::Func(func) => func.schema,
+            Builtin::StorageCollection(coll) => coll.schema,
         }
     }
 }
@@ -81,6 +84,13 @@ pub struct BuiltinTable {
     pub schema: &'static str,
     pub desc: RelationDesc,
     pub externally_managed: bool,
+}
+
+#[derive(Clone, Debug, Hash, Serialize)]
+pub struct BuiltinStorageCollection {
+    pub name: &'static str,
+    pub schema: &'static str,
+    pub desc: RelationDesc,
 }
 
 #[derive(Hash)]
@@ -138,6 +148,7 @@ impl<T: TypeReference> Fingerprint for &Builtin<T> {
             Builtin::View(view) => view.fingerprint(),
             Builtin::Type(typ) => typ.fingerprint(),
             Builtin::Func(func) => func.fingerprint(),
+            Builtin::StorageCollection(coll) => coll.fingerprint(),
         }
     }
 }
@@ -1222,22 +1233,22 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
 });
 
-pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_source_status_history",
-    schema: MZ_CATALOG_SCHEMA,
-    externally_managed: true,
-    desc: RelationDesc::empty()
-        .with_column("timestamp", ScalarType::Timestamp.nullable(false))
-        .with_column("source_name", ScalarType::String.nullable(false))
-        .with_column("source_id", ScalarType::String.nullable(false))
-        .with_column("source_type", ScalarType::String.nullable(false))
-        .with_column("upstream_name", ScalarType::String.nullable(true))
-        .with_column("worker_id", ScalarType::Int64.nullable(false))
-        .with_column("worker_count", ScalarType::Int64.nullable(false))
-        .with_column("status", ScalarType::String.nullable(false))
-        .with_column("error", ScalarType::String.nullable(true))
-        .with_column("metadata", ScalarType::Jsonb.nullable(true)),
-});
+pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinStorageCollection> =
+    Lazy::new(|| BuiltinStorageCollection {
+        name: "mz_source_status_history",
+        schema: MZ_CATALOG_SCHEMA,
+        desc: RelationDesc::empty()
+            .with_column("timestamp", ScalarType::Timestamp.nullable(false))
+            .with_column("source_name", ScalarType::String.nullable(false))
+            .with_column("source_id", ScalarType::String.nullable(false))
+            .with_column("source_type", ScalarType::String.nullable(false))
+            .with_column("upstream_name", ScalarType::String.nullable(true))
+            .with_column("worker_id", ScalarType::Int64.nullable(false))
+            .with_column("worker_count", ScalarType::Int64.nullable(false))
+            .with_column("status", ScalarType::String.nullable(false))
+            .with_column("error", ScalarType::String.nullable(true))
+            .with_column("metadata", ScalarType::Jsonb.nullable(true)),
+    });
 
 pub const MZ_RELATIONS: BuiltinView = BuiltinView {
     name: "mz_relations",
@@ -2173,7 +2184,6 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_CLUSTER_REPLICA_STATUSES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
         Builtin::Table(&MZ_AUDIT_EVENTS),
-        Builtin::Table(&MZ_SOURCE_STATUS_HISTORY),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_CATALOG_NAMES),
@@ -2217,6 +2227,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_INHERITS),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
+        Builtin::StorageCollection(&MZ_SOURCE_STATUS_HISTORY),
     ]);
 
     builtins

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -212,6 +212,9 @@ impl CatalogState {
             CatalogItem::Connection(connection) => {
                 self.pack_connection_update(id, oid, schema_id, name, connection, diff)
             }
+            CatalogItem::StorageCollection(_) => {
+                self.pack_source_update(id, oid, schema_id, name, "storage collection", diff)
+            }
         };
 
         if let Ok(desc) = entry.desc(&self.resolve_full_name(entry.name(), entry.conn_id())) {

--- a/src/adapter/src/coord/dataflow_builder.rs
+++ b/src/adapter/src/coord/dataflow_builder.rs
@@ -163,6 +163,9 @@ impl<'a> DataflowBuilder<'a, mz_repr::Timestamp> {
                     CatalogItem::Log(log) => {
                         dataflow.import_source(*id, log.variant.desc().typ().clone(), false);
                     }
+                    CatalogItem::StorageCollection(coll) => {
+                        dataflow.import_source(*id, coll.desc.typ().clone(), false);
+                    }
                     _ => unreachable!(),
                 }
             }

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -82,7 +82,8 @@ impl<T: CoordTimestamp> ComputeInstanceIndexOracle<'_, T> {
                     CatalogItem::Source(_)
                     | CatalogItem::Table(_)
                     | CatalogItem::Log(_)
-                    | CatalogItem::RecordedView(_) => {
+                    | CatalogItem::RecordedView(_)
+                    | CatalogItem::StorageCollection(_) => {
                         // Record that we are missing at least one index.
                         id_bundle.storage_ids.insert(id);
                     }

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -88,7 +88,6 @@ async fn datadriven() {
                                         defaults: vec![Expr::null(); 0],
                                         conn_id: None,
                                         depends_on: vec![],
-                                        externally_managed: false,
                                     }),
                                 }],
                                 |_| Ok(()),

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -88,6 +88,7 @@ async fn datadriven() {
                                         defaults: vec![Expr::null(); 0],
                                         conn_id: None,
                                         depends_on: vec![],
+                                        externally_managed: false,
                                     }),
                                 }],
                                 |_| Ok(()),

--- a/src/storage/src/controller.proto
+++ b/src/storage/src/controller.proto
@@ -18,4 +18,5 @@ message ProtoCollectionMetadata {
     string consensus_uri = 2;
     string data_shard = 3;
     string remap_shard = 4;
+    string status_shard = 5;
 }

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -521,6 +521,7 @@ mod tests {
             },
             remap_shard: shard,
             data_shard: ShardId::new(),
+            status_shard: ShardId::new(),
         };
 
         ReclockOperator::new(

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -384,6 +384,7 @@ mz_scheduling_histogram_internal
 mz_scheduling_histogram_internal_1
 mz_scheduling_parks_internal
 mz_scheduling_parks_internal_1
+mz_source_status_history
 mz_worker_materialization_frontiers
 mz_worker_materialization_frontiers_1
 
@@ -422,6 +423,7 @@ mz_scheduling_histogram_internal              system log
 mz_scheduling_histogram_internal_1            system log
 mz_scheduling_parks_internal                  system log
 mz_scheduling_parks_internal_1                system log
+mz_source_status_history                      system "storage collection"
 mz_worker_materialization_frontiers           system log
 mz_worker_materialization_frontiers_1         system log
 


### PR DESCRIPTION
This is the first part of the work on exposing source errors, and it includes the necessary changes in the communication between the coordinator and the storage controller to support the rest of the work.

There are two changes being made here:
- Adding `status_collection_id` as an optional field in `CollectionDescription`, as a way to allow the Adapter to pass an existing `GlobalId` to be used as the collection for storing source status updates.
- Adding `status_shard` as a new field `CollectionMetadata`. It is going to store the ShardId of the collection used to persist errors and other status information for each source. In the initial proposal, a single shared collection will be used for all sources, but having this exposed in `CollectionMetadata` (similarly to `remap_shard` for reclocking) allows us to change this in the future without breaking the stored state for the storage controller (and it makes the code cleaner overall).

I wanted to get this change merged first, as the rest of work should not involve any breaking changes and can be done/reviewed in smaller pieces at a calmer pace, in particular on the Healthchecker.

For more context on this change, please feel free to check the [design doc on Notion](https://www.notion.so/materialize/Exposing-source-errors-via-SQL-1c83b2070b5a48db967b829b7ccd88dc) or the [WIP branch](https://github.com/andrioni/materialize/tree/andrioni/test-storage-v3) from where the next PRs will come from as it stabilizes.

### Motivation
  * This PR makes progress towards a known-desirable feature: #12864

### Tips for reviewer
For Matt and Joe in particular, please feel free to focus only in the changes in Adapter: the biggest one is adding a new `externally_managed` field to tables to track tables whose storage collections are updated/managed outside of the Adapter. This is used to ensure we don't advance timestamps for those tables (as otherwise coord panics), and to avoid hardcoding it for the table we have in that scenario right now (`mz_source_status_history`, for now).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
