### PR TITLE
Remove incorrect error message on persisted logs

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -184,24 +184,35 @@ impl CatalogState {
 
     /// Computes the IDs of any log sources this catalog entry transitively
     /// depends on.
-    pub fn log_dependencies(&self, id: GlobalId) -> Vec<GlobalId> {
+    pub fn active_log_dependencies(&self, id: GlobalId) -> Vec<GlobalId> {
         let mut out = Vec::new();
-        self.log_dependencies_inner(id, &mut out);
-        out
+        self.active_log_dependencies_inner(id, &mut out);
+
+        // Filter out persisted logs
+        let mut persisted_logs = HashSet::new();
+        for instance in self.compute_instances_by_id.values() {
+            for replica in instance.replicas_by_id.values() {
+                persisted_logs.extend(replica.config.persisted_logs.get_log_ids());
+            }
+        }
+
+        out.into_iter()
+            .filter(|x| !persisted_logs.contains(x))
+            .collect()
     }
 
-    fn log_dependencies_inner(&self, id: GlobalId, out: &mut Vec<GlobalId>) {
+    fn active_log_dependencies_inner(&self, id: GlobalId, out: &mut Vec<GlobalId>) {
         match self.get_entry(&id).item() {
             CatalogItem::Log(_) => out.push(id),
             item @ (CatalogItem::View(_)
             | CatalogItem::MaterializedView(_)
             | CatalogItem::Connection(_)) => {
                 for id in item.uses() {
-                    self.log_dependencies_inner(*id, out);
+                    self.active_log_dependencies_inner(*id, out);
                 }
             }
-            CatalogItem::Sink(sink) => self.log_dependencies_inner(sink.from, out),
-            CatalogItem::Index(idx) => self.log_dependencies_inner(idx.on, out),
+            CatalogItem::Sink(sink) => self.active_log_dependencies_inner(sink.from, out),
+            CatalogItem::Index(idx) => self.active_log_dependencies_inner(idx.on, out),
             CatalogItem::Table(_)
             | CatalogItem::Source(_)
             | CatalogItem::Type(_)
@@ -3621,9 +3632,9 @@ impl<S: Append> Catalog<S> {
         self.state.uses_tables(id)
     }
 
-    /// Return the names of all log sources the given object depends on.
-    pub fn log_dependencies(&self, id: GlobalId) -> Vec<GlobalId> {
-        self.state.log_dependencies(id)
+    /// Return the ids of all active log sources the given object depends on.
+    pub fn active_log_dependencies(&self, id: GlobalId) -> Vec<GlobalId> {
+        self.state.active_log_dependencies(id)
     }
 
     /// Serializes the catalog's in-memory state.

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1175,7 +1175,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // are replaced with persist-based ones.
         let log_names = depends_on
             .iter()
-            .flat_map(|id| self.catalog.log_dependencies(*id))
+            .flat_map(|id| self.catalog.active_log_dependencies(*id))
             .map(|id| self.catalog.get_entry(&id).name().item.clone())
             .collect::<Vec<_>>();
         if !log_names.is_empty() {
@@ -1653,7 +1653,7 @@ impl<S: Append + 'static> Coordinator<S> {
         ) -> Result<(), AdapterError> {
             let log_names = source_ids
                 .iter()
-                .flat_map(|id| catalog.log_dependencies(*id))
+                .flat_map(|id| catalog.active_log_dependencies(*id))
                 .map(|id| catalog.get_entry(&id).name().item.clone())
                 .collect::<Vec<_>>();
 

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -102,6 +102,10 @@ CREATE VIEW introspection_view AS SELECT * FROM mz_materializations
 query error log source reads must target a replica
 SELECT * FROM introspection_view
 
+# Verify that the logic does not apply to persisted logs
+statement ok
+SELECT * FROM mz_peek_active_1
+
 # Verify that untargeted introspection queries on unreplicated clusters are
 # allowed.
 


### PR DESCRIPTION
Allow to select from persisted logs on a cluster with more than one replica.

Fixes #13883 

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

 - Allow to select from persisted logs on a cluster with more than one replica.
