### PR TITLE
cloudtest: A new batch of tests

### DIFF
--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -51,6 +51,14 @@ class Application:
                     ]
                 )
 
+    def kubectl(self, *args: str) -> str:
+        return subprocess.check_output(
+            ["kubectl", "--context", self.context(), *args]
+        ).decode("ascii")
+
+    def context(self) -> str:
+        return "kind-kind"
+
 
 class MaterializeApplication(Application):
     def __init__(self) -> None:
@@ -70,16 +78,11 @@ class MaterializeApplication(Application):
         self.images = ["environmentd", "computed", "storaged", "testdrive"]
 
         # Label the minicube node in a way that mimics Materialize cloud
-        subprocess.check_call(
-            [
-                "kubectl",
-                "label",
-                "--context",
-                "kind-kind",
-                "--overwrite",
-                "node/kind-control-plane",
-                "materialize.cloud/availability-zone=",
-            ]
+        self.kubectl(
+            "label",
+            "--overwrite",
+            "node/kind-control-plane",
+            "materialize.cloud/availability-zone=",
         )
 
         super().__init__()

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -34,8 +34,10 @@ from materialize import ROOT, mzbuild
 
 
 class K8sResource:
-    def kubectl(self, *args: str) -> None:
-        subprocess.check_call(["kubectl", "--context", self.context(), *args])
+    def kubectl(self, *args: str) -> str:
+        return subprocess.check_output(
+            ["kubectl", "--context", self.context(), *args]
+        ).decode("ascii")
 
     def kube_config(self) -> Any:
         with open(Path.home() / ".kube" / "config") as f:

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -76,7 +76,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             args=[
                 "--storaged-image=" + self.image("storaged"),
                 "--computed-image=" + self.image("computed"),
-                f"--persist-blob-url=s3://minio:minio123@test/test?endpoint={s3_endpoint}&region=minio",
+                f"--persist-blob-url=s3://minio:minio123@persist/persist?endpoint={s3_endpoint}&region=minio",
                 "--orchestrator=kubernetes",
                 "--orchestrator-kubernetes-image-pull-policy=never",
                 "--persist-consensus-url=postgres://postgres@postgres.default?options=--search_path=consensus",

--- a/misc/python/materialize/cloudtest/k8s/minio.py
+++ b/misc/python/materialize/cloudtest/k8s/minio.py
@@ -37,6 +37,9 @@ class Minio(K8sResource):
             condition="condition=Available=True",
         )
 
+        self.create_bucket("persist")
+
+    def create_bucket(self, bucket: str) -> None:
         self.kubectl(
             "run",
             "minio",
@@ -49,8 +52,8 @@ class Minio(K8sResource):
             ";".join(
                 [
                     "mc config host add myminio http://minio-service.default:9000 minio minio123",
-                    "mc rm -r --force myminio/test",
-                    "mc mb myminio/test",
+                    f"mc rm -r --force myminio/{bucket}",
+                    f"mc mb myminio/{bucket}",
                 ]
             ),
         )

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import subprocess
+from typing import Optional
 
 from kubernetes.client import V1Container, V1ObjectMeta, V1Pod, V1PodSpec
 
@@ -28,7 +29,9 @@ class Testdrive(K8sPod):
         pod_spec = V1PodSpec(containers=[container])
         self.pod = V1Pod(metadata=metadata, spec=pod_spec)
 
-    def run_string(self, input: str) -> None:
+    def run_string(
+        self, input: str, no_reset: bool = False, seed: Optional[int] = None
+    ) -> None:
         wait(condition="condition=Ready", resource="pod/testdrive")
         subprocess.run(
             [
@@ -44,6 +47,11 @@ class Testdrive(K8sPod):
                 "--kafka-addr=redpanda:9092",
                 "--schema-registry-url=http://redpanda:8081",
                 "--default-timeout=300s",
+                "--aws-endpoint=http://minio-service.default:9000",
+                "--aws-access-key-id=minio",
+                "--aws-secret-access-key=minio123",
+                *(["--no-reset"] if no_reset else []),
+                *([f"--seed={seed}"] if seed else []),
             ],
             check=True,
             input=input,

--- a/misc/python/materialize/cloudtest/wait.py
+++ b/misc/python/materialize/cloudtest/wait.py
@@ -33,11 +33,17 @@ def wait(
     error = None
     for remaining in ui.timeout_loop(timeout_secs, tick=0.1):
         try:
-            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-            if "condition met" in output.decode("ascii"):
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode(
+                "ascii"
+            )
+            # output is:
+            # - an empty string when a 'delete' condition is satisfied
+            # - 'condition met' for all other conditions
+            if len(output) == 0 or "condition met" in output:
                 ui.progress("success!", finish=True)
                 return
         except subprocess.CalledProcessError as e:
+            print(e, e.output)
             error = e
 
     ui.progress(finish=True)

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -172,14 +172,40 @@ struct Args {
     /// Named AWS region to target for AWS API requests.
     ///
     /// Cannot be specified if --aws-endpoint is specified.
-    #[clap(long, conflicts_with = "aws-endpoint", value_name = "REGION")]
+    #[clap(
+        long,
+        conflicts_with = "aws-endpoint",
+        value_name = "REGION",
+        env = "AWS_REGION"
+    )]
     aws_region: Option<String>,
     /// Custom AWS endpoint.
     ///
     /// Defaults to http://localhost:4566 unless --aws-region is specified.
     /// Cannot be specified if --aws-region is specified.
-    #[clap(long, conflicts_with = "aws-region", value_name = "URL")]
+    #[clap(
+        long,
+        conflicts_with = "aws-region",
+        value_name = "URL",
+        env = "AWS_ENDPOINT"
+    )]
     aws_endpoint: Option<Uri>,
