### PR TITLE
expr: show subqueries in HIR `EXPLAIN ... AS TEXT` output

### DIFF
--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -417,7 +417,10 @@ impl From<EvalError> for AdapterError {
 
 impl From<ExplainError> for AdapterError {
     fn from(e: ExplainError) -> AdapterError {
-        AdapterError::Explain(e)
+        match e {
+            ExplainError::RecursionLimitError(e) => AdapterError::RecursionLimit(e),
+            e => AdapterError::Explain(e),
+        }
     }
 }
 

--- a/src/adapter/src/explain_new/hir/mod.rs
+++ b/src/adapter/src/explain_new/hir/mod.rs
@@ -11,8 +11,16 @@
 
 pub(crate) mod text;
 
-use mz_repr::explain_new::{Explain, ExplainConfig, ExplainError, UnsupportedFormat};
-use mz_sql::plan::HirRelationExpr;
+use mz_expr::{
+    visit::{Visit, VisitChildren},
+    Id, LocalId,
+};
+use mz_ore::stack::RecursionLimitError;
+use mz_repr::{
+    explain_new::{Explain, ExplainConfig, ExplainError, UnsupportedFormat},
+    RelationType,
+};
+use mz_sql::plan::{HirRelationExpr, HirScalarExpr};
 
 use super::{AnnotatedPlan, ExplainContext, ExplainSinglePlan, Explainable};
 
@@ -31,6 +39,9 @@ impl<'a> Explain<'a> for Explainable<'a, HirRelationExpr> {
         config: &'a ExplainConfig,
         context: &'a Self::Context,
     ) -> Result<Self::Text, ExplainError> {
+        // ensure that all nested subqueries are wrapped in Let blocks
+        normalize_subqueries(self.0)?;
+
         // TODO: use config values to infer requested
         // plan annotations
         let plan = AnnotatedPlan {
@@ -39,4 +50,99 @@ impl<'a> Explain<'a> for Explainable<'a, HirRelationExpr> {
         };
         Ok(ExplainSinglePlan { context, plan })
     }
+}
+
+/// Normalize the way subqueries appear in [`HirScalarExpr::Exists`]
+/// or [`HirScalarExpr::Select`] variants.
+///
+/// After the transform is applied, subqueries are pulled as a value in
+/// a let binding enclosing the [`HirRelationExpr`] parent of the
+/// [`HirScalarExpr::Exists`] or [`HirScalarExpr::Select`] where the
+/// subquery appears, and the corresponding variant references the
+/// new binding with a [`HirRelationExpr::Get`].
+fn normalize_subqueries<'a>(expr: &'a mut HirRelationExpr) -> Result<(), RecursionLimitError> {
+    // A helper struct to represent accumulated `$local_id = $subquery`
+    // bindings that need to be installed in `let ... in $expr` nodes
+    // that wrap their parent $expr.
+    struct Binding {
+        local_id: LocalId,
+        subquery: HirRelationExpr,
+    }
+
+    // Context for the transformation
+    // - a stack of bindings
+    let mut bindings = Vec::<Binding>::new();
+    // - a generator of fresh local ids
+    let mut id_gen = id_gen(expr)?.peekable();
+
+    // Grow the `bindings` stack by collecting subqueries appearing in
+    // one of the HirScalarExpr children at the given HirRelationExpr.
+    // As part of this, the subquery is replaced by a `Get(id)` for a
+    // fresh local id.
+    let mut collect_subqueries = |expr: &mut HirRelationExpr, bindings: &mut Vec<Binding>| {
+        expr.try_visit_mut_children(|expr: &mut HirScalarExpr| {
+            use HirRelationExpr::Get;
+            use HirScalarExpr::{Exists, Select};
+            expr.visit_mut_post(&mut |expr: &mut HirScalarExpr| match expr {
+                Exists(expr) | Select(expr) => match expr.as_mut() {
+                    Get { .. } => (),
+                    expr => {
+                        // generate fresh local id
+                        let local_id = id_gen.next().unwrap();
+                        // generate a `Get(local_id)` to be used as a subquery replacement
+                        let mut subquery = Get {
+                            id: Id::Local(local_id.clone()),
+                            typ: RelationType::empty(), // TODO (#13732)
+                        };
+                        // swap the current subquery with the replacement
+                        std::mem::swap(expr, &mut subquery);
+                        // push a new $local_id = $subquery binding for a wrapping Let { ... }
+                        bindings.push(Binding { local_id, subquery });
+                    }
+                },
+                _ => (),
+            })
+        })
+    };
+
+    // Drain the `bindings` stack by wrapping the given `HirRelationExpr` with
+    // a sequence of `Let { ... }` nodes, one for each binding.
+    let insert_let_bindings = |expr: &mut HirRelationExpr, bindings: &mut Vec<Binding>| {
+        for binding in bindings.drain(..) {
+            let name = format!("subquery-{}", Into::<u64>::into(&binding.local_id));
+            let id = binding.local_id;
+            let value = Box::new(binding.subquery);
+            let body = Box::new(expr.take());
+            *expr = HirRelationExpr::Let {
+                name,
+                id,
+                value,
+                body,
+            }
+        }
+    };
+
+    expr.try_visit_mut_post(&mut |expr: &mut HirRelationExpr| {
+        // first grow bindings stack
+        collect_subqueries(expr, &mut bindings)?;
+        // then drain bindings stack
+        insert_let_bindings(expr, &mut bindings);
+        // done!
+        Ok(())
+    })
+}
+
+// Create an [`Iterator`] for [`LocalId`] values that are guaranteed to be
+// fresh within the scope of the given [`HirRelationExpr`].
+fn id_gen(expr: &HirRelationExpr) -> Result<impl Iterator<Item = LocalId>, RecursionLimitError> {
+    let mut max_id = 0_u64;
+
+    expr.visit_post(&mut |expr| {
+        match expr {
+            HirRelationExpr::Let { id, .. } => max_id = std::cmp::max(max_id, id.into()),
+            _ => (),
+        };
+    })?;
+
+    Ok((max_id + 1..).map(LocalId::new))
 }

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -203,6 +203,7 @@ impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
 
 impl<'a> DisplayText for Displayable<'a, HirScalarExpr> {
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut ()) -> fmt::Result {
+        use HirRelationExpr::Get;
         use HirScalarExpr::*;
 
         match self.0 {
@@ -307,8 +308,14 @@ impl<'a> DisplayText for Displayable<'a, HirScalarExpr> {
                 }
                 Ok(())
             }
-            Exists(_expr) => write!(f, "???"), // TODO
-            Select(_expr) => write!(f, "???"), // TODO
+            Exists(expr) => match expr.as_ref() {
+                Get { id, .. } => write!(f, "Exists(Get {})", id), // TODO: optional humanizer
+                _ => write!(f, "Exists(???)"),
+            },
+            Select(expr) => match expr.as_ref() {
+                Get { id, .. } => write!(f, "Select(Get {})", id), // TODO: optional humanizer
+                _ => write!(f, "Select(???)"),
+            },
         }
     }
 }

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -13,9 +13,9 @@ use std::fmt;
 
 use mz_expr::explain::Indices;
 use mz_expr::Id;
-use mz_ore::str::{bracketed, separated, IndentLike};
+use mz_ore::str::{separated, IndentLike};
 use mz_repr::explain_new::{separated_text, DisplayText};
