### PR TITLE
Revert "storage: factor out initialization of storage hosts (#13924)"

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -425,6 +425,8 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + Unpin> {
     persist_location: PersistLocation,
     /// A persist client used to write to storage collections
     persist_client: PersistClient,
+    /// Set to `true` once `initialization_complete` has been called.
+    initialized: bool,
 }
 
 #[derive(Debug)]
@@ -550,7 +552,10 @@ where
     type Timestamp = T;
 
     fn initialization_complete(&mut self) {
-        self.hosts.initialization_complete();
+        self.initialized = true;
+        for client in self.hosts.clients() {
+            client.send(StorageCommand::InitializationComplete);
+        }
     }
 
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, StorageError> {
@@ -705,7 +710,12 @@ where
                         ),
                     )
                     .await?;
+
                 client.send(StorageCommand::IngestSources(vec![augmented_ingestion]));
+
+                if self.initialized {
+                    client.send(StorageCommand::InitializationComplete);
+                }
             }
         }
 
@@ -1005,6 +1015,7 @@ where
             internal_response_queue: rx,
             persist_location,
             persist_client,
+            initialized: false,
         }
     }
 


### PR DESCRIPTION
This reverts commit 9b2eb6d70df8924df3b590727c6726ccfdb0a20e.

This commit is the first reported to have had the `deadline elapsed` errors we've been seeing frequently. Try reverting to see if it fixes those.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a