### PR TITLE
adapter: match PostgreSQL values for transaction_isolation var

### DIFF
--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -1197,11 +1197,11 @@ pub enum IsolationLevel {
 impl IsolationLevel {
     pub(super) fn as_str(&self) -> &'static str {
         match self {
-            Self::ReadUncommitted => "READ_UNCOMMITTED",
-            Self::ReadCommitted => "READ_COMMITTED",
-            Self::RepeatableRead => "REPEATABLE_READ",
-            Self::Serializable => "SERIALIZABLE",
-            Self::StrictSerializable => "STRICT_SERIALIZABLE",
+            Self::ReadUncommitted => "read uncommitted",
+            Self::ReadCommitted => "read committed",
+            Self::RepeatableRead => "repeatable read",
+            Self::Serializable => "serializable",
+            Self::StrictSerializable => "strict serializable",
         }
     }
 

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1406,20 +1406,20 @@ fn test_linearizability() -> Result<(), Box<dyn Error>> {
     // than queries that involve the user table. However, we prevent this when in strict
     // serializable mode.
 
-    mz_client.batch_execute(&"SET transaction_isolation = SERIALIZABLE")?;
+    mz_client.batch_execute(&"SET transaction_isolation = serializable")?;
     let view_ts = get_explain_timestamp(view_name, &mut mz_client);
     let join_ts = get_explain_timestamp(&format!("{view_name}, t"), &mut mz_client);
     // In serializable transaction isolation, read timestamps can go backwards.
     assert!(join_ts < view_ts);
 
-    mz_client.batch_execute(&"SET transaction_isolation = STRICT_SERIALIZABLE")?;
+    mz_client.batch_execute(&"SET transaction_isolation = 'strict serializable'")?;
     let view_ts = get_explain_timestamp(view_name, &mut mz_client);
     let join_ts = get_explain_timestamp(&format!("{view_name}, t"), &mut mz_client);
     // Since the query on the join was done after the query on the view, it should have a higher or
     // equal timestamp in strict serializable mode.
     assert!(join_ts >= view_ts);
 
-    mz_client.batch_execute(&"SET transaction_isolation = SERIALIZABLE")?;
+    mz_client.batch_execute(&"SET transaction_isolation = serializable")?;
     let view_ts = get_explain_timestamp(view_name, &mut mz_client);
     let join_ts = get_explain_timestamp(&format!("{view_name}, t"), &mut mz_client);
     // If we go back to serializable, then timestamps can revert again.
@@ -1596,7 +1596,7 @@ fn wait_for_view_population(
         })
         .unwrap();
     let _ = mz_client.query_one(
-        &format!("SET transaction_isolation = STRICT_SERIALIZABLE"),
+        &format!("SET transaction_isolation = 'strict serializable'"),
         &[],
     );
     Ok(())

--- a/test/cluster/storaged/03-while-storaged-down.td
+++ b/test/cluster/storaged/03-while-storaged-down.td
@@ -10,7 +10,7 @@
 # Verify that the data ingested before `storaged` crashed is still present but
 # that newly ingested data does not appear.
 
-> SET transaction_isolation = SERIALIZABLE
+> SET transaction_isolation = serializable
 
 > SELECT * from remote1
 one
@@ -31,4 +31,4 @@ two
 one
 two
 
-> SET transaction_isolation = STRICT_SERIALIZABLE
+> SET transaction_isolation = 'strict serializable'

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -137,29 +137,29 @@ RESET does_not_exist
 query T
 SHOW transaction_isolation
 ----
-STRICT_SERIALIZABLE
+strict serializable
 
 statement ok
-SET transaction_isolation = SERIALIZABLE
+SET transaction_isolation = serializable
 
 query T
 SHOW transaction_isolation
 ----
-SERIALIZABLE
+serializable
 
 statement ok
-SET transaction_isolation = READ_COMMITTED
+SET transaction_isolation = 'read committed'
 
 query T
 SHOW transaction_isolation
 ----
-SERIALIZABLE
+serializable
 
-statement error invalid value for parameter "transaction_isolation": "snapshot_isolation"
-SET transaction_isolation = SNAPSHOT_ISOLATION
+statement error invalid value for parameter "transaction_isolation": "snapshot isolation"
+SET transaction_isolation = 'snapshot isolation'
 
 statement ok
-SET transaction_isolation = STRICT_SERIALIZABLE
+SET transaction_isolation = 'strict serializable'
 
 # Test that a failed transaction will not commit var changes.
 

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -10,25 +10,25 @@
 $ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
 
 > SHOW ALL
-application_name            ""              "Sets the application name to be reported in statistics and logs (PostgreSQL)."
-client_encoding             UTF8            "Sets the client's character set encoding (PostgreSQL)."
-client_min_messages         notice          "Sets the message levels that are sent to the client (PostgreSQL)."
-cluster                     <CLUSTER_NAME>  "Sets the current cluster (Materialize)."
-cluster_replica             ""              "Sets a target cluster replica for SELECT queries (Materialize)."
-database                    materialize     "Sets the current database (CockroachDB)."
-extra_float_digits          3               "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
-failpoints                  ""              "Allows failpoints to be dynamically activated."
-integer_datetimes           on              "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
-IntervalStyle               postgres        "Sets the display format for interval values (PostgreSQL)."
-DateStyle                   "ISO, MDY"      "Sets the display format for date and time values (PostgreSQL)."
-search_path                 "public"        "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
-server_version              9.5.0           "Shows the server version (PostgreSQL)."
-server_version_num          90500           "Shows the server version as an integer (PostgreSQL)."
-sql_safe_updates            off             "Prohibits SQL statements that may be overly destructive (CockroachDB)."
-standard_conforming_strings on              "Causes '...' strings to treat backslashes literally (PostgreSQL)."
-statement_timeout           "10 s"          "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
-TimeZone                    UTC             "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
-transaction_isolation       STRICT_SERIALIZABLE    "Sets the current transaction's isolation level (PostgreSQL)."
+application_name            ""                     "Sets the application name to be reported in statistics and logs (PostgreSQL)."
+client_encoding             UTF8                   "Sets the client's character set encoding (PostgreSQL)."
+client_min_messages         notice                 "Sets the message levels that are sent to the client (PostgreSQL)."
+cluster                     <CLUSTER_NAME>         "Sets the current cluster (Materialize)."
+cluster_replica             ""                     "Sets a target cluster replica for SELECT queries (Materialize)."
+database                    materialize            "Sets the current database (CockroachDB)."
+extra_float_digits          3                      "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."
+failpoints                  ""                     "Allows failpoints to be dynamically activated."
+integer_datetimes           on                     "Reports whether the server uses 64-bit-integer dates and times (PostgreSQL)."
+IntervalStyle               postgres               "Sets the display format for interval values (PostgreSQL)."
+DateStyle                   "ISO, MDY"             "Sets the display format for date and time values (PostgreSQL)."
+search_path                 "public"               "Sets the schema search order for names that are not schema-qualified (PostgreSQL)."
+server_version              9.5.0                  "Shows the server version (PostgreSQL)."
+server_version_num          90500                  "Shows the server version as an integer (PostgreSQL)."
+sql_safe_updates            off                    "Prohibits SQL statements that may be overly destructive (CockroachDB)."
+standard_conforming_strings on                     "Causes '...' strings to treat backslashes literally (PostgreSQL)."
+statement_timeout           "10 s"                 "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations."
+TimeZone                    UTC                    "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
+transaction_isolation       "strict serializable"  "Sets the current transaction's isolation level (PostgreSQL)."
 
 > SET application_name = 'foo'
 
@@ -99,10 +99,10 @@ contains:invalid value for parameter "TimeZone": "nope"
 # The `transaction_isolation` variable has dedicated syntax as mandated by the
 # SQL standard.
 > SHOW TRANSACTION ISOLATION LEVEL
-STRICT_SERIALIZABLE
+"strict serializable"
 
-! SET transaction_isolation = 'read committed'
-contains:invalid value for parameter "transaction_isolation": "read committed"
+! SET transaction_isolation = 'read draft'
+contains:invalid value for parameter "transaction_isolation": "read draft"
 
 ! SET integer_datetimes = false
 contains:parameter "integer_datetimes" cannot be changed

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -190,7 +190,7 @@ b  sum
 1  10
 
 # Under weaker isolation levels we can see the row at time 2 before all objects have closed time 2.
-> SET transaction_isolation = SERIALIZABLE
+> SET transaction_isolation = serializable
 
 > SELECT * FROM bar;
 b  sum
@@ -198,7 +198,7 @@ b  sum
 1  10
 3  30
 
-> SET transaction_isolation = STRICT_SERIALIZABLE
+> SET transaction_isolation = 'strict serializable'
 
 > SELECT * FROM join;
 b foo_sum bar_sum


### PR DESCRIPTION
In PostgreSQL, the two-word isolation levels (e.g. read committed) are
represented as strings with spaces. Make Materialize match PostgreSQL,
and follow the pattern for our own isolation level invention ('strict
serializability').

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
