### PR TITLE
run.py: limit process killing on reset to current user's processes

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -188,10 +188,15 @@ def _run_sql(url: str, sql: str) -> None:
 
 
 def _handle_lingering_services(kill: bool = False) -> None:
+    uid = os.getuid()
     for proc in psutil.process_iter():
         try:
             if proc.name() in REQUIRED_SERVICES:
-                if kill:
+                if proc.uids().real != uid:
+                    print(
+                        f"Ignoring {proc.name()} process with different UID (PID {proc.pid}, likely running in Docker)"
+                    )
+                elif kill:
                     print(f"Killing orphaned {proc.name()} process (PID {proc.pid})")
                     proc.kill()
                 else:


### PR DESCRIPTION
This avoids crashing when there are storaged and computed processes
running in Docker; the user running run.py almost certainly is not
running as root and so can't kill the processes in Docker. The processes
in Docker are containerized, though, and therefore won't fight with the
storaged and computed processes spun up by run.py.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack: https://materializeinc.slack.com/archives/C01KV5PEZ9R/p1658864189998009.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
