### PR TITLE
[sinks] Framework for creating storaged instance per-sink

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -157,7 +157,7 @@ use mz_transform::Optimizer;
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
 use crate::catalog::{
     self, storage, BuiltinTableUpdate, Catalog, CatalogItem, CatalogState, ClusterReplicaSizeMap,
-    ComputeInstance, Connection, SinkConnectionState, Sink,
+    ComputeInstance, Connection, Sink, SinkConnectionState,
 };
 use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{
@@ -2399,13 +2399,18 @@ impl<S: Append + 'static> Coordinator<S> {
         };
 
         // TODO(chae): This is where we'll create the export/sink in storaged
-        let _ = self.controller.storage_mut().create_exports(vec![(
-            id,
-            ExportDescription {
-                sink: storage_sink_desc,
-                remote_addr: None,
-            },
-        )]).await.unwrap();
+        let _ = self
+            .controller
+            .storage_mut()
+            .create_exports(vec![(
+                id,
+                ExportDescription {
+                    sink: storage_sink_desc,
+                    remote_addr: None,
+                },
+            )])
+            .await
+            .unwrap();
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -55,10 +55,11 @@ use mz_stash::{self, StashError, TypedCollection};
 
 use crate::controller::hosts::{StorageHosts, StorageHostsConfig};
 use crate::protocol::client::{
-    IngestSourceCommand, ProtoStorageCommand, ProtoStorageResponse, StorageCommand,
-    StorageResponse, Update,
+    ExportSinkCommand, IngestSourceCommand, ProtoStorageCommand, ProtoStorageResponse,
+    StorageCommand, StorageResponse, Update,
 };
 use crate::types::errors::DataflowError;
+use crate::types::sinks::{PersistSinkConnection, SinkAsOf, SinkConnection, SinkDesc};
 use crate::types::sources::{IngestionDescription, MzOffset, SourceData, SourceEnvelope};
 
 mod hosts;
@@ -96,6 +97,16 @@ impl<T> From<RelationDesc> for CollectionDescription<T> {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ExportDescription {
+    pub sink: SinkDesc,
+    /// The address of a `storaged` process on which to install the source.
+    ///
+    /// If `None`, the controller manages the lifetime of the `storaged`
+    /// process.
+    pub remote_addr: Option<String>,
+}
+
 #[async_trait(?Send)]
 pub trait StorageController: Debug + Send {
     type Timestamp;
@@ -128,6 +139,12 @@ pub trait StorageController: Debug + Send {
     async fn create_collections(
         &mut self,
         collections: Vec<(GlobalId, CollectionDescription<Self::Timestamp>)>,
+    ) -> Result<(), StorageError>;
+
+    /// Create the sinks described by the `ExportDescription`.
+    async fn create_exports(
+        &mut self,
+        exports: Vec<(GlobalId, ExportDescription)>,
     ) -> Result<(), StorageError>;
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
@@ -608,6 +625,49 @@ where
             }
         }
 
+        Ok(())
+    }
+
+    async fn create_exports(
+        &mut self,
+        exports: Vec<(GlobalId, ExportDescription)>,
+    ) -> Result<(), StorageError> {
+        for (id, description) in exports {
+            let augmented_sink_desc = SinkDesc {
+                from: description.sink.from,
+                from_desc: description.sink.from_desc,
+                connection: match description.sink.connection {
+                    SinkConnection::Kafka(k) => SinkConnection::Kafka(k),
+                    SinkConnection::Tail(t) => SinkConnection::Tail(t),
+                    SinkConnection::Persist(PersistSinkConnection {
+                        value_desc,
+                        storage_metadata: (),
+                    }) => SinkConnection::Persist(PersistSinkConnection {
+                        value_desc,
+                        storage_metadata: self.collection(id)?.collection_metadata.clone(),
+                    }),
+                },
+                envelope: description.sink.envelope,
+                // TODO(chae): derive this (sink_description.as_of is hardcoded to u64 instead of general timestamp T)
+                as_of: SinkAsOf {
+                    frontier: Antichain::from_elem(T::minimum()),
+                    strict: description.sink.as_of.strict,
+                },
+            };
+            let cmd = ExportSinkCommand {
+                id,
+                description: augmented_sink_desc,
+                // TODO(chae): derive this
+                resume_upper: Antichain::from_elem(T::minimum()),
+            };
+            // Provision a storage host for the ingestion.
+            let client = self
+                .hosts
+                .provision(id, description.remote_addr.clone())
+                .await?;
+
+            client.send(StorageCommand::ExportSinks(vec![cmd]));
+        }
         Ok(())
     }
 

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -34,7 +34,8 @@ use mz_repr::GlobalId;
 use mz_service::client::GenericClient;
 
 use crate::protocol::client::{
-    IngestSourceCommand, StorageClient, StorageCommand, StorageGrpcClient, StorageResponse,
+    ExportSinkCommand, IngestSourceCommand, StorageClient, StorageCommand, StorageGrpcClient,
+    StorageResponse,
 };
 
 /// A storage client that replays the command stream on failure.
