### PR TITLE
Move `StorageController` persist writers to a Tokio task

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1049,6 +1049,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.controller
             .storage_mut()
             .append(appends)
+            .expect("invalid updates")
             .await
             .expect("One-shot shouldn't fail")
             .unwrap();
@@ -1275,7 +1276,11 @@ impl<S: Append + 'static> Coordinator<S> {
             .collect::<Vec<_>>();
         let num_updates = appends.len();
         // Note: Do not await the result; let it drop (as we don't need to block on completion)
-        self.controller.storage_mut().append(appends);
+        // The error that could be return
+        self.controller
+            .storage_mut()
+            .append(appends)
+            .expect("Empty updates cannot be invalid");
         let elapsed = start.elapsed();
         if elapsed > (MAX_WAIT + WINDOW) {
             self.advance_tables.decrease_batch();
@@ -1400,6 +1405,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.controller
             .storage_mut()
             .append(appends)
+            .expect("invalid updates")
             .await
             .expect("One-shot shouldn't fail")
             .unwrap();
@@ -5813,6 +5819,7 @@ impl<S: Append + 'static> Coordinator<S> {
         self.controller
             .storage_mut()
             .append(appends)
+            .expect("invalid updates")
             .await
             .expect("One-shot shouldn't fail")
             .unwrap();

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -31,9 +31,7 @@ use async_trait::async_trait;
 use bytes::BufMut;
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
-use futures::future;
-use futures::stream::TryStreamExt as _;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::StreamExt;
 use proptest_derive::Arbitrary;
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -47,7 +45,7 @@ use mz_build_info::BuildInfo;
 use mz_expr::PartitionId;
 use mz_orchestrator::NamespacedOrchestrator;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::{write::WriteHandle, PersistClient, PersistLocation, ShardId};
+use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_persist_types::{Codec, Codec64};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
@@ -135,10 +133,10 @@ pub trait StorageController: Debug + Send {
 
     /// Append `updates` into the local input named `id` and advance its upper to `upper`.
     // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
-    async fn append(
+    fn append(
         &mut self,
         commands: Vec<(GlobalId, Vec<Update<Self::Timestamp>>, Self::Timestamp)>,
-    ) -> Result<(), StorageError>;
+    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>>;
 
     /// Returns the snapshot of the contents of the local input named `id` at `as_of`.
     async fn snapshot(
@@ -325,12 +323,12 @@ pub struct StorageControllerState<
     pub(super) collections: BTreeMap<GlobalId, CollectionState<T>>,
     pub(super) stash: S,
     /// Write handle for persist shards.
-    pub(super) persist_write_handles: BTreeMap<GlobalId, WriteHandle<SourceData, (), T, Diff>>,
+    pub(super) persist_write_handles: persist_write_handles::PersistWorker<T>,
     /// Read handles for persist shards.
     ///
     /// These handles are on the other end of a Tokio task, so that work can be done asynchronously
     /// without blocknig the storage controller.
-    persist_read_handles: persist_read_downgrade::PersistWorker<T>,
+    persist_read_handles: persist_read_handles::PersistWorker<T>,
     stashed_response: Option<StorageResponse<T>>,
 }
 
@@ -340,6 +338,8 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + Unpin> {
     state: StorageControllerState<T>,
     /// Storage host provisioning and storage object assignment.
     hosts: StorageHosts<T>,
+    /// Mechanism for returning frontier advancement for tables.
+    internal_response_queue: tokio::sync::mpsc::UnboundedReceiver<StorageResponse<T>>,
     /// The persist location where all storage collections are being written to
     persist_location: PersistLocation,
     /// A persist client used to write to storage collections
@@ -434,7 +434,10 @@ impl From<DataflowError> for StorageError {
 }
 
 impl<T: Timestamp + Lattice + Codec64> StorageControllerState<T> {
-    pub(super) async fn new(postgres_url: String) -> Self {
+    pub(super) async fn new(
+        postgres_url: String,
+        tx: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
+    ) -> Self {
         let tls = mz_postgres_util::make_tls(
             &tokio_postgres::config::Config::from_str(&postgres_url)
                 .expect("invalid postgres url for storage stash"),
@@ -447,8 +450,8 @@ impl<T: Timestamp + Lattice + Codec64> StorageControllerState<T> {
         Self {
             collections: BTreeMap::default(),
             stash,
-            persist_write_handles: BTreeMap::default(),
-            persist_read_handles: persist_read_downgrade::PersistWorker::new(),
+            persist_write_handles: persist_write_handles::PersistWorker::new(tx),
+            persist_read_handles: persist_read_handles::PersistWorker::new(),
             stashed_response: None,
         }
     }
@@ -537,7 +540,7 @@ where
             let collection_state =
                 CollectionState::new(description.clone(), read.since().clone(), metadata);
 
-            self.state.persist_write_handles.insert(id, write);
+            self.state.persist_write_handles.register(id, write);
             self.state.persist_read_handles.register(id, read);
 
             self.state.collections.insert(id, collection_state);
@@ -622,75 +625,11 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    async fn append(
+    fn append(
         &mut self,
         commands: Vec<(GlobalId, Vec<Update<Self::Timestamp>>, Self::Timestamp)>,
-    ) -> Result<(), StorageError> {
-        // TODO(petrosagg): validate appends against the expected RelationDesc of the collection
-        let mut updates_by_id = HashMap::new();
-
-        for (id, updates, batch_upper) in commands {
-            for update in &updates {
-                if !update.timestamp.less_than(&batch_upper) {
-                    return Err(StorageError::UpdateBeyondUpper(id));
-                }
-            }
-
-            let (total_updates, new_upper) = updates_by_id
-                .entry(id)
-                .or_insert_with(|| (Vec::new(), T::minimum()));
-            total_updates.push(updates);
-            new_upper.join_assign(&batch_upper);
-        }
-
-        let mut appends_by_id = HashMap::new();
-        for (id, (updates, upper)) in updates_by_id {
-            let current_upper = self.state.persist_write_handles[&id].upper().clone();
-            appends_by_id.insert(id, (updates.into_iter().flatten(), current_upper, upper));
-        }
-
-        let futs = FuturesUnordered::new();
-
-        // We cannot iterate through the updates and then set off a persist call
-        // on the write handle because we cannot mutably borrow the write handle
-        // multiple times.
-        //
-        // Instead, we first group the update by ID above and then iterate
-        // through all available write handles and see if there are any updates
-        // for it. If yes, we send them all in one go.
-        for (id, write) in self.state.persist_write_handles.iter_mut() {
-            let (updates, upper, new_upper) = match appends_by_id.remove(id) {
-                Some(updates) => updates,
-                None => continue,
-            };
-
-            let new_upper = Antichain::from_elem(new_upper);
-
-            let updates = updates
-                .into_iter()
-                .map(|u| ((SourceData(Ok(u.row)), ()), u.timestamp, u.diff));
-
-            futs.push(async move {
-                write
-                    .compare_and_append(updates, upper.clone(), new_upper.clone())
-                    .await
-                    .expect("cannot append updates")
-                    .expect("cannot append updates")
-                    .or(Err(StorageError::InvalidUpper(*id)))?;
-
-                let mut change_batch = ChangeBatch::new();
-                change_batch.extend(new_upper.iter().cloned().map(|t| (t, 1)));
-                change_batch.extend(upper.iter().cloned().map(|t| (t, -1)));
-
-                Ok::<_, StorageError>((*id, change_batch))
-            })
-        }
-
-        let change_batches = futs.try_collect::<Vec<_>>().await?;
-
-        self.update_write_frontiers(&change_batches).await?;
-
-        Ok(())
+    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
+        self.state.persist_write_handles.append(commands)
     }
 
     async fn snapshot(
@@ -806,16 +745,11 @@ where
         // downgrade persist sinces. The actual downgrades are performed by a Tokio
         // task asynchorously.
         let mut compaction_commands = BTreeMap::default();
-        for (id, _) in self.state.persist_write_handles.iter_mut() {
-            let (mut changes, frontier) = match storage_net.remove(id) {
-                Some(changes) => changes,
-                None => continue,
-            };
+        for (key, (mut changes, frontier)) in storage_net {
             if !changes.is_empty() {
-                compaction_commands.insert(*id, frontier);
+                compaction_commands.insert(key, frontier);
             }
         }
-
         self.state
             .persist_read_handles
             .downgrade(compaction_commands.clone());
@@ -843,15 +777,17 @@ where
             .map(|client| client.response_stream())
             .enumerate()
             .collect::<StreamMap<_, _>>();
-        if clients.is_empty() {
-            // If there are no clients, block forever. This signals that there
-            // may be more work to do (e.g., if this future is dropped and
-            // `create_collections` is called). Awaiting the stream map would
-            // return `None`, which would incorrectly indicate the completion
-            // of the stream.
-            return future::pending().await;
-        }
-        self.state.stashed_response = clients.next().await.map(|(_id, res)| res)
+
+        let msg = tokio::select! {
+            // Order matters here. We want to process internal commands
+            // before processing external commands.
+            biased;
+
+            Some(m) = self.internal_response_queue.recv() => m,
+            Some((_id, m)) = clients.next() => m,
+        };
+
+        self.state.stashed_response = Some(msg);
     }
 
     async fn process(&mut self) -> Result<(), anyhow::Error> {
@@ -891,13 +827,16 @@ where
             .await
             .unwrap();
 
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
         Self {
-            state: StorageControllerState::new(postgres_url).await,
+            state: StorageControllerState::new(postgres_url, tx).await,
             hosts: StorageHosts::new(StorageHostsConfig {
                 build_info,
                 orchestrator,
                 storaged_image,
             }),
+            internal_response_queue: rx,
             persist_location,
             persist_client,
             initialized: false,
@@ -959,7 +898,7 @@ impl<T: Timestamp> CollectionState<T> {
     }
 }
 
-mod persist_read_downgrade {
+mod persist_read_handles {
 
     use std::collections::BTreeMap;
 
@@ -1018,7 +957,7 @@ mod persist_read_downgrade {
         pub(crate) fn new() -> Self {
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
-            mz_ore::task::spawn(|| "PersistReadDowngrade", async move {
+            mz_ore::task::spawn(|| "PersistReadHandles", async move {
                 let mut read_handles: BTreeMap<GlobalId, ReadHandle<SourceData, (), T, Diff>> =
                     BTreeMap::new();
 
@@ -1134,6 +1073,228 @@ mod persist_read_downgrade {
         ) -> tokio::sync::oneshot::Receiver<Result<Vec<(Row, Diff)>, StorageError>> {
             let (tx, rx) = tokio::sync::oneshot::channel();
             self.send(PersistWorkerCmd::Snapshot(id, since, tx));
+            rx
+        }
+
+        fn send(&self, cmd: PersistWorkerCmd<T>) {
+            match self.tx.send(cmd) {
+                Ok(()) => (), // All good!
+                Err(e) => {
+                    tracing::error!("could not forward command: {:?}", e);
+                }
+            }
+        }
+    }
+}
+
+mod persist_write_handles {
+
+    use std::collections::BTreeMap;
+
+    use differential_dataflow::lattice::Lattice;
+    use futures::stream::FuturesUnordered;
+    use timely::progress::{Antichain, Timestamp};
+    use tokio::sync::mpsc::UnboundedSender;
+
+    use mz_persist_client::write::WriteHandle;
+    use mz_persist_types::Codec64;
+    use mz_repr::{Diff, GlobalId};
+
+    use crate::controller::StorageError;
+    use crate::protocol::client::StorageResponse;
+    use crate::protocol::client::Update;
+    use crate::types::sources::SourceData;
+
+    #[derive(Debug)]
+    pub struct PersistWorker<T: Timestamp + Lattice + Codec64> {
+        tx: UnboundedSender<PersistWorkerCmd<T>>,
+    }
+
+    impl<T> Drop for PersistWorker<T>
+    where
+        T: Timestamp + Lattice + Codec64,
+    {
+        fn drop(&mut self) {
+            self.send(PersistWorkerCmd::Shutdown);
+            // TODO: Can't easily block on shutdown occurring.
+        }
+    }
+
+    /// Commands for [PersistWorker].
+    #[derive(Debug)]
+    enum PersistWorkerCmd<T: Timestamp + Lattice + Codec64> {
+        Register(GlobalId, WriteHandle<SourceData, (), T, Diff>),
+        Append(
+            Vec<(GlobalId, Vec<Update<T>>, T)>,
+            tokio::sync::oneshot::Sender<Result<(), StorageError>>,
+        ),
+        Shutdown,
+    }
+
+    impl<T: Timestamp + Lattice + Codec64> PersistWorker<T> {
+        pub(crate) fn new(
+            mut frontier_responses: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
+        ) -> Self {
+            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+            mz_ore::task::spawn(|| "PersistWriteHandles", async move {
+                let mut write_handles: BTreeMap<GlobalId, WriteHandle<SourceData, (), T, Diff>> =
+                    BTreeMap::new();
+
+                while let Some(cmd) = rx.recv().await {
+                    // Peel off all available commands.
+                    // We do this in case we can consolidate commands.
+                    // It would be surprising to receive multiple concurrent `Append` commands, but let's write it.
+                    let mut commands = vec![cmd];
+                    while let Ok(cmd) = rx.try_recv() {
+                        commands.push(cmd);
+                    }
+
+                    let mut shutdown = false;
+
+                    for command in commands {
+                        match command {
+                            PersistWorkerCmd::Register(id, write_handle) => {
+                                let previous = write_handles.insert(id, write_handle);
+                                if previous.is_some() {
+                                    panic!(
+                                        "already registered a ReadHandle for collection {:?}",
+                                        id
+                                    );
+                                }
+                            }
+                            PersistWorkerCmd::Append(updates, response) => {
+                                async fn append_work<T2: Timestamp + Lattice + Codec64>(
+                                    frontier_responses: &mut tokio::sync::mpsc::UnboundedSender<
+                                        StorageResponse<T2>,
+                                    >,
+                                    write_handles: &mut BTreeMap<
+                                        GlobalId,
+                                        WriteHandle<SourceData, (), T2, Diff>,
+                                    >,
+                                    commands: Vec<(GlobalId, Vec<Update<T2>>, T2)>,
+                                ) -> Result<(), StorageError> {
+                                    // TODO(petrosagg): validate appends against the expected RelationDesc of the collection
+                                    let mut updates_by_id = BTreeMap::new();
+
+                                    for (id, updates, batch_upper) in commands {
+                                        for update in &updates {
+                                            if !update.timestamp.less_than(&batch_upper) {
+                                                return Err(StorageError::UpdateBeyondUpper(id));
+                                            }
+                                        }
+
+                                        let (total_updates, new_upper) = updates_by_id
+                                            .entry(id)
+                                            .or_insert_with(|| (Vec::new(), T2::minimum()));
+                                        total_updates.push(updates);
+                                        new_upper.join_assign(&batch_upper);
+                                    }
+
+                                    let mut appends_by_id = BTreeMap::new();
+                                    for (id, (updates, upper)) in updates_by_id {
+                                        let current_upper = write_handles[&id].upper().clone();
+                                        appends_by_id.insert(
+                                            id,
+                                            (updates.into_iter().flatten(), current_upper, upper),
+                                        );
+                                    }
+
+                                    let futs = FuturesUnordered::new();
+
+                                    // We cannot iterate through the updates and then set off a persist call
+                                    // on the write handle because we cannot mutably borrow the write handle
+                                    // multiple times.
+                                    //
+                                    // Instead, we first group the update by ID above and then iterate
+                                    // through all available write handles and see if there are any updates
+                                    // for it. If yes, we send them all in one go.
+                                    for (id, write) in write_handles.iter_mut() {
+                                        let (updates, upper, new_upper) =
+                                            match appends_by_id.remove(id) {
+                                                Some(updates) => updates,
+                                                None => continue,
+                                            };
+
+                                        let new_upper = Antichain::from_elem(new_upper);
+
+                                        let updates = updates.into_iter().map(|u| {
+                                            ((SourceData(Ok(u.row)), ()), u.timestamp, u.diff)
+                                        });
+
+                                        futs.push(async move {
+                                            write
+                                                .compare_and_append(
+                                                    updates,
+                                                    upper.clone(),
+                                                    new_upper.clone(),
+                                                )
+                                                .await
+                                                .expect("cannot append updates")
+                                                .expect("cannot append updates")
+                                                .or(Err(StorageError::InvalidUpper(*id)))?;
+
+                                            let mut change_batch =
+                                                timely::progress::ChangeBatch::new();
+                                            change_batch
+                                                .extend(new_upper.iter().cloned().map(|t| (t, 1)));
+                                            change_batch
+                                                .extend(upper.iter().cloned().map(|t| (t, -1)));
+
+                                            Ok::<_, StorageError>((*id, change_batch))
+                                        })
+                                    }
+
+                                    use futures_util::TryStreamExt;
+                                    let change_batches = futs.try_collect::<Vec<_>>().await?;
+
+                                    frontier_responses
+                                        .send(StorageResponse::FrontierUppers(change_batches))
+                                        .expect("In-memory queues should not fail");
+
+                                    Ok(())
+                                }
+
+                                let result = append_work(
+                                    &mut frontier_responses,
+                                    &mut write_handles,
+                                    updates,
+                                )
+                                .await;
+
+                                // It is not an error for the other end to hang up.
+                                let _ = response.send(result);
+                            }
+                            PersistWorkerCmd::Shutdown => {
+                                shutdown = true;
+                            }
+                        }
+                    }
+
+                    if shutdown {
+                        tracing::trace!("shutting down persist write append task");
+                        break;
+                    }
+                }
+            });
+
+            Self { tx }
+        }
+
+        pub(crate) fn register(
+            &self,
+            id: GlobalId,
+            write_handle: WriteHandle<SourceData, (), T, Diff>,
+        ) {
+            self.send(PersistWorkerCmd::Register(id, write_handle))
+        }
+
+        pub(crate) fn append(
+            &self,
+            updates: Vec<(GlobalId, Vec<Update<T>>, T)>,
+        ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.send(PersistWorkerCmd::Append(updates, tx));
             rx
         }
 


### PR DESCRIPTION
This PR moves the `WriteHandle`s from the storage controller implementation to a tokio task, which allows folks who call `append` to either block or not block on the returned future (a `oneshot::Receiver`). This allows certain unopinionated write frontier advancement to happen off of the main thread, while still allowing group commit to block. However, it also allows group commit to *not* block, if we would like to tweak that implementation (i.e. allow the future to prompt a future completion for the group commit, rather than blocking the main thread while it happens).

cc: @jkosh44 on some of these ideas.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
