### PR TITLE
persist: add hacky temporary impl of automatic read lease expiration

### DIFF
--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -159,10 +159,11 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             command_wrapper: vec![],
         }))?,
     );
-    let persist_clients = PersistClientCache::new(
-        PersistConfig::new_for_test(config.now.clone()),
-        &metrics_registry,
-    );
+    // Messing with the clock causes persist to expire leases, causing hangs and
+    // panics. Is it possible/desirable to put this back somehow?
+    let persist_now = SYSTEM_TIME.clone();
+    let persist_clients =
+        PersistClientCache::new(PersistConfig::new_for_test(persist_now), &metrics_registry);
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let inner = runtime.block_on(mz_environmentd::serve(mz_environmentd::Config {
         adapter_stash_url,

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -46,6 +46,8 @@ pub struct Metrics {
     pub compaction: CompactionMetrics,
     /// Metrics for garbage collection.
     pub gc: GcMetrics,
+    /// Metrics for leasing and automatic lease expiry.
+    pub lease: LeaseMetrics,
     /// Metrics for various encodings and decodings.
     pub codecs: CodecsMetrics,
 }
@@ -63,6 +65,7 @@ impl Metrics {
             user: BatchWriteMetrics::new(registry, "user"),
             compaction: CompactionMetrics::new(registry),
             gc: GcMetrics::new(registry),
+            lease: LeaseMetrics::new(registry),
             _vecs: vecs,
         }
     }
@@ -499,6 +502,22 @@ impl GcMetrics {
             seconds: registry.register(metric!(
                 name: "mz_persist_gc_seconds",
                 help: "time spent in garbage collections",
+            )),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct LeaseMetrics {
+    pub(crate) timeout_read: IntCounter,
+}
+
+impl LeaseMetrics {
+    fn new(registry: &MetricsRegistry) -> Self {
+        LeaseMetrics {
+            timeout_read: registry.register(metric!(
+                name: "mz_persist_lease_timeout_read",
+                help: "count of readers whose lease timed out",
             )),
         }
     }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -355,6 +355,7 @@ impl PersistClient {
             Arc::clone(&self.metrics),
         );
         let mut machine = Machine::new(
+            self.cfg.clone(),
             shard_id,
             Arc::clone(&self.consensus),
             Arc::clone(&self.metrics),
@@ -400,6 +401,7 @@ impl PersistClient {
             Arc::clone(&self.metrics),
         );
         let mut machine = Machine::new(
+            self.cfg.clone(),
             shard_id,
             Arc::clone(&self.consensus),
             Arc::clone(&self.metrics),


### PR DESCRIPTION
When a process holding a ReadHandle restarts without dropping it (the
common case currently in our deployments) this ReadHandle holds a
permanent capability on seqno (and presumably since). This prevents GC,
leaking data into blob and consensus like crazy.

To prevent this situation, this commit introduces a simple, hacky
version of the automatic read lease expiration while we wait for the
real one that Paul is writing soon.

Touches #13861 (hopefully fixes it)

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I haven't yet tested this locally, getting it up for a CI run and initial reviewer eyes. I plan to add metrics to track when this happens before merging, but tests (beyond manual testing) would likely be left for a followup.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
