### PR TITLE
compute: use boring persist_sink for logging

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -320,7 +320,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, &collection);
+                persist_sink(*id, meta, compute_state, collection);
             }
         }
         result

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -194,7 +194,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, &collection);
+                persist_sink(*id, meta, compute_state, collection);
             }
         }
         result

--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -7,14 +7,21 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
+use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::input::Input;
-use differential_dataflow::Collection;
+use differential_dataflow::{Collection, Hashable};
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
+use tokio::runtime::Handle as TokioHandle;
+use tokio::sync::Mutex;
 
+use mz_persist_client::cache::PersistClientCache;
 use mz_repr::GlobalId;
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::sources::SourceData;
 
 use crate::compute_state::ComputeState;
 
@@ -26,6 +33,20 @@ pub(crate) fn persist_sink<G>(
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
+    // The target storage collection might still contain data written by a
+    // previous incarnation of the replica. Empty it, so we don't end up with
+    // stale data that never gets retracted.
+    // TODO(teskje,lh): Remove the truncation step once/if #13740 gets merged.
+    //
+    // We need to ensure that only a single timely worker tries to perform the
+    // truncate, to avoid retracting the old data multiple times.
+    let scope = desired_collection.scope();
+    let is_active_worker = (target_id.hashed() as usize) % scope.peers() == scope.index();
+    if is_active_worker {
+        let persist_clients = Arc::clone(&compute_state.persist_clients);
+        TokioHandle::current().block_on(truncate_storage_collection(target, persist_clients));
+    }
+
     let (_, err_collection) = desired_collection.scope().new_collection();
 
     let token = crate::sink::persist_sink(
@@ -50,4 +71,55 @@ pub(crate) fn persist_sink<G>(
             is_tail: false,
         },
     );
+}
+
+async fn truncate_storage_collection(
+    collection: &CollectionMetadata,
+    persist_clients: Arc<Mutex<PersistClientCache>>,
+) {
+    let client = persist_clients
+        .lock()
+        .await
+        .open(collection.persist_location.clone())
+        .await
+        .expect("could not open persist client");
+
+    let (mut write, read) = client
+        .open::<SourceData, (), Timestamp, Diff>(collection.data_shard)
+        .await
+        .expect("could not open persist shard");
+
+    let upper = write.upper().clone();
+    let upper_ts = upper[0];
+    if let Some(ts) = upper_ts.checked_sub(1) {
+        let as_of = Antichain::from_elem(ts);
+
+        let mut snapshot_iter = read
+            .snapshot(as_of)
+            .await
+            .expect("cannot serve requested as_of");
+
+        let mut updates = Vec::new();
+        while let Some(next) = snapshot_iter.next().await {
+            updates.extend(next);
+        }
+        snapshot_iter.expire().await;
+
+        consolidate_updates(&mut updates);
+
+        let retractions = updates
+            .into_iter()
+            .map(|((k, v), _ts, diff)| ((k.unwrap(), v.unwrap()), upper_ts, diff * -1));
+
+        let new_upper = Antichain::from_elem(upper_ts + 1);
+        write
+            .compare_and_append(retractions, upper, new_upper)
+            .await
+            .expect("external durability failure")
+            .expect("invalid usage")
+            .expect("unexpected upper");
+    }
+
+    write.expire().await;
+    read.expire().await;
 }

--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -7,28 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
-use std::cell::RefCell;
-use std::rc::Rc;
-use std::sync::Arc;
-
-use differential_dataflow::AsCollection;
+use differential_dataflow::input::Input;
 use differential_dataflow::Collection;
-use differential_dataflow::Hashable;
-use timely::dataflow::channels::pact::Exchange;
-use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
-use timely::progress::Timestamp as TimelyTimestamp;
-use timely::PartialOrder;
 
 use mz_repr::GlobalId;
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage::controller::CollectionMetadata;
-use mz_storage::types::errors::DataflowError;
-use mz_storage::types::sinks::SinkAsOf;
-use mz_storage::types::sources::SourceData;
-use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::compute_state::ComputeState;
 
