### PR TITLE
Alternate alternate approach to recording collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ name = "mz-compute"
 version = "0.26.1-dev"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum",
  "clap",

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.58"
+async-stream = "0.3.3"
 async-trait = "0.1.56"
 axum = "0.5.13"
 clap = { version = "3.2.14", features = ["derive", "env"] }


### PR DESCRIPTION
@frankmcsherry opened a PR for a `persist_sink` implementation that continually reads back the data it has written, to ensure it matches the desired input collection, and corrects as necessary: #13740.

This PR is an alternative implementation of the above approach that differs in that it reads data from persist directly instead of relying on `persist_source`. I implemented this mainly out of curiosity, to see if the implementation would be easier than the original one. I am aware of two functional differences:

* The `persist_source`-less implementation is less CPU intensive for idle `computed` instances (on my machine: ~15% vs ~50% in debug mode, ~3% vs ~??% in release mode). The cause is likely that the `persist_source` implementation yields significantly more often, so `computed` maintenance is also executed significantly more often. It is not clear whether this makes a different when the system is not idle.
* The `persist_souce`-less implementation cannot make use of improvements to `persist_source`, such as sharded reading. Such features would have to be re-implemented for the `persist_sink`, duplicating logic.

### Motivation

  * This PR fixes a recognized bug.

https://github.com/MaterializeInc/materialize/issues/13496

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
