### PR TITLE
Fix of port for Web UI in developer guide

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -196,8 +196,8 @@ UI which defaults to `localhost:9021`.
 
 ## Web UI
 
-Materialize embeds a web UI, which it serves from port 6875. If you're running
-Materialize locally, you can view the web UI at http://localhost:6875.
+Materialize embeds a web UI, which it serves from port 6876. If you're running
+Materialize locally, you can view the web UI at http://localhost:6876.
 
 Developing the web UI can be painful, as by default the HTML, CSS, and JS source
 code for the UI gets baked into the binary, and so making a change requires a


### PR DESCRIPTION
This PR fixes the port of the web UI in the developer guide from 6875 to its new default of 6876. 

### Motivation

* This PR improves developer documentation.

### Tips for reviewer

### Checklist

- [ N/A ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ N/A ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ N/A ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note).

