### PR TITLE
explain: print out fast path in explain

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2257,6 +2257,7 @@ impl<S: Append + 'static> Coordinator<S> {
             row_set_finishing,
             stage,
             options,
+            view_id
         } = plan;
 
         struct Timings {
@@ -2290,12 +2291,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 let mut dataflow = DataflowDesc::new(format!("explanation"));
                 coord
                     .dataflow_builder(compute_instance)
-                    .import_view_into_dataflow(
-                        // TODO: If explaining a view, pipe the actual id of the view.
-                        &GlobalId::Explain,
-                        &optimized_plan,
-                        &mut dataflow,
-                    )?;
+                    .import_view_into_dataflow(&view_id, &optimized_plan, &mut dataflow)?;
                 mz_transform::optimize_dataflow(
                     &mut dataflow,
                     &coord.index_oracle(compute_instance),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1945,7 +1945,7 @@ impl<S: Append + 'static> Coordinator<S> {
         if when == QueryWhen::Immediately
             && (!matches!(
                 fast_path,
-                peek::Plan::FastPath(peek::FastPathPlan::Constant(_))
+                peek::Plan::FastPath(peek::FastPathPlan::Constant(_, _))
             ) || !timestamp_independent)
         {
             session.add_transaction_ops(TransactionOps::Peeks(timestamp))?;
@@ -2367,12 +2367,13 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 let mut explanation = explanation.to_string();
                 if view_id == GlobalId::Explain {
-                    let fast_path_plan = peek::create_plan(&mut dataflow, view_id).expect("Fast path planning failed; unrecoverable error");
+                    let fast_path_plan = peek::create_plan(&mut dataflow, view_id)
+                        .expect("Fast path planning failed; unrecoverable error");
                     if let peek::Plan::FastPath(fast_path_plan) = fast_path_plan {
-                        explanation = fast_path_plan.explain_old(&catalog);
+                        explanation = fast_path_plan.explain_old(&catalog, options.typed);
                     }
                 }
-                explanation.to_string()
+                explanation
             }
             ExplainStageOld::PhysicalPlan => {
                 let decorrelated_plan = decorrelate(&mut timings, raw_plan)?;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2101,6 +2101,7 @@ impl<S: Append + 'static> Coordinator<S> {
             stage,
             format,
             config,
+            explainee
         } = plan;
 
         let decorrelate = |raw_plan: HirRelationExpr| -> Result<MirRelationExpr, AdapterError> {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2208,7 +2208,6 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                     _ => None,
                 };
-                println!("fast_path_plan {:?}", fast_path_plan);
                 let context = ExplainContext {
                     config: &config,
                     humanizer: &catalog,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2207,6 +2207,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                     _ => None,
                 };
+                println!("fast_path_plan {:?}", fast_path_plan);
                 let context = ExplainContext {
                     config: &config,
                     humanizer: &catalog,

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -15,7 +15,7 @@ use mz_expr::explain::Indices;
 use mz_expr::virtual_syntax::{AlgExcept, Except};
 use mz_expr::Id;
 use mz_ore::str::{separated, IndentLike};
-use mz_repr::explain_new::{separated_text, DisplayText};
+use mz_repr::explain_new::{fmt_text_constant_rows, separated_text, DisplayText};
 use mz_sql::plan::{AggregateExpr, Hir, HirRelationExpr, HirScalarExpr, JoinKind, WindowExprType};
 
 use crate::explain_new::{Displayable, PlanRenderingContext};
@@ -40,18 +40,12 @@ impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
                 Displayable::from(lhs).fmt_text(f, ctx)?;
                 Displayable::from(rhs).fmt_text(f, ctx)?;
                 Ok(())
-            })?;
+            })?
         } else {
             match &self.0 {
                 // Lets are annotated on the chain ID that they correspond to.
                 Constant { rows, .. } => {
-                    writeln!(f, "{}Constant", ctx.indent)?;
-                    ctx.indented(|ctx| {
-                        for row in rows {
-                            writeln!(f, "{}- {}", ctx.indent, row)?;
-                        }
-                        Ok(())
-                    })?;
+                    fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.inner.indent)?;
                 }
                 Let {
                     name: _,

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -45,7 +45,7 @@ impl<'a> DisplayText<PlanRenderingContext<'_, HirRelationExpr>>
             match &self.0 {
                 // Lets are annotated on the chain ID that they correspond to.
                 Constant { rows, .. } => {
-                    fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.inner.indent)?;
+                    fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.indent)?;
                 }
                 Let {
                     name: _,

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -19,7 +19,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use mz_expr::{OptimizedMirRelationExpr, RowSetFinishing};
+use mz_expr::RowSetFinishing;
 use mz_ore::str::{Indent, IndentLike};
 use mz_repr::explain_new::{DisplayText, ExplainConfig, ExprHumanizer};
 use mz_repr::GlobalId;
@@ -67,7 +67,7 @@ pub(crate) struct ExplainContext<'a> {
     pub(crate) humanizer: &'a dyn ExprHumanizer,
     pub(crate) used_indexes: UsedIndexes,
     pub(crate) finishing: Option<RowSetFinishing>,
-    pub(crate) fast_path_plan: Option<peek::Plan<OptimizedMirRelationExpr>>,
+    pub(crate) fast_path_plan: Option<peek::FastPathPlan>,
 }
 
 #[derive(Clone)]

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -32,9 +32,9 @@
 
 use std::{collections::HashSet, fmt};
 
-use mz_ore::{stack::RecursionLimitError, str::Indent};
+use mz_ore::{stack::RecursionLimitError, str::Indent, str::IndentLike};
 
-use crate::{ColumnType, GlobalId, ScalarType};
+use crate::{ColumnType, GlobalId, Row, ScalarType};
 
 /// Wraps a reference to a type that implements `Display$Format` for a specific
 /// [`ExplainFormat`] and implements [`fmt::Display`] by delegating to this
@@ -388,7 +388,6 @@ pub enum Explainee {
     Query,
 }
 
-
 /// A trait that provides a unified interface for objects that
 /// can be explained.
 ///
@@ -561,6 +560,56 @@ impl ExprHumanizer for DummyHumanizer {
         // The debug implementation is better than nothing.
         format!("{:?}", ty)
     }
+}
+
+fn write_first_rows(
+    f: &mut fmt::Formatter<'_>,
+    first_rows: &Vec<(&Row, &crate::Diff)>,
+    ctx: &mut Indent,
+) -> fmt::Result {
+    ctx.indented(move |ctx| {
+        for (row, diff) in first_rows {
+            if **diff == 1 {
+                writeln!(f, "{}- {}", ctx, row)?;
+            } else {
+                writeln!(f, "{}- ({} x {})", ctx, row, diff)?;
+            }
+        }
+        Ok(())
+    })?;
+    Ok(())
+}
+
+pub fn fmt_text_constant_rows<'a, I>(
+    f: &mut fmt::Formatter<'_>,
+    mut rows: I,
+    ctx: &mut Indent,
+) -> fmt::Result
+where
+    I: Iterator<Item = (&'a Row, &'a crate::Diff)>,
+{
+    writeln!(f, "{}Constant", ctx)?;
+    let mut row_count = 0;
+    let mut first_rows = Vec::with_capacity(20);
+    for _ in 0..20 {
+        if let Some((row, diff)) = rows.next() {
+            row_count += diff;
+            first_rows.push((row, diff));
+        }
+    }
+    let rest_of_row_count = rows.into_iter().map(|(_, diff)| diff).sum::<crate::Diff>();
+    if rest_of_row_count != 0 {
+        ctx.indented(move |ctx| {
+            writeln!(f, "{}total_rows: {}", ctx, row_count + rest_of_row_count)?;
+            writeln!(f, "{}first_rows:", ctx)?;
+            write_first_rows(f, &first_rows, ctx)?;
+            Ok(())
+        })?;
+    } else {
+        write_first_rows(f, &first_rows, ctx)?;
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -519,6 +519,12 @@ impl<'a> AsMut<Indent> for RenderingContext<'a> {
     }
 }
 
+impl<'a> AsRef<&'a dyn ExprHumanizer> for RenderingContext<'a> {
+    fn as_ref(&self) -> &&'a dyn ExprHumanizer {
+        &self.humanizer
+    }
+}
+
 /// A trait for humanizing components of an expression.
 ///
 /// This will be most often used as part of the rendering context

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -378,6 +378,17 @@ impl TryFrom<HashSet<String>> for ExplainConfig {
     }
 }
 
