### PR TITLE
persist: move maintenance tasks into machine API

### DIFF
--- a/src/persist-client/src/impl/compact.rs
+++ b/src/persist-client/src/impl/compact.rs
@@ -21,6 +21,8 @@ use mz_persist::location::Blob;
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::Timestamp;
 use timely::PartialOrder;
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
 use tracing::{debug_span, warn, Instrument, Span};
 
 use crate::async_runtime::CpuHeavyRuntime;
@@ -89,7 +91,8 @@ impl Compactor {
         &self,
         machine: &Machine<K, V, T, D>,
         req: CompactReq<T>,
-    ) where
+    ) -> Option<JoinHandle<()>>
+    where
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
@@ -107,7 +110,7 @@ impl Compactor {
                 >= self.cfg.compaction_heuristic_min_updates;
         if !should_compact {
             self.metrics.compaction.skipped.inc();
-            return;
+            return None;
         }
 
         let cfg = self.cfg.clone();
@@ -123,7 +126,7 @@ impl Compactor {
             debug_span!(parent: None, "compact::apply", shard_id=%machine.shard_id());
         compact_span.follows_from(&Span::current());
 
-        let _ = mz_ore::task::spawn(
+        Some(mz_ore::task::spawn(
             || "persist::compact::apply",
             async move {
                 metrics.compaction.started.inc();
@@ -166,7 +169,7 @@ impl Compactor {
                 }
             }
             .instrument(compact_span),
-        );
+        ))
     }
 
     pub async fn compact<T, D>(

--- a/src/persist-client/src/impl/compact.rs
+++ b/src/persist-client/src/impl/compact.rs
@@ -21,7 +21,6 @@ use mz_persist::location::Blob;
 use mz_persist_types::{Codec, Codec64};
 use timely::progress::Timestamp;
 use timely::PartialOrder;
-use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tracing::{debug_span, warn, Instrument, Span};
 

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -217,7 +217,6 @@ where
                 state.apply_merge_res(&res)
             })
             .await;
-        // WIP: think more about how/whether compaction should apply routine maintenance
         applied
     }
 
@@ -248,24 +247,24 @@ where
         (seqno, maintenance)
     }
 
-    pub async fn expire_reader(&mut self, reader_id: &ReaderId) -> (SeqNo, RoutineMaintenance) {
+    pub async fn expire_reader(&mut self, reader_id: &ReaderId) -> SeqNo {
         let metrics = Arc::clone(&self.metrics);
-        let (seqno, _existed, maintenance) = self
+        let (seqno, _existed, _maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_reader, |_, state| {
                 state.expire_reader(reader_id)
             })
             .await;
-        (seqno, maintenance)
+        seqno
     }
 
-    pub async fn expire_writer(&mut self, writer_id: &WriterId) -> (SeqNo, RoutineMaintenance) {
+    pub async fn expire_writer(&mut self, writer_id: &WriterId) -> SeqNo {
         let metrics = Arc::clone(&self.metrics);
-        let (seqno, _existed, maintenance) = self
+        let (seqno, _existed, _maintenance) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.expire_writer, |_, state| {
                 state.expire_writer(writer_id)
             })
             .await;
-        (seqno, maintenance)
+        seqno
     }
 
     pub async fn snapshot(
@@ -482,7 +481,7 @@ where
                             .inc_by(u64::cast_from(expired_readers.len()));
                         let lease_expiration = Some(LeaseExpiration {
                             readers: expired_readers,
-                            ..Default::default()
+                            writers: vec![],
                         });
 
                         let maintenance = RoutineMaintenance {

--- a/src/persist-client/src/impl/maintenance.rs
+++ b/src/persist-client/src/impl/maintenance.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 use timely::progress::Timestamp;
 use tokio::task::JoinHandle;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct LeaseExpiration {
     pub(crate) readers: Vec<ReaderId>,
     pub(crate) writers: Vec<WriterId>,
@@ -38,7 +38,7 @@ pub struct LeaseExpiration {
 /// Operations that run regularly once a handle is registered, such
 /// as heartbeats, are expected to always perform maintenance.
 #[must_use]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RoutineMaintenance {
     pub(crate) garbage_collection: Option<GcReq>,
     pub(crate) lease_expiration: Option<LeaseExpiration>,
@@ -110,7 +110,7 @@ impl RoutineMaintenance {
                 join_handles.push(mz_ore::task::spawn(
                     || "persist::automatic_write_expiration",
                     async move {
-                        let _ = machine.expire_writer(&expired).await;
+                        machine.expire_writer(&expired).await;
                     },
                 ));
             }
@@ -124,7 +124,7 @@ impl RoutineMaintenance {
 /// routine maintenance common to all handles. It is expected that
 /// writers always perform maintenance.
 #[must_use]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct WriterMaintenance<T> {
     pub(crate) routine: RoutineMaintenance,
     pub(crate) compaction: Vec<CompactReq<T>>,

--- a/src/persist-client/src/impl/maintenance.rs
+++ b/src/persist-client/src/impl/maintenance.rs
@@ -19,6 +19,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_persist_types::{Codec, Codec64};
 use std::fmt::Debug;
 use timely::progress::Timestamp;
+use tokio::task::JoinHandle;
 
 #[derive(Debug, Default)]
 pub struct LeaseExpiration {
@@ -44,6 +45,7 @@ pub struct RoutineMaintenance {
 }
 
 impl RoutineMaintenance {
+    /// Initiates any routine maintenance necessary in background tasks
     pub(crate) fn perform<K, V, T, D>(self, machine: &Machine<K, V, T, D>, gc: &GarbageCollector)
     where
         K: Debug + Codec,
@@ -51,24 +53,70 @@ impl RoutineMaintenance {
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64,
     {
+        let _ = self.perform_in_background(machine, gc);
+    }
+
+    /// Performs any routine maintenance necessary in background tasks. Can be awaited
+    /// to ensure all background work has completed.
+    ///
+    /// Used for testing maintenance-related state transitions deterministically
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) async fn perform_awaitable<K, V, T, D>(
+        self,
+        machine: &Machine<K, V, T, D>,
+        gc: &GarbageCollector,
+    ) where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        for handle in self.perform_in_background(machine, gc) {
+            let _ = handle.await;
+        }
+    }
+
+    fn perform_in_background<K, V, T, D>(
+        self,
+        machine: &Machine<K, V, T, D>,
+        gc: &GarbageCollector,
+    ) -> Vec<JoinHandle<()>>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let mut join_handles = vec![];
         if let Some(gc_req) = self.garbage_collection {
-            gc.gc_and_truncate_background(gc_req);
+            if let Some(join) = gc.gc_and_truncate_background(gc_req) {
+                join_handles.push(join);
+            }
         }
 
         if let Some(lease_expiration) = self.lease_expiration {
             for expired in lease_expiration.readers {
                 let mut machine = machine.clone();
-                let _ = mz_ore::task::spawn(|| "persist::automatic_read_expiration", async move {
-                    machine.expire_reader(&expired).await
-                });
+                join_handles.push(mz_ore::task::spawn(
+                    || "persist::automatic_read_expiration",
+                    async move {
+                        let _ = machine.expire_reader(&expired).await;
+                    },
+                ));
             }
             for expired in lease_expiration.writers {
                 let mut machine = machine.clone();
-                let _ = mz_ore::task::spawn(|| "persist::automatic_write_expiration", async move {
-                    machine.expire_writer(&expired).await
-                });
+                join_handles.push(mz_ore::task::spawn(
+                    || "persist::automatic_write_expiration",
+                    async move {
+                        let _ = machine.expire_writer(&expired).await;
+                    },
+                ));
             }
         }
+
+        join_handles
     }
 }
 
@@ -86,6 +134,7 @@ impl<T> WriterMaintenance<T>
 where
     T: Timestamp + Lattice + Codec64,
 {
+    /// Initiates any writer maintenance necessary in background tasks
     pub(crate) fn perform<K, V, D>(
         self,
         machine: &Machine<K, V, T, D>,
@@ -96,12 +145,50 @@ where
         V: Debug + Codec,
         D: Semigroup + Codec64,
     {
-        self.routine.perform(machine, gc);
+        let _ = self.perform_in_background(machine, gc, compactor);
+    }
+
+    /// Performs any writer maintenance necessary in background tasks. Can be awaited
+    /// to ensure all background work has completed.
+    ///
+    /// Used for testing maintenance-related state transitions deterministically
+    #[cfg(test)]
+    pub(crate) async fn perform_awaitable<K, V, D>(
+        self,
+        machine: &Machine<K, V, T, D>,
+        gc: &GarbageCollector,
+        compactor: Option<&Compactor>,
+    ) where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        D: Semigroup + Codec64,
+    {
+        for handle in self.perform_in_background(machine, gc, compactor) {
+            let _ = handle.await;
+        }
+    }
+
+    fn perform_in_background<K, V, D>(
+        self,
+        machine: &Machine<K, V, T, D>,
+        gc: &GarbageCollector,
+        compactor: Option<&Compactor>,
+    ) -> Vec<JoinHandle<()>>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        D: Semigroup + Codec64,
+    {
+        let mut handles = self.routine.perform_in_background(machine, gc);
 
         if let Some(compactor) = compactor {
             for req in self.compaction {
-                compactor.compact_and_apply_background(machine, req);
+                if let Some(handle) = compactor.compact_and_apply_background(machine, req) {
+                    handles.push(handle);
+                }
             }
         }
+
+        handles
     }
 }

--- a/src/persist-client/src/impl/maintenance.rs
+++ b/src/persist-client/src/impl/maintenance.rs
@@ -38,7 +38,7 @@ pub struct LeaseExpiration {
 /// Operations that run regularly once a handle is registered, such
 /// as heartbeats, are expected to always perform maintenance.
 #[must_use]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RoutineMaintenance {
     pub(crate) garbage_collection: Option<GcReq>,
     pub(crate) lease_expiration: Option<LeaseExpiration>,
@@ -51,7 +51,7 @@ impl RoutineMaintenance {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         let _ = self.perform_in_background(machine, gc);
     }
@@ -70,7 +70,7 @@ impl RoutineMaintenance {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         for handle in self.perform_in_background(machine, gc) {
             let _ = handle.await;
@@ -86,7 +86,7 @@ impl RoutineMaintenance {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         let mut join_handles = vec![];
         if let Some(gc_req) = self.garbage_collection {
@@ -124,7 +124,7 @@ impl RoutineMaintenance {
 /// routine maintenance common to all handles. It is expected that
 /// writers always perform maintenance.
 #[must_use]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct WriterMaintenance<T> {
     pub(crate) routine: RoutineMaintenance,
     pub(crate) compaction: Vec<CompactReq<T>>,
@@ -143,7 +143,7 @@ where
     ) where
         K: Debug + Codec,
         V: Debug + Codec,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         let _ = self.perform_in_background(machine, gc, compactor);
     }
@@ -161,7 +161,7 @@ where
     ) where
         K: Debug + Codec,
         V: Debug + Codec,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         for handle in self.perform_in_background(machine, gc, compactor) {
             let _ = handle.await;
@@ -177,7 +177,7 @@ where
     where
         K: Debug + Codec,
         V: Debug + Codec,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         let mut handles = self.routine.perform_in_background(machine, gc);
 

--- a/src/persist-client/src/impl/maintenance.rs
+++ b/src/persist-client/src/impl/maintenance.rs
@@ -1,0 +1,88 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! All machines need maintenance
+//!
+//! Maintenance operations for persist, shared among active handles
+
+use crate::r#impl::compact::CompactReq;
+use crate::r#impl::gc::GcReq;
+use crate::{Compactor, GarbageCollector, Machine};
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist_types::{Codec, Codec64};
+use std::fmt::Debug;
+use timely::progress::Timestamp;
+
+/// TODO: Actually implement lease expiration as a routine maintenance task
+#[derive(Debug)]
+pub struct LeaseExpiration;
+
+/// Every handle to this shard may be occasionally asked to perform
+/// routine maintenance after a successful compare_and_set operation.
+///
+/// For one-shot operations (like registering a reader) handles are
+/// allowed to skip routine maintenance if necessary, as the same
+/// maintenance operations will be recomputed by the next successful
+/// compare_and_set of any handle.
+///
+/// Operations that run regularly once a handle is registered, such
+/// as heartbeats, are expected to always perform maintenance.
+#[must_use]
+#[derive(Debug, Default)]
+pub struct RoutineMaintenance {
+    pub(crate) garbage_collection: Option<GcReq>,
+    pub(crate) lease_expiration: Option<LeaseExpiration>,
+}
+
+impl RoutineMaintenance {
+    pub(crate) fn perform(self, gc: &GarbageCollector) {
+        if let Some(gc_req) = self.garbage_collection {
+            gc.gc_and_truncate_background(gc_req);
+        }
+
+        if let Some(_lease_expiration) = self.lease_expiration {
+            unimplemented!("lease expiration coming soon");
+        }
+    }
+}
+
+/// Writers may be asked to perform additional tasks beyond the
+/// routine maintenance common to all handles. It is expected that
+/// writers always perform maintenance.
+#[must_use]
+#[derive(Debug, Default)]
+pub struct WriterMaintenance<T> {
+    pub(crate) routine: RoutineMaintenance,
+    pub(crate) compaction: Vec<CompactReq<T>>,
+}
+
+impl<T> WriterMaintenance<T>
+where
+    T: Timestamp + Lattice + Codec64,
+{
+    pub(crate) fn perform<K, V, D>(
+        self,
+        machine: &Machine<K, V, T, D>,
+        gc: &GarbageCollector,
+        compactor: Option<&Compactor>,
+    ) where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        D: Semigroup + Codec64,
+    {
+        self.routine.perform(gc);
+
+        if let Some(compactor) = compactor {
+            for req in self.compaction {
+                compactor.compact_and_apply_background(machine, req);
+            }
+        }
+    }
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -58,6 +58,7 @@ pub(crate) mod r#impl {
     pub mod encoding;
     pub mod gc;
     pub mod machine;
+    pub mod maintenance;
     pub mod metrics;
     pub mod paths;
     pub mod state;
@@ -364,7 +365,6 @@ impl PersistClient {
             shard_id,
             Arc::clone(&self.consensus),
             Arc::clone(&self.metrics),
-            gc,
         )
         .await?;
 
@@ -375,6 +375,7 @@ impl PersistClient {
             metrics: Arc::clone(&self.metrics),
             reader_id,
             machine,
+            gc,
             blob: Arc::clone(&self.blob),
             since: read_cap.since,
             last_heartbeat: Instant::now(),
@@ -410,7 +411,6 @@ impl PersistClient {
             shard_id,
             Arc::clone(&self.consensus),
             Arc::clone(&self.metrics),
-            gc,
         )
         .await?;
         let writer_id = WriterId::new();
@@ -429,6 +429,7 @@ impl PersistClient {
             metrics: Arc::clone(&self.metrics),
             writer_id,
             machine,
+            gc,
             compact,
             blob: Arc::clone(&self.blob),
             upper: shard_upper.0,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -330,7 +330,7 @@ impl PersistClient {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         trace!("Client::open shard_id={:?}", shard_id);
         Ok((
@@ -352,7 +352,7 @@ impl PersistClient {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         trace!("Client::open_reader shard_id={:?}", shard_id);
         let gc = GarbageCollector::new(
@@ -398,7 +398,7 @@ impl PersistClient {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         trace!("Client::open_writer shard_id={:?}", shard_id);
         let gc = GarbageCollector::new(
@@ -449,7 +449,7 @@ impl PersistClient {
         K: Debug + Codec,
         V: Debug + Codec,
         T: Timestamp + Lattice + Codec64,
-        D: Semigroup + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
     {
         self.open(shard_id).await.expect("codec mismatch")
     }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -95,7 +95,7 @@ where
     // These are only here so we can use them in the auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     handle: ReadHandle<K, V, T, D>,
     as_of: Antichain<T>,
@@ -109,7 +109,7 @@ where
     K: Debug + Codec,
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     fn new(handle: ReadHandle<K, V, T, D>, split: SnapshotSplit<T>) -> Self {
         debug_assert_eq!(handle.reader_id, split.reader_id);
@@ -212,7 +212,7 @@ where
     K: Debug + Codec + Ord,
     V: Debug + Codec + Ord,
     T: Timestamp + Lattice + Codec64 + Ord,
-    D: Semigroup + Codec64 + Ord,
+    D: Semigroup + Codec64 + Ord + Send + Sync,
 {
     /// Test helper to read all data in the snapshot and return it sorted.
     #[cfg(test)]
@@ -247,7 +247,7 @@ where
     // These are only here so we can use them in the auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     handle: ReadHandle<K, V, T, D>,
     as_of: Antichain<T>,
@@ -261,7 +261,7 @@ where
     K: Debug + Codec,
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     async fn new(handle: ReadHandle<K, V, T, D>, as_of: Antichain<T>) -> Self {
         let mut ret = Listen {
@@ -469,7 +469,7 @@ where
     // These are only here so we can use them in the auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
@@ -488,7 +488,7 @@ where
     K: Debug + Codec,
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     /// This handle's `since` frontier.
     ///
@@ -782,7 +782,7 @@ where
     // These are only here so we can use them in this auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     fn drop(&mut self) {
         if self.explicitly_expired {

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -162,7 +162,7 @@ where
                         .machine
                         .expire_reader(&self.handle.reader_id)
                         .await;
-                    maintenance.perform(&self.handle.gc);
+                    maintenance.perform(&self.handle.machine, &self.handle.gc);
                     self.handle.explicitly_expired = true;
                     return None;
                 }
@@ -519,7 +519,7 @@ where
         // A heartbeat is just any downgrade_since traffic, so update the
         // internal rate limiter here to play nicely with `maybe_heartbeat`.
         self.last_heartbeat = Instant::now();
-        maintenance.perform(&self.gc);
+        maintenance.perform(&self.machine, &self.gc);
     }
 
     /// Returns an ongoing subscription of updates to a shard.
@@ -740,7 +740,7 @@ where
                 .heartbeat_reader(&self.reader_id, (self.cfg.now)())
                 .await;
             self.last_heartbeat = Instant::now();
-            maintenance.perform(&self.gc);
+            maintenance.perform(&self.machine, &self.gc);
         }
     }
 
@@ -756,7 +756,7 @@ where
     pub async fn expire(mut self) {
         trace!("ReadHandle::expire");
         let (_, maintenance) = self.machine.expire_reader(&self.reader_id).await;
-        maintenance.perform(&self.gc);
+        maintenance.perform(&self.machine, &self.gc);
         self.explicitly_expired = true;
     }
 
@@ -812,7 +812,7 @@ where
             async move {
                 trace!("ReadHandle::expire");
                 let (_, maintenance) = machine.expire_reader(&reader_id).await;
-                maintenance.perform(&gc);
+                maintenance.perform(&machine, &gc);
             }
             .instrument(expire_span),
         );

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -545,7 +545,7 @@ where
     pub async fn expire(mut self) {
         trace!("WriteHandle::expire");
         let (_seq_no, maintenance) = self.machine.expire_writer(&self.writer_id).await;
-        maintenance.perform(&self.gc);
+        maintenance.perform(&self.machine, &self.gc);
         self.explicitly_expired = true;
     }
 
@@ -638,7 +638,7 @@ where
             async move {
                 trace!("WriteHandle::expire");
                 let (_, maintenance) = machine.expire_writer(&writer_id).await;
-                maintenance.perform(&gc);
+                maintenance.perform(&machine, &gc);
             }
             .instrument(expire_span),
         );

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -87,7 +87,7 @@ where
     // These are only here so we can use them in the auto-expiring `Drop` impl.
     K: Debug + Codec,
     V: Debug + Codec,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
@@ -106,7 +106,7 @@ where
     K: Debug + Codec,
     V: Debug + Codec,
     T: Timestamp + Lattice + Codec64,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     /// This handle's `upper` frontier.
     ///
@@ -610,7 +610,7 @@ where
     T: Timestamp + Lattice + Codec64,
     K: Debug + Codec,
     V: Debug + Codec,
-    D: Semigroup + Codec64,
+    D: Semigroup + Codec64 + Send + Sync,
 {
     fn drop(&mut self) {
         if self.explicitly_expired {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR refactors `Machine` to return maintenance work from each successful `apply_unbatched_cmd`. The maintenance work is passed on to the caller on the public methods we expect to be called consistently by open handles, like `compare_and_append`, `downgrade_since`, `heartbeat_reader|writer`.

This work is a generalization of how compaction works for WriteHandles currently, where a successful `compare_and_append` call may reward the handle with compaction requests it should execute in the background. With this PR, we can pass back garbage collection and lease expiration tasks to all handles, in addition to compaction for write handles.

This PR also makes some tweaks to compact/gc tasks, returning `JoinHandle`s  so we can await their completion in tests, now that we no longer have background tasks initiated inside `Machine` itself.


### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

Please note that this PR does _not_ try to make lease expiration better. It's pretty much a 1:1 port with what we have, and future/separate work can be done to make it more robust

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
