### PR TITLE
compute: only truncate log collections on one worker

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -147,7 +147,7 @@ where
                 .await
                 .expect("could not open persist client");
 
-            if truncate {
+            if truncate && active_write_worker {
                 truncate_persist_shard(shard_id, &persist_client).await;
             }
 


### PR DESCRIPTION
In https://github.com/MaterializeInc/materialize/pull/13897 I missed limiting the truncation of log storage collections to a single timely worker. As a consequence, restarting multi-process computed clusters panics because of the conflicting writes. 

### Motivation

  * This PR fixes a previously unreported bug.

Restarting a multi-process computed cluster panics with this error:
```
thread 'timely:work-1' panicked at 'unexpected upper: Upper(Antichain { elements: [1658931676001] })', src/compute/src/sink/persist_sink.rs:258:14
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