+/// The type of object to be explained
+#[derive(Debug)]
+pub enum Explainee {
+    /// An object that will be served using a dataflow
+    Dataflow(GlobalId),
+    /// The object to be explained is a one-off query and may or may not served
+    /// using a dataflow.
+    Query,
+}
+
+
 /// A trait that provides a unified interface for objects that
 /// can be explained.
 ///

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -406,6 +406,7 @@ pub struct ExplainPlanOld {
     pub row_set_finishing: Option<RowSetFinishing>,
     pub stage: ExplainStageOld,
     pub options: ExplainOptions,
+    pub view_id: GlobalId,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -398,6 +398,7 @@ pub struct ExplainPlanNew {
     pub stage: ExplainStageNew,
     pub format: ExplainFormat,
     pub config: ExplainConfig,
+    pub explainee: mz_repr::explain_new::Explainee,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -356,7 +356,7 @@ pub fn plan_explain_old(
         row_set_finishing: finishing,
         stage,
         options,
-        view_id
+        view_id,
     })))
 }
 
@@ -371,7 +371,7 @@ pub fn plan_explain_new(
     params: &Params,
 ) -> Result<Plan, PlanError> {
     let is_view = matches!(explainee, Explainee::View(_));
-    let query = match explainee {
+    let (explainee, query) = match explainee {
         Explainee::View(name) => {
             let view = scx.get_item_by_resolved_name(&name)?;
             let item_type = view.item_type();
@@ -397,7 +397,10 @@ pub fn plan_explain_new(
                 _ => panic!("Sql for existing view should parse as a view"),
             };
             let qcx = QueryContext::root(&scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
-            names::resolve(qcx.scx.catalog, query)?.0
+            (
+                mz_repr::explain_new::Explainee::Dataflow(view.id()),
+                names::resolve(qcx.scx.catalog, query)?.0,
+            )
         }
         Explainee::MaterializedView(name) => {
             let mview = scx.get_item_by_resolved_name(&name)?;
@@ -421,9 +424,12 @@ pub fn plan_explain_new(
                 }
             };
             let qcx = QueryContext::root(&scx, QueryLifetime::OneShot(scx.pcx().unwrap()));
-            names::resolve(qcx.scx.catalog, query)?.0
+            (
+                mz_repr::explain_new::Explainee::Dataflow(mview.id()),
+                names::resolve(qcx.scx.catalog, query)?.0,
+            )
         }
-        Explainee::Query(query) => query,
+        Explainee::Query(query) => (mz_repr::explain_new::Explainee::Query, query),
     };
     // Previously we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
     // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
@@ -461,6 +467,7 @@ pub fn plan_explain_new(
         stage,
         format,
         config,
+        explainee,
     })))
 }
 

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -20,7 +20,6 @@ use mz_compute_client::command::DataflowDesc;
 use mz_expr::visit::Visit;
 use mz_expr::{CollectionPlan, Id, LocalId, MirRelationExpr};
 use mz_ore::id_gen::IdGen;
