### PR TITLE
sqllogictest: CREATE INDEX on CREATE TABLE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3972,6 +3972,7 @@ dependencies = [
  "mz-repr",
  "mz-secrets",
  "mz-sql",
+ "mz-sql-parser",
  "mz-storage",
  "once_cell",
  "postgres-protocol",

--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -26,6 +26,10 @@ sqllogictest \
     -v "$@" \
     test/sqllogictest/*.slt \
     test/sqllogictest/explain/*.slt \
-    test/sqllogictest/sqlite/test \
     test/sqllogictest/transform/*.slt \
+    | tee -a target/slt.log
+
+sqllogictest --auto-index-tables \
+    -v "$@" \
+    test/sqllogictest/sqlite/test \
     | tee -a target/slt.log

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -26,6 +26,7 @@ mz-pgrepr = { path = "../pgrepr" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
 mz-sql = { path = "../sql" }
+mz-sql-parser = { path = "../sql-parser" }
 mz-storage = { path = "../storage" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
 regex = "1.6.0"

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -54,6 +54,9 @@ struct Args {
     /// Stop on first failure.
     #[clap(long)]
     fail_fast: bool,
+    /// Inject `CREATE INDEX` after all `CREATE TABLE` statements.
+    #[clap(long)]
+    auto_index_tables: bool,
 }
 
 #[tokio::main]
@@ -70,6 +73,7 @@ async fn main() {
         postgres_url: args.postgres_url.clone(),
         no_fail: args.no_fail,
         fail_fast: args.fail_fast,
+        auto_index_tables: args.auto_index_tables,
     };
 
     if args.rewrite_results {


### PR DESCRIPTION
Add a crate that can produce SQL mutations based on some input. Because
it only has a single use at the moment, don't bother with a struct or
configuration yet. Currently it does a single mutation: for each CREATE
TABLE, add a CREATE DEFAULT INDEX on it.

Teach sqllogictest to run this after successful `statement` directives.

On my machine in release mode, the time of running
`sqlite/test/index/orderby/10/slt_good_3.test` went from 3.5 minutes to
36 seconds.

### Motivation

  * This PR fixes a recognized bug. #13786

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
