### PR TITLE
expr: use virtual syntax for SQL-oriented concepts

### DIFF
--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -12,10 +12,11 @@
 use std::fmt;
 
 use mz_expr::explain::Indices;
+use mz_expr::virtual_syntax::{AlgExcept, Except};
 use mz_expr::Id;
 use mz_ore::str::{separated, IndentLike};
 use mz_repr::explain_new::{separated_text, DisplayText};
-use mz_sql::plan::{AggregateExpr, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
+use mz_sql::plan::{AggregateExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
 
 use crate::explain_new::{Displayable, PlanRenderingContext};
 
@@ -29,176 +30,190 @@ impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
     ) -> fmt::Result {
         use HirRelationExpr::*;
 
-        match &self.0 {
-            // Lets are annotated on the chain ID that they correspond to.
-            Constant { rows, .. } => {
-                writeln!(f, "{}Constant", ctx.indent)?;
-                ctx.indented(|ctx| {
-                    for row in rows {
-                        writeln!(f, "{}- {}", ctx.indent, row)?;
-                    }
-                    Ok(())
-                })?;
+        if let Some(Except { all, lhs, rhs }) = Hir::un_except(&self.0) {
+            if all {
+                writeln!(f, "{}ExceptAll", ctx.indent)?;
+            } else {
+                writeln!(f, "{}Except", ctx.indent)?;
             }
-            Let {
-                name: _,
-                id,
-                value,
-                body,
-            } => {
-                let mut bindings = vec![(id, value.as_ref())];
-                let mut head = body.as_ref();
-
-                // Render Let-blocks nested in the body an outer Let-block in one step
-                // with a flattened list of bindings
-                while let Let {
+            ctx.indented(|ctx| {
+                Displayable::from(lhs).fmt_text(f, ctx)?;
+                Displayable::from(rhs).fmt_text(f, ctx)?;
+                Ok(())
+            })?;
+        } else {
+            match &self.0 {
+                // Lets are annotated on the chain ID that they correspond to.
+                Constant { rows, .. } => {
+                    writeln!(f, "{}Constant", ctx.indent)?;
+                    ctx.indented(|ctx| {
+                        for row in rows {
+                            writeln!(f, "{}- {}", ctx.indent, row)?;
+                        }
+                        Ok(())
+                    })?;
+                }
+                Let {
                     name: _,
                     id,
                     value,
                     body,
-                } = head
-                {
-                    bindings.push((id, value.as_ref()));
-                    head = body.as_ref();
-                }
+                } => {
+                    let mut bindings = vec![(id, value.as_ref())];
+                    let mut head = body.as_ref();
 
-                // The body comes first in the text output format in order to
-                // align with the format convention the dataflow is rendered
-                // top to bottom
-                writeln!(f, "{}Let", ctx.indent)?;
-                ctx.indented(|ctx| {
-                    Displayable::from(head).fmt_text(f, ctx)?;
-                    writeln!(f, "{}Where", ctx.indent)?;
+                    // Render Let-blocks nested in the body an outer Let-block in one step
+                    // with a flattened list of bindings
+                    while let Let {
+                        name: _,
+                        id,
+                        value,
+                        body,
+                    } = head
+                    {
+                        bindings.push((id, value.as_ref()));
+                        head = body.as_ref();
+                    }
+
+                    // The body comes first in the text output format in order to
+                    // align with the format convention the dataflow is rendered
+                    // top to bottom
+                    writeln!(f, "{}Let", ctx.indent)?;
                     ctx.indented(|ctx| {
-                        for (id, value) in bindings.iter().rev() {
-                            // TODO: print the name and not the id
-                            writeln!(f, "{}{} =", ctx.indent, *id)?;
-                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                        Displayable::from(head).fmt_text(f, ctx)?;
+                        writeln!(f, "{}Where", ctx.indent)?;
+                        ctx.indented(|ctx| {
+                            for (id, value) in bindings.iter().rev() {
+                                // TODO: print the name and not the id
+                                writeln!(f, "{}{} =", ctx.indent, *id)?;
+                                ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                            }
+                            Ok(())
+                        })?;
+                        Ok(())
+                    })?;
+                }
+                Get { id, .. } => match id {
+                    Id::Local(id) => {
+                        // TODO: resolve local id to the human-readable name from the context
+                        writeln!(f, "{}Get {}", ctx.indent, id)?;
+                    }
+                    Id::Global(id) => {
+                        let humanized_id = ctx.humanizer.humanize_id(*id).ok_or(fmt::Error)?;
+                        writeln!(f, "{}Get {}", ctx.indent, humanized_id)?;
+                    }
+                },
+                Project { outputs, input } => {
+                    let outputs = Indices(outputs);
+                    writeln!(f, "{}Project {}", ctx.indent, outputs)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                Map { scalars, input } => {
+                    let scalars = separated_text(", ", scalars.iter().map(Displayable::from));
+                    writeln!(f, "{}Map {}", ctx.indent, scalars)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                CallTable { func, exprs } => {
+                    let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                    writeln!(f, "{}CallTable {}({})", ctx.indent, func, exprs)?;
+                }
+                Filter { predicates, input } => {
+                    let predicates =
+                        separated_text(" AND ", predicates.iter().map(Displayable::from));
+                    writeln!(f, "{}Filter {}", ctx.indent, predicates)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                Join {
+                    left,
+                    right,
+                    on,
+                    kind,
+                } => {
+                    if on.is_literal_true() && kind == &JoinKind::Inner {
+                        write!(f, "{}CrossJoin", ctx.indent)?;
+                    } else {
+                        write!(f, "{}{}Join ", ctx.indent, kind)?;
+                        Displayable::from(on).fmt_text(f, &mut ())?;
+                    }
+                    writeln!(f)?;
+                    ctx.indented(|ctx| {
+                        Displayable::from(left.as_ref()).fmt_text(f, ctx)?;
+                        Displayable::from(right.as_ref()).fmt_text(f, ctx)?;
+                        Ok(())
+                    })?;
+                }
+                Reduce {
+                    group_key,
+                    aggregates,
+                    expected_group_size,
+                    input,
+                } => {
+                    write!(f, "{}Reduce", ctx.indent)?;
+                    if group_key.len() > 0 {
+                        let group_key = Indices(group_key);
+                        write!(f, " group_by=[{}]", group_key)?;
+                    }
+                    if aggregates.len() > 0 {
+                        let aggregates =
+                            separated_text(", ", aggregates.iter().map(Displayable::from));
+                        write!(f, " aggregates=[{}]", aggregates)?;
+                    }
+                    if let Some(expected_group_size) = expected_group_size {
+                        write!(f, " exp_group_size={}", expected_group_size)?;
+                    }
+                    writeln!(f)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                Distinct { input } => {
+                    writeln!(f, "{}Distinct", ctx.indent)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                TopK {
+                    group_key,
+                    order_key,
+                    limit,
+                    offset,
+                    input,
+                } => {
+                    write!(f, "{}TopK", ctx.indent)?;
+                    if group_key.len() > 0 {
+                        let group_by = Indices(group_key);
+                        write!(f, " group_by=[{}]", group_by)?;
+                    }
+                    if order_key.len() > 0 {
+                        let order_by = separated(", ", order_key);
+                        write!(f, " order_by=[{}]", order_by)?;
+                    }
+                    if let Some(limit) = limit {
+                        write!(f, " limit={}", limit)?;
+                    }
+                    if offset > &0 {
+                        write!(f, " offset={}", offset)?
+                    }
+                    writeln!(f)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                Negate { input } => {
+                    writeln!(f, "{}Negate", ctx.indent)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                Threshold { input } => {
+                    writeln!(f, "{}Threshold", ctx.indent)?;
+                    ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+                }
+                Union { base, inputs } => {
+                    writeln!(f, "{}Union", ctx.indent)?;
+                    ctx.indented(|ctx| {
+                        Displayable::from(base.as_ref()).fmt_text(f, ctx)?;
+                        for input in inputs.iter() {
+                            Displayable::from(input).fmt_text(f, ctx)?;
                         }
                         Ok(())
                     })?;
-                    Ok(())
-                })?;
-            }
-            Get { id, .. } => match id {
-                Id::Local(id) => {
-                    // TODO: resolve local id to the human-readable name from the context
-                    writeln!(f, "{}Get {}", ctx.indent, id)?;
                 }
-                Id::Global(id) => {
-                    let humanized_id = ctx.humanizer.humanize_id(*id).ok_or(fmt::Error)?;
-                    writeln!(f, "{}Get {}", ctx.indent, humanized_id)?;
-                }
-            },
-            Project { outputs, input } => {
-                let outputs = Indices(outputs);
-                writeln!(f, "{}Project {}", ctx.indent, outputs)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            Map { scalars, input } => {
-                let scalars = separated_text(", ", scalars.iter().map(Displayable::from));
-                writeln!(f, "{}Map {}", ctx.indent, scalars)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            CallTable { func, exprs } => {
-                let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
-                writeln!(f, "{}CallTable {}({})", ctx.indent, func, exprs)?;
-            }
-            Filter { predicates, input } => {
-                let predicates = separated_text(" AND ", predicates.iter().map(Displayable::from));
-                writeln!(f, "{}Filter {}", ctx.indent, predicates)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            Join {
-                left,
-                right,
-                on,
-                kind,
-            } => {
-                if on.is_literal_true() && kind == &JoinKind::Inner {
-                    write!(f, "{}CrossJoin", ctx.indent)?;
-                } else {
-                    write!(f, "{}{}Join ", ctx.indent, kind)?;
-                    Displayable::from(on).fmt_text(f, &mut ())?;
-                }
-                writeln!(f)?;
-                ctx.indented(|ctx| {
-                    Displayable::from(left.as_ref()).fmt_text(f, ctx)?;
-                    Displayable::from(right.as_ref()).fmt_text(f, ctx)?;
-                    Ok(())
-                })?;
-            }
-            Reduce {
-                group_key,
-                aggregates,
-                expected_group_size,
-                input,
-            } => {
-                write!(f, "{}Reduce", ctx.indent)?;
-                if group_key.len() > 0 {
-                    let group_key = Indices(group_key);
-                    write!(f, " group_by=[{}]", group_key)?;
-                }
-                if aggregates.len() > 0 {
-                    let aggregates = separated_text(", ", aggregates.iter().map(Displayable::from));
-                    write!(f, " aggregates=[{}]", aggregates)?;
-                }
-                if let Some(expected_group_size) = expected_group_size {
-                    write!(f, " exp_group_size={}", expected_group_size)?;
-                }
-                writeln!(f)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            Distinct { input } => {
-                writeln!(f, "{}Distinct", ctx.indent)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            TopK {
-                group_key,
-                order_key,
-                limit,
-                offset,
-                input,
-            } => {
-                write!(f, "{}TopK", ctx.indent)?;
-                if group_key.len() > 0 {
-                    let group_by = Indices(group_key);
-                    write!(f, " group_by=[{}]", group_by)?;
-                }
-                if order_key.len() > 0 {
-                    let order_by = separated(", ", order_key);
-                    write!(f, " order_by=[{}]", order_by)?;
-                }
-                if let Some(limit) = limit {
-                    write!(f, " limit={}", limit)?;
-                }
-                if offset > &0 {
-                    write!(f, " offset={}", offset)?
-                }
-                writeln!(f)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            Negate { input } => {
-                writeln!(f, "{}Negate", ctx.indent)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            Threshold { input } => {
-                writeln!(f, "{}Threshold", ctx.indent)?;
-                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
-            }
-            Union { base, inputs } => {
-                writeln!(f, "{}Union", ctx.indent)?;
-                ctx.indented(|ctx| {
-                    Displayable::from(base.as_ref()).fmt_text(f, ctx)?;
-                    for input in inputs.iter() {
-                        Displayable::from(input).fmt_text(f, ctx)?;
-                    }
-                    Ok(())
-                })?;
             }
         }
 
-        // TODO: subqueries
         // TODO: relation types
 
         Ok(())
@@ -209,7 +224,6 @@ impl<'a> DisplayText for Displayable<'a, HirScalarExpr> {
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut ()) -> fmt::Result {
         use HirRelationExpr::Get;
         use HirScalarExpr::*;
-
         match self.0 {
             Column(i) => write!(
                 f,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -24,6 +24,7 @@ mod relation;
 mod scalar;
 
 pub mod explain;
+pub mod virtual_syntax;
 pub mod visit;
 
 pub use relation::canonicalize;

--- a/src/expr/src/virtual_syntax.rs
+++ b/src/expr/src/virtual_syntax.rs
@@ -1,0 +1,28 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A set of virtual nodes that are used to recover some high-level
+//! concepts that are desugared to non-trival terms in some IRs.
+
+pub trait IR: Sized {
+    type Relation;
+    type Scalar;
+}
+
+#[allow(missing_debug_implementations)]
+pub struct Except<'a, U: IR> {
+    pub all: bool,
+    pub lhs: &'a U::Relation,
+    pub rhs: &'a U::Relation,
+}
+
+pub trait AlgExcept: IR {
+    fn except(all: &bool, lhs: Self::Relation, rhs: Self::Relation) -> Self::Relation;
+    fn un_except<'a>(expr: &'a Self::Relation) -> Option<Except<'a, Self>>;
+}

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -65,7 +65,9 @@ pub(crate) mod transform_expr;
 pub(crate) mod typeconv;
 pub(crate) mod with_options;
 
-pub use self::expr::{AggregateExpr, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
+pub use self::expr::{
+    AggregateExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType,
+};
 pub use error::PlanError;
 pub use explain::Explanation;
 use mz_sql_parser::ast::TransactionIsolationLevel;

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -42,6 +42,7 @@ use std::mem;
 use itertools::Itertools;
 use uuid::Uuid;
 
+use mz_expr::virtual_syntax::AlgExcept;
 use mz_expr::{func as expr_func, Id, LocalId, MirScalarExpr, RowSetFinishing};
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
@@ -70,7 +71,7 @@ use crate::normalize::{self, SqlValueOrSecret};
 use crate::plan::error::PlanError;
 use crate::plan::expr::{
     AbstractColumnType, AbstractExpr, AggregateExpr, AggregateFunc, BinaryFunc,
-    CoercibleScalarExpr, ColumnOrder, ColumnRef, HirRelationExpr, HirScalarExpr, JoinKind,
+    CoercibleScalarExpr, ColumnOrder, ColumnRef, Hir, HirRelationExpr, HirScalarExpr, JoinKind,
     ScalarWindowExpr, ScalarWindowFunc, UnaryFunc, ValueWindowExpr, VariadicFunc, WindowExpr,
     WindowExprType,
 };
@@ -1235,16 +1236,7 @@ fn plan_set_expr(
                         lhs.union(rhs).distinct()
                     }
                 }
-                SetOperator::Except => {
-                    if *all {
-                        let rhs = rhs.negate();
-                        HirRelationExpr::union(lhs, rhs).threshold()
-                    } else {
-                        let lhs = lhs.distinct();
-                        let rhs = rhs.distinct().negate();
-                        HirRelationExpr::union(lhs, rhs).threshold()
-                    }
-                }
+                SetOperator::Except => Hir::except(all, lhs, rhs),
                 SetOperator::Intersect => {
                     // TODO: Let's not duplicate the left-hand expression into TWO dataflows!
                     // Though we believe that render() does The Right Thing (TM)

--- a/src/sql/src/plan/virtual_syntax.rs
+++ b/src/sql/src/plan/virtual_syntax.rs
@@ -1,0 +1,13 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A set of virtual nodes that are used to recover some high-level
+//! concepts that are desugared to non-trival terms in some IRs.
+
+use mz_sql::plan::{HirRelationExpr, HirScalarExpr};

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -55,19 +55,32 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
-Threshold
-  Union
-    Distinct
+Except
+  Project #1
+    Map #0
+      Project #0
+        Get materialize.public.t
+  Project #1
+    Map #0
       Project #1
-        Map #0
-          Project #0
-            Get materialize.public.t
-    Negate
-      Distinct
-        Project #1
-          Map #0
-            Project #1
-              Get materialize.public.mv
+        Get materialize.public.mv
+
+EOF
+
+# Test Threshold, Union, Distinct, Negate.
+query T multiline
+EXPLAIN RAW PLAN AS TEXT FOR
+SELECT a FROM t EXCEPT ALL SELECT b FROM mv
+----
+ExceptAll
+  Project #1
+    Map #0
+      Project #0
+        Get materialize.public.t
+  Project #1
+    Map #0
+      Project #1
+        Get materialize.public.mv
 
 EOF
 


### PR DESCRIPTION
This PR introduces a way to consistently represent and deal with high-level concepts (such as SQL-specific operators) within
low-level IRs. I would like to get @wangandi's and @ggevay's take on this.

CC'ing @benesch and @frankmcsherry as this is one way to deal with SQL level concepts in the optimizer without changing the underlying IR representation. One can imagine using this in MIR to tackle some of the long-standing limitations related to outer join optimization. Another use would be plan simplification based on an `AtMostOnce` virtual operator.

PS. If we opt to merge this, a good next candidate to exercise the pattern would be `Intersect`.


### Motivation

  * This PR adds a known-desirable feature.

Variants of this feature are requested in #13485 under **collapsing various patterns**.

### Tips for reviewer

The proposal is based on the concepts of virtual syntax nodes and virtual syntax algebras, illustrated here by `Except` and
`AlgExcept`.

Complementary, to model various IRs, I introduce the `IR` trait

```rust
pub trait IR: Sized {
    type Relation;
    type Scalar;
}
```

which allows concrete IRs (`Hir`, `Mir`) to be represented as a single nullary object that fixes the concrete data types representing these IRs.

```rust
pub struct Hir;

impl IR for Hir {
    type Relation = HirRelationExpr;
    type Scalar = HirScalarExpr;
}
```

The virtual syntax variant `$S` can then be selectively introduced for each IR `$L` by implementing `Alg$S for $L`.

An example is provided by introducing an `Hir` struct and implementing `AlgExcept for Hir`. The implementation is used in the `AST ⇒ HIR` planning (in the "apply" direction) and [in the new `EXPLAIN RAW PLAN AS TEXT` output](https://github.com/MaterializeInc/materialize/pull/13801/files#diff-69ad8ed49dda0b561a262ff764816a5a9ba619ac3eebff6064dfda627dd6ca63R55-R61) (in the
"unapply" direction).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
