### PR TITLE
storage: don't drop append futures when there's an error

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -500,7 +500,7 @@ impl fmt::Display for StorageError {
             Self::InvalidUppers(id) => {
                 write!(
                     f,
-                    "expected upper was different than actual upper for: {}",
+                    "expected upper was different from the actual upper for: {}",
                     id.iter().map(|id| id.to_string()).join(", ")
                 )
             }

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -454,7 +454,7 @@ pub enum StorageError {
     UpdateBeyondUpper(GlobalId),
     /// The read was at a timestamp before the collection's since
     ReadBeforeSince(GlobalId),
-    /// The expected upper of one or more appends was different than the actual appends of the collections
+    /// The expected upper of one or more appends was different from the actual upper of the collection
     InvalidUppers(Vec<GlobalId>),
     /// An error from the underlying client.
     ClientError(anyhow::Error),


### PR DESCRIPTION
Change how errors are handled while appending multiple updates at once: instead of eagerly failing and cancelling all pending futures in case one fails, wait until all of them are finished, handle successes and then failures separately.

Also return the IDs of all failed appends, instead of just selecting the first.

### Motivation

  * This PR fixes a previously unreported bug: appends that failed would cause other appends to be cancelled, which in some corner cases could lead to panics due to uppers being in unexpected places.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
