### PR TITLE
coord: initialize read policy for log indexes

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -489,13 +489,13 @@ impl CatalogState {
         id: ComputeInstanceId,
         name: String,
         introspection: Option<ComputeInstanceIntrospectionConfig>,
-        introspection_sources: Vec<(&'static BuiltinLog, GlobalId)>,
+        introspection_source_indexes: Vec<(&'static BuiltinLog, GlobalId)>,
     ) {
         let logging = match introspection {
             None => None,
             Some(introspection) => {
                 let mut active_logs = BTreeMap::new();
-                for (log, index_id) in introspection_sources {
+                for (log, index_id) in introspection_source_indexes {
                     let source_name = FullObjectName {
                         database: RawDatabaseSpecifier::Ambient,
                         schema: log.schema.into(),
@@ -3025,7 +3025,7 @@ impl<S: Append> Catalog<S> {
                 name: String,
                 config: Option<ComputeInstanceIntrospectionConfig>,
                 // These are the legacy, active logs of this compute instance
-                introspection_sources: Vec<(&'static BuiltinLog, GlobalId)>,
+                introspection_source_indexes: Vec<(&'static BuiltinLog, GlobalId)>,
             },
             CreateComputeInstanceReplica {
                 id: ReplicaId,
@@ -3165,14 +3165,15 @@ impl<S: Append> Catalog<S> {
                 Op::CreateComputeInstance {
                     name,
                     config,
-                    introspection_source_indexes: introspection_sources,
+                    introspection_source_indexes,
                 } => {
                     if is_reserved_name(&name) {
                         return Err(AdapterError::Catalog(Error::new(
                             ErrorKind::ReservedClusterName(name),
                         )));
                     }
-                    let id = tx.insert_compute_instance(&name, &config, &introspection_sources)?;
+                    let id =
+                        tx.insert_compute_instance(&name, &config, &introspection_source_indexes)?;
                     self.add_to_audit_log(
                         session,
                         &mut tx,
@@ -3185,7 +3186,7 @@ impl<S: Append> Catalog<S> {
                         id,
                         name,
                         config,
-                        introspection_sources,
+                        introspection_source_indexes,
                     }]
                 }
                 Op::CreateComputeInstanceReplica {
@@ -3595,13 +3596,21 @@ impl<S: Append> Catalog<S> {
                     id,
                     name,
                     config,
-                    introspection_sources,
+                    introspection_source_indexes,
                 } => {
                     info!("create cluster {}", name);
                     let introspection_source_index_ids: Vec<GlobalId> =
-                        introspection_sources.iter().map(|(_, id)| *id).collect();
+                        introspection_source_indexes
+                            .iter()
+                            .map(|(_, id)| *id)
+                            .collect();
                     state
-                        .insert_compute_instance(id, name.clone(), config, introspection_sources)
+                        .insert_compute_instance(
+                            id,
+                            name.clone(),
+                            config,
+                            introspection_source_indexes,
+                        )
                         .await;
                     builtin_table_updates.push(state.pack_compute_instance_update(&name, 1));
                     for id in introspection_source_index_ids {

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3165,7 +3165,7 @@ impl<S: Append> Catalog<S> {
                 Op::CreateComputeInstance {
                     name,
                     config,
-                    introspection_sources,
+                    introspection_source_indexes: introspection_sources,
                 } => {
                     if is_reserved_name(&name) {
                         return Err(AdapterError::Catalog(Error::new(
@@ -4030,7 +4030,7 @@ pub enum Op {
     CreateComputeInstance {
         name: String,
         config: Option<ComputeInstanceIntrospectionConfig>,
-        introspection_sources: Vec<(&'static BuiltinLog, GlobalId)>,
+        introspection_source_indexes: Vec<(&'static BuiltinLog, GlobalId)>,
     },
     CreateComputeInstanceReplica {
         name: String,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -918,7 +918,7 @@ impl<'a, S: Append> Transaction<'a, S> {
         &mut self,
         cluster_name: &str,
         config: &Option<ComputeInstanceIntrospectionConfig>,
-        introspection_sources: &Vec<(&'static BuiltinLog, GlobalId)>,
+        introspection_source_indexes: &Vec<(&'static BuiltinLog, GlobalId)>,
     ) -> Result<ComputeInstanceId, Error> {
         let id = self.get_and_increment_id(COMPUTE_ID_ALLOC_KEY.to_string())?;
         let config = serde_json::to_string(config)
@@ -935,7 +935,7 @@ impl<'a, S: Append> Transaction<'a, S> {
             )));
         };
 
-        for (builtin, index_id) in introspection_sources {
+        for (builtin, index_id) in introspection_source_indexes {
             let index_id = if let GlobalId::System(id) = index_id {
                 *id
             } else {

--- a/test/sqllogictest/cluster_log_compaction.slt
+++ b/test/sqllogictest/cluster_log_compaction.slt
@@ -1,0 +1,29 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Ensure correct log creation on `CREATE CLUSTER` initializes read policies for introspection source indexes.
+
+mode cockroach
+
+statement ok
+CREATE CLUSTER c1 REPLICAS (r (SIZE '1'));
+
+statement ok
+SET CLUSTER TO c1;
+
+statement ok
+BEGIN
+
+# Transaction will force a read hold on this index.
+query T rowsort
+SELECT * FROM mz_arrangement_batches_internal_2;
+----
+
+statement ok
+COMMIT


### PR DESCRIPTION
Fixes #14024

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
