### PR TITLE
expr: introduce `Visit*` framework for `HIR` types

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1297,9 +1297,9 @@ impl CollectionPlan for MirRelationExpr {
 }
 
 impl VisitChildren<Self> for MirRelationExpr {
-    fn visit_children<'a, F>(&'a self, mut f: F)
+    fn visit_children<F>(&self, mut f: F)
     where
-        F: FnMut(&'a Self),
+        F: FnMut(&Self),
     {
         use MirRelationExpr::*;
         match self {
@@ -1333,9 +1333,9 @@ impl VisitChildren<Self> for MirRelationExpr {
         }
     }
 
-    fn visit_mut_children<'a, F>(&'a mut self, mut f: F)
+    fn visit_mut_children<F>(&mut self, mut f: F)
     where
-        F: FnMut(&'a mut Self),
+        F: FnMut(&mut Self),
     {
         use MirRelationExpr::*;
         match self {
@@ -1369,9 +1369,9 @@ impl VisitChildren<Self> for MirRelationExpr {
         }
     }
 
-    fn try_visit_children<'a, F, E>(&'a self, mut f: F) -> Result<(), E>
+    fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a Self) -> Result<(), E>,
+        F: FnMut(&Self) -> Result<(), E>,
     {
         use MirRelationExpr::*;
         match self {
@@ -1406,9 +1406,9 @@ impl VisitChildren<Self> for MirRelationExpr {
         Ok(())
     }
 
-    fn try_visit_mut_children<'a, F, E>(&'a mut self, mut f: F) -> Result<(), E>
+    fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a mut Self) -> Result<(), E>,
+        F: FnMut(&mut Self) -> Result<(), E>,
     {
         use MirRelationExpr::*;
         match self {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1372,6 +1372,7 @@ impl VisitChildren<Self> for MirRelationExpr {
     fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirRelationExpr::*;
         match self {
@@ -1409,6 +1410,7 @@ impl VisitChildren<Self> for MirRelationExpr {
     fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&mut Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirRelationExpr::*;
         match self {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1296,7 +1296,7 @@ impl CollectionPlan for MirRelationExpr {
     }
 }
 
-impl VisitChildren for MirRelationExpr {
+impl VisitChildren<Self> for MirRelationExpr {
     fn visit_children<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a Self),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1354,7 +1354,7 @@ impl fmt::Display for MirScalarExpr {
     }
 }
 
-impl VisitChildren for MirScalarExpr {
+impl VisitChildren<Self> for MirScalarExpr {
     fn visit_children<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a Self),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1355,9 +1355,9 @@ impl fmt::Display for MirScalarExpr {
 }
 
 impl VisitChildren<Self> for MirScalarExpr {
-    fn visit_children<'a, F>(&'a self, mut f: F)
+    fn visit_children<F>(&self, mut f: F)
     where
-        F: FnMut(&'a Self),
+        F: FnMut(&Self),
     {
         use MirScalarExpr::*;
         match self {
@@ -1382,9 +1382,9 @@ impl VisitChildren<Self> for MirScalarExpr {
         }
     }
 
-    fn visit_mut_children<'a, F>(&'a mut self, mut f: F)
+    fn visit_mut_children<F>(&mut self, mut f: F)
     where
-        F: FnMut(&'a mut Self),
+        F: FnMut(&mut Self),
     {
         use MirScalarExpr::*;
         match self {
@@ -1409,9 +1409,9 @@ impl VisitChildren<Self> for MirScalarExpr {
         }
     }
 
-    fn try_visit_children<'a, F, E>(&'a self, mut f: F) -> Result<(), E>
+    fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a Self) -> Result<(), E>,
+        F: FnMut(&Self) -> Result<(), E>,
     {
         use MirScalarExpr::*;
         match self {
@@ -1437,9 +1437,9 @@ impl VisitChildren<Self> for MirScalarExpr {
         Ok(())
     }
 
-    fn try_visit_mut_children<'a, F, E>(&'a mut self, mut f: F) -> Result<(), E>
+    fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a mut Self) -> Result<(), E>,
+        F: FnMut(&mut Self) -> Result<(), E>,
     {
         use MirScalarExpr::*;
         match self {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::mem;
 
+use mz_ore::stack::RecursionLimitError;
 use mz_proto::IntoRustIfSome;
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -1412,6 +1413,7 @@ impl VisitChildren<Self> for MirScalarExpr {
     fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirScalarExpr::*;
         match self {
@@ -1440,6 +1442,7 @@ impl VisitChildren<Self> for MirScalarExpr {
     fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&mut Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirScalarExpr::*;
         match self {

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -54,14 +54,26 @@ pub trait VisitChildren<T> {
         F: FnMut(&mut T);
 
     /// Apply a fallible immutable function `f` to each direct child.
+    ///
+    /// For mutually recursive implementations (say consisting of two
+    /// types `A` and `B`), recursing through `B` in order to find all
+    /// `A`-children of a node of type `A` might cause lead to a
+    /// [`RecursionLimitError`], hence the bound on `E`.
     fn try_visit_children<F, E>(&self, f: F) -> Result<(), E>
     where
-        F: FnMut(&T) -> Result<(), E>;
+        F: FnMut(&T) -> Result<(), E>,
+        E: From<RecursionLimitError>;
 
     /// Apply a fallible mutable function `f` to each direct child.
+    ///
+    /// For mutually recursive implementations (say consisting of two
+    /// types `A` and `B`), recursing through `B` in order to find all
+    /// `A`-children of a node of type `A` might cause lead to a
+    /// [`RecursionLimitError`], hence the bound on `E`.
     fn try_visit_mut_children<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: FnMut(&mut T) -> Result<(), E>;
+        F: FnMut(&mut T) -> Result<(), E>,
+        E: From<RecursionLimitError>;
 }
 
 /// A trait for types that can recursively visit their children of the

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -42,6 +42,15 @@ use crate::RECURSION_LIMIT;
 ///
 /// Implementing [`VisitChildren<Self>`] automatically also implements
 /// the [`Visit`] trait, which enables recursive traversal.
+///
+/// Note that care needs to be taken when implementing this trait for
+/// mutually recursive types (such as a type A where A has children
+/// of type B and vice versa). More specifically, at the moment it is
+/// not possible to implement versions of `VisitChildren<A> for A` such
+/// that A considers as its children all A-nodes occurring at leaf
+/// positions of B-children and vice versa for `VisitChildren<B> for B`.
+/// Doing this will result in recusion limit violations as indicated
+/// in the accompanying `test_recursive_types_b` test.
 pub trait VisitChildren<T> {
     /// Apply an infallible immutable function `f` to each direct child.
     fn visit_children<F>(&self, f: F)
@@ -573,5 +582,415 @@ impl<T: VisitChildren<T>> Visitor<T> {
             }
             post(value);
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum A {
+        Add(Box<A>, Box<A>),
+        Lit(u64),
+        FrB(Box<B>),
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum B {
+        Mul(Box<B>, Box<B>),
+        Lit(u64),
+        FrA(Box<A>),
+    }
+
+    impl VisitChildren<A> for A {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&A),
+        {
+            VisitChildren::visit_children(self, |expr: &B| {
+                #[allow(deprecated)]
+                Visit::visit_post_nolimit(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_ref()),
+                    _ => (),
+                });
+            });
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut A),
+        {
+            VisitChildren::visit_mut_children(self, |expr: &mut B| {
+                #[allow(deprecated)]
+                Visit::visit_mut_post_nolimit(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_mut()),
+                    _ => (),
+                });
+            });
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            VisitChildren::try_visit_children(self, |expr: &B| {
+                Visit::try_visit_post(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_ref()),
+                    _ => Ok(()),
+                })
+            })?;
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+            Ok(())
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            VisitChildren::try_visit_mut_children(self, |expr: &mut B| {
+                Visit::try_visit_mut_post(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_mut()),
+                    _ => Ok(()),
+                })
+            })?;
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+            Ok(())
+        }
+    }
+
+    impl VisitChildren<B> for A {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&B),
+        {
+            match self {
+                A::Add(_, _) => (),
+                A::Lit(_) => (),
+                A::FrB(expr) => f(expr),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut B),
+        {
+            match self {
+                A::Add(_, _) => (),
+                A::Lit(_) => (),
+                A::FrB(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                A::Add(_, _) => Ok(()),
+                A::Lit(_) => Ok(()),
+                A::FrB(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                A::Add(_, _) => Ok(()),
+                A::Lit(_) => Ok(()),
+                A::FrB(expr) => f(expr),
+            }
+        }
+    }
+
+    impl VisitChildren<B> for B {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&B),
+        {
+            // VisitChildren::visit_children(self, |expr: &A| {
+            //     #[allow(deprecated)]
+            //     Visit::visit_post_nolimit(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_ref()),
+            //         _ => (),
+            //     });
+            // });
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut B),
+        {
+            // VisitChildren::visit_mut_children(self, |expr: &mut A| {
+            //     #[allow(deprecated)]
+            //     Visit::visit_mut_post_nolimit(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_mut()),
+            //         _ => (),
+            //     });
+            // });
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            // VisitChildren::try_visit_children(self, |expr: &A| {
+            //     Visit::try_visit_post(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_ref()),
+            //         _ => Ok(()),
+            //     })
+            // })?;
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+            Ok(())
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            // VisitChildren::try_visit_mut_children(self, |expr: &mut A| {
+            //     Visit::try_visit_mut_post(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_mut()),
+            //         _ => Ok(()),
+            //     })
+            // })?;
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+            Ok(())
+        }
+    }
+
+    impl VisitChildren<A> for B {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&A),
+        {
+            match self {
+                B::Mul(_, _) => (),
+                B::Lit(_) => (),
+                B::FrA(expr) => f(expr),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut A),
+        {
+            match self {
+                B::Mul(_, _) => (),
+                B::Lit(_) => (),
+                B::FrA(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                B::Mul(_, _) => Ok(()),
+                B::Lit(_) => Ok(()),
+                B::FrA(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                B::Mul(_, _) => Ok(()),
+                B::Lit(_) => Ok(()),
+                B::FrA(expr) => f(expr),
+            }
+        }
+    }
+
+    /// x + (y + z)
+    fn test_term_a(x: A, y: A, z: A) -> A {
+        let x = Box::new(x);
+        let y = Box::new(y);
+        let z = Box::new(z);
+        A::Add(x, Box::new(A::Add(y, z)))
+    }
+
+    /// u + (v + w)
+    fn test_term_b(u: B, v: B, w: B) -> B {
+        let u = Box::new(u);
+        let v = Box::new(v);
+        let w = Box::new(w);
+        B::Mul(u, Box::new(B::Mul(v, w)))
+    }
+
+    fn a_to_b(x: A) -> B {
+        B::FrA(Box::new(x))
+    }
+
+    fn b_to_a(x: B) -> A {
+        A::FrB(Box::new(x))
+    }
+
+    fn test_term_rec_b(b: u64) -> B {
+        test_term_b(
+            a_to_b(test_term_a(
+                b_to_a(test_term_b(B::Lit(b + 11), B::Lit(b + 12), B::Lit(b + 13))),
+                b_to_a(test_term_b(B::Lit(b + 14), B::Lit(b + 15), B::Lit(b + 16))),
+                b_to_a(test_term_b(B::Lit(b + 17), B::Lit(b + 18), B::Lit(b + 19))),
+            )),
+            a_to_b(test_term_a(
+                b_to_a(test_term_b(B::Lit(b + 21), B::Lit(b + 22), B::Lit(b + 23))),
+                b_to_a(test_term_b(B::Lit(b + 24), B::Lit(b + 25), B::Lit(b + 26))),
+                b_to_a(test_term_b(B::Lit(b + 27), B::Lit(b + 28), B::Lit(b + 29))),
+            )),
+            a_to_b(test_term_a(
+                b_to_a(test_term_b(B::Lit(b + 31), B::Lit(b + 32), B::Lit(b + 33))),
+                b_to_a(test_term_b(B::Lit(b + 34), B::Lit(b + 35), B::Lit(b + 36))),
+                b_to_a(test_term_b(B::Lit(b + 37), B::Lit(b + 38), B::Lit(b + 39))),
+            )),
+        )
+    }
+
+    fn test_term_rec_a(b: u64) -> A {
+        test_term_a(
+            b_to_a(test_term_b(
+                a_to_b(test_term_a(A::Lit(b + 11), A::Lit(b + 12), A::Lit(b + 13))),
+                a_to_b(test_term_a(A::Lit(b + 14), A::Lit(b + 15), A::Lit(b + 16))),
+                a_to_b(test_term_a(A::Lit(b + 17), A::Lit(b + 18), A::Lit(b + 19))),
+            )),
+            b_to_a(test_term_b(
+                a_to_b(test_term_a(A::Lit(b + 21), A::Lit(b + 22), A::Lit(b + 23))),
+                a_to_b(test_term_a(A::Lit(b + 24), A::Lit(b + 25), A::Lit(b + 26))),
+                a_to_b(test_term_a(A::Lit(b + 27), A::Lit(b + 28), A::Lit(b + 29))),
+            )),
+            b_to_a(test_term_b(
+                a_to_b(test_term_a(A::Lit(b + 31), A::Lit(b + 32), A::Lit(b + 33))),
+                a_to_b(test_term_a(A::Lit(b + 34), A::Lit(b + 35), A::Lit(b + 36))),
+                a_to_b(test_term_a(A::Lit(b + 37), A::Lit(b + 38), A::Lit(b + 39))),
+            )),
+        )
+    }
+
+    #[test]
+    fn test_recursive_types_a() {
+        let mut act = test_term_rec_a(0);
+        let exp = test_term_rec_a(20);
+
+        let res = act.visit_mut_pre(&mut |expr| match expr {
+            A::Lit(x) => *x = *x + 20,
+            _ => (),
+        });
+
+        assert!(res.is_ok());
+        assert_eq!(act, exp);
+    }
+
+    /// This test currently fails with the following error:
+    ///
+    ///   reached the recursion limit while instantiating
+    ///   `<visit::Visitor<B> as CheckedRec...ore::stack::RecursionLimitError>`
+    ///
+    /// The problem (I think) is in the fact that the lambdas passed in the
+    /// VisitChildren<A> for A and the VisitChildren<B> for B definitions end
+    /// up in an infinite loop.
+    ///
+    /// More specifically, we run into the following cycle:
+    ///
+    /// - `<A as VisitChildren<A>>::visit_children`
+    ///   - <A as VisitChildren<B>>::visit_children`
+    ///     - <B as Visit>::visit_post_nolimit`
+    ///       - <B as VisitChildren<B>>::visit_children`
+    ///         - <B as VisitChildren<A>>::visit_children`
+    ///           - <A as Visit>::visit_post_nolimit`
+    ///             - <A as VisitChildren<A>>::visit_children`
+    #[test]
+    #[ignore = "making the VisitChildren definitions symmetric breaks the compiler"]
+    fn test_recursive_types_b() {
+        let mut act = test_term_rec_b(0);
+        let exp = test_term_rec_b(30);
+
+        let res = act.visit_mut_pre(&mut |expr| match expr {
+            B::Lit(x) => *x = *x + 30,
+            _ => (),
+        });
+
+        assert!(res.is_ok());
+        assert_eq!(act, exp);
     }
 }

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -44,28 +44,24 @@ use crate::RECURSION_LIMIT;
 /// the [`Visit`] trait, which enables recursive traversal.
 pub trait VisitChildren<T> {
     /// Apply an infallible immutable function `f` to each direct child.
-    fn visit_children<'a, F>(&'a self, f: F)
+    fn visit_children<F>(&self, f: F)
     where
-        T: 'a,
-        F: FnMut(&'a T);
+        F: FnMut(&T);
 
     /// Apply an infallible mutable function `f` to each direct child.
-    fn visit_mut_children<'a, F>(&'a mut self, f: F)
+    fn visit_mut_children<F>(&mut self, f: F)
     where
-        T: 'a,
-        F: FnMut(&'a mut T);
+        F: FnMut(&mut T);
 
     /// Apply a fallible immutable function `f` to each direct child.
-    fn try_visit_children<'a, F, E>(&'a self, f: F) -> Result<(), E>
+    fn try_visit_children<F, E>(&self, f: F) -> Result<(), E>
     where
-        T: 'a,
-        F: FnMut(&'a T) -> Result<(), E>;
+        F: FnMut(&T) -> Result<(), E>;
 
     /// Apply a fallible mutable function `f` to each direct child.
-    fn try_visit_mut_children<'a, F, E>(&'a mut self, f: F) -> Result<(), E>
+    fn try_visit_mut_children<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        T: 'a,
-        F: FnMut(&'a mut T) -> Result<(), E>;
+        F: FnMut(&mut T) -> Result<(), E>;
 }
 
 /// A trait for types that can recursively visit their children of the

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -65,7 +65,7 @@ pub(crate) mod transform_expr;
 pub(crate) mod typeconv;
 pub(crate) mod with_options;
 
-pub use self::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
+pub use self::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
 pub use error::PlanError;
 pub use explain::Explanation;
 use mz_sql_parser::ast::TransactionIsolationLevel;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1479,6 +1479,26 @@ impl HirScalarExpr {
         Ok(HirScalarExpr::Literal(row, scalar_type))
     }
 
+    pub fn as_literal(&self) -> Option<Datum> {
+        if let HirScalarExpr::Literal(row, _column_type) = self {
+            Some(row.unpack_first())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_literal_true(&self) -> bool {
+        Some(Datum::True) == self.as_literal()
+    }
+
+    pub fn is_literal_false(&self) -> bool {
+        Some(Datum::False) == self.as_literal()
+    }
+
+    pub fn is_literal_null(&self) -> bool {
+        Some(Datum::Null) == self.as_literal()
+    }
+
     pub fn call_unary(self, func: UnaryFunc) -> Self {
         HirScalarExpr::CallUnary {
             func,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -182,6 +182,7 @@ impl WindowExpr {
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.func.visit_expressions(f)?;
         for expr in self.partition.iter() {
             f(expr)?;
@@ -196,6 +197,7 @@ impl WindowExpr {
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.func.visit_expressions_mut(f)?;
         for expr in self.partition.iter_mut() {
             f(expr)?;
@@ -286,20 +288,24 @@ pub enum WindowExprType {
 }
 
 impl WindowExprType {
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_children` instead."]
     pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         match self {
             Self::Scalar(expr) => expr.visit_expressions(f),
             Self::Value(expr) => expr.visit_expressions(f),
         }
     }
 
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_mut_children` instead."]
     pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         match self {
             Self::Scalar(expr) => expr.visit_expressions_mut(f),
             Self::Value(expr) => expr.visit_expressions_mut(f),
@@ -370,6 +376,7 @@ pub struct ScalarWindowExpr {
 }
 
 impl ScalarWindowExpr {
+    #[deprecated = "Implement `VisitChildren<HirScalarExpr>` if needed."]
     pub fn visit_expressions<'a, F, E>(&'a self, _f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
@@ -381,6 +388,7 @@ impl ScalarWindowExpr {
         Ok(())
     }
 
+    #[deprecated = "Implement `VisitChildren<HirScalarExpr>` if needed."]
     pub fn visit_expressions_mut<'a, F, E>(&'a mut self, _f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
@@ -438,6 +446,7 @@ pub struct ValueWindowExpr {
 }
 
 impl ValueWindowExpr {
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_children` instead."]
     pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
@@ -445,6 +454,7 @@ impl ValueWindowExpr {
         f(&self.expr)
     }
 
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_mut_children` instead."]
     pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
@@ -1047,6 +1057,7 @@ impl HirRelationExpr {
     /// direct parent scope.
     pub fn is_correlated(&self) -> bool {
         let mut correlated = false;
+        #[allow(deprecated)]
         self.visit_columns(0, &mut |depth, col| {
             if col.level > depth && col.level - depth == 1 {
                 correlated = true;
@@ -1176,6 +1187,7 @@ impl HirRelationExpr {
             // The join can be elided, but we need to adjust column references
             // on the right-hand side to account for the removal of the scope
             // introduced by the join.
+            #[allow(deprecated)]
             right.visit_columns_mut(0, &mut |depth, col| {
                 if col.level > depth {
                     col.level -= 1;
@@ -1204,10 +1216,12 @@ impl HirRelationExpr {
         )
     }
 
+    #[deprecated = "Use `Visit::visit_post`."]
     pub fn visit<'a, F>(&'a self, depth: usize, f: &mut F)
     where
         F: FnMut(&'a Self, usize),
     {
+        #[allow(deprecated)]
         let _ = self.visit_fallible(depth, &mut |e: &HirRelationExpr,
                                                  depth: usize|
          -> Result<(), ()> {
@@ -1216,16 +1230,19 @@ impl HirRelationExpr {
         });
     }
 
+    #[deprecated = "Use `Visit::try_visit_post`."]
     pub fn visit_fallible<'a, F, E>(&'a self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a Self, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit1(depth, |e: &HirRelationExpr, depth: usize| {
             e.visit_fallible(depth, f)
         })?;
         f(self, depth)
     }
 
+    #[deprecated = "Use `VisitChildren<HirRelationExpr>::try_visit_children` instead."]
     pub fn visit1<'a, F, E>(&'a self, depth: usize, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a Self, usize) -> Result<(), E>,
@@ -1276,10 +1293,12 @@ impl HirRelationExpr {
         Ok(())
     }
 
+    #[deprecated = "Use `Visit::visit_mut_post` instead."]
     pub fn visit_mut<F>(&mut self, depth: usize, f: &mut F)
     where
         F: FnMut(&mut Self, usize),
     {
+        #[allow(deprecated)]
         let _ = self.visit_mut_fallible(depth, &mut |e: &mut HirRelationExpr,
                                                      depth: usize|
          -> Result<(), ()> {
@@ -1288,16 +1307,19 @@ impl HirRelationExpr {
         });
     }
 
+    #[deprecated = "Use `Visit::try_visit_mut_post` instead."]
     pub fn visit_mut_fallible<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut Self, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit1_mut(depth, |e: &mut HirRelationExpr, depth: usize| {
             e.visit_mut_fallible(depth, f)
         })?;
         f(self, depth)
     }
 
+    #[deprecated = "Use `VisitChildren<HirRelationExpr>::try_visit_mut_children` instead."]
     pub fn visit1_mut<'a, F, E>(&'a mut self, depth: usize, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a mut Self, usize) -> Result<(), E>,
@@ -1348,6 +1370,7 @@ impl HirRelationExpr {
         Ok(())
     }
 
+    #[deprecated = "Use a combination of `Visit` and `VisitChildren` methods."]
     /// Visits all scalar expressions within the sub-tree of the given relation.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
@@ -1357,6 +1380,7 @@ impl HirRelationExpr {
     where
         F: FnMut(&HirScalarExpr, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit_fallible(depth, &mut |e: &HirRelationExpr,
                                          depth: usize|
          -> Result<(), E> {
@@ -1398,11 +1422,13 @@ impl HirRelationExpr {
         })
     }
 
+    #[deprecated = "Use a combination of `Visit` and `VisitChildren` methods."]
     /// Like `visit_scalar_expressions`, but permits mutating the expressions.
     pub fn visit_scalar_expressions_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut HirScalarExpr, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit_mut_fallible(depth, &mut |e: &mut HirRelationExpr,
                                              depth: usize|
          -> Result<(), E> {
@@ -1444,6 +1470,7 @@ impl HirRelationExpr {
         })
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Visits the column references in this relation expression.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
@@ -1453,6 +1480,7 @@ impl HirRelationExpr {
     where
         F: FnMut(usize, &ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_scalar_expressions(depth, &mut |e: &HirScalarExpr,
                                                            depth: usize|
          -> Result<(), ()> {
@@ -1461,11 +1489,13 @@ impl HirRelationExpr {
         });
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit_columns`, but permits mutating the column references.
     pub fn visit_columns_mut<F>(&mut self, depth: usize, f: &mut F)
     where
         F: FnMut(usize, &mut ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_scalar_expressions_mut(depth, &mut |e: &mut HirScalarExpr,
                                                                depth: usize|
          -> Result<(), ()> {
@@ -1477,6 +1507,7 @@ impl HirRelationExpr {
     /// Replaces any parameter references in the expression with the
     /// corresponding datum from `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), PlanError> {
+        #[allow(deprecated)]
         self.visit_scalar_expressions_mut(0, &mut |e: &mut HirScalarExpr, _: usize| {
             e.bind_parameters(params)
         })
@@ -1484,6 +1515,7 @@ impl HirRelationExpr {
 
     /// See the documentation for [`HirScalarExpr::splice_parameters`].
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
+        #[allow(deprecated)]
         let _ = self.visit_scalar_expressions_mut(depth, &mut |e: &mut HirScalarExpr,
                                                                depth: usize|
          -> Result<(), ()> {
@@ -2105,6 +2137,7 @@ impl HirScalarExpr {
     /// Replaces any parameter references in the expression with the
     /// corresponding datum in `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), PlanError> {
+        #[allow(deprecated)]
         self.visit_recursively_mut(0, &mut |_: usize, e: &mut HirScalarExpr| {
             if let HirScalarExpr::Parameter(n) = e {
                 let datum = match params.datums.iter().nth(*n - 1) {
@@ -2131,6 +2164,7 @@ impl HirScalarExpr {
     /// Column references in parameters will be corrected to account for the
     /// depth at which they are spliced.
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
+        #[allow(deprecated)]
         let _ = self.visit_recursively_mut(depth, &mut |depth: usize,
                                                         e: &mut HirScalarExpr|
          -> Result<(), ()> {
@@ -2273,22 +2307,27 @@ impl HirScalarExpr {
         }
     }
 
+    #[deprecated = "Use `Visit::visit_post` instead."]
     pub fn visit_mut<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self),
     {
+        #[allow(deprecated)]
         self.visit1_mut(|e: &mut HirScalarExpr| e.visit_mut(f));
         f(self);
     }
 
+    #[deprecated = "Use `Visit::visit_mut_pre` instead."]
     pub fn visit_mut_pre<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self),
     {
         f(self);
+        #[allow(deprecated)]
         self.visit1_mut(|e: &mut HirScalarExpr| e.visit_mut(f));
     }
 
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_children` instead."]
     pub fn visit1_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Self),
@@ -2321,6 +2360,7 @@ impl HirScalarExpr {
         }
     }
 
+    #[deprecated = "Use `Visit::visit_pre_post` instead."]
     /// A generalization of `visit`. The function `pre` runs on a
     /// `HirScalarExpr` before it runs on any of the child `HirScalarExpr`s.
     /// The function `post` runs on child `HirScalarExpr`s first before the
@@ -2342,6 +2382,7 @@ impl HirScalarExpr {
         post(self);
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Visits the column references in this scalar expression.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
@@ -2351,6 +2392,7 @@ impl HirScalarExpr {
     where
         F: FnMut(usize, &ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_recursively(depth, &mut |depth: usize,
                                                     e: &HirScalarExpr|
          -> Result<(), ()> {
@@ -2361,11 +2403,13 @@ impl HirScalarExpr {
         });
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit_columns`, but permits mutating the column references.
     pub fn visit_columns_mut<F>(&mut self, depth: usize, f: &mut F)
     where
         F: FnMut(usize, &mut ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_recursively_mut(depth, &mut |depth: usize,
                                                         e: &mut HirScalarExpr|
          -> Result<(), ()> {
@@ -2376,6 +2420,7 @@ impl HirScalarExpr {
         });
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit` but it enters the subqueries visiting the scalar expressions contained
     /// in them. It takes the current depth of the expression and increases it when
     /// entering a subquery.
@@ -2404,6 +2449,7 @@ impl HirScalarExpr {
                 els.visit_recursively(depth, f)?;
             }
             HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
+                #[allow(deprecated)]
                 expr.visit_scalar_expressions(depth + 1, &mut |e, depth| {
                     e.visit_recursively(depth, f)
                 })?;
@@ -2415,6 +2461,7 @@ impl HirScalarExpr {
         f(depth, self)
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit_recursively`, but permits mutating the scalar expressions.
     pub fn visit_recursively_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
@@ -2441,6 +2488,7 @@ impl HirScalarExpr {
                 els.visit_recursively_mut(depth, f)?;
             }
             HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
+                #[allow(deprecated)]
                 expr.visit_scalar_expressions_mut(depth + 1, &mut |e, depth| {
                     e.visit_recursively_mut(depth, f)
                 })?;

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -319,6 +319,7 @@ impl HirRelationExpr {
                             .iter_mut()
                             .position(|s| {
                                 let mut requires_nonexistent_column = false;
+                                #[allow(deprecated)]
                                 s.visit_columns(0, &mut |depth, col| {
                                     if col.level == depth {
                                         requires_nonexistent_column |= (col.column + 1) > old_arity
@@ -1284,6 +1285,7 @@ impl HirScalarExpr {
             let mut subqueries = Vec::new();
             let distinct_inner = get_inner.clone().distinct();
             for expr in exprs.iter() {
+                #[allow(deprecated)]
                 expr.visit_pre_post(
                     &mut |e| match e {
                         // For simplicity, subqueries within a conditional statement will be
@@ -1484,6 +1486,7 @@ where
     // detecting the moment of decorrelation in the optimizer right now is too
     // hard.
     let mut is_simple = true;
+    #[allow(deprecated)]
     inner.visit(0, &mut |expr, _| match expr {
         HirRelationExpr::Constant { .. }
         | HirRelationExpr::Project { .. }
@@ -1508,6 +1511,7 @@ where
     // each outer column, according to the passed-in `col_map`, and
     // `new_col_map` maps each outer column to its new ordinal position in key.
     let mut outer_cols = BTreeSet::new();
+    #[allow(deprecated)]
     inner.visit_columns(0, &mut |depth, col| {
         // Test if the column reference escapes the subquery.
         if col.level > depth {
@@ -1519,6 +1523,7 @@ where
     });
     // Collect all the outer columns referenced by any CTE referenced by
     // the inner relation.
+    #[allow(deprecated)]
     inner.visit(0, &mut |e, _| match e {
         HirRelationExpr::Get {
             id: mz_expr::Id::Local(id),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -713,6 +713,7 @@ fn handle_mutation_using_clause(
         // those to the right of `using_rel_expr`) to instead be correlated to
         // the outer relation, i.e. `get`.
         let using_rel_arity = qcx.relation_type(&using_rel_expr).arity();
+        #[allow(deprecated)]
         expr.visit_mut(&mut |e| {
             if let HirScalarExpr::Column(c) = e {
                 if c.column >= using_rel_arity {
@@ -3908,6 +3909,7 @@ fn plan_aggregate(
 
     let mut seen_outer = false;
     let mut seen_inner = false;
+    #[allow(deprecated)]
     expr.visit_columns(0, &mut |depth, col| {
         if depth == 0 && col.level == 0 {
             seen_inner = true;

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -53,6 +53,7 @@ use crate::plan::expr::{
 /// subquery, especially when the original conjunction contains join keys.
 pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
     fn walk_relation(expr: &mut HirRelationExpr) {
+        #[allow(deprecated)]
         expr.visit_mut(0, &mut |expr, _| match expr {
             HirRelationExpr::Map { scalars, .. } => {
                 for scalar in scalars {
@@ -84,6 +85,7 @@ pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
     }
 
     fn walk_scalar(expr: &mut HirScalarExpr) {
+        #[allow(deprecated)]
         expr.visit_mut(&mut |expr| match expr {
             HirScalarExpr::Exists(input) | HirScalarExpr::Select(input) => walk_relation(input),
             _ => (),
@@ -191,6 +193,7 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
                 walk_relation(right, &outers);
             }
             expr => {
+                #[allow(deprecated)]
                 let _ = expr.visit1_mut(0, &mut |expr, _| -> Result<(), ()> {
                     walk_relation(expr, outers);
                     Ok(())
@@ -200,6 +203,7 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
     }
 
     fn walk_scalar(expr: &mut HirScalarExpr, outers: &[RelationType], mut in_filter: bool) {
+        #[allow(deprecated)]
         expr.visit_mut_pre(&mut |e| match e {
             HirScalarExpr::Exists(input) => walk_relation(input, outers),
             HirScalarExpr::Select(input) => {

--- a/src/sql/src/query_model/hir/qgm_from_hir.rs
+++ b/src/sql/src/query_model/hir/qgm_from_hir.rs
@@ -157,6 +157,7 @@ impl FromHir {
                         .iter_mut()
                         .position(|s| {
                             let mut requires_nonexistent_column = false;
+                            #[allow(deprecated)]
                             s.visit_columns(0, &mut |depth, col| {
                                 if col.level == depth {
                                     requires_nonexistent_column |= (col.column + 1) > old_arity

--- a/src/transform/src/cse/relation_cse.rs
+++ b/src/transform/src/cse/relation_cse.rs
@@ -112,7 +112,7 @@ impl Bindings {
 
                 _ => {
                     // All other expressions just need to apply the logic recursively.
-                    relation.try_visit_mut_children(&mut |expr| this.intern_expression(expr))?;
+                    relation.try_visit_mut_children(|expr| this.intern_expression(expr))?;
                 }
             };
 

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -87,7 +87,7 @@ impl UpdateLet {
                     }
                     Ok(())
                 }
-                _ => relation.try_visit_mut_children(&mut |e| self.action(e, remap, id_gen)),
+                _ => relation.try_visit_mut_children(|e| self.action(e, remap, id_gen)),
             }
         })
     }


### PR DESCRIPTION
Continues a line of work started with #9396 and continued with #11922 and #13590 by achieving the following goals:

1. Generalize `VisitChildren` to `VisitChildren<T>`  so we can have multiple implementations per `Self` type (one for each children type.
2. Implements `VisitChildren<T>` for all `HIR` types. This is unblocked by the above refactoring, as we now can use the framework for mutually recursive data types such as `Hir` where `HirRelationExpr` contains children of type `HirScalarExpr` and vice versa.
3. Deprecates current `fn visit_` methods appearing in all `HIR` types.

### Motivation

  * This PR adds a feature that has not yet been specified.

We want to increase the level of consistency and the alignment between naming and implementation patterns across all internal IRs. Currently, we use the `Visit*` framework only in `MIR`, and with this we can also use it in `HIR`.

### Tips for reviewer

- See commit messages for details.
- Somewhat surprisingly for me, I had to do the refactor in fcd2daddd9705ec91b0b59115bb7b032b31be0b7 to make things work in the implementation.
- Observe that the implementation of `VisitChildren<HirRelationExpr> for HirRelationExpr` now piggy-backs on `VisitChildren<HirScalarExpr> for HirRelationExpr` in order to also visit subqueries. 
- I think that doing the above is a somewhat hard constraint in the sense that it can be done only for one type `Ti` from a family of mutually dependent types `T1, ..., Tn`. I will add a test tomorrow, and if so, I will also put some explanation in the `visit.rs` module docs.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes
