### PR TITLE
limits test: fortify the Partitions scenario

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -181,7 +181,7 @@ class KafkaPartitions(Generator):
     @classmethod
     def body(cls) -> None:
         # gh#12193 : topic_metadata_refresh_interval_ms is not observed so a default refresh interval of 300s applies
-        print("$ set-sql-timeout duration=360s")
+        print("$ set-sql-timeout duration=600s")
         print('$ set key-schema={"type": "string"}')
         print(
             '$ set value-schema={"type": "record", "name": "r", "fields": [{"name": "f1", "type": "string"}]}'


### PR DESCRIPTION
Apparently 360 seconds are not enough for Mz to pick the
extra partitions, so try with 600 seconds instead.
### Motivation

  * This PR fixes a previously unreported bug.

Nightly limits is failing.