### PR TITLE
Add C-triage label as a default

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -11,7 +11,7 @@ name: Bug
 description: >
   A defect in an existing feature. For example, "consistency is violated if
   Kafka Connect restarts."
-labels: C-bug
+labels: [C-bug, C-triage]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Adds a new default label for triage to the bug template