### PR TITLE
Rename default cluster name

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -89,6 +89,7 @@ use crate::util::index_sql;
 
 pub const SYSTEM_CONN_ID: ConnectionId = 0;
 const SYSTEM_USER: &str = "mz_system";
+pub const DEFAULT_CLUSTER_NAME: &str = "default_cluster";
 
 /// A `Catalog` keeps track of the SQL objects known to the planner.
 ///
@@ -2068,7 +2069,7 @@ impl<S: Append> Catalog<S> {
         ConnCatalog {
             state: Cow::Borrowed(&self.state),
             conn_id: SYSTEM_CONN_ID,
-            compute_instance: "default".into(),
+            compute_instance: DEFAULT_CLUSTER_NAME.into(),
             database: self
                 .resolve_database(DEFAULT_DATABASE_NAME)
                 .ok()

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -40,7 +40,7 @@ use mz_storage::types::sources::Timeline;
 
 use crate::catalog::builtin::BuiltinLog;
 use crate::catalog::error::{Error, ErrorKind};
-use crate::catalog::SerializedComputeInstanceReplicaConfig;
+use crate::catalog::{SerializedComputeInstanceReplicaConfig, DEFAULT_CLUSTER_NAME};
 
 const USER_VERSION: &str = "user_version";
 
@@ -204,7 +204,7 @@ async fn migrate<S: Append>(
                     id: DEFAULT_COMPUTE_INSTANCE_ID,
                 },
                 ComputeInstanceValue {
-                    name: "default".into(),
+                    name: DEFAULT_CLUSTER_NAME.into(),
                     config: Some(
                         "{\"debugging\":false,\"granularity\":{\"secs\":1,\"nanos\":0}}".into(),
                     ),

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -15,6 +15,7 @@ use const_format::concatcp;
 use once_cell::sync::Lazy;
 use uncased::UncasedStr;
 
+use crate::catalog::DEFAULT_CLUSTER_NAME;
 use mz_ore::cast;
 use mz_sql::DEFAULT_SCHEMA;
 use mz_sql_parser::ast::TransactionIsolationLevel;
@@ -59,7 +60,7 @@ const CLIENT_MIN_MESSAGES: ServerVar<ClientSeverity> = ServerVar {
 
 const CLUSTER: ServerVar<str> = ServerVar {
     name: UncasedStr::new("cluster"),
-    value: "default",
+    value: DEFAULT_CLUSTER_NAME,
     description: "Sets the current cluster (Materialize).",
 };
 

--- a/src/testdrive/src/action/sql.rs
+++ b/src/testdrive/src/action/sql.rs
@@ -16,6 +16,7 @@ use std::time::SystemTime;
 use anyhow::{bail, Context};
 use async_trait::async_trait;
 use md5::{Digest, Md5};
+use mz_adapter::catalog::DEFAULT_CLUSTER_NAME;
 use postgres_array::Array;
 use regex::Regex;
 use tokio_postgres::error::DbError;
@@ -103,7 +104,7 @@ impl Action for SqlAction {
                 // isolating tests from one another, so testdrive won't let you.
                 assert_ne!(
                     name,
-                    &mz_sql::ast::Ident::from("default"),
+                    &mz_sql::ast::Ident::from(DEFAULT_CLUSTER_NAME),
                     "testdrive cannot create default cluster"
                 );
                 self.try_drop(
@@ -121,7 +122,7 @@ impl Action for SqlAction {
                 // isolating tests from one another, so testdrive won't let you.
                 assert_ne!(
                     of_cluster.to_string(),
-                    "default",
+                    DEFAULT_CLUSTER_NAME,
                     "testdrive cannot create default cluster replicas"
                 );
                 self.try_drop(

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -208,5 +208,5 @@ def workflow_test_drop_default_cluster(c: Composition) -> None:
     c.up("materialized")
     c.wait_for_materialized()
 
-    c.sql("DROP CLUSTER default CASCADE")
-    c.sql("CREATE CLUSTER default REPLICAS (default (SIZE '1'))")
+    c.sql("DROP CLUSTER default_cluster CASCADE")
+    c.sql("CREATE CLUSTER default_cluster REPLICAS (default_replica (SIZE '1'))")

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -43,7 +43,7 @@ CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235']), r2 (REMOTE ['localh
 query TT rowsort
 SELECT * FROM mz_clusters
 ----
-1 default
+1 default_cluster
 3 foo
 4 bar
 
@@ -51,13 +51,13 @@ query T rowsort
 SHOW CLUSTERS
 ----
 bar
-default
+default_cluster
 foo
 
 query T rowsort
 SHOW CLUSTERS LIKE 'd%'
 ----
-default
+default_cluster
 
 # Test invalid option combinations.
 
@@ -69,7 +69,7 @@ CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], SIZE 'small'))
 query T
 SHOW cluster
 ----
-default
+default_cluster
 
 statement ok
 SET cluster = 'bar'
@@ -86,7 +86,7 @@ statement ok
 CREATE DEFAULT INDEX ON v
 
 statement ok
-SET cluster = 'default'
+SET cluster = 'default_cluster'
 
 query T
 SELECT * FROM v
@@ -190,7 +190,7 @@ CREATE VIEW unmat AS SELECT 1
 
 # Test `CREATE INDEX ... IN CLUSTER`.
 statement ok
-SET cluster = 'default'
+SET cluster = 'default_cluster'
 
 query T
 SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
@@ -215,7 +215,7 @@ CREATE DEFAULT INDEX IN CLUSTER noexist ON v
 query T
 SHOW cluster
 ----
-default
+default_cluster
 
 statement error unknown cluster 'baz'
 DROP CLUSTER baz
@@ -325,16 +325,16 @@ SELECT COUNT(name) FROM mz_indexes;
 17
 
 statement error nvalid SIZE: must provide a string value
-CREATE CLUSTER REPLICA default.size_1 SIZE;
+CREATE CLUSTER REPLICA default_cluster.size_1 SIZE;
 
 statement ok
-CREATE CLUSTER REPLICA default.size_1 SIZE '1';
+CREATE CLUSTER REPLICA default_cluster.size_1 SIZE '1';
 
 query TT
 SHOW CLUSTER REPLICAS
 ----
-default default_replica
-default size_1
+default_cluster default_replica
+default_cluster size_1
 
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
@@ -342,25 +342,25 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 query TT
 SHOW CLUSTER REPLICAS
 ----
-default default_replica
-default size_1
+default_cluster default_replica
+default_cluster size_1
 foo size_1
 foo size_2
 
 statement ok
-DROP CLUSTER REPLICA IF EXISTS default.bar
+DROP CLUSTER REPLICA IF EXISTS default_cluster.bar
 
 statement ok
 DROP CLUSTER REPLICA IF EXISTS bar.foo
 
 statement ok
-DROP CLUSTER REPLICA IF EXISTS default.foo
+DROP CLUSTER REPLICA IF EXISTS default_cluster.foo
 
 query error CLUSTER foo has no CLUSTER REPLICA named foo
-DROP CLUSTER REPLICA default.size_1, foo.foo
+DROP CLUSTER REPLICA default_cluster.size_1, foo.foo
 
 statement ok
-DROP CLUSTER REPLICA default.size_1
+DROP CLUSTER REPLICA default_cluster.size_1
 
 statement ok
 DROP CLUSTER REPLICA foo.size_1, foo.size_2
@@ -368,31 +368,31 @@ DROP CLUSTER REPLICA foo.size_1, foo.size_2
 query TT
 SHOW CLUSTER REPLICAS
 ----
-default default_replica
+default_cluster default_replica
 
 statement ok
-CREATE CLUSTER REPLICA default.foo_bar SIZE '1'
+CREATE CLUSTER REPLICA default_cluster.foo_bar SIZE '1'
 
 statement ok
-DROP CLUSTER REPLICA default.foo_bar
+DROP CLUSTER REPLICA default_cluster.foo_bar
 
 statement ok
-CREATE CLUSTER REPLICA default."foo-bar" SIZE '1'
+CREATE CLUSTER REPLICA default_cluster."foo-bar" SIZE '1'
 
 statement ok
-DROP CLUSTER REPLICA default."foo-bar"
+DROP CLUSTER REPLICA default_cluster."foo-bar"
 
 statement ok
-CREATE CLUSTER REPLICA default."好-好" SIZE '1'
+CREATE CLUSTER REPLICA default_cluster."好-好" SIZE '1'
 
 statement ok
-DROP CLUSTER REPLICA default."好-好"
+DROP CLUSTER REPLICA default_cluster."好-好"
 
 statement ok
-CREATE CLUSTER REPLICA default."好_好" SIZE '1'
+CREATE CLUSTER REPLICA default_cluster."好_好" SIZE '1'
 
 statement ok
-DROP CLUSTER REPLICA default."好_好"
+DROP CLUSTER REPLICA default_cluster."好_好"
 
 # clusters wo replicas cannot service selects
 
@@ -409,7 +409,7 @@ SELECT 1;
 # Phillip's tests
 
 statement error zero-length delimited identifier
-CREATE CLUSTER REPLICA default."" SIZE '1';
+CREATE CLUSTER REPLICA default_cluster."" SIZE '1';
 
 statement error unknown cluster
 CREATE CLUSTER REPLICA no_such_cluster.size_1 SIZE '1';
@@ -463,19 +463,19 @@ DROP CLUSTER foo CASCADE
 # can't be meaningfully specified
 
 statement error unknown cluster replica availability zone a
-CREATE CLUSTER REPLICA default.replica SIZE '1', AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default_cluster.replica SIZE '1', AVAILABILITY ZONE 'a'
 
 statement error AVAILABILITY ZONE specified more than once
-CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
+CREATE CLUSTER REPLICA default_cluster.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default_cluster.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default_cluster.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1']
+CREATE CLUSTER REPLICA default_cluster.replica AVAILABILITY ZONE 'a', REMOTE ['host1']
 
 # Test that the contents of mz_cluster_replicas look sensible
 

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -24,7 +24,7 @@ statement ok
 create index i1 on t1 (f2)
 
 statement ok
-set cluster = default
+set cluster = default_cluster
 
 statement ok
 begin;

--- a/test/sqllogictest/github-13857.slt
+++ b/test/sqllogictest/github-13857.slt
@@ -10,7 +10,7 @@
 # Regression test for https://github.com/MaterializeInc/materialize/issues/13857
 
 statement ok
-DROP CLUSTER default CASCADE
+DROP CLUSTER default_cluster CASCADE
 
 statement ok
 CREATE CLUSTER test

--- a/test/sqllogictest/id_reuse.slt
+++ b/test/sqllogictest/id_reuse.slt
@@ -90,7 +90,7 @@ CREATE CLUSTER foo REPLICAS (r1 (size '1'))
 query IT rowsort
 SELECT id, name FROM mz_clusters
 ----
-1 default
+1 default_cluster
 2 foo
 
 statement ok
@@ -102,5 +102,5 @@ CREATE CLUSTER bar REPLICAS (r1 (size '1'))
 query IT rowsort
 SELECT id, name FROM mz_clusters
 ----
-1 default
+1 default_cluster
 3 bar

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -78,9 +78,9 @@ CREATE MATERIALIZED VIEW other_mv IN CLUSTER other AS SELECT 1
 query TTT colnames,rowsort
 SHOW FULL MATERIALIZED VIEWS
 ----
-cluster name     type
-default mv       user
-other   other_mv user
+cluster         name     type
+default_cluster mv       user
+other           other_mv user
 
 statement ok
 DROP MATERIALIZED VIEW other_mv
@@ -254,7 +254,7 @@ query TT colnames
 SHOW CREATE MATERIALIZED VIEW mv
 ----
 Materialized␠View     Create␠Materialized␠View
-materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"␠IN␠CLUSTER␠"default"␠AS␠SELECT␠1
+materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"␠IN␠CLUSTER␠"default_cluster"␠AS␠SELECT␠1
 
 
 # Test: SHOW MATERIALIZED VIEWS
@@ -272,9 +272,9 @@ other_mv
 query TTT colnames,rowsort
 SHOW FULL MATERIALIZED VIEWS
 ----
-cluster name     type
-default mv       user
-other   other_mv user
+cluster         name     type
+default_cluster mv       user
+other           other_mv user
 
 query TTT colnames,rowsort
 SHOW FULL MATERIALIZED VIEWS IN CLUSTER other
@@ -341,8 +341,8 @@ CREATE DEFAULT INDEX ON mv
 query TTTITTT colnames
 SHOW INDEXES ON mv
 ----
-cluster on_name key_name       seq_in_index column_name expression nullable
-default mv      mv_primary_idx 1            ?column?    NULL       false
+cluster         on_name key_name       seq_in_index column_name expression nullable
+default_cluster mv      mv_primary_idx 1            ?column?    NULL       false
 
 
 # Test: Creating materialized views that depend on log sources is forbidden.

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -10,7 +10,7 @@
 # Test that a dependency chain with multiple links is properly maintained
 # across creation and deletion.
 
-$ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
+$ set-regex match=cluster1|default_cluster replacement=<CLUSTER_NAME>
 
 $ set schema={
     "name": "row",

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default replacement=<VARIABLE_OUTPUT>
+$ set-regex match=cluster1|default_cluster replacement=<VARIABLE_OUTPUT>
 
 $ set writer-schema={
     "name": "row",

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -43,9 +43,9 @@ data_view   user
 test1
 
 > SHOW FULL MATERIALIZED VIEWS
-cluster   name     type
+cluster             name     type
 -----------------------
-default   test1    user
+default_cluster     test1    user
 
 > SELECT * FROM test1
 b  sum
@@ -75,7 +75,7 @@ data_view
 > SHOW CREATE MATERIALIZED VIEW test1
 "Materialized View"       "Create Materialized View"
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.test1  "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"test1\" IN CLUSTER \"default\" AS SELECT \"b\", \"pg_catalog\".\"sum\"(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
+materialize.public.test1  "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"test1\" IN CLUSTER \"default_cluster\" AS SELECT \"b\", \"pg_catalog\".\"sum\"(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
 
 # Materialized view can be built on a not-materialized view.
 > CREATE MATERIALIZED VIEW test2 AS

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=u\d+|cluster1|default replacement=<VARIABLE_OUTPUT>
+$ set-regex match=u\d+|cluster1|default_cluster replacement=<VARIABLE_OUTPUT>
 
 $ set writer-schema={
     "name": "row",

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
+$ set-regex match=cluster1|default_cluster replacement=<CLUSTER_NAME>
 
 > SHOW ALL
 application_name            ""              "Sets the application name to be reported in statistics and logs (PostgreSQL)."

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
+$ set-regex match=cluster1|default_cluster replacement=<CLUSTER_NAME>
 
 $ kafka-create-topic topic=test
 $ kafka-ingest topic=test format=bytes

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
+$ set-regex match=cluster1|default_cluster replacement=<CLUSTER_NAME>
 
 ! INSERT INTO t VALUES (1, 'a');
 contains:unknown catalog item 't'

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=cluster1|default replacement=<CLUSTER_NAME>
+$ set-regex match=cluster1|default_cluster replacement=<CLUSTER_NAME>
 
 > CREATE VIEW v AS VALUES (1, 'foo'), (2, 'bar'), (3, 'foo'), (1, 'bar')
 

--- a/test/upgrade/check-from-current_source-json.td
+++ b/test/upgrade/check-from-current_source-json.td
@@ -8,4 +8,4 @@
 # by the Apache License, Version 2.0.
 
 > SHOW CREATE MATERIALIZED VIEW json_view;
-"materialize.public.json_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"json_view\" IN CLUSTER \"default\" AS SELECT \"a\" -> 1 AS \"c1\", \"a\" ->> 'b' AS \"c2\", \"a\" #> '{b,1}' AS \"c3\", \"a\" #>> '{b, 1}' AS \"c4\", \"a\" - 'b' AS \"c5\", \"a\" @> '{b, 1}' AS \"c6\", \"a\" <@ '{b, 1}'::\"pg_catalog\".\"jsonb\" AS \"c7\", \"a\" ? 'b' AS \"c8\" FROM \"materialize\".\"public\".\"json_table\""
+"materialize.public.json_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"json_view\" IN CLUSTER \"default_cluster\" AS SELECT \"a\" -> 1 AS \"c1\", \"a\" ->> 'b' AS \"c2\", \"a\" #> '{b,1}' AS \"c3\", \"a\" #>> '{b, 1}' AS \"c4\", \"a\" - 'b' AS \"c5\", \"a\" @> '{b, 1}' AS \"c6\", \"a\" <@ '{b, 1}'::\"pg_catalog\".\"jsonb\" AS \"c7\", \"a\" ? 'b' AS \"c8\" FROM \"materialize\".\"public\".\"json_table\""

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER \"default\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" IN CLUSTER \"default_cluster\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA BROKER 'kafka:9092' TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://schema-registry:8081/' WITH SNAPSHOT"
 
 $ kafka-verify format=avro sink=materialize.public.upgrade_kafka_sink sort-messages=true
 {"before": null, "after": {"row": {"f1": 1}}}

--- a/test/upgrade/check-from-current_source-regexp.td
+++ b/test/upgrade/check-from-current_source-regexp.td
@@ -8,4 +8,4 @@
 # by the Apache License, Version 2.0.
 
 > SHOW CREATE MATERIALIZED VIEW regexp_view;
-"materialize.public.regexp_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"regexp_view\" IN CLUSTER \"default\" AS SELECT \"a\" !~~ 'b' AS \"c1\", \"a\" ~~* 'b' AS \"c2\", \"a\" ~ 'b' AS \"c3\", \"a\" ~* 'b' AS \"c4\", \"a\" !~ 'b' AS \"c5\", \"a\" !~* 'b' AS \"c6\" FROM \"materialize\".\"public\".\"regexp_table\""
+"materialize.public.regexp_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"regexp_view\" IN CLUSTER \"default_cluster\" AS SELECT \"a\" !~~ 'b' AS \"c1\", \"a\" ~~* 'b' AS \"c2\", \"a\" ~ 'b' AS \"c3\", \"a\" ~* 'b' AS \"c4\", \"a\" !~ 'b' AS \"c5\", \"a\" !~* 'b' AS \"c6\" FROM \"materialize\".\"public\".\"regexp_table\""

--- a/test/upgrade/check-from-current_source-special-functions.td
+++ b/test/upgrade/check-from-current_source-special-functions.td
@@ -14,4 +14,4 @@
 #
 
 > SHOW CREATE MATERIALIZED VIEW special_functions_view;
-"materialize.public.special_functions_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"special_functions_view\" IN CLUSTER \"default\" AS SELECT * FROM \"materialize\".\"public\".\"special_functions\" WHERE \"mz_catalog\".\"mz_logical_timestamp\"() > \"f1\""
+"materialize.public.special_functions_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"special_functions_view\" IN CLUSTER \"default_cluster\" AS SELECT * FROM \"materialize\".\"public\".\"special_functions\" WHERE \"mz_catalog\".\"mz_logical_timestamp\"() > \"f1\""

--- a/test/upgrade/check-from-current_source-subquery.td
+++ b/test/upgrade/check-from-current_source-subquery.td
@@ -11,4 +11,4 @@
 # CREATE a view containing subqueries/derived tables of various types
 
 > SHOW CREATE MATERIALIZED VIEW subquery_view;
-"materialize.public.subquery_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"subquery_view\" IN CLUSTER \"default\" AS SELECT (SELECT 1) FROM (SELECT 2) AS \"derived\" WHERE 2 NOT IN (SELECT 3) AND NOT EXISTS (SELECT 4) AND 5 >= ALL (SELECT 6) AND 7 <ANY (SELECT 8)"
+"materialize.public.subquery_view" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"subquery_view\" IN CLUSTER \"default_cluster\" AS SELECT (SELECT 1) FROM (SELECT 2) AS \"derived\" WHERE 2 NOT IN (SELECT 3) AND NOT EXISTS (SELECT 4) AND 5 >= ALL (SELECT 6) AND 7 <ANY (SELECT 8)"


### PR DESCRIPTION
This commit renames the default cluster name from "default" to
"default_cluster". This makes it consistent with the default cluster
replica name which is "default_replica".

### Motivation
This PR refactors existing code.

### Tips for reviewer
- I don't think it's possible to create a proper migration for this. We'd have to rename the existing cluster names, which I don't think is possible with our current migration framework. Let me know your thoughts.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
