### PR TITLE
limits test: Tone down ViewsMaterializedNested to match reality

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -564,6 +564,10 @@ class ViewsNested(Generator):
 
 
 class ViewsMaterializedNested(Generator):
+    COUNT = min(
+        Generator.COUNT, 25
+    )  # https://github.com/MaterializeInc/materialize/issues/13840
+
     @classmethod
     def body(cls) -> None:
         print("> CREATE TABLE t (f1 INTEGER);")


### PR DESCRIPTION
Due to #13840 it is not possible to have extended chains of
materialized views.

### Motivation
  * This PR fixes a previously unreported bug.
Nightly limits test started failing after the meaning of `MATERIALIZED` had changed.