### PR TITLE
    cloudtest: Enable Buildkite integration

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -240,6 +240,10 @@ ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnu-cc
 ENV CARGO_TARGET_DIR=/mnt/build
 ENV CARGO_INCREMENTAL=0
 
+# The kubeconfig file needs to be in the working directory so that it can be shared
+# across invocations of the container
+ENV KUBECONFIG=kubeconfig
+
 # Set a environment variable that tools can check to see if they're in the
 # builder or not.
 

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -18,6 +18,7 @@ steps:
         key: tests
         options:
           - { value: coverage }
+          - { value: cloudtest }
           - { value: kafka-matrix }
           - { value: kafka-multi-broker }
           - { value: redpanda-testdrive }
@@ -55,6 +56,13 @@ steps:
       queue: linux
 
   - wait: ~
+
+  - id: cloudtest
+    label: "Cloudtest"
+    artifact_paths: junit_cloudtest_*.xml
+    plugins:
+      - ./ci/plugins/cloudtest:
+          args: ["test/cloudtest/"]
 
   - id: feature-benchmark-single-node
     label: "Feature benchmark (single node)"

--- a/ci/plugins/cloudtest/README.md
+++ b/ci/plugins/cloudtest/README.md
@@ -1,0 +1,15 @@
+# mzcompose Buildkite Plugin
+
+A [Buildkite plugin] that runs cloudtest.
+
+## Example
+
+```yml
+steps:
+  - id: cloudtest-using-step
+    plugins:
+      - ./ci/plugins/cloudtest:
+          args: [--some, pytest, args]
+```
+
+[Buildkite plugin]: https://buildkite.com/docs/agent/v3/plugins

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -euo pipefail
+
+# read_list PREFIX
+#
+# Appends the environment variables `PREFIX_0`, `PREFIX_1`, ... `PREFIX_N` to
+# the `result` global variable, stopping when `PREFIX_N` is an empty string.
+read_list() {
+    result=()
+
+    local i=0
+    local param="${1}_${i}"
+
+    if [[ "${!1:-}" ]]; then
+        echo "error: pytest arguments must be an array, not a string" >&2
+        exit 1
+    fi
+
+    while [[ "${!param:-}" ]]; do
+        result+=("${!param}")
+        i=$((i+1))
+        param="${1}_${i}"
+    done
+
+    [[ ${#result[@]} -gt 0 ]] || return 1
+}
+
+run_args=("--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml")
+if read_list BUILDKITE_PLUGIN_CLOUDTEST_ARGS; then
+    for arg in "${result[@]}"; do
+        run_args+=("$arg")
+    done
+fi
+
+# Make sure KinD is running
+
+echo "--- KinD: Make sure KinD is running ..."
+
+bin/ci-builder run stable kind create cluster --config misc/kind/cluster.yaml --wait 30s || true
+
+# Sometimes build cancellations prevent us from properly cleaning up the last
+# cloudtest run, so force a cleanup just in case
+
+echo "--- KinD: Purging containers and volumes from previous builds ..."
+
+bin/ci-builder run stable kubectl --context kind-kind delete all --all || true
+
+echo "+++ cloudtest: Running \`bin/pytest ${run_args[*]}\`" >&2
+
+bin/ci-builder run stable bin/pytest "${run_args[@]}"

--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+set -xeu
+
+echo "~~~ Cleaning up after cloudtest" >&2
+
+bin/ci-builder run stable kubectl --context kind-kind get pods -o name | grep -v -E 'kubernetes|minio|postgres|redpanda' | xargs -L 1 bin/ci-builder run stable kubectl --context kind-kind logs --prefix=true > services.log || true
+buildkite-agent artifact upload services.log
+
+bin/ci-builder run stable kubectl --context kind-kind delete all --all

--- a/ci/plugins/cloudtest/plugin.yml
+++ b/ci/plugins/cloudtest/plugin.yml
@@ -1,5 +1,3 @@
-#!/usr/bin/env bash
-
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -8,7 +6,13 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-#
-# mzcompose — runs Docker Compose with Materialize customizations.
 
-exec "$(dirname "$0")"/pyactivate -u -m pytest -s --tb=native "$@"
+name: cloudtest
+description: Runs cloudtest pytest-based tests
+author: "Materialize, Inc."
+requirements: []
+configuration:
+  properties:
+    args:
+      type: array
+  additionalProperties: false

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -8,12 +8,10 @@
 # by the Apache License, Version 2.0.
 
 import subprocess
-from pathlib import Path
 from typing import Any
 
 import pg8000
 import sqlparse
-import yaml
 from kubernetes.client import (
     AppsV1Api,
     CoreV1Api,
@@ -27,7 +25,7 @@ from kubernetes.client import (
     V1StatefulSet,
 )
 from kubernetes.client.exceptions import ApiException
-from kubernetes.config import new_client_from_config_dict  # type: ignore
+from kubernetes.config import new_client_from_config  # type: ignore
 from pg8000 import Cursor
 
 from materialize import ROOT, mzbuild
@@ -39,26 +37,16 @@ class K8sResource:
             ["kubectl", "--context", self.context(), *args]
         ).decode("ascii")
 
-    def kube_config(self) -> Any:
-        with open(Path.home() / ".kube" / "config") as f:
-            return yaml.safe_load(f)
-
     def api(self) -> CoreV1Api:
-        api_client = new_client_from_config_dict(
-            self.kube_config(), context=self.context()
-        )
+        api_client = new_client_from_config(context=self.context())
         return CoreV1Api(api_client)
 
     def apps_api(self) -> AppsV1Api:
-        api_client = new_client_from_config_dict(
-            self.kube_config(), context=self.context()
-        )
+        api_client = new_client_from_config(context=self.context())
         return AppsV1Api(api_client)
 
     def rbac_api(self) -> RbacAuthorizationV1Api:
-        api_client = new_client_from_config_dict(
-            self.kube_config(), context=self.context()
-        )
+        api_client = new_client_from_config(context=self.context())
         return RbacAuthorizationV1Api(api_client)
 
     def context(self) -> str:


### PR DESCRIPTION
    - create a dedicated Buildkite plugin that initializes a KinD cluster
      and runs pytest
    - make sure kubeconfig is shared between invocations of 'mzcompose run'
      by placing it in the working directory rather than ~/.kube/
    - add a Nightly CI job that runs the existing cloudtests

Fixes #13744

### Motivation

  * This PR adds a known-desirable feature.
- #13744