### PR TITLE
persist: add metrics coverage of how many versions truncate deletes

### DIFF
--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -156,9 +156,9 @@ impl Consensus for MaelstromConsensus {
         unimplemented!("not yet used")
     }
 
-    async fn truncate(&self, _key: &str, _seqno: SeqNo) -> Result<(), ExternalError> {
+    async fn truncate(&self, _key: &str, _seqno: SeqNo) -> Result<usize, ExternalError> {
         // No-op until we implement `scan`.
-        Ok(())
+        Ok(0)
     }
 }
 

--- a/src/persist-client/src/impl/gc.rs
+++ b/src/persist-client/src/impl/gc.rs
@@ -204,7 +204,7 @@ impl GarbageCollector {
 
         // Now that we've deleted the eligible blobs, "commit" this info by
         // truncating the state versions that referenced them.
-        let () = retry_external(&metrics.retries.external.gc_truncate, || async {
+        let _deleted_count = retry_external(&metrics.retries.external.gc_truncate, || async {
             consensus.truncate(&path, req.new_seqno_since).await
         })
         .instrument(debug_span!("gc::truncate"))

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -17,6 +17,7 @@ use deadpool_postgres::tokio_postgres::types::{to_sql_checked, FromSql, IsNull, 
 use deadpool_postgres::tokio_postgres::Config;
 use deadpool_postgres::{Hook, HookError, HookErrorCause, ManagerConfig, RecyclingMethod};
 use deadpool_postgres::{Manager, Pool};
+use mz_ore::cast::CastFrom;
 use openssl::pkey::PKey;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use openssl::x509::X509;
@@ -366,7 +367,7 @@ impl Consensus for PostgresConsensus {
         }
     }
 
-    async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<(), ExternalError> {
+    async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError> {
         let q = "DELETE FROM consensus
                 WHERE shard = $1 AND sequence_number < $2 AND
                 EXISTS(
@@ -398,7 +399,7 @@ impl Consensus for PostgresConsensus {
             }
         }
 
-        Ok(())
+        Ok(usize::cast_from(result))
     }
 }
 

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -207,7 +207,7 @@ impl Consensus for UnreliableConsensus {
             .await
     }
 
-    async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<(), ExternalError> {
+    async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError> {
         self.handle
             .run_op("truncate", || self.consensus.truncate(key, seqno))
             .await


### PR DESCRIPTION
Discovered this hole in our coverage while investigating #13861 and also
in the great prod gc backlog of 2022.


### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
