### PR TITLE
doc/user: add remaining connection pages

### DIFF
--- a/doc/user/content/sql/drop-connection.md
+++ b/doc/user/content/sql/drop-connection.md
@@ -27,13 +27,13 @@ _connection&lowbar;name_ | The connection you want to drop. For available connec
 To drop an existing connection, run:
 
 ```sql
-DROP CONNECTION my_connection;
+DROP CONNECTION kafka_connection;
 ```
 
 To avoid issuing an error if the specified connection does not exist, use the `IF NOT EXISTS` option:
 
 ```sql
-DROP CONNECTION IF EXISTS my_connection;
+DROP CONNECTION IF EXISTS kafka_connection;
 ```
 
 ### Dropping a connection with dependencies
@@ -41,18 +41,18 @@ DROP CONNECTION IF EXISTS my_connection;
 If the connection has dependencies, Materialize will throw an error similar to:
 
 ```sql
-DROP CONNECTION my_connection;
+DROP CONNECTION kafka_connection;
 ```
 
 ```nofmt
-ERROR:  cannot drop materialize.public.my_connection: still depended upon by catalog item
-'materialize.public.my_source'
+ERROR:  cannot drop materialize.public.kafka_connection: still depended upon by catalog item
+'materialize.public.kafka_source'
 ```
 
 , and you'll have to explicitly ask to also remove any dependent objects using the `CASCADE` option:
 
 ```sql
-DROP CONNECTION my_connection CASCADE;
+DROP CONNECTION kafka_connection CASCADE;
 ```
 
 ## Related pages

--- a/doc/user/content/sql/drop-connection.md
+++ b/doc/user/content/sql/drop-connection.md
@@ -1,0 +1,60 @@
+---
+title: "DROP CONNECTION"
+description: "`DROP CONNECTION` removes a connection from Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`DROP CONNECTION` removes a connection from Materialize. If there are sources depending on the connection, you must explicitly drop them first, or use the `CASCADE` option.
+
+## Syntax
+
+{{< diagram "drop-connection.svg" >}}
+
+Field | Use
+------|-----
+**IF EXISTS** | Do not return an error if the specified connection does not exist.
+_connection&lowbar;name_ | The connection you want to drop. For available connections, see [`SHOW CONNECTIONS`](../show-connections).
+**CASCADE** | Remove the connection and its dependent objects.
+**RESTRICT** | Do not drop the connection if it has dependencies. _(Default)_
+
+## Examples
+
+### Dropping a connection with no dependencies
+
+To drop an existing connection, run:
+
+```sql
+DROP CONNECTION my_connection;
+```
+
+To avoid issuing an error if the specified connection does not exist, use the `IF NOT EXISTS` option:
+
+```sql
+DROP CONNECTION IF EXISTS my_connection;
+```
+
+### Dropping a connection with dependencies
+
+If the connection has dependencies, Materialize will throw an error similar to:
+
+```sql
+DROP CONNECTION my_connection;
+```
+
+```nofmt
+ERROR:  cannot drop materialize.public.my_connection: still depended upon by catalog item
+'materialize.public.my_source'
+```
+
+, and you'll have to explicitly ask to also remove any dependent objects using the `CASCADE` option:
+
+```sql
+DROP CONNECTION my_connection CASCADE;
+```
+
+## Related pages
+
+- [`SHOW CONNECTIONS`](../show-connections)

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -56,4 +56,4 @@ SHOW CONNECTIONS LIKE 'kafka%';
 ## Related pages
 
 - [`CREATE CONNECTION`](../create-connection)
