### PR TITLE
sql: mark LOGICAL COMPACTION WINDOW as unsafe

### DIFF
--- a/doc/user/content/sql/alter-index.md
+++ b/doc/user/content/sql/alter-index.md
@@ -15,14 +15,6 @@ menu:
 Field | Use
 ------|-----
 _name_ | The identifier of the index you want to alter.
-_field_ | The name of the option you want to alter.
-_val_ | The new value for the option.
-
-### `SET`/`RESET` options
-
-The following option is valid within the `SET` and `RESET` clauses:
-
-{{% index-with-options %}}
 
 ## Details
 
@@ -32,20 +24,6 @@ Note that when enabling indexes on tables, the first index you enable must be
 the table's primary index, which was created at the same time as the table
 itself. Only after enabling the primary index can you enable any secondary
 indexes.
-
-## Examples
-
-To adjust the logical compaction window for the index named `some_primary_idx`:
-
-```sql
-ALTER INDEX some_primary_idx SET (logical_compaction_window = '500ms');
-```
-
-To reset the logical compaction window to its default value:
-
-```sql
-ALTER INDEX some_primary_idx RESET (logical_compaction_window);
-```
 
 ## See also
 

--- a/doc/user/content/sql/create-index.md
+++ b/doc/user/content/sql/create-index.md
@@ -52,12 +52,6 @@ _col&lowbar;expr_**...** | The expressions to use as the key for the index.
 _field_ | The name of the option you want to set.
 _val_ | The value for the option.
 
-### `WITH` options
-
-The following option is valid within the `WITH` clause:
-
-{{% index-with-options %}}
-
 ## Details
 
 ### Restrictions

