### PR TITLE
Correctly capture changes to upper

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1335,9 +1335,9 @@ mod persist_write_handles {
                                         .or(Err(*id))?;
 
                                     let mut change_batch = timely::progress::ChangeBatch::new();
-                                    let old_upper = old_upper.clone();
                                     change_batch.extend(new_upper.iter().cloned().map(|t| (t, 1)));
                                     change_batch.extend(old_upper.iter().cloned().map(|t| (t, -1)));
+                                    old_upper.clone_from(&new_upper);
 
                                     Ok::<_, GlobalId>((*id, change_batch))
                                 })


### PR DESCRIPTION
When https://github.com/MaterializeInc/materialize/pull/13784 added in the ability to restart `environmentd` with non-zero `upper` for tables, it did so with a local stash of `upper` that it initialized correctly, but forgot to update. With this change, the updates actually get applied. Very small diff, but big difference.

### Motivation

  * This PR fixes a previously unreported bug.

The PR mentioned above fixed on symptom of the problem, but introduced another that would only be visible after watching the system. We don't seem to have tests that do this, which is another issue!

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
