### PR TITLE
coord: optimize drop_temp_items

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -307,6 +307,9 @@ impl<S: Append + 'static> Coordinator<S> {
     /// not the temporary schema itself.
     pub(crate) async fn drop_temp_items(&mut self, session: &Session) {
         let ops = self.catalog.drop_temp_item_ops(session.conn_id());
+        if ops.is_empty() {
+            return;
+        }
         self.catalog_transact(Some(session), ops, |_| Ok(()))
             .await
             .expect("unable to drop temporary items for conn_id");


### PR DESCRIPTION
Don't execute catalog_transact with an empty ops. Putting this check
right in catalog_transact is a bit questionable because it has other
guarantees. Drop temp items is run on each session termination, so it
makes sense to optimize specifically that code path instead of changing
the semantics of catalog_transact.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a