### PR TITLE
*: ban use of futures::executor::block_on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -1151,6 +1152,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -3414,6 +3416,7 @@ dependencies = [
  "prost-reflect",
  "serde_json",
  "timely",
+ "tokio",
  "tracing",
  "uuid 1.1.2",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,13 +1,14 @@
 disallowed-methods = [
-    # We have better wrappers for tokio task spawning
+    { path = "futures_executor::block_on", reason = "tokio::runtime::Handle::block_on instead" },
+    { path = "futures::executor::block_on", reason = "tokio::runtime::Handle::block_on instead" },
+
     { path = "tokio::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::task::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::task::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    # as well as an extention trait for inherent methods
     { path = "tokio::runtime::Handle::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::runtime::Handle::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::runtime::Runtime::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::runtime::Runtime::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
-    # Use the wrapper that sets the log level correctly
+
     { path = "rdkafka::config::ClientConfig::new", reason = "use the `client::create_new_client_config` wrapper in `kafka_util` instead" },
 ]

--- a/src/compute/src/sink/kafka.rs
+++ b/src/compute/src/sink/kafka.rs
@@ -19,7 +19,6 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
 use differential_dataflow::{AsCollection, Collection, Hashable};
-use futures::executor::block_on;
 use futures::{StreamExt, TryFutureExt};
 use itertools::Itertools;
 use prometheus::core::AtomicU64;
@@ -40,6 +39,7 @@ use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, Timestamp as _};
 use timely::scheduling::Activator;
+use tokio::runtime::Handle as TokioHandle;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info};
 
@@ -501,7 +501,7 @@ impl KafkaSinkState {
         connection_context: &ConnectionContext,
     ) -> ClientConfig {
         let mut config = create_new_client_config(connection_context.librdkafka_log_level);
-        block_on(
+        TokioHandle::current().block_on(
             connection.populate_client_config(&mut config, &*connection_context.secrets_reader),
         );
 
@@ -544,7 +544,7 @@ impl KafkaSinkState {
         connection_context: &ConnectionContext,
     ) -> ClientConfig {
         let mut config = create_new_client_config(connection_context.librdkafka_log_level);
-        block_on(
+        TokioHandle::current().block_on(
             connection.populate_client_config(&mut config, &*connection_context.secrets_reader),
         );
 

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -34,7 +34,8 @@ tracing = "0.1.35"
 uuid = { version = "1.1.2", features = ["serde"] }
 
 [dev-dependencies]
-criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git" }
+criterion = { git = "https://github.com/MaterializeInc/criterion.rs.git", features = ["async_tokio"] }
+tokio = { version = "1.19.2", features = ["macros"] }
 
 [build-dependencies]
 prost-build = { version = "0.10.3", features = ["vendored"] }

--- a/src/storage/src/decode/protobuf.rs
+++ b/src/storage/src/decode/protobuf.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use tokio::runtime::Handle as TokioHandle;
+
 use mz_interchange::protobuf::{DecodedDescriptors, Decoder};
 use mz_repr::Row;
 
@@ -15,6 +17,7 @@ use crate::types::sources::encoding::ProtobufEncoding;
 
 #[derive(Debug)]
 pub struct ProtobufDecoderState {
+    tokio_handle: TokioHandle,
     decoder: Decoder,
     events_success: i64,
     events_error: i64,
@@ -31,16 +34,14 @@ impl ProtobufDecoderState {
         let descriptors = DecodedDescriptors::from_bytes(&descriptors, message_name)
             .expect("descriptors provided to protobuf source are pre-validated");
         Ok(ProtobufDecoderState {
+            tokio_handle: TokioHandle::current(),
             decoder: Decoder::new(descriptors, confluent_wire_format)?,
             events_success: 0,
             events_error: 0,
         })
     }
     pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DecodeError>> {
-        // TODO(guswynn): make this async-sync-async sandwich open-faced.
-        //   Figuring out how to do async-to-sync work in timely land needs a general solution.
-        use futures::executor::block_on;
-        match block_on(self.decoder.decode(bytes)) {
+        match self.tokio_handle.block_on(self.decoder.decode(bytes)) {
             Ok(row) => {
                 if let Some(row) = row {
                     self.events_success += 1;

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
-use futures::executor::block_on;
 use rdkafka::consumer::base_consumer::PartitionQueue;
 use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
 use rdkafka::error::KafkaError;
@@ -21,6 +20,7 @@ use rdkafka::statistics::Statistics;
 use rdkafka::topic_partition_list::Offset;
 use rdkafka::{ClientConfig, ClientContext, Message, TopicPartitionList};
 use timely::scheduling::activate::SyncActivator;
+use tokio::runtime::Handle as TokioHandle;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -105,7 +105,7 @@ impl SourceReader for KafkaSourceReader {
             cluster_id,
             ..
         } = kc;
-        let kafka_config = block_on(create_kafka_config(
+        let kafka_config = TokioHandle::current().block_on(create_kafka_config(
             &source_name,
             group_id_prefix,
             cluster_id,


### PR DESCRIPTION
We recently had a lost wakeups bug caused by calling
futures::executor::block_on inside of a future (#13755). Replace all
usage of futures::executor::block_on with
tokio::runtime::Handle::block_on, which will panic if nested inside a
Tokio executor. Unfortunate that we can't enforce this statically, but
this is still better than tasks that silently never wake up.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR decreases the probability of a reoccurrence of a bug.
