### PR TITLE
storage: add a LOAD GENERATOR source

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -807,6 +807,10 @@ pub enum CreateSourceConnection<T: AstInfo> {
         /// The PubNub channel to subscribe to
         channel: String,
     },
+    LoadGenerator {
+        generator: LoadGenerator,
+        options: Vec<LoadGeneratorOption<T>>,
+    },
 }
 
 impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
@@ -874,10 +878,66 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
                 f.write_str(&display::escape_single_quote_string(channel));
                 f.write_str("'");
             }
+            CreateSourceConnection::LoadGenerator { generator, options } => {
+                f.write_str("LOAD GENERATOR ");
+                f.write_node(generator);
+                if !options.is_empty() {
+                    f.write_str(" ");
+                    f.write_node(&display::comma_separated(&options));
+                }
+            }
         }
     }
 }
 impl_display_t!(CreateSourceConnection);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum LoadGenerator {
+    Counter,
+}
+
+impl AstDisplay for LoadGenerator {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            Self::Counter => {
+                f.write_str("COUNTER");
+            }
+        }
+    }
+}
+impl_display!(LoadGenerator);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum LoadGeneratorOptionName {
+    TickInterval,
+}
+
+impl AstDisplay for LoadGeneratorOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str(match self {
+            LoadGeneratorOptionName::TickInterval => "TICK INTERVAL",
+        })
+    }
+}
+impl_display!(LoadGeneratorOptionName);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// An option in a `CREATE CONNECTION...SSH`.
+pub struct LoadGeneratorOption<T: AstInfo> {
+    pub name: LoadGeneratorOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for LoadGeneratorOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
+impl_display_t!(LoadGeneratorOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSinkConnection<T: AstInfo> {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -74,6 +74,7 @@ Connections
 Consistency
 Constraint
 Copy
+Counter
 Create
 Cross
 Csv
@@ -128,6 +129,7 @@ Format
 Forward
 From
 Full
+Generator
 Granularity
 Graph
 Greatest
@@ -177,6 +179,7 @@ Level
 Like
 Limit
 List
+Load
 Local
 Log
 Logical
@@ -304,6 +307,7 @@ Temp
 Temporary
 Text
 Then
+Tick
 Ties
 Time
 Timeout

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1423,3 +1423,17 @@ CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, US
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST = 'ssh-bastion', PORT = 1234, USER = 'blah'
 =>
 CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("my_ssh_tunnel")]), connection: Ssh { with_options: [SshConnectionOption { name: Host, value: Some(Value(String("ssh-bastion"))) }, SshConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, SshConnectionOption { name: User, value: Some(Value(String("blah"))) }] }, if_not_exists: false })
+
+parse-statement
+CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
+----
+CREATE SOURCE lg FROM LOAD GENERATOR COUNTER
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), col_names: [], connection: LoadGenerator { generator: Counter, options: [] }, with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, remote: None })
+
+parse-statement
+CREATE SOURCE lg FROM LOAD GENERATOR COUNTER TICK INTERVAL '1s'
+----
+CREATE SOURCE lg FROM LOAD GENERATOR COUNTER TICK INTERVAL = '1s'
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), col_names: [], connection: LoadGenerator { generator: Counter, options: [LoadGeneratorOption { name: TickInterval, value: Some(Value(String("1s"))) }] }, with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, remote: None })

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -196,6 +196,7 @@ pub async fn purify_create_source(
             *details_ast = Some(hex::encode(details.into_proto().encode_to_vec()));
         }
         CreateSourceConnection::PubNub { .. } => (),
