### PR TITLE
persist: assign gc work preferentially to writers

### DIFF
--- a/src/persist-client/src/impl/encoding.rs
+++ b/src/persist-client/src/impl/encoding.rs
@@ -154,6 +154,7 @@ where
             val_codec: V::codec_name(),
             ts_codec: T::codec_name(),
             diff_codec: D::codec_name(),
+            last_gc_req: self.collections.last_gc_req.into_proto(),
             readers: self
                 .collections
                 .readers
@@ -232,6 +233,7 @@ where
             );
         }
         let collections = StateCollections {
+            last_gc_req: x.last_gc_req.into_rust()?,
             readers,
             writers,
             trace: x.trace.into_rust_if_some("trace")?,

--- a/src/persist-client/src/impl/maintenance.rs
+++ b/src/persist-client/src/impl/maintenance.rs
@@ -90,9 +90,7 @@ impl RoutineMaintenance {
     {
         let mut join_handles = vec![];
         if let Some(gc_req) = self.garbage_collection {
-            if let Some(join) = gc.gc_and_truncate_background(gc_req) {
-                join_handles.push(join);
-            }
+            join_handles.push(gc.gc_and_truncate_background(gc_req));
         }
 
         if let Some(lease_expiration) = self.lease_expiration {

--- a/src/persist-client/src/impl/state.proto
+++ b/src/persist-client/src/impl/state.proto
@@ -56,6 +56,7 @@ message ProtoStateRollup {
     string ts_codec = 4;
     string diff_codec = 5;
     uint64 seqno = 6;
+    uint64 last_gc_req = 10;
     ProtoTrace trace = 7;
     repeated ProtoReaderState readers = 8;
     repeated ProtoWriterState writers = 9;

--- a/src/persist-client/src/impl/trace.rs
+++ b/src/persist-client/src/impl/trace.rs
@@ -175,7 +175,6 @@ impl<T: Timestamp + Lattice> Trace<T> {
         ret
     }
 
-    #[cfg(test)]
     pub fn num_hollow_batches(&self) -> usize {
         let mut ret = 0;
         self.map_batches(|_| ret += 1);


### PR DESCRIPTION
I originally thought it made sense to assign gc work proportionally to
whoever caused the seqno_since to move forward (either the last readers
to stop using a given seqno, or if there are no readers, any writer).
This has turned out to be wrong for at least two reasons:

- I was imagining that it would usually be some computed persist_source
  that would be selected. This might be the case for a big snapshot at
  computed startup, but in practice the steady-state case has turned out
  to be that this is some controller (enforcing our since compaction
  policy) and so _all_ gc runs in environmentd. The GC traffic for an
  env scales with the total persist traffic, so this is a pretty bad
  scaling bottleneck. Plus, environmentd is the most latency sensitive
  of any mz process. Fixing this is the immediate motivation for this
  PR.
- Even if the above hadn't been the case, we'd have continually selected
  whichever persist_source was most behind, potentially keeping it
  behind by adding additional (background) work.

Instead, Aljoscha suggested making GC, like compaction, the
responsibility of writers. Paul points out that we still want GC to
happen even if some storaged is down for a source while a potentially
large number of computed processes are calling downgrade_since, so this
probably means "preferentially writers". He also points out that we
happen to know in state whether there are any writers. It takes a
village to raise a GC policy.

So, now GC works as follows:

 - A new last_seq_req is maintained in State.
 - Whenever `apply_unbatched_cmd` computes a new_state for some cmd, it
   after checks if this should result in a GC req. If so, this is noted
   in new_state before we CaS (this allows us to sneak last_seq_req
   maintenance in without adding any new state versions).
 - This logic compares the current seqno_since of State to the last
   request against some threshold (to rate-limit GC a bit). It also only
   generates a request if the current cmd is a writer or if there are no
   writers registered.

In practice, this means in the common case user table GC still falls on
environmentd, but source GC happens in storaged and materialized view GC
happens in computed. If the uncommon case, someone still picks it up.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

We probably want a test for this, but I was curious to get a CI run while I type that up.

We add a proto field for last_gc_req, but the decode interprets missing as "0", which is backward_compatible and does the right thing.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