-- [`DROP CONNECTION`](../drop-connection-.)
+- [`DROP CONNECTION`](../drop-connection)

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -1,0 +1,59 @@
+---
+title: "SHOW CONNECTIONS"
+description: "`SHOW CONNECTIONS` lists the connections configured in Materialize."
+menu:
+  main:
+    parent: commands
+aliases:
+    - /sql/show-connection
+---
+
+`SHOW CONNECTIONS` lists the connections configured in Materialize.
+
+## Syntax
+
+{{< diagram "show-connections.svg" >}}
+
+Field                | Use
+---------------------|-----
+_schema&lowbar;name_ | The schema to show connections from. If omitted, connections from all schemas are shown. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+
+## Examples
+
+```sql
+SHOW CONNECTIONS;
+```
+
+```nofmt
+       name
+------------------
+ kafka_connection
+ postgres_connection
+```
+
+```sql
+SHOW FULL CONNECTIONS;
+```
+
+```nofmt
+       name          | type
+---------------------+------
+ kafka_connection    | user
+ postgres_connection | user
+```
+
+```sql
+SHOW CONNECTIONS LIKE 'kafka%';
+```
+
+```nofmt
+       name
+------------------
+ kafka_connection
+```
+
+
+## Related pages
+
+- [`CREATE CONNECTION`](../create-connection)
+- [`DROP CONNECTION`](../drop-connection-.)

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -17,7 +17,6 @@ aliases:
 Field                | Use
 ---------------------|-----
 _schema&lowbar;name_ | The schema to show connections from. If omitted, connections from all schemas are shown. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**EXTENDED**         | Returns all connections.
 **FULL**             | Returns all connections, including information about the connection type.
 
 ## Examples

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -17,6 +17,8 @@ aliases:
 Field                | Use
 ---------------------|-----
 _schema&lowbar;name_ | The schema to show connections from. If omitted, connections from all schemas are shown. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+**EXTENDED**         | Returns all connections.
+**FULL**             | Returns all connections, including information about the connection type.
 
 ## Examples
 