--- a/doc/user/layouts/partials/index-with-options.html
+++ b/doc/user/layouts/partials/index-with-options.html
@@ -1,3 +1,0 @@
-Name | Permitted values | Default value | Description
-----------------------------|--------|--------|--------
-`LOGICAL COMPACTION WINDOW` | SQL [interval](/sql/types/interval/) string | '1s' | Overrides the [logical compaction window](/ops/optimization/#compaction) for the data stored in this index. A value of `0` disables logical compaction.

--- a/doc/user/layouts/partials/sql-grammar/alter-index.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-index.svg
@@ -1,116 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="485" height="279">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="66" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="455" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">ALTER</text>
-   <rect x="119" y="3" width="62" height="32" rx="10"/>
-   <rect x="117"
+   <text class="terminal" x="39" y="21">ALTER</text>
+   <rect x="117" y="3" width="62" height="32" rx="10"/>
+   <rect x="115"
          y="1"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="127" y="21">INDEX</text>
-   <rect x="201" y="3" width="56" height="32"/>
-   <rect x="199" y="1" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="209" y="21">name</text>
-   <rect x="45" y="69" width="46" height="32" rx="10"/>
-   <rect x="43"
-         y="67"
+   <text class="terminal" x="125" y="21">INDEX</text>
+   <rect x="199" y="3" width="56" height="32"/>
+   <rect x="197" y="1" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="207" y="21">name</text>
+   <rect x="275" y="3" width="46" height="32" rx="10"/>
+   <rect x="273"
+         y="1"
          width="46"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="87">SET</text>
-   <rect x="131" y="69" width="86" height="32" rx="10"/>
-   <rect x="129"
-         y="67"
+   <text class="terminal" x="283" y="21">SET</text>
+   <rect x="341" y="3" width="86" height="32" rx="10"/>
+   <rect x="339"
+         y="1"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="139" y="87">ENABLED</text>
-   <rect x="131" y="157" width="26" height="32" rx="10"/>
-   <rect x="129"
-         y="155"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="139" y="175">(</text>
-   <rect x="197" y="157" width="48" height="32"/>
-   <rect x="195" y="155" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="205" y="175">field</text>
-   <rect x="265" y="157" width="28" height="32" rx="10"/>
-   <rect x="263"
-         y="155"
-         width="28"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="273" y="175">=</text>
-   <rect x="313" y="157" width="38" height="32"/>
-   <rect x="311" y="155" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="321" y="175">val</text>
-   <rect x="197" y="113" width="24" height="32" rx="10"/>
-   <rect x="195"
-         y="111"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="205" y="131">,</text>
-   <rect x="391" y="157" width="26" height="32" rx="10"/>
-   <rect x="389"
-         y="155"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="399" y="175">)</text>
-   <rect x="45" y="245" width="64" height="32" rx="10"/>
-   <rect x="43"
-         y="243"
-         width="64"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="53" y="263">RESET</text>
-   <rect x="129" y="245" width="26" height="32" rx="10"/>
-   <rect x="127"
-         y="243"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="137" y="263">(</text>
-   <rect x="195" y="245" width="48" height="32"/>
-   <rect x="193" y="243" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="203" y="263">field</text>
-   <rect x="195" y="201" width="24" height="32" rx="10"/>
-   <rect x="193"
-         y="199"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="203" y="219">,</text>
-   <rect x="283" y="245" width="26" height="32" rx="10"/>
-   <rect x="281"
-         y="243"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="291" y="263">)</text>
+   <text class="terminal" x="349" y="21">ENABLED</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-276 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m46 0 h10 m20 0 h10 m86 0 h10 m0 0 h200 m-326 0 h20 m306 0 h20 m-346 0 q10 0 10 10 m326 0 q0 -10 10 -10 m-336 10 v68 m326 0 v-68 m-326 68 q0 10 10 10 m306 0 q10 0 10 -10 m-316 10 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-412 -88 h20 m412 0 h20 m-452 0 q10 0 10 10 m432 0 q0 -10 10 -10 m-442 10 v156 m432 0 v-156 m-432 156 q0 10 10 10 m412 0 q10 0 10 -10 m-422 10 h10 m64 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m-88 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m68 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-68 0 h10 m24 0 h10 m0 0 h24 m20 44 h10 m26 0 h10 m0 0 h128 m23 -176 h-3"/>
-   <polygon points="475 83 483 79 483 87"/>
-   <polygon points="475 83 467 79 467 87"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m46 0 h10 m0 0 h10 m86 0 h10 m3 0 h-3"/>
+   <polygon points="445 17 453 13 453 21"/>
+   <polygon points="445 17 437 13 437 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/create-index.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-index.svg
@@ -1,14 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1195" height="381">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="76" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="1201" height="255">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="76" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">CREATE</text>
+   <text class="terminal" x="41" y="21">CREATE</text>
    <rect x="45" y="113" width="62" height="32" rx="10"/>
    <rect x="43"
          y="111"
@@ -129,54 +129,8 @@
    <rect x="755" y="221" width="70" height="32"/>
    <rect x="753" y="219" width="70" height="32" class="nonterminal"/>
    <text class="nonterminal" x="763" y="239">method</text>
-   <rect x="783" y="331" width="58" height="32" rx="10"/>
-   <rect x="781"
-         y="329"
-         width="58"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="791" y="349">WITH</text>
-   <rect x="861" y="331" width="26" height="32" rx="10"/>
-   <rect x="859"
-         y="329"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="869" y="349">(</text>
-   <rect x="927" y="331" width="48" height="32"/>
-   <rect x="925" y="329" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="935" y="349">field</text>
-   <rect x="995" y="331" width="28" height="32" rx="10"/>
-   <rect x="993"
-         y="329"
-         width="28"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="1003" y="349">=</text>
-   <rect x="1043" y="331" width="38" height="32"/>
-   <rect x="1041" y="329" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="1051" y="349">val</text>
-   <rect x="927" y="287" width="24" height="32" rx="10"/>
-   <rect x="925"
-         y="285"
-         width="24"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="935" y="305">,</text>
-   <rect x="1121" y="331" width="26" height="32" rx="10"/>
-   <rect x="1119"
-         y="329"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="1129" y="349">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-126 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m20 44 h10 m26 0 h10 m-1148 0 h20 m1128 0 h20 m-1168 0 q10 0 10 10 m1148 0 q0 -10 10 -10 m-1158 10 v56 m1148 0 v-56 m-1148 56 q0 10 10 10 m1128 0 q10 0 10 -10 m-1138 10 h10 m158 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 -32 h308 m22 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-454 218 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="1185 345 1193 341 1193 349"/>
-   <polygon points="1185 345 1177 341 1177 349"/>
+         d="m19 17 h2 m0 0 h10 m76 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-128 110 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m62 0 h10 m0 0 h10 m98 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m20 44 h10 m26 0 h10 m-1148 0 h20 m1128 0 h20 m-1168 0 q10 0 10 10 m1148 0 q0 -10 10 -10 m-1158 10 v56 m1148 0 v-56 m-1148 56 q0 10 10 10 m1128 0 q10 0 10 -10 m-1138 10 h10 m158 0 h10 m0 0 h10 m82 0 h10 m20 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m0 0 h164 m-194 0 h20 m174 0 h20 m-214 0 q10 0 10 10 m194 0 q0 -10 10 -10 m-204 10 v12 m194 0 v-12 m-194 12 q0 10 10 10 m174 0 q10 0 10 -10 m-184 10 h10 m64 0 h10 m0 0 h10 m70 0 h10 m20 -32 h308 m23 -76 h-3"/>
+   <polygon points="1191 127 1199 123 1199 131"/>
+   <polygon points="1191 127 1183 123 1183 131"/>
 </svg>

--- a/doc/user/layouts/shortcodes/index-with-options.html
+++ b/doc/user/layouts/shortcodes/index-with-options.html
@@ -1,1 +1,0 @@
-{{ partial (printf "index-with-options") . -}}

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -2,13 +2,7 @@ aggregate_with_filter ::= aggregate_name '(' expression ')' ('FILTER' '(' 'WHERE
 alter_rename ::=
   'ALTER' ('INDEX' | 'SOURCE' | 'VIEW' | 'MATERIALIZED VIEW' | 'TABLE') name 'RENAME TO' new_name
 alter_index ::=
-  'ALTER' 'INDEX' name (
-    'SET' (
-      'ENABLED'
-      | '(' field '=' val ( ',' field '=' val )* ')'
-    )
-    | 'RESET' '(' field ( ',' field )* ')'
-  )
+  'ALTER' 'INDEX' name 'SET' 'ENABLED'
 array_agg ::=
   'array_agg' '(' values  ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 as_of ::=
@@ -52,7 +46,6 @@ create_index ::=
         'INDEX' index_name 'ON' obj_name ('IN' 'CLUSTER' cluster_name)? ('USING' method)? '(' ( ( col_expr ) ( ( ',' col_expr ) )* ) ')'
         | 'DEFAULT INDEX ON' obj_name ('IN' 'CLUSTER' cluster_name)? ('USING' method)?
     )
-    ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 create_materialized_view ::=
   'CREATE' 'MATERIALIZED VIEW' 'IF NOT EXISTS'?
     view_name ( '(' col_ident ( ',' col_ident )* ')' )?

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -359,7 +359,10 @@ fn test_tail_basic() -> Result<(), Box<dyn Error>> {
         let nowfn = Arc::clone(&nowfn);
         NowFn::from(move || (nowfn.lock().unwrap())())
     };
-    let config = util::Config::default().workers(2).with_now(now);
+    let config = util::Config::default()
+        .workers(2)
+        .with_now(now)
+        .unsafe_mode();
     let server = util::start_server(config)?;
     let mut client_writes = server.connect(postgres::NoTls)?;
     let mut client_reads = server.connect(postgres::NoTls)?;


### PR DESCRIPTION
This is a feature we need to rethink, and probably build into
storage. Disallow in cloud for now.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Disable `LOGICAL COMPACTION WINDOW` when creating and altering indexes.