### PR TITLE
orchestrator-process: restrict permissions on secrets directory

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -10,7 +10,9 @@
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fmt::Debug;
+use std::fs::Permissions;
 use std::net::{IpAddr, Ipv4Addr};
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex};
@@ -92,6 +94,9 @@ impl ProcessOrchestrator {
         fs::create_dir_all(&secrets_dir)
             .await
             .context("creating secrets directory")?;
+        fs::set_permissions(&secrets_dir, Permissions::from_mode(0o700))
+            .await
+            .context("setting secrets directory permissions")?;
         Ok(ProcessOrchestrator {
             image_dir: fs::canonicalize(image_dir).await?,
             port_allocator,


### PR DESCRIPTION
I accidentally lost the permission restriction code in 7fa63fe.

Fix #13745.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Sorry, Philip!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
