### PR TITLE
otel: fix insecure tls config

### DIFF
--- a/misc/opentelemetry/mzcompose.py
+++ b/misc/opentelemetry/mzcompose.py
@@ -13,7 +13,7 @@ SERVICES = [
     Service(
         "jaeger",
         {
-            "image": "jaegertracing/all-in-one:latest",
+            "image": "jaegertracing/all-in-one:1.36",
             "ports": ["16686:16686", 14268, 14250],
             "allow_host_ports": True,
         },
@@ -21,7 +21,7 @@ SERVICES = [
     Service(
         "otel-collector",
         {
-            "image": "otel/opentelemetry-collector:latest",
+            "image": "otel/opentelemetry-collector:0.56.0",
             "command": "--config=/etc/otel-collector-config.yaml",
             "ports": [
                 1888,  # pprof

--- a/misc/opentelemetry/otel-collector-config.yaml
+++ b/misc/opentelemetry/otel-collector-config.yaml
@@ -21,7 +21,8 @@ exporters:
 
   jaeger:
     endpoint: jaeger:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:


### PR DESCRIPTION
This seems to have changed some time ago. Maybe was recently fully removed? Unclear.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a