+
+    #[clap(
+        long,
+        value_name = "KEY_ID",
+        default_value = "dummy-access-key-id",
+        env = "AWS_ACCESS_KEY_ID"
+    )]
+    aws_access_key_id: String,
+
+    #[clap(
+        long,
+        value_name = "KEY",
+        default_value = "dummy-secret-access-key",
+        env = "AWS_SECRET_ACCESS_KEY"
+    )]
+    aws_secret_access_key: String,
 }
 
 #[tokio::main]
@@ -217,17 +243,15 @@ async fn main() {
         }
         None => {
             // The user specified a a custom endpoint. We assume we're targeting
-            // a stubbed-out AWS implementation that does not use regions or
-            // check authentication credentials, so we use dummy credentials and
-            // a dummy region.
+            // a stubbed-out AWS implementation.
             let endpoint = args
                 .aws_endpoint
                 .unwrap_or_else(|| "http://localhost:4566".parse().unwrap());
             let config = aws_config::from_env()
                 .region(Region::new("us-east-1"))
                 .credentials_provider(Credentials::from_keys(
-                    "dummy-access-key-id",
-                    "dummy-secret-access-key",
+                    args.aws_access_key_id,
+                    args.aws_secret_access_key,
                     None,
                 ))
                 .endpoint_resolver(Endpoint::immutable(endpoint))

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -1,0 +1,126 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from pg8000.exceptions import InterfaceError  # type: ignore
+
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.wait import wait
+
+
+def populate(mz: MaterializeApplication, seed: int) -> None:
+    mz.testdrive.run_string(
+        dedent(
+            """
+            > CREATE TABLE t1 (f1 INTEGER);
+
+            > INSERT INTO t1 VALUES (123);
+
+            > CREATE DEFAULT INDEX ON t1;
+
+            > INSERT INTO t1 VALUES (234);
+
+            > CREATE CONNECTION kafka FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+            > CREATE SOURCE s1
+              FROM KAFKA CONNECTION kafka
+              TOPIC 'testdrive-crash-${testdrive.seed}'
+              FORMAT BYTES
+              ENVELOPE NONE;
+
+            $ kafka-create-topic topic=crash
+
+            $ kafka-ingest format=bytes topic=crash
+            CDE
+
+            > CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) FROM t1 UNION ALL SELECT COUNT(*) FROM s1;
+
+            $ kafka-ingest format=bytes topic=crash
+            DEF
+
+            > CREATE DEFAULT INDEX ON v1;
+
+            > SELECT COUNT(*) > 0 FROM s1;
+            true
+            """
+        ),
+        seed=seed,
+    )
+
+
+def validate(mz: MaterializeApplication, seed: int) -> None:
+    mz.testdrive.run_string(
+        dedent(
+            """
+            > INSERT INTO t1 VALUES (345);
+
+            $ kafka-ingest format=bytes topic=crash
+            EFG
+
+            > SELECT COUNT(*) FROM t1;
+            3
+
+            > SELECT COUNT(*) FROM s1;
+            3
+
+            > SELECT * FROM v1;
+            3
+            3
+            """
+        ),
+        no_reset=True,
+        seed=seed,
+    )
+
+
+def test_crash_storaged(mz: MaterializeApplication) -> None:
+    populate(mz, 1)
+
+    source_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_sources WHERE name = 's1';"
+    )[0][0]
+    assert source_id is not None
+    pod_name = f"pod/storage-{source_id}-0"
+
+    wait(condition="jsonpath={.status.phase}=Running", resource=pod_name)
+    mz.kubectl("exec", pod_name, "--", "bash", "-c", "kill -9 `pidof storaged` || true")
+    wait(condition="jsonpath={.status.phase}=Running", resource=pod_name)
+
+    validate(mz, 1)
+
+
+def test_crash_environmentd(mz: MaterializeApplication) -> None:
+    populate(mz, 2)
+    try:
+        mz.environmentd.sql("SELECT mz_internal.mz_panic('forced panic')")
+    except InterfaceError:
+        pass
+    validate(mz, 2)
+
+
+def test_crash_computed(mz: MaterializeApplication) -> None:
+    populate(mz, 3)
+    mz.environmentd.sql("CREATE TABLE crash_table (f1 TEXT)")
+    mz.environmentd.sql(
+        "CREATE MATERIALIZED VIEW crash_view AS SELECT mz_internal.mz_panic(f1) FROM crash_table"
+    )
+    mz.environmentd.sql("INSERT INTO crash_table VALUES ('forced panic')")
+
+    mz.testdrive.run_string(
+        dedent(
+            """
+            > DROP MATERIALIZED VIEW crash_view
+            """
+        ),
+        no_reset=True,
+        seed=3,
+    )
+
+    validate(mz, 3)

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.wait import wait
+
+
+def test_secrets(mz: MaterializeApplication) -> None:
+    mz.testdrive.run_string(
+        dedent(
+            """
+            > CREATE SECRET username AS '123';
+            > CREATE SECRET password AS '234';
+
+            # Our Redpanda instance is not configured for SASL, so we can not
+            # really establish a successful connection.
+
+            ! CREATE SOURCE secrets_source
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
+              TOPIC 'testdrive-secrets-topic-${testdrive.seed}' WITH (
+                  security_protocol = 'SASL_SSL',
+                  sasl_mechanisms = 'PLAIN',
+                  sasl_username = SECRET username,
+                  sasl_password = SECRET password
+              )
+              FORMAT BYTES
+              ENVELOPE NONE;
+            contains: SSL handshake failed
+            """
+        )
+    )
+
+    id = mz.environmentd.sql_query("SELECT id FROM mz_secrets WHERE name = 'username'")[
+        0
+    ][0]
+    assert id is not None
+
+    secret = f"user-managed-{id}"
+
+    #    wait(condition="condition=Ready", resource=f"secret/{secret}")
+
+    describe = mz.kubectl("describe", "secret", secret)
+    assert "contents:  3 bytes" in describe
+
+    mz.environmentd.sql("ALTER SECRET username AS '1234567890'")
+
+    describe = mz.kubectl("describe", "secret", secret)
+    assert "contents:  10 bytes" in describe
+
+    mz.environmentd.sql("DROP SECRET username CASCADE")
+
+    wait(condition="delete", resource=f"secret/{secret}")

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -20,10 +20,13 @@ def test_wait(mz: MaterializeApplication) -> None:
 def test_sql(mz: MaterializeApplication) -> None:
     mz.environmentd.sql("SELECT 1")
 
+    one = mz.environmentd.sql_query("SELECT 1")[0][0]
+    assert int(one) == 1
+
 
 def test_testdrive(mz: MaterializeApplication) -> None:
     mz.testdrive.run_string(
-        input=dedent(
+        dedent(
             """
                 $ kafka-create-topic topic=test
 


### PR DESCRIPTION
- tests that crash environmentd, computed and storaged and confirm
  that they are restarted properly

- a test for CREATE SECRET in a K8s environment

- testdrive has been fixed to allow minio to be used an S3 endpoint
  in preparation for future S3 tests

### Motivation

  * This PR adds a known-desirable feature.

Relates to #13580

### Tips for reviewer

@benesch I made a change to testdrive (not currently used) to make it compatible with minio in K8s, which requires authentication (as opposed to minio on localstack, which does not).