### PR TITLE
persist: bigger connection pool

### DIFF
--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -80,9 +80,12 @@ impl PersistClientCache {
             Entry::Vacant(x) => {
                 // Intentionally hold the lock, so we don't double connect under
                 // concurrency.
-                let consensus =
-                    ConsensusConfig::try_from(x.key(), self.cfg.consensus_connection_pool_max_size)
-                        .await?;
+                let consensus = ConsensusConfig::try_from(
+                    x.key(),
+                    self.cfg.consensus_connection_pool_max_size,
+                    self.metrics.postgres_consensus.clone(),
+                )
+                .await?;
                 let consensus =
                     retry_external(&self.metrics.retries.external.consensus_open, || {
                         consensus.clone().open()

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -21,6 +21,7 @@ use mz_ore::metrics::{ComputedIntGauge, ComputedUIntGauge, Counter, IntCounter, 
 use mz_persist::location::{
     Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData,
 };
+use mz_persist::metrics::PostgresConsensusMetrics;
 use mz_persist::retry::RetryStream;
 use mz_persist_types::Codec64;
 use prometheus::core::{Atomic, AtomicI64, AtomicU64};
@@ -58,6 +59,9 @@ pub struct Metrics {
     pub codecs: CodecsMetrics,
     /// Metrics for various per-shard measurements.
     pub shards: ShardsMetrics,
+
+    /// Metrics for Postgres-backed consensus implementation
+    pub postgres_consensus: PostgresConsensusMetrics,
 }
 
 impl Metrics {
@@ -75,6 +79,7 @@ impl Metrics {
             gc: GcMetrics::new(registry),
             lease: LeaseMetrics::new(registry),
             shards: ShardsMetrics::new(registry),
+            postgres_consensus: PostgresConsensusMetrics::new(registry),
             _vecs: vecs,
         }
     }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -109,6 +109,7 @@ impl PersistLocation {
         let consensus = ConsensusConfig::try_from(
             &self.consensus_uri,
             config.consensus_connection_pool_max_size,
+            metrics.postgres_consensus.clone(),
         )
         .await?;
         let consensus = retry_external(&metrics.retries.external.consensus_open, || {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -241,7 +241,7 @@ impl PersistConfig {
             compaction_enabled: !compaction_disabled,
             compaction_heuristic_min_inputs: 8,
             compaction_heuristic_min_updates: 1024,
-            consensus_connection_pool_max_size: 8,
+            consensus_connection_pool_max_size: 50,
         }
     }
 

--- a/src/persist/src/cfg.rs
+++ b/src/persist/src/cfg.rs
@@ -19,6 +19,7 @@ use url::Url;
 use crate::file::{FileBlob, FileBlobConfig};
 use crate::location::{Blob, Consensus, ExternalError};
 use crate::mem::{MemBlob, MemBlobConfig, MemConsensus};
+use crate::metrics::PostgresConsensusMetrics;
 use crate::postgres::{PostgresConsensus, PostgresConsensusConfig};
 use crate::s3::{S3Blob, S3BlobConfig};
 
@@ -143,6 +144,7 @@ impl ConsensusConfig {
     pub async fn try_from(
         value: &str,
         connection_pool_max_size: usize,
+        metrics: PostgresConsensusMetrics,
     ) -> Result<Self, ExternalError> {
         let url = Url::parse(value).map_err(|err| {
             anyhow!(
@@ -154,7 +156,7 @@ impl ConsensusConfig {
 
         let config = match url.scheme() {
             "postgres" | "postgresql" => Ok(ConsensusConfig::Postgres(
-                PostgresConsensusConfig::new(value, connection_pool_max_size).await?,
+                PostgresConsensusConfig::new(value, connection_pool_max_size, metrics).await?,
             )),
             "mem" => {
                 if !cfg!(debug_assertions) {

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -24,6 +24,7 @@ pub mod gen;
 pub mod indexed;
 pub mod location;
 pub mod mem;
+pub mod metrics;
 pub mod postgres;
 pub mod retry;
 pub mod s3;

--- a/src/persist/src/metrics.rs
+++ b/src/persist/src/metrics.rs
@@ -1,0 +1,41 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Implementation-specific metrics for persist blobs and consensus
+
+use mz_ore::metric;
+use mz_ore::metrics::{Counter, IntCounter, MetricsRegistry, UIntGauge};
+
+/// Metrics specific to PostgresConsensus's internal workings.
+#[derive(Debug, Clone)]
+pub struct PostgresConsensusMetrics {
+    pub(crate) connpool_size: UIntGauge,
+    pub(crate) connpool_acquires: IntCounter,
+    pub(crate) connpool_acquire_seconds: Counter,
+}
+
+impl PostgresConsensusMetrics {
+    /// Returns a new [PostgresConsensusMetrics] instance connected to the given registry.
+    pub fn new(registry: &MetricsRegistry) -> Self {
+        Self {
+            connpool_size: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_size",
+                help: "number of connections currently in pool",
+            )),
+            connpool_acquires: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_acquires",
+                help: "times a connection has been acquired from pool",
+            )),
+            connpool_acquire_seconds: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_acquire_seconds",
+                help: "time spent acquiring connections from pool",
+            )),
+        }
+    }
+}

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -15,17 +15,22 @@ use bytes::Bytes;
 use deadpool_postgres::tokio_postgres::config::SslMode;
 use deadpool_postgres::tokio_postgres::types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use deadpool_postgres::tokio_postgres::Config;
-use deadpool_postgres::{Hook, HookError, HookErrorCause, ManagerConfig, RecyclingMethod};
+use deadpool_postgres::{
+    Hook, HookError, HookErrorCause, ManagerConfig, Object, PoolError, RecyclingMethod,
+};
 use deadpool_postgres::{Manager, Pool};
 use mz_ore::cast::CastFrom;
+use mz_ore::metrics::MetricsRegistry;
 use openssl::pkey::PKey;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use openssl::x509::X509;
 use postgres_openssl::MakeTlsConnector;
+use std::time::Instant;
 use tracing::debug;
 
 use crate::error::Error;
 use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
+use crate::metrics::PostgresConsensusMetrics;
 
 const SCHEMA: &str = "
 CREATE TABLE IF NOT EXISTS consensus (
@@ -77,6 +82,7 @@ impl<'a> FromSql<'a> for SeqNo {
 pub struct PostgresConsensusConfig {
     url: String,
     connection_pool_max_size: usize,
+    metrics: PostgresConsensusMetrics,
 }
 
 impl PostgresConsensusConfig {
@@ -84,10 +90,15 @@ impl PostgresConsensusConfig {
         "MZ_PERSIST_EXTERNAL_STORAGE_TEST_POSTGRES_URL";
 
     /// Returns a new [PostgresConsensusConfig] for use in production.
-    pub async fn new(url: &str, connection_pool_max_size: usize) -> Result<Self, Error> {
+    pub async fn new(
+        url: &str,
+        connection_pool_max_size: usize,
+        metrics: PostgresConsensusMetrics,
+    ) -> Result<Self, Error> {
         Ok(PostgresConsensusConfig {
             url: url.to_string(),
             connection_pool_max_size,
+            metrics,
         })
     }
 
@@ -111,7 +122,12 @@ impl PostgresConsensusConfig {
             }
         };
 
-        let config = PostgresConsensusConfig::new(&url, 2).await?;
+        let config = PostgresConsensusConfig::new(
+            &url,
+            2,
+            PostgresConsensusMetrics::new(&MetricsRegistry::new()),
+        )
+        .await?;
         Ok(Some(config))
     }
 }
@@ -119,6 +135,7 @@ impl PostgresConsensusConfig {
 /// Implementation of [Consensus] over a Postgres database.
 pub struct PostgresConsensus {
     pool: Pool,
+    metrics: PostgresConsensusMetrics,
 }
 
 impl std::fmt::Debug for PostgresConsensus {
@@ -193,7 +210,10 @@ impl PostgresConsensus {
         }
 
         tx.commit().await?;
-        Ok(PostgresConsensus { pool })
+        Ok(PostgresConsensus {
+            pool,
+            metrics: config.metrics,
+        })
     }
 
     /// Drops and recreates the `consensus` table in Postgres
@@ -201,10 +221,24 @@ impl PostgresConsensus {
     /// ONLY FOR TESTING
     pub async fn drop_and_recreate(&self) -> Result<(), ExternalError> {
         // this could be a TRUNCATE if we're confident the db won't reuse any state
-        let client = self.pool.get().await?;
+        let client = self.get_connection().await?;
         client.execute("DROP TABLE consensus", &[]).await?;
         client.execute(SCHEMA, &[]).await?;
         Ok(())
+    }
+
+    async fn get_connection(&self) -> Result<Object, PoolError> {
+        let start = Instant::now();
+        let res = self.pool.get().await;
+        self.metrics
+            .connpool_acquire_seconds
+            .inc_by(start.elapsed().as_secs_f64());
+        self.metrics.connpool_acquires.inc();
+        // note that getting the pool size here requires briefly locking the pool
+        self.metrics
+            .connpool_size
+            .set(u64::cast_from(self.pool.status().size));
+        res
     }
 }
 
@@ -273,7 +307,7 @@ impl Consensus for PostgresConsensus {
         let q = "SELECT sequence_number, data FROM consensus
              WHERE shard = $1 ORDER BY sequence_number DESC LIMIT 1";
         let row = {
-            let client = self.pool.get().await?;
+            let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
             client.query_opt(&statement, &[&key]).await?
         };
@@ -323,7 +357,7 @@ impl Consensus for PostgresConsensus {
                          SELECT * FROM consensus WHERE shard = $1 AND sequence_number > $4
                      )
                      ON CONFLICT DO NOTHING";
-            let client = self.pool.get().await?;
+            let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
             client
                 .execute(
@@ -338,7 +372,7 @@ impl Consensus for PostgresConsensus {
                          SELECT * FROM consensus WHERE shard = $1
                      )
                      ON CONFLICT DO NOTHING";
-            let client = self.pool.get().await?;
+            let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
             client
                 .execute(&statement, &[&key, &new.seqno, &new.data.as_ref()])
@@ -364,7 +398,7 @@ impl Consensus for PostgresConsensus {
              WHERE shard = $1 AND sequence_number >= $2
              ORDER BY sequence_number";
         let rows = {
-            let client = self.pool.get().await?;
+            let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
             client.query(&statement, &[&key, &from]).await?
         };
@@ -397,7 +431,7 @@ impl Consensus for PostgresConsensus {
                 )";
 
         let result = {
-            let client = self.pool.get().await?;
+            let client = self.get_connection().await?;
             let statement = client.prepare_cached(q).await?;
             client.execute(&statement, &[&key, &seqno]).await?
         };


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

We had been seeing unexpectedly high latency performing `compare_and_set`, in a way that seemed too high to just be time spent querying CRDB. Pulling a connection from the pool is the other major contributor to `compare_and_set`'s end-to-end timing, so this PR raises the limit substantially. In practice, a process will only create `n` connections if it ever needed `n` concurrent calls, so this will only affect (positively!) processes that need more connections than they're currently given.

I tried running this change on my personal environment, and saw an immediate and substantial improvement in `compare_and_set` timings (the red line), previously spending 20-45s in `compare_and_set` per reporting interval down to 4-4.5s (!) 

<img width="1193" alt="Screen Shot 2022-08-02 at 4 54 38 PM" src="https://user-images.githubusercontent.com/785446/182471791-22a37abc-51be-4a57-94ae-d3c209961925.png">

TODO:
- [x] Gauge metric for connection pool size
- [x] Counter metrics for time spent acquiring connections

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
