### PR TITLE
persist: add connection pool to consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c668a58063c6331e3437e3146970943ad82b1b36169fd979bb2645ac2088209a"
+dependencies = [
+ "deadpool",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3634,6 +3668,7 @@ dependencies = [
  "bytes",
  "criterion",
  "crossbeam-channel",
+ "deadpool-postgres",
  "differential-dataflow",
  "fail",
  "futures-util",
@@ -5472,6 +5507,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,7 @@ prost = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" 
 prost-build = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-derive = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-types = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ prost = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" 
 prost-build = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-derive = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-types = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ name = "strum-macros"
 [[bans.deny]]
 name = "log"
 wrappers = [
+    "deadpool-postgres",
     "env_logger",
     "fail",
     "globset",

--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update \
     && groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize \
     && pg_dropcluster 14 main \
-    && pg_createcluster 14 materialize --user=materialize \
-    && pg_ctlcluster 14 materialize start \
-    && echo "listen_addresses = '*'" >> /etc/postgresql/14/materialize/postgresql.conf \
+    && pg_createcluster 14 materialize --user=materialize --start \
+        --pgoption listen_addresses=* \
+        --pgoption max_connections=5000 \
     && su materialize -c "createdb materialize" \
     && mkdir /mzdata \
     && chown materialize /mzdata

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -462,7 +462,7 @@ class Postgres(Service):
         mzbuild: str = "postgres",
         image: Optional[str] = None,
         port: int = 5432,
-        command: str = "postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20",
+        command: str = "postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20 -c max_connections=5000",
         environment: List[str] = ["POSTGRESDB=postgres", "POSTGRES_PASSWORD=postgres"],
     ) -> None:
         config: ServiceConfig = {"image": image} if image else {"mzbuild": mzbuild}

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -159,8 +159,10 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             command_wrapper: vec![],
         }))?,
     );
