### PR TITLE
Revert "compute: use boring persist_sink for logging"

### DIFF
--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -320,7 +320,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, collection);
+                persist_sink(*id, meta, compute_state, &collection);
             }
         }
         result

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -194,7 +194,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, collection);
+                persist_sink(*id, meta, compute_state, &collection);
             }
         }
         result

--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -7,14 +7,28 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use differential_dataflow::input::Input;
+use std::any::Any;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::Arc;
+
+use differential_dataflow::AsCollection;
 use differential_dataflow::Collection;
+use differential_dataflow::Hashable;
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
+use timely::progress::Timestamp as TimelyTimestamp;
+use timely::PartialOrder;
 
 use mz_repr::GlobalId;
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage::controller::CollectionMetadata;
+use mz_storage::types::errors::DataflowError;
+use mz_storage::types::sinks::SinkAsOf;
+use mz_storage::types::sources::SourceData;
+use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::compute_state::ComputeState;
 
@@ -22,19 +36,39 @@ pub(crate) fn persist_sink<G>(
     target_id: GlobalId,
     target: &CollectionMetadata,
     compute_state: &mut ComputeState,
-    desired_collection: Collection<G, Row, Diff>,
+    desired_collection: &Collection<G, Row, Diff>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    let (_, err_collection) = desired_collection.scope().new_collection();
+    let scope = desired_collection.scope();
+    let as_of: SinkAsOf = SinkAsOf {
+        frontier: Antichain::from_elem(0),
+        strict: false,
+    };
 
-    let token = crate::sink::persist_sink(
-        target_id,
-        target,
-        desired_collection,
-        err_collection,
-        compute_state,
+    // To create the diffs we also need to read from persist.
+    let (ok_stream, err_stream, token) = mz_storage::source::persist_source::persist_source(
+        &scope,
+        Arc::clone(&compute_state.persist_clients),
+        target.clone(),
+        as_of.frontier.clone(),
     );
+    let persist_collection = ok_stream
+        .as_collection()
+        .map(Ok)
+        .concat(&err_stream.as_collection().map(Err));
+
+    let token = Rc::new((
+        install_desired_into_persist(
+            target,
+            compute_state,
+            as_of,
+            target_id,
+            desired_collection.map(Ok),
+            persist_collection,
+        ),
+        token,
+    ));
 
     // Report frontier of collection back to coord
     compute_state
@@ -50,4 +84,159 @@ pub(crate) fn persist_sink<G>(
             is_tail: false,
         },
     );
+}
+
+//TODO(lh): Replace this with persist_sink::install_desired_sink once #13740 is merged.
+fn install_desired_into_persist<G>(
+    target: &CollectionMetadata,
+    compute_state: &mut crate::compute_state::ComputeState,
+    sink_as_of: SinkAsOf,
+    sink_id: GlobalId,
+    desired_collection: Collection<G, Result<Row, DataflowError>, Diff>,
+    persist_collection: Collection<G, Result<Row, DataflowError>, Diff>,
+) -> Option<Rc<dyn Any>>
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let scope = desired_collection.scope();
+
+    let persist_clients = Arc::clone(&compute_state.persist_clients);
+    let persist_location = target.persist_location.clone();
+    let shard_id = target.data_shard;
+
+    let operator_name = format!("persist_sink({})", shard_id);
+    let mut persist_op = OperatorBuilder::new(operator_name, scope.clone());
+
+    // Only attempt to write from this frontier onward, as our data are not necessarily
+    // correct for times not greater or equal to this frontier. Ignore as_of strictness.
+    let mut write_lower_bound = sink_as_of.frontier;
+
+    // TODO(mcsherry): this is shardable, eventually. But for now use a single writer.
+    let hashed_id = sink_id.hashed();
+    // TODO(lh): Figure out why this is necessary for introspection sources.
+    let active_write_worker = scope.index() == 0;
+    let mut desired_input =
+        persist_op.new_input(&desired_collection.inner, Exchange::new(move |_| hashed_id));
+    let mut persist_input =
+        persist_op.new_input(&persist_collection.inner, Exchange::new(move |_| hashed_id));
+
+    // Dropping this token signals that the operator should shut down cleanly.
+    let token = Rc::new(());
+    let token_weak = Rc::downgrade(&token);
+
+    // Only the active_write_worker will ever produce data so all other workers have
+    // an empty frontier. It's necessary to insert all of these into `compute_state.
+    // sink_write_frontier` below so we properly clear out default frontiers of
+    // non-active workers.
+    let shared_frontier = Rc::new(RefCell::new(if active_write_worker {
+        Antichain::from_elem(TimelyTimestamp::minimum())
+    } else {
+        Antichain::new()
+    }));
+
+    compute_state
+        .sink_write_frontiers
+        .insert(sink_id, Rc::clone(&shared_frontier));
+
+    // This operator accepts the current and desired update streams for a `persist` shard.
+    // It attempts to write out updates, starting from the current's upper frontier, that
+    // will cause the changes of desired to be committed to persist.
+
+    persist_op.build_async(
+        scope,
+        move |_capabilities, frontiers, scheduler| async move {
+            let mut buffer = Vec::new();
+
+            // Contains `desired - persist`, reflecting the updates we would like to commit
+            // to `persist` in order to "correct" it to track `desired`.
+            let mut correction = Vec::new();
+
+            // TODO(aljoscha): We need to figure out what to do with error results from these calls.
+            let mut write = persist_clients
+                .lock()
+                .await
+                .open(persist_location)
+                .await
+                .expect("could not open persist client")
+                .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
+                .await
+                .expect("could not open persist shard");
+
+            while scheduler.notified().await {
+                if !active_write_worker
+                    || token_weak.upgrade().is_none()
+                    // FRANK: I don't understand this case.
+                    || shared_frontier.borrow().is_empty()
+                {
+                    return;
+                }
+
+                // Extract desired rows as positive contributions to `correction`.
+                desired_input.for_each(|_cap, data| {
+                    data.swap(&mut buffer);
+                    correction.append(&mut buffer);
+                });
+
+                // Extract persist rows as negative contributions to `correction`.
+                persist_input.for_each(|_cap, data| {
+                    data.swap(&mut buffer);
+                    correction.extend(buffer.drain(..).map(|(d,t,r)| (d,t,-r)));
+                });
+
+                // Capture current frontiers.
+                let frontiers = frontiers.borrow().clone();
+                let desired_frontier = &frontiers[0];
+                let persist_frontier = &frontiers[1];
+
+                // We should only attempt a commit to an interval at least our lower bound.
+                if PartialOrder::less_equal(&write_lower_bound, persist_frontier) {
+
+                    // We may have the opportunity to commit updates.
+                    if PartialOrder::less_than(persist_frontier, desired_frontier) {
+
+                        // Advance all updates to `persist`'s frontier.
+                        for (_, time, _) in correction.iter_mut() {
+                            use differential_dataflow::lattice::Lattice;
+                            time.advance_by(persist_frontier.borrow());
+                        }
+                        // Consolidate updates within.
+                        differential_dataflow::consolidation::consolidate_updates(&mut correction);
+
+                        let to_append =
+                        correction
+                            .iter()
+                            .filter(|(_, time, _)| persist_frontier.less_equal(time) && !desired_frontier.less_equal(time))
+                            .map(|(data, time, diff)| ((SourceData(data.clone()), ()), time, diff));
+
+                        let result =
+                        write
+                            .compare_and_append(to_append, persist_frontier.clone(), desired_frontier.clone())
+                            .await
+                            .expect("Indeterminate")    // TODO: What does this error mean?
+                            .expect("Invalid usage")    // TODO: What does this error mean?
+                            ;
+
+                        // If the result is `Ok`, we will eventually see the appended data return through `persist_input`,
+                        // which will remove the results from `correction`; we should not do this directly ourselves.
+                        // In either case, we have new information about the next frontier we should attempt to commit from.
+                        match result {
+                            Ok(()) => {
+                                write_lower_bound.clone_from(desired_frontier);
+                            }
+                            Err(mz_persist_client::Upper(frontier)) => {
+                                write_lower_bound.clone_from(&frontier);
+                            }
+                        }
+                    } else {
+                        write_lower_bound.clone_from(&persist_frontier);
+                    }
+                }
+
+                // Confirm that we only require updates from our lower bound onward.
+                shared_frontier.borrow_mut().clone_from(&write_lower_bound);
+            }
+        },
+    );
+
+    Some(token)
 }

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -165,7 +165,7 @@ pub fn construct<A: Allocate>(
                         row_buf.clone()
                     },
                 );
