### PR TITLE
adapter: implement `EXPLAIN ... AS TEXT` for `Mir` plans

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -171,11 +171,17 @@ where
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
         // TODO: (#13299) print out types?
         match self {
-            FastPathPlan::Constant(Ok(rows), _) => fmt_text_constant_rows(
-                f,
-                rows.iter().map(|(row, _, diff)| (row, diff)),
-                ctx.as_mut(),
-            ),
+            FastPathPlan::Constant(Ok(rows), _) => {
+                writeln!(f, "{}Constant", ctx.as_mut())?;
+                *ctx.as_mut() += 1;
+                fmt_text_constant_rows(
+                    f,
+                    rows.iter().map(|(row, _, diff)| (row, diff)),
+                    ctx.as_mut(),
+                )?;
+                *ctx.as_mut() -= 1;
+                Ok(())
+            }
             FastPathPlan::Constant(Err(err), _) => {
                 writeln!(f, "{}Error {}", ctx.as_mut(), err.to_string().quoted())
             }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2227,9 +2227,8 @@ impl<S: Append + 'static> Coordinator<S> {
             }
             ExplainStageNew::DecorrelatedPlan => {
                 // run partial pipeline
-                let decorrelated_plan = decorrelate(raw_plan)?;
+                let mut decorrelated_plan = decorrelate(raw_plan)?;
                 self.validate_timeline(decorrelated_plan.depends_on())?;
-                let mut dataflow = OptimizedMirRelationExpr::declare_optimized(decorrelated_plan);
                 // construct explanation context
                 let catalog = self.catalog.for_session(session);
                 let context = ExplainContext {
@@ -2240,7 +2239,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     fast_path_plan: Default::default(),
                 };
                 // explain plan
-                Explainable::new(&mut dataflow).explain(&format, &config, &context)?
+                Explainable::new(&mut decorrelated_plan).explain(&format, &config, &context)?
             }
             ExplainStageNew::OptimizedPlan => {
                 // run partial pipeline

--- a/src/adapter/src/explain_new/common.rs
+++ b/src/adapter/src/explain_new/common.rs
@@ -70,20 +70,6 @@ impl<'a, Formatter, ViewExpr> Explanation<'a, Formatter, ViewExpr>
 where
     Formatter: ViewFormatter<ViewExpr>,
 {
-    pub fn new(
-        expr: &'a ViewExpr,
-        expr_humanizer: &'a dyn ExprHumanizer,
-        formatter: Formatter,
-    ) -> Self {
-        Self {
-            formatter,
-            expr_humanizer,
-            sources: vec![],
-            views: vec![(GlobalId::Explain, expr)],
-            finishing: None,
-        }
-    }
-
     pub fn new_from_dataflow(
         dataflow: &'a DataflowDescription<ViewExpr>,
         expr_humanizer: &'a dyn ExprHumanizer,
@@ -198,15 +184,6 @@ impl<ViewExpr: serde::Serialize> ViewFormatter<ViewExpr> for JsonViewFormatter {
 pub struct DataflowGraphFormatter<'a> {
     expr_humanizer: &'a dyn ExprHumanizer,
     typed: bool,
-}
-
-impl<'a> DataflowGraphFormatter<'a> {
-    pub fn new(expr_humanizer: &'a dyn ExprHumanizer, typed: bool) -> Self {
-        Self {
-            expr_humanizer,
-            typed,
-        }
-    }
 }
 
 impl<'a> ViewFormatter<OptimizedMirRelationExpr> for DataflowGraphFormatter<'a> {

--- a/src/adapter/src/explain_new/hir/mod.rs
+++ b/src/adapter/src/explain_new/hir/mod.rs
@@ -39,8 +39,11 @@ impl<'a> Explain<'a> for Explainable<'a, HirRelationExpr> {
         config: &'a ExplainConfig,
         context: &'a Self::Context,
     ) -> Result<Self::Text, ExplainError> {
+        // unless raw plans are explicitly requested
         // ensure that all nested subqueries are wrapped in Let blocks
-        normalize_subqueries(self.0)?;
+        if !config.raw_plans {
+            normalize_subqueries(self.0)?;
+        }
 
         // TODO: use config values to infer requested
         // plan annotations

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -69,7 +69,10 @@ impl<'a> Displayable<'a, HirRelationExpr> {
         use HirRelationExpr::*;
         match &self.0 {
             Constant { rows, .. } => {
-                fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.indent)?;
+                writeln!(f, "{}Constant", ctx.indent)?;
+                ctx.indented(|ctx| {
+                    fmt_text_constant_rows(f, rows.iter().map(|row| (row, &1)), &mut ctx.indent)
+                })?;
             }
             Let {
                 name: _,

--- a/src/adapter/src/explain_new/mir/mod.rs
+++ b/src/adapter/src/explain_new/mir/mod.rs
@@ -11,55 +11,169 @@
 
 pub(crate) mod text;
 
+use std::collections::HashMap;
+
 use mz_compute_client::command::DataflowDescription;
-use mz_expr::OptimizedMirRelationExpr;
+use mz_expr::{
+    visit::{Visit, Visitor},
+    MirRelationExpr, OptimizedMirRelationExpr,
+};
+use mz_ore::stack::RecursionLimitError;
 use mz_repr::explain_new::{Explain, ExplainConfig, ExplainError, UnsupportedFormat};
+use mz_transform::attribute::{non_negative::NonNegative, subtree_size::SubtreeSize, Attribute};
 
-use super::common::{DataflowGraphFormatter, Explanation};
-use super::{ExplainContext, Explainable};
+use super::{
+    AnnotatedPlan, Attributes, ExplainContext, ExplainMultiPlan, ExplainSinglePlan, Explainable,
+};
 
-impl<'a> Explain<'a> for Explainable<'a, OptimizedMirRelationExpr> {
+impl<'a> Explain<'a> for Explainable<'a, MirRelationExpr> {
     type Context = ExplainContext<'a>;
 
-    type Text = Explanation<'a, DataflowGraphFormatter<'a>, OptimizedMirRelationExpr>;
+    type Text = ExplainSinglePlan<'a, MirRelationExpr>;
 
     type Json = UnsupportedFormat;
 
     type Dot = UnsupportedFormat;
 
+    #[allow(unused_variables)] // TODO (#13299)
     fn explain_text(
         &'a mut self,
         config: &'a ExplainConfig,
         context: &'a Self::Context,
     ) -> Result<Self::Text, ExplainError> {
-        let formatter = DataflowGraphFormatter::new(context.humanizer, config.types);
-        let mut explanation = Explanation::new(self.0, context.humanizer, formatter);
-        if let Some(row_set_finishing) = context.finishing.clone() {
-            explanation.explain_row_set_finishing(row_set_finishing);
-        }
-        Ok(explanation)
+        let plan = AnnotatedPlan::try_from(config, self.0)?;
+        Ok(ExplainSinglePlan { context, plan })
     }
 }
 
 impl<'a> Explain<'a> for Explainable<'a, DataflowDescription<OptimizedMirRelationExpr>> {
     type Context = ExplainContext<'a>;
 
-    type Text = Explanation<'a, DataflowGraphFormatter<'a>, OptimizedMirRelationExpr>;
+    type Text = ExplainMultiPlan<'a, MirRelationExpr>;
 
     type Json = UnsupportedFormat;
 
     type Dot = UnsupportedFormat;
 
+    #[allow(unused_variables)] // TODO (#13299)
     fn explain_text(
         &'a mut self,
         config: &'a ExplainConfig,
         context: &'a Self::Context,
     ) -> Result<Self::Text, ExplainError> {
-        let formatter = DataflowGraphFormatter::new(context.humanizer, config.types);
-        let mut explanation = Explanation::new_from_dataflow(self.0, context.humanizer, formatter);
-        if let Some(row_set_finishing) = context.finishing.clone() {
-            explanation.explain_row_set_finishing(row_set_finishing);
+        let plans = self
+            .0
+            .objects_to_build
+            .iter_mut()
+            .rev()
+            .map(|build_desc| {
+                let id = context
+                    .humanizer
+                    .humanize_id(build_desc.id)
+                    .unwrap_or_else(|| build_desc.id.to_string());
+                let plan = AnnotatedPlan::try_from(config, build_desc.plan.as_inner())?;
+                Ok((id, plan))
+            })
+            .collect::<Result<Vec<_>, RecursionLimitError>>()?;
+
+        let sources = self
+            .0
+            .source_imports
+            .iter_mut()
+            .filter_map(|(id, (source_desc, _))| {
+                source_desc.arguments.operators.as_ref().map(|op| {
+                    let id = context
+                        .humanizer
+                        .humanize_id(*id)
+                        .unwrap_or_else(|| id.to_string());
+                    (id, op)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        Ok(ExplainMultiPlan {
+            context,
+            sources,
+            plans,
+        })
+    }
+}
+
+struct ExplainAttributes<'a> {
+    config: &'a ExplainConfig,
+    non_negative: NonNegative,
+    subtree_size: SubtreeSize,
+}
+
+impl<'a> From<&'a ExplainConfig> for ExplainAttributes<'a> {
+    fn from(config: &'a ExplainConfig) -> ExplainAttributes<'a> {
+        ExplainAttributes {
+            config,
+            non_negative: NonNegative::default(),
+            subtree_size: SubtreeSize::default(),
         }
-        Ok(explanation)
+    }
+}
+
+impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
+    fn try_from(
+        config: &'a ExplainConfig,
+        plan: &'a MirRelationExpr,
+    ) -> Result<Self, RecursionLimitError> {
+        let mut annotations = HashMap::<&MirRelationExpr, Attributes>::default();
+
+        if config.requires_attributes() {
+            // get the annotation keys
+            let subtree_refs = plan.post_order_vec();
+            // get the annotation values
+            let mut explain_attrs = ExplainAttributes::from(config);
+            plan.visit(&mut explain_attrs)?;
+
+            if config.subtree_size {
+                for (expr, attr) in std::iter::zip(
+                    subtree_refs.iter(),
+                    explain_attrs.subtree_size.results.into_iter(),
+                ) {
+                    let attrs = annotations.entry(expr).or_default();
+                    attrs.subtree_size = Some(attr);
+                }
+            }
+            if config.non_negative {
+                for (expr, attr) in std::iter::zip(
+                    subtree_refs.iter(),
+                    explain_attrs.non_negative.results.into_iter(),
+                ) {
+                    let attrs = annotations.entry(expr).or_default();
+                    attrs.non_negative = Some(attr);
+                }
+            }
+        }
+
+        Ok(AnnotatedPlan { plan, annotations })
+    }
+}
+
+// TODO: Model dependencies as part of the core attributes framework.
+impl<'a> Visitor<MirRelationExpr> for ExplainAttributes<'a> {
+    fn pre_visit(&mut self, expr: &MirRelationExpr) {
+        if self.config.subtree_size || self.config.non_negative {
+            self.subtree_size.schedule_env_tasks(expr);
+        }
+        if self.config.non_negative {
+            self.non_negative.schedule_env_tasks(expr);
+        }
+    }
+
+    fn post_visit(&mut self, expr: &MirRelationExpr) {
+        // Derive attributes and handle environment maintenance tasks
+        // in reverse dependency order.
+        if self.config.subtree_size || self.config.non_negative {
+            self.subtree_size.derive(expr, &());
+            self.subtree_size.handle_env_tasks();
+        }
+        if self.config.non_negative {
+            self.non_negative.derive(expr, &self.subtree_size);
+            self.non_negative.handle_env_tasks();
+        }
     }
 }

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -10,15 +10,434 @@
 //! `EXPLAIN` support for `Mir` structures.
 
 use std::fmt;
-use std::fmt::Display;
 
-use mz_expr::OptimizedMirRelationExpr;
-use mz_repr::explain_new::DisplayText;
+use mz_expr::{
+    explain::Indices, AggregateExpr, Id, JoinImplementation, MirRelationExpr, MirScalarExpr,
+};
+use mz_ore::str::{bracketed, separated, IndentLike, StrExt};
+use mz_repr::explain_new::{fmt_text_constant_rows, separated_text, DisplayText};
 
-use crate::explain_new::common::{DataflowGraphFormatter, Explanation};
+use crate::explain_new::{Displayable, PlanRenderingContext};
 
-impl<'a> DisplayText for Explanation<'a, DataflowGraphFormatter<'a>, OptimizedMirRelationExpr> {
-    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
-        self.fmt(f)
+impl<'a> DisplayText<PlanRenderingContext<'_, MirRelationExpr>>
+    for Displayable<'a, MirRelationExpr>
+{
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, MirRelationExpr>,
+    ) -> fmt::Result {
+        if ctx.config.raw_syntax {
+            self.fmt_raw_syntax(f, ctx)
+        } else {
+            self.fmt_virtual_syntax(f, ctx)
+        }
+    }
+}
+
+impl<'a> Displayable<'a, MirRelationExpr> {
+    fn fmt_virtual_syntax(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, MirRelationExpr>,
+    ) -> fmt::Result {
+        // no virtual syntax support for now, evolve this
+        // method as its HirRelationExpr counterpart
+        self.fmt_raw_syntax(f, ctx)
+    }
+    fn fmt_raw_syntax(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, MirRelationExpr>,
+    ) -> fmt::Result {
+        use MirRelationExpr::*;
+
+        match &self.0 {
+            Constant { rows, typ: _ } => match rows {
+                Ok(rows) => {
+                    write!(f, "{}Constant", ctx.indent)?;
+                    self.fmt_attributes(f, ctx)?;
+                    ctx.indented(|ctx| {
+                        fmt_text_constant_rows(f, rows.iter().map(|(x, y)| (x, y)), &mut ctx.indent)
+                    })?;
+                }
+                Err(err) => {
+                    writeln!(f, "{}Error {}", ctx.indent, err.to_string().quoted())?;
+                }
+            },
+            Let { id, value, body } => {
+                let mut bindings = vec![(id, value.as_ref())];
+                let mut head = body.as_ref();
+
+                // Render Let-blocks nested in the body an outer Let-block in one step
+                // with a flattened list of bindings
+                while let Let { id, value, body } = head {
+                    bindings.push((id, value.as_ref()));
+                    head = body.as_ref();
+                }
+
+                // The body comes first in the text output format in order to
+                // align with the format convention the dataflow is rendered
+                // top to bottom
+                write!(f, "{}Let", ctx.indent)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| {
+                    Displayable::from(head).fmt_text(f, ctx)?;
+                    writeln!(f, "{}Where", ctx.indent)?;
+                    ctx.indented(|ctx| {
+                        for (id, value) in bindings.iter().rev() {
+                            writeln!(f, "{}{} =", ctx.indent, *id)?;
+                            ctx.indented(|ctx| Displayable::from(*value).fmt_text(f, ctx))?;
+                        }
+                        Ok(())
+                    })?;
+                    Ok(())
+                })?;
+            }
+            Get { id, .. } => {
+                match id {
+                    Id::Local(id) => {
+                        write!(f, "{}Get {}", ctx.indent, id)?;
+                    }
+                    Id::Global(id) => {
+                        let humanized_id = ctx.humanizer.humanize_id(*id).ok_or(fmt::Error)?;
+                        write!(f, "{}Get {}", ctx.indent, humanized_id)?;
+                    }
+                }
+                self.fmt_attributes(f, ctx)?;
+            }
+            Project { outputs, input } => {
+                let outputs = Indices(outputs);
+                write!(f, "{}Project ({})", ctx.indent, outputs)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            Map { scalars, input } => {
+                let scalars = separated_text(", ", scalars.iter().map(Displayable::from));
+                write!(f, "{}Map ({})", ctx.indent, scalars)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            FlatMap { input, func, exprs } => {
+                let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                write!(f, "{}FlatMap {}({})", ctx.indent, func, exprs)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            Filter { predicates, input } => {
+                let predicates = separated_text(" AND ", predicates.iter().map(Displayable::from));
+                write!(f, "{}Filter {}", ctx.indent, predicates)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            Join {
+                inputs,
+                equivalences,
+                implementation,
+            } => {
+                let has_equivalences = !equivalences.is_empty();
+                let equivalences = separated(
+                    " AND ",
+                    equivalences.iter().map(|equivalence| {
+                        if equivalence.len() == 2 {
+                            bracketed("", "", separated(" = ", equivalence))
+                        } else {
+                            bracketed("eq(", ")", separated(", ", equivalence))
+                        }
+                    }),
+                );
+
+                if ctx.config.join_impls && implementation.is_implemented() {
+                    match implementation {
+                        JoinImplementation::Differential((head_idx, _head_key), tail) => {
+                            write!(f, "{}Filter {}", ctx.indent, equivalences)?;
+                            self.fmt_attributes(f, ctx)?;
+
+                            debug_assert_eq!(inputs.len(), tail.len() + 1);
+
+                            for (idx, key) in tail.iter().rev() {
+                                ctx.indent += 1;
+                                let key = separated_text(", ", key.iter().map(Displayable::from));
+                                writeln!(f, "{}LinearJoin using=[{}]", ctx.indent, key)?;
+                                ctx.indented(|ctx| {
+                                    Displayable::from(&inputs[*idx]).fmt_text(f, ctx)
+                                })?;
+                            }
+                            ctx.indented(|ctx| {
+                                Displayable::from(&inputs[*head_idx]).fmt_text(f, ctx)
+                            })?;
+                            ctx.indent -= tail.len();
+                        }
+                        JoinImplementation::DeltaQuery(half_join_chains) => {
+                            write!(f, "{}Filter {}", ctx.indent, equivalences)?;
+                            self.fmt_attributes(f, ctx)?;
+
+                            debug_assert_eq!(inputs.len(), half_join_chains.len());
+
+                            ctx.indent += 1;
+                            writeln!(f, "{}Union", ctx.indent)?;
+                            for (input, half_join_chain) in std::iter::zip(inputs, half_join_chains)
+                            {
+                                for (idx, key) in half_join_chain.iter().rev() {
+                                    ctx.indent += 1;
+                                    let key =
+                                        separated_text(", ", key.iter().map(Displayable::from));
+                                    writeln!(f, "{}HalfJoin using=[{}]", ctx.indent, key)?;
+                                    ctx.indented(|ctx| {
+                                        Displayable::from(&inputs[*idx]).fmt_text(f, ctx)
+                                    })?;
+                                }
+                                ctx.indented(|ctx| Displayable::from(input).fmt_text(f, ctx))?;
+                                ctx.indent -= half_join_chain.len();
+                            }
+                            ctx.indent -= 1;
+                        }
+                        JoinImplementation::PredicateIndex(_, key, row) => {
+                            write!(f, "{}Lookup ", ctx.indent)?;
+
+                            debug_assert_eq!(inputs.len(), 1);
+
+                            for (i, (expr, lit)) in std::iter::zip(key, row.unpack()).enumerate() {
+                                Displayable::from(expr).fmt_text(f, &mut ())?;
+                                write!(f, " = ")?;
+                                write!(f, "{}", lit)?;
+                                if i < key.len() - 1 {
+                                    write!(f, " AND ")?;
+                                }
+                            }
+                            writeln!(f, "")?;
+                            ctx.indented(|ctx| Displayable::from(&inputs[0]).fmt_text(f, ctx))?;
+                        }
+                        JoinImplementation::Unimplemented => {
+                            unreachable!();
+                        }
+                    }
+                } else {
+                    // unimplemented or impl_joins not set
+                    if has_equivalences {
+                        write!(f, "{}Join on=({})", ctx.indent, equivalences)?;
+                    } else {
+                        write!(f, "{}CrossJoin", ctx.indent)?;
+                    }
+                    if let Some(name) = implementation.name() {
+                        write!(f, " type={}", name)?;
+                    }
+                    self.fmt_attributes(f, ctx)?;
+
+                    ctx.indented(|ctx| {
+                        for input in inputs {
+                            Displayable::from(input).fmt_text(f, ctx)?;
+                        }
+                        Ok(())
+                    })?;
+                }
+            }
+            Reduce {
+                group_key,
+                aggregates,
+                expected_group_size,
+                monotonic: _, // TODO: monotonic should be an attribute
+                input,
+            } => {
+                if aggregates.len() > 0 {
+                    write!(f, "{}Reduce", ctx.indent)?;
+                } else {
+                    write!(f, "{}Distinct", ctx.indent)?;
+                }
+                if group_key.len() > 0 {
+                    let group_key = separated_text(", ", group_key.iter().map(Displayable::from));
+                    write!(f, " group_by=[{}]", group_key)?;
+                }
+                if aggregates.len() > 0 {
+                    let aggregates = separated_text(", ", aggregates.iter().map(Displayable::from));
+                    write!(f, " aggregates=[{}]", aggregates)?;
+                }
+                if let Some(expected_group_size) = expected_group_size {
+                    write!(f, " exp_group_size={}", expected_group_size)?;
+                }
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            TopK {
+                group_key,
+                order_key,
+                limit,
+                offset,
+                monotonic,
+                input,
+            } => {
+                write!(f, "{}TopK", ctx.indent)?;
+                if group_key.len() > 0 {
+                    let group_by = Indices(group_key);
+                    write!(f, " group_by=[{}]", group_by)?;
+                }
+                if order_key.len() > 0 {
+                    let order_by = separated(", ", order_key);
+                    write!(f, " order_by=[{}]", order_by)?;
+                }
+                if let Some(limit) = limit {
+                    write!(f, " limit={}", limit)?;
+                }
+                if offset > &0 {
+                    write!(f, " offset={}", offset)?
+                }
+                write!(f, " monotonic={}", monotonic)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            Negate { input } => {
+                write!(f, "{}Negate", ctx.indent)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            Threshold { input } => {
+                write!(f, "{}Threshold", ctx.indent)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+            Union { base, inputs } => {
+                write!(f, "{}Union", ctx.indent)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| {
+                    Displayable::from(base.as_ref()).fmt_text(f, ctx)?;
+                    for input in inputs.iter() {
+                        Displayable::from(input).fmt_text(f, ctx)?;
+                    }
+                    Ok(())
+                })?;
+            }
+            ArrangeBy { input, keys } => {
+                let keys = separated(
+                    "], [",
+                    keys.iter()
+                        .map(|key| separated_text(", ", key.iter().map(Displayable::from))),
+                );
+                write!(f, "{}ArrangeBy keys=[[{}]]", ctx.indent, keys)?;
+                self.fmt_attributes(f, ctx)?;
+                ctx.indented(|ctx| Displayable::from(input.as_ref()).fmt_text(f, ctx))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fmt_attributes(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, MirRelationExpr>,
+    ) -> fmt::Result {
+        if ctx.config.requires_attributes() {
+            if let Some(attrs) = ctx.annotations.get(self.0) {
+                writeln!(f, " {}", attrs)
+            } else {
+                writeln!(f, " # error: no attrs for subtree in map")
+            }
+        } else {
+            writeln!(f)
+        }
+    }
+}
+
+impl<'a> DisplayText for Displayable<'a, MirScalarExpr> {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut ()) -> fmt::Result {
+        use MirScalarExpr::*;
+        match self.0 {
+            Column(i) => write!(f, "#{}", i),
+            Literal(row, _) => match row {
+                Ok(row) => write!(f, "{}", row.unpack_first()),
+                Err(err) => write!(f, "error({})", err.to_string().quoted()),
+            },
+            CallUnmaterializable(func) => write!(f, "{}()", func),
+            CallUnary { func, expr } => {
+                if let mz_expr::UnaryFunc::Not(_) = *func {
+                    if let CallUnary {
+                        func,
+                        expr: inner_expr,
+                    } = expr.as_ref()
+                    {
+                        if let Some(is) = func.is() {
+                            write!(f, "(")?;
+                            Displayable::from(inner_expr.as_ref()).fmt_text(f, ctx)?;
+                            write!(f, ") IS NOT {}", is)?;
+                            return Ok(());
+                        }
+                    }
+                }
+                if let Some(is) = func.is() {
+                    write!(f, "(")?;
+                    Displayable::from(expr.as_ref()).fmt_text(f, ctx)?;
+                    write!(f, ") IS {}", is)
+                } else {
+                    write!(f, "{}(", func)?;
+                    Displayable::from(expr.as_ref()).fmt_text(f, ctx)?;
+                    write!(f, ")")
+                }
+            }
+            CallBinary { func, expr1, expr2 } => {
+                if func.is_infix_op() {
+                    write!(f, "(")?;
+                    Displayable::from(expr1.as_ref()).fmt_text(f, ctx)?;
+                    write!(f, " {} ", func)?;
+                    Displayable::from(expr2.as_ref()).fmt_text(f, ctx)?;
+                    write!(f, ")")
+                } else {
+                    write!(f, "{}", func)?;
+                    write!(f, "(")?;
+                    Displayable::from(expr1.as_ref()).fmt_text(f, ctx)?;
+                    write!(f, ", ")?;
+                    Displayable::from(expr2.as_ref()).fmt_text(f, ctx)?;
+                    write!(f, ")")
+                }
+            }
+            CallVariadic { func, exprs } => {
+                use mz_expr::VariadicFunc::*;
+                match func {
+                    ArrayCreate { .. } => {
+                        let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                        write!(f, "array[{}]", exprs)
+                    }
+                    ListCreate { .. } => {
+                        let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                        write!(f, "list[{}]", exprs)
+                    }
+                    RecordCreate { .. } => {
+                        let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                        write!(f, "row({})", exprs)
+                    }
+                    func if func.is_infix_op() && exprs.len() > 1 => {
+                        let func = format!(" {} ", func);
+                        let exprs = separated_text(&func, exprs.iter().map(Displayable::from));
+                        write!(f, "({})", exprs)
+                    }
+                    func => {
+                        let exprs = separated_text(", ", exprs.iter().map(Displayable::from));
+                        write!(f, "{}({})", func, exprs)
+                    }
+                }
+            }
+            If { cond, then, els } => {
+                write!(f, "case when ")?;
+                Displayable::from(cond.as_ref()).fmt_text(f, ctx)?;
+                write!(f, " then ")?;
+                Displayable::from(then.as_ref()).fmt_text(f, ctx)?;
+                write!(f, " else ")?;
+                Displayable::from(els.as_ref()).fmt_text(f, ctx)?;
+                write!(f, " end")
+            }
+        }
+    }
+}
+
+impl<'a> DisplayText for Displayable<'a, AggregateExpr> {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut ()) -> fmt::Result {
+        let func = self.0.func.clone();
+        if self.0.distinct {
+            write!(f, "{}(distinct ", func)?;
+            Displayable::from(&self.0.expr).fmt_text(f, ctx)?;
+        } else {
+            write!(f, "{}(", func)?;
+            Displayable::from(&self.0.expr).fmt_text(f, ctx)?;
+        }
+        write!(f, ")")
     }
 }

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -19,9 +19,12 @@
 use std::collections::HashMap;
 use std::fmt;
 
+use mz_expr::explain::Indices;
 use mz_expr::RowSetFinishing;
 use mz_ore::str::{Indent, IndentLike};
-use mz_repr::explain_new::{DisplayText, ExplainConfig, ExprHumanizer, RenderingContext};
+use mz_repr::explain_new::{
+    separated_text, DisplayText, ExplainConfig, ExprHumanizer, RenderingContext,
+};
 use mz_repr::GlobalId;
 use mz_storage::types::transforms::LinearOperator;
 
@@ -70,15 +73,32 @@ pub(crate) struct ExplainContext<'a> {
     pub(crate) fast_path_plan: Option<peek::FastPathPlan>,
 }
 
-#[derive(Clone)]
-pub(crate) struct Attributes;
-
 /// A somewhat ad-hoc way to keep carry a plan with a set
 /// of attributes derived for each node in that plan.
 #[allow(dead_code)] // TODO (#13299)
 pub(crate) struct AnnotatedPlan<'a, T> {
     pub(crate) plan: &'a T,
     pub(crate) annotations: HashMap<&'a T, Attributes>,
+}
+
+/// A container for derived attributes.
+#[derive(Clone, Default, Debug)]
+pub struct Attributes {
+    non_negative: Option<bool>,
+    subtree_size: Option<usize>,
+}
+
+impl fmt::Display for Attributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut builder = f.debug_struct("//");
+        if let Some(subtree_size) = &self.subtree_size {
+            builder.field("subtree_size", subtree_size);
+        }
+        if let Some(non_negative) = &self.non_negative {
+            builder.field("non_negative", non_negative);
+        }
+        builder.finish()
+    }
 }
 
 /// A set of indexes that are used in the physical plan
@@ -91,6 +111,10 @@ impl UsedIndexes {
     pub(crate) fn new(values: Vec<GlobalId>) -> UsedIndexes {
         UsedIndexes(values)
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl<'a, C> DisplayText<C> for UsedIndexes
@@ -98,14 +122,14 @@ where
     C: AsMut<Indent> + AsRef<&'a dyn ExprHumanizer>,
 {
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut C) -> fmt::Result {
-        write!(f, "{}used_indexes:", ctx.as_mut())?;
+        writeln!(f, "{}Used Indexes:", ctx.as_mut())?;
         *ctx.as_mut() += 1;
         for id in &self.0 {
             let index_name = ctx
                 .as_ref()
                 .humanize_id(*id)
                 .unwrap_or_else(|| id.to_string());
-            write!(f, "{}- {}", ctx.as_mut(), index_name)?;
+            writeln!(f, "{}- {}", ctx.as_mut(), index_name)?;
         }
         *ctx.as_mut() -= 1;
         Ok(())
@@ -157,7 +181,7 @@ where
             fmt_plan(&mut ctx, f, &self.context.fast_path_plan, self.plan.plan)?;
         }
 
-        if !self.context.used_indexes.0.is_empty() {
+        if !self.context.used_indexes.is_empty() {
             writeln!(f, "")?;
             self.context.used_indexes.fmt_text(f, &mut ctx)?;
         }
@@ -170,16 +194,15 @@ where
 /// [`mz_repr::explain_new::Explain`] implementations at points
 /// in the optimization pipeline identified with a
 /// `DataflowDescription` instance with plans of type `T`.
-#[allow(dead_code)] // TODO (#13299)
 pub(crate) struct ExplainMultiPlan<'a, T> {
-    pub(crate) context: ExplainContext<'a>,
+    pub(crate) context: &'a ExplainContext<'a>,
     // Maps the names of the sources to the linear operators that will be
     // on them.
     // TODO: implement DisplayText and DisplayJson for LinearOperator
     // there are plans to replace LinearOperator with MFP struct (#6657)
-    pub(crate) sources: Vec<(String, LinearOperator)>,
+    pub(crate) sources: Vec<(String, &'a LinearOperator)>,
     // elements of the vector are in topological order
-    pub(crate) plans: Vec<AnnotatedPlan<'a, T>>,
+    pub(crate) plans: Vec<(String, AnnotatedPlan<'a, T>)>,
 }
 
 impl<'a, T: 'a> DisplayText<()> for ExplainMultiPlan<'a, T>
@@ -187,54 +210,70 @@ where
     Displayable<'a, T>: DisplayText<PlanRenderingContext<'a, T>>,
 {
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
-        // TODO (#13472)
         let mut ctx = RenderingContext::new(Indent::default(), self.context.humanizer);
 
-        fn fmt_plan<'a, T>(
-            ctx: &mut RenderingContext<'a>,
-            f: &mut fmt::Formatter<'_>,
-            fast_path_plan: &Option<FastPathPlan>,
-            _plans: &Vec<AnnotatedPlan<'a, T>>,
-            _sources: &Vec<(String, LinearOperator)>,
-        ) -> fmt::Result
-        where
-            Displayable<'a, T>: DisplayText<PlanRenderingContext<'a, T>>,
-        {
-            if let Some(fast_path_plan) = fast_path_plan {
-                fast_path_plan.fmt_text(f, ctx)?;
-            } else {
-                // self.plans.fmt_text(..., f)?;
-                // writeln!(f, "")?;
-                // self.sources.fmt_text(..., f)?;
+        if let Some(fast_path_plan) = &self.context.fast_path_plan {
+            fast_path_plan.fmt_text(f, &mut ctx)?;
+        } else {
+            // render plans
+            for (no, (id, plan)) in self.plans.iter().enumerate() {
+                let mut ctx = PlanRenderingContext::new(
+                    ctx.indent.clone(),
+                    ctx.humanizer,
+                    plan.annotations.clone(),
+                    self.context.config,
+                );
+
+                writeln!(f, "{}{}", ctx.indent, id)?;
+                ctx.indented(|ctx| {
+                    match &self.context.finishing {
+                        // if present, a RowSetFinishing always applies to the first rendered plan
+                        Some(finishing) if no == 0 => {
+                            finishing.fmt_text(f, &mut ctx.indent)?;
+                            ctx.indented(|ctx| Displayable(plan.plan).fmt_text(f, ctx))?;
+                        }
+                        // all other plans are rendered without a RowSetFinishing
+                        _ => {
+                            Displayable(plan.plan).fmt_text(f, ctx)?;
+                        }
+                    }
+                    Ok(())
+                })?;
             }
-            Ok(())
+            if !self.sources.is_empty() {
+                // render one blank line between the plans and sources
+                writeln!(f, "")?;
+                // render sources
+                for (id, operator) in self.sources.iter() {
+                    writeln!(f, "{}Source {}", ctx.indent, id)?;
+                    ctx.indented(|ctx| Displayable(*operator).fmt_text(f, ctx))?;
+                }
+            }
         }
 
-        if let Some(finishing) = &self.context.finishing {
-            finishing.fmt_text(f, &mut ctx.indent)?;
-            ctx.indented(|ctx| {
-                fmt_plan(
-                    ctx,
-                    f,
-                    &self.context.fast_path_plan,
-                    &self.plans,
-                    &self.sources,
-                )
-            })?;
-        } else {
-            fmt_plan(
-                &mut ctx,
-                f,
-                &self.context.fast_path_plan,
-                &self.plans,
-                &self.sources,
-            )?;
-        }
-        if !self.context.used_indexes.0.is_empty() {
+        if !self.context.used_indexes.is_empty() {
             writeln!(f, "")?;
             self.context.used_indexes.fmt_text(f, &mut ctx)?;
         }
 
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<RenderingContext<'a>> for Displayable<'a, LinearOperator> {
+    fn fmt_text(&self, f: &mut fmt::Formatter<'_>, ctx: &mut RenderingContext<'a>) -> fmt::Result {
+        let LinearOperator {
+            predicates,
+            projection,
+        } = self.0;
+        // handle projection
+        let outputs = Indices(projection);
+        writeln!(f, "{}Demand ({})", ctx.indent, outputs)?;
+        // handle predicates
+        if !predicates.is_empty() {
+            let predicates = separated_text(" AND ", predicates.iter().map(Displayable::from));
+            writeln!(f, "{}Filter {}", ctx.indent, predicates)?;
+        }
         Ok(())
     }
 }
@@ -249,7 +288,6 @@ pub(crate) struct PlanRenderingContext<'a, T> {
 }
 
 impl<'a, T> PlanRenderingContext<'a, T> {
-    #[allow(dead_code)] // TODO (#13299)
     pub fn new(
         indent: Indent,
         humanizer: &'a dyn ExprHumanizer,

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -242,9 +242,9 @@ where
 #[allow(dead_code)] // TODO (#13299)
 #[allow(missing_debug_implementations)]
 pub(crate) struct PlanRenderingContext<'a, T> {
-    pub(crate) indent: Indent,
+    pub(crate) indent: Indent, // TODO: can this be a ref?
     pub(crate) humanizer: &'a dyn ExprHumanizer,
-    pub(crate) annotations: HashMap<&'a T, Attributes>, // TODO: can this be a ref
+    pub(crate) annotations: HashMap<&'a T, Attributes>, // TODO: can this be a ref?
     pub(crate) config: &'a ExplainConfig,
 }
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -68,6 +68,14 @@ impl OptimizedMirRelationExpr {
     ///
     /// Callers of this method need to ensure that the underlying expression stays optimized after
     /// any mutations are applied
+    pub fn as_inner(&self) -> &MirRelationExpr {
+        &self.0
+    }
+
+    /// Get mutable access to the inner [MirRelationExpr]
+    ///
+    /// Callers of this method need to ensure that the underlying expression stays optimized after
+    /// any mutations are applied
     pub fn as_inner_mut(&mut self) -> &mut MirRelationExpr {
         &mut self.0
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -233,7 +233,8 @@ pub enum MirRelationExpr {
         inputs: Vec<MirRelationExpr>,
     },
     /// Technically a no-op. Used to render an index. Will be used to optimize queries
-    /// on finer grain
+    /// on finer grain. Each `keys` item represents a different index that should be
+    /// produced from the `keys`.
     ///
     /// The runtime memory footprint of this operator is proportional to its input.
     ArrangeBy {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1376,6 +1376,19 @@ impl MirRelationExpr {
             .chain(second)
             .chain(rest.into_iter().flatten())
     }
+
+    /// Return a vector of references to the subtrees of this expression
+    /// in post-visit order (the last element is `&self`).
+    pub fn post_order_vec(&self) -> Vec<&Self> {
+        let mut stack = vec![self];
+        let mut result = vec![];
+        while let Some(expr) = stack.pop() {
+            result.push(expr);
+            stack.extend(expr.children());
+        }
+        result.reverse();
+        result
+    }
 }
 
 impl VisitChildren<Self> for MirRelationExpr {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1937,6 +1937,26 @@ impl Default for JoinImplementation {
     }
 }
 
+impl JoinImplementation {
+    /// Returns `true` iff the value is not [`JoinImplementation::Unimplemented`].
+    pub fn is_implemented(&self) -> bool {
+        match self {
+            Self::Unimplemented => false,
+            _ => true,
+        }
+    }
+
+    /// Returns an optional implementation name if the value is not [`JoinImplementation::Unimplemented`].
+    pub fn name(&self) -> Option<&'static str> {
+        match self {
+            Self::Differential(..) => Some("differential"),
+            Self::DeltaQuery(..) => Some("delta"),
+            Self::PredicateIndex(..) => Some("predicate_index"),
+            Self::Unimplemented => None,
+        }
+    }
+}
+
 /// Instructions for finishing the result of a query.
 ///
 /// The primary reason for the existence of this structure and attendant code

--- a/src/ore/src/str.rs
+++ b/src/ore/src/str.rs
@@ -150,7 +150,7 @@ where
 ///
 /// This will be most often used as part of the rendering context
 /// type for various `Display$Format` implementation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Indent {
     unit: String,
     buff: String,

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -623,16 +623,13 @@ fn write_first_rows(
     first_rows: &Vec<(&Row, &crate::Diff)>,
     ctx: &mut Indent,
 ) -> fmt::Result {
-    ctx.indented(move |ctx| {
-        for (row, diff) in first_rows {
-            if **diff == 1 {
-                writeln!(f, "{}- {}", ctx, row)?;
-            } else {
-                writeln!(f, "{}- ({} x {})", ctx, row, diff)?;
-            }
+    for (row, diff) in first_rows {
+        if **diff == 1 {
+            writeln!(f, "{}- {}", ctx, row)?;
+        } else {
+            writeln!(f, "{}- ({} x {})", ctx, row, diff)?;
         }
-        Ok(())
-    })?;
+    }
     Ok(())
 }
 
@@ -644,7 +641,6 @@ pub fn fmt_text_constant_rows<'a, I>(
 where
     I: Iterator<Item = (&'a Row, &'a crate::Diff)>,
 {
-    writeln!(f, "{}Constant", ctx)?;
     let mut row_count = 0;
     let mut first_rows = Vec::with_capacity(20);
     for _ in 0..20 {
@@ -655,12 +651,9 @@ where
     }
     let rest_of_row_count = rows.into_iter().map(|(_, diff)| diff).sum::<crate::Diff>();
     if rest_of_row_count != 0 {
-        ctx.indented(move |ctx| {
-            writeln!(f, "{}total_rows: {}", ctx, row_count + rest_of_row_count)?;
-            writeln!(f, "{}first_rows:", ctx)?;
-            write_first_rows(f, &first_rows, ctx)?;
-            Ok(())
-        })?;
+        writeln!(f, "{}total_rows: {}", ctx, row_count + rest_of_row_count)?;
+        writeln!(f, "{}first_rows:", ctx)?;
+        ctx.indented(move |ctx| write_first_rows(f, &first_rows, ctx))?;
     } else {
         write_first_rows(f, &first_rows, ctx)?;
     }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -31,606 +31,544 @@ mode cockroach
 
 # Test constant error.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT 1 / 0
 ----
-Let
-  Project (#0)
-    Map ((1 / 0))
-      Let
-        Get l1
-        Where
-          l1 =
-            CrossJoin
-              Get l0
-              Constant
-                - ()
+Let // { subtree_size: 9 }
+  Project (#0) // { subtree_size: 3 }
+    Map ((1 / 0)) // { subtree_size: 2 }
+      Get l1 // { subtree_size: 1 }
   Where
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - ()
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test constant with two elements.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
-Let
-  Union
-    Project (#2, #3)
-      Project (#0..=#3)
-        Map (#1)
-          Map (#0)
-            Let
-              Get l5
-              Where
-                l5 =
-                  Union
-                    Project (#2, #3)
-                      Project (#0..=#3)
-                        Map (#1)
-                          Map (#0)
-                            Let
-                              Get l2
-                              Where
-                                l2 =
-                                  Project (#0, #1)
-                                    Map (2)
-                                      Map (1)
-                                        Let
-                                          Get l1
-                                          Where
-                                            l1 =
-                                              CrossJoin
-                                                Get l0
-                                                Constant
-                                                  - ()
-                    Project (#2, #3)
-                      Project (#0..=#3)
-                        Map (#1)
-                          Map (#0)
-                            Let
-                              Get l4
-                              Where
-                                l4 =
-                                  Project (#0, #1)
-                                    Map (2)
-                                      Map (1)
-                                        Let
-                                          Get l3
-                                          Where
-                                            l3 =
-                                              CrossJoin
-                                                Get l0
-                                                Constant
-                                                  - ()
-    Project (#2, #3)
-      Project (#0..=#3)
-        Map (#1)
-          Map (#0)
-            Let
-              Get l7
-              Where
-                l7 =
-                  Project (#0, #1)
-                    Map (4)
-                      Map (3)
-                        Let
-                          Get l6
-                          Where
-                            l6 =
-                              CrossJoin
-                                Get l0
-                                Constant
-                                  - ()
+Let // { subtree_size: 52 }
+  Union // { subtree_size: 11 }
+    Project (#2, #3) // { subtree_size: 5 }
+      Project (#0..=#3) // { subtree_size: 4 }
+        Map (#1) // { subtree_size: 3 }
+          Map (#0) // { subtree_size: 2 }
+            Get l5 // { subtree_size: 1 }
+    Project (#2, #3) // { subtree_size: 5 }
+      Project (#0..=#3) // { subtree_size: 4 }
+        Map (#1) // { subtree_size: 3 }
+          Map (#0) // { subtree_size: 2 }
+            Get l7 // { subtree_size: 1 }
   Where
+    l5 =
+      Union // { subtree_size: 11 }
+        Project (#2, #3) // { subtree_size: 5 }
+          Project (#0..=#3) // { subtree_size: 4 }
+            Map (#1) // { subtree_size: 3 }
+              Map (#0) // { subtree_size: 2 }
+                Get l2 // { subtree_size: 1 }
+        Project (#2, #3) // { subtree_size: 5 }
+          Project (#0..=#3) // { subtree_size: 4 }
+            Map (#1) // { subtree_size: 3 }
+              Map (#0) // { subtree_size: 2 }
+                Get l4 // { subtree_size: 1 }
+    l4 =
+      Project (#0, #1) // { subtree_size: 4 }
+        Map (2) // { subtree_size: 3 }
+          Map (1) // { subtree_size: 2 }
+            Get l3 // { subtree_size: 1 }
+    l2 =
+      Project (#0, #1) // { subtree_size: 4 }
+        Map (2) // { subtree_size: 3 }
+          Map (1) // { subtree_size: 2 }
+            Get l1 // { subtree_size: 1 }
+    l7 =
+      Project (#0, #1) // { subtree_size: 4 }
+        Map (4) // { subtree_size: 3 }
+          Map (3) // { subtree_size: 2 }
+            Get l6 // { subtree_size: 1 }
+    l3 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - ()
+    l6 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - ()
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - ()
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test basic linear chains.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
 ----
-Let
-  Project (#2, #3)
-    Project (#0..=#3)
-      Map ((#0 + #1))
-        Map (1)
-          Let
-            Get l1
-            Where
-              l1 =
-                Filter (((#0 > 0) AND (#1 < 0)) AND ((#0 + #1) > 0))
-                  CrossJoin
-                    Get l0
-                    Get materialize.public.mv
+Let // { subtree_size: 12 }
+  Project (#2, #3) // { subtree_size: 5 }
+    Project (#0..=#3) // { subtree_size: 4 }
+      Map ((#0 + #1)) // { subtree_size: 3 }
+        Map (1) // { subtree_size: 2 }
+          Get l1 // { subtree_size: 1 }
   Where
+    l1 =
+      Filter (((#0 > 0) AND (#1 < 0)) AND ((#0 + #1) > 0)) // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.mv // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test table functions in the select clause (FlatMap).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT generate_series(a, b) from t
 ----
-Let
-  Project (#2)
-    Let
-      Filter true
-        FlatMap generate_series(#0, #1, 1)
-          Get l1
-      Where
-        l1 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
+Let // { subtree_size: 10 }
+  Project (#2) // { subtree_size: 4 }
+    Filter true // { subtree_size: 3 }
+      FlatMap generate_series(#0, #1, 1) // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
   Where
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
-Let
-  Threshold
-    Union
-      Distinct group_by=[#0]
-        Project (#1)
-          Project (#0, #1)
-            Map (#0)
-              Let
-                Get l1
-                Where
-                  l1 =
-                    Project (#0)
-                      CrossJoin
-                        Get l0
-                        Get materialize.public.t
-      Negate
-        Distinct group_by=[#0]
-          Project (#1)
-            Project (#0, #1)
-              Map (#0)
-                Let
-                  Get l2
-                  Where
-                    l2 =
-                      Project (#1)
-                        CrossJoin
-                          Get l0
-                          Get materialize.public.mv
+Let // { subtree_size: 25 }
+  Threshold // { subtree_size: 13 }
+    Union // { subtree_size: 12 }
+      Distinct group_by=[#0] // { subtree_size: 5 }
+        Project (#1) // { subtree_size: 4 }
+          Project (#0, #1) // { subtree_size: 3 }
+            Map (#0) // { subtree_size: 2 }
+              Get l1 // { subtree_size: 1 }
+      Negate // { subtree_size: 6 }
+        Distinct group_by=[#0] // { subtree_size: 5 }
+          Project (#1) // { subtree_size: 4 }
+            Project (#0, #1) // { subtree_size: 3 }
+              Map (#0) // { subtree_size: 2 }
+                Get l2 // { subtree_size: 1 }
   Where
+    l2 =
+      Project (#1) // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.mv // { subtree_size: 1 }
+    l1 =
+      Project (#0) // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
-Let
-  Threshold
-    Union
-      Project (#1)
-        Project (#0, #1)
-          Map (#0)
-            Let
-              Get l1
-              Where
-                l1 =
-                  Project (#0)
-                    CrossJoin
-                      Get l0
-                      Get materialize.public.t
-      Negate
-        Project (#1)
-          Project (#0, #1)
-            Map (#0)
-              Let
-                Get l2
-                Where
-                  l2 =
-                    Project (#1)
-                      CrossJoin
-                        Get l0
-                        Get materialize.public.mv
+Let // { subtree_size: 23 }
+  Threshold // { subtree_size: 11 }
+    Union // { subtree_size: 10 }
+      Project (#1) // { subtree_size: 4 }
+        Project (#0, #1) // { subtree_size: 3 }
+          Map (#0) // { subtree_size: 2 }
+            Get l1 // { subtree_size: 1 }
+      Negate // { subtree_size: 5 }
+        Project (#1) // { subtree_size: 4 }
+          Project (#0, #1) // { subtree_size: 3 }
+            Map (#0) // { subtree_size: 2 }
+              Get l2 // { subtree_size: 1 }
   Where
+    l2 =
+      Project (#1) // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.mv // { subtree_size: 1 }
+    l1 =
+      Project (#0) // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test TopK.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 VIEW ov
 ----
-Let
-  Project (#0, #1)
-    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
-      CrossJoin
-        Get l0
-        Get materialize.public.t
+Let // { subtree_size: 7 }
+  Project (#0, #1) // { subtree_size: 5 }
+    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false // { subtree_size: 4 }
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
   Where
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test Finish.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
-  Let
-    CrossJoin
-      Get l0
-      Get materialize.public.t
+  Let // { subtree_size: 5 }
+    CrossJoin // { subtree_size: 3 }
+      Get l0 // { subtree_size: 1 }
+      Get materialize.public.t // { subtree_size: 1 }
     Where
       l0 =
-        Constant
+        Constant // { subtree_size: 1 }
           - ()
 
 EOF
 
 # Test Reduce (global).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
-Let
-  Project (#2)
-    Project (#0..=#2)
-      Map (abs((#0 - #1)))
-        Let
-          Get l2
-          Where
-            l2 =
-              Let
-                Union
-                  Get l1
-                  CrossJoin
-                    Project ()
-                      CrossJoin
-                        Union
-                          Negate
-                            Distinct
-                              Get l1
-                          Distinct
-                            Get l0
-                        Get l0
-                    Constant
-                      - (null, null)
-                Where
-                  l1 =
-                    Reduce aggregates=[min(#0), max(#0)]
-                      CrossJoin
-                        Get l0
-                        Get materialize.public.t
+Let // { subtree_size: 25 }
+  Project (#2) // { subtree_size: 4 }
+    Project (#0..=#2) // { subtree_size: 3 }
+      Map (abs((#0 - #1))) // { subtree_size: 2 }
+        Get l2 // { subtree_size: 1 }
   Where
+    l2 =
+      Union // { subtree_size: 13 }
+        Get l1 // { subtree_size: 1 }
+        CrossJoin // { subtree_size: 11 }
+          Project () // { subtree_size: 9 }
+            CrossJoin // { subtree_size: 8 }
+              Union // { subtree_size: 6 }
+                Negate // { subtree_size: 3 }
+                  Distinct // { subtree_size: 2 }
+                    Get l1 // { subtree_size: 1 }
+                Distinct // { subtree_size: 2 }
+                  Get l0 // { subtree_size: 1 }
+              Get l0 // { subtree_size: 1 }
+          Constant // { subtree_size: 1 }
+            - (null, null)
+    l1 =
+      Reduce aggregates=[min(#0), max(#0)] // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test Reduce (local).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
-Let
-  Project (#3)
-    Project (#0..=#3)
-      Map (abs((#1 - #2)))
-        Let
-          Get l2
-          Where
-            l2 =
-              Reduce group_by=[#2] aggregates=[min(#0), max(#0)]
-                Project (#0..=#2)
-                  Map (#1)
-                    Let
-                      Get l1
-                      Where
-                        l1 =
-                          CrossJoin
-                            Get l0
-                            Get materialize.public.t
+Let // { subtree_size: 15 }
+  Project (#3) // { subtree_size: 4 }
+    Project (#0..=#3) // { subtree_size: 3 }
+      Map (abs((#1 - #2))) // { subtree_size: 2 }
+        Get l2 // { subtree_size: 1 }
   Where
+    l2 =
+      Reduce group_by=[#2] aggregates=[min(#0), max(#0)] // { subtree_size: 4 }
+        Project (#0..=#2) // { subtree_size: 3 }
+          Map (#1) // { subtree_size: 2 }
+            Get l1 // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test EXISTS subqueries.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
-Let
-  Project (#0, #1)
-    Filter #2
-      Let
-        Project (#0, #1, #3)
-          Join on=(#1 = #2)
-            Get l4
-            Let
-              Union
-                Get l6
-                CrossJoin
-                  Project (#0)
-                    Join on=(#0 = #1)
-                      Union
-                        Negate
-                          Distinct group_by=[#0]
-                            Get l6
-                        Distinct group_by=[#0]
-                          Get l5
-                      Get l5
-                  Constant
-                    - (false)
-              Where
-                l6 =
-                  CrossJoin
-                    Distinct group_by=[#0]
-                      Filter (#0 > #2)
-                        CrossJoin
-                          Get l5
-                          Get materialize.public.mv
-                    Constant
-                      - (true)
-        Where
-          l5 =
-            Distinct group_by=[#1]
-              Get l4
-          l4 =
-            Project (#0, #1)
-              Filter #2
-                Let
-                  Project (#0, #1, #3)
-                    Join on=(#0 = #2)
-                      Get l1
-                      Let
-                        Union
-                          Get l3
-                          CrossJoin
-                            Project (#0)
-                              Join on=(#0 = #1)
-                                Union
-                                  Negate
-                                    Distinct group_by=[#0]
-                                      Get l3
-                                  Distinct group_by=[#0]
-                                    Get l2
-                                Get l2
-                            Constant
-                              - (false)
-                        Where
-                          l3 =
-                            CrossJoin
-                              Distinct group_by=[#0]
-                                Filter (#0 < #1)
-                                  CrossJoin
-                                    Get l2
-                                    Get materialize.public.mv
-                              Constant
-                                - (true)
-                  Where
-                    l2 =
-                      Distinct group_by=[#0]
-                        Get l1
-                    l1 =
-                      Filter (true AND true)
-                        CrossJoin
-                          Get l0
-                          Get materialize.public.t
+Let // { subtree_size: 66 }
+  Project (#0, #1) // { subtree_size: 18 }
+    Filter #2 // { subtree_size: 17 }
+      Project (#0, #1, #3) // { subtree_size: 16 }
+        Join on=(#1 = #2) // { subtree_size: 15 }
+          Get l4 // { subtree_size: 1 }
+          Union // { subtree_size: 13 }
+            Get l6 // { subtree_size: 1 }
+            CrossJoin // { subtree_size: 11 }
+              Project (#0) // { subtree_size: 9 }
+                Join on=(#0 = #1) // { subtree_size: 8 }
+                  Union // { subtree_size: 6 }
+                    Negate // { subtree_size: 3 }
+                      Distinct group_by=[#0] // { subtree_size: 2 }
+                        Get l6 // { subtree_size: 1 }
+                    Distinct group_by=[#0] // { subtree_size: 2 }
+                      Get l5 // { subtree_size: 1 }
+                  Get l5 // { subtree_size: 1 }
+              Constant // { subtree_size: 1 }
+                - (false)
   Where
+    l6 =
+      CrossJoin // { subtree_size: 7 }
+        Distinct group_by=[#0] // { subtree_size: 5 }
+          Filter (#0 > #2) // { subtree_size: 4 }
+            CrossJoin // { subtree_size: 3 }
+              Get l5 // { subtree_size: 1 }
+              Get materialize.public.mv // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - (true)
+    l5 =
+      Distinct group_by=[#1] // { subtree_size: 2 }
+        Get l4 // { subtree_size: 1 }
+    l4 =
+      Project (#0, #1) // { subtree_size: 18 }
+        Filter #2 // { subtree_size: 17 }
+          Project (#0, #1, #3) // { subtree_size: 16 }
+            Join on=(#0 = #2) // { subtree_size: 15 }
+              Get l1 // { subtree_size: 1 }
+              Union // { subtree_size: 13 }
+                Get l3 // { subtree_size: 1 }
+                CrossJoin // { subtree_size: 11 }
+                  Project (#0) // { subtree_size: 9 }
+                    Join on=(#0 = #1) // { subtree_size: 8 }
+                      Union // { subtree_size: 6 }
+                        Negate // { subtree_size: 3 }
+                          Distinct group_by=[#0] // { subtree_size: 2 }
+                            Get l3 // { subtree_size: 1 }
+                        Distinct group_by=[#0] // { subtree_size: 2 }
+                          Get l2 // { subtree_size: 1 }
+                      Get l2 // { subtree_size: 1 }
+                  Constant // { subtree_size: 1 }
+                    - (false)
+    l3 =
+      CrossJoin // { subtree_size: 7 }
+        Distinct group_by=[#0] // { subtree_size: 5 }
+          Filter (#0 < #1) // { subtree_size: 4 }
+            CrossJoin // { subtree_size: 3 }
+              Get l2 // { subtree_size: 1 }
+              Get materialize.public.mv // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - (true)
+    l2 =
+      Distinct group_by=[#0] // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
+    l1 =
+      Filter (true AND true) // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l0 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test SELECT subqueries.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
-Let
-  Project (#2, #3)
-    Project (#0, #1, #8, #9)
-      Map (#7)
-        Map (#4)
-          Let
-            Join on=(eq(#0, #2, #5) AND eq(#1, #3, #6))
-              Get l1
-              Let
-                Project (#0, #1, #3)
-                  Join on=(#1 = #2)
-                    Get l2
-                    Let
-                      Union
-                        Get l5
-                        CrossJoin
-                          Project (#0)
-                            Join on=(#0 = #1)
-                              Union
-                                Negate
-                                  Distinct group_by=[#0]
-                                    Get l5
-                                Distinct group_by=[#0]
-                                  Get l3
-                              Get l3
-                          Constant
-                            - (null)
-                      Where
-                        l5 =
-                          Let
-                            Union
-                              Get l4
-                              Map (error("more than one record produced in subquery"))
-                                Project (#0)
-                                  Filter (#1 > 1)
-                                    Reduce group_by=[#0] aggregates=[count(true)]
-                                      Get l4
-                            Where
-                              l4 =
-                                Project (#0, #1)
-                                  TopK group_by=[#0] limit=1 monotonic=false
-                                    Filter (#2 = #0)
-                                      CrossJoin
-                                        Get l3
-                                        Get materialize.public.v
-                Where
-                  l3 =
-                    Distinct group_by=[#1]
-                      Get l2
-                  l2 =
-                    Distinct group_by=[#0, #1]
-                      Get l1
-              Let
-                Project (#0, #1, #3)
-                  Join on=(#1 = #2)
-                    Get l6
-                    Let
-                      Union
-                        Get l9
-                        CrossJoin
-                          Project (#0)
-                            Join on=(#0 = #1)
-                              Union
-                                Negate
-                                  Distinct group_by=[#0]
-                                    Get l9
-                                Distinct group_by=[#0]
-                                  Get l7
-                              Get l7
-                          Constant
-                            - (null)
-                      Where
-                        l9 =
-                          Let
-                            Union
-                              Get l8
-                              Map (error("more than one record produced in subquery"))
-                                Project (#0)
-                                  Filter (#1 > 1)
-                                    Reduce group_by=[#0] aggregates=[count(true)]
-                                      Get l8
-                            Where
-                              l8 =
-                                Project (#0, #1)
-                                  TopK group_by=[#0] limit=1 monotonic=false
-                                    Filter (#2 = #0)
-                                      CrossJoin
-                                        Get l7
-                                        Get materialize.public.mv
-                Where
-                  l7 =
-                    Distinct group_by=[#1]
-                      Get l6
-                  l6 =
-                    Distinct group_by=[#0, #1]
-                      Get l1
-            Where
-              l1 =
-                CrossJoin
-                  Get l0
-                  Get materialize.public.t
+Let // { subtree_size: 86 }
+  Project (#2, #3) // { subtree_size: 38 }
+    Project (#0, #1, #8, #9) // { subtree_size: 37 }
+      Map (#7) // { subtree_size: 36 }
+        Map (#4) // { subtree_size: 35 }
+          Join on=(eq(#0, #2, #5) AND eq(#1, #3, #6)) // { subtree_size: 34 }
+            Get l1 // { subtree_size: 1 }
+            Project (#0, #1, #3) // { subtree_size: 16 }
+              Join on=(#1 = #2) // { subtree_size: 15 }
+                Get l2 // { subtree_size: 1 }
+                Union // { subtree_size: 13 }
+                  Get l5 // { subtree_size: 1 }
+                  CrossJoin // { subtree_size: 11 }
+                    Project (#0) // { subtree_size: 9 }
+                      Join on=(#0 = #1) // { subtree_size: 8 }
+                        Union // { subtree_size: 6 }
+                          Negate // { subtree_size: 3 }
+                            Distinct group_by=[#0] // { subtree_size: 2 }
+                              Get l5 // { subtree_size: 1 }
+                          Distinct group_by=[#0] // { subtree_size: 2 }
+                            Get l3 // { subtree_size: 1 }
+                        Get l3 // { subtree_size: 1 }
+                    Constant // { subtree_size: 1 }
+                      - (null)
+            Project (#0, #1, #3) // { subtree_size: 16 }
+              Join on=(#1 = #2) // { subtree_size: 15 }
+                Get l6 // { subtree_size: 1 }
+                Union // { subtree_size: 13 }
+                  Get l9 // { subtree_size: 1 }
+                  CrossJoin // { subtree_size: 11 }
+                    Project (#0) // { subtree_size: 9 }
+                      Join on=(#0 = #1) // { subtree_size: 8 }
+                        Union // { subtree_size: 6 }
+                          Negate // { subtree_size: 3 }
+                            Distinct group_by=[#0] // { subtree_size: 2 }
+                              Get l9 // { subtree_size: 1 }
+                          Distinct group_by=[#0] // { subtree_size: 2 }
+                            Get l7 // { subtree_size: 1 }
+                        Get l7 // { subtree_size: 1 }
+                    Constant // { subtree_size: 1 }
+                      - (null)
   Where
+    l9 =
+      Union // { subtree_size: 7 }
+        Get l8 // { subtree_size: 1 }
+        Map (error("more than one record produced in subquery")) // { subtree_size: 5 }
+          Project (#0) // { subtree_size: 4 }
+            Filter (#1 > 1) // { subtree_size: 3 }
+              Reduce group_by=[#0] aggregates=[count(true)] // { subtree_size: 2 }
+                Get l8 // { subtree_size: 1 }
+    l5 =
+      Union // { subtree_size: 7 }
+        Get l4 // { subtree_size: 1 }
+        Map (error("more than one record produced in subquery")) // { subtree_size: 5 }
+          Project (#0) // { subtree_size: 4 }
+            Filter (#1 > 1) // { subtree_size: 3 }
+              Reduce group_by=[#0] aggregates=[count(true)] // { subtree_size: 2 }
+                Get l4 // { subtree_size: 1 }
+    l8 =
+      Project (#0, #1) // { subtree_size: 6 }
+        TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
+          Filter (#2 = #0) // { subtree_size: 4 }
+            CrossJoin // { subtree_size: 3 }
+              Get l7 // { subtree_size: 1 }
+              Get materialize.public.mv // { subtree_size: 1 }
+    l4 =
+      Project (#0, #1) // { subtree_size: 6 }
+        TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
+          Filter (#2 = #0) // { subtree_size: 4 }
+            CrossJoin // { subtree_size: 3 }
+              Get l3 // { subtree_size: 1 }
+              Get materialize.public.v // { subtree_size: 1 }
+    l7 =
+      Distinct group_by=[#1] // { subtree_size: 2 }
+        Get l6 // { subtree_size: 1 }
+    l3 =
+      Distinct group_by=[#1] // { subtree_size: 2 }
+        Get l2 // { subtree_size: 1 }
+    l6 =
+      Distinct group_by=[#0, #1] // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
+    l2 =
+      Distinct group_by=[#0, #1] // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test CrossJoin derived from a comma join without a predicate.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
-Let
-  Project (#0, #2)
-    Let
-      Get l3
-      Where
-        l3 =
-          Filter true
-            Project (#0..=#3)
-              CrossJoin
-                Get l1
-                Get l2
-        l2 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
-        l1 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
+Let // { subtree_size: 18 }
+  Project (#0, #2) // { subtree_size: 2 }
+    Get l3 // { subtree_size: 1 }
   Where
+    l3 =
+      Filter true // { subtree_size: 5 }
+        Project (#0..=#3) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l1 // { subtree_size: 1 }
+            Get l2 // { subtree_size: 1 }
+    l2 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test CrossJoin derived from an INNER JOIN with a trivial ON clause.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
 ----
-Let
-  Project (#0, #2)
-    Let
-      Get l3
-      Where
-        l3 =
-          Filter true
-            Project (#0..=#3)
-              CrossJoin
-                Get l1
-                Get l2
-        l2 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
-        l1 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
+Let // { subtree_size: 18 }
+  Project (#0, #2) // { subtree_size: 2 }
+    Get l3 // { subtree_size: 1 }
   Where
+    l3 =
+      Filter true // { subtree_size: 5 }
+        Project (#0..=#3) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l1 // { subtree_size: 1 }
+            Get l2 // { subtree_size: 1 }
+    l2 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test InnerJoin (comma syntax).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT t1.a, t2.a
 FROM
   t as t1,
@@ -638,208 +576,188 @@ FROM
   t as t3
 WHERE t1.b = t2.b AND t2.b = t3.b
 ----
-Let
-  Project (#0, #2)
-    Filter ((#1 = #3) AND (#3 = #5))
-      Let
-        Get l6
-        Where
-          l6 =
-            Filter true
-              Project (#0..=#5)
-                CrossJoin
-                  Get l4
-                  Get l5
-          l5 =
-            CrossJoin
-              Get l0
-              Get materialize.public.t
-          l4 =
-            Let
-              Get l3
-              Where
-                l3 =
-                  Filter true
-                    Project (#0..=#3)
-                      CrossJoin
-                        Get l1
-                        Get l2
-                l2 =
-                  CrossJoin
-                    Get l0
-                    Get materialize.public.t
-                l1 =
-                  CrossJoin
-                    Get l0
-                    Get materialize.public.t
+Let // { subtree_size: 31 }
+  Project (#0, #2) // { subtree_size: 3 }
+    Filter ((#1 = #3) AND (#3 = #5)) // { subtree_size: 2 }
+      Get l6 // { subtree_size: 1 }
   Where
+    l6 =
+      Filter true // { subtree_size: 5 }
+        Project (#0..=#5) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l4 // { subtree_size: 1 }
+            Get l5 // { subtree_size: 1 }
+    l5 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l4 =
+      Get l3 // { subtree_size: 1 }
+    l3 =
+      Filter true // { subtree_size: 5 }
+        Project (#0..=#3) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l1 // { subtree_size: 1 }
+            Get l2 // { subtree_size: 1 }
+    l2 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test InnerJoin (ON syntax).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT t1.a, t2.a
 FROM t as t1
 INNER JOIN t as t2 ON t1.b = t2.b
 INNER JOIN t as t3 ON t2.b = t3.b
 ----
-Let
-  Project (#0, #2)
-    Let
-      Get l6
-      Where
-        l6 =
-          Filter (#3 = #5)
-            Project (#0..=#5)
-              CrossJoin
-                Get l4
-                Get l5
-        l5 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
-        l4 =
-          Let
-            Get l3
-            Where
-              l3 =
-                Filter (#1 = #3)
-                  Project (#0..=#3)
-                    CrossJoin
-                      Get l1
-                      Get l2
-              l2 =
-                CrossJoin
-                  Get l0
-                  Get materialize.public.t
-              l1 =
-                CrossJoin
-                  Get l0
-                  Get materialize.public.t
+Let // { subtree_size: 30 }
+  Project (#0, #2) // { subtree_size: 2 }
+    Get l6 // { subtree_size: 1 }
   Where
+    l6 =
+      Filter (#3 = #5) // { subtree_size: 5 }
+        Project (#0..=#5) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l4 // { subtree_size: 1 }
+            Get l5 // { subtree_size: 1 }
+    l5 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l4 =
+      Get l3 // { subtree_size: 1 }
+    l3 =
+      Filter (#1 = #3) // { subtree_size: 5 }
+        Project (#0..=#3) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l1 // { subtree_size: 1 }
+            Get l2 // { subtree_size: 1 }
+    l2 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test InnerJoin (ON syntax).
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT t1.a, t2.a
 FROM t as t1
 LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
-Let
-  Project (#0, #2)
-    Let
-      Union
-        Project (#2..=#5, #0, #1)
-          Map (null, null, null, null)
-            Union
-              Negate
-                Project (#0, #1)
-                  Join on=(#1 = #2)
-                    Get l6
-                    Get l8
-              Get l6
-        Get l7
-      Where
-        l8 =
-          Distinct group_by=[#0]
-            Project (#3)
-              Get l7
-        l7 =
-          Filter (#3 = #5)
-            Project (#0..=#5)
-              CrossJoin
-                Get l5
-                Get l6
-        l6 =
-          CrossJoin
-            Get l0
-            Get materialize.public.t
-        l5 =
-          Let
-            Union
-              Map (null, null)
-                Union
-                  Negate
-                    Project (#0, #1)
-                      Join on=(#1 = #2)
-                        Get l1
-                        Get l4
-                  Get l1
-              Get l3
-            Where
-              l4 =
-                Distinct group_by=[#0]
-                  Project (#1)
-                    Get l3
-              l3 =
-                Filter (#1 = #3)
-                  Project (#0..=#3)
-                    CrossJoin
-                      Get l1
-                      Get l2
-              l2 =
-                CrossJoin
-                  Get l0
-                  Get materialize.public.t
-              l1 =
-                CrossJoin
-                  Get l0
-                  Get materialize.public.t
+Let // { subtree_size: 57 }
+  Project (#0, #2) // { subtree_size: 12 }
+    Union // { subtree_size: 11 }
+      Project (#2..=#5, #0, #1) // { subtree_size: 9 }
+        Map (null, null, null, null) // { subtree_size: 8 }
+          Union // { subtree_size: 7 }
+            Negate // { subtree_size: 5 }
+              Project (#0, #1) // { subtree_size: 4 }
+                Join on=(#1 = #2) // { subtree_size: 3 }
+                  Get l6 // { subtree_size: 1 }
+                  Get l8 // { subtree_size: 1 }
+            Get l6 // { subtree_size: 1 }
+      Get l7 // { subtree_size: 1 }
   Where
+    l8 =
+      Distinct group_by=[#0] // { subtree_size: 3 }
+        Project (#3) // { subtree_size: 2 }
+          Get l7 // { subtree_size: 1 }
+    l7 =
+      Filter (#3 = #5) // { subtree_size: 5 }
+        Project (#0..=#5) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l5 // { subtree_size: 1 }
+            Get l6 // { subtree_size: 1 }
+    l6 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l5 =
+      Union // { subtree_size: 10 }
+        Map (null, null) // { subtree_size: 8 }
+          Union // { subtree_size: 7 }
+            Negate // { subtree_size: 5 }
+              Project (#0, #1) // { subtree_size: 4 }
+                Join on=(#1 = #2) // { subtree_size: 3 }
+                  Get l1 // { subtree_size: 1 }
+                  Get l4 // { subtree_size: 1 }
+            Get l1 // { subtree_size: 1 }
+        Get l3 // { subtree_size: 1 }
+    l4 =
+      Distinct group_by=[#0] // { subtree_size: 3 }
+        Project (#1) // { subtree_size: 2 }
+          Get l3 // { subtree_size: 1 }
+    l3 =
+      Filter (#1 = #3) // { subtree_size: 5 }
+        Project (#0..=#3) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l1 // { subtree_size: 1 }
+            Get l2 // { subtree_size: 1 }
+    l2 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
 
 # Test a single CTE.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
 ----
-Let
-  Project (#2)
-    Let
-      Project (#0..=#2)
-        Map ((#0 + #1))
-          Let
-            Get l4
-            Where
-              l4 =
-                Let
-                  Get l3
-                  Where
-                    l3 =
-                      Filter true
-                        Project (#0, #1)
-                          CrossJoin
-                            Get l2
-                            Get l2
-      Where
-        l2 =
-          Project (#2)
-            Project (#0..=#2)
-              Map ((#0 * #1))
-                Let
-                  Get l1
-                  Where
-                    l1 =
-                      CrossJoin
-                        Get l0
-                        Get materialize.public.t
+Let // { subtree_size: 23 }
+  Project (#2) // { subtree_size: 4 }
+    Project (#0..=#2) // { subtree_size: 3 }
+      Map ((#0 + #1)) // { subtree_size: 2 }
+        Get l4 // { subtree_size: 1 }
   Where
+    l4 =
+      Get l3 // { subtree_size: 1 }
+    l3 =
+      Filter true // { subtree_size: 5 }
+        Project (#0, #1) // { subtree_size: 4 }
+          CrossJoin // { subtree_size: 3 }
+            Get l2 // { subtree_size: 1 }
+            Get l2 // { subtree_size: 1 }
+    l2 =
+      Project (#2) // { subtree_size: 4 }
+        Project (#0..=#2) // { subtree_size: 3 }
+          Map ((#0 * #1)) // { subtree_size: 2 }
+            Get l1 // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
@@ -847,7 +765,7 @@ EOF
 # Test multiple CTEs: a case where we cannot pull the let statement up through
 # the join because the local l0 is correlated against the lhs of the enclosing join.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT
   *
 FROM
@@ -867,87 +785,73 @@ FROM
     SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
   ) as r5;
 ----
-Let
-  Filter true
-    Let
-      Project (#0..=#2, #4)
-        Join on=(#0 = #3)
-          Get l5
-          Let
-            Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
-              Get l8
-            Where
-              l8 =
-                Let
-                  Union
-                    Get l7
-                    CrossJoin
-                      Project (#0)
-                        Join on=(#0 = #1)
-                          Union
-                            Negate
-                              Distinct group_by=[#0]
-                                Get l7
-                            Distinct group_by=[#0]
-                              Get l6
-                          Get l6
-                      Constant
-                        - (null)
-                  Where
-                    l7 =
-                      Reduce group_by=[#0] aggregates=[max((#0 * #1))]
-                        CrossJoin
-                          Get l6
-                          Get materialize.public.t
-      Where
-        l6 =
-          Distinct group_by=[#0]
-            Get l5
+Let // { subtree_size: 63 }
+  Filter true // { subtree_size: 6 }
+    Project (#0..=#2, #4) // { subtree_size: 5 }
+      Join on=(#0 = #3) // { subtree_size: 4 }
+        Get l5 // { subtree_size: 1 }
+        Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL)) // { subtree_size: 2 }
+          Get l8 // { subtree_size: 1 }
   Where
+    l8 =
+      Union // { subtree_size: 13 }
+        Get l7 // { subtree_size: 1 }
+        CrossJoin // { subtree_size: 11 }
+          Project (#0) // { subtree_size: 9 }
+            Join on=(#0 = #1) // { subtree_size: 8 }
+              Union // { subtree_size: 6 }
+                Negate // { subtree_size: 3 }
+                  Distinct group_by=[#0] // { subtree_size: 2 }
+                    Get l7 // { subtree_size: 1 }
+                Distinct group_by=[#0] // { subtree_size: 2 }
+                  Get l6 // { subtree_size: 1 }
+              Get l6 // { subtree_size: 1 }
+          Constant // { subtree_size: 1 }
+            - (null)
+    l7 =
+      Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l6 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
+    l6 =
+      Distinct group_by=[#0] // { subtree_size: 2 }
+        Get l5 // { subtree_size: 1 }
     l5 =
-      Let
-        Filter true
-          Let
-            Project (#0, #1, #3)
-              Join on=(#0 = #2)
-                Get l1
-                Let
-                  Filter (#1 != #0)
-                    Get l4
-                  Where
-                    l4 =
-                      Let
-                        Union
-                          Get l3
-                          CrossJoin
-                            Project (#0)
-                              Join on=(#0 = #1)
-                                Union
-                                  Negate
-                                    Distinct group_by=[#0]
-                                      Get l3
-                                  Distinct group_by=[#0]
-                                    Get l2
-                                Get l2
-                            Constant
-                              - (null)
-                        Where
-                          l3 =
-                            Reduce group_by=[#0] aggregates=[max((#0 * #1))]
-                              CrossJoin
-                                Get l2
-                                Get materialize.public.t
-            Where
-              l2 =
-                Distinct group_by=[#0]
-                  Get l1
-        Where
-          l1 =
-            CrossJoin
-              Get l0
-              Get materialize.public.t
+      Filter true // { subtree_size: 6 }
+        Project (#0, #1, #3) // { subtree_size: 5 }
+          Join on=(#0 = #2) // { subtree_size: 4 }
+            Get l1 // { subtree_size: 1 }
+            Filter (#1 != #0) // { subtree_size: 2 }
+              Get l4 // { subtree_size: 1 }
+    l4 =
+      Union // { subtree_size: 13 }
+        Get l3 // { subtree_size: 1 }
+        CrossJoin // { subtree_size: 11 }
+          Project (#0) // { subtree_size: 9 }
+            Join on=(#0 = #1) // { subtree_size: 8 }
+              Union // { subtree_size: 6 }
+                Negate // { subtree_size: 3 }
+                  Distinct group_by=[#0] // { subtree_size: 2 }
+                    Get l3 // { subtree_size: 1 }
+                Distinct group_by=[#0] // { subtree_size: 2 }
+                  Get l2 // { subtree_size: 1 }
+              Get l2 // { subtree_size: 1 }
+          Constant // { subtree_size: 1 }
+            - (null)
+    l3 =
+      Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l2 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
+    l2 =
+      Distinct group_by=[#0] // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
+    l1 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF
@@ -956,7 +860,7 @@ EOF
 # through the join because the local l0 is correlated against the lhs of
 # the enclosing join.
 query T multiline
-EXPLAIN DECORRELATED PLAN AS TEXT FOR
+EXPLAIN DECORRELATED PLAN WITH(subtree_size) AS TEXT FOR
 SELECT
   *
 FROM
@@ -979,83 +883,71 @@ FROM
     WHERE a != r1.a
   ) as r5;
 ----
-Let
-  Filter true
-    Let
-      Project (#0, #1, #3, #4)
-        Join on=(#0 = #2)
-          Get l1
-          Let
-            Filter (#0 != #0)
-              Filter true
-                Let
-                  Project (#0, #1, #4)
-                    Join on=(#1 = #2 AND #0 = #3)
-                      Get l4
-                      Let
-                        Filter ((#1 = #0) AND (#2 > 5))
-                          Get l7
-                        Where
-                          l7 =
-                            Let
-                              Union
-                                Get l6
-                                CrossJoin
-                                  Project (#0, #1)
-                                    Join on=(#0 = #2 AND #1 = #3)
-                                      Union
-                                        Negate
-                                          Distinct group_by=[#0, #1]
-                                            Get l6
-                                        Distinct group_by=[#0, #1]
-                                          Get l5
-                                      Get l5
-                                  Constant
-                                    - (null)
-                              Where
-                                l6 =
-                                  Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]
-                                    CrossJoin
-                                      Get l5
-                                      Get materialize.public.t
-                  Where
-                    l5 =
-                      Distinct group_by=[#1, #0]
-                        Get l4
-            Where
-              l4 =
-                Let
-                  Union
-                    Get l3
-                    CrossJoin
-                      Project (#0)
-                        Join on=(#0 = #1)
-                          Union
-                            Negate
-                              Distinct group_by=[#0]
-                                Get l3
-                            Distinct group_by=[#0]
-                              Get l2
-                          Get l2
-                      Constant
-                        - (null)
-                  Where
-                    l3 =
-                      Reduce group_by=[#0] aggregates=[max((#0 * #1))]
-                        CrossJoin
-                          Get l2
-                          Get materialize.public.t
-      Where
-        l2 =
-          Distinct group_by=[#0]
-            Get l1
+Let // { subtree_size: 61 }
+  Filter true // { subtree_size: 11 }
+    Project (#0, #1, #3, #4) // { subtree_size: 10 }
+      Join on=(#0 = #2) // { subtree_size: 9 }
+        Get l1 // { subtree_size: 1 }
+        Filter (#0 != #0) // { subtree_size: 7 }
+          Filter true // { subtree_size: 6 }
+            Project (#0, #1, #4) // { subtree_size: 5 }
+              Join on=(#1 = #2 AND #0 = #3) // { subtree_size: 4 }
+                Get l4 // { subtree_size: 1 }
+                Filter ((#1 = #0) AND (#2 > 5)) // { subtree_size: 2 }
+                  Get l7 // { subtree_size: 1 }
   Where
+    l7 =
+      Union // { subtree_size: 13 }
+        Get l6 // { subtree_size: 1 }
+        CrossJoin // { subtree_size: 11 }
+          Project (#0, #1) // { subtree_size: 9 }
+            Join on=(#0 = #2 AND #1 = #3) // { subtree_size: 8 }
+              Union // { subtree_size: 6 }
+                Negate // { subtree_size: 3 }
+                  Distinct group_by=[#0, #1] // { subtree_size: 2 }
+                    Get l6 // { subtree_size: 1 }
+                Distinct group_by=[#0, #1] // { subtree_size: 2 }
+                  Get l5 // { subtree_size: 1 }
+              Get l5 // { subtree_size: 1 }
+          Constant // { subtree_size: 1 }
+            - (null)
+    l6 =
+      Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))] // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l5 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
+    l5 =
+      Distinct group_by=[#1, #0] // { subtree_size: 2 }
+        Get l4 // { subtree_size: 1 }
+    l4 =
+      Union // { subtree_size: 13 }
+        Get l3 // { subtree_size: 1 }
+        CrossJoin // { subtree_size: 11 }
+          Project (#0) // { subtree_size: 9 }
+            Join on=(#0 = #1) // { subtree_size: 8 }
+              Union // { subtree_size: 6 }
+                Negate // { subtree_size: 3 }
+                  Distinct group_by=[#0] // { subtree_size: 2 }
+                    Get l3 // { subtree_size: 1 }
+                Distinct group_by=[#0] // { subtree_size: 2 }
+                  Get l2 // { subtree_size: 1 }
+              Get l2 // { subtree_size: 1 }
+          Constant // { subtree_size: 1 }
+            - (null)
+    l3 =
+      Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { subtree_size: 4 }
+        CrossJoin // { subtree_size: 3 }
+          Get l2 // { subtree_size: 1 }
+          Get materialize.public.t // { subtree_size: 1 }
+    l2 =
+      Distinct group_by=[#0] // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
     l1 =
-      CrossJoin
-        Get l0
-        Get materialize.public.t
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Get materialize.public.t // { subtree_size: 1 }
     l0 =
-      Constant
+      Constant // { subtree_size: 1 }
         - ()
 
 EOF

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -14,6 +14,9 @@ CREATE TABLE t (
 )
 
 statement ok
+CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+
+statement ok
 CREATE VIEW v AS
 SELECT * FROM t WHERE a IS NOT NULL
 
@@ -26,131 +29,1033 @@ SELECT * FROM t WHERE a IS NOT NULL
 
 mode cockroach
 
+# Test constant error.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT 1 / 0
+----
+Let
+  Project (#0)
+    Map ((1 / 0))
+      Let
+        Get l1
+        Where
+          l1 =
+            CrossJoin
+              Get l0
+              Constant
+                - ()
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test constant with two elements.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+(SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
+----
+Let
+  Union
+    Project (#2, #3)
+      Project (#0..=#3)
+        Map (#1)
+          Map (#0)
+            Let
+              Get l5
+              Where
+                l5 =
+                  Union
+                    Project (#2, #3)
+                      Project (#0..=#3)
+                        Map (#1)
+                          Map (#0)
+                            Let
+                              Get l2
+                              Where
+                                l2 =
+                                  Project (#0, #1)
+                                    Map (2)
+                                      Map (1)
+                                        Let
+                                          Get l1
+                                          Where
+                                            l1 =
+                                              CrossJoin
+                                                Get l0
+                                                Constant
+                                                  - ()
+                    Project (#2, #3)
+                      Project (#0..=#3)
+                        Map (#1)
+                          Map (#0)
+                            Let
+                              Get l4
+                              Where
+                                l4 =
+                                  Project (#0, #1)
+                                    Map (2)
+                                      Map (1)
+                                        Let
+                                          Get l3
+                                          Where
+                                            l3 =
+                                              CrossJoin
+                                                Get l0
+                                                Constant
+                                                  - ()
+    Project (#2, #3)
+      Project (#0..=#3)
+        Map (#1)
+          Map (#0)
+            Let
+              Get l7
+              Where
+                l7 =
+                  Project (#0, #1)
+                    Map (4)
+                      Map (3)
+                        Let
+                          Get l6
+                          Where
+                            l6 =
+                              CrossJoin
+                                Get l0
+                                Constant
+                                  - ()
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test basic linear chains.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
+----
+Let
+  Project (#2, #3)
+    Project (#0..=#3)
+      Map ((#0 + #1))
+        Map (1)
+          Let
+            Get l1
+            Where
+              l1 =
+                Filter (((#0 > 0) AND (#1 < 0)) AND ((#0 + #1) > 0))
+                  CrossJoin
+                    Get l0
+                    Get materialize.public.mv
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test table functions in the select clause (FlatMap).
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT generate_series(a, b) from t
+----
+Let
+  Project (#2)
+    Let
+      Filter true
+        FlatMap generate_series(#0, #1, 1)
+          Get l1
+      Where
+        l1 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test Threshold, Union, Distinct, Negate.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT a FROM t EXCEPT SELECT b FROM mv
+----
+Let
+  Threshold
+    Union
+      Distinct group_by=[#0]
+        Project (#1)
+          Project (#0, #1)
+            Map (#0)
+              Let
+                Get l1
+                Where
+                  l1 =
+                    Project (#0)
+                      CrossJoin
+                        Get l0
+                        Get materialize.public.t
+      Negate
+        Distinct group_by=[#0]
+          Project (#1)
+            Project (#0, #1)
+              Map (#0)
+                Let
+                  Get l2
+                  Where
+                    l2 =
+                      Project (#1)
+                        CrossJoin
+                          Get l0
+                          Get materialize.public.mv
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test Threshold, Union, Distinct, Negate.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT a FROM t EXCEPT ALL SELECT b FROM mv
+----
+Let
+  Threshold
+    Union
+      Project (#1)
+        Project (#0, #1)
+          Map (#0)
+            Let
+              Get l1
+              Where
+                l1 =
+                  Project (#0)
+                    CrossJoin
+                      Get l0
+                      Get materialize.public.t
+      Negate
+        Project (#1)
+          Project (#0, #1)
+            Map (#0)
+              Let
+                Get l2
+                Where
+                  l2 =
+                    Project (#1)
+                      CrossJoin
+                        Get l0
+                        Get materialize.public.mv
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test TopK.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+VIEW ov
+----
+Let
+  Project (#0, #1)
+    TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false
+      CrossJoin
+        Get l0
+        Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test Finish.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+----
+Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
+  Let
+    CrossJoin
+      Get l0
+      Get materialize.public.t
+    Where
+      l0 =
+        Constant
+          - ()
+
+EOF
+
+# Test Reduce (global).
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t
+----
+Let
+  Project (#2)
+    Project (#0..=#2)
+      Map (abs((#0 - #1)))
+        Let
+          Get l2
+          Where
+            l2 =
+              Let
+                Union
+                  Get l1
+                  CrossJoin
+                    Project ()
+                      CrossJoin
+                        Union
+                          Negate
+                            Distinct
+                              Get l1
+                          Distinct
+                            Get l0
+                        Get l0
+                    Constant
+                      - (null, null)
+                Where
+                  l1 =
+                    Reduce aggregates=[min(#0), max(#0)]
+                      CrossJoin
+                        Get l0
+                        Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test Reduce (local).
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t GROUP BY b
+----
+Let
+  Project (#3)
+    Project (#0..=#3)
+      Map (abs((#1 - #2)))
+        Let
+          Get l2
+          Where
+            l2 =
+              Reduce group_by=[#2] aggregates=[min(#0), max(#0)]
+                Project (#0..=#2)
+                  Map (#1)
+                    Let
+                      Get l1
+                      Where
+                        l1 =
+                          CrossJoin
+                            Get l0
+                            Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test EXISTS subqueries.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
+----
+Let
+  Project (#0, #1)
+    Filter #2
+      Let
+        Project (#0, #1, #3)
+          Join on=(#1 = #2)
+            Get l4
+            Let
+              Union
+                Get l6
+                CrossJoin
+                  Project (#0)
+                    Join on=(#0 = #1)
+                      Union
+                        Negate
+                          Distinct group_by=[#0]
+                            Get l6
+                        Distinct group_by=[#0]
+                          Get l5
+                      Get l5
+                  Constant
+                    - (false)
+              Where
+                l6 =
+                  CrossJoin
+                    Distinct group_by=[#0]
+                      Filter (#0 > #2)
+                        CrossJoin
+                          Get l5
+                          Get materialize.public.mv
+                    Constant
+                      - (true)
+        Where
+          l5 =
+            Distinct group_by=[#1]
+              Get l4
+          l4 =
+            Project (#0, #1)
+              Filter #2
+                Let
+                  Project (#0, #1, #3)
+                    Join on=(#0 = #2)
+                      Get l1
+                      Let
+                        Union
+                          Get l3
+                          CrossJoin
+                            Project (#0)
+                              Join on=(#0 = #1)
+                                Union
+                                  Negate
+                                    Distinct group_by=[#0]
+                                      Get l3
+                                  Distinct group_by=[#0]
+                                    Get l2
+                                Get l2
+                            Constant
+                              - (false)
+                        Where
+                          l3 =
+                            CrossJoin
+                              Distinct group_by=[#0]
+                                Filter (#0 < #1)
+                                  CrossJoin
+                                    Get l2
+                                    Get materialize.public.mv
+                              Constant
+                                - (true)
+                  Where
+                    l2 =
+                      Distinct group_by=[#0]
+                        Get l1
+                    l1 =
+                      Filter (true AND true)
+                        CrossJoin
+                          Get l0
+                          Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test SELECT subqueries.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
+----
+Let
+  Project (#2, #3)
+    Project (#0, #1, #8, #9)
+      Map (#7)
+        Map (#4)
+          Let
+            Join on=(eq(#0, #2, #5) AND eq(#1, #3, #6))
+              Get l1
+              Let
+                Project (#0, #1, #3)
+                  Join on=(#1 = #2)
+                    Get l2
+                    Let
+                      Union
+                        Get l5
+                        CrossJoin
+                          Project (#0)
+                            Join on=(#0 = #1)
+                              Union
+                                Negate
+                                  Distinct group_by=[#0]
+                                    Get l5
+                                Distinct group_by=[#0]
+                                  Get l3
+                              Get l3
+                          Constant
+                            - (null)
+                      Where
+                        l5 =
+                          Let
+                            Union
+                              Get l4
+                              Map (error("more than one record produced in subquery"))
+                                Project (#0)
+                                  Filter (#1 > 1)
+                                    Reduce group_by=[#0] aggregates=[count(true)]
+                                      Get l4
+                            Where
+                              l4 =
+                                Project (#0, #1)
+                                  TopK group_by=[#0] limit=1 monotonic=false
+                                    Filter (#2 = #0)
+                                      CrossJoin
+                                        Get l3
+                                        Get materialize.public.v
+                Where
+                  l3 =
+                    Distinct group_by=[#1]
+                      Get l2
+                  l2 =
+                    Distinct group_by=[#0, #1]
+                      Get l1
+              Let
+                Project (#0, #1, #3)
+                  Join on=(#1 = #2)
+                    Get l6
+                    Let
+                      Union
+                        Get l9
+                        CrossJoin
+                          Project (#0)
+                            Join on=(#0 = #1)
+                              Union
+                                Negate
+                                  Distinct group_by=[#0]
+                                    Get l9
+                                Distinct group_by=[#0]
+                                  Get l7
+                              Get l7
+                          Constant
+                            - (null)
+                      Where
+                        l9 =
+                          Let
+                            Union
+                              Get l8
+                              Map (error("more than one record produced in subquery"))
+                                Project (#0)
+                                  Filter (#1 > 1)
+                                    Reduce group_by=[#0] aggregates=[count(true)]
+                                      Get l8
+                            Where
+                              l8 =
+                                Project (#0, #1)
+                                  TopK group_by=[#0] limit=1 monotonic=false
+                                    Filter (#2 = #0)
+                                      CrossJoin
+                                        Get l7
+                                        Get materialize.public.mv
+                Where
+                  l7 =
+                    Distinct group_by=[#1]
+                      Get l6
+                  l6 =
+                    Distinct group_by=[#0, #1]
+                      Get l1
+            Where
+              l1 =
+                CrossJoin
+                  Get l0
+                  Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test CrossJoin derived from a comma join without a predicate.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1, t as t2
+----
+Let
+  Project (#0, #2)
+    Let
+      Get l3
+      Where
+        l3 =
+          Filter true
+            Project (#0..=#3)
+              CrossJoin
+                Get l1
+                Get l2
+        l2 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+        l1 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test CrossJoin derived from an INNER JOIN with a trivial ON clause.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
+----
+Let
+  Project (#0, #2)
+    Let
+      Get l3
+      Where
+        l3 =
+          Filter true
+            Project (#0..=#3)
+              CrossJoin
+                Get l1
+                Get l2
+        l2 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+        l1 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test InnerJoin (comma syntax).
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT t1.a, t2.a
+FROM
+  t as t1,
+  t as t2,
+  t as t3
+WHERE t1.b = t2.b AND t2.b = t3.b
+----
+Let
+  Project (#0, #2)
+    Filter ((#1 = #3) AND (#3 = #5))
+      Let
+        Get l6
+        Where
+          l6 =
+            Filter true
+              Project (#0..=#5)
+                CrossJoin
+                  Get l4
+                  Get l5
+          l5 =
+            CrossJoin
+              Get l0
+              Get materialize.public.t
+          l4 =
+            Let
+              Get l3
+              Where
+                l3 =
+                  Filter true
+                    Project (#0..=#3)
+                      CrossJoin
+                        Get l1
+                        Get l2
+                l2 =
+                  CrossJoin
+                    Get l0
+                    Get materialize.public.t
+                l1 =
+                  CrossJoin
+                    Get l0
+                    Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test InnerJoin (ON syntax).
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT t1.a, t2.a
+FROM t as t1
+INNER JOIN t as t2 ON t1.b = t2.b
+INNER JOIN t as t3 ON t2.b = t3.b
+----
+Let
+  Project (#0, #2)
+    Let
+      Get l6
+      Where
+        l6 =
+          Filter (#3 = #5)
+            Project (#0..=#5)
+              CrossJoin
+                Get l4
+                Get l5
+        l5 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+        l4 =
+          Let
+            Get l3
+            Where
+              l3 =
+                Filter (#1 = #3)
+                  Project (#0..=#3)
+                    CrossJoin
+                      Get l1
+                      Get l2
+              l2 =
+                CrossJoin
+                  Get l0
+                  Get materialize.public.t
+              l1 =
+                CrossJoin
+                  Get l0
+                  Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test InnerJoin (ON syntax).
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT t1.a, t2.a
+FROM t as t1
+LEFT JOIN t as t2 ON t1.b = t2.b
+RIGHT JOIN t as t3 ON t2.b = t3.b
+----
+Let
+  Project (#0, #2)
+    Let
+      Union
+        Project (#2..=#5, #0, #1)
+          Map (null, null, null, null)
+            Union
+              Negate
+                Project (#0, #1)
+                  Join on=(#1 = #2)
+                    Get l6
+                    Get l8
+              Get l6
+        Get l7
+      Where
+        l8 =
+          Distinct group_by=[#0]
+            Project (#3)
+              Get l7
+        l7 =
+          Filter (#3 = #5)
+            Project (#0..=#5)
+              CrossJoin
+                Get l5
+                Get l6
+        l6 =
+          CrossJoin
+            Get l0
+            Get materialize.public.t
+        l5 =
+          Let
+            Union
+              Map (null, null)
+                Union
+                  Negate
+                    Project (#0, #1)
+                      Join on=(#1 = #2)
+                        Get l1
+                        Get l4
+                  Get l1
+              Get l3
+            Where
+              l4 =
+                Distinct group_by=[#0]
+                  Project (#1)
+                    Get l3
+              l3 =
+                Filter (#1 = #3)
+                  Project (#0..=#3)
+                    CrossJoin
+                      Get l1
+                      Get l2
+              l2 =
+                CrossJoin
+                  Get l0
+                  Get materialize.public.t
+              l1 =
+                CrossJoin
+                  Get l0
+                  Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test a single CTE.
+query T multiline
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
+----
+Let
+  Project (#2)
+    Let
+      Project (#0..=#2)
+        Map ((#0 + #1))
+          Let
+            Get l4
+            Where
+              l4 =
+                Let
+                  Get l3
+                  Where
+                    l3 =
+                      Filter true
+                        Project (#0, #1)
+                          CrossJoin
+                            Get l2
+                            Get l2
+      Where
+        l2 =
+          Project (#2)
+            Project (#0..=#2)
+              Map ((#0 * #1))
+                Let
+                  Get l1
+                  Where
+                    l1 =
+                      CrossJoin
+                        Get l0
+                        Get materialize.public.t
+  Where
+    l0 =
+      Constant
+        - ()
+
+EOF
+
+# Test multiple CTEs: a case where we cannot pull the let statement up through
+# the join because the local l0 is correlated against the lhs of the enclosing join.
 query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT
   *
 FROM
-  T as X
-WHERE
-  NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
-LIMIT 10
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r2 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r2 WHERE r2.m != r1.a
+  ) as r3
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
+  ) as r5;
 ----
-%0 = Let l0 =
-| Constant ()
-
-%1 =
-| Get materialize.public.t (u1)
-
-%2 = Let l1 =
-| Join %0 %1
-| | implementation = Unimplemented
-| Filter true
-
-%3 = Let l2 =
-| Get %2 (l1)
-| Distinct group=(#0)
-
-%4 =
-| Get materialize.public.t (u1)
-
-%5 =
-| Join %3 %4
-| | implementation = Unimplemented
-| Filter (#0 = #2)
-| Distinct group=(#0)
-
-%6 =
-| Constant (true)
-
-%7 = Let l3 =
-| Join %5 %6
-| | implementation = Unimplemented
-
-%8 =
-| Get %7 (l3)
-| Distinct group=(#0)
-| Negate
-
-%9 =
-| Get %3 (l2)
-| Distinct group=(#0)
-
-%10 =
-| Union %8 %9
-
-%11 =
-| Join %10 %3 (= #0 #1)
-| | implementation = Unimplemented
-| Project (#0)
-
-%12 =
-| Constant (false)
-
-%13 =
-| Join %11 %12
-| | implementation = Unimplemented
-
-%14 =
-| Union %7 %13
-
-%15 =
-| Join %2 %14 (= #0 #2)
-| | implementation = Unimplemented
-| Project (#0, #1, #3)
-| Filter NOT(#2)
-| Project (#0, #1)
-
-Finish order_by=() limit=10 offset=0 project=(#0, #1)
+Let
+  Filter true
+    Let
+      Project (#0..=#2, #4)
+        Join on=(#0 = #3)
+          Get l5
+          Let
+            Filter ((#1 != #0) OR ((#1) IS NOT NULL AND (#0) IS NULL))
+              Get l8
+            Where
+              l8 =
+                Let
+                  Union
+                    Get l7
+                    CrossJoin
+                      Project (#0)
+                        Join on=(#0 = #1)
+                          Union
+                            Negate
+                              Distinct group_by=[#0]
+                                Get l7
+                            Distinct group_by=[#0]
+                              Get l6
+                          Get l6
+                      Constant
+                        - (null)
+                  Where
+                    l7 =
+                      Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+                        CrossJoin
+                          Get l6
+                          Get materialize.public.t
+      Where
+        l6 =
+          Distinct group_by=[#0]
+            Get l5
+  Where
+    l5 =
+      Let
+        Filter true
+          Let
+            Project (#0, #1, #3)
+              Join on=(#0 = #2)
+                Get l1
+                Let
+                  Filter (#1 != #0)
+                    Get l4
+                  Where
+                    l4 =
+                      Let
+                        Union
+                          Get l3
+                          CrossJoin
+                            Project (#0)
+                              Join on=(#0 = #1)
+                                Union
+                                  Negate
+                                    Distinct group_by=[#0]
+                                      Get l3
+                                  Distinct group_by=[#0]
+                                    Get l2
+                                Get l2
+                            Constant
+                              - (null)
+                        Where
+                          l3 =
+                            Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+                              CrossJoin
+                                Get l2
+                                Get materialize.public.t
+            Where
+              l2 =
+                Distinct group_by=[#0]
+                  Get l1
+        Where
+          l1 =
+            CrossJoin
+              Get l0
+              Get materialize.public.t
+    l0 =
+      Constant
+        - ()
 
 EOF
 
+# Test multiple CTEs: a case where we cannot pull the let statement up
+# through the join because the local l0 is correlated against the lhs of
+# the enclosing join.
 query T multiline
-EXPLAIN DECORRELATED PLAN WITH (TYPES) AS TEXT FOR
-VIEW v
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+SELECT
+  *
+FROM
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT *
+    FROM
+      r4
+      CROSS JOIN LATERAL (
+        WITH r2 as (
+          SELECT MAX(r1.a * t.a) AS m FROM t
+        )
+        SELECT * FROM r2 WHERE r1.a = r4.m AND r2.m > 5
+      ) as r3
+    WHERE a != r1.a
+  ) as r5;
 ----
-%0 = Let l0 =
-| Constant ()
-| | types = ()
-| | keys = (())
-
-%1 =
-| Get materialize.public.t (u1)
-| | types = (integer?, integer?)
-| | keys = ()
-
-%2 =
-| Join %0 %1
-| | implementation = Unimplemented
-| | types = (integer?, integer?)
-| | keys = ()
-| Filter (#0) IS NOT NULL
-| | types = (integer, integer?)
-| | keys = ()
-
-EOF
-
-query T multiline
-EXPLAIN DECORRELATED PLAN WITH (TYPES) AS TEXT FOR
-MATERIALIZED VIEW mv
-----
-%0 = Let l0 =
-| Constant ()
-| | types = ()
-| | keys = (())
-
-%1 =
-| Get materialize.public.t (u1)
-| | types = (integer?, integer?)
-| | keys = ()
-
-%2 =
-| Join %0 %1
-| | implementation = Unimplemented
-| | types = (integer?, integer?)
-| | keys = ()
-| Filter (#0) IS NOT NULL
-| | types = (integer, integer?)
-| | keys = ()
+Let
+  Filter true
+    Let
+      Project (#0, #1, #3, #4)
+        Join on=(#0 = #2)
+          Get l1
+          Let
+            Filter (#0 != #0)
+              Filter true
+                Let
+                  Project (#0, #1, #4)
+                    Join on=(#1 = #2 AND #0 = #3)
+                      Get l4
+                      Let
+                        Filter ((#1 = #0) AND (#2 > 5))
+                          Get l7
+                        Where
+                          l7 =
+                            Let
+                              Union
+                                Get l6
+                                CrossJoin
+                                  Project (#0, #1)
+                                    Join on=(#0 = #2 AND #1 = #3)
+                                      Union
+                                        Negate
+                                          Distinct group_by=[#0, #1]
+                                            Get l6
+                                        Distinct group_by=[#0, #1]
+                                          Get l5
+                                      Get l5
+                                  Constant
+                                    - (null)
+                              Where
+                                l6 =
+                                  Reduce group_by=[#0, #1] aggregates=[max((#1 * #2))]
+                                    CrossJoin
+                                      Get l5
+                                      Get materialize.public.t
+                  Where
+                    l5 =
+                      Distinct group_by=[#1, #0]
+                        Get l4
+            Where
+              l4 =
+                Let
+                  Union
+                    Get l3
+                    CrossJoin
+                      Project (#0)
+                        Join on=(#0 = #1)
+                          Union
+                            Negate
+                              Distinct group_by=[#0]
+                                Get l3
+                            Distinct group_by=[#0]
+                              Get l2
+                          Get l2
+                      Constant
+                        - (null)
+                  Where
+                    l3 =
+                      Reduce group_by=[#0] aggregates=[max((#0 * #1))]
+                        CrossJoin
+                          Get l2
+                          Get materialize.public.t
+      Where
+        l2 =
+          Distinct group_by=[#0]
+            Get l1
+  Where
+    l1 =
+      CrossJoin
+        Get l0
+        Get materialize.public.t
+    l0 =
+      Constant
+        - ()
 
 EOF

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -68,6 +68,16 @@ Let // { subtree_size: 52 }
           Map (#0) // { subtree_size: 2 }
             Get l7 // { subtree_size: 1 }
   Where
+    l7 =
+      Project (#0, #1) // { subtree_size: 4 }
+        Map (4) // { subtree_size: 3 }
+          Map (3) // { subtree_size: 2 }
+            Get l6 // { subtree_size: 1 }
+    l6 =
+      CrossJoin // { subtree_size: 3 }
+        Get l0 // { subtree_size: 1 }
+        Constant // { subtree_size: 1 }
+          - ()
     l5 =
       Union // { subtree_size: 11 }
         Project (#2, #3) // { subtree_size: 5 }
@@ -85,26 +95,16 @@ Let // { subtree_size: 52 }
         Map (2) // { subtree_size: 3 }
           Map (1) // { subtree_size: 2 }
             Get l3 // { subtree_size: 1 }
-    l2 =
-      Project (#0, #1) // { subtree_size: 4 }
-        Map (2) // { subtree_size: 3 }
-          Map (1) // { subtree_size: 2 }
-            Get l1 // { subtree_size: 1 }
-    l7 =
-      Project (#0, #1) // { subtree_size: 4 }
-        Map (4) // { subtree_size: 3 }
-          Map (3) // { subtree_size: 2 }
-            Get l6 // { subtree_size: 1 }
     l3 =
       CrossJoin // { subtree_size: 3 }
         Get l0 // { subtree_size: 1 }
         Constant // { subtree_size: 1 }
           - ()
-    l6 =
-      CrossJoin // { subtree_size: 3 }
-        Get l0 // { subtree_size: 1 }
-        Constant // { subtree_size: 1 }
-          - ()
+    l2 =
+      Project (#0, #1) // { subtree_size: 4 }
+        Map (2) // { subtree_size: 3 }
+          Map (1) // { subtree_size: 2 }
+            Get l1 // { subtree_size: 1 }
     l1 =
       CrossJoin // { subtree_size: 3 }
         Get l0 // { subtree_size: 1 }
@@ -464,6 +464,19 @@ Let // { subtree_size: 86 }
             Filter (#1 > 1) // { subtree_size: 3 }
               Reduce group_by=[#0] aggregates=[count(true)] // { subtree_size: 2 }
                 Get l8 // { subtree_size: 1 }
+    l8 =
+      Project (#0, #1) // { subtree_size: 6 }
+        TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
+          Filter (#2 = #0) // { subtree_size: 4 }
+            CrossJoin // { subtree_size: 3 }
+              Get l7 // { subtree_size: 1 }
+              Get materialize.public.mv // { subtree_size: 1 }
+    l7 =
+      Distinct group_by=[#1] // { subtree_size: 2 }
+        Get l6 // { subtree_size: 1 }
+    l6 =
+      Distinct group_by=[#0, #1] // { subtree_size: 2 }
+        Get l1 // { subtree_size: 1 }
     l5 =
       Union // { subtree_size: 7 }
         Get l4 // { subtree_size: 1 }
@@ -472,13 +485,6 @@ Let // { subtree_size: 86 }
             Filter (#1 > 1) // { subtree_size: 3 }
               Reduce group_by=[#0] aggregates=[count(true)] // { subtree_size: 2 }
                 Get l4 // { subtree_size: 1 }
-    l8 =
-      Project (#0, #1) // { subtree_size: 6 }
-        TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
-          Filter (#2 = #0) // { subtree_size: 4 }
-            CrossJoin // { subtree_size: 3 }
-              Get l7 // { subtree_size: 1 }
-              Get materialize.public.mv // { subtree_size: 1 }
     l4 =
       Project (#0, #1) // { subtree_size: 6 }
         TopK group_by=[#0] limit=1 monotonic=false // { subtree_size: 5 }
@@ -486,15 +492,9 @@ Let // { subtree_size: 86 }
             CrossJoin // { subtree_size: 3 }
               Get l3 // { subtree_size: 1 }
               Get materialize.public.v // { subtree_size: 1 }
-    l7 =
-      Distinct group_by=[#1] // { subtree_size: 2 }
-        Get l6 // { subtree_size: 1 }
     l3 =
       Distinct group_by=[#1] // { subtree_size: 2 }
         Get l2 // { subtree_size: 1 }
-    l6 =
-      Distinct group_by=[#0, #1] // { subtree_size: 2 }
-        Get l1 // { subtree_size: 1 }
     l2 =
       Distinct group_by=[#0, #1] // { subtree_size: 2 }
         Get l1 // { subtree_size: 1 }

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+
 statement ok
 CREATE TABLE t (
   a int,
@@ -14,11 +15,29 @@ CREATE TABLE t (
 )
 
 statement ok
-CREATE VIEW v AS
+CREATE TABLE u (
+  c int,
+  d int
+)
+
+statement ok
+CREATE TABLE v (
+  e int,
+  f int
+)
+
+statement ok
+CREATE INDEX t_a_idx ON T(a);
+
+statement ok
+CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+
+statement ok
+CREATE VIEW iv AS
 SELECT * FROM t WHERE a IS NOT NULL
 
 statement ok
-CREATE DEFAULT INDEX ON v
+CREATE DEFAULT INDEX ON iv
 
 statement ok
 CREATE MATERIALIZED VIEW mv AS
@@ -26,94 +45,650 @@ SELECT * FROM t WHERE a IS NOT NULL
 
 mode cockroach
 
+# Test constant error.
 query T multiline
-EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT 1 / 0
+----
+Error "division by zero"
+
+EOF
+
+# Test constant with two elements.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+(SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
+----
+Constant
+  - ((1, 2) x 2)
+  - (3, 4)
+
+EOF
+
+# Test basic linear chains.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
+----
+Explained Query
+  Project (#3, #2) // { non_negative: true }
+    Filter (#1 < 0) AND (#0 > 0) AND (#2 > 0) // { non_negative: true }
+      Map ((#0 + #1), 1) // { non_negative: true }
+        Get materialize.public.mv // { non_negative: true }
+
+Source materialize.public.mv
+  Demand (#0, #1)
+  Filter (#1 < 0) AND (#0 > 0) AND ((#0 + #1) > 0)
+
+EOF
+
+# Test table functions in the select clause (FlatMap).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT generate_series(a, b) from t
+----
+Explained Query
+  Project (#2) // { non_negative: true }
+    FlatMap generate_series(#0, #1, 1) // { non_negative: true }
+      Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Threshold, Union, Distinct, Negate.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT a FROM t EXCEPT SELECT b FROM mv
+----
+Explained Query
+  Threshold // { non_negative: true }
+    Union // { non_negative: false }
+      Distinct group_by=[#0] // { non_negative: true }
+        Project (#0) // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
+      Negate // { non_negative: false }
+        Distinct group_by=[#0] // { non_negative: true }
+          Project (#1) // { non_negative: true }
+            Get materialize.public.mv // { non_negative: true }
+
+Source materialize.public.mv
+  Demand (#1)
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Threshold, Union, Distinct, Negate.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT a FROM t EXCEPT ALL SELECT b FROM mv
+----
+Explained Query
+  Threshold // { non_negative: true }
+    Union // { non_negative: false }
+      Project (#0) // { non_negative: true }
+        Get materialize.public.t // { non_negative: true }
+      Negate // { non_negative: false }
+        Project (#1) // { non_negative: true }
+          Get materialize.public.mv // { non_negative: true }
+
+Source materialize.public.mv
+  Demand (#1)
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test TopK.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+VIEW ov
+----
+Explained Query
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 monotonic=false // { non_negative: true }
+    Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Finish.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
+----
+ReadExistingIndex materialize.public.t_a_idx
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Reduce (global).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t
+----
+Explained Query
+  Let // { non_negative: false }
+    Project (#2) // { non_negative: false }
+      Map (abs((#0 - #1))) // { non_negative: false }
+        Union // { non_negative: false }
+          Get l0 // { non_negative: true }
+          Map (null, null) // { non_negative: false }
+            Union // { non_negative: false }
+              Negate // { non_negative: false }
+                Project () // { non_negative: true }
+                  Get l0 // { non_negative: true }
+              Constant // { non_negative: false }
+                - ()
+    Where
+      l0 =
+        Reduce aggregates=[min(#0), max(#0)] // { non_negative: true }
+          Project (#0) // { non_negative: true }
+            Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test Reduce (local).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT abs(min(a) - max(a)) FROM t GROUP BY b
+----
+Explained Query
+  Project (#3) // { non_negative: true }
+    Map (abs((#1 - #2))) // { non_negative: true }
+      Reduce group_by=[#1] aggregates=[min(#0), max(#0)] // { non_negative: true }
+        Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test EXISTS subqueries.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
+----
+Explained Query
+  Let // { non_negative: true }
+    Project (#0, #1) // { non_negative: true }
+      Join on=(#1 = #2) type=differential // { non_negative: true }
+        Get l0 // { non_negative: true }
+        ArrangeBy keys=[[#0]] // { non_negative: true }
+          Distinct group_by=[#0] // { non_negative: true }
+            Project (#0) // { non_negative: true }
+              Filter (#0 > #1) // { non_negative: true }
+                CrossJoin type=differential // { non_negative: true }
+                  ArrangeBy keys=[[]] // { non_negative: true }
+                    Distinct group_by=[#0] // { non_negative: true }
+                      Project (#1) // { non_negative: true }
+                        Get l0 // { non_negative: true }
+                  Project (#1) // { non_negative: true }
+                    Get materialize.public.mv // { non_negative: true }
+    Where
+      l0 =
+        Project (#0, #1) // { non_negative: true }
+          Join on=(#0 = #2) type=delta // { non_negative: true }
+            ArrangeBy keys=[[#0]] // { non_negative: true }
+              Get materialize.public.t // { non_negative: true }
+            ArrangeBy keys=[[#0]] // { non_negative: true }
+              Distinct group_by=[#0] // { non_negative: true }
+                Project (#0) // { non_negative: true }
+                  Filter (#0 < #1) // { non_negative: true }
+                    CrossJoin type=differential // { non_negative: true }
+                      ArrangeBy keys=[[]] // { non_negative: true }
+                        Distinct group_by=[#0] // { non_negative: true }
+                          Project (#0) // { non_negative: true }
+                            Get materialize.public.t // { non_negative: true }
+                      Project (#0) // { non_negative: true }
+                        Get materialize.public.mv // { non_negative: true }
+
+Source materialize.public.mv
+  Demand (#0, #1)
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test SELECT subqueries.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
+----
+Explained Query
+  Let // { non_negative: false }
+    Project (#2, #4) // { non_negative: false }
+      Join on=(eq(#0, #1, #3)) type=differential // { non_negative: false }
+        ArrangeBy keys=[[#0]] // { non_negative: true }
+          Get l0 // { non_negative: true }
+        ArrangeBy keys=[[#0]] // { non_negative: false }
+          Union // { non_negative: false }
+            Get l3 // { non_negative: true }
+            Map (null) // { non_negative: false }
+              Union // { non_negative: false }
+                Negate // { non_negative: false }
+                  Project (#0) // { non_negative: true }
+                    Get l3 // { non_negative: true }
+                Get l1 // { non_negative: true }
+        Union // { non_negative: false }
+          Get l4 // { non_negative: true }
+          Map (null) // { non_negative: false }
+            Union // { non_negative: false }
+              Negate // { non_negative: false }
+                Project (#0) // { non_negative: true }
+                  Get l4 // { non_negative: true }
+              Get l1 // { non_negative: true }
+    Where
+      l4 =
+        TopK group_by=[#0] limit=1 monotonic=false // { non_negative: true }
+          Project (#0, #1) // { non_negative: true }
+            Join on=(#0 = #2) type=differential // { non_negative: true }
+              Get l2 // { non_negative: true }
+              Filter (#1) IS NOT NULL // { non_negative: true }
+                Get materialize.public.mv // { non_negative: true }
+      l3 =
+        TopK group_by=[#0] limit=1 monotonic=false // { non_negative: true }
+          Project (#0, #1) // { non_negative: true }
+            Join on=(#0 = #2) type=differential // { non_negative: true }
+              Get l2 // { non_negative: true }
+              Filter (#1) IS NOT NULL // { non_negative: true }
+                Get materialize.public.iv // { non_negative: true }
+      l2 =
+        ArrangeBy keys=[[#0]] // { non_negative: true }
+          Get l1 // { non_negative: true }
+      l1 =
+        Distinct group_by=[#0] // { non_negative: true }
+          Get l0 // { non_negative: true }
+      l0 =
+        Project (#1) // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
+
+Source materialize.public.mv
+  Demand (#0, #1)
+  Filter (#1) IS NOT NULL
+
+Used Indexes:
+  - materialize.public.t_a_idx
+  - materialize.public.iv_primary_idx
+
+EOF
+
+# Test outer joins (ON syntax).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT t1.a, t2.a
+FROM t as t1
+LEFT JOIN t as t2 ON t1.b = t2.b
+RIGHT JOIN t as t3 ON t2.b = t3.b
+----
+Explained Query
+  Let // { non_negative: false }
+    Union // { non_negative: false }
+      Map (null, null) // { non_negative: false }
+        Union // { non_negative: false }
+          Negate // { non_negative: false }
+            Project () // { non_negative: true }
+              Join on=(#0 = #1) type=differential // { non_negative: true }
+                Project (#1) // { non_negative: true }
+                  Get materialize.public.t // { non_negative: true }
+                ArrangeBy keys=[[#0]] // { non_negative: true }
+                  Distinct group_by=[#0] // { non_negative: true }
+                    Project (#1) // { non_negative: true }
+                      Get l2 // { non_negative: true }
+          Project () // { non_negative: true }
+            Get materialize.public.t // { non_negative: true }
+      Project (#0, #2) // { non_negative: true }
+        Get l2 // { non_negative: true }
+    Where
+      l2 =
+        Project (#0..=#2) // { non_negative: true }
+          Join on=(eq(#1, #3, #4)) type=differential // { non_negative: true }
+            Get l1 // { non_negative: true }
+            Get l1 // { non_negative: true }
+            Project (#1) // { non_negative: true }
+              Get l0 // { non_negative: true }
+      l1 =
+        ArrangeBy keys=[[#1]] // { non_negative: true }
+          Get l0 // { non_negative: true }
+      l0 =
+        Filter (#1) IS NOT NULL // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test a single CTE.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+WITH x AS (SELECT t.a * t.b as v from t) SELECT a.v + b.v FROM x as a, x as b
+----
+Explained Query
+  Let // { non_negative: true }
+    Project (#2) // { non_negative: true }
+      Map ((#0 + #1)) // { non_negative: true }
+        CrossJoin type=differential // { non_negative: true }
+          ArrangeBy keys=[[]] // { non_negative: true }
+            Get l0 // { non_negative: true }
+          Get l0 // { non_negative: true }
+    Where
+      l0 =
+        Project (#2) // { non_negative: true }
+          Map ((#0 * #1)) // { non_negative: true }
+            Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test multiple CTEs: a case where we cannot pull the let statement up through
+# the join because the local l0 is correlated against the lhs of the enclosing join.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
 SELECT
   *
 FROM
-  T as X
-WHERE
-  NOT EXISTS (SELECT * FROM T as Y WHERE X.a = Y.b)
-LIMIT 10
+  (
+    SELECT * FROM t
+  ) as r1
+  CROSS JOIN LATERAL (
+    WITH r2 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r2 WHERE r2.m != r1.a
+  ) as r3
+  CROSS JOIN LATERAL (
+    WITH r4 as (
+      SELECT MAX(r1.a * t.a) AS m FROM t
+    )
+    SELECT * FROM r4 WHERE r4.m != r1.a OR (r4.m IS NOT NULL AND r1.a IS NULL)
+  ) as r5;
 ----
-Source materialize.public.t (u1):
-| Project (#0, #1)
+Explained Query
+  Let // { non_negative: true }
+    Project (#0..=#2, #4) // { non_negative: true }
+      Filter ((#0 != #4) OR ((#4) IS NOT NULL AND (#0) IS NULL)) // { non_negative: true }
+        Join on=(#0 = #3) type=differential // { non_negative: true }
+          Get l1 // { non_negative: true }
+          ArrangeBy keys=[[#0]] // { non_negative: true }
+            Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { non_negative: true }
+              CrossJoin type=differential // { non_negative: true }
+                ArrangeBy keys=[[]] // { non_negative: true }
+                  Distinct group_by=[#0] // { non_negative: true }
+                    Project (#0) // { non_negative: true }
+                      Get l1 // { non_negative: true }
+                Get l0 // { non_negative: true }
+    Where
+      l1 =
+        Project (#0, #1, #3) // { non_negative: true }
+          Filter (#0 != #3) // { non_negative: true }
+            Join on=(#0 = #2) type=delta // { non_negative: true }
+              ArrangeBy keys=[[#0]] // { non_negative: true }
+                Get materialize.public.t // { non_negative: true }
+              ArrangeBy keys=[[#0]] // { non_negative: true }
+                Reduce group_by=[#0] aggregates=[max((#0 * #1))] // { non_negative: true }
+                  CrossJoin type=differential // { non_negative: true }
+                    ArrangeBy keys=[[]] // { non_negative: true }
+                      Distinct group_by=[#0] // { non_negative: true }
+                        Get l0 // { non_negative: true }
+                    Get l0 // { non_negative: true }
+      l0 =
+        Project (#0) // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
 
-Query:
-%0 = Let l0 =
-| Get materialize.public.t (u1)
-| Project (#0)
-| Distinct group=(#0)
-
-%1 =
-| Get materialize.public.t (u1)
-| ArrangeBy (#0)
-
-%2 =
-| Get %0 (l0)
-| ArrangeBy (#0)
-
-%3 =
-| Get materialize.public.t (u1)
-| Filter (#1) IS NOT NULL
-| Project (#1)
-| Distinct group=(#0)
-| ArrangeBy (#0)
-
-%4 =
-| Join %2 %3 (= #0 #1)
-| | implementation = DeltaQuery
-| |   delta %2 %3.(#0)
-| |   delta %3 %2.(#0)
-| Project (#0)
-| Negate
-
-%5 =
-| Union %4 %0
-
-%6 =
-| Join %1 %5 (= #0 #2)
-| | implementation = Differential %5 %1.(#0)
-| Project (#0, #1)
-
-Finish order_by=() limit=10 offset=0 project=(#0, #1)
+Used Indexes:
+  - materialize.public.t_a_idx
 
 EOF
 
+# Test cross join.
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH (TYPES) AS TEXT FOR
-VIEW v
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
-Source materialize.public.t (u1):
-| Filter (#0) IS NOT NULL
-| Project (#0, #1)
+Explained Query
+  Let // { non_negative: true }
+    CrossJoin type=differential // { non_negative: true }
+      ArrangeBy keys=[[]] // { non_negative: true }
+        Get l0 // { non_negative: true }
+      Get l0 // { non_negative: true }
+    Where
+      l0 =
+        Project (#0) // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
 
-Query:
-%0 =
-| Get materialize.public.t (u1)
-| | types = (integer?, integer?)
-| | keys = ()
-| Filter (#0) IS NOT NULL
-| | types = (integer, integer?)
-| | keys = ()
+Used Indexes:
+  - materialize.public.t_a_idx
 
 EOF
 
+# Test cyclic join.
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH (TYPES) AS TEXT FOR
-MATERIALIZED VIEW mv
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT t1.a, t2.a
+FROM
+  t as t1,
+  t as t2,
+  t as t3
+WHERE t1.b = t2.b AND t2.b = t3.b
 ----
-Source materialize.public.t (u1):
-| Filter (#0) IS NOT NULL
-| Project (#0, #1)
+Explained Query
+  Let // { non_negative: true }
+    Project (#0, #2) // { non_negative: true }
+      Join on=(eq(#1, #3, #4)) type=differential // { non_negative: true }
+        Get l1 // { non_negative: true }
+        Get l1 // { non_negative: true }
+        Project (#1) // { non_negative: true }
+          Get l0 // { non_negative: true }
+    Where
+      l1 =
+        ArrangeBy keys=[[#1]] // { non_negative: true }
+          Get l0 // { non_negative: true }
+      l0 =
+        Filter (#1) IS NOT NULL // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
 
-Query:
-%0 =
-| Get materialize.public.t (u1)
-| | types = (integer?, integer?)
-| | keys = ()
-| Filter (#0) IS NOT NULL
-| | types = (integer, integer?)
-| | keys = ()
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Create indexes required for differential join tests
+
+statement ok
+CREATE INDEX u_c_idx ON U(c);
+
+statement ok
+CREATE INDEX u_d_idx ON U(d);
+
+statement ok
+CREATE INDEX v_e_idx ON V(e);
+
+# Test a differential join.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c and d = e and b = f
+----
+Explained Query
+  Project (#0, #1, #0, #3, #3, #1) // { non_negative: true }
+    Filter (#0) IS NOT NULL // { non_negative: true }
+      Join on=(#0 = #2 AND #1 = #5 AND #3 = #4) type=differential // { non_negative: true }
+        ArrangeBy keys=[[#0]] // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
+        ArrangeBy keys=[[#0]] // { non_negative: true }
+          Get materialize.public.u // { non_negative: true }
+        ArrangeBy keys=[[#0, #1]] // { non_negative: true }
+          Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { non_negative: true }
+            Get materialize.public.v // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+  - materialize.public.u_c_idx
+  - materialize.public.v_e_idx
+
+EOF
+
+# Test a differential join WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join_impls, non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c and d = e and b = f
+----
+Explained Query
+  Project (#0, #1, #0, #3, #3, #1) // { non_negative: true }
+    Filter (#0) IS NOT NULL // { non_negative: true }
+      Filter #0 = #2 AND #1 = #5 AND #3 = #4 // { non_negative: true }
+        LinearJoin using=[#0, #1]
+          ArrangeBy keys=[[#0, #1]] // { non_negative: true }
+            Filter (#0) IS NOT NULL AND (#1) IS NOT NULL // { non_negative: true }
+              Get materialize.public.v // { non_negative: true }
+          LinearJoin using=[#0]
+            ArrangeBy keys=[[#0]] // { non_negative: true }
+              Get materialize.public.t // { non_negative: true }
+            ArrangeBy keys=[[#0]] // { non_negative: true }
+              Get materialize.public.u // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+  - materialize.public.u_c_idx
+  - materialize.public.v_e_idx
+
+EOF
+
+# Create indexes required for delta join tests
+
+statement ok
+CREATE INDEX t_b_idx ON T(b);
+
+# Test a delta join WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE b = c and d = e
+----
+Explained Query
+  Project (#0, #1, #1, #3, #3, #5) // { non_negative: true }
+    Filter (#1) IS NOT NULL AND (#3) IS NOT NULL // { non_negative: true }
+      Join on=(#1 = #2 AND #3 = #4) type=delta // { non_negative: true }
+        ArrangeBy keys=[[#1]] // { non_negative: true }
+          Get materialize.public.t // { non_negative: true }
+        ArrangeBy keys=[[#0], [#1]] // { non_negative: true }
+          Get materialize.public.u // { non_negative: true }
+        ArrangeBy keys=[[#0]] // { non_negative: true }
+          Get materialize.public.v // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.u_c_idx
+  - materialize.public.u_d_idx
+  - materialize.public.v_e_idx
+  - materialize.public.t_b_idx
+
+EOF
+
+# Test a delta join WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join_impls, non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE b = c and d = e
+----
+Explained Query
+  Project (#0, #1, #1, #3, #3, #5) // { non_negative: true }
+    Filter (#1) IS NOT NULL AND (#3) IS NOT NULL // { non_negative: true }
+      Filter #1 = #2 AND #3 = #4 // { non_negative: true }
+        Union
+          HalfJoin using=[#0]
+            ArrangeBy keys=[[#0]] // { non_negative: true }
+              Get materialize.public.v // { non_negative: true }
+            HalfJoin using=[#0]
+              ArrangeBy keys=[[#0], [#1]] // { non_negative: true }
+                Get materialize.public.u // { non_negative: true }
+              ArrangeBy keys=[[#1]] // { non_negative: true }
+                Get materialize.public.t // { non_negative: true }
+          HalfJoin using=[#0]
+            ArrangeBy keys=[[#0]] // { non_negative: true }
+              Get materialize.public.v // { non_negative: true }
+            HalfJoin using=[#1]
+              ArrangeBy keys=[[#1]] // { non_negative: true }
+                Get materialize.public.t // { non_negative: true }
+              ArrangeBy keys=[[#0], [#1]] // { non_negative: true }
+                Get materialize.public.u // { non_negative: true }
+          HalfJoin using=[#1]
+            ArrangeBy keys=[[#1]] // { non_negative: true }
+              Get materialize.public.t // { non_negative: true }
+            HalfJoin using=[#1]
+              ArrangeBy keys=[[#0], [#1]] // { non_negative: true }
+                Get materialize.public.u // { non_negative: true }
+              ArrangeBy keys=[[#0]] // { non_negative: true }
+                Get materialize.public.v // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.u_c_idx
+  - materialize.public.u_d_idx
+  - materialize.public.v_e_idx
+  - materialize.public.t_b_idx
+
+EOF
+
+# Test a predicate index join.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, max(b)
+FROM t
+WHERE a = 0
+GROUP BY a
+----
+Explained Query
+  Project (#1, #0) // { non_negative: true }
+    Map (0) // { non_negative: true }
+      Reduce aggregates=[max(#0)] // { non_negative: true }
+        Project (#1) // { non_negative: true }
+          Filter (#0 = 0) // { non_negative: true }
+            CrossJoin type=predicate_index // { non_negative: true }
+              ArrangeBy keys=[[#0]] // { non_negative: true }
+                Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test a predicate index join WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join_impls, non_negative) AS TEXT FOR
+SELECT a, max(b)
+FROM t
+WHERE a = 0
+GROUP BY a
+----
+Explained Query
+  Project (#1, #0) // { non_negative: true }
+    Map (0) // { non_negative: true }
+      Reduce aggregates=[max(#0)] // { non_negative: true }
+        Project (#1) // { non_negative: true }
+          Filter (#0 = 0) // { non_negative: true }
+            Lookup #0 = 0
+              ArrangeBy keys=[[#0]] // { non_negative: true }
+                Get materialize.public.t // { non_negative: true }
+
+Used Indexes:
+  - materialize.public.t_a_idx
 
 EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -52,6 +52,27 @@ EOF
 
 # Test Threshold, Union, Distinct, Negate.
 query T multiline
+EXPLAIN RAW PLAN WITH (raw_syntax) AS TEXT FOR
+SELECT a FROM t EXCEPT SELECT b FROM mv
+----
+Threshold
+  Union
+    Distinct
+      Project #1
+        Map #0
+          Project #0
+            Get materialize.public.t
+    Negate
+      Distinct
+        Project #1
+          Map #0
+            Project #1
+              Get materialize.public.mv
+
+EOF
+
+# Test virtual syntax (EXCEPT).
+query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
@@ -67,7 +88,7 @@ Except
 
 EOF
 
-# Test Threshold, Union, Distinct, Negate.
+# Test virtual syntax (EXCEPT ALL).
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
@@ -249,7 +270,7 @@ Project (#0, #2)
 
 EOF
 
-# Test a single CTEs.
+# Test a single CTE.
 query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -58,15 +58,15 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
 Threshold
   Union
     Distinct
-      Project #1
-        Map #0
-          Project #0
+      Project (#1)
+        Map (#0)
+          Project (#0)
             Get materialize.public.t
     Negate
       Distinct
-        Project #1
-          Map #0
-            Project #1
+        Project (#1)
+          Map (#0)
+            Project (#1)
               Get materialize.public.mv
 
 EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -34,8 +34,8 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a + 1, b, 4 FROM mv WHERE a > 0
 ----
-Project #2, #1, #3
-  Map (#0 + 1), 4
+Project (#2, #1, #3)
+  Map ((#0 + 1), 4)
     Filter (#0 > 0)
       Get materialize.public.mv
 
@@ -56,13 +56,13 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
 Except
-  Project #1
-    Map #0
-      Project #0
+  Project (#1)
+    Map (#0)
+      Project (#0)
         Get materialize.public.t
-  Project #1
-    Map #0
-      Project #1
+  Project (#1)
+    Map (#0)
+      Project (#1)
         Get materialize.public.mv
 
 EOF
@@ -73,13 +73,13 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT a FROM t EXCEPT ALL SELECT b FROM mv
 ----
 ExceptAll
-  Project #1
-    Map #0
-      Project #0
+  Project (#1)
+    Map (#0)
+      Project (#0)
         Get materialize.public.t
-  Project #1
-    Map #0
-      Project #1
+  Project (#1)
+    Map (#0)
+      Project (#1)
         Get materialize.public.mv
 
 EOF
@@ -89,7 +89,7 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 VIEW ov
 ----
-Project #0, #1
+Project (#0, #1)
   TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
     Get materialize.public.t
 
@@ -110,8 +110,8 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t
 ----
-Project #2
-  Map abs((#0 - #1))
+Project (#2)
+  Map (abs((#0 - #1)))
     Reduce aggregates=[min(#0), max(#0)]
       Get materialize.public.t
 
@@ -122,10 +122,10 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT abs(min(a) - max(a)) FROM t GROUP BY b
 ----
-Project #3
-  Map abs((#1 - #2))
+Project (#3)
+  Map (abs((#1 - #2)))
     Reduce group_by=[#2] aggregates=[min(#0), max(#0)]
-      Map #1
+      Map (#1)
         Get materialize.public.t
 
 EOF
@@ -136,7 +136,7 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t WHERE EXISTS(SELECT * FROM mv WHERE t.a < mv.a) AND EXISTS(SELECT * FROM mv WHERE t.b > mv.b)
 ----
 Let
-  Filter (Exists(Get l1) AND Exists(Get l2))
+  Filter (exists(Get l1) AND exists(Get l2))
     Get materialize.public.t
   Where
     l1 =
@@ -153,18 +153,18 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT (SELECT v.a FROM v WHERE v.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHERE mv.b = t.b LIMIT 1) FROM t
 ----
-Project #2, #3
+Project (#2, #3)
   Let
-    Map Select(Get l1), Select(Get l2)
+    Map (select(Get l1), select(Get l2))
       Get materialize.public.t
     Where
       l1 =
-        Project #0
+        Project (#0)
           TopK limit=1
             Filter (#1 = #^1)
               Get materialize.public.v
       l2 =
-        Project #0
+        Project (#0)
           TopK limit=1
             Filter (#1 = #^1)
               Get materialize.public.mv
@@ -176,7 +176,7 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1, t as t2
 ----
-Project #0, #2
+Project (#0, #2)
   CrossJoin
     Get materialize.public.t
     Get materialize.public.t
@@ -188,7 +188,7 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 SELECT t1.a, t2.a FROM t as t1 INNER JOIN t as t2 ON true
 ----
-Project #0, #2
+Project (#0, #2)
   CrossJoin
     Get materialize.public.t
     Get materialize.public.t
@@ -205,7 +205,7 @@ FROM
   t as t3
 WHERE t1.b = t2.b AND t2.b = t3.b
 ----
-Project #0, #2
+Project (#0, #2)
   Filter ((#1 = #3) AND (#3 = #5))
     CrossJoin
       CrossJoin
@@ -223,7 +223,7 @@ FROM t as t1
 INNER JOIN t as t2 ON t1.b = t2.b
 INNER JOIN t as t3 ON t2.b = t3.b
 ----
-Project #0, #2
+Project (#0, #2)
   InnerJoin (#3 = #5)
     InnerJoin (#1 = #3)
       Get materialize.public.t
@@ -240,7 +240,7 @@ FROM t as t1
 LEFT JOIN t as t2 ON t1.b = t2.b
 RIGHT JOIN t as t3 ON t2.b = t3.b
 ----
-Project #0, #2
+Project (#0, #2)
   RightOuterJoin (#3 = #5)
     LeftOuterJoin (#1 = #3)
       Get materialize.public.t
@@ -254,14 +254,14 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 WITH x AS (SELECT t.a * t.b as v from t) SELECT x.v + 5 FROM x
 ----
-Project #1
+Project (#1)
   Let
-    Map (#0 + 5)
+    Map ((#0 + 5))
       Get l0
     Where
       l0 =
-        Project #2
-          Map (#0 * #1)
+        Project (#2)
+          Map ((#0 * #1))
             Get materialize.public.t
 
 EOF
@@ -280,7 +280,7 @@ Let
       Filter (#0 > 0)
         Get l0
     l0 =
-      Map 1
+      Map (1)
         Constant
           - ()
 


### PR DESCRIPTION
This adds support for explanation of `MIR` trees including some attributes.

### Motivation

  * This PR adds a known-desirable feature.

A step towards resolving #13472.

### Tips for reviewer

* e33352ef1 adds `MirRelationExpr::post_order_vec` method which is needed for the `AnnotatedPlan::try_from` definition.
* d6e58e4cc improves the `MirRelationExpr::ArrangeBy` docstring (explains why the vector dimension was 2).
* c617f5bc6 adds `OptimizedMirRelationExpr::as_inner` method (needed in the `Explain::explain_text` definition for `DataflowDescription<OptimizedMirRelationExpr>`). This really should be `AsRef` and `AsMut`.
* 45467da9f implements `Clone` for `Indent` (needed for `DisplayText::fmt_text` for `ExplainMultiPlan<'a, T>`).
* 04df1f381 minor fixes in the `EXPLAIN AS TEXT` syntax for Hir (see commit message for details).
* 95b269ba6 adds more `ExplainConfig` options and implements some of those for Hir (see `ExplainConfig` docstrings for what they do).
* 61f076d84 changes the definition of `fmt_text_constant_rows` so it does not print the `Constant` (this needs to be decoupled so the `DisplayText` implementation for Mir can print requested attributes next to the `Constant` line).
* 9e90ed2ab implements `EXPLAIN AS TEXT` for Mir. I wasn't happy with the output (especially for the decorrelated plans) so I added some pre-processing logic in the next commits.
* 763497fe9 add `normalize_lets_in_tree` function (the decorrelated plans output is now a bit flatter).
* dd1ec8339 improves `normalize_lets_in_tree` performance (this is a technicality, you can only review this commit).
* 168f439e6 removes dead code (which will be even more once I port this to LIR).


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The new `EXPLAIN` API is not public yet, we have a separate issue for updating the docs.
