### PR TITLE
persist: collect some shard level metrics

### DIFF
--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -301,6 +301,10 @@ where
         self.seqno
     }
 
+    pub fn since(&self) -> &Antichain<T> {
+        self.collections.trace.since()
+    }
+
     pub fn upper(&self) -> Antichain<T> {
         self.collections.trace.upper().clone()
     }


### PR DESCRIPTION
Ideally, we'd break these down per-shard, but that might be too
expensive for prometheus. Instead, start with the plumbing and aggregate
the interesting per-shard metrics across a process (min of since, max of
upper, sum of state size bytes). It's not ideal, but it's definitely
safe to ship.

The structure of the code makes it pretty trivial to do this swap
(actually tracking them per-shard) later: replace the ComputedFooGauge
in ShardsMetrics with a FooCounterVec and the AtomicFoo in ShardMetrics
with a FooCounter.

We hand out `Arc<ShardMetrics>` to read and write handles, but store it
here as `Weak`. This allows us to discover if it's no longer in use and
so we can remove it from the map.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
