### PR TITLE
test/postgres: upgrade PostgreSQL version

### DIFF
--- a/test/postgres/Dockerfile
+++ b/test/postgres/Dockerfile
@@ -9,7 +9,7 @@
 
 MZFROM test-certs as certs
 
-FROM postgres:10
+FROM postgres:10.21-bullseye
 
 ENV POSTGRES_PASSWORD=postgres
 


### PR DESCRIPTION
Use a newer version of the `postgres` image in the hope of fixing the
strange TLS failure in the pg-cdc tests.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.
