### PR TITLE
sqllogictest: add a --log-filter option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,7 @@ dependencies = [
  "mz-environmentd",
  "mz-orchestrator",
  "mz-orchestrator-process",
+ "mz-orchestrator-tracing",
  "mz-ore",
  "mz-persist-client",
  "mz-pgrepr",

--- a/deny.toml
+++ b/deny.toml
@@ -55,8 +55,8 @@ wrappers = [
 [[bans.deny]]
 name = "rustls"
 
-# once_cell is going to be added to std, and doesn't use macros
-# Unfortunately, its heavily used, so we have lots of exceptions.
+# The once_cell crate provides a replacement for the lazy_static crate that is
+# on track for inclusion in the standard library.
 [[bans.deny]]
 name = "lazy_static"
 wrappers = [

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -134,7 +134,7 @@ fn create_communication_config(args: &Args) -> Result<CommunicationConfig, anyho
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let otel_enable_callback = mz_ore::tracing::configure("computed", &args.tracing).await?;
+    let tracing_handle = mz_ore::tracing::configure("computed", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -172,7 +172,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
+                            mz_http_util::handle_opentelemetry_configure(tracing_handle, payload)
+                                .await
                         }),
                     )
                     .into_make_service(),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -401,7 +401,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     } else {
         None
     };
-    let otel_enable_callback =
+    let tracing_handle =
         runtime.block_on(mz_ore::tracing::configure("environmentd", &args.tracing))?;
 
     // Initialize fail crate for failpoint support
@@ -544,7 +544,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     let orchestrator = Arc::new(TracingOrchestrator::new(
         orchestrator,
         args.tracing.clone(),
-        otel_enable_callback.clone(),
+        tracing_handle.clone(),
     ));
     let controller = ControllerConfig {
         build_info: &mz_environmentd::BUILD_INFO,
@@ -669,7 +669,7 @@ max log level: {max_log_level}",
             args.aws_external_id_prefix,
             secrets_reader,
         ),