@@ -62,6 +63,7 @@ where
             command_rx,
             response_tx,
             ingestions: BTreeMap::new(),
+            exports: BTreeMap::new(),
             uppers: HashMap::new(),
             initialized: false,
         };
@@ -97,6 +99,8 @@ struct RehydrationTask<T> {
     response_tx: UnboundedSender<StorageResponse<T>>,
     /// The ingestions that have been observed.
     ingestions: BTreeMap<GlobalId, IngestSourceCommand<T>>,
+    /// The exports that have been observed.
+    exports: BTreeMap<GlobalId, ExportSinkCommand<T>>,
     /// The upper frontier information received.
     uppers: HashMap<GlobalId, (Antichain<T>, MutableAntichain<T>)>,
     /// Set to `true` once [`StorageCommand::InitializationComplete`] has been
@@ -157,9 +161,10 @@ where
             .expect("retry retries forever");
 
         // Rehydrate all commands.
-        let mut commands = vec![StorageCommand::IngestSources(
-            self.ingestions.values().cloned().collect(),
-        )];
+        let mut commands = vec![
+            StorageCommand::IngestSources(self.ingestions.values().cloned().collect()),
+            StorageCommand::ExportSinks(self.exports.values().cloned().collect()),
+        ];
         if self.initialized {
             commands.push(StorageCommand::InitializationComplete)
         }
@@ -240,6 +245,19 @@ where
                     // Initialize the uppers we are tracking
                     self.uppers.insert(
                         ingestion.id,
+                        (
+                            Antichain::from_elem(T::minimum()),
+                            MutableAntichain::new_bottom(T::minimum()),
+                        ),
+                    );
+                }
+            }
+            StorageCommand::ExportSinks(sinks) => {
+                for sink in sinks {
+                    self.exports.insert(sink.id, sink.clone());
+                    // Initialize the uppers we are tracking
+                    self.uppers.insert(
+                        sink.id,
                         (
                             Antichain::from_elem(T::minimum()),
                             MutableAntichain::new_bottom(T::minimum()),

--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -13,6 +13,7 @@ import "persist/src/persist.proto";
 import "proto/src/proto.proto";
 import "repr/src/global_id.proto";
 import "storage/src/types/sources.proto";
+import "storage/src/types/sinks.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -41,6 +42,16 @@ message ProtoIngestSources {
     repeated ProtoIngestSourceCommand ingestions = 1;
 }
 
+message ProtoExportSinkCommand {
+    mz_repr.global_id.ProtoGlobalId id = 1;
+    mz_storage.types.sinks.ProtoSinkDesc description = 2;
+    mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
+}
+
+message ProtoExportSinks {
+    repeated ProtoExportSinkCommand exports = 1;
+}
+
 message ProtoFrontierUppersKind {
     repeated ProtoTrace traces = 1;
 }
@@ -60,6 +71,7 @@ message ProtoStorageCommand {
         ProtoIngestSources ingest_sources = 1;
         ProtoAllowCompaction allow_compaction = 2;
         google.protobuf.Empty initialization_complete = 3;
+        ProtoExportSinks export_sinks = 4;
     }
 }
 

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -37,6 +37,7 @@ use mz_timely_util::progress::any_change_batch;
 use crate::controller::CollectionMetadata;
 use crate::protocol::client::proto_storage_client::ProtoStorageClient;
 use crate::protocol::client::proto_storage_server::ProtoStorage;
+use crate::types::sinks::SinkDesc;
 use crate::types::sources::IngestionDescription;
 
 include!(concat!(env!("OUT_DIR"), "/mz_storage.protocol.client.rs"));
@@ -108,6 +109,7 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// Each entry in the vector names a collection and provides a frontier after which
     /// accumulations must be correct.
     AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
+    ExportSinks(Vec<ExportSinkCommand<T>>),
 }
 
 /// A command that starts ingesting the given ingestion description
@@ -156,12 +158,42 @@ impl RustType<ProtoIngestSourceCommand> for IngestSourceCommand<mz_repr::Timesta
             description: proto
                 .description
                 .into_rust_if_some("ProtoIngestSourceCommand::description")?,
-            resume_upper: proto
-                .resume_upper
-                .map(Into::into)
-                .ok_or_else(|| TryFromProtoError::missing_field("ProtoCompaction::resume_upper"))?,
+            resume_upper: proto.resume_upper.map(Into::into).ok_or_else(|| {
+                TryFromProtoError::missing_field("ProtoIngestSourceCommand::resume_upper")
+            })?,
         })
     }
