### PR TITLE
storage: Retry indeterminate table writes

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1429,15 +1429,57 @@ mod persist_write_handles {
                                     .map(|u| ((SourceData(Ok(u.row)), ()), u.timestamp, u.diff));
 
                                 futs.push(async move {
+                                    let persist_upper = persist_upper.clone();
+                                    let mut result =
                                     write
                                         .compare_and_append(
-                                            updates,
+                                            updates.clone(),
                                             persist_upper.clone(),
                                             new_upper.clone(),
                                         )
-                                        .instrument(span)
-                                        .await
-                                        .expect("cannot append updates")
+                                        .instrument(span.clone())
+                                        .await;
+
+                                    // Indeterminate results can occur when persist is not certain
+                                    // whether the transaction has applied or not. We will attempt
+                                    // to suss this out by looking at the recent `upper`, and retrying
+                                    // if it is still appropriate, not retrying if it has advanced
+                                    // to `new_upper`, and panicking if it is anything else.
+                                    while let Err(indeterminate) = result {
+                                        tracing::warn!("Retrying indeterminate table write: {:?}", indeterminate);
+                                        write.fetch_recent_upper().await;
+                                        if write.upper() == &persist_upper {
+                                            // If the upper frontier is the prior frontier, the commit
+                                            // did not happen and we should retry it.
+                                            result =
+                                            write
+                                                .compare_and_append(
+                                                    updates.clone(),
+                                                    persist_upper.clone(),
+                                                    new_upper.clone(),
+                                                )
+                                                .instrument(span.clone())
+                                                .await;
+
+                                        } else if write.upper() == &new_upper {
+                                            // If the upper frontier is the new frontier, then because
+                                            // of mutual exclusion of writes, no other writer should be
+                                            // advancing the frontier to `new_upper`.
+                                            //
+                                            // TODO: This may succeed if `new_upper` is where we cut over
+                                            // to a new leader, who advanced tables to `new_upper` when it
+                                            // started. In that case, a success here will soon be followed
+                                            // by a failure on our next interaction with the catalog stash,
+                                            // but we would incorrectly think this committed and may serve
+                                            // results in the meantime.
+                                            result = Ok(Ok(Ok(())))
+                                        } else {
+                                            panic!("Table write failed: `write.upper` set to value that signals we have lost leadership");
+                                        }
+                                    }
+
+                                    result
+                                        .expect("Indeterminate response not resolved")
                                         .expect("cannot append updates")
                                         .or(Err(*id))?;
 


### PR DESCRIPTION
Table writes through `persist`'s `compare_and_append` may error as `Indeterminate` when something funny has happened under the hood and it is not clear whether the transaction succeeded or failed. More information here: https://github.com/MaterializeInc/materialize/issues/12797

In the case of table writes in the controller, we can rely on the mutual exclusion of written timestamps to "know" that there should only be a few valid states for `write.upper` after a transaction:
1. The `old_upper` from which we hoped to append,
2. The `new_upper` to which we hoped to append,
3. Something greater or equal to the timestamp allocation our `environmentd` has been given.

Although there is some ambiguity between (2.) and (3.) (@jkosh44: to discuss!) we can treat (1.) as "failed to commit; retry", (2.) as "commit succeeded; hooray" and (3.) as "you are no longer leader; please crash".

### Motivation

  * This PR fixes a previously unreported bug.

Indeterminate errors in shutdown have been somewhat annoying for CI, but we also believe they may occur more generally as connections flake. They are not reason to crash `environmentd`, though, at least if the reasoning above is correct.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
