### PR TITLE
feature-benchmark: Allow Redpanda to be used in place of Confluent stack

### DIFF
--- a/ci/cleanup/aws.py
+++ b/ci/cleanup/aws.py
@@ -72,7 +72,7 @@ def clean_up_sqs() -> None:
                 print("Skipping non-testdrive queue {}".format(name))
                 continue
             attributes = client.get_queue_attributes(
-                QueueUrl=queue, AttributeNames=["CreatedTimestamp"]
+                QueueUrl=queue, AttributeNames=["All"]
             )
             created_at = int(attributes["Attributes"]["CreatedTimestamp"])
             age = datetime.now(timezone.utc) - datetime.fromtimestamp(


### PR DESCRIPTION
Provide a --redpanda option to the default workflow that starts Redpanda
instead of the Confluent stack.

### Motivation

  * This PR fixes a previously unreported bug.
The feature benchmark was not usable on M macs due to very slow Confluent stack.