### PR TITLE
Only block on non-empty updates for append

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -335,6 +335,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for (_, updates) in &mut appends {
             differential_dataflow::consolidation::consolidate(updates);
         }
+        appends.retain(|_key, updates| !updates.is_empty());
         let appends = appends
             .into_iter()
             .map(|(id, updates)| {
@@ -348,14 +349,16 @@ impl<S: Append + 'static> Coordinator<S> {
                     .collect();
                 (id, updates, advance_to)
             })
-            .collect();
-        self.controller
-            .storage_mut()
-            .append(appends)
-            .expect("invalid updates")
-            .await
-            .expect("One-shot shouldn't fail")
-            .unwrap();
+            .collect::<Vec<_>>();
+        if !appends.is_empty() {
+            self.controller
+                .storage_mut()
+                .append(appends)
+                .expect("invalid updates")
+                .await
+                .expect("One-shot shouldn't fail")
+                .unwrap();
+        }
     }
 
     /// Enqueue requests to advance all local inputs (tables) to the current wall


### PR DESCRIPTION
A few changes to reduce the occurrence of system table updates resulting in blocking on futures. We thin down the updates to be certain of non-emptiness, and then only call `append` if there are updates. Moreover, `append` checks non-emptiness, and if empty returns a pre-loaded oneshot that should immediately resolve.

This means to correct hypothesized behavior where empty system table updates might enqueue a no-op `append` call, which is nonetheless enqueued behind other, lower priority, table advancement work.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
