### PR TITLE
Reintroduce persist connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1331,6 +1331,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c668a58063c6331e3437e3146970943ad82b1b36169fd979bb2645ac2088209a"
+dependencies = [
+ "deadpool",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,6 +3574,7 @@ dependencies = [
  "bytes",
  "criterion",
  "crossbeam-channel",
+ "deadpool-postgres",
  "differential-dataflow",
  "fail",
  "futures-util",
@@ -5330,6 +5365,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "ring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,7 @@ prost = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" 
 prost-build = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-derive = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
 prost-types = { git = "https://github.com/MaterializeInc/prost.git", branch = "v0.10" }
+postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ name = "strum-macros"
 [[bans.deny]]
 name = "log"
 wrappers = [
+    "deadpool-postgres",
     "env_logger",
     "fail",
     "globset",

--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -20,9 +20,9 @@ RUN apt-get update \
     && groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize \
     && pg_dropcluster 14 main \
-    && pg_createcluster 14 materialize --user=materialize \
-    && pg_ctlcluster 14 materialize start \
-    && echo "listen_addresses = '*'" >> /etc/postgresql/14/materialize/postgresql.conf \
+    && pg_createcluster 14 materialize --user=materialize --start \
+        --pgoption listen_addresses=* \
+        --pgoption max_connections=5000 \
     && su materialize -c "createdb materialize" \
     && mkdir /mzdata \
     && chown materialize /mzdata

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -462,7 +462,7 @@ class Postgres(Service):
         mzbuild: str = "postgres",
         image: Optional[str] = None,
         port: int = 5432,
-        command: str = "postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20",
+        command: str = "postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20 -c max_connections=5000",
         environment: List[str] = ["POSTGRESDB=postgres", "POSTGRES_PASSWORD=postgres"],
     ) -> None:
         config: ServiceConfig = {"image": image} if image else {"mzbuild": mzbuild}

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -159,8 +159,10 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             command_wrapper: vec![],
         }))?,
     );
-    let persist_clients =
-        PersistClientCache::new(PersistConfig::new(config.now.clone()), &metrics_registry);
+    let persist_clients = PersistClientCache::new(
+        PersistConfig::new_for_test(config.now.clone()),
+        &metrics_registry,
+    );
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let inner = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         adapter_stash_url,

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -440,9 +440,10 @@ impl Service for TransactorService {
         let blob = CachingBlob::new(blob);
 
         // Construct requested Consensus.
+        let config = PersistConfig::new(SYSTEM_TIME.clone());
         let consensus = match &args.consensus_uri {
             Some(consensus_uri) => {
-                ConsensusConfig::try_from(consensus_uri)
+                ConsensusConfig::try_from(consensus_uri, config.consensus_connection_pool_max_size)
                     .await?
                     .open()
                     .await?
@@ -454,13 +455,7 @@ impl Service for TransactorService {
 
         // Wire up the TransactorService.
         let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-        let client = PersistClient::new(
-            PersistConfig::new(SYSTEM_TIME.clone()),
-            blob,
-            consensus,
-            metrics,
-        )
-        .await?;
+        let client = PersistClient::new(config, blob, consensus, metrics).await?;
         let transactor = Transactor::new(&client, shard_id).await?;
         let service = TransactorService(Arc::new(Mutex::new(transactor)));
         Ok(service)

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -186,7 +186,8 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         consensus_uri: args.consensus_uri,
     };
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-    let (blob, consensus) = location.open_locations(&metrics).await?;
+    let config = PersistConfig::new(SYSTEM_TIME.clone());
+    let (blob, consensus) = location.open_locations(&config, &metrics).await?;
     let unreliable = UnreliableHandle::default();
     let should_happen = 1.0 - args.unreliability;
     let should_timeout = args.unreliability;
@@ -195,13 +196,7 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         Arc::new(UnreliableBlob::new(blob, unreliable.clone())) as Arc<dyn Blob + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
-    PersistClient::new(
-        PersistConfig::new(SYSTEM_TIME.clone()),
-        blob,
-        consensus,
-        metrics,
-    )
-    .await
+    PersistClient::new(config, blob, consensus, metrics).await
 }
 
 mod api {

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -77,7 +77,9 @@ impl PersistClientCache {
             Entry::Vacant(x) => {
                 // Intentionally hold the lock, so we don't double connect under
                 // concurrency.
-                let consensus = ConsensusConfig::try_from(x.key()).await?;
+                let consensus =
+                    ConsensusConfig::try_from(x.key(), self.cfg.consensus_connection_pool_max_size)
+                        .await?;
                 let consensus =
                     retry_external(&self.metrics.retries.external.consensus_open, || {
                         consensus.clone().open()

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -29,6 +29,7 @@ aws-types = { version = "0.46.0", features = ["hardcoded-credentials"] }
 base64 = "0.13.0"
 bytes = "1.2.0"
 crossbeam-channel = "0.5.6"
+deadpool-postgres = "0.10.2"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 fail = { version = "0.5.0", features = ["failpoints"] }
 futures-util = "0.3.19"

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -140,7 +140,10 @@ impl ConsensusConfig {
     }
 
     /// Parses a [Consensus] config from a uri string.
-    pub async fn try_from(value: &str) -> Result<Self, ExternalError> {
+    pub async fn try_from(
+        value: &str,
+        connection_pool_max_size: usize,
+    ) -> Result<Self, ExternalError> {
         let url = Url::parse(value).map_err(|err| {
             anyhow!(
                 "failed to parse consensus location {} as a url: {}",
@@ -151,7 +154,7 @@ impl ConsensusConfig {
 
         let config = match url.scheme() {
             "postgres" | "postgresql" => Ok(ConsensusConfig::Postgres(
-                PostgresConsensusConfig::new(value).await?,
+                PostgresConsensusConfig::new(value, connection_pool_max_size).await?,
             )),
             "mem" => {
                 if !cfg!(debug_assertions) {


### PR DESCRIPTION
This PR re-introduces the persist connection pool originally merged in https://github.com/MaterializeInc/materialize/pull/13794 and then removed again in https://github.com/MaterializeInc/materialize/pull/13856.

It is based on https://github.com/MaterializeInc/materialize/pull/13897, which should fix the bug that made the revert of #13794 necessary.

### Motivation

  * This PR adds a known-desirable bugfix.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
