### PR TITLE
persist_source: emit progress before the snapshot

### DIFF
--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -87,18 +87,21 @@ where
             .await
             .expect("could not open persist shard");
 
+        // Report initial progress so we can already downgrade our capability before potentially
+        // having to wait for the snapshot.
+        yield ListenEvent::Progress(as_of.clone());
+
         let mut snapshot_iter = read
             .snapshot(as_of.clone())
             .await
             .expect("cannot serve requested as_of");
 
-        // First, yield all the updates from the snapshot.
+        // Yield all the updates from the snapshot.
         while let Some(next) = snapshot_iter.next().await {
             yield ListenEvent::Updates(next);
         }
 
-        // Then, listen continuously and yield any new updates. This loop is expected to never
-        // finish.
+        // Listen continuously and yield any new updates. This loop is expected to never finish.
         let mut listen = read
             .listen(as_of)
             .await

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -150,7 +150,8 @@ id price
 
 > DECLARE c CURSOR FOR TAIL data_schema_inline WITH (SNAPSHOT = FALSE, PROGRESS = TRUE);
 
-> FETCH 1 FROM c WITH (timeout = '60s')
+> FETCH 2 FROM c WITH (timeout = '60s')
+14 true <null> <null> <null>
 15 true <null> <null> <null>
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=6


### PR DESCRIPTION
This PR makes the `persist_source` operator downgrade its capability immediately before trying to read from the persist shard. This ensures downstream operators can already make progress, even if `persist_source` still needs to wait for the snapshot to be ready.

### Motivation

This is required to make @frankmcsherry's alternative persist_sink work (https://github.com/MaterializeInc/materialize/pull/13740, [Slack discussion](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1658998887303829)). But even without this consideration, this seems like a sensible change to make.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
