### PR TITLE
checks framework: Move the jobs from Nightly to regular CI

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -34,11 +34,6 @@ steps:
           - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
           - { value: zippy-user-tables }
-          - { value: checks-drop-create-default-replica }
-          - { value: checks-restart-computed }
-          - { value: checks-restart-entire-mz }
-          - { value: checks-restart-environmentd-storaged }
-          - { value: checks-kill-storaged }
           - { value: secrets }
           - { value: unused-deps }
         multiple: true

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -454,6 +454,56 @@ steps:
     agents:
       queue: linux-x86_64
 
+  - id: checks-drop-create-default-replica
+    label: "Checks + DROP/CREATE replica"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=DropCreateDefaultReplica]
+
+  - id: checks-restart-computed
+    label: "Checks + restart computed"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartComputed]
+
+  - id: checks-restart-entire-mz
+    label: "Checks + restart of the entire Mz"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEntireMz]
+
+  - id: checks-restart-environmentd-storaged
+    label: "Checks + restart of environmentd & storaged"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEnvironmentdStoraged]
+
+  - id: checks-kill-storaged
+    label: "Checks + kill storaged"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=KillStoraged]
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build-x86_64


### PR DESCRIPTION
Move the platform checks jobs to the regular CI so that testing of
reconciliation happens on a per-push basis.
### Motivation

  * This PR adds a feature that has not yet been specified.
The "platform checks" jobs have been green now for quite a while and provide important testing of reconciliation.