### PR TITLE
persist: be more lenient about sinces when applying compaction results

### DIFF
--- a/src/persist-client/tests/trace/compaction_apply_res_since
+++ b/src/persist-client/tests/trace/compaction_apply_res_since
@@ -1,0 +1,58 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Insert some len=1 batches followed by a larger batch to squish them up and
+# force a compaction. In the middle, advance the since so our merge req has a non-zero since.
+insert
+0 1 0 1 k0
+1 2 0 1 k1
+2 3 0 1 k2
+3 4 0 1 k3
+----
+ok
+
+downgrade-since
+4
+----
+ok
+
+insert
+4 5 4 100 k4
+----
+ok
+
+batches
+----
+[0][4][4] 4/4 k0 k1 k2 k3
+[4][5][4] 100 k4
+
+take-merge-reqs
+----
+[0][2][0] k0 k1
+[0][4][4] k0 k1 k2 k3
+[2][4][0] k2 k3
+
+# We cannot use a compaction response with a since in advance of the spine batch
+apply-merge-res
+0 4 5 0 nope
+----
+no-op
+
+# We can, however, use one where the spine batch's since is in advance of the
+# compaction response's since (we've simply lost more fidelity than we're
+# allowed to).
+apply-merge-res
+0 4 3 2 k0-4
+----
+applied
+
+batches
+----
+[0][4][3] 2 k0-4
+[4][5][4] 100 k4


### PR DESCRIPTION
It is perfectly safe, if the sinces don't match, as long as Spine
metadata's since is in advance of the one in the compaction result. This
mismatch can happen when the Spine has to be reloaded from state
(because of a compare_and_set mismatch).

This might also help an issue we're seeing in prod where compaction is
taking far longer than my mental model says it should.

Touches #13861

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
