### PR TITLE
doc/user: add new materialized view syntax

### DIFF
--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -22,11 +22,11 @@ query in memory. For more information, see [Key Concepts: Materialized views](/o
 
 Field | Use
 ------|-----
-**TEMP** / **TEMPORARY** | Mark the materialized view as [temporary](#temporary-materialized-views).
 **OR REPLACE** | If a view exists with the same name, replace it with the view defined in this statement. You cannot replace views that other views depend on, nor can you replace a non-view object with a view.
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a view of the same name already exists. <br/><br/>If _not_ specified, throw an error if a view of the same name already exists. _(Default)_
 _view&lowbar;name_ | A name for the view.
 **(** _col_ident_... **)** | Rename the `SELECT` statement's columns to the list of identifiers, both of which must be the same length. Note that this is required for statements that return multiple columns with the same identifier.
+_cluster&lowbar;name_ | The cluster to maintain this materialized view. If not provided, uses the session’s cluster variable.
 _select&lowbar;stmt_ | The [`SELECT` statement](../select) whose output you want to materialize and maintain.
 
 ## Details
@@ -54,16 +54,6 @@ Some things you might want to do with indexes...
 - If you find that your queries would benefit from other indexes, e.g. you want
   to join two relations on some foreign key, you can [create
   indexes](../create-index).
-
-### Temporary materialized views
-
-The `TEMP`/`TEMPORARY` keyword creates a temporary materialized view. Temporary
-materialized views are automatically dropped at the end of the SQL session and
-are not visible to other connections. They are always created in the special `mz_temp`
-schema.
-
-Temporary materialized views may depend upon other temporary database objects,
-but non-temporary materialized views may not depend on temporary objects.
 
 ## Examples
 

--- a/doc/user/content/sql/create-views.md
+++ b/doc/user/content/sql/create-views.md
@@ -16,7 +16,6 @@ menu:
 
 Field | Use
 ------|-----
-**MATERIALIZED**  |  Create the view as materialized. To minimize memory usage, we recommend that you first create nonmaterialized views to see tables instead of the multiplexed data stream and only materialize the views for the queries on those initial table-like views.
 **TEMP** / **TEMPORARY** | Mark the view as [temporary](#temporary-views).  |
 **IF NOT EXISTS** | If specified, _do not_ generate an error if a view of the same name already exists. <br/><br/>If _not_ specified, throw an error if a view of the same name already exists. _(Default)_
 _src_name_ | The name of the [Postgres source](/sql/create-source/postgres) for which you are creating table views.

--- a/doc/user/content/sql/drop-materialized-view.md
+++ b/doc/user/content/sql/drop-materialized-view.md
@@ -1,0 +1,51 @@
+---
+title: "DROP MATERIALIZED VIEW"
+description: "`DROP MATERIALIZED VIEW` removes a materialized view from your Materialize instances."
+menu:
+  main:
+    parent: commands
+---
+
+`DROP MATERIALIZED VIEW` removes a materialized view from your Materialize instances.
+
+## Conceptual framework
+
+Materialize maintains materialized views after you create them. If you no longer need the
+materialized view, you can remove it.
+
+Because materialized views rely on receiving data from sources, you must drop all materialized views that
+rely on a source before you can [drop the source](../drop-source) itself. You can achieve this easily using **DROP SOURCE...CASCADE**.
+
+## Syntax
+
+{{< diagram "drop-materialized-view.svg" >}}
+
+Field | Use
+------|-----
+**IF EXISTS** | Do not return an error if the named materialized view does not exist.
+_view&lowbar;name_ | The materialized view you want to drop. You can find available materialized view names through [`SHOW MATERIALIZED VIEWS`](../show-materialized-views).
+**RESTRICT** | Do not drop this materialized view if any other views depend on it. _(Default)_
+**CASCADE** | Drop all views that depend on this materialized view.
+
+## Examples
+
+```sql
+SHOW MATERIALIZED VIEWS;
+```
+```nofmt
+         name
+----------------------
+ my_materialized_view
+```
+```sql
+DROP MATERIALIZED VIEW my_materialized_view;
+```
+```nofmt
+DROP MATERIALIZED VIEW
+```
+
+## Related pages
+
+- [`CREATE MATERIALIZED VIEW`](../create-materialized-view)
+- [`SHOW MATERIALIZED VIEWS`](../show-materialized-views)
+- [`SHOW CREATE MATERIALIZED VIEW`](../show-create-materialized-view)

--- a/doc/user/content/sql/drop-view.md
+++ b/doc/user/content/sql/drop-view.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`DROP VIEW` removes a view from your Materialize instances. This works on both materialized and non-materialized views.
+`DROP VIEW` removes a view from your Materialize instances.
 
 ## Conceptual framework
 
@@ -33,7 +33,9 @@ _view&lowbar;name_ | The view you want to drop. You can find available view name
 SHOW VIEWS;
 ```
 ```nofmt
-my_view
+  name
+---------
+ my_view
 ```
 ```sql
 DROP VIEW my_view;

--- a/doc/user/content/sql/explain.md
+++ b/doc/user/content/sql/explain.md
@@ -32,6 +32,7 @@ Field | Use
 **DECORRELATED** | Display the decorrelated plan
 **OPTIMIZED** | _(Default)_ Display the optimized plan
 **VIEW** | Display the plan for an existing view
+**MATERIALIZED VIEW** | Display the plan for an existing materialized view
 
 ## Details
 

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -1,0 +1,33 @@
+---
+title: "SHOW CREATE MATERIALIZED VIEW"
+description: "`SHOW CREATE MATERIALIZED VIEW` returns the `SELECT` statement used to create the materialized view."
+menu:
+  main:
+    parent: commands
+---
+
+`SHOW CREATE MATERIALIZED VIEW` returns the [`SELECT`](../select) statement used to create the materialized view.
+
+## Syntax
+
+{{< diagram "show-create-materialized-view.svg" >}}
+
+Field | Use
+------|-----
+_view&lowbar;name_ | The materialized view you want to use. You can find available materialized view names through [`SHOW MATERIALIZED VIEWS`](../show-materialized-views).
+
+## Examples
+
+```sql
+SHOW CREATE MATERIALIZED VIEW my_materialized_view;
+```
+```nofmt
+            Materialized View            |        Create Materialized View
+-----------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------
+ materialize.public.my_materialized_view | CREATE MATERIALIZED VIEW "materialize"."public"."my_materialized_view" IN CLUSTER "default" AS SELECT * FROM "materialize"."public"."my_source"
+```
+
+## Related pages
+
+- [`SHOW MATERIALIZED VIEWS`](../show-materialized-views)
+- [`CREATE MATERIALIZED VIEW`](../create-materialized-view)

--- a/doc/user/content/sql/show-create-view.md
+++ b/doc/user/content/sql/show-create-view.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`SHOW CREATE VIEW` returns the [`SELECT`](../select) statement used to create the view. This works on both materialized and non-materialized views.
+`SHOW CREATE VIEW` returns the [`SELECT`](../select) statement used to create the view.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -1,0 +1,66 @@
+---
+title: "SHOW MATERIALIZED VIEWS"
+description: "`SHOW MATERIALIZED VIEWS` returns a list of materialized views in your Materialize instances."
+menu:
+  main:
+    parent: commands
+---
+
+`SHOW MATERIALIZED VIEWS` returns a list of materialized views in your Materialize instances.
+
+## Syntax
+
+{{< diagram "show-materialized-views.svg" >}}
+
+Field | Use
+------|-----
+_schema&lowbar;name_ | The schema to show materialized views from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+_cluster&lowbar;name_ | The cluster to show materialized views from. If omitted, materialized views from all clusters are shown.
+**FULL** | Return details about your materialized views.
+
+## Details
+
+### Output format for `SHOW FULL MATERIALIZED VIEWS`
+
+`SHOW FULL MATERIALIZED VIEWS`'s output is a table, with this structure:
+
+```nofmt
+ cluster | name  | type
+---------+-------+------
+ ...     | ...   | ...
+```
+
+Field | Meaning
+------|--------
+**cluster** | The name of the [cluster](/overview/key-concepts/#clusters) maintaining the materialized view.
+**name** | The name of the materialized view.
+**type** | Whether the materialized view was created by the `user` or the `system`.
+
+## Examples
+
+### Default behavior
+
+```sql
+SHOW MATERIALIZED VIEWS;
+```
+```nofmt
+         name
+----------------------
+ my_materialized_view
+```
+
+### Show details about views
+
+```sql
+SHOW FULL MATERIALIZED VIEWS;
+```
+```nofmt
+ cluster |         name         | type
+---------+----------------------+------
+ default | my_materialized_view | user
+```
+
+## Related pages
+
+- [`SHOW CREATE MATERIALIZED VIEW`](../show-create-materialized-view)
+- [`CREATE MATERIALIZED VIEW`](../create-materialized-view)

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -15,7 +15,6 @@ menu:
 Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show views from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**MATERIALIZED** | Only return materialized views, i.e. those with [indexes](../create-index). Without specifying this option, this command returns all views, including non-materialized views.
 **FULL** | Return details about your views.
 
 ## Details
@@ -25,16 +24,15 @@ _schema&lowbar;name_ | The schema to show views from. Defaults to `public` in th
 `SHOW FULL VIEWS`'s output is a table, with this structure:
 
 ```nofmt
- name  | type | materialized
--------+------+--------------
- ...   | ...  | ...
+ name  | type
+-------+------
+ ...   | ...
 ```
 
 Field | Meaning
 ------|--------
 **name** | The name of the view.
 **type** | Whether the view was created by the `user` or the `system`.
-**materialized** | Does the view have an in-memory index? For more details, see [`CREATE INDEX`](../create-index).
 
 ## Examples
 
@@ -44,37 +42,23 @@ Field | Meaning
 SHOW VIEWS;
 ```
 ```nofmt
-         name
--------------------------
- my_nonmaterialized_view
- my_materialized_view
-```
-
-### Only show materialized views
-
-```sql
-SHOW MATERIALIZED VIEWS;
-```
-```nofmt
-        name
-----------------------
- my_materialized_view
+  name
+---------
+ my_view
 ```
 
 ### Show details about views
 
 ```sql
-SHOW FULL VIEWS
+SHOW FULL VIEWS;
 ```
 ```nofmt
-          name           | type | materialized
--------------------------+------+--------------
- my_nonmaterialized_view | user | f
- my_materialized_view    | user | t
+  name   | type
+---------+------
+ my_view | user
 ```
 
 ## Related pages
 
 - [`SHOW CREATE VIEW`](../show-create-view)
-- [`SHOW INDEX`](../show-index)
 - [`CREATE VIEW`](../create-view)

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -88,7 +88,7 @@ Field           | Type                         | Meaning
 ----------------|------------------------------|--------
 `id  `          | [`bigint`]                   | The ordered id of the event.
 `event_type`    | [`text`]                     | The type of the event: `create`, `drop`, `alter`, or `rename`.
-`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `index`, `sink`, `source`, or `view`.
+`object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `index`, `materialized-view`, `sink`, `source`, or `view`.
 `event_details` | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
 `user`          | [`text`]                     | The user who triggered the event.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
@@ -296,6 +296,19 @@ Field    | Type       | Meaning
 ---------|------------|--------
 `name`   | [`text`]   | The ID of the index. (`name` is a misnomer.)
 `worker` | [`bigint`] | The ID of the worker thread hosting the index.
+
+### `mz_materialized_views`
+
+The `mz_materialized_views` table contains a row for each materialized view in the system.
+
+Field          | Type        | Meaning
+---------------|-------------|----------
+`id`           | [`text`]    | Materialize's unique ID for the materialized view.
+`oid`          | [`oid`]     | A [PostgreSQL-compatible OID][oid] for the materialized view.
+`schema_id`    | [`bigint`]  | The ID of the schema to which the materialized view belongs.
+`name`         | [`text`]    | The name of the materialized view.
+`cluster_id`   | [`bigint`]  | The ID of the cluster maintaining the materialized view.
+`definition`   | [`text`]    | The materialized view definition (a `SELECT` query).
 
 ### `mz_map_types`
 

--- a/doc/user/layouts/partials/sql-grammar/alter-rename.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-rename.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="573" height="169">
+<svg xmlns="http://www.w3.org/2000/svg" width="545" height="279">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="66" height="32" rx="10"/>
@@ -33,30 +33,38 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="145" y="109">VIEW</text>
-   <rect x="137" y="135" width="66" height="32" rx="10"/>
+   <rect x="137" y="135" width="166" height="32" rx="10"/>
    <rect x="135"
          y="133"
+         width="166"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="153">MATERIALIZED VIEW</text>
+   <rect x="137" y="179" width="66" height="32" rx="10"/>
+   <rect x="135"
+         y="177"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="153">TABLE</text>
-   <rect x="255" y="3" width="56" height="32"/>
-   <rect x="253" y="1" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="263" y="21">name</text>
-   <rect x="331" y="3" width="104" height="32" rx="10"/>
-   <rect x="329"
+   <text class="terminal" x="145" y="197">TABLE</text>
+   <rect x="343" y="3" width="56" height="32"/>
+   <rect x="341" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="351" y="21">name</text>
+   <rect x="419" y="3" width="104" height="32" rx="10"/>
+   <rect x="417"
          y="1"
          width="104"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="339" y="21">RENAME TO</text>
-   <rect x="455" y="3" width="90" height="32"/>
-   <rect x="453" y="1" width="90" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="463" y="21">new_name</text>
+   <text class="terminal" x="427" y="21">RENAME TO</text>
+   <rect x="427" y="245" width="90" height="32"/>
+   <rect x="425" y="243" width="90" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="435" y="263">new_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m62 0 h10 m0 0 h16 m-118 0 h20 m98 0 h20 m-138 0 q10 0 10 10 m118 0 q0 -10 10 -10 m-128 10 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m78 0 h10 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m58 0 h10 m0 0 h20 m-108 -10 v20 m118 0 v-20 m-118 20 v24 m118 0 v-24 m-118 24 q0 10 10 10 m98 0 q10 0 10 -10 m-108 10 h10 m66 0 h10 m0 0 h12 m20 -132 h10 m56 0 h10 m0 0 h10 m104 0 h10 m0 0 h10 m90 0 h10 m3 0 h-3"/>
-   <polygon points="563 17 571 13 571 21"/>
-   <polygon points="563 17 555 13 555 21"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m20 0 h10 m62 0 h10 m0 0 h104 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m78 0 h10 m0 0 h88 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m58 0 h10 m0 0 h108 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m166 0 h10 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m66 0 h10 m0 0 h100 m20 -176 h10 m56 0 h10 m0 0 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-140 242 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m90 0 h10 m3 0 h-3"/>
+   <polygon points="535 259 543 255 543 263"/>
+   <polygon points="535 259 527 255 527 263"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-materialized-view.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-materialized-view.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="603" height="425">
+<svg xmlns="http://www.w3.org/2000/svg" width="535" height="337">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -9,113 +9,92 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">CREATE</text>
-   <rect x="65" y="101" width="60" height="32" rx="10"/>
-   <rect x="63"
-         y="99"
-         width="60"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="119">TEMP</text>
-   <rect x="65" y="145" width="110" height="32" rx="10"/>
-   <rect x="63"
-         y="143"
-         width="110"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="73" y="163">TEMPORARY</text>
-   <rect x="215" y="69" width="166" height="32" rx="10"/>
-   <rect x="213"
-         y="67"
+   <rect x="147" y="3" width="166" height="32" rx="10"/>
+   <rect x="145"
+         y="1"
          width="166"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="223" y="87">MATERIALIZED VIEW</text>
-   <rect x="421" y="101" width="120" height="32" rx="10"/>
-   <rect x="419"
-         y="99"
+   <text class="terminal" x="155" y="21">MATERIALIZED VIEW</text>
+   <rect x="353" y="35" width="120" height="32" rx="10"/>
+   <rect x="351"
+         y="33"
          width="120"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="429" y="119">IF NOT EXISTS</text>
-   <rect x="45" y="189" width="108" height="32" rx="10"/>
-   <rect x="43"
-         y="187"
+   <text class="terminal" x="361" y="53">IF NOT EXISTS</text>
+   <rect x="147" y="79" width="108" height="32" rx="10"/>
+   <rect x="145"
+         y="77"
          width="108"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="207">OR REPLACE</text>
-   <rect x="193" y="221" width="60" height="32" rx="10"/>
-   <rect x="191"
-         y="219"
-         width="60"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="201" y="239">TEMP</text>
-   <rect x="193" y="265" width="110" height="32" rx="10"/>
-   <rect x="191"
-         y="263"
-         width="110"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="201" y="283">TEMPORARY</text>
-   <rect x="343" y="189" width="166" height="32" rx="10"/>
-   <rect x="341"
-         y="187"
+   <text class="terminal" x="155" y="97">OR REPLACE</text>
+   <rect x="275" y="79" width="166" height="32" rx="10"/>
+   <rect x="273"
+         y="77"
          width="166"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="351" y="207">MATERIALIZED VIEW</text>
-   <rect x="37" y="375" width="92" height="32"/>
-   <rect x="35" y="373" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="45" y="393">view_name</text>
-   <rect x="169" y="375" width="26" height="32" rx="10"/>
-   <rect x="167"
-         y="373"
+   <text class="terminal" x="283" y="97">MATERIALIZED VIEW</text>
+   <rect x="88" y="189" width="92" height="32"/>
+   <rect x="86" y="187" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="96" y="207">view_name</text>
+   <rect x="220" y="189" width="26" height="32" rx="10"/>
+   <rect x="218"
+         y="187"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="177" y="393">(</text>
-   <rect x="235" y="375" width="78" height="32"/>
-   <rect x="233" y="373" width="78" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="243" y="393">col_ident</text>
-   <rect x="235" y="331" width="24" height="32" rx="10"/>
-   <rect x="233"
-         y="329"
+   <text class="terminal" x="228" y="207">(</text>
+   <rect x="286" y="189" width="78" height="32"/>
+   <rect x="284" y="187" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="294" y="207">col_ident</text>
+   <rect x="286" y="145" width="24" height="32" rx="10"/>
+   <rect x="284"
+         y="143"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="243" y="349">,</text>
-   <rect x="353" y="375" width="26" height="32" rx="10"/>
-   <rect x="351"
-         y="373"
+   <text class="terminal" x="294" y="163">,</text>
+   <rect x="404" y="189" width="26" height="32" rx="10"/>
+   <rect x="402"
+         y="187"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="361" y="393">)</text>
-   <rect x="419" y="375" width="40" height="32" rx="10"/>
-   <rect x="417"
-         y="373"
+   <text class="terminal" x="412" y="207">)</text>
+   <rect x="79" y="303" width="104" height="32" rx="10"/>
+   <rect x="77"
+         y="301"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="87" y="321">IN CLUSTER</text>
+   <rect x="203" y="303" width="108" height="32"/>
+   <rect x="201" y="301" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="211" y="321">cluster_name</text>
+   <rect x="351" y="271" width="40" height="32" rx="10"/>
+   <rect x="349"
+         y="269"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="427" y="393">AS</text>
-   <rect x="479" y="375" width="96" height="32"/>
-   <rect x="477" y="373" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="487" y="393">select_stmt</text>
+   <text class="terminal" x="359" y="289">AS</text>
+   <rect x="411" y="271" width="96" height="32"/>
+   <rect x="409" y="269" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="419" y="289">select_stmt</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-126 66 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m60 0 h10 m0 0 h50 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -76 h10 m166 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m-536 -32 h20 m536 0 h20 m-576 0 q10 0 10 10 m556 0 q0 -10 10 -10 m-566 10 v100 m556 0 v-100 m-556 100 q0 10 10 10 m536 0 q10 0 10 -10 m-546 10 h10 m108 0 h10 m20 0 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m60 0 h10 m0 0 h50 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -76 h10 m166 0 h10 m0 0 h52 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-588 306 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m78 0 h10 m-118 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m98 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-98 0 h10 m24 0 h10 m0 0 h54 m20 44 h10 m26 0 h10 m-250 0 h20 m230 0 h20 m-270 0 q10 0 10 10 m250 0 q0 -10 10 -10 m-260 10 v14 m250 0 v-14 m-250 14 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m0 0 h220 m20 -34 h10 m40 0 h10 m0 0 h10 m96 0 h10 m3 0 h-3"/>
-   <polygon points="593 389 601 385 601 393"/>
-   <polygon points="593 389 585 385 585 393"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m166 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m-366 -32 h20 m366 0 h20 m-406 0 q10 0 10 10 m386 0 q0 -10 10 -10 m-396 10 v56 m386 0 v-56 m-386 56 q0 10 10 10 m366 0 q10 0 10 -10 m-376 10 h10 m108 0 h10 m0 0 h10 m166 0 h10 m0 0 h52 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-469 186 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m92 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m78 0 h10 m-118 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m98 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-98 0 h10 m24 0 h10 m0 0 h54 m20 44 h10 m26 0 h10 m-250 0 h20 m230 0 h20 m-270 0 q10 0 10 10 m250 0 q0 -10 10 -10 m-260 10 v14 m250 0 v-14 m-250 14 q0 10 10 10 m230 0 q10 0 10 -10 m-240 10 h10 m0 0 h220 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-435 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m40 0 h10 m0 0 h10 m96 0 h10 m3 0 h-3"/>
+   <polygon points="525 285 533 281 533 289"/>
+   <polygon points="525 285 517 281 517 289"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-views.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-views.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="735" height="329">
+<svg xmlns="http://www.w3.org/2000/svg" width="735" height="297">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="76" height="32" rx="10"/>
@@ -9,140 +9,132 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="41" y="21">CREATE</text>
-   <rect x="149" y="35" width="124" height="32" rx="10"/>
+   <rect x="149" y="35" width="60" height="32" rx="10"/>
    <rect x="147"
-         y="33"
-         width="124"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="157" y="53">MATERIALIZED</text>
-   <rect x="333" y="35" width="60" height="32" rx="10"/>
-   <rect x="331"
          y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="53">TEMP</text>
-   <rect x="333" y="79" width="110" height="32" rx="10"/>
-   <rect x="331"
+   <text class="terminal" x="157" y="53">TEMP</text>
+   <rect x="149" y="79" width="110" height="32" rx="10"/>
+   <rect x="147"
          y="77"
          width="110"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="97">TEMPORARY</text>
-   <rect x="483" y="3" width="66" height="32" rx="10"/>
-   <rect x="481"
+   <text class="terminal" x="157" y="97">TEMPORARY</text>
+   <rect x="299" y="3" width="66" height="32" rx="10"/>
+   <rect x="297"
          y="1"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="491" y="21">VIEWS</text>
-   <rect x="124" y="177" width="120" height="32" rx="10"/>
-   <rect x="122"
-         y="175"
+   <text class="terminal" x="307" y="21">VIEWS</text>
+   <rect x="405" y="35" width="120" height="32" rx="10"/>
+   <rect x="403"
+         y="33"
          width="120"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="132" y="195">IF NOT EXISTS</text>
-   <rect x="284" y="145" width="60" height="32" rx="10"/>
-   <rect x="282"
+   <text class="terminal" x="413" y="53">IF NOT EXISTS</text>
+   <rect x="194" y="145" width="60" height="32" rx="10"/>
+   <rect x="192"
          y="143"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="292" y="163">FROM</text>
-   <rect x="364" y="145" width="78" height="32" rx="10"/>
-   <rect x="362"
+   <text class="terminal" x="202" y="163">FROM</text>
+   <rect x="274" y="145" width="78" height="32" rx="10"/>
+   <rect x="272"
          y="143"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="372" y="163">SOURCE</text>
-   <rect x="462" y="145" width="26" height="32" rx="10"/>
-   <rect x="460"
+   <text class="terminal" x="282" y="163">SOURCE</text>
+   <rect x="372" y="145" width="26" height="32" rx="10"/>
+   <rect x="370"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="470" y="163">"</text>
-   <rect x="508" y="145" width="82" height="32"/>
-   <rect x="506" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="516" y="163">src_name</text>
-   <rect x="610" y="145" width="26" height="32" rx="10"/>
-   <rect x="608"
+   <text class="terminal" x="380" y="163">"</text>
+   <rect x="418" y="145" width="82" height="32"/>
+   <rect x="416" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="426" y="163">src_name</text>
+   <rect x="520" y="145" width="26" height="32" rx="10"/>
+   <rect x="518"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="618" y="163">"</text>
-   <rect x="45" y="263" width="26" height="32" rx="10"/>
+   <text class="terminal" x="528" y="163">"</text>
+   <rect x="45" y="231" width="26" height="32" rx="10"/>
    <rect x="43"
-         y="261"
+         y="229"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="281">(</text>
-   <rect x="91" y="263" width="26" height="32" rx="10"/>
+   <text class="terminal" x="53" y="249">(</text>
+   <rect x="91" y="231" width="26" height="32" rx="10"/>
    <rect x="89"
-         y="261"
+         y="229"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="99" y="281">"</text>
-   <rect x="137" y="263" width="122" height="32"/>
-   <rect x="135" y="261" width="122" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="145" y="281">upstream_table</text>
-   <rect x="279" y="263" width="26" height="32" rx="10"/>
+   <text class="terminal" x="99" y="249">"</text>
+   <rect x="137" y="231" width="122" height="32"/>
+   <rect x="135" y="229" width="122" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="145" y="249">upstream_table</text>
+   <rect x="279" y="231" width="26" height="32" rx="10"/>
    <rect x="277"
-         y="261"
+         y="229"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="287" y="281">"</text>
-   <rect x="345" y="295" width="38" height="32"/>
-   <rect x="343" y="293" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="353" y="313">AS</text>
-   <rect x="403" y="295" width="26" height="32" rx="10"/>
+   <text class="terminal" x="287" y="249">"</text>
+   <rect x="345" y="263" width="38" height="32"/>
+   <rect x="343" y="261" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="353" y="281">AS</text>
+   <rect x="403" y="263" width="26" height="32" rx="10"/>
    <rect x="401"
-         y="293"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="411" y="313">"</text>
-   <rect x="449" y="295" width="126" height="32"/>
-   <rect x="447" y="293" width="126" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="457" y="313">new_view_name</text>
-   <rect x="595" y="295" width="26" height="32" rx="10"/>
-   <rect x="593"
-         y="293"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="603" y="313">"</text>
-   <rect x="661" y="263" width="26" height="32" rx="10"/>
-   <rect x="659"
          y="261"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="669" y="281">)</text>
+   <text class="terminal" x="411" y="281">"</text>
+   <rect x="449" y="263" width="126" height="32"/>
+   <rect x="447" y="261" width="126" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="457" y="281">new_view_name</text>
+   <rect x="595" y="263" width="26" height="32" rx="10"/>
+   <rect x="593"
+         y="261"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="603" y="281">"</text>
+   <rect x="661" y="231" width="26" height="32" rx="10"/>
+   <rect x="659"
+         y="229"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="669" y="249">)</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m40 -32 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m60 0 h10 m0 0 h50 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -76 h10 m66 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-489 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m60 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-655 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h652 m-682 0 h20 m662 0 h20 m-702 0 q10 0 10 10 m682 0 q0 -10 10 -10 m-692 10 v12 m682 0 v-12 m-682 12 q0 10 10 10 m662 0 q10 0 10 -10 m-672 10 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h286 m-316 0 h20 m296 0 h20 m-336 0 q10 0 10 10 m316 0 q0 -10 10 -10 m-326 10 v12 m316 0 v-12 m-316 12 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m26 0 h10 m23 -32 h-3"/>
-   <polygon points="725 245 733 241 733 249"/>
-   <polygon points="725 245 717 241 717 249"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m20 0 h10 m0 0 h120 m-150 0 h20 m130 0 h20 m-170 0 q10 0 10 10 m150 0 q0 -10 10 -10 m-160 10 v12 m150 0 v-12 m-150 12 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m60 0 h10 m0 0 h50 m-140 -10 v20 m150 0 v-20 m-150 20 v24 m150 0 v-24 m-150 24 q0 10 10 10 m130 0 q10 0 10 -10 m-140 10 h10 m110 0 h10 m20 -76 h10 m66 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-395 142 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m60 0 h10 m0 0 h10 m78 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m82 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-565 54 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h652 m-682 0 h20 m662 0 h20 m-702 0 q10 0 10 10 m682 0 q0 -10 10 -10 m-692 10 v12 m682 0 v-12 m-682 12 q0 10 10 10 m662 0 q10 0 10 -10 m-672 10 h10 m26 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m122 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m0 0 h286 m-316 0 h20 m296 0 h20 m-336 0 q10 0 10 10 m316 0 q0 -10 10 -10 m-326 10 v12 m316 0 v-12 m-316 12 q0 10 10 10 m296 0 q10 0 10 -10 m-306 10 h10 m38 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m126 0 h10 m0 0 h10 m26 0 h10 m20 -32 h10 m26 0 h10 m23 -32 h-3"/>
+   <polygon points="725 213 733 209 733 217"/>
+   <polygon points="725 213 717 209 717 217"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/drop-materialized-view.svg
+++ b/doc/user/layouts/partials/sql-grammar/drop-materialized-view.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="557" height="199">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="60" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">DROP</text>
+   <rect x="111" y="3" width="166" height="32" rx="10"/>
+   <rect x="109"
+         y="1"
+         width="166"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="119" y="21">MATERIALIZED VIEW</text>
+   <rect x="317" y="35" width="86" height="32" rx="10"/>
+   <rect x="315"
+         y="33"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="325" y="53">IF EXISTS</text>
+   <rect x="443" y="3" width="92" height="32"/>
+   <rect x="441" y="1" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="451" y="21">view_name</text>
+   <rect x="419" y="121" width="90" height="32" rx="10"/>
+   <rect x="417"
+         y="119"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="427" y="139">RESTRICT</text>
+   <rect x="419" y="165" width="90" height="32" rx="10"/>
+   <rect x="417"
+         y="163"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="427" y="183">CASCADE</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m60 0 h10 m0 0 h10 m166 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m92 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-180 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h100 m-130 0 h20 m110 0 h20 m-150 0 q10 0 10 10 m130 0 q0 -10 10 -10 m-140 10 v12 m130 0 v-12 m-130 12 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m-120 -10 v20 m130 0 v-20 m-130 20 v24 m130 0 v-24 m-130 24 q0 10 10 10 m110 0 q10 0 10 -10 m-120 10 h10 m90 0 h10 m23 -76 h-3"/>
+   <polygon points="547 103 555 99 555 107"/>
+   <polygon points="547 103 539 99 539 107"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/explain.svg
+++ b/doc/user/layouts/partials/sql-grammar/explain.svg
@@ -1,70 +1,78 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="371" height="381">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="80" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="411" height="425">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="80" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">EXPLAIN</text>
-   <rect x="151" y="35" width="68" height="32" rx="10"/>
-   <rect x="149"
+   <text class="terminal" x="41" y="21">EXPLAIN</text>
+   <rect x="153" y="35" width="68" height="32" rx="10"/>
+   <rect x="151"
          y="33"
          width="68"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="159" y="53">TYPED</text>
-   <rect x="65" y="149" width="54" height="32" rx="10"/>
-   <rect x="63"
+   <text class="terminal" x="161" y="53">TYPED</text>
+   <rect x="86" y="149" width="54" height="32" rx="10"/>
+   <rect x="84"
          y="147"
          width="54"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="167">RAW</text>
-   <rect x="65" y="193" width="134" height="32" rx="10"/>
-   <rect x="63"
+   <text class="terminal" x="94" y="167">RAW</text>
+   <rect x="86" y="193" width="134" height="32" rx="10"/>
+   <rect x="84"
          y="191"
          width="134"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="211">DECORRELATED</text>
-   <rect x="65" y="237" width="98" height="32" rx="10"/>
-   <rect x="63"
+   <text class="terminal" x="94" y="211">DECORRELATED</text>
+   <rect x="86" y="237" width="98" height="32" rx="10"/>
+   <rect x="84"
          y="235"
          width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="255">OPTIMIZED</text>
-   <rect x="239" y="117" width="90" height="32" rx="10"/>
-   <rect x="237"
+   <text class="terminal" x="94" y="255">OPTIMIZED</text>
+   <rect x="260" y="117" width="90" height="32" rx="10"/>
+   <rect x="258"
          y="115"
          width="90"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="247" y="135">PLAN FOR</text>
-   <rect x="153" y="303" width="96" height="32"/>
-   <rect x="151" y="301" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="161" y="321">select_stmt</text>
-   <rect x="153" y="347" width="58" height="32" rx="10"/>
-   <rect x="151"
+   <text class="terminal" x="268" y="135">PLAN FOR</text>
+   <rect x="45" y="303" width="96" height="32"/>
+   <rect x="43" y="301" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="53" y="321">select_stmt</text>
+   <rect x="65" y="347" width="58" height="32" rx="10"/>
+   <rect x="63"
          y="345"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="161" y="365">VIEW</text>
-   <rect x="231" y="347" width="92" height="32"/>
-   <rect x="229" y="345" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="239" y="365">view_name</text>
+   <text class="terminal" x="73" y="365">VIEW</text>
+   <rect x="65" y="391" width="166" height="32" rx="10"/>
+   <rect x="63"
+         y="389"
+         width="166"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="409">MATERIALIZED VIEW</text>
+   <rect x="271" y="347" width="92" height="32"/>
+   <rect x="269" y="345" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="279" y="365">view_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h78 m-108 0 h20 m88 0 h20 m-128 0 q10 0 10 10 m108 0 q0 -10 10 -10 m-118 10 v12 m108 0 v-12 m-108 12 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-258 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-294 10 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m54 0 h10 m0 0 h80 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m98 0 h10 m0 0 h36 m20 -120 h10 m90 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-260 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m96 0 h10 m0 0 h74 m-210 0 h20 m190 0 h20 m-230 0 q10 0 10 10 m210 0 q0 -10 10 -10 m-220 10 v24 m210 0 v-24 m-210 24 q0 10 10 10 m190 0 q10 0 10 -10 m-200 10 h10 m58 0 h10 m0 0 h10 m92 0 h10 m23 -44 h-3"/>
-   <polygon points="361 317 369 313 369 321"/>
-   <polygon points="361 317 353 313 353 321"/>
+         d="m19 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h78 m-108 0 h20 m88 0 h20 m-128 0 q10 0 10 10 m108 0 q0 -10 10 -10 m-118 10 v12 m108 0 v-12 m-108 12 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m68 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-239 82 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h294 m-324 0 h20 m304 0 h20 m-344 0 q10 0 10 10 m324 0 q0 -10 10 -10 m-334 10 v12 m324 0 v-12 m-324 12 q0 10 10 10 m304 0 q10 0 10 -10 m-294 10 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m54 0 h10 m0 0 h80 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m98 0 h10 m0 0 h36 m20 -120 h10 m90 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-389 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m96 0 h10 m0 0 h222 m-358 0 h20 m338 0 h20 m-378 0 q10 0 10 10 m358 0 q0 -10 10 -10 m-368 10 v24 m358 0 v-24 m-358 24 q0 10 10 10 m338 0 q10 0 10 -10 m-328 10 h10 m58 0 h10 m0 0 h108 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m166 0 h10 m20 -44 h10 m92 0 h10 m23 -44 h-3"/>
+   <polygon points="401 317 409 313 409 321"/>
+   <polygon points="401 317 393 313 393 321"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-create-materialized-view.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-create-materialized-view.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="517" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="76" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">CREATE</text>
+   <rect x="211" y="3" width="166" height="32" rx="10"/>
+   <rect x="209"
+         y="1"
+         width="166"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="219" y="21">MATERIALIZED VIEW</text>
+   <rect x="397" y="3" width="92" height="32"/>
+   <rect x="395" y="1" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="405" y="21">view_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m76 0 h10 m0 0 h10 m166 0 h10 m0 0 h10 m92 0 h10 m3 0 h-3"/>
+   <polygon points="507 17 515 13 515 21"/>
+   <polygon points="507 17 499 13 499 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/show-materialized-views.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-materialized-views.svg
@@ -1,0 +1,54 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="579" height="155">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="137" y="35" width="54" height="32" rx="10"/>
+   <rect x="135"
+         y="33"
+         width="54"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="145" y="53">FULL</text>
+   <rect x="231" y="3" width="176" height="32" rx="10"/>
+   <rect x="229"
+         y="1"
+         width="176"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="239" y="21">MATERIALIZED VIEWS</text>
+   <rect x="45" y="121" width="60" height="32" rx="10"/>
+   <rect x="43"
+         y="119"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="139">FROM</text>
+   <rect x="125" y="121" width="114" height="32"/>
+   <rect x="123" y="119" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="133" y="139">schema_name</text>
+   <rect x="299" y="121" width="104" height="32" rx="10"/>
+   <rect x="297"
+         y="119"
+         width="104"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="307" y="139">IN CLUSTER</text>
+   <rect x="423" y="121" width="108" height="32"/>
+   <rect x="421" y="119" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="431" y="139">cluster_name</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m176 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-426 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m40 -32 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"/>
+   <polygon points="569 103 577 99 577 107"/>
+   <polygon points="569 103 561 99 561 107"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/show-views.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-views.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="501" height="155">
+<svg xmlns="http://www.w3.org/2000/svg" width="577" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -17,35 +17,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="143" y="53">FULL</text>
-   <rect x="249" y="35" width="124" height="32" rx="10"/>
-   <rect x="247"
-         y="33"
-         width="124"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="257" y="53">MATERIALIZED</text>
-   <rect x="413" y="3" width="66" height="32" rx="10"/>
-   <rect x="411"
+   <rect x="229" y="3" width="66" height="32" rx="10"/>
+   <rect x="227"
          y="1"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="421" y="21">VIEWS</text>
-   <rect x="259" y="121" width="60" height="32" rx="10"/>
-   <rect x="257"
-         y="119"
+   <text class="terminal" x="237" y="21">VIEWS</text>
+   <rect x="335" y="35" width="60" height="32" rx="10"/>
+   <rect x="333"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="267" y="139">FROM</text>
-   <rect x="339" y="121" width="114" height="32"/>
-   <rect x="337" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="347" y="139">schema_name</text>
+   <text class="terminal" x="343" y="53">FROM</text>
+   <rect x="415" y="35" width="114" height="32"/>
+   <rect x="413" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="423" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m40 -32 h10 m0 0 h134 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v12 m164 0 v-12 m-164 12 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m20 -32 h10 m66 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-284 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
-   <polygon points="491 103 499 99 499 107"/>
-   <polygon points="491 103 483 99 483 107"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m66 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="567 17 575 13 575 21"/>
+   <polygon points="567 17 559 13 559 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -1,6 +1,6 @@
 aggregate_with_filter ::= aggregate_name '(' expression ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 alter_rename ::=
-  'ALTER' ('INDEX' | 'SOURCE' | 'VIEW' | 'TABLE') name 'RENAME TO' new_name
+  'ALTER' ('INDEX' | 'SOURCE' | 'VIEW' | 'MATERIALIZED VIEW' | 'TABLE') name 'RENAME TO' new_name
 alter_index ::=
   'ALTER' 'INDEX' name (
     'SET' (
@@ -54,9 +54,14 @@ create_index ::=
     )
     ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_materialized_view ::=
-  'CREATE' ('TEMP' | 'TEMPORARY')? 'MATERIALIZED VIEW' view_name ( '(' col_ident ( ',' col_ident )* ')' )? 'AS' select_stmt |
-  'CREATE' ('TEMP' | 'TEMPORARY')? 'MATERIALIZED VIEW' 'IF NOT EXISTS' view_name ( '(' col_ident ( ',' col_ident )* ')' )? 'AS' select_stmt |
-  'CREATE' 'OR REPLACE' ('TEMP' | 'TEMPORARY')? 'MATERIALIZED VIEW' view_name ( '(' col_ident ( ',' col_ident )* ')' )? 'AS' select_stmt
+  'CREATE' 'MATERIALIZED VIEW' 'IF NOT EXISTS'?
+    view_name ( '(' col_ident ( ',' col_ident )* ')' )?
+    ('IN CLUSTER' cluster_name)?
+    'AS' select_stmt |
+  'CREATE' 'OR REPLACE' 'MATERIALIZED VIEW'
+    view_name ( '(' col_ident ( ',' col_ident )* ')' )?
+    ('IN CLUSTER' cluster_name)?
+    'AS' select_stmt
 create_role ::=
     'CREATE' 'ROLE' role_name ('LOGIN' | 'NOLOGIN' | 'SUPERUSER' | 'NOSUPERUSER')*
 create_schema ::=
@@ -124,7 +129,7 @@ create_view ::=
   'CREATE' ('TEMP' | 'TEMPORARY')? 'VIEW' 'IF NOT EXISTS' view_name ( '(' col_ident ( ',' col_ident )* ')' )? 'AS' select_stmt |
   'CREATE' 'OR REPLACE' 'VIEW' view_name ( '(' col_ident ( ',' col_ident )* ')' )? 'AS' select_stmt
 create_views ::=
-  'CREATE' ('MATERIALIZED')? ('TEMP' | 'TEMPORARY')? 'VIEWS' 'IF NOT EXISTS'? 'FROM' 'SOURCE' '"'src_name'"' ( '(' '"' upstream_table '"'  (AS '"' new_view_name '"' )? ')' )?
+  'CREATE' ('TEMP' | 'TEMPORARY')? 'VIEWS' 'IF NOT EXISTS'? 'FROM' 'SOURCE' '"'src_name'"' ( '(' '"' upstream_table '"'  (AS '"' new_view_name '"' )? ')' )?
 create_table ::=
   'CREATE' ('TEMP' | 'TEMPORARY')? 'TABLE' table_name
   '(' ((col_name col_type col_option*) (',' col_name col_type col_option*)*)? ')'
@@ -152,6 +157,8 @@ drop_database ::=
     'DROP' 'DATABASE' ('IF EXISTS')? database_name ('CASCADE' | 'RESTRICT')?
 drop_index ::=
     'DROP' 'INDEX' ('IF EXISTS')? index_name ('CASCADE' | 'RESTRICT')?
+drop_materialized_view ::=
+  'DROP' 'MATERIALIZED VIEW' 'IF EXISTS'? view_name ('RESTRICT' | 'CASCADE')?
 drop_role ::=
     'DROP' 'ROLE' ('IF EXISTS')? role_name
 drop_schema ::=
@@ -175,7 +182,8 @@ explain ::=
   'TYPED'? ( ( 'RAW' | 'DECORRELATED' | 'OPTIMIZED' )? 'PLAN FOR' )?
   (
     select_stmt |
-    'VIEW' view_name
+    'VIEW' view_name |
+    'MATERIALIZED VIEW' view_name
   )
 fetch ::=
   'FETCH' 'FORWARD'? ('ALL' | count)? 'FROM'? cursor_name
@@ -295,6 +303,8 @@ show_create_connection ::=
   'SHOW' 'CREATE' 'CONNECTION' connection_name
 show_create_index ::=
   'SHOW' 'CREATE' 'INDEX' index_name
+show_create_materialized_view ::=
+  'SHOW' 'CREATE' 'MATERIALIZED VIEW' view_name
 show_create_sink ::=
   'SHOW' 'CREATE' 'SINK' sink_name
 show_create_source ::=
@@ -310,6 +320,8 @@ show_index ::=
     (('FROM' | 'IN') on_name)?
     ('IN' 'CLUSTER' cluster_name)?
     ('LIKE' 'pattern' | 'WHERE' expr)
+show_materialized_views ::=
+    'SHOW' 'FULL'? 'MATERIALIZED VIEWS' ('FROM' schema_name)? ('IN CLUSTER' cluster_name)?
 show_schemas ::=
     'SHOW' 'SCHEMAS' ('FROM' database_name)?
 show_sinks ::=
@@ -321,7 +333,7 @@ show_tables ::=
 show_types ::=
   'SHOW' 'EXTENDED'? 'FULL'?
 show_views ::=
-  'SHOW' 'FULL'? 'MATERIALIZED'? 'VIEWS' ('FROM' schema_name)?
+  'SHOW' 'FULL'? 'VIEWS' ('FROM' schema_name)?
 show_objects ::=
   'SHOW' 'EXTENDED'? 'FULL'?  'OBJECTS' ('FROM' schema_name)?
 string_agg ::=


### PR DESCRIPTION
This PR adds the syntax introduced to support the new materialized views to the user docs. It also adds documentation for the `mz_materialized_views` system catalog table.

There is still a lot of outdated documentation left that describes the old materialized views concept. Updating that is future work.

### Motivation

  * This PR adds a known-desirable feature.

Part of #12860 and https://github.com/MaterializeInc/developer-experience/issues/165.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - 