### PR TITLE
Establish that read holds are valid as acquired

### DIFF
--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -156,7 +156,13 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                         .to_owned();
                     let TimelineState { read_holds, .. } =
                         self.ensure_timeline_state(timeline).await;
-                    assert!(initial_frontier.less_equal(&read_holds.time));
+                    assert!(initial_frontier.less_equal(&read_holds.time),
+                        "Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal to read_hold.time: {:?}",
+                        id,
+                        compute_instance,
+                        initial_frontier,
+                        read_holds.time,
+                    );
                     read_capability
                         .holds
                         .update_iter(Some((read_holds.time, 1)));
@@ -198,7 +204,12 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     .frontier()
                     .to_owned();
                 let TimelineState { read_holds, .. } = self.ensure_timeline_state(timeline).await;
-                assert!(initial_frontier.less_equal(&read_holds.time));
+                assert!(initial_frontier.less_equal(&read_holds.time),
+                    "Storage collection {:?} has read frontier {:?} not less-equal to read_hold.time: {:?}",
+                    id,
+                    initial_frontier,
+                    read_holds.time,
+                );
                 read_capability
                     .holds
                     .update_iter(Some((read_holds.time, 1)));

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -156,13 +156,15 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                         .to_owned();
                     let TimelineState { read_holds, .. } =
                         self.ensure_timeline_state(timeline).await;
-                    assert!(initial_frontier.less_equal(&read_holds.time),
-                        "Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal to read_hold.time: {:?}",
-                        id,
-                        compute_instance,
-                        initial_frontier,
-                        read_holds.time,
-                    );
+                    if !initial_frontier.less_equal(&read_holds.time) {
+                        // This error *SHOULD* be fatal, but it is not currently maintained and cannot merge as an assert.
+                        tracing::error!("Compute collection {:?} (instance {:?}) has read frontier {:?} not less-equal to read_hold.time: {:?}",
+                            id,
+                            compute_instance,
+                            initial_frontier,
+                            read_holds.time,
+                        );
+                    }
                     read_capability
                         .holds
                         .update_iter(Some((read_holds.time, 1)));
@@ -204,12 +206,14 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     .frontier()
                     .to_owned();
                 let TimelineState { read_holds, .. } = self.ensure_timeline_state(timeline).await;
-                assert!(initial_frontier.less_equal(&read_holds.time),
-                    "Storage collection {:?} has read frontier {:?} not less-equal to read_hold.time: {:?}",
-                    id,
-                    initial_frontier,
-                    read_holds.time,
-                );
+                if !initial_frontier.less_equal(&read_holds.time) {
+                    // This error *SHOULD* be fatal, but it is not currently maintained and cannot merge as an assert.
+                    tracing::error!("Storage collection {:?} has read frontier {:?} not less-equal to read_hold.time: {:?}",
+                        id,
+                        initial_frontier,
+                        read_holds.time,
+                    );
+                }
                 read_capability
                     .holds
                     .update_iter(Some((read_holds.time, 1)));

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -145,8 +145,18 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 let mut read_capability: ReadCapability<_> = policy.into();
 
                 if let Some(timeline) = self.get_timeline(*id) {
+                    let initial_frontier = self
+                        .controller
+                        .compute(*compute_instance)
+                        .unwrap()
+                        .collection(*id)
+                        .unwrap()
+                        .read_capabilities
+                        .frontier()
+                        .to_owned();
                     let TimelineState { read_holds, .. } =
                         self.ensure_timeline_state(timeline).await;
+                    assert!(initial_frontier.less_equal(&read_holds.time));
                     read_capability
                         .holds
                         .update_iter(Some((read_holds.time, 1)));
@@ -179,7 +189,16 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             let mut read_capability: ReadCapability<_> = policy.into();
 
             if let Some(timeline) = self.get_timeline(*id) {
+                let initial_frontier = self
+                    .controller
+                    .storage()
+                    .collection(*id)
+                    .unwrap()
+                    .read_capabilities
+                    .frontier()
+                    .to_owned();
                 let TimelineState { read_holds, .. } = self.ensure_timeline_state(timeline).await;
+                assert!(initial_frontier.less_equal(&read_holds.time));
                 read_capability
                     .holds
                     .update_iter(Some((read_holds.time, 1)));


### PR DESCRIPTION
Light diagnostic assert that should tell us if we initialize read holds that are not valid at the moment we establish them.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
