### PR TITLE
compute,storage: avoid lost wakeups when stepping timely

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -202,11 +202,23 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 compute_state.traces.maintenance();
             }
 
-            // Ask Timely to execute a unit of work. If Timely decides there's
-            // nothing to do, it will park the thread. We rely on another thread
+            // Ask Timely to execute a unit of work.
+            //
+            // If there are no pending commands, we ask Timely to park the
+            // thread if there's nothing to do. We rely on another thread
             // unparking us when there's new work to be done, e.g., when sending
             // a command or when new Kafka messages have arrived.
-            self.timely_worker.step_or_park(None);
+            //
+            // It is critical that we allow Timely to park iff there are no
+            // pending commands. The unpark token associated with any pending
+            // commands may have already been consumed by the call to
+            // `client_rx.recv`. For details, see:
+            // https://github.com/MaterializeInc/materialize/pull/13973#issuecomment-1200312212
+            if command_rx.is_empty() {
+                self.timely_worker.step_or_park(None);
+            } else {
+                self.timely_worker.step();
+            }
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {

--- a/src/storage/src/controller/hosts.rs
+++ b/src/storage/src/controller/hosts.rs
@@ -69,6 +69,8 @@ pub struct StorageHosts<T> {
     hosts: HashMap<StorageHostAddr, StorageHost<T>>,
     /// The assignment of storage objects to storage hosts.
     objects: HashMap<GlobalId, StorageHostAddr>,
+    /// Set to `true` once `initialization_complete` has been called.
+    initialized: bool,
 }
 
 /// Metadata about a single storage host.
@@ -82,7 +84,12 @@ struct StorageHost<T> {
     orchestrated: bool,
 }
 
-impl<T> StorageHosts<T> {
+impl<T> StorageHosts<T>
+where
+    T: Timestamp + Lattice,
+    StorageCommand<T>: RustType<ProtoStorageCommand>,
+    StorageResponse<T>: RustType<ProtoStorageResponse>,
+{
     /// Constructs a new [`StorageHosts`] from its configuration.
     pub fn new(config: StorageHostsConfig) -> StorageHosts<T> {
         StorageHosts {
@@ -91,6 +98,20 @@ impl<T> StorageHosts<T> {
             storaged_image: config.storaged_image,
             objects: HashMap::new(),
             hosts: HashMap::new(),
+            initialized: false,
+        }
+    }
+
+    /// Marks the end of any initialization commands.
+    ///
+    /// The implementor may wait for this method to be called before
+    /// implementing prior commands, and so it is important for a user to invoke
+    /// this method as soon as it is comfortable. This method can be invoked
+    /// immediately, at the potential expense of performance.
+    pub fn initialization_complete(&mut self) {
+        self.initialized = true;
+        for client in self.clients() {
+            client.send(StorageCommand::InitializationComplete);
         }
     }
 
@@ -133,7 +154,10 @@ impl<T> StorageHosts<T> {
         info!("assigned storage object {id} to storage host {host_addr}");
         match self.hosts.entry(host_addr.clone()) {
             Entry::Vacant(entry) => {
-                let client = RehydratingStorageClient::new(host_addr, self.build_info);
+                let mut client = RehydratingStorageClient::new(host_addr, self.build_info);
+                if self.initialized {
+                    client.send(StorageCommand::InitializationComplete);
+                }
                 let host = entry.insert(StorageHost {
                     client,
                     objects: HashSet::from_iter([id]),


### PR DESCRIPTION
This is an alternative to https://github.com/MaterializeInc/materialize/pull/13972 that avoids hardcoding the 1s timeout.
As described there:

> This addresses a race that appears in storaged where the LocalClient
 will wake worker threads that have inbound messages to read, but the
wake-ups are (or appear to be) eaten by various non-Timely sleepy
moments in the code. If these wake-ups are quietly eaten, and then
Timely is entered with a None timeout and nothing to do, it will
sleep forever.

Would close https://github.com/MaterializeInc/materialize/pull/13972 if merged.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
