### PR TITLE
adapter: advance timestamps for storage collections

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1413,6 +1413,11 @@ impl CatalogEntry {
         matches!(self.item(), CatalogItem::Table(_))
     }
 
+    /// Reports whether this catalog entry is a storage collection.
+    pub fn is_storage_collection(&self) -> bool {
+        matches!(self.item(), CatalogItem::StorageCollection(_))
+    }
+
     /// Collects the identifiers of the dataflows that this dataflow depends
     /// upon.
     pub fn uses(&self) -> &[GlobalId] {

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -370,9 +370,13 @@ impl<S: Append + 'static> Coordinator<S> {
     pub(crate) async fn queue_local_input_advances(&mut self, advance_to: mz_repr::Timestamp) {
         self.advance_tables.insert(
             advance_to,
-            self.catalog
-                .entries()
-                .filter_map(|e| if e.is_table() { Some(e.id()) } else { None }),
+            self.catalog.entries().filter_map(|e| {
+                if e.is_table() || e.is_storage_collection() {
+                    Some(e.id())
+                } else {
+                    None
+                }
+            }),
         );
     }
 


### PR DESCRIPTION
This fixes the issue of `mz_source_status_history` not being queryable, and it appears to not conflict with the Healthchecker updates.

### Motivation

  * This PR fixes a previously unreported bug: `mz_source_status_history` [not being queryable](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1658911883186399) when the Healthchecker is not running.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):