### PR TITLE
storage: hoist block_on calls from Kafka configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4519,7 +4519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "360bcc8316bf6363aa3954c3ccc4de8add167b087e0259190a043c9514f910fe"
 dependencies = [
  "pathdiff",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]

--- a/src/adapter/src/sink_connection.rs
+++ b/src/adapter/src/sink_connection.rs
@@ -207,7 +207,9 @@ async fn build_kafka(
 ) -> Result<SinkConnection, AdapterError> {
     // Create Kafka topic
     let mut config = create_new_client_config(connection_context.librdkafka_log_level);
-    builder.populate_client_config(&mut config, &*connection_context.secrets_reader);
+    builder
+        .populate_client_config(&mut config, &*connection_context.secrets_reader)
+        .await;
 
     let client: AdminClient<_> = config
         .create_with_context(MzClientContext)

--- a/src/compute/src/sink/kafka.rs
+++ b/src/compute/src/sink/kafka.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
 use differential_dataflow::{AsCollection, Collection, Hashable};
+use futures::executor::block_on;
 use futures::{StreamExt, TryFutureExt};
 use itertools::Itertools;
 use prometheus::core::AtomicU64;
@@ -500,7 +501,9 @@ impl KafkaSinkState {
         connection_context: &ConnectionContext,
     ) -> ClientConfig {
         let mut config = create_new_client_config(connection_context.librdkafka_log_level);
-        connection.populate_client_config(&mut config, &*connection_context.secrets_reader);
+        block_on(
+            connection.populate_client_config(&mut config, &*connection_context.secrets_reader),
+        );
 
         // Ensure that messages are sinked in order and without duplicates. Note that
         // this only applies to a single instance of a producer - in the case of restarts,
@@ -541,7 +544,9 @@ impl KafkaSinkState {
         connection_context: &ConnectionContext,
     ) -> ClientConfig {
         let mut config = create_new_client_config(connection_context.librdkafka_log_level);
-        connection.populate_client_config(&mut config, &*connection_context.secrets_reader);
+        block_on(
+            connection.populate_client_config(&mut config, &*connection_context.secrets_reader),
+        );
 
         config
             .set(

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -230,7 +230,8 @@ pub async fn create_consumer(
         std::collections::HashSet::new(),
         &mut config,
         secrets_reader,
-    );
+    )
+    .await;
 
     // We need this only for logging which broker we're connecting to; the
     // setting itself makes its way into `config`.


### PR DESCRIPTION
I have a suspicion that these `block_on` calls are leading to lost wakeups
when called from within the Tokio executor. This presents as `CREATE
SOURCE` getting wedged.

This commit hoists those `block_on` calls to `storaged` and `computed`,
where Tokio isn't running.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR maybe fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
