### PR TITLE
sql: mark LOAD GENERATOR as safe

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -620,7 +620,6 @@ pub fn plan_create_source(
             )
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
-            scx.require_unsafe_mode("LOAD GENERATOR")?;
             let load_generator = match generator {
                 LoadGenerator::Auction => mz_storage::types::sources::LoadGenerator::Auction,
                 LoadGenerator::Counter => mz_storage::types::sources::LoadGenerator::Counter,


### PR DESCRIPTION
Syntax seems to be stable enough!

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a