### PR TITLE
test: force regenerating test certs

### DIFF
--- a/test/test-certs/create-certs.sh
+++ b/test/test-certs/create-certs.sh
@@ -80,7 +80,7 @@ create_cert() {
     local ca_name=$2
     local common_name=$3
 
-    # Create key & csr
+    # Create key & CSR.
     openssl req -nodes \
         -newkey rsa:2048 \
         -keyout secrets/"$client_name".key \


### PR DESCRIPTION
This will hopefully fix the current certificate errors in CI.

### Motivation

  * This PR fixes a previously unreported bug.

Postgres CDC tests are failing again with:
```
pg-cdc-ssl.td:163:1: error: executing query failed: db error: ERROR: error performing TLS handshake: [...]
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
