### PR TITLE
Revert "Revert "storage: factor out initialization of storage hosts (…

### DIFF
--- a/src/storage/src/controller/hosts.rs
+++ b/src/storage/src/controller/hosts.rs
@@ -69,6 +69,8 @@ pub struct StorageHosts<T> {
     hosts: HashMap<StorageHostAddr, StorageHost<T>>,
     /// The assignment of storage objects to storage hosts.
     objects: HashMap<GlobalId, StorageHostAddr>,
+    /// Set to `true` once `initialization_complete` has been called.
+    initialized: bool,
 }
 
 /// Metadata about a single storage host.
@@ -82,7 +84,12 @@ struct StorageHost<T> {
     orchestrated: bool,
 }
 
-impl<T> StorageHosts<T> {
+impl<T> StorageHosts<T>
+where
+    T: Timestamp + Lattice,
+    StorageCommand<T>: RustType<ProtoStorageCommand>,
+    StorageResponse<T>: RustType<ProtoStorageResponse>,
+{
     /// Constructs a new [`StorageHosts`] from its configuration.
     pub fn new(config: StorageHostsConfig) -> StorageHosts<T> {
         StorageHosts {
@@ -91,6 +98,20 @@ impl<T> StorageHosts<T> {
             storaged_image: config.storaged_image,
             objects: HashMap::new(),
             hosts: HashMap::new(),
+            initialized: false,
+        }
+    }
+
+    /// Marks the end of any initialization commands.
+    ///
+    /// The implementor may wait for this method to be called before
+    /// implementing prior commands, and so it is important for a user to invoke
+    /// this method as soon as it is comfortable. This method can be invoked
+    /// immediately, at the potential expense of performance.
+    pub fn initialization_complete(&mut self) {
+        self.initialized = true;
+        for client in self.clients() {
+            client.send(StorageCommand::InitializationComplete);
         }
     }
 
@@ -133,7 +154,10 @@ impl<T> StorageHosts<T> {
         info!("assigned storage object {id} to storage host {host_addr}");
         match self.hosts.entry(host_addr.clone()) {
             Entry::Vacant(entry) => {
-                let client = RehydratingStorageClient::new(host_addr, self.build_info);
+                let mut client = RehydratingStorageClient::new(host_addr, self.build_info);
+                if self.initialized {
+                    client.send(StorageCommand::InitializationComplete);
+                }
                 let host = entry.insert(StorageHost {
                     client,
                     objects: HashSet::from_iter([id]),


### PR DESCRIPTION
…#13924)""

This reverts commit 9ae043a5fd3e5f2c62a299c328fc8bcceddc3f4f.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