-use mz_repr::GlobalId;
 use mz_storage::types::transforms::LinearOperator;
 
 use crate::{monotonic::MonotonicFlag, IndexOracle, Optimizer, TransformError};

--- a/test/sqllogictest/explain.slt
+++ b/test/sqllogictest/explain.slt
@@ -294,7 +294,7 @@ EXPLAIN TYPED OPTIMIZED PLAN FOR VIEW ordered_view
 Source materialize.public.ordered (u2):
 | Project (#0, #1)
 
-Query:
+View materialize.public.ordered_view (u3):
 %0 =
 | Get materialize.public.ordered (u2)
 | | types = (integer?, text?)
@@ -388,7 +388,7 @@ Source materialize.public.ordered (u2):
   ]
 }
 
-Query:
+View materialize.public.ordered_view (u3):
 {
   "TopK": {
     "input": {
@@ -442,7 +442,7 @@ Source materialize.public.ordered (u2):
   ]
 }
 
-Query:
+View materialize.public.ordered_view (u3):
 {
   "TopK": {
     "input": {

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -2599,7 +2599,7 @@ query T multiline
 EXPLAIN SELECT LIST[f1, f2, f3, f4, f5][3] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Project (#2)
 
 EOF
@@ -2616,7 +2616,7 @@ query T multiline
 EXPLAIN SELECT LIST[[f1, f2], [f3, f4]][2][1] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Project (#2)
 
 EOF
@@ -2631,7 +2631,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [2][1][2] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Project (#5)
 
 EOF
@@ -2648,7 +2648,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f7, f8, f3, f4]], [[f5, f6], [f7, f8]]] [n][m][n] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(list_create(list_create(#0, #1), list_create(#6, #7, #2, #3)), list_create(list_create(#4, #5), list_create(#6, #7))), integer_to_bigint(#8), integer_to_bigint(#9), integer_to_bigint(#8))
 | Project (#11)
 
@@ -2664,7 +2664,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [n][m][1] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(list_create(#0, #2), list_create(#4, #6)), integer_to_bigint(#8), integer_to_bigint(#9))
 | Project (#11)
 
@@ -2680,7 +2680,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [n][2][m] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(list_create(#2, #3), list_create(#6, #7)), integer_to_bigint(#8), integer_to_bigint(#9))
 | Project (#11)
 
@@ -2696,7 +2696,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [1][n][m] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(list_create(#0, #1), list_create(#2, #3)), integer_to_bigint(#8), integer_to_bigint(#9))
 | Project (#11)
 
@@ -2712,7 +2712,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [2][1][n] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(#4, #5), integer_to_bigint(#8))
 | Project (#11)
 
@@ -2728,7 +2728,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [2][n][2] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(#5, #7), integer_to_bigint(#8))
 | Project (#11)
 
@@ -2744,7 +2744,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [[f5, f6], [f7, f8]]] [n][2][2] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(list_create(#3, #7), integer_to_bigint(#8))
 | Project (#11)
 
@@ -2762,7 +2762,7 @@ query T multiline
 EXPLAIN SELECT LIST[f1, f2, f3, f4, f5][6] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map null
 | Project (#11)
 
@@ -2772,7 +2772,7 @@ query T multiline
 EXPLAIN SELECT LIST[f1, f2, f3, f4, f5][0] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map null
 | Project (#11)
 
@@ -2782,7 +2782,7 @@ query T multiline
 EXPLAIN SELECT LIST[f1, f2, f3, f4, f5][-1] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map null
 | Project (#11)
 
@@ -2801,7 +2801,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [l, [f7, f8]]] [1+1][-1][2] from m3;
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map null
 | Project (#11)
 
@@ -2814,7 +2814,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [NULL, [f7, f8]]] [1+1][1][2] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map null
 | Project (#11)
 
@@ -2827,7 +2827,7 @@ query T multiline
 EXPLAIN SELECT LIST[[[f1, f2], [f3, f4]], [l, [f7, f8]]] [1+1][1][2] from m3
 ----
 %0 =
-| Get materialize.public.m3 (u28)
+| ReadExistingIndex materialize.public.m3_primary_idx
 | Map list_index(#10, 2)
 | Project (#11)
 

--- a/test/sqllogictest/transform/dataflow.slt
+++ b/test/sqllogictest/transform/dataflow.slt
@@ -43,7 +43,7 @@ Source materialize.public.foo (u1):
 | Filter (#0 = 5), (#1 = 6)
 | Project (#0, #1)
 
-Query:
+View materialize.public.foo3 (u3):
 %0 =
 | Get materialize.public.foo (u1)
 | Filter (#0 = 5), (#1 = 6)

--- a/test/sqllogictest/transform/dataflow.slt
+++ b/test/sqllogictest/transform/dataflow.slt
@@ -72,12 +72,8 @@ query T multiline
 EXPLAIN PLAN FOR SELECT * from foo3
 ----
 %0 =
-| Get materialize.public.foo2 (u2)
-| ArrangeBy (#0)
-
-%1 =
-| Join %0
-| | implementation = IndexedFilter #0 = 6
+| ReadExistingIndex materialize.public.foo2_primary_idx
+| | Lookup value (6)
 | Filter (#0 = 6)
 
 EOF

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -37,7 +37,7 @@ EXPLAIN
 SELECT * FROM v1, (SELECT DISTINCT (v1.t1).f1 as f1 FROM v1) Y WHERE (v1.t1).f1 = y.f1;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Map record_get[0](#0)
 | Filter (#1) IS NOT NULL
 

--- a/test/sqllogictest/transform/topk.slt
+++ b/test/sqllogictest/transform/topk.slt
@@ -62,7 +62,7 @@ EXPLAIN PLAN FOR VIEW plan_test1
 Source materialize.public.test1 (u1):
 | Project (#0..=#3)
 
-Query:
+View materialize.public.plan_test1 (u2):
 %0 =
 | Get materialize.public.test1 (u1)
 | Reduce group=(((#0 + #1) + #2), ((#0 + #1) + #3))
@@ -129,7 +129,7 @@ explain view v1;
 Source materialize.public.t1 (u5):
 | Project (#0, #1)
 
-Query:
+View materialize.public.v1 (u6):
 %0 =
 | Get materialize.public.t1 (u5)
 | TopK group=() order=(#0 asc nulls_last) limit=3 offset=3

--- a/test/sqllogictest/uniqueness_propagation_filter.slt
+++ b/test/sqllogictest/uniqueness_propagation_filter.slt
@@ -29,7 +29,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f2 FROM v1 WHERE f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #2)
 | Project (#0, #1)
 
@@ -39,7 +39,7 @@ query T multiline
 EXPLAIN SELECT f1, f2 FROM v1 WHERE f1 = f3 GROUP BY f1, f2;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #2)
 | Project (#0, #1)
 
@@ -49,7 +49,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f3 FROM v1 WHERE f1 = f2;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #1)
 | Project (#0, #2)
 
@@ -59,7 +59,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #1)
 | Project (#1, #2)
 
@@ -69,7 +69,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1 FROM v1 WHERE f1 = f2 AND f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #1), (#0 = #2)
 | Project (#0)
 
@@ -79,7 +79,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f1, f3 FROM v1 WHERE f1 = f2 AND f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #1), (#0 = #2)
 | Project (#0, #2)
 
@@ -89,7 +89,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2 AND f1 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #1), (#0 = #2)
 | Project (#1, #2)
 
@@ -99,7 +99,7 @@ query T multiline
 EXPLAIN SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2 AND f2 = f3;
 ----
 %0 =
-| Get materialize.public.v1 (u2)
+| ReadExistingIndex materialize.public.v1_primary_idx
 | Filter (#0 = #1), (#1 = #2)
 | Project (#1, #2)
 

--- a/test/testdrive/explain-timers.td
+++ b/test/testdrive/explain-timers.td
@@ -16,25 +16,25 @@ $ set-regex match=(\s\(u\d+\)|materialize\.public\.|\s\d\d:\d\d:\d\d\.\d\d\d\d\d
 
 ? EXPLAIN (TIMING true) SELECT * FROM t1;
 %0 =
-| Get t1
+| ReadExistingIndex t1_primary_idx
 
 Decorrelation time:
 Optimization time:
 
 ? EXPLAIN (TIMING false, TIMING true) SELECT * FROM t1;
 %0 =
-| Get t1
+| ReadExistingIndex t1_primary_idx
 
 Decorrelation time:
 Optimization time:
 
 ? EXPLAIN (TIMING false) SELECT * FROM t1;
 %0 =
-| Get t1
+| ReadExistingIndex t1_primary_idx
 
 ? EXPLAIN (TIMING true, TIMING false) SELECT * FROM t1;
 %0 =
-| Get t1
+| ReadExistingIndex t1_primary_idx
 
 ? EXPLAIN (TIMING true) RAW PLAN FOR SELECT * FROM t1;
 %0 =

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -152,7 +152,7 @@ a  b
 $ set-regex match=(\s\(u\d+\)|\n) replacement=
 
 > EXPLAIN SELECT * FROM test5
-"%0 =| Get materialize.public.test5"
+"%0 =| ReadExistingIndex materialize.public.test5_primary_idx"
 
 > SELECT * FROM test5
 b  c
@@ -174,7 +174,7 @@ contains:catalog item 'materialize.public.idx1' is an index and so cannot be dep
 > DROP INDEX test5_primary_idx
 
 > EXPLAIN SELECT * FROM test5
-"%0 =| Get materialize.public.test5"
+"%0 =| ReadExistingIndex materialize.public.idx1| Project (#1, #0)"
 
 > SELECT * from test5
 b  c

--- a/test/testdrive/monotonic.td
+++ b/test/testdrive/monotonic.td
@@ -467,7 +467,7 @@ Source materialize.public.m1 UID:
   ]
 }
 
-Query:
+View materialize.public.v11 UID:
 {
   "TopK": {
     "input": {

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -47,28 +47,28 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 # Optimization is possible - no distinct is mentioned in the plan
 
 > EXPLAIN SELECT DISTINCT key1, key2 FROM t1;
-"%0 =| Get t1| Project (#0, #1)"
+"%0 =| ReadExistingIndex t1_primary_idx| Project (#0, #1)"
 
 > EXPLAIN SELECT DISTINCT key2, key1 FROM t1;
-"%0 =| Get t1| Project (#1, #0)"
+"%0 =| ReadExistingIndex t1_primary_idx| Project (#1, #0)"
 
 > EXPLAIN SELECT DISTINCT key2, key1, key2 FROM t1;
-"%0 =| Get t1| Project (#1, #0, #1)"
+"%0 =| ReadExistingIndex t1_primary_idx| Project (#1, #0, #1)"
 
 > EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2;
-"%0 =| Get t1| Project (#1, #0)"
+"%0 =| ReadExistingIndex t1_primary_idx| Project (#1, #0)"
 
 > EXPLAIN SELECT key2, key1 FROM t1 GROUP BY key1, key2, key2 || 'a';
-"%0 =| Get t1| Project (#1, #0)"
+"%0 =| ReadExistingIndex t1_primary_idx| Project (#1, #0)"
 
 > EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1;
-"%0 =| Get t1"
+"%0 =| ReadExistingIndex t1_primary_idx"
 
 > EXPLAIN SELECT key1, key2, nokey FROM t1 GROUP BY key1, key2, nokey;
-"%0 =| Get t1"
+"%0 =| ReadExistingIndex t1_primary_idx"
 
 > EXPLAIN SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
-"%0 =| Get t1| Map \"a\"| Filter (#0 = \"a\")| Project (#3, #1)"
+"%0 =| ReadExistingIndex t1_primary_idx| Map \"a\"| Filter (#0 = \"a\")| Project (#3, #1)"
 
 # Optimization not possible - explicit distinct is present in plan
 
@@ -97,13 +97,13 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 > CREATE VIEW v1 AS SELECT * FROM t1;
 
 > EXPLAIN SELECT DISTINCT key1, key2 FROM v1;
-"%0 =| Get t1| Project (#0, #1)"
+"%0 =| ReadExistingIndex t1_primary_idx| Project (#0, #1)"
 
 > CREATE VIEW v2 AS SELECT * FROM t1;
 > CREATE DEFAULT INDEX ON v2;
 
 > EXPLAIN SELECT DISTINCT key1, key2 FROM v2;
-"%0 =| Get v2| Project (#0, #1)"
+"%0 =| ReadExistingIndex v2_primary_idx| Project (#0, #1)"
 
 # Make sure that having a DISTINCT or GROUP BY confers PK semantics on upstream views
 
@@ -111,24 +111,24 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 > CREATE DEFAULT INDEX ON distinct_view;
 
 > EXPLAIN SELECT DISTINCT nokey FROM distinct_view
-"%0 =| Get distinct_view"
+"%0 =| ReadExistingIndex distinct_view_primary_idx"
 
 > CREATE VIEW group_by_view AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1 GROUP BY nokey || 'a', nokey || 'b';
 > CREATE DEFAULT INDEX ON group_by_view;
 
 > EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view;
-"%0 =| Get group_by_view"
+"%0 =| ReadExistingIndex group_by_view_primary_idx"
 
 # Redundant table is eliminated from an inner join using PK information
 
 > EXPLAIN SELECT a1.* FROM t1 AS a1, t1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
-"%0 =| Get t1"
+"%0 =| ReadExistingIndex t1_primary_idx"
 
 > EXPLAIN SELECT a1.* FROM v1 AS a1, v1 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
-"%0 =| Get t1"
+"%0 =| ReadExistingIndex t1_primary_idx"
 
 > EXPLAIN SELECT a1.* FROM v2 AS a1, v2 AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
-"%0 =| Get v2"
+"%0 =| ReadExistingIndex v2_primary_idx"
 
 # Declare a key constraint (PRIMARY KEY NOT ENFORCED); otherwise identical tests as above.
 
@@ -157,28 +157,28 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema} publish=true
 # Optimization is possible - no distinct is mentioned in the plan
 
 > EXPLAIN SELECT DISTINCT key1, key2 FROM t1_pkne;
-"%0 =| Get t1_pkne| Project (#0, #1)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Project (#0, #1)"
 
 > EXPLAIN SELECT DISTINCT key2, key1 FROM t1_pkne;
-"%0 =| Get t1_pkne| Project (#1, #0)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Project (#1, #0)"
 
 > EXPLAIN SELECT DISTINCT key2, key1, key2 FROM t1_pkne;
-"%0 =| Get t1_pkne| Project (#1, #0, #1)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Project (#1, #0, #1)"
 
 > EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2;
-"%0 =| Get t1_pkne| Project (#1, #0)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Project (#1, #0)"
 
 > EXPLAIN SELECT key2, key1 FROM t1_pkne GROUP BY key1, key2, key2 || 'a';
-"%0 =| Get t1_pkne| Project (#1, #0)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Project (#1, #0)"
 
 > EXPLAIN SELECT DISTINCT key1, key2, nokey FROM t1_pkne;
-"%0 =| Get t1_pkne"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx"
 
 > EXPLAIN SELECT key1, key2, nokey FROM t1_pkne GROUP BY key1, key2, nokey;
-"%0 =| Get t1_pkne"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx"
 
 > EXPLAIN SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
-"%0 =| Get t1_pkne| Map \"a\"| Filter (#0 = \"a\")| Project (#3, #1)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Map \"a\"| Filter (#0 = \"a\")| Project (#3, #1)"
 
 # Optimization not possible - explicit distinct is present in plan
 
@@ -208,13 +208,13 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema} publish=true
 > CREATE VIEW v1_pkne AS SELECT * FROM t1_pkne;
 
 > EXPLAIN SELECT DISTINCT key1, key2 FROM v1_pkne;
-"%0 =| Get t1_pkne| Project (#0, #1)"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx| Project (#0, #1)"
 
 > CREATE VIEW v2_pkne AS SELECT * FROM t1_pkne;
 > CREATE DEFAULT INDEX ON v2_pkne;
 
 > EXPLAIN SELECT DISTINCT key1, key2 FROM v2_pkne;
-"%0 =| Get v2_pkne| Project (#0, #1)"
+"%0 =| ReadExistingIndex v2_pkne_primary_idx| Project (#0, #1)"
 
 # Make sure that having a DISTINCT or GROUP BY confers PK semantics on upstream views
 
@@ -222,21 +222,21 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema} publish=true
 > CREATE DEFAULT INDEX ON distinct_view_pkne;
 
 > EXPLAIN SELECT DISTINCT nokey FROM distinct_view_pkne
-"%0 =| Get distinct_view_pkne"
+"%0 =| ReadExistingIndex distinct_view_pkne_primary_idx"
 
 > CREATE VIEW group_by_view_pkne AS SELECT nokey || 'a' AS f1 , nokey || 'b' AS f2 FROM t1_pkne GROUP BY nokey || 'a', nokey || 'b';
 > CREATE DEFAULT INDEX ON group_by_view_pkne;
 
 > EXPLAIN SELECT DISTINCT f1, f2 FROM group_by_view_pkne;
-"%0 =| Get group_by_view_pkne"
+"%0 =| ReadExistingIndex group_by_view_pkne_primary_idx"
 
 # Redundant table is eliminated from an inner join using PK information
 
 > EXPLAIN SELECT a1.* FROM t1_pkne AS a1, t1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
-"%0 =| Get t1_pkne"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx"
 
 > EXPLAIN SELECT a1.* FROM v1_pkne AS a1, v1_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
-"%0 =| Get t1_pkne"
+"%0 =| ReadExistingIndex t1_pkne_primary_idx"
 
 > EXPLAIN SELECT a1.* FROM v2_pkne AS a1, v2_pkne AS a2 WHERE a1.key1 = a2.key1 AND a1.key2 = a2.key2;
-"%0 =| Get v2_pkne"
+"%0 =| ReadExistingIndex v2_pkne_primary_idx"

--- a/test/testdrive/source-linear-operators.td
+++ b/test/testdrive/source-linear-operators.td
@@ -45,7 +45,7 @@ Source materialize.public.data (UID):
 | Filter (#0 = 1), (#3 = 3)
 | Project (#0..=#3)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#0 = 1), (#3 = 3)
@@ -65,7 +65,7 @@ Source materialize.public.data (UID):
 | Filter (#1 = 1)
 | Project (#1)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#1 = 1)
@@ -90,7 +90,7 @@ Source materialize.public.data (UID):
 | Filter (#0 = 1), (#3 = 4)
 | Project (#0, #1, #3)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#0 = 1), (#3 = 4)
@@ -111,7 +111,7 @@ Source materialize.public.data (UID):
 | Filter (#0 = 1), (#3 = 4)
 | Project (#0, #3)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#0 = 1), (#3 = 4)
@@ -129,7 +129,7 @@ Query:
 Source materialize.public.data (UID):
 | Project (#0, #1, #3)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#0) IS NOT NULL
@@ -164,7 +164,7 @@ Source materialize.public.data (UID):
 | Filter (#3 = 4)
 | Project (#0, #1, #3)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#3 = 4), (#0) IS NOT NULL
@@ -195,7 +195,7 @@ Source materialize.public.data (UID):
 | Filter (#0) IS NOT NULL
 | Project (#0, #2)
 
-Query:
+View materialize.public.v (UID):
 %0 = Let l0 =
 | Get materialize.public.data (UID)
 | Filter (#0) IS NOT NULL
@@ -232,7 +232,7 @@ Source materialize.public.data (UID):
 | Filter (#0 = 1)
 | Project (#0..=#2)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Filter (#0 = 1)
@@ -281,7 +281,7 @@ Source materialize.public.data2 (UID):
 | Filter (#3) IS NULL
 | Project (#0, #2, #3)
 
-Query:
+View materialize.public.v (UID):
 %0 =
 | Get materialize.public.data (UID)
 | Project (#0, #2)

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -25,55 +25,55 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # The simplest expression there could be
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL AND col_not_null = 5);
-"%0 =| Get t1| Filter (#0) IS NULL, (#1 = 5)"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#0) IS NULL, (#1 = 5)"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
-"%0 =| Get t1| ArrangeBy (#0, #1)%1 =| Join %0| | implementation = IndexedFilter #0 = 5 AND #1 = 1| Filter (#0 = 5), (#1 = 1)"
+"%0 =| ReadExistingIndex t1_primary_idx| | Lookup value (5, 1)| Filter (#0 = 5), (#1 = 1)"
 
 # NULL-able expressions are dedupped
 > EXPLAIN SELECT * FROM t1 WHERE col_null = 1 AND (col_null = 1 AND col_not_null = 5);
-"%0 =| Get t1| ArrangeBy (#0, #1)%1 =| Join %0| | implementation = IndexedFilter #0 = 1 AND #1 = 5| Filter (#0 = 1), (#1 = 5)"
+"%0 =| ReadExistingIndex t1_primary_idx| | Lookup value (1, 5)| Filter (#0 = 1), (#1 = 5)"
 
 # OR/disjunction at the top level
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL AND col_not_null = 5);
-"%0 =| Get t1| Filter (#0) IS NULL"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#0) IS NULL"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR col_null IS NULL OR (col_null IS NULL AND col_not_null = 5);
-"%0 =| Get t1| Filter (#0) IS NULL"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#0) IS NULL"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL AND col_not_null = 5) OR (col_null IS NULL AND col_not_null = 6);
-"%0 =| Get t1| Filter (#0) IS NULL"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#0) IS NULL"
 
 # OR/disjunction at the lower level
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL OR col_not_null = 5);
-"%0 =| Get t1| Filter (#0) IS NULL"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#0) IS NULL"
 
 # Nested OR/disjunction
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL OR (col_null IS NULL OR col_not_null = 5);
-"%0 =| Get t1| Filter ((#0) IS NULL OR (#1 = 5))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#0) IS NULL OR (#1 = 5))"
 
 # A more complex expression
 
 > EXPLAIN SELECT * FROM t1 WHERE (col_not_null + 1 / col_not_null) = 5 AND ((col_not_null + 1 / col_not_null) = 5 AND col_null = 6);
-"%0 =| Get t1| Filter (#0 = 6), (5 = (#1 + (1 / #1)))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#0 = 6), (5 = (#1 + (1 / #1)))"
 
 # More nesting
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null + col_not_null + col_not_null = 5 AND (col_not_null + col_not_null + col_not_null = 5);
-"%0 =| Get t1| Filter (5 = ((#1 + #1) + #1))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (5 = ((#1 + #1) + #1))"
 
 # The common expression contains an AND/conjunction itself
 
 > EXPLAIN SELECT * FROM t1 WHERE ((col_not_null > 3) AND (col_not_null < 5)) AND ((col_not_null > 3) AND (col_not_null < 5) OR col_not_null = 10);
-"%0 =| Get t1| Filter (#1 < 5), (#1 > 3)"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#1 < 5), (#1 > 3)"
 
 # The common expression contains an OR/disjunction
 
 > EXPLAIN SELECT * FROM t1 WHERE ((col_not_null > 3) OR (col_not_null < 5)) OR ((col_not_null > 3) OR (col_not_null < 5));
-"%0 =| Get t1| Filter ((#1 < 5) OR (#1 > 3))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 < 5) OR (#1 > 3))"
 
 # Use of a deterministic function
 
@@ -82,40 +82,40 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 
 # This is not optimized
 > EXPLAIN SELECT * FROM t1 WHERE (col_not_null % 2) = 1 AND (((col_not_null % 2) = 1) = TRUE);
-"%0 =| Get t1| Filter (1 = (#1 % 2))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (1 = (#1 % 2))"
 
 # Column used on both sides of the expression
 > EXPLAIN SELECT * FROM t1 WHERE (col_not_null = col_not_null + 1) AND (col_not_null = col_not_null + 1);
-"%0 =| Get t1| Filter (#1 = (#1 + 1))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#1 = (#1 + 1))"
 
 # TODO (materialize#6043):  Avoid simplifying mz_sleep.
 
 > EXPLAIN SELECT * FROM t1
   WHERE mz_internal.mz_sleep(col_not_null) > mz_internal.mz_sleep(col_not_null)
   AND (mz_internal.mz_sleep(col_not_null) > mz_internal.mz_sleep(col_not_null) = true);
-"%0 =| Get t1| Filter (mz_sleep(integer_to_double(#1)) > mz_sleep(integer_to_double(#1)))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (mz_sleep(integer_to_double(#1)) > mz_sleep(integer_to_double(#1)))"
 
 # IN list inside the expression
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (2, 3);
-"%0 =| Get t1| Filter ((#1 = 2) OR (#1 = 3))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 = 2) OR (#1 = 3))"
 
 # Partial matches are not optimized
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (3, 4);
-"%0 =| Get t1| Filter ((#1 = 3) OR ((#1 = 2) AND (#1 = 4)))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 = 3) OR ((#1 = 2) AND (#1 = 4)))"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (4, 5);
-"%0 =| Get t1| Filter ((#1 = 2) OR (#1 = 3)), ((#1 = 4) OR (#1 = 5))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 = 2) OR (#1 = 3)), ((#1 = 4) OR (#1 = 5))"
 
 # Expression inside an IN list
 
 # Optimized in AND/conjunctions
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND TRUE IN (col_not_null = 1, col_not_null = 2)
-"%0 =| Get t1| Filter (#1 = 1)"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#1 = 1)"
 
 # Not optimized in OR/disjunctions
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 OR TRUE IN (col_not_null = 1, col_not_null = 2)
-"%0 =| Get t1| Map (#1 = 1)| Filter (#2 OR (#2 = true) OR (true = (#1 = 2)))| Project (#0, #1)"
+"%0 =| ReadExistingIndex t1_primary_idx| Map (#1 = 1)| Filter (#2 OR (#2 = true) OR (true = (#1 = 2)))| Project (#0, #1)"


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.

Touches #13138.

* Both the current and future EXPLAIN API will display use of fast path. While having the current EXPLAIN API display fast path is extra work, most of the extra work was already done in #12597, and I think it's useful to have an idea of what existing fast path tests we have.

Touches #12629.

* The future EXPLAIN API will display indexes that are used in OPTIMIZED and PHYSICAL plans.

Touches #13485 

* The future EXPLAIN API prints out the total number of rows in a constant and cap the number of distinct rows from the constant at 20. This is accomplished by having constants all call a common Constant-formatting method `fmt_text_constant_rows`.

### Tips for reviewer

The future EXPLAIN API now has the concept of an `Explainee` to distinguish between when something to be explained is definitely to be turned into a dataflow vs. may be served using fast path. Currently, we can make the distinction by figuring out if the user typed in a view name vs. a query; however, this might not be the case in the future. For example, we could want to explain a tail, and `TAIL <query>` will be always be a dataflow. See [Slack thread here](https://materializeinc.slack.com/archives/C01BE3RN82F/p1658422690189279?thread_ts=1658422234.896599&cid=C01BE3RN82F).

In order to pass a `FastPathPlan` object to the future EXPLAIN API, 
```
enum peek::Plan {
  Constant(..),
  PeekExisting(..),
  PeekDataflow(PeekDataflowPlan{..})
} 
```

has been changed to

```
enum peek::Plan {
  FastPath(FastPathPlan)
  SlowPath(..)
}

enum FastPathPlan {
  Constant(..)
  PeekExisting(..)
}
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

There are unit tests for rendering fast path plan as text in the new explain format, which also tests that the code to cap the maximum number of constant rows printed works. Tests for rendering used indexes as text in the new explain format are postponed until MIR and LIR can be entirely printed in the new text explain format.

I can't test formatting an HIR constant where the HIR constant has more than one row because I don't know how to construct a SQL query that would translate into a HIR constant with more than one row. `SELECT * FROM (VALUES...)` becomes a table function.

EXPLAIN changes do not require a release note.
