### PR TITLE
github: add notify triage workflow

### DIFF
--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -19,7 +19,7 @@
 
 #     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
 
-name: Slack - Notify P1
+name: Slack Issue Notifications
 
 on:
   issues:
@@ -35,7 +35,16 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (#${{ github.event.issue.number }}).
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (https://github.com/MaterializeInc/materialize/issues/${{ github.event.issue.number }}).
           channel: github-p1
           color: red
-          verbose: true
+          verbose: false
+      - uses: actions-ecosystem/action-slack-notifier@v1
+        if: ${{ github.event.label.name == 'C-triage' }}
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          message: |
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (https://github.com/MaterializeInc/materialize/issues/${{ github.event.issue.number }}).
+          channel: github-triage
+          color: red
+          verbose: false


### PR DESCRIPTION
Adds a GitHub Actions workflow that posts new issues with label
C-triage to the Materialize #github-triage Slack channel.

@morsapaes Is there a way to test this without merging? Thanks for the pointer to the existing workflow.

### Motivation

This should help implement the new [bug triage process](https://www.notion.so/materialize/Bug-Triage-Process-848417b94da64a7cbe59d1c73dc4e403).

### Tips for reviewer

This has been mostly copy-pasted from the existing [slack_notify_p1.yml](https://github.com/MaterializeInc/materialize/blob/cb8bb30/.github/workflows/slack_notify_p1.yml) workflow.

### Checklist

  - No user-facing behavior changes
