### PR TITLE
adapter,environmentd: push validation logic as deep as possible

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -71,7 +71,7 @@ use crate::catalog::builtin::{
 };
 use crate::catalog::storage::BootstrapArgs;
 use crate::session::{PreparedStatement, Session, DEFAULT_DATABASE_NAME};
-use crate::AdapterError;
+use crate::{AdapterError, DUMMY_AVAILABILITY_ZONE};
 
 mod builtin_table_updates;
 mod config;
@@ -2077,7 +2077,7 @@ impl<S: Append> Catalog<S> {
             stash,
             &BootstrapArgs {
                 default_cluster_replica_size: "1".into(),
-                default_availability_zone: "".into(),
+                default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
             },
         )
         .await?;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -748,7 +748,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         // Choose the least popular AZ among all replicas of this cluster as the default
                         // if none was specified. If there is a tie for "least popular", pick the first one.
                         // That is globally unbiased (for Materialize, not necessarily for this customer)
-                        // because we shuffle the AZs on boot.
+                        // because we shuffle the AZs on boot in `crate::serve`.
                         let instance = self.catalog.resolve_compute_instance(&of_cluster)?;
                         let azs = self.catalog.state().availability_zones();
                         let mut n_replicas_per_az = azs

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -47,5 +47,5 @@ pub mod session;
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{Canceled, ExecuteResponse, RowsFuture, StartupMessage, StartupResponse};
 pub use crate::coord::peek::PeekResponseUnary;
-pub use crate::coord::{serve, Config};
+pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};
 pub use crate::error::AdapterError;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -632,20 +632,6 @@ max log level: {max_log_level}",
         None => Default::default(),
         Some(json) => serde_json::from_str(&json).context("parsing replica size map")?,
     };
-    if !cluster_replica_sizes
-        .0
-        .contains_key(&args.bootstrap_default_cluster_replica_size)
-    {
-        bail!("--bootstrap-default-cluster-replica-size must name a size in the cluster replica size map");
-    }
-
-    if !args.availability_zone.iter().all_unique() {
-        bail!("--availability-zone values must be unique");
-    }
-
-    // Make later logic for choosing AZs unbiased
-    use rand::seq::SliceRandom;
-    args.availability_zone.shuffle(&mut rand::thread_rng());
 
     let server = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         sql_listen_addr: args.sql_listen_addr,


### PR DESCRIPTION
@umanwizard just some minor restructuring of where the AZ/replica size validation lives!

----

Push the validation logic for the various cluster replica parameters as
deep as possible. The coordinator has the constraints on the valid
availability zones, for example, so it should be responsible for their
validation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