@@ -36,39 +22,19 @@ pub(crate) fn persist_sink<G>(
     target_id: GlobalId,
     target: &CollectionMetadata,
     compute_state: &mut ComputeState,
-    desired_collection: &Collection<G, Row, Diff>,
+    desired_collection: Collection<G, Row, Diff>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    let scope = desired_collection.scope();
-    let as_of: SinkAsOf = SinkAsOf {
-        frontier: Antichain::from_elem(0),
-        strict: false,
-    };
+    let (_, err_collection) = desired_collection.scope().new_collection();
 
-    // To create the diffs we also need to read from persist.
-    let (ok_stream, err_stream, token) = mz_storage::source::persist_source::persist_source(
-        &scope,
-        Arc::clone(&compute_state.persist_clients),
-        target.clone(),
-        as_of.frontier.clone(),
+    let token = crate::sink::persist_sink(
+        target_id,
+        target,
+        desired_collection,
+        err_collection,
+        compute_state,
     );
-    let persist_collection = ok_stream
-        .as_collection()
-        .map(Ok)
-        .concat(&err_stream.as_collection().map(Err));
-
-    let token = Rc::new((
-        install_desired_into_persist(
-            target,
-            compute_state,
-            as_of,
-            target_id,
-            desired_collection.map(Ok),
-            persist_collection,
-        ),
-        token,
-    ));
 
     // Report frontier of collection back to coord
     compute_state
@@ -84,159 +50,4 @@ pub(crate) fn persist_sink<G>(
             is_tail: false,
         },
     );
-}
-
-//TODO(lh): Replace this with persist_sink::install_desired_sink once #13740 is merged.
-fn install_desired_into_persist<G>(
-    target: &CollectionMetadata,
-    compute_state: &mut crate::compute_state::ComputeState,
-    sink_as_of: SinkAsOf,
-    sink_id: GlobalId,
-    desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
-    persist_collection: Collection<G, Result<Row, DataflowError>, Diff>,
-) -> Option<Rc<dyn Any>>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    let scope = desired_collection.scope();
-
-    let persist_clients = Arc::clone(&compute_state.persist_clients);
-    let persist_location = target.persist_location.clone();
-    let shard_id = target.data_shard;
-
-    let operator_name = format!("persist_sink({})", shard_id);
-    let mut persist_op = OperatorBuilder::new(operator_name, scope.clone());
-
-    // Only attempt to write from this frontier onward, as our data are not necessarily
-    // correct for times not greater or equal to this frontier. Ignore as_of strictness.
-    let mut write_lower_bound = sink_as_of.frontier;
-
-    // TODO(mcsherry): this is shardable, eventually. But for now use a single writer.
-    let hashed_id = sink_id.hashed();
-    // TODO(lh): Figure out why this is necessary for introspection sources.
-    let active_write_worker = scope.index() == 0;
-    let mut desired_input =
-        persist_op.new_input(&desired_collection.inner, Exchange::new(move |_| hashed_id));
-    let mut persist_input =
-        persist_op.new_input(&persist_collection.inner, Exchange::new(move |_| hashed_id));
-
-    // Dropping this token signals that the operator should shut down cleanly.
-    let token = Rc::new(());
-    let token_weak = Rc::downgrade(&token);
-
-    // Only the active_write_worker will ever produce data so all other workers have
-    // an empty frontier. It's necessary to insert all of these into `compute_state.
-    // sink_write_frontier` below so we properly clear out default frontiers of
-    // non-active workers.
-    let shared_frontier = Rc::new(RefCell::new(if active_write_worker {
-        Antichain::from_elem(TimelyTimestamp::minimum())
-    } else {
-        Antichain::new()
-    }));
-
-    compute_state
-        .sink_write_frontiers
-        .insert(sink_id, Rc::clone(&shared_frontier));
-
-    // This operator accepts the current and desired update streams for a `persist` shard.
-    // It attempts to write out updates, starting from the current's upper frontier, that
-    // will cause the changes of desired to be committed to persist.
-
-    persist_op.build_async(
-        scope,
-        move |_capabilities, frontiers, scheduler| async move {
-            let mut buffer = Vec::new();
-
-            // Contains `desired - persist`, reflecting the updates we would like to commit
-            // to `persist` in order to "correct" it to track `desired`.
-            let mut correction = Vec::new();
-
-            // TODO(aljoscha): We need to figure out what to do with error results from these calls.
-            let mut write = persist_clients
-                .lock()
-                .await
-                .open(persist_location)
-                .await
-                .expect("could not open persist client")
-                .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
-                .await
-                .expect("could not open persist shard");
-
-            while scheduler.notified().await {
-                if !active_write_worker
-                    || token_weak.upgrade().is_none()
-                    // FRANK: I don't understand this case.
-                    || shared_frontier.borrow().is_empty()
-                {
-                    return;
-                }
-
-                // Extract desired rows as positive contributions to `correction`.
-                desired_input.for_each(|_cap, data| {
-                    data.swap(&mut buffer);
-                    correction.append(&mut buffer);
-                });
-
-                // Extract persist rows as negative contributions to `correction`.
-                persist_input.for_each(|_cap, data| {
-                    data.swap(&mut buffer);
-                    correction.extend(buffer.drain(..).map(|(d,t,r)| (d,t,-r)));
-                });
-
-                // Capture current frontiers.
-                let frontiers = frontiers.borrow().clone();
-                let desired_frontier = &frontiers[0];
-                let persist_frontier = &frontiers[1];
-
-                // We should only attempt a commit to an interval at least our lower bound.
-                if PartialOrder::less_equal(&write_lower_bound, persist_frontier) {
-
-                    // We may have the opportunity to commit updates.
-                    if PartialOrder::less_than(persist_frontier, desired_frontier) {
-
-                        // Advance all updates to `persist`'s frontier.
-                        for (_, time, _) in correction.iter_mut() {
-                            use differential_dataflow::lattice::Lattice;
-                            time.advance_by(persist_frontier.borrow());
-                        }
-                        // Consolidate updates within.
-                        differential_dataflow::consolidation::consolidate_updates(&mut correction);
-
-                        let to_append =
-                        correction
-                            .iter()
-                            .filter(|(_, time, _)| persist_frontier.less_equal(time) && !desired_frontier.less_equal(time))
-                            .map(|(data, time, diff)| ((SourceData(data.clone()), ()), time, diff));
-
-                        let result =
-                        write
-                            .compare_and_append(to_append, persist_frontier.clone(), desired_frontier.clone())
-                            .await
-                            .expect("Indeterminate")    // TODO: What does this error mean?
-                            .expect("Invalid usage")    // TODO: What does this error mean?
-                            ;
-
-                        // If the result is `Ok`, we will eventually see the appended data return through `persist_input`,
-                        // which will remove the results from `correction`; we should not do this directly ourselves.
-                        // In either case, we have new information about the next frontier we should attempt to commit from.
-                        match result {
-                            Ok(()) => {
-                                write_lower_bound.clone_from(desired_frontier);
-                            }
-                            Err(mz_persist_client::Upper(frontier)) => {
-                                write_lower_bound.clone_from(&frontier);
-                            }
-                        }
-                    } else {
-                        write_lower_bound.clone_from(&persist_frontier);
-                    }
-                }
-
-                // Confirm that we only require updates from our lower bound onward.
-                shared_frontier.borrow_mut().clone_from(&write_lower_bound);
-            }
-        },
-    );
-
-    Some(token)
 }

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -165,7 +165,7 @@ pub fn construct<A: Allocate>(
                         row_buf.clone()
                     },
                 );