-                persist_sink(*id, meta, compute_state, sinked);
+                persist_sink(*id, meta, compute_state, &sinked);
             }
 
             for variant in logs_active {

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -501,7 +501,7 @@ pub fn construct<A: Allocate>(
 
             if let Some((id, meta)) = config.sink_logs.get(&variant) {
                 tracing::debug!("Persisting {:?} to {:?}", &variant, meta);
-                persist_sink(*id, meta, compute_state, collection);
+                persist_sink(*id, meta, compute_state, &collection);
             }
         }
         result

--- a/src/compute/src/sink/mod.rs
+++ b/src/compute/src/sink/mod.rs
@@ -13,6 +13,4 @@ mod persist_sink;
 mod tail;
 
 pub(crate) use metrics::KafkaBaseMetrics;
-pub(crate) use persist_sink::persist_sink;
-
 pub use metrics::SinkBaseMetrics;

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -28,7 +28,6 @@ use mz_storage::types::sinks::{PersistSinkConnection, SinkDesc};
 use mz_storage::types::sources::SourceData;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
-use crate::compute_state::ComputeState;
 use crate::render::sinks::SinkRender;
 
 impl<G> SinkRender<G> for PersistSinkConnection<CollectionMetadata>
@@ -49,7 +48,7 @@ where
 
     fn render_continuous_sink(
         &self,
-        compute_state: &mut ComputeState,
+        compute_state: &mut crate::compute_state::ComputeState,
         _sink: &SinkDesc<CollectionMetadata>,
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
@@ -58,155 +57,136 @@ where
     where
         G: Scope<Timestamp = Timestamp>,
     {
-        let ok_collection = sinked_collection.map(|(key, value)| {
-            assert!(key.is_none(), "persist_source does not support keys");
-            value.expect("persist_source must have values")
-        });
+        let scope = sinked_collection.scope();
 
-        persist_sink(
-            sink_id,
-            &self.storage_metadata,
-            ok_collection,
-            err_collection,
-            compute_state,
-        )
+        let persist_clients = Arc::clone(&compute_state.persist_clients);
+        let persist_location = self.storage_metadata.persist_location.clone();
+        let shard_id = self.storage_metadata.data_shard;
+
+        let operator_name = format!("persist_sink({})", shard_id);
+        let mut persist_op = OperatorBuilder::new(operator_name, scope.clone());
+
+        // We want exactly one worker (in the cluster) to send all the data to persist. It's fine
+        // if other workers from replicated clusters write the same data, though. In the real
+        // implementation, we would use a storage client that transparently handles writing to
+        // multiple shards. One shard would then only be written to by one worker but we get
+        // parallelism from the sharding.
+        // TODO(aljoscha): Storage must learn to keep track of collections, which consist of
+        // multiple persist shards. Then we should set it up such that each worker can write to one
+        // shard.
+        let hashed_id = sink_id.hashed();
+        let active_write_worker = (hashed_id as usize) % scope.peers() == scope.index();
+
+        let mut input =
+            persist_op.new_input(&sinked_collection.inner, Exchange::new(move |_| hashed_id));
+        let mut err_input =
+            persist_op.new_input(&err_collection.inner, Exchange::new(move |_| hashed_id));
+
+        let token = Rc::new(());
+        let token_weak = Rc::downgrade(&token);
+
+        // Only the active_write_worker will ever produce data so all other workers have
+        // an empty frontier. It's necessary to insert all of these into `compute_state.
+        // sink_write_frontier` below so we properly clear out default frontiers of
+        // non-active workers.
+        let shared_frontier = Rc::new(RefCell::new(if active_write_worker {
+            Antichain::from_elem(TimelyTimestamp::minimum())
+        } else {
+            Antichain::new()
+        }));
+
+        compute_state
+            .sink_write_frontiers
+            .insert(sink_id, Rc::clone(&shared_frontier));
+
+        // NOTE(aljoscha): It might be better to roll our own async operator that deals with
+        // handling multiple in-flight write futures, similar to how the persist operators in
+        // `operators/stream.rs` do it. That would allow us to have multiple write requests in
+        // flight concurrently.
+        persist_op.build_async(
+            scope,
+            move |_capabilities, frontiers, scheduler| async move {
+                let mut buffer = Vec::new();
+                let mut err_buffer = Vec::new();
+                let mut stash: HashMap<_, Vec<_>> = HashMap::new();
+
+                // TODO(aljoscha): We need to figure out what to do with error results from these calls.
+                let mut write = persist_clients
+                    .lock()
+                    .await
+                    .open(persist_location)
+                    .await
+                    .expect("could not open persist client")
+                    .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
+                    .await
+                    .expect("could not open persist shard");
+
+                while scheduler.notified().await {
+                    let mut input_frontier = Antichain::new();
+                    for frontier in frontiers.borrow().clone() {
+                        input_frontier.extend(frontier);
+                    }
+
+                    if !active_write_worker
+                        || token_weak.upgrade().is_none()
+                        || shared_frontier.borrow().is_empty()
+                    {
+                        return;
+                    }
+
+                    input.for_each(|_cap, data| {
+                        data.swap(&mut buffer);
+
+                        for ((key, value), ts, diff) in buffer.drain(..) {
+                            assert!(key.is_none(), "persist_source does not support keys");
+                            let row = value.expect("persist_source must have values");
+                            stash.entry(ts).or_default().push((
+                                (SourceData(Ok(row)), ()),
+                                ts,
+                                diff,
+                            ));
+                        }
+                    });
+
+                    err_input.for_each(|_cap, data| {
+                        data.swap(&mut err_buffer);
+
+                        for (error, ts, diff) in err_buffer.drain(..) {
+                            stash.entry(ts).or_default().push((
+                                (SourceData(Err(error)), ()),
+                                ts,
+                                diff,
+                            ));
+                        }
+                    });
+
+                    let mut updates = stash
+                        .iter()
+                        .filter(|(ts, _updates)| !input_frontier.less_equal(ts))
+                        .flat_map(|(_ts, updates)| updates.iter());
+
+                    if PartialOrder::less_than(&*shared_frontier.borrow(), &input_frontier) {
+                        // We always append, even in case we don't have any updates, because appending
+                        // also advances the frontier.
+                        let lower = shared_frontier.borrow().clone();
+                        // TODO(aljoscha): Figure out how errors from this should be reported.
+                        write
+                            .append(updates, lower, input_frontier.clone())
+                            .await
+                            .expect("cannot append updates")
+                            .expect("invalid/outdated upper");
+
+                        *shared_frontier.borrow_mut() = input_frontier.clone();
+                    } else {
+                        // We cannot have updates without the frontier advancing.
+                        assert!(updates.next().is_none());
+                    }
+
+                    stash.retain(|ts, _updates| input_frontier.less_equal(ts));
+                }
+            },
+        );
+
+        Some(token)
     }
-}
-
-pub(crate) fn persist_sink<G>(
-    sink_id: GlobalId,
-    target: &CollectionMetadata,
-    ok_collection: Collection<G, Row, Diff>,
-    err_collection: Collection<G, DataflowError, Diff>,
-    compute_state: &mut ComputeState,
-) -> Option<Rc<dyn Any>>
-where
-    G: Scope<Timestamp = Timestamp>,
-{
-    let scope = ok_collection.scope();
-
-    let persist_clients = Arc::clone(&compute_state.persist_clients);
-    let persist_location = target.persist_location.clone();
-    let shard_id = target.data_shard;
-
-    let operator_name = format!("persist_sink({})", shard_id);
-    let mut persist_op = OperatorBuilder::new(operator_name, scope.clone());
-
-    // We want exactly one worker (in the cluster) to send all the data to persist. It's fine
-    // if other workers from replicated clusters write the same data, though. In the real
-    // implementation, we would use a storage client that transparently handles writing to
-    // multiple shards. One shard would then only be written to by one worker but we get
-    // parallelism from the sharding.
-    // TODO(aljoscha): Storage must learn to keep track of collections, which consist of
-    // multiple persist shards. Then we should set it up such that each worker can write to one
-    // shard.
-    let hashed_id = sink_id.hashed();
-    let active_write_worker = (hashed_id as usize) % scope.peers() == scope.index();
-
-    let mut input = persist_op.new_input(&ok_collection.inner, Exchange::new(move |_| hashed_id));
-    let mut err_input =
-        persist_op.new_input(&err_collection.inner, Exchange::new(move |_| hashed_id));
-
-    let token = Rc::new(());
-    let token_weak = Rc::downgrade(&token);
-
-    // Only the active_write_worker will ever produce data so all other workers have
-    // an empty frontier. It's necessary to insert all of these into `compute_state.
-    // sink_write_frontier` below so we properly clear out default frontiers of
-    // non-active workers.
-    let shared_frontier = Rc::new(RefCell::new(if active_write_worker {
-        Antichain::from_elem(TimelyTimestamp::minimum())
-    } else {
-        Antichain::new()
-    }));
-
-    compute_state
-        .sink_write_frontiers
-        .insert(sink_id, Rc::clone(&shared_frontier));
-
-    // NOTE(aljoscha): It might be better to roll our own async operator that deals with
-    // handling multiple in-flight write futures, similar to how the persist operators in
-    // `operators/stream.rs` do it. That would allow us to have multiple write requests in
-    // flight concurrently.
-    persist_op.build_async(
-        scope,
-        move |_capabilities, frontiers, scheduler| async move {
-            let mut buffer = Vec::new();
-            let mut err_buffer = Vec::new();
-            let mut stash: HashMap<_, Vec<_>> = HashMap::new();
-
-            // TODO(aljoscha): We need to figure out what to do with error results from these calls.
-            let mut write = persist_clients
-                .lock()
-                .await
-                .open(persist_location)
-                .await
-                .expect("could not open persist client")
-                .open_writer::<SourceData, (), Timestamp, Diff>(shard_id)
-                .await
-                .expect("could not open persist shard");
-
-            while scheduler.notified().await {
-                let mut input_frontier = Antichain::new();
-                for frontier in frontiers.borrow().clone() {
-                    input_frontier.extend(frontier);
-                }
-
-                if !active_write_worker
-                    || token_weak.upgrade().is_none()
-                    || shared_frontier.borrow().is_empty()
-                {
-                    return;
-                }
-
-                input.for_each(|_cap, data| {
-                    data.swap(&mut buffer);
-
-                    for (row, ts, diff) in buffer.drain(..) {
-                        stash
-                            .entry(ts)
-                            .or_default()
-                            .push(((SourceData(Ok(row)), ()), ts, diff));
-                    }
-                });
-
-                err_input.for_each(|_cap, data| {
-                    data.swap(&mut err_buffer);
-
-                    for (error, ts, diff) in err_buffer.drain(..) {
-                        stash
-                            .entry(ts)
-                            .or_default()
-                            .push(((SourceData(Err(error)), ()), ts, diff));
-                    }
-                });
-
-                let mut updates = stash
-                    .iter()
-                    .filter(|(ts, _updates)| !input_frontier.less_equal(ts))
-                    .flat_map(|(_ts, updates)| updates.iter());
-
-                if PartialOrder::less_than(&*shared_frontier.borrow(), &input_frontier) {
-                    // We always append, even in case we don't have any updates, because appending
-                    // also advances the frontier.
-                    let lower = shared_frontier.borrow().clone();
-                    // TODO(aljoscha): Figure out how errors from this should be reported.
-                    write
-                        .append(updates, lower, input_frontier.clone())
-                        .await
-                        .expect("cannot append updates")
-                        .expect("invalid/outdated upper");
-
-                    *shared_frontier.borrow_mut() = input_frontier.clone();
-                } else {
-                    // We cannot have updates without the frontier advancing.
-                    assert!(updates.next().is_none());
-                }
-
-                stash.retain(|ts, _updates| input_frontier.less_equal(ts));
-            }
-        },
-    );
-
-    Some(token)
 }


### PR DESCRIPTION
This reverts commit 35914db3bab3b6d1b17718f9a91cb34043099b6c.

I messed up rebasing of #13706 and this got into main by accident.

### Motivation

  * This PR reverts a commit that was accidentally merged.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).