### PR TITLE
Permit hydration of an uninitialized cluster

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -386,6 +386,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
             }
 
+            assert!(old_config.is_some() || old_dataflows.is_empty() && old_frontiers.is_empty());
+
             // Compaction commands that can be applied to existing dataflows.
             let mut old_compaction = BTreeMap::default();
 
@@ -435,7 +437,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                     ComputeCommand::CreateInstance(new_config) => {
                         // Cluster creation should not be performed again!
-                        assert_eq!(old_config, Some(new_config));
+                        if let Some(old_config) = old_config {
+                            assert_eq!(old_config, new_config);
+                        }
                     }
                     // All other commands we apply as requested.
                     command => {


### PR DESCRIPTION
A cluster that has never received a command before a client disconnects
is in a state where it has no old config. When a new client connects, the
hydration logic would assert that the new config would be equal to the old
one, but the test only makes sense of the cluster was initialized before.

Move the check into a condition to only assert if an old config exists. In
addition to this, add an assertion that if there is no previous config,
then there are also no old dataflows and frontiers.

This change fixes a previously unreported bug.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
