### PR TITLE
persist: sharded reads (HollowBatch-based snapshot/listen distribution)

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -168,6 +168,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                 // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
                 let (mut ok_stream, err_stream, token) = persist_source::persist_source(
                     region,
+                    *source_id,
                     Arc::clone(&compute_state.persist_clients),
                     source.storage_metadata.clone(),
                     dataflow.as_of.clone().unwrap(),

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -222,7 +222,7 @@ where
 }
 
 async fn truncate_persist_shard(shard_id: ShardId, persist_client: &PersistClient) {
-    let (mut write, read) = persist_client
+    let (mut write, mut read) = persist_client
         .open::<SourceData, (), Timestamp, Diff>(shard_id)
         .await
         .expect("could not open persist shard");

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -232,16 +232,10 @@ async fn truncate_persist_shard(shard_id: ShardId, persist_client: &PersistClien
     if let Some(ts) = upper_ts.checked_sub(1) {
         let as_of = Antichain::from_elem(ts);
 
-        let mut snapshot_iter = read
-            .snapshot(as_of)
+        let mut updates = read
+            .snapshot_and_fetch(as_of)
             .await
             .expect("cannot serve requested as_of");
-
-        let mut updates = Vec::new();
-        while let Some(next) = snapshot_iter.next().await {
-            updates.extend(next);
-        }
-        snapshot_iter.expire().await;
 
         consolidate_updates(&mut updates);
 

--- a/src/persist-client/README.md
+++ b/src/persist-client/README.md
@@ -108,7 +108,7 @@ bigger than this cap.
 [blob_target_size]: crate::PersistConfig::blob_target_size
 [batch_builder_max_outstanding_parts]: crate::PersistConfig::batch_builder_max_outstanding_parts
 
-A persist reader uses as most `3B` memory per [Listen] and per [SnapshotIter].
+A persist reader uses as most `3B` memory per [Listen] and per [Subscribe].
 
 - `B` is [blob_target_size]
 - We have one part fetched that is being iterated
@@ -117,7 +117,7 @@ A persist reader uses as most `3B` memory per [Listen] and per [SnapshotIter].
   memory.
 
 [Listen]: crate::read::Listen
-[SnapshotIter]: crate::read::SnapshotIter
+[Subscribe]: crate::read::Subscribe
 
 Both of these might have _small_ additive and multiplicative constants. This is
 true even when reading data that is far bigger than this cap.

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -214,13 +214,11 @@ async fn bench_snapshot_one_iter(
         .open_reader::<Vec<u8>, Vec<u8>, u64, i64>(*shard_id)
         .await?;
 
-    let mut snap = read
-        .snapshot(as_of.clone())
+    let x = read
+        .snapshot_and_fetch(as_of.clone())
         .await
         .expect("cannot serve requested as_of");
-    while let Some(x) = snap.next().await {
-        black_box(x);
-    }
+    black_box(x);
 
     // Gracefully expire the ReadHandle.
     read.expire().await;

--- a/src/persist-client/benches/porcelain.rs
+++ b/src/persist-client/benches/porcelain.rs
@@ -210,7 +210,7 @@ async fn bench_snapshot_one_iter(
     shard_id: &ShardId,
     as_of: &Antichain<u64>,
 ) -> Result<(), anyhow::Error> {
-    let read = client
+    let mut read = client
         .open_reader::<Vec<u8>, Vec<u8>, u64, i64>(*shard_id)
         .await?;
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -195,7 +195,7 @@ impl Transactor {
         }
     }
 
-    async fn read(&self) -> Result<HashMap<MaelstromKey, MaelstromVal>, MaelstromError> {
+    async fn read(&mut self) -> Result<HashMap<MaelstromKey, MaelstromVal>, MaelstromError> {
         // We're reading as of read_ts, but we can split the read between the
         // snapshot and listen at any ts in `[since_ts, read_ts]`. Intentionally
         // pick one that uses a combination of both to get coverage.

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -204,23 +204,11 @@ impl Transactor {
         let snap_ts = self.since_ts + (self.read_ts - self.since_ts) / 2;
         let snap_as_of = Antichain::from_elem(snap_ts);
 
-        let mut snap = self
-            .read
-            .snapshot(snap_as_of.clone())
-            .await
-            .map_err(|since| MaelstromError {
-                code: ErrorCode::Abort,
-                text: format!(
-                    "snapshot cannot serve requested as_of {} since is {:?}",
-                    snap_ts,
-                    since.0.as_option(),
-                ),
-            })?;
         let listen = self
             .read
             .clone()
             .await
-            .listen(snap_as_of)
+            .listen(snap_as_of.clone())
             .await
             .map_err(|since| MaelstromError {
                 code: ErrorCode::Abort,
@@ -231,10 +219,19 @@ impl Transactor {
                 ),
             })?;
 
-        let mut updates = Vec::new();
-        while let Some(mut dataz) = snap.next().await {
-            updates.append(&mut dataz);
-        }
+        let mut updates = self
+            .read
+            .snapshot_and_fetch(snap_as_of.clone())
+            .await
+            .map_err(|since| MaelstromError {
+                code: ErrorCode::Abort,
+                text: format!(
+                    "snapshot cannot serve requested as_of {} since is {:?}",
+                    snap_ts,
+                    since.0.as_option(),
+                ),
+            })?;
+
         trace!(
             "read updates from snapshot as_of {}: {:?}",
             snap_ts,

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -363,7 +363,8 @@ mod api {
         ///
         /// Returns an `Err` with the current upper if the given `as_of` is beyond the current
         /// upper.
-        async fn snapshot(&self, as_of: Antichain<T>) -> Result<Vec<((K, V), T)>, Antichain<T>>;
+        async fn snapshot(&mut self, as_of: Antichain<T>)
+            -> Result<Vec<((K, V), T)>, Antichain<T>>;
 
         async fn current_upper(&mut self) -> Antichain<T>;
 
@@ -897,16 +898,11 @@ mod impls {
                 return Ok(vec![]);
             }
 
-            let mut iter = self
+            let updates = self
                 .read
-                .snapshot(as_of.clone())
+                .snapshot_and_fetch(as_of.clone())
                 .await
                 .expect("wrong as_of");
-
-            let mut updates = Vec::new();
-            while let Some(mut next) = iter.next().await {
-                updates.append(&mut next)
-            }
 
             let result = updates
                 .into_iter()
@@ -1374,13 +1370,14 @@ mod reader {
         let reader_task = mz_ore::task::spawn(|| "reader", async move {
             // Cannot snapshot at `[0]` if that's not ready.
             if !PartialOrder::less_equal(&as_of, &Antichain::from_elem(T::minimum())) {
-                let mut iter = read.snapshot(as_of.clone()).await.expect("invalid as_of");
-
-                while let Some(next) = iter.next().await {
+                for next in read
+                    .snapshot_and_fetch(as_of.clone())
+                    .await
+                    .expect("invalid as_of")
+                {
                     println!("instance {}: got from snapshot: {:?}", name, next);
                 }
             }
-
             let mut listen = read
                 .clone()
                 .await

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -892,7 +892,10 @@ mod impls {
             self.write.fetch_recent_upper().await
         }
 
-        async fn snapshot(&self, as_of: Antichain<T>) -> Result<Vec<((K, V), T)>, Antichain<T>> {
+        async fn snapshot(
+            &mut self,
+            as_of: Antichain<T>,
+        ) -> Result<Vec<((K, V), T)>, Antichain<T>> {
             if PartialOrder::less_equal(&as_of, &Antichain::from_elem(T::minimum())) {
                 // Early exit, because snapshot errors if we try and do this.
                 return Ok(vec![]);

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -533,7 +533,7 @@ mod tests {
             })
             .await
             .expect("client construction failed");
-        let (mut write, read) = client
+        let (mut write, mut read) = client
             .expect_open::<String, String, u64, i64>(ShardId::new())
             .await;
 
@@ -581,10 +581,7 @@ mod tests {
             .await
             .expect("invalid usage")
             .expect("unexpected upper");
-        assert_eq!(
-            read.expect_snapshot(3).await.read_all().await,
-            all_ok(&data, 3)
-        );
+        assert_eq!(read.expect_snapshot_and_fetch(3).await, all_ok(&data, 3));
     }
 
     #[tokio::test]

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -93,16 +93,8 @@ pub enum InvalidUsage<T> {
         /// The expected upper of the batch
         expected_upper: Antichain<T>,
     },
-    /// A [crate::read::SnapshotSplit] was given to
-    /// [crate::read::ReadHandle::snapshot_iter] from a different shard
-    SnapshotNotFromThisShard {
-        /// The shard of the snapshot
-        snapshot_shard: ShardId,
-        /// The shard of the handle
-        handle_shard: ShardId,
-    },
-    /// A [crate::batch::Batch] was given to a [crate::write::WriteHandle] from
-    /// a different shard
+    /// A [crate::batch::Batch] or [crate::read::ReaderEnrichedHollowBatch] was
+    /// given to a [crate::write::WriteHandle] from a different shard
     BatchNotFromThisShard {
         /// The shard of the batch
         batch_shard: ShardId,
@@ -150,14 +142,6 @@ impl<T: Debug> std::fmt::Display for InvalidUsage<T> {
                 f,
                 "maximum timestamp {:?} is beyond the expected batch upper: {:?}",
                 max_ts, expected_upper
-            ),
-            InvalidUsage::SnapshotNotFromThisShard {
-                snapshot_shard,
-                handle_shard,
-            } => write!(
-                f,
-                "snapshot was from {} not {}",
-                snapshot_shard, handle_shard
             ),
             InvalidUsage::BatchNotFromThisShard {
                 batch_shard,

--- a/src/persist-client/src/impl/encoding.rs
+++ b/src/persist-client/src/impl/encoding.rs
@@ -354,12 +354,15 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatchReaderMetadata>
                         as_of: Some(as_of.into_proto()),
                     })
                 }
-                HollowBatchReaderMetadata::Listen { as_of, until } => {
-                    Kind::Listen(ProtoHollowBatchReaderMetadataListen {
-                        as_of: Some(as_of.into_proto()),
-                        until: Some(until.into_proto()),
-                    })
-                }
+                HollowBatchReaderMetadata::Listen {
+                    as_of,
+                    until,
+                    since,
+                } => Kind::Listen(ProtoHollowBatchReaderMetadataListen {
+                    as_of: Some(as_of.into_proto()),
+                    until: Some(until.into_proto()),
+                    since: Some(since.into_proto()),
+                }),
             }),
         }
     }
@@ -379,6 +382,9 @@ impl<T: Timestamp + Codec64> RustType<ProtoHollowBatchReaderMetadata>
                 until: listen
                     .until
                     .into_rust_if_some("ProtoHollowBatchReaderMetadata::Kind::Listen::until")?,
+                since: listen
+                    .since
+                    .into_rust_if_some("ProtoHollowBatchReaderMetadata::Kind::Listen::since")?,
             },
             None => {
                 return Err(TryFromProtoError::missing_field(

--- a/src/persist-client/src/impl/state.proto
+++ b/src/persist-client/src/impl/state.proto
@@ -83,10 +83,3 @@ message ProtoReadEnrichedHollowBatch {
     ProtoHollowBatchReaderMetadata reader_metadata = 2;
     ProtoHollowBatch batch = 3;
 }
-
-message ProtoSnapshotSplit {
-    string reader_id = 4;
-    string shard_id = 1;
-    ProtoU64Antichain as_of = 2;
-    repeated ProtoHollowBatchPart batches = 3;
-}

--- a/src/persist-client/src/impl/state.proto
+++ b/src/persist-client/src/impl/state.proto
@@ -62,6 +62,28 @@ message ProtoStateRollup {
     repeated ProtoWriterState writers = 9;
 }
 
+message ProtoHollowBatchReaderMetadata {
+    message ProtoHollowBatchReaderMetadataSnapshot {
+        ProtoU64Antichain as_of = 1;
+    }
+
+    message ProtoHollowBatchReaderMetadataListen {
+        ProtoU64Antichain as_of = 1;
+        ProtoU64Antichain until = 2;
+    }
+
+    oneof kind {
+        ProtoHollowBatchReaderMetadataSnapshot snapshot = 1;
+        ProtoHollowBatchReaderMetadataListen listen = 2;
+    }
+}
+
+message ProtoReadEnrichedHollowBatch {
+    string shard_id = 1;
+    ProtoHollowBatchReaderMetadata reader_metadata = 2;
+    ProtoHollowBatch batch = 3;
+}
+
 message ProtoSnapshotSplit {
     string reader_id = 4;
     string shard_id = 1;

--- a/src/persist-client/src/impl/state.proto
+++ b/src/persist-client/src/impl/state.proto
@@ -70,6 +70,7 @@ message ProtoHollowBatchReaderMetadata {
     message ProtoHollowBatchReaderMetadataListen {
         ProtoU64Antichain as_of = 1;
         ProtoU64Antichain until = 2;
+        ProtoU64Antichain since = 3;
     }
 
     oneof kind {

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -741,7 +741,7 @@ mod tests {
             (("3".to_owned(), "three".to_owned()), 3, 1),
         ];
 
-        let (mut write, read) = new_test_client()
+        let (mut write, mut read) = new_test_client()
             .await
             .expect_open::<String, String, u64, i64>(ShardId::new())
             .await;
@@ -758,7 +758,7 @@ mod tests {
             (("2".to_owned(), "two".to_owned()), 2, 2),
             (("3".to_owned(), "three".to_owned()), 3, 1),
         ];
-        let mut actual = read.expect_snapshot(3).await.read_all().await;
+        let mut actual = read.expect_snapshot_and_fetch(3).await;
         consolidate_updates(&mut actual);
         assert_eq!(actual, all_ok(&expected, 3));
     }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -297,6 +297,7 @@ where
                             let (tx_source_ok_stream, tx_source_err_stream, tx_token) =
                                 persist_source::persist_source(
                                     scope,
+                                    id,
                                     persist_clients,
                                     tx_storage_metadata,
                                     as_of,

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -13,23 +13,25 @@ use std::any::Any;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::time::Instant;
 
 use futures_util::Stream as FuturesStream;
-use mz_persist_client::cache::PersistClientCache;
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::OkErr;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
-use timely::PartialOrder;
 use tokio::sync::Mutex;
 use tracing::trace;
 
+use mz_ore::cast::CastFrom;
 use mz_persist::location::ExternalError;
-use mz_persist_client::read::ListenEvent;
+use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::read::{ListenEvent, ReaderEnrichedHollowBatch};
 use mz_repr::{Diff, Row, Timestamp};
+use mz_timely_util::async_op;
+use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::controller::CollectionMetadata;
-use crate::source::YIELD_INTERVAL;
 use crate::types::errors::DataflowError;
 use crate::types::sources::SourceData;
 
@@ -38,12 +40,6 @@ use crate::types::sources::SourceData;
 /// All times emitted will have been [advanced by] the given `as_of` frontier.
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-//
-// TODO(aljoscha): We need to change the `shard_id` parameter to be a `Vec<ShardId>` and teach the
-// operator to concurrently poll from multiple `Listen` instances. This will require us to put in
-// place the code that allows selecting from multiple `Listen`s, potentially by implementing async
-// `Stream` for it and then using `select_all`. And it will require us to properly combine the
-// upper frontier from all shards.
 pub fn persist_source<G>(
     scope: &G,
     persist_clients: Arc<Mutex<PersistClientCache>>,
@@ -58,140 +54,150 @@ where
     G: Scope<Timestamp = mz_repr::Timestamp>,
 {
     let worker_index = scope.index();
+    let peers = scope.peers();
 
-    // This source is split into two parts: a first part that sets up `async_stream` and a timely
-    // source operator that the continuously reads from that stream.
-    //
-    // It is split that way because there is currently no easy way of setting up an async source
-    // operator in materialize/timely.
+    let persist_clients_stream = Arc::<Mutex<PersistClientCache>>::clone(&persist_clients);
+    let persist_location_stream = metadata.persist_location.clone();
+    let data_shard = metadata.data_shard.clone();
+    let as_of_stream = as_of;
+
+    // This source is split as such:
+    // 1. Sets up `async_stream`, which only yields data (hollow batches) on one
+    //    worker.
+    // 2. A timely source operator which continuously reads from that stream,
+    //    and distributes the data among workers.
+    // 3. A timely operator which downloads the batch's contents from S3, and
+    //    outputs them to a timely stream.
 
     // This is a generator that sets up an async `Stream` that can be continously polled to get the
     // values that are `yield`-ed from it's body.
     let async_stream = async_stream::try_stream!({
-        // We are reading only from worker 0. We can split the work of reading from the snapshot to
-        // multiple workers, but someone has to distribute the splits. Also, in the glorious
-        // STORAGE future, we will use multiple persist shards to back a STORAGE collection. Then,
-        // we can read in parallel, by distributing shard reading amongst workers.
+        // Worker 0 is responsible for distributing splits from listen
         if worker_index != 0 {
             trace!("We are not worker 0, exiting...");
             return;
         }
 
-        let read = persist_clients
+        let read = persist_clients_stream
             .lock()
             .await
-            .open(metadata.persist_location)
+            .open(persist_location_stream)
             .await
             .expect("could not open persist client")
-            .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(metadata.data_shard)
+            .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(data_shard.clone())
             .await
             .expect("could not open persist shard");
 
-        let mut snapshot_iter = read
-            .snapshot(as_of.clone())
-            .await
-            .expect("cannot serve requested as_of");
-
-        // First, yield all the updates from the snapshot.
-        while let Some(next) = snapshot_iter.next().await {
-            yield ListenEvent::Updates(next);
-        }
-
-        // Then, listen continuously and yield any new updates. This loop is expected to never
-        // finish.
-        let mut listen = read
-            .listen(as_of)
+        let mut subscription = read
+            .subscribe(as_of_stream)
             .await
             .expect("cannot serve requested as_of");
 
         loop {
-            for event in listen.next().await {
-                yield event;
-            }
+            yield subscription.next().await;
         }
     });
 
     let mut pinned_stream = Box::pin(async_stream);
 
-    let (timely_stream, token) =
+    let (inner, token) =
         crate::source::util::source(scope, "persist_source".to_string(), move |info| {
             let waker_activator = Arc::new(scope.sync_activator_for(&info.address[..]));
             let waker = futures_util::task::waker(waker_activator);
-            let activator = scope.activator_for(&info.address[..]);
+
+            let mut current_ts = 0;
 
             move |cap_set, output| {
                 let mut context = Context::from_waker(&waker);
-                // Bound execution of operator to prevent a single operator from hogging
-                // the CPU if there are many messages to process
-                let timer = Instant::now();
+
+                let mut i = 0;
 
                 while let Poll::Ready(item) = pinned_stream.as_mut().poll_next(&mut context) {
                     match item {
-                        Some(Ok(ListenEvent::Progress(upper))) => {
-                            cap_set.downgrade(upper.iter());
+                        Some(Ok(batch)) => {
+                            let session_cap = cap_set.delayed(&current_ts);
+                            let mut session = output.session(&session_cap);
+                            let progress = batch.generate_progress();
 
-                            if upper.is_empty() {
-                                // Return early because we're done now.
-                                return;
+                            session.give((i, batch));
+
+                            // Round robin
+                            i = (i + 1) % peers;
+                            if let Some(frontier) = progress {
+                                cap_set.downgrade(frontier.iter());
+                                match frontier.into_option() {
+                                    Some(ts) => {
+                                        current_ts = ts;
+                                    }
+                                    None => {
+                                        cap_set.downgrade(&[]);
+                                        return;
+                                    }
+                                }
                             }
-                        }
-                        Some(Ok(ListenEvent::Updates(mut updates))) => {
-                            // This operator guarantees that its output has been advanced by `as_of.
-                            // The persist SnapshotIter already has this contract, so nothing to do
-                            // here.
-
-                            if updates.is_empty() {
-                                continue;
-                            }
-
-                            // Swing through all the capabilities we have and
-                            // peel off updates that we can emit with it. For
-                            // the case of totally ordered times, we have at
-                            // most on capability and will peel off all updates
-                            // in one go.
-                            //
-                            // NOTE: We use this seemingly complicated approach
-                            // such that the code is ready to deal with
-                            // partially ordered times.
-                            for cap in cap_set.iter() {
-                                // NOTE: The nightly `drain_filter()` would use
-                                // less allocations than this. Should switch to
-                                // it once it's available in stable rust.
-                                let (mut to_emit, remaining_updates) =
-                                    updates.into_iter().partition(|(_update, ts, _diff)| {
-                                        PartialOrder::less_equal(cap.time(), ts)
-                                    });
-                                updates = remaining_updates;
-
-                                let mut session = output.session(&cap);
-                                session.give_vec(&mut to_emit);
-                            }
-
-                            assert!(
-                                updates.is_empty(),
-                                "did not have matching Capability for updates: {:?}",
-                                updates
-                            );
                         }
                         Some(Err::<_, ExternalError>(e)) => {
-                            // TODO(petrosagg): error handling
-                            panic!("unexpected error from persist {e}");
+                            panic!("unexpected error from persist {e}")
                         }
+                        // We never expect any further output from
+                        // `pinned_stream`, so propagate that information
+                        // downstream.
                         None => {
-                            // Empty out the `CapabilitySet` to indicate that we're done.
                             cap_set.downgrade(&[]);
                             return;
                         }
-                    }
-                    if timer.elapsed() > YIELD_INTERVAL {
-                        activator.activate();
-                        break;
                     }
                 }
             }
         });
 
-    let (ok_stream, err_stream) = timely_stream.ok_err(|x| match x {
+    let mut builder = OperatorBuilder::new(
+        format!(
+            "persist_source: sharded reader {} of {:?}",
+            worker_index, source_id
+        ),
+        scope.clone(),
+    );
+    let dist = |&(i, _): &(usize, ReaderEnrichedHollowBatch<Timestamp>)| u64::cast_from(i);
+    let mut input = builder.new_input(&inner, Exchange::new(dist));
+    let (mut output, output_stream) = builder.new_output();
+
+    builder.build_async(
+        scope.clone(),
+        async_op!(|initial_capabilities, _frontiers| {
+            let read = persist_clients
+                .lock()
+                .await
+                .open(metadata.persist_location.clone())
+                .await
+                .expect("could not open persist client")
+                .open_reader::<SourceData, (), mz_repr::Timestamp, mz_repr::Diff>(
+                    data_shard.clone(),
+                )
+                .await
+                .expect("could not open persist shard");
+
+            initial_capabilities.clear();
+
+            let mut output_handle = output.activate();
+
+            while let Some((cap, data)) = input.next() {
+                let cap = cap.retain();
+                for (_idx, batch) in data.iter() {
+                    for update in read
+                        .fetch_batch(batch.clone())
+                        .await
+                        .expect("shard_id generated for sources must match across all workers");
+
+                    let mut session = output_handle.session(&cap);
+                    session.give_vec(&mut updates);
+                }
+            }
+            false
+        }),
+    );
+
+    let (ok_stream, err_stream) = output_stream.ok_err(|x| match x {
         ((Ok(SourceData(Ok(row))), Ok(())), ts, diff) => Ok((row, ts, diff)),
         ((Ok(SourceData(Err(err))), Ok(())), ts, diff) => Err((err, ts, diff)),
         // TODO(petrosagg): error handling

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -175,7 +175,7 @@ where
     builder.build_async(
         scope.clone(),
         async_op!(|initial_capabilities, _frontiers| {
-            let read = persist_clients
+            let mut read = persist_clients
                 .lock()
                 .await
                 .open(metadata.persist_location.clone())

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -253,16 +253,14 @@ impl ReclockOperator {
         // If this is the first sync and the collection is non-empty load the initial snapshot
         let first_sync = self.upper.elements() == [Timestamp::minimum()];
         if first_sync && PartialOrder::less_than(&self.upper, target_upper) {
-            let mut snapshot = self
+            for ((_, pid), ts, diff) in self
                 .read_handle
-                .snapshot(self.since.clone())
+                .snapshot_and_fetch(self.since.clone())
                 .await
-                .expect("local since is not beyond read handle's since");
-            while let Some(updates) = snapshot.next().await {
-                for ((_, pid), ts, diff) in updates {
-                    let pid = pid.expect("failed to decode partition");
-                    pending_batch.push((pid, ts, diff));
-                }
+                .expect("local since is not beyond read handle's since")
+            {
+                let pid = pid.expect("failed to decode partition");
+                pending_batch.push((pid, ts, diff));
             }
         }
 


### PR DESCRIPTION
To enable parallelism in reading from persist, we determined a strategy that involves exchanging `HollowBatch`es across timely workers, and having them download blobs from S3. For more details, see #13884

### Motivation

This PR adds a known-desirable feature. This PR adds the read side of #13884

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
