### PR TITLE
persist: client to audit storage usage

### DIFF
--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -196,8 +196,8 @@ impl Blob for MaelstromBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        _key_prefix: Option<&str>,
-        _f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+        key_prefix: &str,
+        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         unimplemented!("not yet used")
     }
@@ -270,7 +270,7 @@ impl Blob for CachingBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         self.blob.list_keys_and_metadata(key_prefix, f).await

--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -196,8 +196,8 @@ impl Blob for MaelstromBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: &str,
-        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+        _key_prefix: &str,
+        _f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         unimplemented!("not yet used")
     }

--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -19,7 +19,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::Mutex;
 
-use mz_persist::location::{Atomicity, Blob, Consensus, ExternalError, SeqNo, VersionedData};
+use mz_persist::location::{
+    Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData,
+};
 
 use crate::maelstrom::api::{ErrorCode, MaelstromError};
 use crate::maelstrom::node::Handle;
@@ -192,7 +194,11 @@ impl Blob for MaelstromBlob {
         Ok(Some(value))
     }
 
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+    async fn list_keys_and_metadata(
+        &self,
+        _key_prefix: Option<&str>,
+        _f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+    ) -> Result<(), ExternalError> {
         unimplemented!("not yet used")
     }
 
@@ -262,8 +268,12 @@ impl Blob for CachingBlob {
         Ok(value)
     }
 
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
-        self.blob.list_keys().await
+    async fn list_keys_and_metadata(
+        &self,
+        key_prefix: Option<&str>,
+        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+    ) -> Result<(), ExternalError> {
+        self.blob.list_keys_and_metadata(key_prefix, f).await
     }
 
     async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -33,7 +33,7 @@ use crate::{PersistClient, PersistConfig, PersistLocation};
 #[derive(Debug, Clone)]
 pub struct PersistClientCache {
     pub(crate) cfg: PersistConfig,
-    metrics: Arc<Metrics>,
+    pub(crate) metrics: Arc<Metrics>,
     blob_by_uri: HashMap<String, Arc<dyn Blob + Send + Sync>>,
     consensus_by_uri: HashMap<String, Arc<dyn Consensus + Send + Sync>>,
 }

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -71,21 +71,7 @@ impl PersistClientCache {
             "PersistClientCache::open blob={} consensus={}",
             location.blob_uri, location.consensus_uri,
         );
-        let blob = match self.blob_by_uri.entry(location.blob_uri) {
-            Entry::Occupied(x) => Arc::clone(x.get()),
-            Entry::Vacant(x) => {
-                // Intentionally hold the lock, so we don't double connect under
-                // concurrency.
-                let blob = BlobConfig::try_from(x.key()).await?;
-                let blob = retry_external(&self.metrics.retries.external.blob_open, || {
-                    blob.clone().open()
-                })
-                .await;
-                Arc::clone(x.insert(blob))
-            }
-        };
-        let blob = Arc::new(MetricsBlob::new(blob, Arc::clone(&self.metrics)))
-            as Arc<dyn Blob + Send + Sync>;
+        let blob = self.open_blob(location.blob_uri).await?;
         let consensus = match self.consensus_by_uri.entry(location.consensus_uri) {
             Entry::Occupied(x) => Arc::clone(x.get()),
             Entry::Vacant(x) => {
@@ -103,6 +89,27 @@ impl PersistClientCache {
         let consensus = Arc::new(MetricsConsensus::new(consensus, Arc::clone(&self.metrics)))
             as Arc<dyn Consensus + Send + Sync>;
         PersistClient::new(self.cfg.clone(), blob, consensus, Arc::clone(&self.metrics)).await
+    }
+
+    pub(crate) async fn open_blob(
+        &mut self,
+        blob_uri: String,
+    ) -> Result<Arc<dyn Blob + Send + Sync>, ExternalError> {
+        let blob = match self.blob_by_uri.entry(blob_uri) {
+            Entry::Occupied(x) => Arc::clone(x.get()),
+            Entry::Vacant(x) => {
+                // Intentionally hold the lock, so we don't double connect under
+                // concurrency.
+                let blob = BlobConfig::try_from(x.key()).await?;
+                let blob = retry_external(&self.metrics.retries.external.blob_open, || {
+                    blob.clone().open()
+                })
+                .await;
+                Arc::clone(x.insert(blob))
+            }
+        };
+        Ok(Arc::new(MetricsBlob::new(blob, Arc::clone(&self.metrics)))
+            as Arc<dyn Blob + Send + Sync>)
     }
 }
 

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -248,6 +248,7 @@ impl MetricsVecs {
                 gc_scan: self.retry_metrics("gc::scan"),
                 gc_delete: self.retry_metrics("gc::delete"),
                 gc_truncate: self.retry_metrics("gc::truncate"),
+                storage_usage_shard_size: self.retry_metrics("storage_usage::shard_size"),
             },
             append_batch: self.retry_metrics("append_batch"),
             fetch_batch_part: self.retry_metrics("fetch_batch_part"),
@@ -390,6 +391,7 @@ pub struct RetryExternal {
     pub(crate) gc_scan: RetryMetrics,
     pub(crate) gc_delete: RetryMetrics,
     pub(crate) gc_truncate: RetryMetrics,
+    pub(crate) storage_usage_shard_size: RetryMetrics,
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -655,7 +655,7 @@ impl Blob for MetricsBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         let mut byte_total = 0;

--- a/src/persist-client/src/impl/paths.rs
+++ b/src/persist-client/src/impl/paths.rs
@@ -129,6 +129,28 @@ impl BlobKey {
     }
 }
 
+/// Represents the prefix of a blob path. Used for selecting subsets of blobs
+#[derive(Debug)]
+pub enum BlobKeyPrefix<'a> {
+    /// For accessing all blobs
+    All,
+    /// Scoped to the blobs of an individual shard
+    Shard(&'a ShardId),
+    /// Scoped to the blobs of an individual writer
+    Writer(&'a ShardId, &'a WriterId),
+}
+
+impl std::fmt::Display for BlobKeyPrefix<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            BlobKeyPrefix::All => "".into(),
+            BlobKeyPrefix::Shard(shard) => format!("{}", shard),
+            BlobKeyPrefix::Writer(shard, writer) => format!("{}/{}", shard, writer),
+        };
+        f.write_str(&s)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::r#impl::paths::BlobKey;

