### PR TITLE
[very wip] persist-client: add a per-writer idempotency token

### DIFF
--- a/src/persist-client/src/impl/state.proto
+++ b/src/persist-client/src/impl/state.proto
@@ -47,6 +47,7 @@ message ProtoReaderState {
 message ProtoWriterState {
     string writer_id = 1;
     uint64 last_heartbeat_timestamp_ms = 2;
+    string last_idempotency_token = 3;
 }
 
 message ProtoStateRollup {

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -447,7 +447,7 @@ where
                 },
                 &self.writer_id,
             )
-            .await?;
+            .await;
 
         let merge_reqs = match res {
             Ok(Ok((_seqno, merge_reqs))) => {


### PR DESCRIPTION
Just noodling with some stuff on the plane. 

----

Track the most recent compare-and-append seqno for each writer in the
persist state. This makes it straightforward for a writer to retry a
compare_and_append operation. When a compare-and-append operation fails
indeterminately, the writer loads the most recent state. If it sees the
idempotency token of the undetermined write in the state, it knows the
write definitely succeeded. If it sees a different idempotency token, it
knows the write definitely failed, either because the CAS network
operation never made it to the consensus backend, or because the CAS
raced and lost with a prior canceled write from the same writer.

Fix #12797.
Fix #13921.
