### PR TITLE
zippy: Add sinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ coverage
 test/feature-benchmark/tmp/*.td
 test/zippy/tmp/*.td
 junit_*.xml
+perf.data*

--- a/misc/python/materialize/zippy/kafka_capabilities.py
+++ b/misc/python/materialize/zippy/kafka_capabilities.py
@@ -37,3 +37,6 @@ class TopicExists(Capability):
         self.partitions = partitions
         self.envelope = envelope
         self.watermarks = Watermarks()
+
+    def get_watermarks(self) -> Watermarks:
+        return self.watermarks

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -12,6 +12,7 @@ from typing import Dict, Type
 from materialize.zippy.framework import Action, Scenario
 from materialize.zippy.kafka_actions import CreateTopic, Ingest, KafkaStart
 from materialize.zippy.mz_actions import KillComputed, KillStoraged, MzStart, MzStop
+from materialize.zippy.sink_actions import CreateSink
 from materialize.zippy.source_actions import CreateSource
 from materialize.zippy.table_actions import DML, CreateTable, ValidateTable
 from materialize.zippy.view_actions import CreateView, ValidateView
@@ -30,8 +31,9 @@ class KafkaSources(Scenario):
             CreateTopic: 5,
             CreateSource: 5,
             CreateView: 5,
+            CreateSink: 5,
             ValidateView: 10,
-            Ingest: 90,
+            Ingest: 50,
         }
 
 

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -1,0 +1,83 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from textwrap import dedent
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.sink_capabilities import SinkExists
+from materialize.zippy.view_capabilities import ViewExists
+
+
+class CreateSink(Action):
+    """Creates a view that is a join over one or more sources or tables"""
+
+    @classmethod
+    def requires(self) -> List[Set[Type[Capability]]]:
+        return [{MzIsRunning, ViewExists}]
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        sink_name = "sink" + str(random.randint(1, 10))
+
+        this_sink = SinkExists(name=sink_name)
+        self.sink = this_sink
+        existing_sinks = [
+            s for s in capabilities.get(SinkExists) if s.name == this_sink.name
+        ]
+
+        if len(existing_sinks) == 0:
+            self.new_sink = True
+            self.source_view = random.choice(capabilities.get(ViewExists))
+            self.dest_view = ViewExists(
+                name=f"{sink_name}_view", froms=[self.source_view]
+            )
+        elif len(existing_sinks) == 1:
+            self.new_sink = False
+            self.sink = existing_sinks[0]
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if not self.new_sink:
+            return
+
+        c.testdrive(
+            dedent(
+                f"""
+                > CREATE SINK {self.sink.name} FROM {self.source_view.name}
+                  INTO KAFKA BROKER '${{testdrive.kafka-addr}}'
+                  TOPIC 'sink-{self.sink.name}' WITH (reuse_topic=true)
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
+
+                # Ingest the sink again in order to be able to validate its contents
+
+                > CREATE SOURCE {self.sink.name}_source
+                  FROM KAFKA BROKER '${{testdrive.kafka-addr}}'
+                  TOPIC 'sink-{self.sink.name}'
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}'
+                  ENVELOPE NONE
+
+                # The sink-dervied source has upsert semantics, so produce a "normal" ViewExists output
+                # from the 'before' and the 'after'
+
+                > CREATE MATERIALIZED VIEW {self.dest_view.name} AS
+                  SELECT SUM(min)::int AS min, SUM(max)::int AS max, SUM(c1)::int AS c1, SUM(c2)::int AS c2 FROM (
+                    SELECT (after).min, (after).max, (after).c1, (after).c2 FROM {self.sink.name}_source
+                    UNION ALL
+                    SELECT - (before).min, - (before).max, -(before).c1, -(before).c2 FROM {self.sink.name}_source
+                  );
+            """
+            )
+        )
+
+    def provides(self) -> List[Capability]:
+        return [self.sink, self.dest_view] if self.new_sink else []

--- a/misc/python/materialize/zippy/sink_capabilities.py
+++ b/misc/python/materialize/zippy/sink_capabilities.py
@@ -1,0 +1,22 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.view_capabilities import ViewExists
+
+
+class SinkExists(Capability):
+    """A sink exists in Materialize."""
+
+    name: str
+    source_view: ViewExists
+    dest_view: ViewExists
+
+    def __init__(self, name: str) -> None:
+        self.name = name

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -91,17 +91,14 @@ class ValidateView(Action):
         self.view = random.choice(capabilities.get(ViewExists))
 
     def run(self, c: Composition) -> None:
-        # Calculate the intersection of the mins/maxs of the inputs
-        # The result from the view should match the calculation.
-
-        froms: WatermarkedObjects = self.view.froms
-        view_min = max([f.get_watermarks().min for f in froms])
-        view_max = min([f.get_watermarks().max for f in froms])
+        watermarks = self.view.get_watermarks()
+        view_min = watermarks.min
+        view_max = watermarks.max
 
         if view_min <= view_max:
             c.testdrive(
                 f"""
-> SELECT * FROM {self.view.name};
+> SELECT * FROM {self.view.name} /* {view_min} {view_max} {(view_max-view_min)+1} {(view_max-view_min)+1} */ ;
 {view_min} {view_max} {(view_max-view_min)+1} {(view_max-view_min)+1}
 """
             )

--- a/misc/python/materialize/zippy/watermarks.py
+++ b/misc/python/materialize/zippy/watermarks.py
@@ -11,9 +11,9 @@
 class Watermarks:
     """Holds the minimum and the maximum value expected to be present in a topic, source, table or view"""
 
-    def __init__(self) -> None:
-        self.min = 0
-        self.max = 0
+    def __init__(self, min_watermark: int = 0, max_watermark: int = 0) -> None:
+        self.min = min_watermark
+        self.max = max_watermark
 
     def shift(self, delta: int) -> None:
         self.min = self.min + delta

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -24,14 +24,13 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    # --persistent-kafka-sources can not be enabled due to gh#11711 , gh#11506
     Materialized(),
     Testdrive(
         validate_data_dir=False,
         no_reset=True,
         seed=1,
         default_timeout="600s",
-        materialize_params={"statement_timeout": "'600s'"},
+        materialize_params={"statement_timeout": "'900s'"},
     ),
 ]
 


### PR DESCRIPTION
Create sinks based on views and then re-ingest the output of those
sinks in a way that allows it to be validated by the standard
ValidateView action.

### Motivation

  * This PR adds a feature that has not yet been specified.

Zippy was missing sinks so any crash and recovery testing from that framework would have given incomplete coverage.