### PR TITLE
Regularly wake from timely to deal with eaten wake-ups

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -206,7 +206,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // nothing to do, it will park the thread. We rely on another thread
             // unparking us when there's new work to be done, e.g., when sending
             // a command or when new Kafka messages have arrived.
-            self.timely_worker.step_or_park(None);
+            self.timely_worker
+                .step_or_park(Some(std::time::Duration::from_secs(1)));
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -106,7 +106,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // nothing to do, it will park the thread. We rely on another thread
             // unparking us when there's new work to be done, e.g., when sending
             // a command or when new Kafka messages have arrived.
-            self.timely_worker.step_or_park(None);
+            self.timely_worker
+                .step_or_park(Some(std::time::Duration::from_secs(1)));
 
             self.report_frontier_progress(&response_tx);
 


### PR DESCRIPTION
This addresses a race that appears in `storaged` where the `LocalClient` will wake worker threads that have inbound messages to read, but the wake-ups are (or appear to be) eaten by various non-Timely sleepy moments in the code. If these wake-ups are quietly eaten, and then Timely is entered with a `None` timeout and nothing to do, it will sleep forever.

It would be nice to fix this better, but just introducing a time-out seems to be the most robust way to fix this.

### Motivation

  * This PR fixes a previously unreported bug.

CI had various timeouts that were experienced when `storaged` clients were "slow-rolled" commands, being provided first with `InitializationComplete` commands and then source creation commands. The creation commands could be missed, when presented in this order, as was introduced in https://github.com/MaterializeInc/materialize/commit/9b2eb6d70df8924df3b590727c6726ccfdb0a20e. This has been reverted, but if it is reintroduced with this change the timeout does not appear to manifest.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
