### PR TITLE
sql-parser: verify parsing roundtrips

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1112,6 +1112,10 @@ impl<T: AstInfo> AstDisplay for ColumnDef<T> {
         f.write_node(&self.name);
         f.write_str(" ");
         f.write_node(&self.data_type);
+        if let Some(collation) = &self.collation {
+            f.write_str(" COLLATE ");
+            f.write_node(collation);
+        }
         for option in &self.options {
             f.write_str(" ");
             f.write_node(option);

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -506,7 +506,6 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
 
         match &self.envelope {
             None => (),
-            Some(Envelope::None) => (),
             Some(envelope) => {
                 f.write_str(" ENVELOPE ");
                 f.write_node(envelope);
@@ -1544,6 +1543,10 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
         if let Some(from) = &self.from {
             f.write_str(" FROM ");
             f.write_node(from);
+        }
+        if let Some(cluster) = &self.in_cluster {
+            f.write_str(" IN CLUSTER ");
+            f.write_node(cluster);
         }
         if let Some(filter) = &self.filter {
             f.write_str(" ");

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -57,11 +57,19 @@ fn datadriven() {
         match parser::parse_statements(input) {
             Ok(s) => {
                 if s.len() != 1 {
-                    "expected exactly one statement".to_string()
-                } else if tc.args.get("roundtrip").is_some() {
-                    format!("{}\n", s.into_element())
+                    return "expected exactly one statement\n".to_string();
+                }
+                let stmt = s.into_element();
+                let parsed = match parser::parse_statements(&stmt.to_string()) {
+                    Ok(parsed) => parsed.into_element(),
+                    Err(err) => return format!("reparse failed: {}\n", err),
+                };
+                if parsed != stmt {
+                    return format!("reparse comparison failed:\n{:?}\n!=\n{:?}\n", stmt, parsed);
+                }
+                if tc.args.get("roundtrip").is_some() {
+                    format!("{}\n", stmt)
                 } else {
-                    let stmt = s.into_element();
                     // TODO(justin): it would be nice to have a middle-ground between this
                     // all-on-one-line and {:#?}'s huge number of lines.
                     format!("{}\n=>\n{:?}\n", stmt, stmt)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -412,49 +412,49 @@ CreateRecordedView(CreateRecordedViewStatement { if_exists: Error, name: Unresol
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("crobat")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Timestamp, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Partition, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Topic, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC as kafka_topic ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC AS kafka_topic
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC AS kafka_topic ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("mykey")) }, SourceIncludeMetadata { ty: Timestamp, alias: None }, SourceIncludeMetadata { ty: Partition, alias: None }, SourceIncludeMetadata { ty: Topic, alias: Some(Ident("kafka_topic")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Avro(Csr { csr_connection: CsrConnectionAvro { connection: Inline { url: "http://localhost:8081" }, key_strategy: None, value_strategy: None, seed: None, with_options: [] } }), value: Avro(Csr { csr_connection: CsrConnectionAvro { connection: Inline { url: "http://localhost:8081" }, key_strategy: None, value_strategy: None, seed: None, with_options: [] } }) }, envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
@@ -475,7 +475,7 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USIN
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (CONFLUENT WIRE FORMAT = false) ENVELOPE NONE
 ----
-CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (CONFLUENT WIRE FORMAT = false)
+CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' WITH (CONFLUENT WIRE FORMAT = false) ENVELOPE NONE
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), with_options: [], include_metadata: [], format: Bare(Avro(InlineSchema { schema: Inline("string"), with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] })), envelope: Some(None), if_not_exists: false, key_constraint: None, remote: None })
 
@@ -988,7 +988,7 @@ CREATE TABLE public.customer (
         active integer NOT NULL
 ) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 ----
-CREATE TABLE public.customer (customer_id int4 DEFAULT nextval(public.customer_customer_id_seq), store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) NOT NULL, email varchar(50), address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamptz, active int4 NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
+CREATE TABLE public.customer (customer_id int4 DEFAULT nextval(public.customer_customer_id_seq), store_id int2 NOT NULL, first_name varchar(45) NOT NULL, last_name varchar(45) COLLATE "es_ES" NOT NULL, email varchar(50), address_id int2 NOT NULL, activebool bool DEFAULT true NOT NULL, create_date date DEFAULT now()::text NOT NULL, last_update timestamp DEFAULT now() NOT NULL, last_update_tz timestamptz, active int4 NOT NULL) WITH (fillfactor = 20, user_catalog_table = true, autovacuum_vacuum_threshold = 100)
 =>
 CreateTable(CreateTableStatement { name: UnresolvedObjectName([Ident("public"), Ident("customer")]), columns: [ColumnDef { name: Ident("customer_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("nextval")]), args: Args { args: [Identifier([Ident("public"), Ident("customer_customer_id_seq")])], order_by: [] }, filter: None, over: None, distinct: false })) }] }, ColumnDef { name: Ident("store_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("first_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_name"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [45] }, collation: Some(UnresolvedObjectName([Ident("es_ES")])), options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("email"), data_type: Other { name: Name(UnresolvedObjectName([Ident("varchar")])), typ_mod: [50] }, collation: None, options: [] }, ColumnDef { name: Ident("address_id"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int2")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("activebool"), data_type: Other { name: Name(UnresolvedObjectName([Ident("bool")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Value(Boolean(true))) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("create_date"), data_type: Other { name: Name(UnresolvedObjectName([Ident("date")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Cast { expr: Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false }), data_type: Other { name: Name(UnresolvedObjectName([Ident("text")])), typ_mod: [] } }) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamp")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: Default(Function(Function { name: UnresolvedObjectName([Ident("now")]), args: Args { args: [], order_by: [] }, filter: None, over: None, distinct: false })) }, ColumnOptionDef { name: None, option: NotNull }] }, ColumnDef { name: Ident("last_update_tz"), data_type: Other { name: Name(UnresolvedObjectName([Ident("timestamptz")])), typ_mod: [] }, collation: None, options: [] }, ColumnDef { name: Ident("active"), data_type: Other { name: Name(UnresolvedObjectName([Ident("int4")])), typ_mod: [] }, collation: None, options: [ColumnOptionDef { name: None, option: NotNull }] }], constraints: [], with_options: [WithOption { key: Ident("fillfactor"), value: Some(Value(Number("20"))) }, WithOption { key: Ident("user_catalog_table"), value: Some(Value(Boolean(true))) }, WithOption { key: Ident("autovacuum_vacuum_threshold"), value: Some(Value(Number("100"))) }], if_not_exists: false, temporary: false })
 

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -112,14 +112,14 @@ ShowObjects(ShowObjectsStatement { object_type: RecordedView, from: Some(Unresol
 parse-statement
 SHOW RECORDED VIEWS FROM foo.bar IN CLUSTER baz
 ----
-SHOW RECORDED VIEWS FROM foo.bar
+SHOW RECORDED VIEWS FROM foo.bar IN CLUSTER baz
 =>
 ShowObjects(ShowObjectsStatement { object_type: RecordedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW RECORDED VIEWS IN CLUSTER baz
 ----
-SHOW RECORDED VIEWS
+SHOW RECORDED VIEWS IN CLUSTER baz
 =>
 ShowObjects(ShowObjectsStatement { object_type: RecordedView, from: None, in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, materialized: false, filter: None })
 
@@ -154,14 +154,14 @@ ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchem
 parse-statement
 SHOW SINKS FROM foo.bar IN CLUSTER baz
 ----
-SHOW SINKS FROM foo.bar
+SHOW SINKS FROM foo.bar IN CLUSTER baz
 =>
 ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, materialized: false, filter: None })
 
 parse-statement
 SHOW SINKS IN CLUSTER baz
 ----
-SHOW SINKS
+SHOW SINKS IN CLUSTER baz
 =>
 ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, materialized: false, filter: None })
 

--- a/test/upgrade/check-from-current_source-schema-registry.td
+++ b/test/upgrade/check-from-current_source-schema-registry.td
@@ -14,4 +14,4 @@
 # injects a `WITH` option into the wrong spot.
 
 > SHOW CREATE SOURCE data
-"materialize.public.data" "CREATE SOURCE \"materialize\".\"public\".\"data\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' SEED VALUE SCHEMA '{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"a\",\"type\":\"int\"}]}'"
+"materialize.public.data" "CREATE SOURCE \"materialize\".\"public\".\"data\" FROM KAFKA BROKER 'kafka:9092' TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' SEED VALUE SCHEMA '{\"type\":\"record\",\"name\":\"foo\",\"fields\":[{\"name\":\"a\",\"type\":\"int\"}]}' ENVELOPE NONE"


### PR DESCRIPTION
Adding this check found some things we were parsing but not printing. It
also would have found a bug when I was adding some new parsing. This
should prevent it from happening in the future.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
