### PR TITLE
scratch-aws-access: remove AWS_DEFAULT_REGION workaround

### DIFF
--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -18,10 +18,6 @@ creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --role-session-na
 AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "$creds")
 AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "$creds")
 AWS_SESSION_TOKEN=$(jq -r '.Credentials.SessionToken' <<< "$creds")
-# This is a hack to get around https://github.com/buildkite/elastic-ci-stack-for-aws/pull/406
-# -- we can't set the environment variable in the pipeline.yml, because it would be overwritten
-# by that elastic-ci-stack-for-aws script.
-AWS_DEFAULT_REGION=us-east-2
 
 export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_DEFAULT_REGION
 
@@ -29,4 +25,3 @@ echo "Role ARN: $AWS_SCRATCH_ROLE_ARN"
 echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
 echo "AWS_SECRET_ACCESS_KEY=(${#AWS_SECRET_ACCESS_KEY} chars)"
 echo "AWS_SESSION_TOKEN=(${#AWS_SESSION_TOKEN} chars)"
-echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -116,6 +116,8 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_cargo-test_*.xml
+    env:
+      AWS_DEFAULT_REGION: "us-east-2"
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
@@ -254,6 +256,8 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_mzcompose_*.xml
+    env:
+      AWS_DEFAULT_REGION: "us-east-2"
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
This PR removes the workaround that fixed `AWS_DEFAULT_REGION` to us-east-2 in the scratch-aws-access Buildkite plugin. It looks like that workaround is no longer required since the underlying issue was fixed in https://github.com/buildkite/elastic-ci-stack-for-aws/pull/892.

Removing this workaround also has the side-effect of making the cleanup of scratch instances in us-east-1 actually work as intended. See [this Slack thread](https://materializeinc.slack.com/archives/C01KV5PEZ9R/p1658392104975319) for details.

### Motivation

  * This PR fixes a previously unreported bug.

scratch instances in us-east-1 are never cleaned up.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).