### PR TITLE
scratch: clean up stopped instances

### DIFF
--- a/misc/python/materialize/scratch.py
+++ b/misc/python/materialize/scratch.py
@@ -372,8 +372,8 @@ def get_instances_by_tag(k: str, v: str) -> List[InstanceTypeDef]:
 
 
 def get_old_instances() -> List[InstanceTypeDef]:
-    def is_running(i: InstanceTypeDef) -> bool:
-        return i["State"]["Name"] == "running"
+    def exists(i: InstanceTypeDef) -> bool:
+        return i["State"]["Name"] != "terminated"
 
     def is_old(i: InstanceTypeDef) -> bool:
         delete_after = instance_typedef_tags(i).get("scratch-delete-after")
@@ -386,7 +386,7 @@ def get_old_instances() -> List[InstanceTypeDef]:
         i
         for r in boto3.client("ec2").describe_instances()["Reservations"]
         for i in r["Instances"]
-        if is_running(i) and is_old(i)
+        if exists(i) and is_old(i)
     ]
 
 


### PR DESCRIPTION
This PR fixes a bug where our automatic AWS cleanup script would only remove old scratch instances that were 'running', not 'stopped' ones.

### Motivation

  * This PR fixes a previously unreported bug.

See [Slack message](https://materializeinc.slack.com/archives/C01KV5PEZ9R/p1658479747531259).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes no [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).