### PR TITLE
storage: AUCTION load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4122,6 +4122,7 @@ dependencies = [
  "proptest-derive",
  "prost",
  "pubnub-hyper",
+ "rand",
  "rdkafka",
  "regex",
  "serde",

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -894,14 +894,14 @@ impl_display_t!(CreateSourceConnection);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LoadGenerator {
     Counter,
+    Auction,
 }
 
 impl AstDisplay for LoadGenerator {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            Self::Counter => {
-                f.write_str("COUNTER");
-            }
+            Self::Counter => f.write_str("COUNTER"),
+            Self::Auction => f.write_str("AUCTION"),
         }
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -33,6 +33,7 @@ Array
 As
 Asc
 At
+Auction
 Authority
 Availability
 Avro

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2338,8 +2338,9 @@ impl<'a> Parser<'a> {
             }
             LOAD => {
                 self.expect_keyword(GENERATOR)?;
-                let generator = match self.expect_one_of_keywords(&[COUNTER])? {
+                let generator = match self.expect_one_of_keywords(&[COUNTER, AUCTION])? {
                     COUNTER => LoadGenerator::Counter,
+                    AUCTION => LoadGenerator::Auction,
                     _ => unreachable!(),
                 };
                 let options = if matches!(self.peek_token(), Some(Token::Semicolon) | None) {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -60,6 +60,7 @@ proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-fea
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git"}
 prost = { version = "0.10.3", features = ["no-recursion-limit"] }
 pubnub-hyper = { git = "https://github.com/MaterializeInc/pubnub-rust", default-features = false }
+rand = "0.8.5"
 rdkafka = { git = "https://github.com/fede1024/rust-rdkafka.git", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.6.0" }
 serde = { version = "1.0.140", features = ["derive"] }

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -1,0 +1,109 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::{collections::VecDeque, iter};
+
+use rand::prelude::{Rng, SmallRng};
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+
+use mz_expr::func::cast_timestamp_tz_to_string;
+use mz_ore::now::{to_datetime, NowFn};
+use mz_repr::{Datum, RelationDesc, Row, ScalarType};
+
+use crate::types::sources::encoding::DataEncodingInner;
+use crate::types::sources::Generator;
+
+pub struct Auction {}
+
+impl Generator for Auction {
+    fn data_encoding_inner(&self) -> DataEncodingInner {
+        DataEncodingInner::RowCodec(
+            RelationDesc::empty()
+                .with_column("table", ScalarType::String.nullable(false))
+                .with_column(
+                    "row_data",
+                    ScalarType::List {
+                        element_type: Box::new(ScalarType::String),
+                        custom_id: None,
+                    }
+                    .nullable(false),
+                ),
+        )
+    }
+
+    fn views(&self) -> Vec<(&str, RelationDesc)> {
+        vec![
+            (
+                "auctions",
+                RelationDesc::empty()
+                    .with_column("id", ScalarType::Int64.nullable(false))
+                    .with_column("item", ScalarType::String.nullable(false))
+                    .with_column("end_time", ScalarType::TimestampTz.nullable(false)),
+            ),
+            (
+                "bids",
+                RelationDesc::empty()
+                    .with_column("id", ScalarType::Int64.nullable(false))
+                    .with_column("auction_id", ScalarType::Int64.nullable(false))
+                    .with_column("amount", ScalarType::Int32.nullable(false))
+                    .with_column("bid_time", ScalarType::TimestampTz.nullable(false)),
+            ),
+        ]
+    }
+
+    fn by_seed(&self, now: NowFn, seed: Option<u64>) -> Box<dyn Iterator<Item = Row>> {
+        let mut pending = VecDeque::new();
+        let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_default());
+        let mut counter = 0;
+        Box::new(iter::from_fn(move || {
+            {
+                if pending.is_empty() {
+                    counter += 1;
+                    let now = to_datetime(now());
+                    let mut auction = Row::with_capacity(2);
+                    let mut packer = auction.packer();
+                    packer.push(Datum::String("auctions"));
+                    packer.push_list(&[
+                        Datum::String(&counter.to_string()),               // auction id
+                        Datum::String(AUCTIONS.choose(&mut rng).unwrap()), // item
+                        Datum::String(&cast_timestamp_tz_to_string(
+                            now + chrono::Duration::seconds(10),
+                        )), // end time
+                    ]);
+                    pending.push_back(auction);
+                    const MAX_BIDS: i64 = 10;
+                    for i in 0..rng.gen_range(2..MAX_BIDS) {
+                        let mut bid = Row::with_capacity(2);
+                        let mut packer = bid.packer();
+                        packer.push(Datum::String("bids"));
+                        packer.push_list(&[
+                            Datum::String(&(counter * MAX_BIDS + i).to_string()), // bid id
+                            Datum::String(&counter.to_string()),                  // auction id
+                            Datum::String(&rng.gen_range(1..100).to_string()),    // amount
+                            Datum::String(&cast_timestamp_tz_to_string(
+                                now + chrono::Duration::seconds(i),
+                            )), // bid time
+                        ]);
+                        pending.push_back(bid);
+                    }
+                }
+                pending.pop_front()
+            }
+        }))
+    }
+}
+
+const AUCTIONS: &[&str] = &[
+    "Signed Memorabilia",
+    "City Bar Crawl",
+    "Best Pizza in Town",
+    "Gift Basket",
+    "Custom Art",
+];

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -1,0 +1,38 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::iter;
+
+use mz_ore::now::NowFn;
+use mz_repr::{Datum, RelationDesc, Row, ScalarType};
+
+use crate::types::sources::encoding::DataEncodingInner;
+use crate::types::sources::Generator;
+
+pub struct Counter {}
+
+impl Generator for Counter {
+    fn data_encoding_inner(&self) -> DataEncodingInner {
+        DataEncodingInner::RowCodec(
+            RelationDesc::empty().with_column("counter", ScalarType::Int64.nullable(false)),
+        )
+    }
+
+    fn views(&self) -> Vec<(&str, RelationDesc)> {
+        Vec::new()
+    }
+
+    fn by_seed(&self, _now: NowFn, _seed: Option<u64>) -> Box<dyn Iterator<Item = Row>> {
+        let mut counter = 0;
+        Box::new(iter::repeat_with(move || {
+            counter += 1;
+            Row::pack_slice(&[Datum::Int64(counter)])
+        }))
+    }
+}

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -66,9 +66,9 @@ use crate::types::errors::{DecodeError, SourceError, SourceErrorDetails};
 use crate::types::sources::encoding::SourceDataEncoding;
 use crate::types::sources::{MzOffset, SourceConnection};
 
+pub mod generator;
 mod kafka;
 mod kinesis;
-mod load_generator;
 pub mod metrics;
 pub mod persist_source;
 mod postgres;
@@ -77,9 +77,9 @@ mod reclock;
 mod s3;
 pub mod util;
 
+pub use generator::LoadGeneratorSourceReader;
 pub use kafka::KafkaSourceReader;
 pub use kinesis::KinesisSourceReader;
-pub use load_generator::LoadGeneratorSourceReader;
 pub use postgres::PostgresSourceReader;
 pub use pubnub::PubNubSourceReader;
 pub use s3::S3SourceReader;

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -205,6 +205,7 @@ message ProtoPubNubSourceConnection {
 message ProtoLoadGeneratorSourceConnection {
     oneof generator {
         google.protobuf.Empty counter = 1;
+        google.protobuf.Empty auction = 3;
     }
     optional uint64 tick_micros = 2;
 }

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -1,0 +1,79 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test verifies the get started page works.
+
+> CREATE SOURCE demo FROM LOAD GENERATOR AUCTION TICK INTERVAL '50ms'
+
+> CREATE VIEWS FROM SOURCE demo
+
+> SHOW VIEWS
+auctions
+bids
+
+> SHOW COLUMNS FROM auctions
+end_time true "timestamp with time zone"
+id true bigint
+item true text
+
+> SHOW COLUMNS FROM bids
+amount true integer
+auction_id true bigint
+bid_time true "timestamp with time zone"
+id true bigint
+
+> CREATE VIEW on_time_bids AS
+  SELECT
+    bids.id       AS bid_id,
+    auctions.id   AS auction_id,
+    auctions.item,
+    bids.bid_time,
+    auctions.end_time,
+    bids.amount
+  FROM bids
+  JOIN auctions ON bids.auction_id = auctions.id
+  WHERE bids.bid_time < auctions.end_time
+
+> CREATE MATERIALIZED VIEW avg_bids AS
+  SELECT auction_id, avg(amount) AS amount
+  FROM on_time_bids
+  GROUP BY auction_id
+
+> SELECT auction_id, MAX(amount)
+  FROM on_time_bids
+  GROUP BY auction_id
+  ORDER BY auction_id LIMIT 5
+1 97
+2 72
+3 97
+4 69
+5 63
+
+> CREATE VIEW highest_bid_per_auction AS
+  SELECT grp.auction_id, bid_id, item, amount, end_time FROM
+    (SELECT DISTINCT auction_id FROM on_time_bids) grp,
+    LATERAL (
+        SELECT * FROM on_time_bids
+        WHERE auction_id = grp.auction_id
+        ORDER BY amount DESC LIMIT 1
+    )
+
+
+> CREATE MATERIALIZED VIEW winning_bids AS
+  SELECT * FROM highest_bid_per_auction WHERE extract(epoch FROM end_time) * 1000 < mz_logical_timestamp()
+
+> SELECT auction_id, bid_id, item, amount FROM winning_bids ORDER BY auction_id LIMIT 5
+1 15 "Best Pizza in Town" 97
+2 20 "City Bar Crawl" 72
+3 31 "Custom Art" 97
+4 42 "Signed Memorabilia" 69
+5 50 "Gift Basket" 63
+
+# Shut down the source so it doesn't keep running until next testdrive reset.
+> DROP SOURCE demo CASCADE


### PR DESCRIPTION
This also adds `CREATE VIEWS` support for supporting load generators.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a