-    let persist_clients =
-        PersistClientCache::new(PersistConfig::new(config.now.clone()), &metrics_registry);
+    let persist_clients = PersistClientCache::new(
+        PersistConfig::new_for_test(config.now.clone()),
+        &metrics_registry,
+    );
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let inner = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         adapter_stash_url,

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -440,9 +440,10 @@ impl Service for TransactorService {
         let blob = CachingBlob::new(blob);
 
         // Construct requested Consensus.
+        let config = PersistConfig::new(SYSTEM_TIME.clone());
         let consensus = match &args.consensus_uri {
             Some(consensus_uri) => {
-                ConsensusConfig::try_from(consensus_uri)
+                ConsensusConfig::try_from(consensus_uri, config.consensus_connection_pool_max_size)
                     .await?
                     .open()
                     .await?
@@ -454,13 +455,7 @@ impl Service for TransactorService {
 
         // Wire up the TransactorService.
         let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-        let client = PersistClient::new(
-            PersistConfig::new(SYSTEM_TIME.clone()),
-            blob,
-            consensus,
-            metrics,
-        )
-        .await?;
+        let client = PersistClient::new(config, blob, consensus, metrics).await?;
         let transactor = Transactor::new(&client, shard_id).await?;
         let service = TransactorService(Arc::new(Mutex::new(transactor)));
         Ok(service)

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -186,7 +186,8 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         consensus_uri: args.consensus_uri,
     };
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-    let (blob, consensus) = location.open_locations(&metrics).await?;
+    let config = PersistConfig::new(SYSTEM_TIME.clone());
+    let (blob, consensus) = location.open_locations(&config, &metrics).await?;
     let unreliable = UnreliableHandle::default();
     let should_happen = 1.0 - args.unreliability;
     let should_timeout = args.unreliability;
@@ -195,13 +196,7 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         Arc::new(UnreliableBlob::new(blob, unreliable.clone())) as Arc<dyn Blob + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
-    PersistClient::new(
-        PersistConfig::new(SYSTEM_TIME.clone()),
-        blob,
-        consensus,
-        metrics,
-    )
-    .await
+    PersistClient::new(config, blob, consensus, metrics).await
 }
 
 mod api {

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -77,7 +77,9 @@ impl PersistClientCache {
             Entry::Vacant(x) => {
                 // Intentionally hold the lock, so we don't double connect under
                 // concurrency.
-                let consensus = ConsensusConfig::try_from(x.key()).await?;
+                let consensus =
+                    ConsensusConfig::try_from(x.key(), self.cfg.consensus_connection_pool_max_size)
+                        .await?;
                 let consensus =
                     retry_external(&self.metrics.retries.external.consensus_open, || {
                         consensus.clone().open()

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -27,8 +27,8 @@ aws-sdk-s3 = { version = "0.16.0", default-features = false, features = ["native
 aws-smithy-http = "0.46.0"
 aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
-bytes = "1.1.0"
-crossbeam-channel = "0.5.5"
+bytes = "1.2.0"
+crossbeam-channel = "0.5.6"
 deadpool-postgres = "0.10.2"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.0", features = ["failpoints"] }

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -27,8 +27,9 @@ aws-sdk-s3 = { version = "0.16.0", default-features = false, features = ["native
 aws-smithy-http = "0.46.0"
 aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
-bytes = "1.2.0"
-crossbeam-channel = "0.5.6"
+bytes = "1.1.0"
+crossbeam-channel = "0.5.5"
+deadpool-postgres = "0.10.2"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.0", features = ["failpoints"] }
 futures-util = "0.3.19"

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -140,7 +140,10 @@ impl ConsensusConfig {
     }
 
     /// Parses a [Consensus] config from a uri string.
-    pub async fn try_from(value: &str) -> Result<Self, ExternalError> {
+    pub async fn try_from(
+        value: &str,
+        connection_pool_max_size: usize,
+    ) -> Result<Self, ExternalError> {
         let url = Url::parse(value).map_err(|err| {
             anyhow!(
                 "failed to parse consensus location {} as a url: {}",
@@ -151,7 +154,7 @@ impl ConsensusConfig {
 
         let config = match url.scheme() {
             "postgres" | "postgresql" => Ok(ConsensusConfig::Postgres(
-                PostgresConsensusConfig::new(value).await?,
+                PostgresConsensusConfig::new(value, connection_pool_max_size).await?,
             )),
             "mem" => {
                 if !cfg!(debug_assertions) {


### PR DESCRIPTION
A slightly updated version of Dan's initial PR https://github.com/MaterializeInc/materialize/pull/12482

Plugs in the `deadpool` connection pooling library so `consensus` operations can draw from a pool of Postgres connections. If we're on CRDB, we don't need to worry about the total connection limit in the same way as Aurora, so this should allow for much greater throughput, and is the `rust-postgres` approved way of reconnecting when a connection to Postgres is lost.

For certain calls into consensus this will add resiliency to network connectivity issues to Postgres/CRDB. I cherry-picked this change onto [Philip's branch](https://github.com/MaterializeInc/materialize/issues/13735) with the `RestartEnvironmentdStoraged` scenario and it now passes 🎉 

That said, it's not a silver bullet and will not smooth over all connectivity issues to Postgres/CRDB by itself. There's still more work to do in [error categorization](https://github.com/MaterializeInc/materialize/issues/13379) and [idempotency tokens](https://github.com/MaterializeInc/materialize/issues/12797) before we can survive transient connectivity issues in general.

---

As for the change itself, I expected more drift from Dan's PR than there actually was. It's mostly the same, with a tiny bit more plumbing to get the pool size value into the right place. 

I'm not sure if more work is needed here to refine the dependencies, but here's the additional `cargo tree` output from the new dependency on `deadpool`: 

```
│   │   ├── deadpool-postgres v0.10.2
│   │   │   ├── deadpool v0.9.5
│   │   │   │   ├── async-trait v0.1.56 (proc-macro) (*)
│   │   │   │   ├── deadpool-runtime v0.1.2
│   │   │   │   │   └── tokio v1.19.2 (*)
│   │   │   │   ├── num_cpus v1.13.1 (*)
│   │   │   │   ├── retain_mut v0.1.9
│   │   │   │   └── tokio v1.19.2 (*)
│   │   │   ├── log v0.4.17 (*)
│   │   │   ├── tokio v1.19.2 (*)
│   │   │   └── tokio-postgres v0.7.6 (https://github.com/MaterializeInc/rust-postgres#abff35ec) (*)
```

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/13735

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A


cc @philip-stoev once this is merged, your `RestartEnvironmentdStoraged` test should pass!
