### PR TITLE
storage: don't keep status_shard for non-sources

### DIFF
--- a/src/storage/src/controller.proto
+++ b/src/storage/src/controller.proto
@@ -18,7 +18,7 @@ message ProtoCollectionMetadata {
     string consensus_uri = 2;
     string data_shard = 3;
     string remap_shard = 4;
-    string status_shard = 5;
+    optional string status_shard = 5;
 }
 
 message ProtoDurableCollectionMetadata {

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -292,7 +292,7 @@ pub struct CollectionMetadata {
     /// The persist shard containing the contents of this storage collection
     pub data_shard: ShardId,
     /// The persist shard containing the status updates for this storage collection
-    pub status_shard: ShardId,
+    pub status_shard: Option<ShardId>,
 }
 
 impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
@@ -302,7 +302,7 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
             consensus_uri: self.persist_location.consensus_uri.clone(),
             data_shard: self.data_shard.to_string(),
             remap_shard: self.remap_shard.to_string(),
-            status_shard: self.status_shard.to_string(),
+            status_shard: self.status_shard.map(|s| s.to_string()),
         }
     }
 
@@ -322,8 +322,8 @@ impl RustType<ProtoCollectionMetadata> for CollectionMetadata {
                 .map_err(TryFromProtoError::InvalidShardId)?,
             status_shard: value
                 .status_shard
-                .parse()
-                .map_err(TryFromProtoError::InvalidShardId)?,
+                .map(|s| s.parse().map_err(TryFromProtoError::InvalidShardId))
+                .transpose()?,
         })
     }
 }
@@ -612,13 +612,15 @@ where
 
             let status_shard = if let Some(status_collection_id) = description.status_collection_id
             {
-                METADATA_COLLECTION
-                    .peek_key_one(&mut self.state.stash, &status_collection_id)
-                    .await?
-                    .ok_or(StorageError::IdentifierMissing(status_collection_id))?
-                    .data_shard
+                Some(
+                    METADATA_COLLECTION
+                        .peek_key_one(&mut self.state.stash, &status_collection_id)
+                        .await?
+                        .ok_or(StorageError::IdentifierMissing(status_collection_id))?
+                        .data_shard,
+                )
             } else {
-                ShardId::new()
+                None
             };
 
             let metadata = CollectionMetadata {

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -521,7 +521,7 @@ mod tests {
             },
             remap_shard: shard,
             data_shard: ShardId::new(),
-            status_shard: ShardId::new(),
+            status_shard: None,
         };
 
         ReclockOperator::new(


### PR DESCRIPTION
`status_shard` is only relevant (and deterministic) for sources, so it is better to just make the field optional, since after with #13806 these `ShardId`s are not persisted anymore.

### Motivation

  * This PR fixes a recognized bug: #13914

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
