### PR TITLE
persist: ensure reader is known before starting snapshot iter

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -659,14 +659,13 @@ where
                 handle_shard: self.machine.shard_id(),
             });
         }
-        // WIP I think we need to fetch the latest state on machine right here
-        // because this one may have an old copy that doesn't know about the
-        // registration of split.reader_id.
+        let mut machine = self.machine.clone();
+        machine.fetch_and_update_state().await;
         let handle = ReadHandle {
             cfg: self.cfg.clone(),
             metrics: Arc::clone(&self.metrics),
             reader_id: split.reader_id.clone(),
-            machine: self.machine.clone(),
+            machine,
             blob: Arc::clone(&self.blob),
             since: self.since.clone(),
             // This isn't quite right since we did the heartbeat before sending


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

@brennanvincent [found a bug](https://github.com/MaterializeInc/materialize/issues/13802) with reading from snapshots, where we were attempting to heartbeat a reader that didn't exist.

Turns out, we were registered the ReaderId from a different `machine` than the one we were calling `heartbeat_reader` on. If the latter instance hadn't updated its state since the ReaderId was registered, it will panic. This PR ensures we update `machine` after registering a reader. Also turns out Dan's WIP comment was exactly on point 😉 

Haven't thought yet about a way to capture this behavior in a test, will revisit next week

### Motivation

* This PR fixes a recognized bug.
https://github.com/MaterializeInc/materialize/issues/13802

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A