### PR TITLE
persist: thread down a tokio runtime for use in blocking work

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -20,6 +20,7 @@ use timely::communication::Allocate;
 use timely::execute::execute_from;
 use timely::worker::Worker as TimelyWorker;
 use timely::WorkerConfig;
+use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 
 use mz_compute_client::command::ComputeCommand;
@@ -92,9 +93,12 @@ pub fn serve(
     let (builders, other) =
         initialize_networking(config.comm_config).map_err(|e| anyhow!("{e}"))?;
 
+    // WIP actually create a second runtime for this.
+    let blocking_runtime = Handle::current();
     let persist_clients = PersistClientCache::new(
         PersistConfig::new(config.now.clone()),
         &config.metrics_registry,
+        blocking_runtime,
     );
     let persist_clients = Arc::new(tokio::sync::Mutex::new(persist_clients));
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -31,6 +31,7 @@ use itertools::Itertools;
 use jsonwebtoken::DecodingKey;
 use once_cell::sync::Lazy;
 use sysinfo::{CpuExt, SystemExt};
+use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 use tower_http::cors::{self, AllowOrigin};
 use url::Url;
@@ -548,8 +549,13 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     };
     let secrets_reader = secrets_controller.reader();
     let now = SYSTEM_TIME.clone();
-    let persist_clients =
-        PersistClientCache::new(PersistConfig::new(now.clone()), &metrics_registry);
+    // WIP actually create a second runtime for this.
+    let blocking_runtime = Handle::current();
+    let persist_clients = PersistClientCache::new(
+        PersistConfig::new(now.clone()),
+        &metrics_registry,
+        blocking_runtime,
+    );
     let persist_clients = Arc::new(Mutex::new(persist_clients));
     let orchestrator = Arc::new(TracingOrchestrator::new(
         orchestrator,

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -15,7 +15,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use tempfile::TempDir;
 use timely::progress::{Antichain, Timestamp};
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 
 use mz_persist::file::{FileBlob, FileBlobConfig};
 use mz_persist::location::{Blob, Consensus, ExternalError};
@@ -104,6 +104,7 @@ async fn create_mem_mem_client() -> Result<PersistClient, ExternalError> {
         blob,
         consensus,
         metrics,
+        Handle::current(),
     )
     .await
 }
@@ -126,6 +127,7 @@ async fn create_file_pg_client(
         blob,
         consensus,
         metrics,
+        Handle::current(),
     )
     .await?;
     Ok(Some((postgres_consensus, client, dir)))
@@ -151,6 +153,7 @@ async fn create_s3_pg_client(
         blob,
         consensus,
         metrics,
+        Handle::current(),
     )
     .await?;
     Ok(Some((postgres_consensus, client)))

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -455,7 +455,14 @@ impl Service for TransactorService {
 
         // Wire up the TransactorService.
         let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-        let client = PersistClient::new(config, blob, consensus, metrics).await?;
+        let client = PersistClient::new(
+            config,
+            blob,
+            consensus,
+            metrics,
+            tokio::runtime::Handle::current(),
+        )
+        .await?;
         let transactor = Transactor::new(&client, shard_id).await?;
         let service = TransactorService(Arc::new(Mutex::new(transactor)));
         Ok(service)

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 
 use futures_util::future::BoxFuture;
 use mz_ore::metrics::MetricsRegistry;
+use tokio::runtime::Handle;
 use tracing::{error, trace};
 
 use mz_ore::now::SYSTEM_TIME;
@@ -196,7 +197,7 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         Arc::new(UnreliableBlob::new(blob, unreliable.clone())) as Arc<dyn Blob + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
-    PersistClient::new(config, blob, consensus, metrics).await
+    PersistClient::new(config, blob, consensus, metrics, Handle::current()).await
 }
 
 mod api {

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -746,6 +746,7 @@ mod tests {
                             let mut builder = BatchBuilder::new(
                                 cfg,
                                 Arc::clone(&client.metrics),
+                                Handle::current(),
                                 0,
                                 Antichain::from_elem(lower),
                                 Arc::clone(&client.blob),

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -91,6 +91,7 @@ where
 {
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
+    pub(crate) blocking_runtime: Handle,
     pub(crate) machine: Machine<K, V, T, D>,
     pub(crate) compact: Option<Compactor>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
@@ -488,6 +489,7 @@ where
         BatchBuilder::new(
             self.cfg.clone(),
             Arc::clone(&self.metrics),
+            self.blocking_runtime.clone(),
             size_hint,
             lower,
             Arc::clone(&self.blob),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -49,7 +49,7 @@ use once_cell::sync::Lazy;
 use postgres_protocol::types;
 use regex::Regex;
 use tempfile::TempDir;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{oneshot, Mutex};
 use tokio_postgres::types::FromSql;
 use tokio_postgres::types::Kind as PgKind;
@@ -601,8 +601,13 @@ impl Runner {
         );
         let now = SYSTEM_TIME.clone();
         let metrics_registry = MetricsRegistry::new();
-        let persist_clients =
-            PersistClientCache::new(PersistConfig::new(now.clone()), &metrics_registry);
+        // WIP actually create a second runtime for this.
+        let blocking_runtime = Handle::current();
+        let persist_clients = PersistClientCache::new(
+            PersistConfig::new(now.clone()),
+            &metrics_registry,
+            blocking_runtime,
+        );
         let persist_clients = Arc::new(Mutex::new(persist_clients));
         let server_config = mz_environmentd::Config {
             adapter_stash_url,

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -507,6 +507,12 @@ mod tests {
         Arc::new(Mutex::new(PersistClientCache::new(
             PersistConfig::new(SYSTEM_TIME.clone()),
             &MetricsRegistry::new(),
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .handle()
+                .clone(),
         )))
     });
 


### PR DESCRIPTION
When the Tokio runtime is shut down, it can't abort the spawn_blocking
closure (because it doesn't have await points). But it turns off the
timer. So the call to tokio::time::sleep explodes. See
tokio-rs/tokio#4862 for a better explanation of this.

To work around this, use a suggestion from the Tokio docs: create a
separate Tokio runtime for CPU-intensive tasks.

Touches #13867
Touches #13930

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

I didn't quite finish the plumbing because I wanted to get a first check on the approach. I don't love having to plumb this at every place a PersistClientCache is used, given that (maybe?) the only place we need to override it is the sqllogictests (at least until/if the binaries start to do some sort of clean shutdown). An alternative that I thought up while typing out this paragraph would be to have an Option<Handle> on PersistConfig and only override it in sqllogictests.

I also have zero idea how to configure the second Runtime (just copy the config of the first one?).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
