### PR TITLE
storage: don't persist entire CollectionMetadata

### DIFF
--- a/src/storage/src/controller.proto
+++ b/src/storage/src/controller.proto
@@ -20,3 +20,10 @@ message ProtoCollectionMetadata {
     string remap_shard = 4;
     string status_shard = 5;
 }
+
+message ProtoDurableCollectionMetadata {
+    // This message is persisted to disk. Changes must be backwards compatible.
+    reserved 1, 2, 5;
+    string data_shard = 3;
+    string remap_shard = 4;
+}

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -615,7 +615,7 @@ where
                 METADATA_COLLECTION
                     .peek_key_one(&mut self.state.stash, &status_collection_id)
                     .await?
-                    .ok_or_else(|| StorageError::IdentifierMissing(status_collection_id))?
+                    .ok_or(StorageError::IdentifierMissing(status_collection_id))?
                     .data_shard
             } else {
                 ShardId::new()


### PR DESCRIPTION
There are two fields of `CollectionMetadata` that ought not be persisted
to the storage controller stash:

  * persist_location, which is supplied at runtime and could
    legitimately change during e.g. an operator migration of
    the persist consensus implementation.

  * status_shard, which is derived from the ID of the status collection
    that is provided by the adapter layer.

This commit creates a new type, called `DurableCollectionMetadata`, for
the subset of `CollectionMetadata` that ought to be persisted to disk.
The controller is responsible for converting a
`DurableCollectionMetadata` into a `CollectionMetadata` on boot by
deriving the necessary fields.

The `ProtoDurableCollectionMetadata` type has the same on-disk encoding
as `ProtoCollectionMetadata`, except with the unnecessary fields
omitted, so no migration is necessary. This leaves the unnecessary
fields on disk for existing stash entries; that seems okay because we'll
be doing at least one or two full wipes in the next few weeks.

Supersedes #13805 by removing the field that would have required the
migration.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes the bug described in #13805.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
