### PR TITLE
storage: introduce default pod limits for storaged pods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4082,6 +4082,7 @@ dependencies = [
  "aws-types",
  "bincode",
  "bytes",
+ "bytesize",
  "chrono",
  "crossbeam-channel",
  "csv-core",

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -234,7 +234,7 @@ pub struct CpuLimit {
 
 impl CpuLimit {
     /// Constructs a new CPU limit from a number of millicpus.
-    pub fn from_millicpus(&self, millicpus: usize) -> CpuLimit {
+    pub fn from_millicpus(millicpus: usize) -> CpuLimit {
         CpuLimit { millicpus }
     }
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -19,6 +19,7 @@ aws-smithy-http = "0.46.0"
 aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
 bincode = { version = "1.3.3" }
 bytes = "1.2.0"
+bytesize = "1.1.0"
 chrono = { version = "0.4.0", default-features = false, features = ["std"] }
 crossbeam-channel = { version = "0.5.6" }
 csv-core = { version = "0.1.10" }

--- a/src/storage/src/controller/hosts.rs
+++ b/src/storage/src/controller/hosts.rs
@@ -24,12 +24,13 @@ use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use bytesize::ByteSize;
 use differential_dataflow::lattice::Lattice;
 use timely::progress::Timestamp;
 use tracing::info;
 
 use mz_build_info::BuildInfo;
-use mz_orchestrator::{NamespacedOrchestrator, ServiceConfig, ServicePort};
+use mz_orchestrator::{CpuLimit, MemoryLimit, NamespacedOrchestrator, ServiceConfig, ServicePort};
 use mz_ore::collections::CollectionExt;
 use mz_proto::RustType;
 use mz_repr::GlobalId;
@@ -234,9 +235,10 @@ impl<T> StorageHosts<T> {
                             port_hint: 6878,
                         },
                     ],
-                    // TODO: limits?
-                    cpu_limit: None,
-                    memory_limit: None,
+                    // TODO(andrioni): placeholder CPU and memory limits while we work on #13125
+                    // Values coming from the xsmall replica size
+                    cpu_limit: Some(CpuLimit::from_millicpus(2000)),
+                    memory_limit: Some(MemoryLimit(ByteSize::gib(16))),
                     scale: NonZeroUsize::new(1).unwrap(),
                     labels: HashMap::new(),
                     availability_zone: None,


### PR DESCRIPTION
This default limit is to ensure that storaged pods do not cause trouble with the rest of the k8s pod, and meant to be temporary while we work on #13125 to introduce user-configurable limits.

### Motivation

  * This PR fixes a recognized bug: #13853

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
