### PR TITLE
Gracefully handle disconnects during reconciliation

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -387,8 +387,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 }
             }
 
-            assert!(old_config.is_some() || old_dataflows.is_empty() && old_frontiers.is_empty());
-
             // Compaction commands that can be applied to existing dataflows.
             let mut old_compaction = BTreeMap::default();
 
@@ -438,9 +436,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                     ComputeCommand::CreateInstance(new_config) => {
                         // Cluster creation should not be performed again!
-                        if let Some(old_config) = old_config {
-                            assert_eq!(old_config, new_config);
-                        }
+                        assert_eq!(old_config, Some(new_config));
                     }
                     // All other commands we apply as requested.
                     command => {


### PR DESCRIPTION
Do not attempt to continue reconciliation if the client hung up while
collecting the initial commands.

Includes a revert of #13844.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
