### PR TITLE
doc/user: small typo fixes

### DIFF
--- a/doc/user/content/overview/key-concepts.md
+++ b/doc/user/content/overview/key-concepts.md
@@ -159,7 +159,7 @@ quickly.
 
 Creating additional indexes on materialized views lets you store some subset of a query's data in memory using a different structure, which can be useful if you want to perform a join over a view's data using non-primary keys (e.g. foreign keys).
 
-For a deeper dive into arrangments, see [Arrangements](/overview/arrangements/).
+For a deeper dive into arrangements, see [Arrangements](/overview/arrangements/).
 
 ## Clusters
 

--- a/doc/user/content/sql/types/list.md
+++ b/doc/user/content/sql/types/list.md
@@ -343,7 +343,7 @@ Feature | Array term | List term
 **Accessing single element** | Subscripting | Indexing<sup>1</sup>
 **Accessing range of elements** | Subscripting | Slicing<sup>1</sup>
 
-<sup>1</sup>In places some places, such as error messages, Materialize refers to
+<sup>1</sup>In some places, such as error messages, Materialize refers to
 both list indexing and list slicing as subscripting.
 
 #### Type definitions


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

Final 2 small typo found in `doc/user/**/.md`

### Motivation

   * This PR refactors existing code.



### Tips for reviewer
- Sorry for the extra small push, these were the last two small typos found in `doc/user`. One I should have fixed correctly in #13783. 
- Moving to `doc/developer` next...

### Checklist
- no user-facing behavior changes
