### PR TITLE
coord: Remove compute instances from timelines

### DIFF
--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -469,6 +469,25 @@ impl<S: Append + 'static> Coordinator<S> {
         empty_timelines
     }
 
+    pub(crate) fn remove_compute_instance_from_timeline(
+        &mut self,
+        compute_instance: ComputeInstanceId,
+    ) -> Vec<Timeline> {
+        let mut empty_timelines = Vec::new();
+        for (timeline, TimelineState { read_holds, .. }) in &mut self.global_timelines {
+            read_holds.id_bundle.compute_ids.remove(&compute_instance);
+            if read_holds.id_bundle.is_empty() {
+                empty_timelines.push(timeline.clone());
+            }
+        }
+
+        for timeline in &empty_timelines {
+            self.global_timelines.remove(timeline);
+        }
+
+        empty_timelines
+    }
+
     pub(crate) fn ids_in_timeline(&self, timeline: &Timeline) -> CollectionIdBundle {
         let mut id_bundle = CollectionIdBundle::default();
         for entry in self.catalog.entries() {

--- a/test/sqllogictest/github-13857.slt
+++ b/test/sqllogictest/github-13857.slt
@@ -1,0 +1,27 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/13857
+
+statement ok
+DROP CLUSTER default CASCADE
+
+statement ok
+CREATE CLUSTER test
+  REPLICAS (replica_a (SIZE '1'))
+
+statement ok
+SET CLUSTER = 'test'
+
+# Give read holds a chance to be updated
+statement ok
+SELECT mz_internal.mz_sleep(2)
+
+statement ok
+DROP CLUSTER test CASCADE


### PR DESCRIPTION
Introspection source indexes are not treated as normal indexes and are
special cased everywhere in the code. When we delete a cluster, we
never actually drop the introspection source indexes. They just
disappear and we manually update the necessary system tables.

When a cluster is deleted we were never removing the introspection
source indexes from the metadata about timeline read holds. Therefore,
the Coordinator would try and update read holds on non-existing indexes
in non-existing clusters and would panic.

This commit cleans up the read hold state when a cluster is dropped.

Fixes #13857

### Motivation

This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
