### PR TITLE
persist: fix more blob leaks

### DIFF
--- a/src/persist-client/src/impl/gc.rs
+++ b/src/persist-client/src/impl/gc.rs
@@ -16,6 +16,7 @@ use std::time::Instant;
 use tracing::{debug, debug_span, Instrument, Span};
 
 use crate::r#impl::machine::retry_external;
+use crate::r#impl::paths::PartialBlobKey;
 use crate::r#impl::state::ProtoStateRollup;
 use crate::{Metrics, ShardId};
 
@@ -195,6 +196,7 @@ impl GarbageCollector {
         // concurrently, but this requires a bunch of Arc cloning, so wait to
         // see if it's worth it.
         for key in deleteable_blobs {
+            let key = PartialBlobKey(key).complete(&req.shard_id);
             retry_external(&metrics.retries.external.gc_delete, || async {
                 blob.delete(&key).await
             })

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -200,7 +200,7 @@ where
         }
     }
 
-    pub async fn merge_res(&mut self, res: FueledMergeRes<T>) -> bool {
+    pub async fn merge_res(&mut self, res: &FueledMergeRes<T>) -> bool {
         let metrics = Arc::clone(&self.metrics);
         let (_seqno, applied) = self
             .apply_unbatched_idempotent_cmd(&metrics.cmds.merge_res, |_, state| {
@@ -948,7 +948,7 @@ mod tests {
                                 .expect("invalid shard types");
                             let applied = write
                                 .machine
-                                .merge_res(FueledMergeRes {
+                                .merge_res(&FueledMergeRes {
                                     output: batch.clone(),
                                 })
                                 .await;

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -248,6 +248,7 @@ impl MetricsVecs {
             external: RetryExternal {
                 batch_set: self.retry_metrics("batch::set"),
                 blob_open: self.retry_metrics("blob::open"),
+                compaction_noop_delete: self.retry_metrics("compaction_noop::delete"),
                 consensus_open: self.retry_metrics("consensus::open"),
                 fetch_and_update_state_head: self.retry_metrics("fetch_and_update_state::head"),
                 fetch_batch_get: self.retry_metrics("fetch_batch::get"),
@@ -393,6 +394,7 @@ pub struct RetryExternal {
     pub(crate) batch_set: RetryMetrics,
     pub(crate) blob_open: RetryMetrics,
     pub(crate) consensus_open: RetryMetrics,
+    pub(crate) compaction_noop_delete: RetryMetrics,
     pub(crate) fetch_and_update_state_head: RetryMetrics,
     pub(crate) fetch_batch_get: RetryMetrics,
     pub(crate) maybe_init_state_cas: RetryMetrics,


### PR DESCRIPTION
GC wasn't correctly using BlobKey and PartialBlobKey because it operates
directly on the proto state. Blob delete has to be resilient to retries,
so it doesn't fail for missing keys. (However, this also means our
blob_delete metric is a lie, it currently only tracks how many times
it's called. This will be fixed in a followup.)

A second smaller leak happened when applying a compaction response to
the state machine resulted in a noop. Since the state doesn't reference
the result of compaction, nothing would know to delete it.

There seems to be at least one minor leak left even after these two
fixes, but it's still being investigated.

Regression test also left for a followup because it will so much easier
to write after #13920.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
