### PR TITLE
compute: log sink frontiers

### DIFF
--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -70,11 +70,6 @@ pub(crate) fn persist_sink<G>(
         token,
     ));
 
-    // Report frontier of collection back to coord
-    compute_state
-        .reported_frontiers
-        .insert(target_id, Antichain::from_elem(0));
-
     // We don't allow these dataflows to be dropped, so the tokens could
     // be stored anywhere.
     compute_state.sink_tokens.insert(

--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/13790
+
+> CREATE TABLE t (a int)
+
+> CREATE MATERIALIZED VIEW mv AS SELECT * FROM t
+
+# Note: We rely on testdrive's retry behavior here, as it takes some time for
+# the logging to catch up.
+
+> SELECT time > 0
+  FROM
+    mz_materialized_views AS views,
+    mz_materialization_frontiers AS frontiers
+  WHERE
+    views.name = 'mv' AND
+    views.id = frontiers.global_id
+true


### PR DESCRIPTION
This commit adjusts the compute code to also emit `ComputeLog::Frontier` events for sinks exported from dataflows, not just indexes. This fixes a bug where `mz_materialization_frontiers` always contains '0' as the frontier of sink dataflows (like those feeding recorded views).

### Motivation

  * This PR fixes a recognized bug.

Fixes #13790.

### Tips for reviewer

I don't know for a fact that not logging sink frontiers was an oversight before. There might be a reason I'm not aware of!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Show the current frontiers of sink dataflows in `mz_materialization_frontiers`, instead of '0'.
