### PR TITLE
Remove introspection sources on drop cluster replica

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2953,15 +2953,15 @@ impl<S: Append> Catalog<S> {
                         introspection_source_index_ids,
                     }]
                 }
-                Op::DropComputeInstanceReplica { name, compute_id } => {
-                    tx.remove_compute_instance_replica(&name, compute_id)?;
+                Op::DropComputeInstanceReplica { name, compute_name } => {
+                    let instance = self.resolve_compute_instance(&compute_name)?;
+                    tx.remove_compute_instance_replica(&name, instance.id)?;
 
-                    let instance = &self.state.compute_instances_by_id[&compute_id];
                     let replica_id = instance.replica_id_by_name[&name];
                     let replica = &instance.replicas_by_id[&replica_id];
                     for process_id in replica.process_status.keys() {
                         let update = self.state.pack_compute_instance_status_update(
-                            compute_id,
+                            instance.id,
                             replica_id,
                             *process_id,
                             -1,
@@ -2969,10 +2969,11 @@ impl<S: Append> Catalog<S> {
                         builtin_table_updates.push(update);
                     }
 
-                    builtin_table_updates.push(
-                        self.state
-                            .pack_compute_instance_replica_update(compute_id, &name, -1),
-                    );
+                    builtin_table_updates.push(self.state.pack_compute_instance_replica_update(
+                        instance.id,
+                        &name,
+                        -1,
+                    ));
 
                     let details = EventDetails::DropComputeInstanceReplicaV1(
                         mz_audit_log::DropComputeInstanceReplicaV1 {
@@ -2989,7 +2990,10 @@ impl<S: Append> Catalog<S> {
                         details,
                     )?;
 
-                    vec![Action::DropComputeInstanceReplica { name, compute_id }]
+                    vec![Action::DropComputeInstanceReplica {
+                        name,
+                        compute_id: instance.id,
+                    }]
                 }
                 Op::DropItem(id) => {
                     let entry = self.get_entry(&id);
@@ -3673,7 +3677,7 @@ pub enum Op {
     },
     DropComputeInstanceReplica {
         name: String,
-        compute_id: ComputeInstanceId,
+        compute_name: String,
     },
     /// Unconditionally removes the identified items. It is required that the
     /// IDs come from the output of `plan_remove`; otherwise consistency rules

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -117,8 +117,23 @@ impl<S: Append + 'static> Coordinator<S> {
                     _ => (),
                 }
             } else if let catalog::Op::DropComputeInstance { name } = op {
-                let id = self.catalog.resolve_compute_instance(name)?.id;
+                let instance = self.catalog.resolve_compute_instance(name)?;
+                let id = instance.id;
+
+                // Drop the introspection sources
+                for replica in instance.replicas_by_id.values() {
+                    sources_to_drop.extend(replica.config.persisted_logs.get_log_ids());
+                }
+
+                // Drop timelines
                 timelines_to_drop.extend(self.remove_compute_instance_from_timeline(id));
+            } else if let catalog::Op::DropComputeInstanceReplica { name, compute_name } = op {
+                let compute_instance = self.catalog.resolve_compute_instance(compute_name)?;
+                let replica_id = &compute_instance.replica_id_by_name[name];
+                let replica = &compute_instance.replicas_by_id[&replica_id];
+
+                // Drop the introspection sources
+                sources_to_drop.extend(replica.config.persisted_logs.get_log_ids());
             }
         }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1407,7 +1407,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let mut ids_to_drop: Vec<GlobalId> = instance.exports().iter().cloned().collect();
 
             // Determine from the replica which additional items to drop. This is the set
-            // of items depend on the introspection sources. The sources
+            // of items that depend on the introspection sources. The sources
             // itself are removed with Op::DropComputeInstanceReplica.
             for replica in instance.replicas_by_id.values() {
                 let log_ids = replica.config.persisted_logs.get_log_ids();

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1454,7 +1454,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let replica_id = instance.replica_id_by_name[&replica_name];
 
             // Determine from the replica which additional items to drop. This is the set
-            // of items depend on the introspection sources. The sources
+            // of items that depend on the introspection sources. The sources
             // itself are removed with Op::DropComputeInstanceReplica.
             for log_id in instance
                 .replicas_by_id

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1394,13 +1394,13 @@ impl<S: Append + 'static> Coordinator<S> {
     ) -> Result<ExecuteResponse, AdapterError> {
         let mut ops = Vec::new();
         let mut instance_replica_drop_sets = Vec::with_capacity(plan.names.len());
-        for name in plan.names {
-            let instance = self.catalog.resolve_compute_instance(&name)?;
+        for compute_name in plan.names {
+            let instance = self.catalog.resolve_compute_instance(&compute_name)?;
             instance_replica_drop_sets.push((instance.id, instance.replicas_by_id.clone()));
             for replica_name in instance.replica_id_by_name.keys() {
                 ops.push(catalog::Op::DropComputeInstanceReplica {
                     name: replica_name.to_string(),
-                    compute_id: instance.id,
+                    compute_name: compute_name.clone(),
                 });
             }
 
@@ -1417,7 +1417,7 @@ impl<S: Append + 'static> Coordinator<S> {
             }
 
             ops.extend(self.catalog.drop_items_ops(&ids_to_drop));
-            ops.push(catalog::Op::DropComputeInstance { name });
+            ops.push(catalog::Op::DropComputeInstance { name: compute_name });
         }
 
         self.catalog_transact(Some(session), ops, |_| Ok(()))
@@ -1449,7 +1449,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let instance = self.catalog.resolve_compute_instance(&instance_name)?;
             ops.push(catalog::Op::DropComputeInstanceReplica {
                 name: replica_name.clone(),
-                compute_id: instance.id,
+                compute_name: instance_name.clone(),
             });
             let replica_id = instance.replica_id_by_name[&replica_name];
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -268,8 +268,11 @@ pub trait CatalogComputeInstance<'a> {
     /// views) of this cluster.
     fn exports(&self) -> &std::collections::HashSet<GlobalId>;
 
-    /// Returns the set of non-transient indexes on this cluster.
+    /// Returns the set of replicas of this cluster.
     fn replica_names(&self) -> HashSet<&String>;
+
+    /// Returns the set of persisted logs of this
+    fn replica_logs(&self, name: &String) -> Option<Vec<GlobalId>>;
 }
 
 /// An item in a [`SessionCatalog`].

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -271,7 +271,7 @@ pub trait CatalogComputeInstance<'a> {
     /// Returns the set of replicas of this cluster.
     fn replica_names(&self) -> HashSet<&String>;
 
-    /// Returns the set of persisted logs of this
+    /// Returns the set of persisted logs of replica `name` of this cluster.
     fn replica_logs(&self, name: &String) -> Option<Vec<GlobalId>>;
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3396,7 +3396,24 @@ pub fn plan_drop_cluster_replica(
         let replica_name = replica.into_string();
         // Check to see if name exists
         if instance.replica_names().contains(&replica_name) {
-            names_out.push((instance.name().to_string(), replica_name))
+            // Check if we have an item that depends on the replica's logs
+            let log_ids = instance.replica_logs(&replica_name).unwrap();
+            for id in log_ids {
+                let log_item = scx.catalog.get_item(&id);
+                for id in log_item.used_by() {
+                    let dep = scx.catalog.get_item(id);
+                    if dependency_prevents_drop(ObjectType::Source, dep) {
+                        sql_bail!(
+                            "cannot drop replica {} of cluster {}: still depended upon by catalog item '{}'",
+                            replica_name.quoted(),
+                            instance.name().quoted(),
+                            scx.catalog.resolve_full_name(dep.name())
+                        );
+                    }
+                }
+            }
+
+            names_out.push((instance.name().to_string(), replica_name));
         } else {
             // If "IF EXISTS" supplied, names allowed to be missing,
             // otherwise error.
@@ -3464,34 +3481,35 @@ pub fn plan_drop_item(
     if !cascade {
         for id in catalog_entry.used_by() {
             let dep = scx.catalog.get_item(id);
-            match object_type {
-                ObjectType::Type => sql_bail!(
+            if dependency_prevents_drop(object_type, dep) {
+                sql_bail!(
                     "cannot drop {}: still depended upon by catalog item '{}'",
                     scx.catalog.resolve_full_name(catalog_entry.name()),
                     scx.catalog.resolve_full_name(dep.name())
-                ),
-                _ => match dep.item_type() {
-                    CatalogItemType::Func
-                    | CatalogItemType::Table
-                    | CatalogItemType::Source
-                    | CatalogItemType::View
-                    | CatalogItemType::MaterializedView
-                    | CatalogItemType::Sink
-                    | CatalogItemType::Type
-                    | CatalogItemType::Secret
-                    | CatalogItemType::Connection => {
-                        sql_bail!(
-                            "cannot drop {}: still depended upon by catalog item '{}'",
-                            scx.catalog.resolve_full_name(catalog_entry.name()),
-                            scx.catalog.resolve_full_name(dep.name())
-                        );
-                    }
-                    CatalogItemType::Index => (),
-                },
+                );
             }
         }
     }
     Ok(Some(catalog_entry.id()))
+}
+
+/// Does the dependency `dep` prevent a drop of a non-cascade query?
+fn dependency_prevents_drop(object_type: ObjectType, dep: &dyn CatalogItem) -> bool {
+    match object_type {
+        ObjectType::Type => true,
+        _ => match dep.item_type() {
+            CatalogItemType::Func
+            | CatalogItemType::Table
+            | CatalogItemType::Source
+            | CatalogItemType::View
+            | CatalogItemType::MaterializedView
+            | CatalogItemType::Sink
+            | CatalogItemType::Type
+            | CatalogItemType::Secret
+            | CatalogItemType::Connection => true,
+            CatalogItemType::Index => false,
+        },
+    }
 }
 
 pub fn describe_alter_index_options(

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -11,8 +11,6 @@
 
 mode cockroach
 
-## REAL starts here
-
 # The default cluster also has log sources, thus we should have one set active at boot
 query T rowsort
 select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
@@ -35,7 +33,7 @@ select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
 ----
 2
 
-statement error
+statement error cannot drop cluster with active indexes.*
 DROP CLUSTER c1;
 
 statement ok
@@ -60,19 +58,19 @@ CREATE VIEW v1 AS SELECT * FROM mz_catalog.mz_peek_active_4;
 statement ok
 CREATE VIEW v2 AS SELECT * FROM v1;
 
-statement error
+statement error cannot drop replica "r1" of cluster "c1".*
 DROP CLUSTER REPLICA c1.r1;
 
-statement error
+statement error cannot drop cluster with active indexes.*
 DROP CLUSTER c1;
 
 statement ok
 DROP CLUSTER c1 CASCADE;
 
-statement error
+query error unknown catalog item 'v1'
 SELECT * FROM v1;
 
-statement error
+query error unknown catalog item 'v2'
 SELECT * FROM v2;
 
 query T rowsort

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -1,0 +1,81 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Ensure correct log creation and destruction on `CREATE CLUSTER`, `DROP CLUSTER` DDL statements.
+
+mode cockroach
+
+## REAL starts here
+
+# The default cluster also has log sources, thus we should have one set active at boot
+query T rowsort
+select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
+----
+1
+
+statement ok
+CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '2'));
+
+query T rowsort
+select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
+----
+3
+
+statement ok
+DROP CLUSTER REPLICA c1.r1;
+
+query T rowsort
+select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
+----
+2
+
+statement error
+DROP CLUSTER c1;
+
+statement ok
+DROP CLUSTER c1 CASCADE;
+
+query T rowsort
+select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
+----
+1
+
+
+# Now create a view and ensure CASCADE works as intended
+
+statement ok
+CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'));
+
+
+# We have to guess the identifier 4 here, it should match c1.r1 at this point
+statement ok
+CREATE VIEW v1 AS SELECT * FROM mz_catalog.mz_peek_active_4;
+
+statement ok
+CREATE VIEW v2 AS SELECT * FROM v1;
+
+statement error
+DROP CLUSTER REPLICA c1.r1;
+
+statement error
+DROP CLUSTER c1;
+
+statement ok
+DROP CLUSTER c1 CASCADE;
+
+statement error
+SELECT * FROM v1;
+
+statement error
+SELECT * FROM v2;
+
+query T rowsort
+select COUNT(*) from mz_catalog.mz_sources WHERE name LIKE 'mz_peek_active_%';
+----
+1


### PR DESCRIPTION
This PR removes the introspection sources (such as `mz_catalog.mz_peek_active_1`) when a replica is dropped. Dependencies are correctly tracked, if there is for example a view defined on the introspection sources, the `DROP REPLICA` will error. I will add the `DROP CLUSTER REPLICA ... CASCADE` in a later PR, but the cascading behavior can be tested with `DROP CLUSTER ... CASCADE`. A test is included.

Fixes #13882 

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
