### PR TITLE
logging: move shard truncation into persist_sink

### DIFF
--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -7,21 +7,13 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-
-use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::input::Input;
-use differential_dataflow::{Collection, Hashable};
+use differential_dataflow::Collection;
 use timely::dataflow::Scope;
-use timely::progress::Antichain;
-use tokio::runtime::Handle as TokioHandle;
-use tokio::sync::Mutex;
 
-use mz_persist_client::cache::PersistClientCache;
 use mz_repr::GlobalId;
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage::controller::CollectionMetadata;
-use mz_storage::types::sources::SourceData;
 
 use crate::compute_state::ComputeState;
 
@@ -33,21 +25,13 @@ pub(crate) fn persist_sink<G>(
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
+    let (_, err_collection) = desired_collection.scope().new_collection();
+
     // The target storage collection might still contain data written by a
     // previous incarnation of the replica. Empty it, so we don't end up with
     // stale data that never gets retracted.
     // TODO(teskje,lh): Remove the truncation step once/if #13740 gets merged.
-    //
-    // We need to ensure that only a single timely worker tries to perform the
-    // truncate, to avoid retracting the old data multiple times.
-    let scope = desired_collection.scope();
-    let is_active_worker = (target_id.hashed() as usize) % scope.peers() == scope.index();
-    if is_active_worker {
-        let persist_clients = Arc::clone(&compute_state.persist_clients);
-        TokioHandle::current().block_on(truncate_storage_collection(target, persist_clients));
-    }
-
-    let (_, err_collection) = desired_collection.scope().new_collection();
+    let truncate = true;
 
     let token = crate::sink::persist_sink(
         target_id,
@@ -55,6 +39,7 @@ pub(crate) fn persist_sink<G>(
         desired_collection,
         err_collection,
         compute_state,
+        truncate,
     );
 
     // We don't allow these dataflows to be dropped, so the tokens could
@@ -66,55 +51,4 @@ pub(crate) fn persist_sink<G>(
             is_tail: false,
         },
     );
-}
-
-async fn truncate_storage_collection(
-    collection: &CollectionMetadata,
-    persist_clients: Arc<Mutex<PersistClientCache>>,
-) {
-    let client = persist_clients
-        .lock()
-        .await
-        .open(collection.persist_location.clone())
-        .await
-        .expect("could not open persist client");
-
-    let (mut write, read) = client
-        .open::<SourceData, (), Timestamp, Diff>(collection.data_shard)
-        .await
-        .expect("could not open persist shard");
-
-    let upper = write.upper().clone();
-    let upper_ts = upper[0];
-    if let Some(ts) = upper_ts.checked_sub(1) {
-        let as_of = Antichain::from_elem(ts);
-
-        let mut snapshot_iter = read
-            .snapshot(as_of)
-            .await
-            .expect("cannot serve requested as_of");
-
-        let mut updates = Vec::new();
-        while let Some(next) = snapshot_iter.next().await {
-            updates.extend(next);
-        }
-        snapshot_iter.expire().await;
-
-        consolidate_updates(&mut updates);
-
-        let retractions = updates
-            .into_iter()
-            .map(|((k, v), _ts, diff)| ((k.unwrap(), v.unwrap()), upper_ts, diff * -1));
-
-        let new_upper = Antichain::from_elem(upper_ts + 1);
-        write
-            .compare_and_append(retractions, upper, new_upper)
-            .await
-            .expect("external durability failure")
-            .expect("invalid usage")
-            .expect("unexpected upper");
-    }
-
-    write.expire().await;
-    read.expire().await;
 }


### PR DESCRIPTION
This PR moves the async persist shard truncation step, performed when creating a logging dataflow sink, into the async persist_sink operator. This removes the need for calling tokio's `block_on`, which previously could lead to deadlocks because the truncate operation needs to `await` while holding a lock on the `persist_clients` mutex and timely wouldn't know how to put that tokio task to sleep and schedule other operators.

[Slack thread for context.](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1658875384490809) 

### Motivation

  * This PR fixes a previously unreported bug.

After merging two PRs that passed CI independently (https://github.com/MaterializeInc/materialize/pull/13794, https://github.com/MaterializeInc/materialize/pull/13795) we started experiencing deadlocks when reading from storage collections. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
