### PR TITLE
environmentd: align lib options with main options

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -144,7 +144,7 @@ pub struct CatalogState {
     roles: HashMap<String, Role>,
     config: mz_sql::catalog::CatalogConfig,
     oid_counter: u32,
-    replica_sizes: ClusterReplicaSizeMap,
+    cluster_replica_sizes: ClusterReplicaSizeMap,
     availability_zones: Vec<String>,
 }
 
@@ -1459,7 +1459,7 @@ impl<S: Append> Catalog<S> {
                     now: config.now.clone(),
                 },
                 oid_counter: FIRST_USER_OID,
-                replica_sizes: config.replica_sizes,
+                cluster_replica_sizes: config.cluster_replica_sizes,
                 availability_zones: config.availability_zones,
             },
             transient_revision: 0,
@@ -2032,7 +2032,7 @@ impl<S: Append> Catalog<S> {
             now,
             skip_migrations: true,
             metrics_registry,
-            replica_sizes: Default::default(),
+            cluster_replica_sizes: Default::default(),
             availability_zones: vec![],
         })
         .await?;
@@ -2518,7 +2518,7 @@ impl<S: Append> Catalog<S> {
         &self,
         location: SerializedComputeInstanceReplicaLocation,
     ) -> Result<ConcreteComputeInstanceReplicaLocation, AdapterError> {
-        let replica_sizes = &self.state.replica_sizes;
+        let cluster_replica_sizes = &self.state.cluster_replica_sizes;
         let location = match location {
             SerializedComputeInstanceReplicaLocation::Remote { addrs } => {
                 ConcreteComputeInstanceReplicaLocation::Remote { addrs }
@@ -2528,8 +2528,8 @@ impl<S: Append> Catalog<S> {
                 availability_zone,
                 az_user_specified,
             } => {
-                let allocation = replica_sizes.0.get(&size).ok_or_else(|| {
-                    let mut entries = replica_sizes.0.iter().collect::<Vec<_>>();
+                let allocation = cluster_replica_sizes.0.get(&size).ok_or_else(|| {
+                    let mut entries = cluster_replica_sizes.0.iter().collect::<Vec<_>>();
                     entries.sort_by_key(
                         |(
                             _name,

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -34,7 +34,7 @@ pub struct Config<'a, S> {
     /// The registry that catalog uses to report metrics.
     pub metrics_registry: &'a MetricsRegistry,
     /// Map of strings to corresponding compute replica sizes.
-    pub replica_sizes: ClusterReplicaSizeMap,
+    pub cluster_replica_sizes: ClusterReplicaSizeMap,
     /// Valid availability zones for replicas.
     pub availability_zones: Vec<String>,
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -200,7 +200,7 @@ pub struct Config<S> {
     pub now: NowFn,
     pub secrets_controller: Arc<dyn SecretsController>,
     pub availability_zones: Vec<String>,
-    pub replica_sizes: ClusterReplicaSizeMap,
+    pub cluster_replica_sizes: ClusterReplicaSizeMap,
     pub connection_context: ConnectionContext,
 }
 
@@ -762,7 +762,7 @@ pub async fn serve<S: Append + 'static>(
         metrics_registry,
         now,
         secrets_controller,
-        replica_sizes,
+        cluster_replica_sizes,
         availability_zones,
         connection_context,
     }: Config<S>,
@@ -777,7 +777,7 @@ pub async fn serve<S: Append + 'static>(
         now: now.clone(),
         skip_migrations: false,
         metrics_registry: &metrics_registry,
-        replica_sizes,
+        cluster_replica_sizes,
         availability_zones,
     })
     .await?;

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -187,7 +187,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         metrics_registry: metrics_registry.clone(),
         now: config.now,
         cors_allowed_origin: AllowOrigin::list([]),
-        replica_sizes: Default::default(),
+        cluster_replica_sizes: Default::default(),
         bootstrap_default_cluster_replica_size: "1".into(),
         availability_zones: Default::default(),
         connection_context: ConnectionContext::for_tests(

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -631,7 +631,7 @@ impl Runner {
             unsafe_mode: true,
             metrics_registry,
             now,
-            replica_sizes: Default::default(),
+            cluster_replica_sizes: Default::default(),
             bootstrap_default_cluster_replica_size: "1".into(),
             availability_zones: Default::default(),
             connection_context: ConnectionContext::for_tests(


### PR DESCRIPTION
Align the environmentd library's options in `environmentd::Config` with
the command-line options in `environmentd::Args`. This is purely
cosmetic, and just aligns names, docstrings, and ordering. No
behavioral changes.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
