### PR TITLE
new explain: A custom serializer for the JSONRow struct.

### DIFF
--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.58"
 bytes = "1.2.0"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.6.3", features = ["serde", "case-insensitive"] }
-dec = {version = "0.4.8", features = ["serde"]}
+dec = "0.4.8"
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 globset = "0.4.9"

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.58"
 bytes = "1.2.0"
 chrono = { version = "0.4.0", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.6.3", features = ["serde", "case-insensitive"] }
-dec = "0.4.8"
+dec = {version = "0.4.8", features = ["serde"]}
 enum-kinds = "0.5.1"
 fast-float = "0.2.0"
 globset = "0.4.9"
@@ -42,7 +42,7 @@ serde_json = { version = "1.0.82", features = ["arbitrary_precision"] }
 serde_regex = "1.1.0"
 smallvec = { version = "1.9.0", features = ["serde", "union"] }
 url = { version = "2.2.2", features = ["serde"] }
-uuid = "1.1.2"
+uuid = { version = "1.1.2", features = ["serde"] }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"] }
 proptest-derive = { git = "https://github.com/MaterializeInc/proptest.git" }
 

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -28,13 +28,11 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.array.rs"));
 pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
 
 /// A variable-length multi-dimensional array.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Array<'a> {
     /// The elements in the array.
-    #[serde(borrow)]
     pub(crate) elements: DatumList<'a>,
     /// The dimensions of the array.
-    #[serde(borrow)]
     pub(crate) dims: ArrayDimensions<'a>,
 }
 
@@ -51,9 +49,8 @@ impl<'a> Array<'a> {
 }
 
 /// The dimensions of an [`Array`].
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ArrayDimensions<'a> {
-    #[serde(borrow)]
     pub(crate) data: &'a [u8],
 }
 

--- a/src/repr/src/adt/array.rs
+++ b/src/repr/src/adt/array.rs
@@ -28,11 +28,13 @@ include!(concat!(env!("OUT_DIR"), "/mz_repr.adt.array.rs"));
 pub const MAX_ARRAY_DIMENSIONS: u8 = 6;
 
 /// A variable-length multi-dimensional array.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Array<'a> {
     /// The elements in the array.
+    #[serde(borrow)]
     pub(crate) elements: DatumList<'a>,
     /// The dimensions of the array.
+    #[serde(borrow)]
     pub(crate) dims: ArrayDimensions<'a>,
 }
 
@@ -49,8 +51,9 @@ impl<'a> Array<'a> {
 }
 
 /// The dimensions of an [`Array`].
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ArrayDimensions<'a> {
+    #[serde(borrow)]
     pub(crate) data: &'a [u8],
 }
 

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -234,7 +234,7 @@ impl PartialOrd for DatumList<'_> {
 }
 
 /// A mapping from string keys to Datums
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct DatumMap<'a> {
     /// Points at the serialized datums, which should be sorted in key order
     data: &'a [u8],

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -209,7 +209,7 @@ pub struct RowArena {
 // DatumList and DatumDict defined here rather than near Datum because we need private access to the unsafe data field
 
 /// A sequence of Datums
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct DatumList<'a> {
     /// Points at the serialized datums
     data: &'a [u8],
@@ -234,7 +234,7 @@ impl PartialOrd for DatumList<'_> {
 }
 
 /// A mapping from string keys to Datums
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct DatumMap<'a> {
     /// Points at the serialized datums, which should be sorted in key order
     data: &'a [u8],

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -22,7 +22,8 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use ordered_float::OrderedFloat;
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Strategy};
-use serde::{Deserialize, Serialize};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Serialize, Serializer};
 use smallvec::SmallVec;
 use uuid::Uuid;
 
@@ -209,7 +210,7 @@ pub struct RowArena {
 // DatumList and DatumDict defined here rather than near Datum because we need private access to the unsafe data field
 
 /// A sequence of Datums
-#[derive(Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
 pub struct DatumList<'a> {
     /// Points at the serialized datums
     data: &'a [u8],
@@ -233,6 +234,20 @@ impl PartialOrd for DatumList<'_> {
     }
 }
 
+impl<'a> Serialize for DatumList<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(None)?;
+        let mut iter = self.iter();
+        while let Some(datum) = iter.next() {
+            seq.serialize_element(&datum)?;
+        }
+        seq.end()
+    }
+}
+
 /// A mapping from string keys to Datums
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct DatumMap<'a> {
@@ -240,6 +255,19 @@ pub struct DatumMap<'a> {
     data: &'a [u8],
 }
 
+impl<'a> Serialize for DatumMap<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+        let mut iter = self.iter();
+        while let Some((key, val)) = iter.next() {
+            map.serialize_entry(&key, &val)?;
+        }
+        map.end()
+    }
+}
 #[derive(Debug, Clone, Copy, PartialEq, Eq, IntoPrimitive, TryFromPrimitive)]
 #[repr(u8)]
 enum Tag {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -46,7 +46,7 @@ pub use crate::relation_and_scalar::ProtoScalarType;
 ///
 /// Note that `Datum` must always derive [`Eq`] to enforce equality with
 /// `repr::Row`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum Datum<'a> {
     /// The `false` boolean value.
     False,

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -155,7 +155,7 @@ impl<'a> Serialize for Datum<'a> {
             Array(a) => a.serialize(serializer),
             List(l) => l.serialize(serializer),
             Map(m) => m.serialize(serializer),
-            Numeric(n) => n.serialize(serializer),
+            Numeric(n) => serializer.serialize_str(&n.to_string()),
             Uuid(u) => u.serialize(serializer),
             Dummy => serializer.serialize_str("Dummy"),
             JsonNull => serializer.serialize_str("JsonNull"),


### PR DESCRIPTION
A custom serialization function that converts a JSONRow into `Vec<Datum<'a>>`. It turns out that what was blocking me from deriving Serialize on `Datum` was the need to add the `serde` feature to some imported crates.

It also turns out that `Datum::List`, `Datum::Map`, and `Datum::Array` themselves contain `Row`s that contain inner `Datum`s, so I need to add a custom serialization function for those variants.

### Tips for Reviewer

Looking for feedback on the output format of the datums.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
A unit test for the json output has been added.

No user facing behavior changes.
