### PR TITLE
cloudtest: Migrate to kind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ test/feature-benchmark/tmp/*.td
 test/zippy/tmp/*.td
 junit_*.xml
 perf.data*
+**/*.rej
+**/*.orig

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -1,0 +1,60 @@
+# Introduction
+
+`cloudtest` is a test framework that allows testing Materialize inside Kubernetes.
+
+Using a K8s environment for testing has the advantage that the same orchestrator that
+is used in the Cloud is used to spawn computeds and storageds. K8s will also be responsible
+for restarting any containers that have exited.
+
+The framework is pased on pytest and KinD and uses, for the most part, the official `kubernetes`
+python library to control the K8s cluster.
+
+# Setup
+
+1. Install kubectl
+
+```
+curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+chmod+x kubectl
+sudo mv kubectl /usr/local/bin
+```
+
+2. Install KinD
+
+```
+go get sigs.k8s.io/kind
+export PATH=$PATH:$(go env GOPATH)/bin
+```
+
+More installation options are available here [https://kind.sigs.k8s.io/docs/user/quick-start/#installing-with-a-package-manager]
+
+3. Create a Kubernetes KinD cluster
+
+```
+~/go/bin/kind create cluster --config=misc/kind/cluster.yaml
+```
+
+# Running
+
+```
+cd test/cloudtest
+./pytest
+```
+
+## Checking K8s cluster status
+
+```
+kubectl --context kind-kind get all
+```
+
+## Resetting the K8s cluster
+
+This command removes almost all resources from the K8s cluster, so that a test can be rerun.
+
+```
+kubectl --context kind-kind delete all --all
+```
+
+# Writing tests
+
+See the examples in `test/clustertest/test_smoke.py`

--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -1,0 +1,153 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Adapted from https://github.com/MaterializeInc/cloud/blob/main/misc/kind/cluster.yaml
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# Constrain the node port range to something relatively small, then forward all
+# those ports from the host. This makes services running in Kubernetes
+# accessible at localhost:$NODEPORT without requiring manual port forwarding.
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        "service-node-port-range": "32000-32063"
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 32000
+        hostPort: 32000
+      - containerPort: 32001
+        hostPort: 32001
+      - containerPort: 32002
+        hostPort: 32002
+      - containerPort: 32003
+        hostPort: 32003
+      - containerPort: 32004
+        hostPort: 32004
+      - containerPort: 32005
+        hostPort: 32005
+      - containerPort: 32006
+        hostPort: 32006
+      - containerPort: 32007
+        hostPort: 32007
+      - containerPort: 32008
+        hostPort: 32008
+      - containerPort: 32009
+        hostPort: 32009
+      - containerPort: 32010
+        hostPort: 32010
+      - containerPort: 32011
+        hostPort: 32011
+      - containerPort: 32012
+        hostPort: 32012
+      - containerPort: 32013
+        hostPort: 32013
+      - containerPort: 32014
+        hostPort: 32014
+      - containerPort: 32015
+        hostPort: 32015
+      - containerPort: 32016
+        hostPort: 32016
+      - containerPort: 32017
+        hostPort: 32017
+      - containerPort: 32018
+        hostPort: 32018
+      - containerPort: 32019
+        hostPort: 32019
+      - containerPort: 32020
+        hostPort: 32020
+      - containerPort: 32021
+        hostPort: 32021
+      - containerPort: 32022
+        hostPort: 32022
+      - containerPort: 32023
+        hostPort: 32023
+      - containerPort: 32024
+        hostPort: 32024
+      - containerPort: 32025
+        hostPort: 32025
+      - containerPort: 32026
+        hostPort: 32026
+      - containerPort: 32027
+        hostPort: 32027
+      - containerPort: 32028
+        hostPort: 32028
+      - containerPort: 32029
+        hostPort: 32029
+      - containerPort: 32030
+        hostPort: 32030
+      - containerPort: 32031
+        hostPort: 32031
+      - containerPort: 32032
+        hostPort: 32032
+      - containerPort: 32033
+        hostPort: 32033
+      - containerPort: 32034
+        hostPort: 32034
+      - containerPort: 32035
+        hostPort: 32035
+      - containerPort: 32036
+        hostPort: 32036
+      - containerPort: 32037
+        hostPort: 32037
+      - containerPort: 32038
+        hostPort: 32038
+      - containerPort: 32039
+        hostPort: 32039
+      - containerPort: 32040
+        hostPort: 32040
+      - containerPort: 32041
+        hostPort: 32041
+      - containerPort: 32042
+        hostPort: 32042
+      - containerPort: 32043
+        hostPort: 32043
+      - containerPort: 32044
+        hostPort: 32044
+      - containerPort: 32045
+        hostPort: 32045
+      - containerPort: 32046
+        hostPort: 32046
+      - containerPort: 32047
+        hostPort: 32047
+      - containerPort: 32048
+        hostPort: 32048
+      - containerPort: 32049
+        hostPort: 32049
+      - containerPort: 32050
+        hostPort: 32050
+      - containerPort: 32051
+        hostPort: 32051
+      - containerPort: 32052
+        hostPort: 32052
+      - containerPort: 32053
+        hostPort: 32053
+      - containerPort: 32054
+        hostPort: 32054
+      - containerPort: 32055
+        hostPort: 32055
+      - containerPort: 32056
+        hostPort: 32056
+      - containerPort: 32057
+        hostPort: 32057
+      - containerPort: 32058
+        hostPort: 32058
+      - containerPort: 32059
+        hostPort: 32059
+      - containerPort: 32060
+        hostPort: 32060
+      - containerPort: 32061
+        hostPort: 32061
+      - containerPort: 32062
+        hostPort: 32062
+      - containerPort: 32063
+        hostPort: 32063

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -33,6 +33,8 @@ class Testdrive(K8sPod):
         subprocess.run(
             [
                 "kubectl",
+                "--context",
+                self.context(),
                 "exec",
                 "-it",
                 "testdrive",

--- a/misc/python/materialize/cloudtest/wait.py
+++ b/misc/python/materialize/cloudtest/wait.py
@@ -14,7 +14,9 @@ from materialize import ui
 from materialize.ui import UIError
 
 
-def wait(condition: str, resource: str, timeout_secs: int = 300) -> None:
+def wait(
+    condition: str, resource: str, timeout_secs: int = 300, context: str = "kind-kind"
+) -> None:
     cmd = [
         "kubectl",
         "wait",
@@ -23,6 +25,8 @@ def wait(condition: str, resource: str, timeout_secs: int = 300) -> None:
         resource,
         "--timeout",
         f"{timeout_secs}s",
+        "--context",
+        context,
     ]
     ui.progress(f'waiting for {" ".join(cmd)} ... ')
 

--- a/test/cloudtest/README.md
+++ b/test/cloudtest/README.md
@@ -1,0 +1,1 @@
+Please see [the cloudtest documentation](../../doc/developer/cloudtest.md) for more information.


### PR DESCRIPTION
- the ability to execute SQL queries directly has been removed
  since making environmentd accessible to the outside is a tedious
  task in Kind. testdrive needs to be used instead.
### Motivation

  * This PR adds a known-desirable feature.

- #13721


### Suggestions to reviewer

"Hide whitespace" is recommended 