### PR TITLE
storage: factor out initialization of storage hosts

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -425,8 +425,6 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + Unpin> {
     persist_location: PersistLocation,
     /// A persist client used to write to storage collections
     persist_client: PersistClient,
-    /// Set to `true` once `initialization_complete` has been called.
-    initialized: bool,
 }
 
 #[derive(Debug)]
@@ -552,10 +550,7 @@ where
     type Timestamp = T;
 
     fn initialization_complete(&mut self) {
-        self.initialized = true;
-        for client in self.hosts.clients() {
-            client.send(StorageCommand::InitializationComplete);
-        }
+        self.hosts.initialization_complete();
     }
 
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, StorageError> {
@@ -710,12 +705,7 @@ where
                         ),
                     )
                     .await?;
-
                 client.send(StorageCommand::IngestSources(vec![augmented_ingestion]));
-
-                if self.initialized {
-                    client.send(StorageCommand::InitializationComplete);
-                }
             }
         }
 
@@ -1015,7 +1005,6 @@ where
             internal_response_queue: rx,
             persist_location,
             persist_client,
-            initialized: false,
         }
     }
 

--- a/src/storage/src/controller/hosts.rs
+++ b/src/storage/src/controller/hosts.rs
@@ -69,6 +69,8 @@ pub struct StorageHosts<T> {
     hosts: HashMap<StorageHostAddr, StorageHost<T>>,
     /// The assignment of storage objects to storage hosts.
     objects: HashMap<GlobalId, StorageHostAddr>,
+    /// Set to `true` once `initialization_complete` has been called.
+    initialized: bool,
 }
 
 /// Metadata about a single storage host.
@@ -82,7 +84,12 @@ struct StorageHost<T> {
     orchestrated: bool,
 }
 
-impl<T> StorageHosts<T> {
+impl<T> StorageHosts<T>
+where
+    T: Timestamp + Lattice,
+    StorageCommand<T>: RustType<ProtoStorageCommand>,
+    StorageResponse<T>: RustType<ProtoStorageResponse>,
+{
     /// Constructs a new [`StorageHosts`] from its configuration.
     pub fn new(config: StorageHostsConfig) -> StorageHosts<T> {
         StorageHosts {
@@ -91,6 +98,20 @@ impl<T> StorageHosts<T> {
             storaged_image: config.storaged_image,
             objects: HashMap::new(),
             hosts: HashMap::new(),
+            initialized: false,
+        }
+    }
+
+    /// Marks the end of any initialization commands.
+    ///
+    /// The implementor may wait for this method to be called before
+    /// implementing prior commands, and so it is important for a user to invoke
+    /// this method as soon as it is comfortable. This method can be invoked
+    /// immediately, at the potential expense of performance.
+    pub fn initialization_complete(&mut self) {
+        self.initialized = true;
+        for client in self.clients() {
+            client.send(StorageCommand::InitializationComplete);
         }
     }
 
@@ -133,7 +154,10 @@ impl<T> StorageHosts<T> {
         info!("assigned storage object {id} to storage host {host_addr}");
         match self.hosts.entry(host_addr.clone()) {
             Entry::Vacant(entry) => {
-                let client = RehydratingStorageClient::new(host_addr, self.build_info);
+                let mut client = RehydratingStorageClient::new(host_addr, self.build_info);
+                if self.initialized {
+                    client.send(StorageCommand::InitializationComplete);
+                }
                 let host = entry.insert(StorageHost {
                     client,
                     objects: HashSet::from_iter([id]),


### PR DESCRIPTION
@cjubb39 as we discussed today! I figured I'd get a CI run out overnight for validation of this fix.

----

There were two issues with the initialization of storage hosts:

  * Creating new sources in an already initialized controller sent the
    `InitializationComplete` command *after* sending the initial
    `CreateSources` command. This was not wrong in practice, because the
    storage host in this case was sure to be empty and performing
    reconciliation was therefore a no-op, but it was conceptually
    incorrect.

  * Creating   new sink did not send `InitializationComplete`, which
    presented as `storaged` processes never receiving the CreateExports
    command.

This commit solves both of these issues by pushing responsibility for
sending `InitializationComplete` into the `StorageHosts` object. Once
`StorageHosts::initialization_complete` is called, new storage hosts are
sent the `InitializeComplete` command during provisioning; the create
source and create sink code paths no longer *both* need to remember to
do this, nor can they send the command in the wrong order.

Co-authored-by: Chae Jubb <chae@materialize.com>

### Motivation

  * This PR fixes a bug @cjubb39 was experiencing in a WIP branch.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. (Not adding tests because they'll be covered by Chae's forthcoming PR.)
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
