### PR TITLE
adapter: enable compaction for all log collections

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -348,8 +348,11 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
 
-        self.initialize_storage_read_policies(persisted_log_ids, None)
-            .await;
+        self.initialize_storage_read_policies(
+            persisted_log_ids,
+            DEFAULT_LOGICAL_COMPACTION_WINDOW_MS,
+        )
+        .await;
 
         let mut entries: Vec<_> = self.catalog.entries().cloned().collect();
         // Topologically sort entries based on the used_by relationship


### PR DESCRIPTION
Enable compaction of introspection storage collections created during bootstrap by initializing their read policies with the default compaction window.

Prior to this change, the introspection collections of replicas existing during bootstrap (e.g. the default replica) had compaction disabled, because they were initialized with a read policy of `ValidFrom(0)`.

### Motivation

  * This PR fixes a previously unreported bug.

The `since`s of introspection storage collections of the default replica are always [0]:

```sql
materialize=> EXPLAIN TIMESTAMP FOR SELECT * FROM mz_worker_materialization_frontiers_1;
                                Timestamp
--------------------------------------------------------------------------
      timestamp: 1658733909359                                           +
          since:[            0]                                          +
          upper:[1658733910000]                                          +
      has table: false                                                   +
                                                                         +
 source mz_catalog.mz_worker_materialization_frontiers_1 (s356, storage):+
  read frontier:[            0]                                          +
 write frontier:[1658733910000]
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