--- a/src/persist-client/src/impl/paths.rs
+++ b/src/persist-client/src/impl/paths.rs
@@ -133,10 +133,12 @@ impl BlobKey {
 #[derive(Debug)]
 pub enum BlobKeyPrefix<'a> {
     /// For accessing all blobs
+    #[allow(dead_code)]
     All,
     /// Scoped to the blobs of an individual shard
     Shard(&'a ShardId),
     /// Scoped to the blobs of an individual writer
+    #[allow(dead_code)]
     Writer(&'a ShardId, &'a WriterId),
 }
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -45,6 +45,7 @@ pub mod batch;
 pub mod cache;
 pub mod error;
 pub mod read;
+pub mod usage;
 pub mod write;
 
 pub use crate::r#impl::state::{Since, Upper};

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -48,7 +48,6 @@ pub mod read;
 pub mod usage;
 pub mod write;
 
-pub use crate::r#impl::paths::BlobKeyPrefix;
 pub use crate::r#impl::state::{Since, Upper};
 
 /// An implementation of the public crate interface.

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -48,6 +48,7 @@ pub mod read;
 pub mod usage;
 pub mod write;
 
+pub use crate::r#impl::paths::BlobKeyPrefix;
 pub use crate::r#impl::state::{Since, Upper};
 
 /// An implementation of the public crate interface.

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -44,7 +44,7 @@ impl StorageUsageClient {
         .await
     }
 
-    /// Returns the size (in bytes) of a subset of blobs specified by [crate::r#impl::paths::BlobKeyPrefix]
+    /// Returns the size (in bytes) of a subset of blobs specified by [crate::impl::paths::BlobKeyPrefix]
     ///
     /// Can be safely called within retry_external to ensure it succeeds
     async fn size(&self, prefix: BlobKeyPrefix<'_>) -> Result<u64, ExternalError> {

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -11,10 +11,10 @@
 
 use std::sync::Arc;
 
+use crate::BlobKeyPrefix;
 use mz_persist::location::{Blob, ExternalError};
 
 use crate::cache::PersistClientCache;
-use crate::r#impl::paths::BlobKeyPrefix;
 
 /// Provides access to storage usage metrics for a specific Blob
 #[derive(Debug)]
@@ -32,8 +32,7 @@ impl StorageUsageClient {
         Ok(StorageUsageClient { blob })
     }
 
-    /// Returns the size (in bytes) of a subset of blobs
-    /// specified by [crate::r#impl::paths::BlobKeyPrefix]
+    /// Returns the size (in bytes) of a subset of blobs specified by [crate::BlobKeyPrefix]
     pub async fn size(&self, prefix: BlobKeyPrefix<'_>) -> Result<u64, ExternalError> {
         let mut total_size = 0;
         self.blob

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -41,7 +41,7 @@ impl StorageUsageClient {
     pub async fn shard_size(&self, shard_id: &ShardId) -> Result<u64, ExternalError> {
         let mut total_size = 0;
         self.blob
-            .list_keys_and_metadata(Some(&shard_id.to_string()), &mut |metadata| {
+            .list_keys_and_metadata(&shard_id.to_string(), &mut |metadata| {
                 total_size += metadata.size_in_bytes;
             })
             .await?;

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -1,0 +1,105 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Introspection of storage utilization by persist
+
+use mz_ore::metrics::MetricsRegistry;
+use std::sync::Arc;
+
+use mz_persist::cfg::BlobConfig;
+use mz_persist::location::{Blob, ExternalError};
+
+use crate::{retry_external, Metrics, ShardId};
+
+/// Provides access to storage usage metrics for a specific Blob
+#[derive(Debug)]
+pub struct StorageUsageClient {
+    blob: Arc<dyn Blob + Send + Sync>,
+}
+
+impl StorageUsageClient {
+    /// Creates a new StorageUsageClient pointed to a specific Blob
+    pub async fn open(blob_uri: &str) -> Result<StorageUsageClient, ExternalError> {
+        let blob = BlobConfig::try_from(blob_uri).await?;
+
+        // TODO: what do we want to do about the metrics here?
+        let metrics_registry = MetricsRegistry::new();
+        let metrics = Metrics::new(&metrics_registry);
+        let blob =
+            retry_external(&metrics.retries.external.blob_open, || blob.clone().open()).await;
+
+        Ok(StorageUsageClient { blob })
+    }
+
+    /// Returns the size (in bytes) of a shard's data stored within this Blob
+    pub async fn shard_size(&self, shard_id: &ShardId) -> Result<u64, ExternalError> {
+        let mut total_size = 0;
+        self.blob
+            .list_keys_and_metadata(Some(&shard_id.to_string()), &mut |metadata| {
+                total_size += metadata.size_in_bytes;
+            })
+            .await?;
+        Ok(total_size)
+    }
+
+    #[cfg(test)]
+    fn open_from_blob(blob: Arc<dyn Blob + Send + Sync>) -> StorageUsageClient {
+        StorageUsageClient {
+            blob: Arc::clone(&blob),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::new_test_client;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn shard_size() {
+        mz_ore::test::init_logging();
+
+        let data = vec![
+            (("1".to_owned(), "one".to_owned()), 1, 1),
+            (("2".to_owned(), "two".to_owned()), 2, 1),
+            (("3".to_owned(), "three".to_owned()), 3, 1),
+        ];
+
+        let client = new_test_client().await;
+        let shard_id_one = ShardId::new();
+        let shard_id_two = ShardId::new();
+
+        // write one row into shard 1
+        let (mut write, _) = client
+            .expect_open::<String, String, u64, i64>(shard_id_one)
+            .await;
+        write.expect_append(&data[..1], vec![0], vec![2]).await;
+
+        // write two rows into shard 2
+        let (mut write, _) = client
+            .expect_open::<String, String, u64, i64>(shard_id_two)
+            .await;
+        write.expect_append(&data[1..], vec![0], vec![4]).await;
+
+        let usage = StorageUsageClient::open_from_blob(Arc::clone(&write.blob));
+        let shard_one_size = usage
+            .shard_size(&shard_id_one)
+            .await
+            .expect("must have shard size");
+        let shard_two_size = usage
+            .shard_size(&shard_id_two)
+            .await
+            .expect("must have shard size");
+
+        assert!(shard_one_size > 0);
+        assert!(shard_two_size > 0);
+        assert!(shard_one_size < shard_two_size);
+    }
+}

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -668,15 +668,23 @@ mod tests {
         write.expect_append(&data[..2], vec![0], vec![upper]).await;
 
         // Write a bunch of empty batches. This shouldn't write blobs, so the count should stay the same.
-        let blob_count_before = blob.list_keys().await.expect("list_keys failed").len();
+        let mut count_before = 0;
+        blob.list_keys_and_metadata(None, &mut |_| {
+            count_before += 1;
+        })
+        .await
+        .expect("list_keys failed");
         for _ in 0..5 {
             let new_upper = upper + 1;
             write.expect_compare_and_append(&[], upper, new_upper).await;
             upper = new_upper;
         }
-        assert_eq!(
-            blob.list_keys().await.expect("list_keys failed").len(),
-            blob_count_before
-        );
+        let mut count_after = 0;
+        blob.list_keys_and_metadata(None, &mut |_| {
+            count_after += 1;
+        })
+        .await
+        .expect("list_keys failed");
+        assert_eq!(count_after, count_before);
     }
 }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -669,7 +669,7 @@ mod tests {
 
         // Write a bunch of empty batches. This shouldn't write blobs, so the count should stay the same.
         let mut count_before = 0;
-        blob.list_keys_and_metadata(None, &mut |_| {
+        blob.list_keys_and_metadata("", &mut |_| {
             count_before += 1;
         })
         .await
@@ -680,7 +680,7 @@ mod tests {
             upper = new_upper;
         }
         let mut count_after = 0;
-        blob.list_keys_and_metadata(None, &mut |_| {
+        blob.list_keys_and_metadata("", &mut |_| {
             count_after += 1;
         })
         .await

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -21,7 +21,7 @@ use tokio::fs::{self, File, OpenOptions};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::error::Error;
-use crate::location::{Atomicity, Blob, ExternalError};
+use crate::location::{Atomicity, Blob, BlobMetadata, ExternalError};
 
 /// Configuration for opening a [FileBlob].
 #[derive(Debug, Clone)]
@@ -87,9 +87,12 @@ impl Blob for FileBlob {
         Ok(Some(buf))
     }
 
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+    async fn list_keys_and_metadata(
+        &self,
+        key_prefix: Option<&str>,
+        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+    ) -> Result<(), ExternalError> {
         let base_dir = self.base_dir.canonicalize()?;
-        let mut ret = vec![];
 
         let mut entries = fs::read_dir(&base_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
@@ -117,11 +120,20 @@ impl Blob for FileBlob {
             if let Some(name) = file_name {
                 let name = name.to_str();
                 if let Some(name) = name {
-                    ret.push(FileBlob::restore_forward_slashes(name));
+                    if let Some(prefix) = key_prefix {
+                        if !name.starts_with(prefix) {
+                            continue;
+                        }
+                    }
+
+                    f(BlobMetadata {
+                        key: &FileBlob::restore_forward_slashes(&name),
+                        size_in_bytes: entry.metadata().await?.len(),
+                    });
                 }
             }
         }
-        Ok(ret)
+        Ok(())
     }
 
     async fn set(&self, key: &str, value: Bytes, atomic: Atomicity) -> Result<(), ExternalError> {

--- a/src/persist/src/file.rs
+++ b/src/persist/src/file.rs
@@ -89,7 +89,7 @@ impl Blob for FileBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         let base_dir = self.base_dir.canonicalize()?;
@@ -120,10 +120,8 @@ impl Blob for FileBlob {
             if let Some(name) = file_name {
                 let name = name.to_str();
                 if let Some(name) = name {
-                    if let Some(prefix) = key_prefix {
-                        if !name.starts_with(prefix) {
-                            continue;
-                        }
+                    if !name.starts_with(key_prefix) {
+                        continue;
                     }
 
                     f(BlobMetadata {

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -368,7 +368,7 @@ pub trait Blob: std::fmt::Debug {
     /// given prefix.
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError>;
 

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -337,6 +337,15 @@ pub trait Consensus: std::fmt::Debug {
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<(), ExternalError>;
 }
 
+/// Metadata about a particular blob stored by persist
+#[derive(Debug)]
+pub struct BlobMetadata<'a> {
+    /// The key for the blob
+    pub key: &'a str,
+    /// Size of the blob
+    pub size_in_bytes: u64,
+}
+
 /// An abstraction over read-write access to a `bytes key`->`bytes value` store.
 ///
 /// Implementations are required to be _linearizable_.
@@ -353,8 +362,15 @@ pub trait Blob: std::fmt::Debug {
     /// Returns a reference to the value corresponding to the key.
     async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, ExternalError>;
 
-    /// List all of the keys in the map.
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError>;
+    /// List all of the keys in the map with metadata about the entry.
+    ///
+    /// Can be optionally restricted to only list keys starting with a
+    /// given prefix.
+    async fn list_keys_and_metadata(
+        &self,
+        key_prefix: Option<&str>,
+        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+    ) -> Result<(), ExternalError>;
 
     /// Inserts a key-value pair into the map.
     ///
@@ -376,6 +392,7 @@ pub mod tests {
     use uuid::Uuid;
 
     use crate::location::Atomicity::{AllowNonAtomic, RequireAtomic};
+    use crate::location::Blob;
 
     use super::*;
 
@@ -384,6 +401,23 @@ pub mod tests {
         ret.extend(new.iter().map(|x| x.to_string()));
         ret.sort();
         ret
+    }
+
+    async fn get_keys(b: &impl Blob) -> Result<Vec<String>, ExternalError> {
+        let mut keys = vec![];
+        b.list_keys_and_metadata(None, &mut |entry| keys.push(entry.key.to_string()))
+            .await?;
+        Ok(keys)
+    }
+
+    async fn get_keys_with_prefix(
+        b: &impl Blob,
+        prefix: &str,
+    ) -> Result<Vec<String>, ExternalError> {
+        let mut keys = vec![];
+        b.list_keys_and_metadata(Some(prefix), &mut |entry| keys.push(entry.key.to_string()))
+            .await?;
+        Ok(keys)
     }
 
     pub async fn blob_impl_test<
@@ -410,9 +444,9 @@ pub mod tests {
         assert_eq!(blob1.get(&k0).await?, None);
 
         // Empty list keys is empty.
-        let empty_keys = blob0.list_keys().await?;
+        let empty_keys = get_keys(&blob0).await?;
         assert_eq!(empty_keys, Vec::<String>::new());
-        let empty_keys = blob1.list_keys().await?;
+        let empty_keys = get_keys(&blob1).await?;
         assert_eq!(empty_keys, Vec::<String>::new());
 
         // Set a key with AllowNonAtomic and get it back.
@@ -430,10 +464,10 @@ pub mod tests {
         assert_eq!(blob1.get("k0a").await?, Some(values[0].clone()));
 
         // Blob contains the key we just inserted.
-        let mut blob_keys = blob0.list_keys().await?;
+        let mut blob_keys = get_keys(&blob0).await?;
         blob_keys.sort();
         assert_eq!(blob_keys, keys(&empty_keys, &[&k0, "k0a"]));
-        let mut blob_keys = blob1.list_keys().await?;
+        let mut blob_keys = get_keys(&blob1).await?;
         blob_keys.sort();
         assert_eq!(blob_keys, keys(&empty_keys, &[&k0, "k0a"]));
 
@@ -462,10 +496,10 @@ pub mod tests {
 
         // Empty blob contains no keys.
         blob0.delete("k0a").await?;
-        let mut blob_keys = blob0.list_keys().await?;
+        let mut blob_keys = get_keys(&blob0).await?;
         blob_keys.sort();
         assert_eq!(blob_keys, empty_keys);
-        let mut blob_keys = blob1.list_keys().await?;
+        let mut blob_keys = get_keys(&blob1).await?;
         blob_keys.sort();
         assert_eq!(blob_keys, empty_keys);
         // Can reset a deleted key to some other value.
@@ -487,12 +521,31 @@ pub mod tests {
         }
 
         // Blob contains the key we just inserted.
-        let mut blob_keys = blob0.list_keys().await?;
+        let mut blob_keys = get_keys(&blob0).await?;
         blob_keys.sort();
         assert_eq!(blob_keys, keys(&expected_keys, &[&k0]));
-        let mut blob_keys = blob1.list_keys().await?;
+        let mut blob_keys = get_keys(&blob1).await?;
         blob_keys.sort();
         assert_eq!(blob_keys, keys(&expected_keys, &[&k0]));
+
+        // Insert multiple keys with a different prefix and validate that we can
+        // list out keys by their prefix
+        let mut expected_prefix_keys = vec![];
+        for i in 1..=3 {
+            let key = format!("k-prefix-{}", i);
+            blob0
+                .set(&key, values[0].clone().into(), AllowNonAtomic)
+                .await?;
+            expected_prefix_keys.push(key);
+        }
+        let mut blob_keys = get_keys_with_prefix(&blob0, "k-prefix").await?;
+        blob_keys.sort();
+        assert_eq!(blob_keys, expected_prefix_keys);
+        let mut blob_keys = get_keys_with_prefix(&blob0, "k").await?;
+        blob_keys.sort();
+        expected_keys.extend(expected_prefix_keys);
+        expected_keys.sort();
+        assert_eq!(blob_keys, expected_keys);
 
         // We can open a new blob to the same path and use it.
         let blob3 = new_fn("path0").await?;

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -405,7 +405,7 @@ pub mod tests {
 
     async fn get_keys(b: &impl Blob) -> Result<Vec<String>, ExternalError> {
         let mut keys = vec![];
-        b.list_keys_and_metadata(None, &mut |entry| keys.push(entry.key.to_string()))
+        b.list_keys_and_metadata("", &mut |entry| keys.push(entry.key.to_string()))
             .await?;
         Ok(keys)
     }
@@ -415,7 +415,7 @@ pub mod tests {
         prefix: &str,
     ) -> Result<Vec<String>, ExternalError> {
         let mut keys = vec![];
-        b.list_keys_and_metadata(Some(prefix), &mut |entry| keys.push(entry.key.to_string()))
+        b.list_keys_and_metadata(prefix, &mut |entry| keys.push(entry.key.to_string()))
             .await?;
         Ok(keys)
     }

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -15,6 +15,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::Bytes;
+use mz_ore::cast::CastFrom;
 
 use crate::error::Error;
 use crate::location::{
@@ -83,7 +84,7 @@ impl MemBlobCore {
 
             f(BlobMetadata {
                 key: &key,
-                size_in_bytes: value.len() as u64,
+                size_in_bytes: u64::cast_from(value.len()),
             });
         }
 

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -73,14 +73,12 @@ impl MemBlobCore {
 
     fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         for (key, value) in &self.dataz {
-            if let Some(prefix) = key_prefix {
-                if !key.starts_with(prefix) {
-                    continue;
-                }
+            if !key.starts_with(key_prefix) {
+                continue;
             }
 
             f(BlobMetadata {
@@ -125,7 +123,7 @@ impl Blob for MemBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         self.core.lock().await.list_keys_and_metadata(key_prefix, f)

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -421,11 +421,11 @@ impl Blob for S3Blob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         let mut continuation_token = None;
-        let prefix = self.get_path(key_prefix.unwrap_or(""));
+        let prefix = self.get_path(key_prefix);
 
         loop {
             let resp = self

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -145,7 +145,7 @@ impl Blob for UnreliableBlob {
 
     async fn list_keys_and_metadata(
         &self,
-        key_prefix: Option<&str>,
+        key_prefix: &str,
         f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
     ) -> Result<(), ExternalError> {
         self.handle

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -21,7 +21,7 @@ use rand::{Rng, SeedableRng};
 use tracing::trace;
 
 use crate::location::{
-    Atomicity, Blob, Consensus, Determinate, ExternalError, SeqNo, VersionedData,
+    Atomicity, Blob, BlobMetadata, Consensus, Determinate, ExternalError, SeqNo, VersionedData,
 };
 
 #[derive(Debug)]
@@ -143,9 +143,15 @@ impl Blob for UnreliableBlob {
         self.handle.run_op("get", || self.blob.get(key)).await
     }
 
-    async fn list_keys(&self) -> Result<Vec<String>, ExternalError> {
+    async fn list_keys_and_metadata(
+        &self,
+        key_prefix: Option<&str>,
+        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+    ) -> Result<(), ExternalError> {
         self.handle
-            .run_op("list_keys", || self.blob.list_keys())
+            .run_op("list_keys", || {
+                self.blob.list_keys_and_metadata(key_prefix, f)
+            })
             .await
     }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR adds in a client for https://github.com/MaterializeInc/materialize/pull/13718 so `environmentd` periodically record storage utilization. It introduces a new client within persist whose only job is to provide usage numbers by shard id.

### Motivation

* This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/12868 and https://github.com/MaterializeInc/cloud/issues/1467

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

The commits are mostly separate and can be reviewed separately if that's helpful. The first updates `list_keys` to take in a closure over a blob's key and metadata, the second is the new client to pull down bytes per shard.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A