### PR TITLE
persist: track how many blob deletes are no-ops

### DIFF
--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -91,9 +91,9 @@ impl MemBlobCore {
         Ok(())
     }
 
-    fn delete(&mut self, key: &str) -> Result<(), ExternalError> {
-        self.dataz.remove(key);
-        Ok(())
+    fn delete(&mut self, key: &str) -> Result<Option<usize>, ExternalError> {
+        let bytes = self.dataz.remove(key).map(|x| x.len());
+        Ok(bytes)
     }
 }
 
@@ -135,7 +135,7 @@ impl Blob for MemBlob {
         self.core.lock().await.set(key, value)
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ExternalError> {
+    async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
         self.core.lock().await.delete(key)
     }
 }

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -161,7 +161,7 @@ impl Blob for UnreliableBlob {
             .await
     }
 
-    async fn delete(&self, key: &str) -> Result<(), ExternalError> {
+    async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
         self.handle.run_op("delete", || self.blob.delete(key)).await
     }
 }


### PR DESCRIPTION
Manually verified that this makes the bug fixed in #13953 immediately
obvious.

    # HELP mz_persist_external_blob_delete_noop_count count of blob delete calls that deleted a non-existent key
    # TYPE mz_persist_external_blob_delete_noop_count counter
    mz_persist_external_blob_delete_noop_count 53
    # HELP mz_persist_external_started_count count of external service calls started
    # TYPE mz_persist_external_started_count counter
    mz_persist_external_started_count{op="blob_delete"} 53

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

As promised in #13953

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