-                persist_sink(*id, meta, compute_state, &sinked);
+                persist_sink(*id, meta, compute_state, sinked);
             }
 
             for variant in logs_active {

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -501,7 +501,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, &collection);
+                persist_sink(*id, meta, compute_state, collection);
             }
         }
         result

--- a/src/compute/src/sink/mod.rs
+++ b/src/compute/src/sink/mod.rs
@@ -13,4 +13,6 @@ mod persist_sink;
 mod tail;
 
 pub(crate) use metrics::KafkaBaseMetrics;
+pub(crate) use persist_sink::persist_sink;
+
 pub use metrics::SinkBaseMetrics;

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -136,12 +136,14 @@ where
             let mut stash: HashMap<_, Vec<_>> = HashMap::new();
 
             // TODO(aljoscha): We need to figure out what to do with error results from these calls.
-            let mut write = persist_clients
+            let client = persist_clients
                 .lock()
                 .await
                 .open(persist_location)
                 .await
-                .expect("could not open persist client")
+                .expect("could not open persist client");
+
+            let mut write = client
                 .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
                 .await
                 .expect("could not open persist shard");

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -1690,7 +1690,7 @@ impl RustType<ProtoS3KeySource> for S3KeySource {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SourceData(pub Result<Row, DataflowError>);
 
 impl Deref for SourceData {


### PR DESCRIPTION
This PR makes the logging sinks use the same persist_sink implementation that is also used by recorded views.

Previously the logging sinks were using an experimental implementation (see https://github.com/MaterializeInc/materialize/pull/13740) that also reads back from the persist shard. This currently introduces significant performance issues, which are fixed by reverting to the old implementation for now.

### Motivation

  * This PR fixes a previously unreported bug.

Materialize UX is severely impacted by computed having significant CPU usage even without any user dataflows installed, and probably other contention issues. See [Slack](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1658489569228959) and [Slack](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1658494373754859).

### Tips for reviewers

Look at the commits separately.

The changes to `persist_sink.rs` in the first commit are easier to read with whitespace ignored.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).