-        otel_enable_callback,
+        tracing_handle,
     }))?;
 
     println!(

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -23,10 +23,10 @@ pub mod util;
 
 #[test]
 fn test_persistence() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
+    let tracing_handle = mz_ore::test::init_tracing_sync();
 
     let data_dir = tempfile::tempdir()?;
-    let config = util::Config::default()
+    let config = util::Config::new(tracing_handle)
         .data_directory(data_dir.path())
         .unsafe_mode();
 
@@ -101,8 +101,8 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
 // Test the /sql POST endpoint of the HTTP server.
 #[test]
 fn test_http_sql() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
-    let server = util::start_server(util::Config::default())?;
+    let tracing_handle = mz_ore::test::init_tracing_sync();
+    let server = util::start_server(util::Config::new(tracing_handle))?;
     let url = Url::parse(&format!(
         "http://{}/api/sql",
         server.inner.http_local_addr()
@@ -168,7 +168,9 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
 // Test that the server properly handles cancellation requests.
 #[test]
 fn test_cancel_long_running_query() -> Result<(), Box<dyn Error>> {
-    let config = util::Config::default();
+    let tracing_handle = mz_ore::test::init_tracing_sync();
+
+    let config = util::Config::new(tracing_handle);
     let server = util::start_server(config)?;
 
     let mut client = server.connect(postgres::NoTls)?;
@@ -198,9 +200,9 @@ fn test_cancel_long_running_query() -> Result<(), Box<dyn Error>> {
 // Test that dataflow uninstalls cancelled peeks.
 #[test]
 fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
-    mz_ore::test::init_logging();
+    let tracing_handle = mz_ore::test::init_tracing_sync();
 
-    let config = util::Config::default();
+    let config = util::Config::new(tracing_handle);
     let server = util::start_server(config)?;
 
     let mut client1 = server.connect(postgres::NoTls)?;

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -55,7 +55,7 @@ fn main() {
         .build()
         .expect("Failed building the Runtime");
 
-    let _ = runtime
+    let tracing_handle = runtime
         .block_on(mz_ore::tracing::configure(
             "persist-open-loop",
             TracingConfig::from(&args.tracing),
@@ -83,7 +83,7 @@ fn main() {
         }
     };
 
-    mz_ore::tracing::shutdown();
+    tracing_handle.shutdown();
 
     if let Err(err) = res {
         eprintln!("error: {:#}", err);

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[tokio::test]
     async fn batch_builder_flushing() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
             (("2".to_owned(), "two".to_owned()), 2, 1),
@@ -589,7 +589,7 @@ mod tests {
 
     #[tokio::test]
     async fn batch_builder_keys() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let mut cache = PersistClientCache::new_no_metrics();
         // Set blob_target_size to 0 so that each row gets forced into its own batch part

--- a/src/persist-client/src/impl/compact.rs
+++ b/src/persist-client/src/impl/compact.rs
@@ -293,7 +293,7 @@ mod tests {
     // since of the minimum timestamp.
     #[tokio::test]
     async fn regression_minimum_since() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("0".to_owned(), "zero".to_owned()), 0, 1),

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -939,7 +939,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn apply_unbatched_cmd_truncate() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let (mut write, _) = new_test_client()
             .await

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -506,7 +506,7 @@ mod tests {
 
     #[test]
     fn compare_and_append() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing_sync();
         let mut state = State::<String, String, u64, i64>::new(ShardId::new()).collections;
 
         let writer_id = WriterId::new();
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn snapshot() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing_sync();
         let now = SYSTEM_TIME.clone();
 
         let mut state = State::<String, String, u64, i64>::new(ShardId::new());
@@ -676,7 +676,7 @@ mod tests {
 
     #[test]
     fn next_listen_batch() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing_sync();
 
         let mut state = State::<String, String, u64, i64>::new(ShardId::new());
 
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn expire_writer() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing_sync();
 
         let mut state = State::<String, String, u64, i64>::new(ShardId::new());
 

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -537,7 +537,7 @@ mod tests {
 
     #[tokio::test]
     async fn sanity_check() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -585,7 +585,7 @@ mod tests {
     // Sanity check that the open_reader and open_writer calls work.
     #[tokio::test]
     async fn open_reader_writer() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -626,7 +626,7 @@ mod tests {
 
     #[tokio::test]
     async fn invalid_usage() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -842,7 +842,7 @@ mod tests {
 
     #[tokio::test]
     async fn multiple_shards() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data1 = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -880,7 +880,7 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_upper() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -912,7 +912,7 @@ mod tests {
 
     #[tokio::test]
     async fn append_with_invalid_upper() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -952,7 +952,7 @@ mod tests {
     // NOTE: This is a compile-time only test. If it compiles, we're good.
     #[allow(unused)]
     async fn sync_send() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         fn is_send_sync<T: Send + Sync>(_x: T) -> bool {
             true
@@ -971,7 +971,7 @@ mod tests {
 
     #[tokio::test]
     async fn compare_and_append() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1022,7 +1022,7 @@ mod tests {
 
     #[tokio::test]
     async fn overlapping_append() {
-        mz_ore::test::init_logging_default("info");
+        mz_ore::test::init_tracing_with_filter("info").await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1073,7 +1073,7 @@ mod tests {
     // be in advance of the current shard upper.
     #[tokio::test]
     async fn contiguous_append() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1117,7 +1117,7 @@ mod tests {
     // combined are contiguous.
     #[tokio::test]
     async fn noncontiguous_append_per_writer() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1162,7 +1162,7 @@ mod tests {
     // batch needs to match the current shard upper.
     #[tokio::test]
     async fn contiguous_compare_and_append() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1206,7 +1206,7 @@ mod tests {
     // all writers combined are contiguous.
     #[tokio::test]
     async fn noncontiguous_compare_and_append_per_writer() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1285,7 +1285,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn concurrency() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = DataGenerator::small();
 
@@ -1382,7 +1382,7 @@ mod tests {
     // upper to advance past as_of.
     #[tokio::test]
     async fn regression_blocking_reads() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -975,7 +975,7 @@ mod tests {
     // the next request.
     #[tokio::test]
     async fn skip_consensus_fetch_optimization() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing();
         let data = vec![
             (("0".to_owned(), "zero".to_owned()), 0, 1),
             (("1".to_owned(), "one".to_owned()), 1, 1),

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[tokio::test]
     async fn size() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -649,7 +649,7 @@ mod tests {
 
     #[tokio::test]
     async fn empty_batches() {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
 
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),

--- a/src/persist/src/s3.rs
+++ b/src/persist/src/s3.rs
@@ -812,7 +812,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn s3_blob() -> Result<(), ExternalError> {
-        mz_ore::test::init_logging();
+        mz_ore::test::init_tracing().await;
         let config = match S3BlobConfig::new_for_test().await? {
             Some(client) => client,
             None => {

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -21,6 +21,7 @@ mz-environmentd = { path = "../environmentd", default-features = false }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-orchestrator = { path = "../orchestrator" }
 mz-orchestrator-process = { path = "../orchestrator-process" }
+mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-persist-client = { path = "../persist-client" }
 mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -124,7 +124,7 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let otel_enable_callback = mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let tracing_handle = mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -162,7 +162,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                     .route(
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
-                            mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
+                            mz_http_util::handle_opentelemetry_configure(tracing_handle, payload)
+                                .await
                         }),
                     )
                     .into_make_service(),

--- a/test/metabase/smoketest/src/bin/metabase-smoketest.rs
+++ b/test/metabase/smoketest/src/bin/metabase-smoketest.rs
@@ -104,7 +104,7 @@ async fn connect_metabase() -> Result<mz_metabase::Client, anyhow::Error> {
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    mz_ore::test::init_logging();
+    mz_ore::test::init_tracing().await;
 
     let pgclient = connect_materialized().await?;
     pgclient


### PR DESCRIPTION
This allows disabling the spammy logs from the various computed and
storaged processes that are spawned during an SLT run.

Also rename the OpenTelemetryEnableCallback to TracingHandle to better
reflect its purpose. It's not actually a callback, but a handle that can
be used to manipulate the state of tracing. Accordingly, the `shutdown`
free function is moved onto the handle.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature requested in Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