+}
+
+impl RustType<ProtoExportSinkCommand> for ExportSinkCommand<mz_repr::Timestamp> {
+    fn into_proto(&self) -> ProtoExportSinkCommand {
+        ProtoExportSinkCommand {
+            id: Some(self.id.into_proto()),
+            description: Some(self.description.into_proto()),
+            resume_upper: Some((&self.resume_upper).into()),
+        }
+    }
+
+    fn from_proto(proto: ProtoExportSinkCommand) -> Result<Self, TryFromProtoError> {
+        Ok(ExportSinkCommand {
+            id: proto.id.into_rust_if_some("ProtoExportSinkCommand::id")?,
+            description: proto
+                .description
+                .into_rust_if_some("ProtoExportSinkCommand::description")?,
+            resume_upper: proto.resume_upper.map(Into::into).ok_or_else(|| {
+                TryFromProtoError::missing_field("ProtoExportSinkCommand::resume_upper")
+            })?,
+        })
+    }
+}
+
+/// A command that starts ingesting the given ingestion description
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ExportSinkCommand<T> {
+    pub id: GlobalId,
+    pub description: SinkDesc<CollectionMetadata, T>,
+    /// The upper frontier that this ingestion should resume at
+    pub resume_upper: Antichain<T>,
 }
 
 impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
@@ -178,6 +210,9 @@ impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
                         collections: collections.into_proto(),
                     })
                 }
+                StorageCommand::ExportSinks(exports) => ExportSinks(ProtoExportSinks {
+                    exports: exports.into_proto(),
+                }),
             }),
         }
     }
@@ -192,6 +227,9 @@ impl RustType<ProtoStorageCommand> for StorageCommand<mz_repr::Timestamp> {
                 Ok(StorageCommand::AllowCompaction(collections.into_rust()?))
             }
             Some(InitializationComplete(())) => Ok(StorageCommand::InitializationComplete),
+            Some(ExportSinks(ProtoExportSinks { exports })) => {
+                Ok(StorageCommand::ExportSinks(exports.into_rust()?))
+            }
             None => Err(TryFromProtoError::missing_field(
                 "ProtoStorageCommand::kind",
             )),

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -187,12 +187,12 @@ impl RustType<ProtoExportSinkCommand> for ExportSinkCommand<mz_repr::Timestamp> 
     }
 }
 
-/// A command that starts ingesting the given ingestion description
+/// A command that starts exporting the given sink description
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ExportSinkCommand<T> {
     pub id: GlobalId,
     pub description: SinkDesc<CollectionMetadata, T>,
-    /// The upper frontier that this ingestion should resume at
+    /// The upper frontier at which this export should resume.
     pub resume_upper: Antichain<T>,
 }
 

