### PR TITLE
Fix some tests failing on nightly

### DIFF
--- a/misc/python/materialize/checks/null_value.py
+++ b/misc/python/materialize/checks/null_value.py
@@ -70,8 +70,8 @@ class NullValue(Check):
                 <null> <null> <null>
                 <null> <null> <null>
 
-                > SHOW CREATE VIEW null_value_view2;
-                materialize.public.null_value_view2 "CREATE VIEW \\"materialize\\".\\"public\\".\\"null_value_view2\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"public\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
+                > SHOW CREATE MATERIALIZED VIEW null_value_view2;
+                materialize.public.null_value_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"null_value_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"public\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
 
                 > SELECT * FROM null_value_view2;
                 <null> <null> <null>

--- a/misc/python/materialize/checks/text_bytea_types.py
+++ b/misc/python/materialize/checks/text_bytea_types.py
@@ -51,8 +51,8 @@ class TextByteaTypes(Check):
         return Testdrive(
             dedent(
                 """
-                > SHOW CREATE VIEW string_bytea_types_view1;
-                materialize.public.string_bytea_types_view1 "CREATE VIEW \\"materialize\\".\\"public\\".\\"string_bytea_types_view1\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"public\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
+                > SHOW CREATE MATERIALIZED VIEW string_bytea_types_view1;
+                materialize.public.string_bytea_types_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"string_bytea_types_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"public\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
 
                 > SELECT text_col, text, LENGTH(bytea_col), LENGTH(bytea) FROM string_bytea_types_view1;
                 aaaa това 2 2

--- a/misc/python/materialize/checks/top_k.py
+++ b/misc/python/materialize/checks/top_k.py
@@ -59,15 +59,15 @@ class BasicTopK(Check):
         return Testdrive(
             dedent(
                 """
-                > SHOW CREATE VIEW basic_topk_view1;
-                materialize.public.basic_topk_view1 "CREATE VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view1\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
+                > SHOW CREATE MATERIALIZED VIEW basic_topk_view1;
+                materialize.public.basic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
 
                 > SELECT * FROM basic_topk_view1;
                 2 32
                 3 48
 
-                > SHOW CREATE VIEW basic_topk_view2;
-                materialize.public.basic_topk_view2 "CREATE VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view2\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
+                > SHOW CREATE MATERIALIZED VIEW basic_topk_view2;
+                materialize.public.basic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
 
                 > SELECT * FROM basic_topk_view2;
                 1 16
@@ -122,15 +122,15 @@ class MonotonicTopK(Check):
         return Testdrive(
             dedent(
                 """
-                > SHOW CREATE VIEW monotonic_topk_view1;
-                materialize.public.monotonic_topk_view1 "CREATE VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view1\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
+                > SHOW CREATE MATERIALIZED VIEW monotonic_topk_view1;
+                materialize.public.monotonic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
 
                 > SELECT * FROM monotonic_topk_view1;
                 E 5
                 D 4
 
-                > SHOW CREATE VIEW monotonic_topk_view2;
-                materialize.public.monotonic_topk_view2 "CREATE VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view2\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
+                > SHOW CREATE MATERIALIZED VIEW monotonic_topk_view2;
+                materialize.public.monotonic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
 
                 > SELECT * FROM monotonic_topk_view2;
                 A 1
@@ -185,14 +185,14 @@ class MonotonicTop1(Check):
         return Testdrive(
             dedent(
                 """
-                > SHOW CREATE VIEW monotonic_top1_view1;
-                materialize.public.monotonic_top1_view1 "CREATE VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view1\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 1"
+                > SHOW CREATE MATERIALIZED VIEW monotonic_top1_view1;
+                materialize.public.monotonic_top1_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 1"
 
                 > SELECT * FROM monotonic_top1_view1;
                 D 5
 
-                > SHOW CREATE VIEW monotonic_top1_view2;
-                materialize.public.monotonic_top1_view2 "CREATE VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view2\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 1"
+                > SHOW CREATE MATERIALIZED VIEW monotonic_top1_view2;
+                materialize.public.monotonic_top1_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 1"
 
                 > SELECT * FROM monotonic_top1_view2;
                 A 1

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -326,7 +326,7 @@ true
         # Explicit LIMIT is needed for the ORDER BY to not be optimized away
         return Td(
             f"""
-> DROP VIEW IF EXISTS v2
+> DROP MATERIALIZED VIEW IF EXISTS v2
   /* A */
 
 > CREATE MATERIALIZED VIEW v2 AS SELECT * FROM v1 ORDER BY f1 LIMIT 999999999999
@@ -429,7 +429,7 @@ class CrossJoin(Dataflow):
     def benchmark(self) -> MeasurementSource:
         return Td(
             f"""
-> DROP VIEW IF EXISTS v1;
+> DROP MATERIALIZED VIEW IF EXISTS v1;
 
 > CREATE MATERIALIZED VIEW v1 AS SELECT {self.unique_values()} FROM {self.join()}
   /* A */
@@ -578,9 +578,9 @@ class FullOuterJoin(Dataflow):
         return [
             Td(
                 f"""
-> DROP VIEW IF EXISTS v2 CASCADE;
+> DROP MATERIALIZED VIEW IF EXISTS v2 CASCADE;
 
-> DROP VIEW IF EXISTS v1 CASCADE;
+> DROP MATERIALIZED VIEW IF EXISTS v1 CASCADE;
 
 > DROP TABLE IF EXISTS ten;
 

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -135,7 +135,7 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=(\d{13}|u\d{1,2}) replacement=<>
+$ set-regex match=(\d{13}|u\d{1,3}) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
 "     timestamp: <>\n         since:[<>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<>]\nwrite frontier:[]\n"
 


### PR DESCRIPTION
This PR fixes some test failures that occur during our nightly test runs. Two of them were introduced in #13706. The one in `csv-sources.td` existed before but was easy to fix.

### Motivation

  * This PR fixes some failing nightly tests.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note)