--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -19,13 +19,13 @@ _connection&lowbar;name_ | The connection you want to get the `CREATE` statement
 ## Examples
 
 ```sql
-SHOW CREATE CONNECTION my_connection;
+SHOW CREATE CONNECTION kafka_connection;
 ```
 
 ```nofmt
     Connection   |        Create Connection
 -----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- my_connection   | CREATE CONNECTION "materialize"."public"."my_connection" FOR KAFKA BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092', SASL MECHANISMS = 'PLAIN', SASL USERNAME = SECRET sasl_username, SASL PASSWORD = SECRET sasl_password
+ kafka_connection   | CREATE CONNECTION "materialize"."public"."kafka_connection" FOR KAFKA BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092', SASL MECHANISMS = 'PLAIN', SASL USERNAME = SECRET sasl_username, SASL PASSWORD = SECRET sasl_password
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -1,0 +1,34 @@
+---
+title: "SHOW CREATE CONNECTION"
+description: "`SHOW CREATE CONNECTION` returns the statement used to create the connection."
+menu:
+  main:
+    parent: commands
+---
+
+`SHOW CREATE CONNECTION` returns the DDL statement used to create the connection.
+
+## Syntax
+
+{{< diagram "show-create-connection.svg" >}}
+
+Field | Use
+------|-----
+_connection&lowbar;name_ | The connection you want to get the `CREATE` statement for. For available connections, see [`SHOW CONNECTIONS`](../show-connections).
+
+## Examples
+
+```sql
+SHOW CREATE CONNECTION my_connection;
+```
+
+```nofmt
+    Connection   |        Create Connection
+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ my_connection   | CREATE CONNECTION "materialize"."public"."my_connection" FOR KAFKA BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092', SASL MECHANISMS = 'PLAIN', SASL USERNAME = SECRET sasl_username, SASL PASSWORD = SECRET sasl_password
+```
+
+## Related pages
+
+- [`SHOW CONNECTIONS`](../show-sources)
+- [`CREATE CONNECTION`](../create-connection)

--- a/doc/user/layouts/partials/sql-grammar/drop-connection.svg
+++ b/doc/user/layouts/partials/sql-grammar/drop-connection.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="551" height="199">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="60" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">DROP</text>
+   <rect x="111" y="3" width="116" height="32" rx="10"/>
+   <rect x="109"
+         y="1"
+         width="116"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="21">CONNECTION</text>
+   <rect x="267" y="35" width="86" height="32" rx="10"/>
+   <rect x="265"
+         y="33"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="275" y="53">IF EXISTS</text>
+   <rect x="393" y="3" width="136" height="32"/>
+   <rect x="391" y="1" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="401" y="21">connection_name</text>
+   <rect x="413" y="121" width="90" height="32" rx="10"/>
+   <rect x="411"
+         y="119"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="421" y="139">CASCADE</text>
+   <rect x="413" y="165" width="90" height="32" rx="10"/>
+   <rect x="411"
+         y="163"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="421" y="183">RESTRICT</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m136 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -76 h-3"/>
+   <polygon points="541 103 549 99 549 107"/>
+   <polygon points="541 103 533 99 533 107"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/show-connections.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-connections.svg
@@ -1,0 +1,78 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="531" height="199">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="135" y="35" width="96" height="32" rx="10"/>
+   <rect x="133"
+         y="33"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="143" y="53">EXTENDED</text>
+   <rect x="291" y="35" width="54" height="32" rx="10"/>
+   <rect x="289"
+         y="33"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="299" y="53">FULL</text>
+   <rect x="385" y="3" width="124" height="32" rx="10"/>
+   <rect x="383"
+         y="1"
+         width="124"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="393" y="21">CONNECTIONS</text>
+   <rect x="89" y="121" width="60" height="32" rx="10"/>
+   <rect x="87"
+         y="119"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="97" y="139">FROM</text>
+   <rect x="169" y="121" width="114" height="32"/>
+   <rect x="167" y="119" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="177" y="139">schema_name</text>
+   <rect x="343" y="121" width="50" height="32" rx="10"/>
+   <rect x="341"
+         y="119"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="139">LIKE</text>
+   <rect x="413" y="121" width="70" height="32" rx="10"/>
+   <rect x="411"
+         y="119"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="421" y="139">pattern</text>
+   <rect x="343" y="165" width="70" height="32" rx="10"/>
+   <rect x="341"
+         y="163"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="351" y="183">WHERE</text>
+   <rect x="433" y="165" width="48" height="32"/>
+   <rect x="431" y="163" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="441" y="183">expr</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m124 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-484 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
+   <polygon points="521 103 529 99 529 107"/>
+   <polygon points="521 103 513 99 513 107"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/show-connections.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-connections.svg
@@ -1,78 +1,70 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="531" height="199">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="64" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="487" height="199">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="96" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="143" y="53">EXTENDED</text>
-   <rect x="291" y="35" width="54" height="32" rx="10"/>
-   <rect x="289"
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="137" y="35" width="54" height="32" rx="10"/>
+   <rect x="135"
          y="33"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="299" y="53">FULL</text>
-   <rect x="385" y="3" width="124" height="32" rx="10"/>
-   <rect x="383"
+   <text class="terminal" x="145" y="53">FULL</text>
+   <rect x="231" y="3" width="124" height="32" rx="10"/>
+   <rect x="229"
          y="1"
          width="124"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="393" y="21">CONNECTIONS</text>
-   <rect x="89" y="121" width="60" height="32" rx="10"/>
-   <rect x="87"
+   <text class="terminal" x="239" y="21">CONNECTIONS</text>
+   <rect x="45" y="121" width="60" height="32" rx="10"/>
+   <rect x="43"
          y="119"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="97" y="139">FROM</text>
-   <rect x="169" y="121" width="114" height="32"/>
-   <rect x="167" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="177" y="139">schema_name</text>
-   <rect x="343" y="121" width="50" height="32" rx="10"/>
-   <rect x="341"
+   <text class="terminal" x="53" y="139">FROM</text>
+   <rect x="125" y="121" width="114" height="32"/>
+   <rect x="123" y="119" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="133" y="139">schema_name</text>
+   <rect x="299" y="121" width="50" height="32" rx="10"/>
+   <rect x="297"
          y="119"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="351" y="139">LIKE</text>
-   <rect x="413" y="121" width="70" height="32" rx="10"/>
-   <rect x="411"
+   <text class="terminal" x="307" y="139">LIKE</text>
+   <rect x="369" y="121" width="70" height="32" rx="10"/>
+   <rect x="367"
          y="119"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="421" y="139">pattern</text>
-   <rect x="343" y="165" width="70" height="32" rx="10"/>
-   <rect x="341"
+   <text class="terminal" x="377" y="139">pattern</text>
+   <rect x="299" y="165" width="70" height="32" rx="10"/>
+   <rect x="297"
          y="163"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="351" y="183">WHERE</text>
-   <rect x="433" y="165" width="48" height="32"/>
-   <rect x="431" y="163" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="441" y="183">expr</text>
+   <text class="terminal" x="307" y="183">WHERE</text>
+   <rect x="389" y="165" width="48" height="32"/>
+   <rect x="387" y="163" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="397" y="183">expr</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m124 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-484 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
-   <polygon points="521 103 529 99 529 107"/>
-   <polygon points="521 103 513 99 513 107"/>
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m124 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-374 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
+   <polygon points="477 103 485 99 485 107"/>
+   <polygon points="477 103 469 99 469 107"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-create-connection.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-create-connection.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="511" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="76" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">CREATE</text>
+   <rect x="211" y="3" width="116" height="32" rx="10"/>
+   <rect x="209"
+         y="1"
+         width="116"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="21">CONNECTION</text>
+   <rect x="347" y="3" width="136" height="32"/>
+   <rect x="345" y="1" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="355" y="21">connection_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m3 0 h-3"/>
+   <polygon points="501 17 509 13 509 21"/>
+   <polygon points="501 17 493 13 493 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -146,6 +146,8 @@ delete_stmt ::=
   'WHERE' condition
 discard ::=
   'DISCARD' ('TEMP' | 'TEMPORARY' | 'ALL')
+drop_connection ::=
+    'DROP' 'CONNECTION' ('IF EXISTS')? connection_name ('CASCADE' | 'RESTRICT')?
 drop_database ::=
     'DROP' 'DATABASE' ('IF EXISTS')? database_name ('CASCADE' | 'RESTRICT')?
 drop_index ::=

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -288,7 +288,9 @@ select_stmt ::=
 show_columns ::=
   'SHOW' 'COLUMNS' 'FROM' item_ref ('LIKE' 'pattern' | 'WHERE' expr)
 show_connections ::=
-  'SHOW' 'EXTENDED'? 'FULL'? 'CONNECTIONS' ('FROM' schema_name)?
+  'SHOW' 'EXTENDED'? 'FULL'? 'CONNECTIONS'
+  ('FROM' schema_name)?
+  ('LIKE' 'pattern' | 'WHERE' expr)?
 show_create_connection ::=
   'SHOW' 'CREATE' 'CONNECTION' connection_name
 show_create_index ::=

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -288,7 +288,7 @@ select_stmt ::=
 show_columns ::=
   'SHOW' 'COLUMNS' 'FROM' item_ref ('LIKE' 'pattern' | 'WHERE' expr)
 show_connections ::=
-  'SHOW' 'EXTENDED'? 'FULL'? 'CONNECTIONS'
+  'SHOW' 'FULL'? 'CONNECTIONS'
   ('FROM' schema_name)?
   ('LIKE' 'pattern' | 'WHERE' expr)?
 show_create_connection ::=

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -287,6 +287,10 @@ select_stmt ::=
   ('AS' 'OF' ( 'AT' 'LEAST' )? timestamp_expression)?
 show_columns ::=
   'SHOW' 'COLUMNS' 'FROM' item_ref ('LIKE' 'pattern' | 'WHERE' expr)
+show_connections ::=
+  'SHOW' 'EXTENDED'? 'FULL'? 'CONNECTIONS' ('FROM' schema_name)?
+show_create_connection ::=
+  'SHOW' 'CREATE' 'CONNECTION' connection_name
 show_create_index ::=
   'SHOW' 'CREATE' 'INDEX' index_name
 show_create_sink ::=


### PR DESCRIPTION
Touches #13657.

@mjibson: IIUC, for `SHOW CONNECTIONS` we're grabbing `mz_internal.mz_classify_object_id(t.id)` and exposing that when the `FULL` option is used. Since the "actual" connection type is available in `mz_catalog.mz_connections`, would it make sense to expose that, too? It'd be more useful in this context.

```sql
materialize=> SHOW FULL CONNECTIONS;
       name       | type
------------------+------
 kafka            | user
 kafka_connection | user
 schema_registry  | user
```

```sql
materialize=> select * from mz_catalog.mz_connections;

  id  |  oid  | schema_id |       name       |           type
------+-------+-----------+------------------+---------------------------
 u43  | 20905 |         3 | kafka            | kafka
 u173 | 22349 |         3 | kafka_connection | kafka
 u174 | 22350 |         3 | schema_registry  | confluent-schema-registry
(3 rows)
```

For connections, will the object type ever be different to `user`? I'd like to add a description for the `EXTENDED` and `FULL` options in the syntax table, but wanted to double check that the returned objects will always be user-created (and never `system` or `temp`).