-use mz_sql::plan::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
+use mz_sql::plan::{AggregateExpr, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
 
 use crate::explain_new::{Displayable, PlanRenderingContext};
 
@@ -115,8 +115,12 @@ impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
                 on,
                 kind,
             } => {
-                write!(f, "{}{}Join ", ctx.indent, kind)?;
-                Displayable::from(on).fmt_text(f, &mut ())?;
+                if on.is_literal_true() && kind == &JoinKind::Inner {
+                    write!(f, "{}CrossJoin", ctx.indent)?;
+                } else {
+                    write!(f, "{}{}Join ", ctx.indent, kind)?;
+                    Displayable::from(on).fmt_text(f, &mut ())?;
+                }
                 writeln!(f)?;
                 ctx.indented(|ctx| {
                     Displayable::from(left.as_ref()).fmt_text(f, ctx)?;
@@ -132,8 +136,8 @@ impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
             } => {
                 write!(f, "{}Reduce", ctx.indent)?;
                 if group_key.len() > 0 {
-                    let group_key = bracketed("[", "]", Indices(group_key));
-                    write!(f, " group_by={} ", group_key)?;
+                    let group_key = Indices(group_key);
+                    write!(f, " group_by=[{}]", group_key)?;
                 }
                 if aggregates.len() > 0 {
                     let aggregates = separated_text(", ", aggregates.iter().map(Displayable::from));

--- a/src/expr/src/id.rs
+++ b/src/expr/src/id.rs
@@ -99,6 +99,12 @@ impl LocalId {
     }
 }
 
+impl From<&LocalId> for u64 {
+    fn from(id: &LocalId) -> Self {
+        id.0
+    }
+}
+
 impl fmt::Display for LocalId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "l{}", self.0)

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1297,9 +1297,9 @@ impl CollectionPlan for MirRelationExpr {
 }
 
 impl VisitChildren<Self> for MirRelationExpr {
-    fn visit_children<'a, F>(&'a self, mut f: F)
+    fn visit_children<F>(&self, mut f: F)
     where
-        F: FnMut(&'a Self),
+        F: FnMut(&Self),
     {
         use MirRelationExpr::*;
         match self {
@@ -1333,9 +1333,9 @@ impl VisitChildren<Self> for MirRelationExpr {
         }
     }
 
-    fn visit_mut_children<'a, F>(&'a mut self, mut f: F)
+    fn visit_mut_children<F>(&mut self, mut f: F)
     where
-        F: FnMut(&'a mut Self),
+        F: FnMut(&mut Self),
     {
         use MirRelationExpr::*;
         match self {
@@ -1369,9 +1369,9 @@ impl VisitChildren<Self> for MirRelationExpr {
         }
     }
 
-    fn try_visit_children<'a, F, E>(&'a self, mut f: F) -> Result<(), E>
+    fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a Self) -> Result<(), E>,
+        F: FnMut(&Self) -> Result<(), E>,
     {
         use MirRelationExpr::*;
         match self {
@@ -1406,9 +1406,9 @@ impl VisitChildren<Self> for MirRelationExpr {
         Ok(())
     }
 
-    fn try_visit_mut_children<'a, F, E>(&'a mut self, mut f: F) -> Result<(), E>
+    fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a mut Self) -> Result<(), E>,
+        F: FnMut(&mut Self) -> Result<(), E>,
     {
         use MirRelationExpr::*;
         match self {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1372,6 +1372,7 @@ impl VisitChildren<Self> for MirRelationExpr {
     fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirRelationExpr::*;
         match self {
@@ -1409,6 +1410,7 @@ impl VisitChildren<Self> for MirRelationExpr {
     fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&mut Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirRelationExpr::*;
         match self {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1296,7 +1296,7 @@ impl CollectionPlan for MirRelationExpr {
     }
 }
 
-impl VisitChildren for MirRelationExpr {
+impl VisitChildren<Self> for MirRelationExpr {
     fn visit_children<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a Self),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1354,7 +1354,7 @@ impl fmt::Display for MirScalarExpr {
     }
 }
 
-impl VisitChildren for MirScalarExpr {
+impl VisitChildren<Self> for MirScalarExpr {
     fn visit_children<'a, F>(&'a self, mut f: F)
     where
         F: FnMut(&'a Self),

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1355,9 +1355,9 @@ impl fmt::Display for MirScalarExpr {
 }
 
 impl VisitChildren<Self> for MirScalarExpr {
-    fn visit_children<'a, F>(&'a self, mut f: F)
+    fn visit_children<F>(&self, mut f: F)
     where
-        F: FnMut(&'a Self),
+        F: FnMut(&Self),
     {
         use MirScalarExpr::*;
         match self {
@@ -1382,9 +1382,9 @@ impl VisitChildren<Self> for MirScalarExpr {
         }
     }
 
-    fn visit_mut_children<'a, F>(&'a mut self, mut f: F)
+    fn visit_mut_children<F>(&mut self, mut f: F)
     where
-        F: FnMut(&'a mut Self),
+        F: FnMut(&mut Self),
     {
         use MirScalarExpr::*;
         match self {
@@ -1409,9 +1409,9 @@ impl VisitChildren<Self> for MirScalarExpr {
         }
     }
 
-    fn try_visit_children<'a, F, E>(&'a self, mut f: F) -> Result<(), E>
+    fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a Self) -> Result<(), E>,
+        F: FnMut(&Self) -> Result<(), E>,
     {
         use MirScalarExpr::*;
         match self {
@@ -1437,9 +1437,9 @@ impl VisitChildren<Self> for MirScalarExpr {
         Ok(())
     }
 
-    fn try_visit_mut_children<'a, F, E>(&'a mut self, mut f: F) -> Result<(), E>
+    fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(&'a mut Self) -> Result<(), E>,
+        F: FnMut(&mut Self) -> Result<(), E>,
     {
         use MirScalarExpr::*;
         match self {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -11,6 +11,7 @@ use std::collections::HashSet;
 use std::fmt;
 use std::mem;
 
+use mz_ore::stack::RecursionLimitError;
 use mz_proto::IntoRustIfSome;
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
@@ -1412,6 +1413,7 @@ impl VisitChildren<Self> for MirScalarExpr {
     fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirScalarExpr::*;
         match self {
@@ -1440,6 +1442,7 @@ impl VisitChildren<Self> for MirScalarExpr {
     fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
         F: FnMut(&mut Self) -> Result<(), E>,
+        E: From<RecursionLimitError>,
     {
         use MirScalarExpr::*;
         match self {

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -54,14 +54,26 @@ pub trait VisitChildren<T> {
         F: FnMut(&mut T);
 
     /// Apply a fallible immutable function `f` to each direct child.
+    ///
+    /// For mutually recursive implementations (say consisting of two
+    /// types `A` and `B`), recursing through `B` in order to find all
+    /// `A`-children of a node of type `A` might cause lead to a
+    /// [`RecursionLimitError`], hence the bound on `E`.
     fn try_visit_children<F, E>(&self, f: F) -> Result<(), E>
     where
-        F: FnMut(&T) -> Result<(), E>;
+        F: FnMut(&T) -> Result<(), E>,
+        E: From<RecursionLimitError>;
 
     /// Apply a fallible mutable function `f` to each direct child.
+    ///
+    /// For mutually recursive implementations (say consisting of two
+    /// types `A` and `B`), recursing through `B` in order to find all
+    /// `A`-children of a node of type `A` might cause lead to a
+    /// [`RecursionLimitError`], hence the bound on `E`.
     fn try_visit_mut_children<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: FnMut(&mut T) -> Result<(), E>;
+        F: FnMut(&mut T) -> Result<(), E>,
+        E: From<RecursionLimitError>;
 }
 
 /// A trait for types that can recursively visit their children of the

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -42,6 +42,15 @@ use crate::RECURSION_LIMIT;
 ///
 /// Implementing [`VisitChildren<Self>`] automatically also implements
 /// the [`Visit`] trait, which enables recursive traversal.
+///
+/// Note that care needs to be taken when implementing this trait for
+/// mutually recursive types (such as a type A where A has children
+/// of type B and vice versa). More specifically, at the moment it is
+/// not possible to implement versions of `VisitChildren<A> for A` such
+/// that A considers as its children all A-nodes occurring at leaf
+/// positions of B-children and vice versa for `VisitChildren<B> for B`.
+/// Doing this will result in recusion limit violations as indicated
+/// in the accompanying `test_recursive_types_b` test.
 pub trait VisitChildren<T> {
     /// Apply an infallible immutable function `f` to each direct child.
     fn visit_children<F>(&self, f: F)
@@ -573,5 +582,415 @@ impl<T: VisitChildren<T>> Visitor<T> {
             }
             post(value);
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum A {
+        Add(Box<A>, Box<A>),
+        Lit(u64),
+        FrB(Box<B>),
+    }
+
+    #[derive(Debug, Eq, PartialEq)]
+    enum B {
+        Mul(Box<B>, Box<B>),
+        Lit(u64),
+        FrA(Box<A>),
+    }
+
+    impl VisitChildren<A> for A {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&A),
+        {
+            VisitChildren::visit_children(self, |expr: &B| {
+                #[allow(deprecated)]
+                Visit::visit_post_nolimit(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_ref()),
+                    _ => (),
+                });
+            });
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut A),
+        {
+            VisitChildren::visit_mut_children(self, |expr: &mut B| {
+                #[allow(deprecated)]
+                Visit::visit_mut_post_nolimit(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_mut()),
+                    _ => (),
+                });
+            });
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            VisitChildren::try_visit_children(self, |expr: &B| {
+                Visit::try_visit_post(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_ref()),
+                    _ => Ok(()),
+                })
+            })?;
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+            Ok(())
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            VisitChildren::try_visit_mut_children(self, |expr: &mut B| {
+                Visit::try_visit_mut_post(expr, &mut |expr| match expr {
+                    B::FrA(expr) => f(expr.as_mut()),
+                    _ => Ok(()),
+                })
+            })?;
+
+            match self {
+                A::Add(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                A::Lit(_) => (),
+                A::FrB(_) => (),
+            }
+            Ok(())
+        }
+    }
+
+    impl VisitChildren<B> for A {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&B),
+        {
+            match self {
+                A::Add(_, _) => (),
+                A::Lit(_) => (),
+                A::FrB(expr) => f(expr),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut B),
+        {
+            match self {
+                A::Add(_, _) => (),
+                A::Lit(_) => (),
+                A::FrB(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                A::Add(_, _) => Ok(()),
+                A::Lit(_) => Ok(()),
+                A::FrB(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                A::Add(_, _) => Ok(()),
+                A::Lit(_) => Ok(()),
+                A::FrB(expr) => f(expr),
+            }
+        }
+    }
+
+    impl VisitChildren<B> for B {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&B),
+        {
+            // VisitChildren::visit_children(self, |expr: &A| {
+            //     #[allow(deprecated)]
+            //     Visit::visit_post_nolimit(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_ref()),
+            //         _ => (),
+            //     });
+            // });
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut B),
+        {
+            // VisitChildren::visit_mut_children(self, |expr: &mut A| {
+            //     #[allow(deprecated)]
+            //     Visit::visit_mut_post_nolimit(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_mut()),
+            //         _ => (),
+            //     });
+            // });
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs);
+                    f(rhs);
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            // VisitChildren::try_visit_children(self, |expr: &A| {
+            //     Visit::try_visit_post(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_ref()),
+            //         _ => Ok(()),
+            //     })
+            // })?;
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+            Ok(())
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut B) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            // VisitChildren::try_visit_mut_children(self, |expr: &mut A| {
+            //     Visit::try_visit_mut_post(expr, &mut |expr| match expr {
+            //         A::FrB(expr) => f(expr.as_mut()),
+            //         _ => Ok(()),
+            //     })
+            // })?;
+
+            match self {
+                B::Mul(lhs, rhs) => {
+                    f(lhs)?;
+                    f(rhs)?;
+                }
+                B::Lit(_) => (),
+                B::FrA(_) => (),
+            }
+            Ok(())
+        }
+    }
+
+    impl VisitChildren<A> for B {
+        fn visit_children<F>(&self, mut f: F)
+        where
+            F: FnMut(&A),
+        {
+            match self {
+                B::Mul(_, _) => (),
+                B::Lit(_) => (),
+                B::FrA(expr) => f(expr),
+            }
+        }
+
+        fn visit_mut_children<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&mut A),
+        {
+            match self {
+                B::Mul(_, _) => (),
+                B::Lit(_) => (),
+                B::FrA(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_children<F, E>(&self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                B::Mul(_, _) => Ok(()),
+                B::Lit(_) => Ok(()),
+                B::FrA(expr) => f(expr),
+            }
+        }
+
+        fn try_visit_mut_children<F, E>(&mut self, mut f: F) -> Result<(), E>
+        where
+            F: FnMut(&mut A) -> Result<(), E>,
+            E: From<RecursionLimitError>,
+        {
+            match self {
+                B::Mul(_, _) => Ok(()),
+                B::Lit(_) => Ok(()),
+                B::FrA(expr) => f(expr),
+            }
+        }
+    }
+
+    /// x + (y + z)
+    fn test_term_a(x: A, y: A, z: A) -> A {
+        let x = Box::new(x);
+        let y = Box::new(y);
+        let z = Box::new(z);
+        A::Add(x, Box::new(A::Add(y, z)))
+    }
+
+    /// u + (v + w)
+    fn test_term_b(u: B, v: B, w: B) -> B {
+        let u = Box::new(u);
+        let v = Box::new(v);
+        let w = Box::new(w);
+        B::Mul(u, Box::new(B::Mul(v, w)))
+    }
+
+    fn a_to_b(x: A) -> B {
+        B::FrA(Box::new(x))
+    }
+
+    fn b_to_a(x: B) -> A {
+        A::FrB(Box::new(x))
+    }
+
+    fn test_term_rec_b(b: u64) -> B {
+        test_term_b(
+            a_to_b(test_term_a(
+                b_to_a(test_term_b(B::Lit(b + 11), B::Lit(b + 12), B::Lit(b + 13))),
+                b_to_a(test_term_b(B::Lit(b + 14), B::Lit(b + 15), B::Lit(b + 16))),
+                b_to_a(test_term_b(B::Lit(b + 17), B::Lit(b + 18), B::Lit(b + 19))),
+            )),
+            a_to_b(test_term_a(
+                b_to_a(test_term_b(B::Lit(b + 21), B::Lit(b + 22), B::Lit(b + 23))),
+                b_to_a(test_term_b(B::Lit(b + 24), B::Lit(b + 25), B::Lit(b + 26))),
+                b_to_a(test_term_b(B::Lit(b + 27), B::Lit(b + 28), B::Lit(b + 29))),
+            )),
+            a_to_b(test_term_a(
+                b_to_a(test_term_b(B::Lit(b + 31), B::Lit(b + 32), B::Lit(b + 33))),
+                b_to_a(test_term_b(B::Lit(b + 34), B::Lit(b + 35), B::Lit(b + 36))),
+                b_to_a(test_term_b(B::Lit(b + 37), B::Lit(b + 38), B::Lit(b + 39))),
+            )),
+        )
+    }
+
+    fn test_term_rec_a(b: u64) -> A {
+        test_term_a(
+            b_to_a(test_term_b(
+                a_to_b(test_term_a(A::Lit(b + 11), A::Lit(b + 12), A::Lit(b + 13))),
+                a_to_b(test_term_a(A::Lit(b + 14), A::Lit(b + 15), A::Lit(b + 16))),
+                a_to_b(test_term_a(A::Lit(b + 17), A::Lit(b + 18), A::Lit(b + 19))),
+            )),
+            b_to_a(test_term_b(
+                a_to_b(test_term_a(A::Lit(b + 21), A::Lit(b + 22), A::Lit(b + 23))),
+                a_to_b(test_term_a(A::Lit(b + 24), A::Lit(b + 25), A::Lit(b + 26))),
+                a_to_b(test_term_a(A::Lit(b + 27), A::Lit(b + 28), A::Lit(b + 29))),
+            )),
+            b_to_a(test_term_b(
+                a_to_b(test_term_a(A::Lit(b + 31), A::Lit(b + 32), A::Lit(b + 33))),
+                a_to_b(test_term_a(A::Lit(b + 34), A::Lit(b + 35), A::Lit(b + 36))),
+                a_to_b(test_term_a(A::Lit(b + 37), A::Lit(b + 38), A::Lit(b + 39))),
+            )),
+        )
+    }
+
+    #[test]
+    fn test_recursive_types_a() {
+        let mut act = test_term_rec_a(0);
+        let exp = test_term_rec_a(20);
+
+        let res = act.visit_mut_pre(&mut |expr| match expr {
+            A::Lit(x) => *x = *x + 20,
+            _ => (),
+        });
+
+        assert!(res.is_ok());
+        assert_eq!(act, exp);
+    }
+
+    /// This test currently fails with the following error:
+    ///
+    ///   reached the recursion limit while instantiating
+    ///   `<visit::Visitor<B> as CheckedRec...ore::stack::RecursionLimitError>`
+    ///
+    /// The problem (I think) is in the fact that the lambdas passed in the
+    /// VisitChildren<A> for A and the VisitChildren<B> for B definitions end
+    /// up in an infinite loop.
+    ///
+    /// More specifically, we run into the following cycle:
+    ///
+    /// - `<A as VisitChildren<A>>::visit_children`
+    ///   - <A as VisitChildren<B>>::visit_children`
+    ///     - <B as Visit>::visit_post_nolimit`
+    ///       - <B as VisitChildren<B>>::visit_children`
+    ///         - <B as VisitChildren<A>>::visit_children`
+    ///           - <A as Visit>::visit_post_nolimit`
+    ///             - <A as VisitChildren<A>>::visit_children`
+    #[test]
+    #[ignore = "making the VisitChildren definitions symmetric breaks the compiler"]
+    fn test_recursive_types_b() {
+        let mut act = test_term_rec_b(0);
+        let exp = test_term_rec_b(30);
+
+        let res = act.visit_mut_pre(&mut |expr| match expr {
+            B::Lit(x) => *x = *x + 30,
+            _ => (),
+        });
+
+        assert!(res.is_ok());
+        assert_eq!(act, exp);
     }
 }

--- a/src/expr/src/visit.rs
+++ b/src/expr/src/visit.rs
@@ -44,28 +44,24 @@ use crate::RECURSION_LIMIT;
 /// the [`Visit`] trait, which enables recursive traversal.
 pub trait VisitChildren<T> {
     /// Apply an infallible immutable function `f` to each direct child.
-    fn visit_children<'a, F>(&'a self, f: F)
+    fn visit_children<F>(&self, f: F)
     where
-        T: 'a,
-        F: FnMut(&'a T);
+        F: FnMut(&T);
 
     /// Apply an infallible mutable function `f` to each direct child.
-    fn visit_mut_children<'a, F>(&'a mut self, f: F)
+    fn visit_mut_children<F>(&mut self, f: F)
     where
-        T: 'a,
-        F: FnMut(&'a mut T);
+        F: FnMut(&mut T);
 
     /// Apply a fallible immutable function `f` to each direct child.
-    fn try_visit_children<'a, F, E>(&'a self, f: F) -> Result<(), E>
+    fn try_visit_children<F, E>(&self, f: F) -> Result<(), E>
     where
-        T: 'a,
-        F: FnMut(&'a T) -> Result<(), E>;
+        F: FnMut(&T) -> Result<(), E>;
 
     /// Apply a fallible mutable function `f` to each direct child.
-    fn try_visit_mut_children<'a, F, E>(&'a mut self, f: F) -> Result<(), E>
+    fn try_visit_mut_children<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        T: 'a,
-        F: FnMut(&'a mut T) -> Result<(), E>;
+        F: FnMut(&mut T) -> Result<(), E>;
 }
 
 /// A trait for types that can recursively visit their children of the

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -32,7 +32,7 @@
 
 use std::{collections::HashSet, fmt};
 
-use mz_ore::str::Indent;
+use mz_ore::{stack::RecursionLimitError, str::Indent};
 
 use crate::{ColumnType, GlobalId, ScalarType};
 
@@ -310,6 +310,7 @@ pub enum ExplainError {
     UnsupportedFormat(ExplainFormat),
     FormatError(fmt::Error),
     AnyhowError(anyhow::Error),
+    RecursionLimitError(RecursionLimitError),
     UnknownError(String),
 }
 
@@ -324,6 +325,9 @@ impl fmt::Display for ExplainError {
                 write!(f, "{}", error)
             }
             ExplainError::AnyhowError(error) => {
+                write!(f, "{}", error)
+            }
+            ExplainError::RecursionLimitError(error) => {
                 write!(f, "{}", error)
             }
             ExplainError::UnknownError(error) => {
@@ -342,6 +346,12 @@ impl From<fmt::Error> for ExplainError {
 impl From<anyhow::Error> for ExplainError {
     fn from(error: anyhow::Error) -> Self {
         ExplainError::AnyhowError(error)
+    }
+}
+
+impl From<RecursionLimitError> for ExplainError {
+    fn from(error: RecursionLimitError) -> Self {
+        ExplainError::RecursionLimitError(error)
     }
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -65,7 +65,7 @@ pub(crate) mod transform_expr;
 pub(crate) mod typeconv;
 pub(crate) mod with_options;
 
-pub use self::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, WindowExprType};
+pub use self::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
 pub use error::PlanError;
 pub use explain::Explanation;
 use mz_sql_parser::ast::TransactionIsolationLevel;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1479,6 +1479,26 @@ impl HirScalarExpr {
         Ok(HirScalarExpr::Literal(row, scalar_type))
     }
 
+    pub fn as_literal(&self) -> Option<Datum> {
+        if let HirScalarExpr::Literal(row, _column_type) = self {
+            Some(row.unpack_first())
+        } else {
+            None
+        }
+    }
+
+    pub fn is_literal_true(&self) -> bool {
+        Some(Datum::True) == self.as_literal()
+    }
+
+    pub fn is_literal_false(&self) -> bool {
+        Some(Datum::False) == self.as_literal()
+    }
+
+    pub fn is_literal_null(&self) -> bool {
+        Some(Datum::Null) == self.as_literal()
+    }
+
     pub fn call_unary(self, func: UnaryFunc) -> Self {
         HirScalarExpr::CallUnary {
             func,

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -182,6 +182,7 @@ impl WindowExpr {
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.func.visit_expressions(f)?;
         for expr in self.partition.iter() {
             f(expr)?;
@@ -196,6 +197,7 @@ impl WindowExpr {
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.func.visit_expressions_mut(f)?;
         for expr in self.partition.iter_mut() {
             f(expr)?;
@@ -286,20 +288,24 @@ pub enum WindowExprType {
 }
 
 impl WindowExprType {
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_children` instead."]
     pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         match self {
             Self::Scalar(expr) => expr.visit_expressions(f),
             Self::Value(expr) => expr.visit_expressions(f),
         }
     }
 
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_mut_children` instead."]
     pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         match self {
             Self::Scalar(expr) => expr.visit_expressions_mut(f),
             Self::Value(expr) => expr.visit_expressions_mut(f),
@@ -370,6 +376,7 @@ pub struct ScalarWindowExpr {
 }
 
 impl ScalarWindowExpr {
+    #[deprecated = "Implement `VisitChildren<HirScalarExpr>` if needed."]
     pub fn visit_expressions<'a, F, E>(&'a self, _f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
@@ -381,6 +388,7 @@ impl ScalarWindowExpr {
         Ok(())
     }
 
+    #[deprecated = "Implement `VisitChildren<HirScalarExpr>` if needed."]
     pub fn visit_expressions_mut<'a, F, E>(&'a mut self, _f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
@@ -438,6 +446,7 @@ pub struct ValueWindowExpr {
 }
 
 impl ValueWindowExpr {
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_children` instead."]
     pub fn visit_expressions<'a, F, E>(&'a self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a HirScalarExpr) -> Result<(), E>,
@@ -445,6 +454,7 @@ impl ValueWindowExpr {
         f(&self.expr)
     }
 
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_mut_children` instead."]
     pub fn visit_expressions_mut<'a, F, E>(&'a mut self, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a mut HirScalarExpr) -> Result<(), E>,
@@ -1047,6 +1057,7 @@ impl HirRelationExpr {
     /// direct parent scope.
     pub fn is_correlated(&self) -> bool {
         let mut correlated = false;
+        #[allow(deprecated)]
         self.visit_columns(0, &mut |depth, col| {
             if col.level > depth && col.level - depth == 1 {
                 correlated = true;
@@ -1176,6 +1187,7 @@ impl HirRelationExpr {
             // The join can be elided, but we need to adjust column references
             // on the right-hand side to account for the removal of the scope
             // introduced by the join.
+            #[allow(deprecated)]
             right.visit_columns_mut(0, &mut |depth, col| {
                 if col.level > depth {
                     col.level -= 1;
@@ -1204,10 +1216,12 @@ impl HirRelationExpr {
         )
     }
 
+    #[deprecated = "Use `Visit::visit_post`."]
     pub fn visit<'a, F>(&'a self, depth: usize, f: &mut F)
     where
         F: FnMut(&'a Self, usize),
     {
+        #[allow(deprecated)]
         let _ = self.visit_fallible(depth, &mut |e: &HirRelationExpr,
                                                  depth: usize|
          -> Result<(), ()> {
@@ -1216,16 +1230,19 @@ impl HirRelationExpr {
         });
     }
 
+    #[deprecated = "Use `Visit::try_visit_post`."]
     pub fn visit_fallible<'a, F, E>(&'a self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&'a Self, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit1(depth, |e: &HirRelationExpr, depth: usize| {
             e.visit_fallible(depth, f)
         })?;
         f(self, depth)
     }
 
+    #[deprecated = "Use `VisitChildren<HirRelationExpr>::try_visit_children` instead."]
     pub fn visit1<'a, F, E>(&'a self, depth: usize, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a Self, usize) -> Result<(), E>,
@@ -1276,10 +1293,12 @@ impl HirRelationExpr {
         Ok(())
     }
 
+    #[deprecated = "Use `Visit::visit_mut_post` instead."]
     pub fn visit_mut<F>(&mut self, depth: usize, f: &mut F)
     where
         F: FnMut(&mut Self, usize),
     {
+        #[allow(deprecated)]
         let _ = self.visit_mut_fallible(depth, &mut |e: &mut HirRelationExpr,
                                                      depth: usize|
          -> Result<(), ()> {
@@ -1288,16 +1307,19 @@ impl HirRelationExpr {
         });
     }
 
+    #[deprecated = "Use `Visit::try_visit_mut_post` instead."]
     pub fn visit_mut_fallible<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut Self, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit1_mut(depth, |e: &mut HirRelationExpr, depth: usize| {
             e.visit_mut_fallible(depth, f)
         })?;
         f(self, depth)
     }
 
+    #[deprecated = "Use `VisitChildren<HirRelationExpr>::try_visit_mut_children` instead."]
     pub fn visit1_mut<'a, F, E>(&'a mut self, depth: usize, mut f: F) -> Result<(), E>
     where
         F: FnMut(&'a mut Self, usize) -> Result<(), E>,
@@ -1348,6 +1370,7 @@ impl HirRelationExpr {
         Ok(())
     }
 
+    #[deprecated = "Use a combination of `Visit` and `VisitChildren` methods."]
     /// Visits all scalar expressions within the sub-tree of the given relation.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
@@ -1357,6 +1380,7 @@ impl HirRelationExpr {
     where
         F: FnMut(&HirScalarExpr, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit_fallible(depth, &mut |e: &HirRelationExpr,
                                          depth: usize|
          -> Result<(), E> {
@@ -1398,11 +1422,13 @@ impl HirRelationExpr {
         })
     }
 
+    #[deprecated = "Use a combination of `Visit` and `VisitChildren` methods."]
     /// Like `visit_scalar_expressions`, but permits mutating the expressions.
     pub fn visit_scalar_expressions_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut HirScalarExpr, usize) -> Result<(), E>,
     {
+        #[allow(deprecated)]
         self.visit_mut_fallible(depth, &mut |e: &mut HirRelationExpr,
                                              depth: usize|
          -> Result<(), E> {
@@ -1444,6 +1470,7 @@ impl HirRelationExpr {
         })
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Visits the column references in this relation expression.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
@@ -1453,6 +1480,7 @@ impl HirRelationExpr {
     where
         F: FnMut(usize, &ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_scalar_expressions(depth, &mut |e: &HirScalarExpr,
                                                            depth: usize|
          -> Result<(), ()> {
@@ -1461,11 +1489,13 @@ impl HirRelationExpr {
         });
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit_columns`, but permits mutating the column references.
     pub fn visit_columns_mut<F>(&mut self, depth: usize, f: &mut F)
     where
         F: FnMut(usize, &mut ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_scalar_expressions_mut(depth, &mut |e: &mut HirScalarExpr,
                                                                depth: usize|
          -> Result<(), ()> {
@@ -1477,6 +1507,7 @@ impl HirRelationExpr {
     /// Replaces any parameter references in the expression with the
     /// corresponding datum from `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), PlanError> {
+        #[allow(deprecated)]
         self.visit_scalar_expressions_mut(0, &mut |e: &mut HirScalarExpr, _: usize| {
             e.bind_parameters(params)
         })
@@ -1484,6 +1515,7 @@ impl HirRelationExpr {
 
     /// See the documentation for [`HirScalarExpr::splice_parameters`].
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
+        #[allow(deprecated)]
         let _ = self.visit_scalar_expressions_mut(depth, &mut |e: &mut HirScalarExpr,
                                                                depth: usize|
          -> Result<(), ()> {
@@ -2105,6 +2137,7 @@ impl HirScalarExpr {
     /// Replaces any parameter references in the expression with the
     /// corresponding datum in `params`.
     pub fn bind_parameters(&mut self, params: &Params) -> Result<(), PlanError> {
+        #[allow(deprecated)]
         self.visit_recursively_mut(0, &mut |_: usize, e: &mut HirScalarExpr| {
             if let HirScalarExpr::Parameter(n) = e {
                 let datum = match params.datums.iter().nth(*n - 1) {
@@ -2131,6 +2164,7 @@ impl HirScalarExpr {
     /// Column references in parameters will be corrected to account for the
     /// depth at which they are spliced.
     pub fn splice_parameters(&mut self, params: &[HirScalarExpr], depth: usize) {
+        #[allow(deprecated)]
         let _ = self.visit_recursively_mut(depth, &mut |depth: usize,
                                                         e: &mut HirScalarExpr|
          -> Result<(), ()> {
@@ -2273,22 +2307,27 @@ impl HirScalarExpr {
         }
     }
 
+    #[deprecated = "Use `Visit::visit_post` instead."]
     pub fn visit_mut<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self),
     {
+        #[allow(deprecated)]
         self.visit1_mut(|e: &mut HirScalarExpr| e.visit_mut(f));
         f(self);
     }
 
+    #[deprecated = "Use `Visit::visit_mut_pre` instead."]
     pub fn visit_mut_pre<F>(&mut self, f: &mut F)
     where
         F: FnMut(&mut Self),
     {
         f(self);
+        #[allow(deprecated)]
         self.visit1_mut(|e: &mut HirScalarExpr| e.visit_mut(f));
     }
 
+    #[deprecated = "Use `VisitChildren<HirScalarExpr>::visit_children` instead."]
     pub fn visit1_mut<F>(&mut self, mut f: F)
     where
         F: FnMut(&mut Self),
@@ -2321,6 +2360,7 @@ impl HirScalarExpr {
         }
     }
 
+    #[deprecated = "Use `Visit::visit_pre_post` instead."]
     /// A generalization of `visit`. The function `pre` runs on a
     /// `HirScalarExpr` before it runs on any of the child `HirScalarExpr`s.
     /// The function `post` runs on child `HirScalarExpr`s first before the
@@ -2342,6 +2382,7 @@ impl HirScalarExpr {
         post(self);
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Visits the column references in this scalar expression.
     ///
     /// The `depth` argument should indicate the subquery nesting depth of the expression,
@@ -2351,6 +2392,7 @@ impl HirScalarExpr {
     where
         F: FnMut(usize, &ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_recursively(depth, &mut |depth: usize,
                                                     e: &HirScalarExpr|
          -> Result<(), ()> {
@@ -2361,11 +2403,13 @@ impl HirScalarExpr {
         });
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit_columns`, but permits mutating the column references.
     pub fn visit_columns_mut<F>(&mut self, depth: usize, f: &mut F)
     where
         F: FnMut(usize, &mut ColumnRef),
     {
+        #[allow(deprecated)]
         let _ = self.visit_recursively_mut(depth, &mut |depth: usize,
                                                         e: &mut HirScalarExpr|
          -> Result<(), ()> {
@@ -2376,6 +2420,7 @@ impl HirScalarExpr {
         });
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit` but it enters the subqueries visiting the scalar expressions contained
     /// in them. It takes the current depth of the expression and increases it when
     /// entering a subquery.
@@ -2404,6 +2449,7 @@ impl HirScalarExpr {
                 els.visit_recursively(depth, f)?;
             }
             HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
+                #[allow(deprecated)]
                 expr.visit_scalar_expressions(depth + 1, &mut |e, depth| {
                     e.visit_recursively(depth, f)
                 })?;
@@ -2415,6 +2461,7 @@ impl HirScalarExpr {
         f(depth, self)
     }
 
+    #[deprecated = "Redefine this based on the `Visit` and `VisitChildren` methods."]
     /// Like `visit_recursively`, but permits mutating the scalar expressions.
     pub fn visit_recursively_mut<F, E>(&mut self, depth: usize, f: &mut F) -> Result<(), E>
     where
@@ -2441,6 +2488,7 @@ impl HirScalarExpr {
                 els.visit_recursively_mut(depth, f)?;
             }
             HirScalarExpr::Exists(expr) | HirScalarExpr::Select(expr) => {
+                #[allow(deprecated)]
                 expr.visit_scalar_expressions_mut(depth + 1, &mut |e, depth| {
                     e.visit_recursively_mut(depth, f)
                 })?;

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -319,6 +319,7 @@ impl HirRelationExpr {
                             .iter_mut()
                             .position(|s| {
                                 let mut requires_nonexistent_column = false;
+                                #[allow(deprecated)]
                                 s.visit_columns(0, &mut |depth, col| {
                                     if col.level == depth {
                                         requires_nonexistent_column |= (col.column + 1) > old_arity
@@ -1284,6 +1285,7 @@ impl HirScalarExpr {
             let mut subqueries = Vec::new();
             let distinct_inner = get_inner.clone().distinct();
             for expr in exprs.iter() {
+                #[allow(deprecated)]
                 expr.visit_pre_post(
                     &mut |e| match e {
                         // For simplicity, subqueries within a conditional statement will be
@@ -1484,6 +1486,7 @@ where
     // detecting the moment of decorrelation in the optimizer right now is too
     // hard.
     let mut is_simple = true;
+    #[allow(deprecated)]
     inner.visit(0, &mut |expr, _| match expr {
         HirRelationExpr::Constant { .. }
         | HirRelationExpr::Project { .. }
@@ -1508,6 +1511,7 @@ where
     // each outer column, according to the passed-in `col_map`, and
     // `new_col_map` maps each outer column to its new ordinal position in key.
     let mut outer_cols = BTreeSet::new();
+    #[allow(deprecated)]
     inner.visit_columns(0, &mut |depth, col| {
         // Test if the column reference escapes the subquery.
         if col.level > depth {
@@ -1519,6 +1523,7 @@ where
     });
     // Collect all the outer columns referenced by any CTE referenced by
     // the inner relation.
+    #[allow(deprecated)]
     inner.visit(0, &mut |e, _| match e {
         HirRelationExpr::Get {
             id: mz_expr::Id::Local(id),

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -713,6 +713,7 @@ fn handle_mutation_using_clause(
         // those to the right of `using_rel_expr`) to instead be correlated to
         // the outer relation, i.e. `get`.
         let using_rel_arity = qcx.relation_type(&using_rel_expr).arity();
+        #[allow(deprecated)]
         expr.visit_mut(&mut |e| {
             if let HirScalarExpr::Column(c) = e {
                 if c.column >= using_rel_arity {
@@ -3908,6 +3909,7 @@ fn plan_aggregate(
 
     let mut seen_outer = false;
     let mut seen_inner = false;
+    #[allow(deprecated)]
     expr.visit_columns(0, &mut |depth, col| {
         if depth == 0 && col.level == 0 {
             seen_inner = true;

--- a/src/sql/src/plan/transform_expr.rs
+++ b/src/sql/src/plan/transform_expr.rs
@@ -53,6 +53,7 @@ use crate::plan::expr::{
 /// subquery, especially when the original conjunction contains join keys.
 pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
     fn walk_relation(expr: &mut HirRelationExpr) {
+        #[allow(deprecated)]
         expr.visit_mut(0, &mut |expr, _| match expr {
             HirRelationExpr::Map { scalars, .. } => {
                 for scalar in scalars {
@@ -84,6 +85,7 @@ pub fn split_subquery_predicates(expr: &mut HirRelationExpr) {
     }
 
     fn walk_scalar(expr: &mut HirScalarExpr) {
+        #[allow(deprecated)]
         expr.visit_mut(&mut |expr| match expr {
             HirScalarExpr::Exists(input) | HirScalarExpr::Select(input) => walk_relation(input),
             _ => (),
@@ -191,6 +193,7 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
                 walk_relation(right, &outers);
             }
             expr => {
+                #[allow(deprecated)]
                 let _ = expr.visit1_mut(0, &mut |expr, _| -> Result<(), ()> {
                     walk_relation(expr, outers);
                     Ok(())
@@ -200,6 +203,7 @@ pub fn try_simplify_quantified_comparisons(expr: &mut HirRelationExpr) {
     }
 
     fn walk_scalar(expr: &mut HirScalarExpr, outers: &[RelationType], mut in_filter: bool) {
+        #[allow(deprecated)]
         expr.visit_mut_pre(&mut |e| match e {
             HirScalarExpr::Exists(input) => walk_relation(input, outers),
             HirScalarExpr::Select(input) => {

--- a/src/sql/src/query_model/hir/qgm_from_hir.rs
+++ b/src/sql/src/query_model/hir/qgm_from_hir.rs
@@ -157,6 +157,7 @@ impl FromHir {
                         .iter_mut()
                         .position(|s| {
                             let mut requires_nonexistent_column = false;
+                            #[allow(deprecated)]
                             s.visit_columns(0, &mut |depth, col| {
                                 if col.level == depth {
                                     requires_nonexistent_column |= (col.column + 1) > old_arity

--- a/src/transform/src/cse/relation_cse.rs
+++ b/src/transform/src/cse/relation_cse.rs
@@ -112,7 +112,7 @@ impl Bindings {
 
                 _ => {
                     // All other expressions just need to apply the logic recursively.
-                    relation.try_visit_mut_children(&mut |expr| this.intern_expression(expr))?;
+                    relation.try_visit_mut_children(|expr| this.intern_expression(expr))?;
                 }
             };
 

--- a/src/transform/src/update_let.rs
+++ b/src/transform/src/update_let.rs
@@ -87,7 +87,7 @@ impl UpdateLet {
                     }
                     Ok(())
                 }
-                _ => relation.try_visit_mut_children(&mut |e| self.action(e, remap, id_gen)),
+                _ => relation.try_visit_mut_children(|e| self.action(e, remap, id_gen)),
             }
         })
     }

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -144,10 +144,18 @@ EOF
 # |     Get materialize.public.t
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
-SELECT * FROM t WHERE EXISTS(SELECT * FROM t as t1 WHERE t.a = t1.a)
+SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
-Filter ???
-  Get materialize.public.t
+Let
+  Filter (Exists(Get l1) && Exists(Get l2))
+    Get materialize.public.t
+  Where
+    l1 =
+      Filter (#^0 < #0)
+        Get materialize.public.mv
+    l2 =
+      Filter (#^1 > #1)
+        Get materialize.public.mv
 
 EOF
 
@@ -288,53 +296,41 @@ InnerJoin true
 EOF
 
 
-# query T multiline
-# EXPLAIN RAW PLAN AS TEXT FOR
-# SELECT
-#   *
-# FROM
-#   T as X
-# WHERE
-#   NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
-# LIMIT 10
-# ----
-# %0 =
-# | Get materialize.public.t (u1)
-# | Filter NOT(exists(%1))
-# | |
-# | | %1 =
-# | | | Get materialize.public.t (u1)
-# | | | Filter (#^0 = #1)
-# | |
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT
+  *
+FROM
+  T as X
+WHERE
+  NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
+LIMIT 10
+----
+Finish limit=10 output=[#0, #1]
+  Let
+    Filter NOT(Exists(Get l1))
+      Get materialize.public.t
+    Where
+      l1 =
+        Filter (#^0 = #1)
+          Get materialize.public.t
 
-# Finish order_by=() limit=10 offset=0 project=(#0, #1)
+EOF
 
-# EOF
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR -- WITH (TYPES)
+VIEW mv
+----
+Filter (#0) IS NOT NULL
+  Get materialize.public.t
 
-# query T multiline
-# EXPLAIN RAW PLAN WITH (TYPES) AS TEXT FOR
-# VIEW v
-# ----
-# %0 =
-# | Get materialize.public.t (u1)
-# | | types = (integer?, integer?)
-# | | keys = ()
-# | Filter NOT(isnull(#0))
-# | | types = (integer?, integer?)
-# | | keys = ()
+EOF
 
-# EOF
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR -- WITH (TYPES)
+RECORDED VIEW rv
+----
+Filter (#0) IS NOT NULL
+  Get materialize.public.t
 
-# query T multiline
-# EXPLAIN RAW PLAN WITH (TYPES) AS TEXT FOR
-# RECORDED VIEW rv
-# ----
-# %0 =
-# | Get materialize.public.t (u1)
-# | | types = (integer?, integer?)
-# | | keys = ()
-# | Filter NOT(isnull(#0))
-# | | types = (integer?, integer?)
-# | | keys = ()
-
-# EOF
+EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -14,6 +14,9 @@ CREATE TABLE t (
 )
 
 statement ok
+CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+
+statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
 
@@ -23,18 +26,19 @@ SELECT * FROM t WHERE a IS NOT NULL
 
 mode cockroach
 
+# Test basic linear chains.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
-SELECT a + 1, b, 4 FROM mv WHERE a > 0 LIMIT 1
+SELECT a + 1, b, 4 FROM mv WHERE a > 0
 ----
-Finish limit=1 output=[#0..=#2]
-  Project #2, #1, #3
-    Map (#0 + 1), 4
-      Filter (#0 > 0)
-        Get materialize.public.mv
+Project #2, #1, #3
+  Map (#0 + 1), 4
+    Filter (#0 > 0)
+      Get materialize.public.mv
 
 EOF
 
+# Test table functions (CallTable).
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM generate_series(1, 7)
@@ -43,6 +47,7 @@ CallTable generate_series(1, 7, 1)
 
 EOF
 
+# Test Threshold, Union, Distinct, Negate.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
@@ -63,46 +68,7 @@ Threshold
 
 EOF
 
-
-query T multiline
-EXPLAIN RAW PLAN FOR
-WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
-----
-%0 = Let x (l0) =
-| Get materialize.public.t (u1)
-| Map (#0 * #1)
-| Project (#2)
-
-%1 =
-| Get x (l0) (%0)
-| Map (#0 + 5)
-| Project (#1)
-
-EOF
-
-# Directly nested 'Let' variants are rendered in a flattened way
-query T multiline
-EXPLAIN RAW PLAN AS TEXT FOR
-WITH A AS (SELECT 1 AS a), B as (SELECT a as b FROM A WHERE a > 0) SELECT * FROM A, B;
-----
-Let
-  InnerJoin true
-    Get l0
-    Get l1
-  Where
-    l1 =
-      Filter (#0 > 0)
-        Get l0
-    l0 =
-      Map 1
-        Constant
-          - ()
-
-EOF
-
-statement ok
-CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
-
+# Test TopK.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 VIEW ov
@@ -113,6 +79,7 @@ Project #0, #1
 
 EOF
 
+# Test Finish.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
@@ -122,26 +89,32 @@ Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
 
 EOF
 
+# Test Reduce (global).
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t
+----
+Project #2
+  Map abs((#0 - #1))
+    Reduce aggregates=[min(#0), max(#0)]
+      Get materialize.public.t
+
+EOF
+
+# Test Reduce (local).
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
 Project #3
   Map abs((#1 - #2))
-    Reduce group_by=[#2]  aggregates=[min(#0), max(#0)]
+    Reduce group_by=[#2] aggregates=[min(#0), max(#0)]
       Map #1
         Get materialize.public.t
 
 EOF
 
-# This should be something like
-#
-# Filter exists(%1)
-# | Get materialize.public.t
-# |
-# | Subquery %1
-# |   Filter (#^0 = #0)
-# |     Get materialize.public.t
+# Test EXISTS subqueries.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
@@ -159,54 +132,146 @@ Let
 
 EOF
 
+# Test SELECT subqueries.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1), (SELECT rv.a FROM rv WHERE rv.b = t.b LIMIT 1) FROM t
+----
+Project #2, #3
+  Let
+    Map Select(Get l1), Select(Get l2)
+      Get materialize.public.t
+    Where
+      l1 =
+        Project #0
+          TopK limit=1
+            Filter (#1 = #^1)
+              Get materialize.public.mv
+      l2 =
+        Project #0
+          TopK limit=1
+            Filter (#1 = #^1)
+              Get materialize.public.rv
+
+EOF
+
+# Test CrossJoin derived from a comma join without a predicate.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
 Project #0, #2
-  InnerJoin true
+  CrossJoin
     Get materialize.public.t
     Get materialize.public.t
 
 EOF
 
+# Test CrossJoin derived from an INNER JOIN with a trivial ON clause.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
-SELECT t1.a, t2.a FROM t as t1, t as t2 WHERE t1.b = t2.b
+SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
 ----
 Project #0, #2
-  Filter (#1 = #3)
-    InnerJoin true
+  CrossJoin
+    Get materialize.public.t
+    Get materialize.public.t
+
+EOF
+
+# Test InnerJoin (comma syntax).
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT t1.a, t2.a
+FROM
+  t as t1,
+  t as t2,
+  t as t3
+WHERE t1.b = t2.b AND t2.b = t3.b
+----
+Project #0, #2
+  Filter ((#1 = #3) && (#3 = #5))
+    CrossJoin
+      CrossJoin
+        Get materialize.public.t
+        Get materialize.public.t
+      Get materialize.public.t
+
+EOF
+
+# Test InnerJoin (ON syntax).
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT t1.a, t2.a
+FROM t as t1
+INNER JOIN t as t2 ON t1.b = t2.b
+INNER JOIN t as t3 ON t2.b = t3.b
+----
+Project #0, #2
+  InnerJoin (#3 = #5)
+    InnerJoin (#1 = #3)
       Get materialize.public.t
       Get materialize.public.t
+    Get materialize.public.t
 
 EOF
 
+# Test InnerJoin (ON syntax).
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
-SELECT t1.a, t2.a FROM t as t1 JOIN t as t2 ON t1.b = t2.b
+SELECT t1.a, t2.a
+FROM t as t1
+LEFT JOIN t as t2 ON t1.b = t2.b
+RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
 Project #0, #2
-  InnerJoin (#1 = #3)
-    Get materialize.public.t
+  RightOuterJoin (#3 = #5)
+    LeftOuterJoin (#1 = #3)
+      Get materialize.public.t
+      Get materialize.public.t
     Get materialize.public.t
 
 EOF
 
+# Test a single CTEs.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
-SELECT t1.a, t2.a FROM t as t1 JOIN t as t2 ON t1.b = t2.b
+WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
 ----
-Project #0, #2
-  InnerJoin (#1 = #3)
-    Get materialize.public.t
-    Get materialize.public.t
+Project #1
+  Let
+    Map (#0 + 5)
+      Get l0
+    Where
+      l0 =
+        Project #2
+          Map (#0 * #1)
+            Get materialize.public.t
 
 EOF
 
+# Test multiple CTEs: directly nested 'Let' variants are rendered in a flattened way.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+WITH A AS (SELECT 1 AS a), B as (SELECT a as b FROM A WHERE a > 0) SELECT * FROM A, B;
+----
+Let
+  CrossJoin
+    Get l0
+    Get l1
+  Where
+    l1 =
+      Filter (#0 > 0)
+        Get l0
+    l0 =
+      Map 1
+        Constant
+          - ()
 
-# A case where we cannot pull the let statement up through teh join,
-# because the local l0 is correlated against the lhs of the enclosing join
+EOF
+
+# Test multiple CTEs: a case where we cannot pull the let statement up through
+# the join because the local l0 is correlated against the lhs of the enclosing join.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT
@@ -228,8 +293,8 @@ FROM
     SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
   ) as r5;
 ----
-InnerJoin true
-  InnerJoin true
+CrossJoin
+  CrossJoin
     Get materialize.public.t
     Let
       Filter (#0 != #^0)
@@ -248,9 +313,9 @@ InnerJoin true
 
 EOF
 
-
-# A case where we cannot pull the let statement up through teh join,
-# because the local l0 is correlated against the lhs of the enclosing join
+# Test multiple CTEs: a case where we cannot pull the let statement up
+# through the join because the local l0 is correlated against the lhs of
+# the enclosing join.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT
@@ -275,11 +340,11 @@ FROM
     WHERE a != r1.a
   ) as r5;
 ----
-InnerJoin true
+CrossJoin
   Get materialize.public.t
   Let
     Filter (#^0 != #^0)
-      InnerJoin true
+      CrossJoin
         Get l0
         Let
           Filter ((#^^0 = #^0) && (#0 > 5))
@@ -292,45 +357,5 @@ InnerJoin true
       l0 =
         Reduce aggregates=[max((#^0 * #0))]
           Get materialize.public.t
-
-EOF
-
-
-query T multiline
-EXPLAIN RAW PLAN AS TEXT FOR
-SELECT
-  *
-FROM
-  T as X
-WHERE
-  NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
-LIMIT 10
-----
-Finish limit=10 output=[#0, #1]
-  Let
-    Filter NOT(Exists(Get l1))
-      Get materialize.public.t
-    Where
-      l1 =
-        Filter (#^0 = #1)
-          Get materialize.public.t
-
-EOF
-
-query T multiline
-EXPLAIN RAW PLAN AS TEXT FOR -- WITH (TYPES)
-VIEW mv
-----
-Filter (#0) IS NOT NULL
-  Get materialize.public.t
-
-EOF
-
-query T multiline
-EXPLAIN RAW PLAN AS TEXT FOR -- WITH (TYPES)
-RECORDED VIEW rv
-----
-Filter (#0) IS NOT NULL
-  Get materialize.public.t
 
 EOF


### PR DESCRIPTION
TODO

### Motivation

  * This PR adds a known-desirable feature. 
  
  Closes #13733.

### Tips for reviewer

- The first six commits are part of #13757 and will be reviewed there.
- The actual feature is implemented in df49b3523243368e46dd18b9b0118e1a1ef1a1cf.
- The final commit polishes the set of tests for `EXPLAIN RAW PLAN AS TEXT`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - There are no user-facing behavior changes.
