### PR TITLE
Improve the information reported by read hold asserts

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -232,10 +232,16 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         let storage = self.controller.storage_mut();
         for id in read_holds.id_bundle.storage_ids.iter() {
             let collection = storage.collection(*id).unwrap();
-            assert!(collection
-                .read_capabilities
-                .frontier()
-                .less_equal(&read_holds.time));
+            assert!(
+                collection
+                    .read_capabilities
+                    .frontier()
+                    .less_equal(&read_holds.time),
+                "Storage collection {:?} has read frontier {:?} not less-equal desired time {:?}",
+                id,
+                collection.read_capabilities.frontier(),
+                read_holds.time,
+            );
             let read_needs = self.read_capability.get_mut(id).unwrap();
             read_needs.holds.update_iter(Some((read_holds.time, 1)));
             policy_changes.push((*id, read_needs.policy()));
@@ -250,7 +256,13 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 assert!(collection
                     .read_capabilities
                     .frontier()
-                    .less_equal(&read_holds.time));
+                    .less_equal(&read_holds.time),
+                    "Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal desired time {:?}",
+                    id,
+                    compute_instance,
+                    collection.read_capabilities.frontier(),
+                    read_holds.time,
+                );
                 let read_needs = self.read_capability.get_mut(id).unwrap();
                 read_needs.holds.update_iter(Some((read_holds.time, 1)));
                 policy_changes.push((*id, read_needs.policy()));
@@ -286,7 +298,13 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             assert!(collection
                 .read_capabilities
                 .frontier()
-                .less_equal(&new_time));
+                .less_equal(&new_time),
+                "Storage collection {:?} has read frontier {:?} not less-equal new time {:?}; old time: {:?}",
+                id,
+                collection.read_capabilities.frontier(),
+                new_time,
+                old_time,
+            );
             let read_needs = self.read_capability.get_mut(id).unwrap();
             read_needs.holds.update_iter(Some((new_time, 1)));
             read_needs.holds.update_iter(Some((*old_time, -1)));
@@ -302,7 +320,14 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 assert!(collection
                     .read_capabilities
                     .frontier()
-                    .less_equal(&new_time));
+                    .less_equal(&new_time),
+                    "Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal new time {:?}; old time: {:?}",
+                    id,
+                    compute_instance,
+                    collection.read_capabilities.frontier(),
+                    new_time,
+                    old_time,
+                );
                 let read_needs = self.read_capability.get_mut(id).unwrap();
                 read_needs.holds.update_iter(Some((new_time, 1)));
                 read_needs.holds.update_iter(Some((*old_time, -1)));


### PR DESCRIPTION
Asserts seen in the wild lack sufficient information to diagnose where the problem may lie.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
