### PR TITLE
platform checks framework: Add restarting of environmentd

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -37,6 +37,7 @@ steps:
           - { value: checks-drop-create-default-replica }
           - { value: checks-restart-computed }
           - { value: checks-restart-entire-mz }
+          - { value: checks-restart-environmentd-storaged }
           - { value: checks-kill-storaged }
           - { value: secrets }
           - { value: unused-deps }
@@ -286,6 +287,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartEntireMz]
+
+  - id: checks-restart-environmentd-storaged
+    label: "Checks + restart of environmentd & storaged"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEnvironmentdStoraged]
 
   - id: checks-kill-storaged
     label: "Checks + kill storaged"

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -80,6 +80,8 @@ class DropCreateDefaultReplica(Scenario):
 
 
 class RestartComputed(Scenario):
+    """Restart computed by having it run in a separate container that is then killed and restarted."""
+
     def actions(self) -> List[Action]:
         return [
             StartMz(),
@@ -94,6 +96,24 @@ class RestartComputed(Scenario):
             Manipulate(self.checks, phase=2),
             KillComputed(),
             StartComputed(),
+            Validate(self.checks),
+        ]
+
+
+class RestartEnvironmentdStoraged(Scenario):
+    """Restart environmentd and storaged (as spawned from it), while keeping computed running by placing it in a separate container."""
+
+    def actions(self) -> List[Action]:
+        return [
+            StartMz(),
+            StartComputed(),
+            UseComputed(),
+            Initialize(self.checks),
+            RestartMzAction(),
+            Manipulate(self.checks, phase=1),
+            RestartMzAction(),
+            Manipulate(self.checks, phase=2),
+            RestartMzAction(),
             Validate(self.checks),
         ]
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -390,23 +390,40 @@ class Composition:
         elapsed = time.time() - start_time
         self.test_results[name] = Composition.TestResult(elapsed, error)
 
-    def sql_cursor(self) -> Cursor:
+    def sql_cursor(
+        self,
+        service: str = "materialized",
+        user: str = "materialize",
+        password: Optional[str] = None,
+    ) -> Cursor:
         """Get a cursor to run SQL queries against the materialized service."""
-        port = self.default_port("materialized")
-        conn = pg8000.connect(host="localhost", user="materialize", port=port)
+        port = self.default_port(service)
+        conn = pg8000.connect(host="localhost", user=user, password=password, port=port)
         conn.autocommit = True
         return conn.cursor()
 
-    def sql(self, sql: str) -> None:
+    def sql(
+        self,
+        sql: str,
+        service: str = "materialized",
+        user: str = "materialize",
+        password: Optional[str] = None,
+    ) -> None:
         """Run a batch of SQL statements against the materialized service."""
-        with self.sql_cursor() as cursor:
+        with self.sql_cursor(service=service, user=user, password=password) as cursor:
             for statement in sqlparse.split(sql):
                 print(f"> {statement}")
                 cursor.execute(statement)
 
-    def sql_query(self, sql: str) -> Any:
+    def sql_query(
+        self,
+        sql: str,
+        service: str = "materialized",
+        user: str = "materialize",
+        password: Optional[str] = None,
+    ) -> Any:
         """Execute and return results of a SQL query."""
-        with self.sql_cursor() as cursor:
+        with self.sql_cursor(service=service, user=user, password=password) as cursor:
             cursor.execute(sql)
             return cursor.fetchall()
 


### PR DESCRIPTION
- storaged is also killed and restarted as a consequence of it being
  spawned by environmentd
- computed is not affected because it is running in a separate container

### Motivation

  * This PR adds a feature that has not yet been specified.

This is part of the testing effort for compute reconciliation.

Relates to #[10549](https://github.com/MaterializeInc/materialize/issues/10549)