### PR TITLE
coord: Keep log index metadata consistent

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -413,6 +413,56 @@ impl CatalogState {
         self.entry_by_id.insert(entry.id, entry.clone());
     }
 
+    fn drop_item(&mut self, id: GlobalId) {
+        let metadata = self.entry_by_id.remove(&id).unwrap();
+        if !metadata.item.is_placeholder() {
+            info!(
+                "drop {} {} ({})",
+                metadata.item_type(),
+                self.resolve_full_name(&metadata.name, metadata.conn_id()),
+                id
+            );
+        }
+        for u in metadata.uses() {
+            if let Some(dep_metadata) = self.entry_by_id.get_mut(&u) {
+                dep_metadata.used_by.retain(|u| *u != metadata.id)
+            }
+        }
+
+        let conn_id = metadata.item.conn_id().unwrap_or(SYSTEM_CONN_ID);
+        let schema = self.get_schema_mut(
+            &metadata.name().qualifiers.database_spec,
+            &metadata.name().qualifiers.schema_spec,
+            conn_id,
+        );
+        schema
+            .items
+            .remove(&metadata.name().item)
+            .expect("catalog out of sync");
+
+        if let CatalogItem::Index(Index {
+            compute_instance, ..
+        })
+        | CatalogItem::Sink(Sink {
+            compute_instance, ..
+        })
+        | CatalogItem::MaterializedView(MaterializedView {
+            compute_instance, ..
+        }) = metadata.item
+        {
+            if !id.is_system() {
+                assert!(
+                    self.compute_instances_by_id
+                        .get_mut(&compute_instance)
+                        .unwrap()
+                        .exports
+                        .remove(&id),
+                    "catalog out of sync"
+                );
+            }
+        };
+    }
+
     fn get_database(&self, database_id: &DatabaseId) -> &Database {
         &self.database_by_id[database_id]
     }
@@ -3236,10 +3286,7 @@ impl<S: Append> Catalog<S> {
                     introspection_source_index_ids,
                 } => {
                     for id in introspection_source_index_ids {
-                        state
-                            .entry_by_id
-                            .remove(&id)
-                            .expect("introspection source index does not exist");
+                        state.drop_item(id);
                     }
 
                     let id = state
@@ -3269,53 +3316,7 @@ impl<S: Append> Catalog<S> {
                 }
 
                 Action::DropItem(id) => {
-                    let metadata = state.entry_by_id.remove(&id).unwrap();
-                    if !metadata.item.is_placeholder() {
-                        info!(
-                            "drop {} {} ({})",
-                            metadata.item_type(),
-                            state.resolve_full_name(&metadata.name, metadata.conn_id()),
-                            id
-                        );
-                    }
-                    for u in metadata.uses() {
-                        if let Some(dep_metadata) = state.entry_by_id.get_mut(&u) {
-                            dep_metadata.used_by.retain(|u| *u != metadata.id)
-                        }
-                    }
-
-                    let conn_id = metadata.item.conn_id().unwrap_or(SYSTEM_CONN_ID);
-                    let schema = state.get_schema_mut(
-                        &metadata.name().qualifiers.database_spec,
-                        &metadata.name().qualifiers.schema_spec,
-                        conn_id,
-                    );
-                    schema
-                        .items
-                        .remove(&metadata.name().item)
-                        .expect("catalog out of sync");
-
-                    if let CatalogItem::Index(Index {
-                        compute_instance, ..
-                    })
-                    | CatalogItem::Sink(Sink {
-                        compute_instance, ..
-                    })
-                    | CatalogItem::MaterializedView(MaterializedView {
-                        compute_instance,
-                        ..
-                    }) = metadata.item
-                    {
-                        assert!(
-                            state
-                                .compute_instances_by_id
-                                .get_mut(&compute_instance)
-                                .unwrap()
-                                .exports
-                                .remove(&id),
-                            "catalog out of sync"
-                        );
-                    };
+                    state.drop_item(id);
                 }
 
                 Action::UpdateItem {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -122,7 +122,7 @@ impl<S: Append + 'static> Coordinator<S> {
             }
         }
 
-        let mut timelines_to_drop = self.remove_storage_ids_from_timeline(
+        timelines_to_drop = self.remove_storage_ids_from_timeline(
             sources_to_drop
                 .iter()
                 .chain(tables_to_drop.iter())


### PR DESCRIPTION
Previously, when a cluster was deleted we would also delete all of the
log indexes (A.K.A. introspection source indexes) contained in the
cluster from the catalog. However, when we deleted the introspection
source indexes from the catalog, we weren't removing it completely.
For example, it was never removed from the Schema objects.

This commit updates the logic of removing introspection source indexes
so that it's identical to removing any other item from the catalog.

Might fix #12760

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR fixes a recognized bug.


### Tips for reviewer
- The code under `op::DropItem` was moved to the method `CatalogState::drop_item`. The only difference is that we check that the ID is not a system ID before removing the ID from the compute instance exports. Introspection source indexes are not stored in the compute instance exports.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
