### PR TITLE
Fix anti-affinity labels

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -142,7 +142,6 @@ impl fmt::Debug for NamespacedKubernetesOrchestrator {
     }
 }
 
-
 impl NamespacedKubernetesOrchestrator {
     /// Return a `ListParams` instance that limits results to the namespace
     /// assigned to this orchestrator.
@@ -193,7 +192,6 @@ impl NamespacedKubernetesOrchestrator {
         };
         Ok(lsr)
     }
-
 }
 
 #[async_trait]
@@ -225,10 +223,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         };
         let mut labels = match_labels.clone();
         for (key, value) in labels_in {
-            labels.insert(
-                self.make_label_key(&key),
-                value,
-            );
+            labels.insert(self.make_label_key(&key), value);
         }
         for port in &ports_in {
             labels.insert(

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -142,41 +142,6 @@ impl fmt::Debug for NamespacedKubernetesOrchestrator {
     }
 }
 
-fn label_selector_to_k8s(
-    MzLabelSelector { label_name, logic }: MzLabelSelector,
-    prefix: &str,
-) -> Result<LabelSelectorRequirement, anyhow::Error> {
-    let (operator, values) = match logic {
-        LabelSelectionLogic::Eq { value } => Ok(("In", vec![value])),
-        LabelSelectionLogic::NotEq { value } => Ok(("NotIn", vec![value])),
-        LabelSelectionLogic::Exists => Ok(("Exists", vec![])),
-        LabelSelectionLogic::NotExists => Ok(("DoesNotExist", vec![])),
-        LabelSelectionLogic::InSet { values } => {
-            if values.is_empty() {
-                Err(anyhow!(
-                    "Invalid selector logic for {label_name}: empty `in` set"
-                ))
-            } else {
-                Ok(("In", values))
-            }
-        }
-        LabelSelectionLogic::NotInSet { values } => {
-            if values.is_empty() {
-                Err(anyhow!(
-                    "Invalid selector logic for {label_name}: empty `notin` set"
-                ))
-            } else {
-                Ok(("NotIn", values))
-            }
-        }
-    }?;
-    let lsr = LabelSelectorRequirement {
-        key: format!("{prefix}/{label_name}"),
-        operator: operator.to_string(),
-        values: Some(values),
-    };
-    Ok(lsr)
-}
 
 impl NamespacedKubernetesOrchestrator {
     /// Return a `ListParams` instance that limits results to the namespace
@@ -188,6 +153,47 @@ impl NamespacedKubernetesOrchestrator {
         );
         ListParams::default().labels(&ns_selector)
     }
+    /// Convert a higher-level label key to the actual one we
+    /// will give to Kubernetes
+    fn make_label_key(&self, key: &str) -> String {
+        format!("{}.environmentd.materialize.cloud/{}", self.namespace, key)
+    }
+    fn label_selector_to_k8s(
+        &self,
+        MzLabelSelector { label_name, logic }: MzLabelSelector,
+    ) -> Result<LabelSelectorRequirement, anyhow::Error> {
+        let (operator, values) = match logic {
+            LabelSelectionLogic::Eq { value } => Ok(("In", vec![value])),
+            LabelSelectionLogic::NotEq { value } => Ok(("NotIn", vec![value])),
+            LabelSelectionLogic::Exists => Ok(("Exists", vec![])),
+            LabelSelectionLogic::NotExists => Ok(("DoesNotExist", vec![])),
+            LabelSelectionLogic::InSet { values } => {
+                if values.is_empty() {
+                    Err(anyhow!(
+                        "Invalid selector logic for {label_name}: empty `in` set"
+                    ))
+                } else {
+                    Ok(("In", values))
+                }
+            }
+            LabelSelectionLogic::NotInSet { values } => {
+                if values.is_empty() {
+                    Err(anyhow!(
+                        "Invalid selector logic for {label_name}: empty `notin` set"
+                    ))
+                } else {
+                    Ok(("NotIn", values))
+                }
+            }
+        }?;
+        let lsr = LabelSelectorRequirement {
+            key: self.make_label_key(&label_name),
+            operator: operator.to_string(),
+            values: Some(values),
+        };
+        Ok(lsr)
+    }
+
 }
 
 #[async_trait]
@@ -220,7 +226,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         let mut labels = match_labels.clone();
         for (key, value) in labels_in {
             labels.insert(
-                format!("{}.environmentd.materialize.cloud/{}", self.namespace, key),
+                self.make_label_key(&key),
                 value,
             );
         }
@@ -314,7 +320,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             .map(|label_selectors| -> Result<_, anyhow::Error> {
                 let label_selector_requirements = label_selectors
                     .into_iter()
-                    .map(|ls| label_selector_to_k8s(ls, &self.namespace))
+                    .map(|ls| self.label_selector_to_k8s(ls))
                     .collect::<Result<Vec<_>, _>>()?;
                 let ls = LabelSelector {
                     match_expressions: Some(label_selector_requirements),


### PR DESCRIPTION
Centralize the logic for creating namespaced labels in a function, to prevent it getting out of sync.

### Motivation

At some point, we changed the prefix of namespaced labels to include `.environmentd.materialize.cloud`, but this wasn't applied to the anti-affinity label selectors. Centralize that logic in a function to prevent drift like this from happening again.

### Tips for reviewer

`label_selector_to_k8s` is just code movement to give it access to `&self`, except for line 190.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
