### PR TITLE
Ban `start_offset` for `ENVELOPE DEBEZIUM` (and CDCv2)

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -417,6 +417,20 @@ pub enum Envelope<T: AstInfo> {
     CdcV2,
 }
 
+impl<T: AstInfo> Envelope<T> {
+    /// `true` iff Materialize is expected to crash or exhibit UB
+    /// when attempting to ingest data starting at an offset other than zero.
+    pub fn requires_all_input(&self) -> bool {
+        match self {
+            Envelope::None => false,
+            Envelope::Debezium(DbzMode::Plain { .. }) => true,
+            Envelope::Debezium(DbzMode::Upsert) => false,
+            Envelope::Upsert => false,
+            Envelope::CdcV2 => true,
+        }
+    }
+}
+
 impl<T: AstInfo> AstDisplay for Envelope<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -139,16 +139,12 @@ a  b  json                     c            d             e                   f
 2  3  "{\"hello\":\"world\"}"  False        FileNotFound  "(43,,\"(44,-1)\")" (45,-2)
 -1  7 "[1,2,3]"                FileNotFound True          <null>              <null>
 
-> CREATE SOURCE fast_forwarded
+! CREATE SOURCE fast_forwarded
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   WITH (start_offset=2)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-
-> SELECT a, b, json, c, d FROM fast_forwarded
-a  b  json            c            d
----------------------------------------
--1  7 "[1,2,3]"       FileNotFound True
+contains:start_offset is not supported with ENVELOPE DEBEZIUM
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -88,17 +88,6 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}, "op": "u", "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
-
-# Test that `WITH (start_offset=<whatever>)` gives an error on SELECT if misconfigured
-> CREATE SOURCE start_offset_misconfigured
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
-  WITH (start_offset = 1)
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-  ENVELOPE DEBEZIUM
-
-! SELECT * FROM start_offset_misconfigured
-contains:Invalid data in source, saw retractions (1) for row that does not exist
-
 ! CREATE SOURCE doin_upsert
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'


### PR DESCRIPTION
### Motivation

It is impossible to make this safe in Platform. See discussion [here](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1658777958059299)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove highly unsafe `start_offset` option for some envelopes (`ENVELOPE MATERIALIZE` and non-upsert `ENVELOPE DEBEZIUM`)