+        CreateSourceConnection::LoadGenerator { .. } => (),
     }
 
     purify_source_format(

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -31,8 +31,8 @@ use crate::decode::{render_decode, render_decode_cdcv2, render_decode_delimited}
 use crate::source::persist_source;
 use crate::source::{
     self, DecodeResult, DelimitedValueSource, KafkaSourceReader, KinesisSourceReader,
-    PostgresSourceReader, PubNubSourceReader, RawSourceCreationConfig, S3SourceReader,
-    SourceOutput,
+    LoadGeneratorSourceReader, PostgresSourceReader, PubNubSourceReader, RawSourceCreationConfig,
+    S3SourceReader, SourceOutput,
 };
 use crate::types::errors::{DataflowError, DecodeError};
 use crate::types::sources::{encoding::*, *};
@@ -189,6 +189,14 @@ where
         }
         SourceConnection::Postgres(_) => {
             let ((ok, err), cap) = source::create_raw_source::<_, PostgresSourceReader>(
+                base_source_config,
+                &connection,
+                storage_state.connection_context.clone(),
+            );
+            ((SourceType::Row(ok), err), cap)
+        }
+        SourceConnection::LoadGenerator(_) => {
+            let ((ok, err), cap) = source::create_raw_source::<_, LoadGeneratorSourceReader>(
                 base_source_config,
                 &connection,
                 storage_state.connection_context.clone(),

--- a/src/storage/src/source/load_generator.rs
+++ b/src/storage/src/source/load_generator.rs
@@ -1,0 +1,95 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::{Duration, Instant};
+
+use timely::scheduling::SyncActivator;
+
+use mz_expr::PartitionId;
+use mz_repr::{Diff, GlobalId, Row};
+
+use super::metrics::SourceBaseMetrics;
+use super::{SourceMessage, SourceMessageType};
+use crate::source::{NextMessage, SourceReader, SourceReaderError};
+use crate::types::connections::ConnectionContext;
+use crate::types::sources::Generator;
+use crate::types::sources::{encoding::SourceDataEncoding, MzOffset, SourceConnection};
+
+pub struct LoadGeneratorSourceReader {
+    generator: Generator,
+    last: Instant,
+    tick: Duration,
+    offset: MzOffset,
+}
+
+impl SourceReader for LoadGeneratorSourceReader {
+    type Key = ();
+    type Value = Row;
+    // LoadGenerator can produce deletes that cause retractions
+    type Diff = Diff;
+
+    fn new(
+        _source_name: String,
+        _source_id: GlobalId,
+        _worker_id: usize,
+        _worker_count: usize,
+        _consumer_activator: SyncActivator,
+        connection: SourceConnection,
+        start_offsets: Vec<(PartitionId, Option<MzOffset>)>,
+        _encoding: SourceDataEncoding,
+        _metrics: SourceBaseMetrics,
+        _connection_context: ConnectionContext,
+    ) -> Result<Self, anyhow::Error> {
+        let connection = match connection {
+            SourceConnection::LoadGenerator(lg) => lg,
+            _ => {
+                panic!("LoadGenerator is the only legitimate SourceConnection for LoadGeneratorSourceReader")
+            }
+        };
+
+        let offset = start_offsets
+            .into_iter()
+            .find_map(|(pid, offset)| {
+                if pid == PartitionId::None {
+                    offset
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            generator: connection.generator,
+            last: Instant::now(),
+            tick: Duration::from_micros(connection.tick_micros.unwrap_or(1_000_000)),
+            offset,
+        })
+    }
+    fn get_next_message(
+        &mut self,
+    ) -> Result<NextMessage<Self::Key, Self::Value, Self::Diff>, SourceReaderError> {
+        if self.last.elapsed() < self.tick {
+            return Ok(NextMessage::Pending);
+        }
+        self.last += self.tick;
+        self.offset += 1;
+        let value = self.generator.by_offset(self.offset);
+        Ok(NextMessage::Ready(SourceMessageType::Finalized(
+            SourceMessage {
+                partition: PartitionId::None,
+                offset: self.offset,
+                upstream_time_millis: None,
+                key: (),
+                value,
+                headers: None,
+                specific_diff: 1,
+            },
+        )))
+    }
+}

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -68,6 +68,7 @@ use crate::types::sources::{MzOffset, SourceConnection};
 
 mod kafka;
 mod kinesis;
+mod load_generator;
 pub mod metrics;
 pub mod persist_source;
 mod postgres;
@@ -78,6 +79,7 @@ pub mod util;
 
 pub use kafka::KafkaSourceReader;
 pub use kinesis::KinesisSourceReader;
+pub use load_generator::LoadGeneratorSourceReader;
 pub use postgres::PostgresSourceReader;
 pub use pubnub::PubNubSourceReader;
 pub use s3::S3SourceReader;

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -170,6 +170,7 @@ message ProtoSourceConnection {
         ProtoS3SourceConnection s3 = 3;
         ProtoPostgresSourceConnection postgres = 4;
         ProtoPubNubSourceConnection pubnub = 5;
+        ProtoLoadGeneratorSourceConnection loadgen = 6;
     }
 }
 
@@ -199,6 +200,13 @@ message ProtoPostgresSourceDetails {
 message ProtoPubNubSourceConnection {
     string subscribe_key = 1;
     string channel = 2;
+}
+
+message ProtoLoadGeneratorSourceConnection {
+    oneof generator {
+        google.protobuf.Empty counter = 1;
+    }
+    optional uint64 tick_micros = 2;
 }
 
 message ProtoS3SourceConnection {


### PR DESCRIPTION
For demos we would like to have something that makes data without having
to connect to it or always run INSERTs manually. Use a load generator
source type to do this.

For now, start with a counter type that increments on a schedule.

### Motivation

  * This PR adds a known-desirable feature. #11828

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a