### PR TITLE
persist: thread down a tokio runtime for use in blocking work

### DIFF
--- a/src/ore/src/task.rs
+++ b/src/ore/src/task.rs
@@ -184,7 +184,7 @@ pub trait RuntimeExt {
         Fut::Output: Send + 'static;
 }
 
-impl RuntimeExt for Arc<Runtime> {
+impl RuntimeExt for &Runtime {
     fn spawn_blocking_named<Function, Output, Name, NameClosure>(
         &self,
         nc: NameClosure,
@@ -213,6 +213,36 @@ impl RuntimeExt for Arc<Runtime> {
     {
         let _g = self.enter();
         spawn(nc, future)
+    }
+}
+
+impl RuntimeExt for Arc<Runtime> {
+    fn spawn_blocking_named<Function, Output, Name, NameClosure>(
+        &self,
+        nc: NameClosure,
+        function: Function,
+    ) -> JoinHandle<Output>
+    where
+        Name: AsRef<str>,
+        NameClosure: FnOnce() -> Name,
+        Function: FnOnce() -> Output + Send + 'static,
+        Output: Send + 'static,
+    {
+        (&**self).spawn_blocking_named(nc, function)
+    }
+
+    fn spawn_named<Fut, Name, NameClosure>(
+        &self,
+        nc: NameClosure,
+        future: Fut,
+    ) -> JoinHandle<Fut::Output>
+    where
+        Name: AsRef<str>,
+        NameClosure: FnOnce() -> Name,
+        Fut: Future + Send + 'static,
+        Fut::Output: Send + 'static,
+    {
+        (&**self).spawn_named(nc, future)
     }
 }
 

--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -27,6 +27,7 @@ use tracing::{debug, info, trace};
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{Blob, Consensus, ExternalError};
 use mz_persist::unreliable::{UnreliableBlob, UnreliableConsensus, UnreliableHandle};
+use mz_persist_client::async_runtime::CpuHeavyRuntime;
 use mz_persist_client::read::{Listen, ListenEvent, ReadHandle};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Metrics, PersistClient, PersistConfig, ShardId};
@@ -455,7 +456,9 @@ impl Service for TransactorService {
 
         // Wire up the TransactorService.
         let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
-        let client = PersistClient::new(config, blob, consensus, metrics).await?;
+        let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
+        let client =
+            PersistClient::new(config, blob, consensus, metrics, cpu_heavy_runtime).await?;
         let transactor = Transactor::new(&client, shard_id).await?;
         let service = TransactorService(Arc::new(Mutex::new(transactor)));
         Ok(service)

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -29,6 +29,7 @@ use std::time::Duration;
 
 use futures_util::future::BoxFuture;
 use mz_ore::metrics::MetricsRegistry;
+use mz_persist_client::async_runtime::CpuHeavyRuntime;
 use tracing::{error, trace};
 
 use mz_ore::now::SYSTEM_TIME;
@@ -196,7 +197,8 @@ async fn persist_client(args: Args) -> Result<PersistClient, ExternalError> {
         Arc::new(UnreliableBlob::new(blob, unreliable.clone())) as Arc<dyn Blob + Send + Sync>;
     let consensus = Arc::new(UnreliableConsensus::new(consensus, unreliable))
         as Arc<dyn Consensus + Send + Sync>;
-    PersistClient::new(config, blob, consensus, metrics).await
+    let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
+    PersistClient::new(config, blob, consensus, metrics, cpu_heavy_runtime).await
 }
 
 mod api {

--- a/src/persist-client/src/async_runtime.rs
+++ b/src/persist-client/src/async_runtime.rs
@@ -1,0 +1,64 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Async runtime extensions.
+
+use std::future::Future;
+
+use tokio::runtime::{Builder, Runtime};
+use tokio::task::JoinHandle;
+
+use mz_ore::task::RuntimeExt;
+
+/// A runtime for running CPU-heavy asynchronous tasks.
+#[derive(Debug)]
+pub struct CpuHeavyRuntime {
+    inner: Option<Runtime>,
+}
+
+impl CpuHeavyRuntime {
+    /// Creates a new CPU heavy runtime.
+    pub fn new() -> CpuHeavyRuntime {
+        // TODO: choose a more principled `worker_limit`. Right now we use the
+        // Tokio default, which is presently the number of cores on the machine.
+        let runtime = Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("known to be valid");
+        CpuHeavyRuntime {
+            inner: Some(runtime),
+        }
+    }
+
+    /// Spawns a CPU-heavy task onto this runtime.
+    pub fn spawn_named<N, S, F>(&self, name: N, fut: F) -> JoinHandle<F::Output>
+    where
+        S: AsRef<str>,
+        N: FnOnce() -> S,
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.inner
+            .as_ref()
+            .expect("exists until drop")
+            .spawn_named(name, fut)
+    }
+}
+
+impl Drop for CpuHeavyRuntime {
+    fn drop(&mut self) {
+        // We don't need to worry about `shutdown_background` leaking
+        // blocking tasks (i.e., tasks spawned with `spawn_blocking`) because
+        // the `CpuHeavyRuntime` wrapper prevents access to `spawn_blocking`.
+        self.inner
+            .take()
+            .expect("cannot drop twice")
+            .shutdown_background()
+    }
+}

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -169,6 +169,7 @@ where
         TB: Borrow<T>,
         DB: Borrow<D>,
         I: IntoIterator<Item = SB>,
+        D: Send + Sync,
     {
         trace!("WriteHandle::append lower={:?} upper={:?}", lower, upper);
         let batch = self.batch(updates, lower.clone(), upper.clone()).await?;
@@ -224,6 +225,7 @@ where
         TB: Borrow<T>,
         DB: Borrow<D>,
         I: IntoIterator<Item = SB>,
+        D: Send + Sync,
     {
         trace!(
             "WriteHandle::compare_and_append expected_upper={:?} new_upper={:?}",
@@ -286,7 +288,10 @@ where
         mut batch: Batch<K, V, T, D>,
         mut lower: Antichain<T>,
         upper: Antichain<T>,
-    ) -> Result<Result<(), Upper<T>>, InvalidUsage<T>> {
+    ) -> Result<Result<(), Upper<T>>, InvalidUsage<T>>
+    where
+        D: Send + Sync,
+    {
         trace!("Batch::append lower={:?} upper={:?}", lower, upper);
 
         let mut retry = self
@@ -406,7 +411,10 @@ where
         batch: &mut Batch<K, V, T, D>,
         expected_upper: Antichain<T>,
         new_upper: Antichain<T>,
-    ) -> Result<Result<Result<(), Upper<T>>, InvalidUsage<T>>, Indeterminate> {
+    ) -> Result<Result<Result<(), Upper<T>>, InvalidUsage<T>>, Indeterminate>
+    where
+        D: Send + Sync,
+    {
         trace!(
             "Batch::compare_and_append expected_upper={:?} new_upper={:?}",
             expected_upper,
@@ -556,6 +564,7 @@ where
     where
         L: Into<Antichain<T>>,
         U: Into<Antichain<T>>,
+        D: Send + Sync,
     {
         self.append(updates.iter(), lower.into(), new_upper.into())
             .await
@@ -572,7 +581,9 @@ where
         updates: &[((K, V), T, D)],
         expected_upper: T,
         new_upper: T,
-    ) {
+    ) where
+        D: Send + Sync,
+    {
         self.compare_and_append(
             updates.iter().map(|((k, v), t, d)| ((k, v), t, d)),
             Antichain::from_elem(expected_upper),


### PR DESCRIPTION
Slight reworking of #13940, as discussed in that PR, that avoids some of the hard plumbing.

----

When the Tokio runtime is shut down, it can't abort the spawn_blocking
closure (because it doesn't have await points). But it turns off the
timer. So the call to tokio::time::sleep explodes. See
tokio-rs/tokio#4862 for a better explanation of this.

To work around this, use a suggestion from the Tokio docs: create a
separate Tokio runtime for CPU-intensive tasks.

Touches #13867
Touches #13930
Would close #13940

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