--- a/src/storage/src/protocol/server.rs
+++ b/src/storage/src/protocol/server.rs
@@ -93,6 +93,7 @@ pub fn serve(
                 decode_metrics,
                 reported_frontiers: HashMap::new(),
                 ingestions: HashMap::new(),
+                exports: HashMap::new(),
                 now: now.clone(),
                 source_metrics,
                 timely_worker_index,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -171,10 +171,10 @@ pub fn build_ingestion_dataflow<A: Allocate>(
 /// do the export dataflow thing
 pub fn build_export_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
-    storage_state: &mut StorageState,
+    _storage_state: &mut StorageState,
     id: GlobalId,
-    description: SinkDesc<CollectionMetadata, mz_repr::Timestamp>,
-    resume_upper: Antichain<mz_repr::Timestamp>,
+    _description: SinkDesc<CollectionMetadata, mz_repr::Timestamp>,
+    _resume_upper: Antichain<mz_repr::Timestamp>,
 ) {
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();
@@ -185,7 +185,7 @@ pub fn build_export_dataflow<A: Allocate>(
         // so that other similar uses (e.g. with iterative scopes) do not require weird
         // alternate type signatures.
         scope.clone().region_named(&name, |region| {
-            let debug_name = format!("{debug_name}-sinks");
+            let _debug_name = format!("{debug_name}-sinks");
             let _: &mut timely::dataflow::scopes::Child<
                 timely::dataflow::scopes::Child<TimelyWorker<A>, _>,
                 mz_repr::Timestamp,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -111,6 +111,7 @@ use mz_repr::GlobalId;
 
 use crate::controller::CollectionMetadata;
 use crate::storage_state::StorageState;
+use crate::types::sinks::SinkDesc;
 use crate::types::sources::IngestionDescription;
 
 mod debezium;
@@ -118,11 +119,11 @@ mod persist_sink;
 pub mod sources;
 mod upsert;
 
-/// Assemble the "storage" side of a dataflow, i.e. the sources.
+/// Assemble the "ingestion" side of a dataflow, i.e. the sources.
 ///
 /// This method creates a new dataflow to host the implementations of sources for the `dataflow`
 /// argument, and returns assets for each source that can import the results into a new dataflow.
-pub fn build_storage_dataflow<A: Allocate>(
+pub fn build_ingestion_dataflow<A: Allocate>(
     timely_worker: &mut TimelyWorker<A>,
     storage_state: &mut StorageState,
     id: GlobalId,
@@ -163,6 +164,32 @@ pub fn build_storage_dataflow<A: Allocate>(
             );
 
             storage_state.source_tokens.insert(id, token);
+        })
+    });
+}
+
+/// do the export dataflow thing
+pub fn build_export_dataflow<A: Allocate>(
+    timely_worker: &mut TimelyWorker<A>,
+    storage_state: &mut StorageState,
+    id: GlobalId,
+    description: SinkDesc<CollectionMetadata, mz_repr::Timestamp>,
+    resume_upper: Antichain<mz_repr::Timestamp>,
+) {
+    let worker_logging = timely_worker.log_register().get("timely");
+    let debug_name = id.to_string();
+    let name = format!("Source dataflow: {debug_name}");
+    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
+        // The scope.clone() occurs to allow import in the region.
+        // We build a region here to establish a pattern of a scope inside the dataflow,
+        // so that other similar uses (e.g. with iterative scopes) do not require weird
+        // alternate type signatures.
+        scope.clone().region_named(&name, |region| {
+            let debug_name = format!("{debug_name}-sinks");
+            let _: &mut timely::dataflow::scopes::Child<
+                timely::dataflow::scopes::Child<TimelyWorker<A>, _>,
+                mz_repr::Timestamp,
+            > = region;
         })
     });
 }


### PR DESCRIPTION
Mostly just modeled from how sources are created.  Sources have an Ingestion / Collection hierarchy in naming; sinks have an Export / Sink hierarchy in naming.

This PR establishes the framework for sending the command.  I've verified that we do in fact create a `storaged` process for each `CREATE SINK` command -- though we don't run anything on it yet.  It should be managed in the exact same way as the `storaged`s for each source.

### Motivation
internal design doc: https://www.notion.so/materialize/Kafka-Sinks-9ba8f8c0ddc949d6b20a67a2558a7604


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
