### PR TITLE
dbt-materialize: audit mz_generate_name, api relations, make database aware

### DIFF
--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -46,7 +46,6 @@ class MaterializeAdapter(PostgresAdapter):
     def list_relations_without_caching(
         self, schema_relation: MaterializeRelation
     ) -> List[MaterializeRelation]:
-        # Adapted from: https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/adapters/snowflake/impl.py#L110
         kwargs = {"schema_relation": schema_relation}
         results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/impl.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/impl.py
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Optional
+
 from dbt.adapters.materialize import MaterializeConnectionManager
 from dbt.adapters.materialize.relation import MaterializeRelation
 from dbt.adapters.postgres import PostgresAdapter
+from dbt.adapters.sql.impl import LIST_RELATIONS_MACRO_NAME
 
 
 class MaterializeAdapter(PostgresAdapter):
@@ -36,3 +39,34 @@ class MaterializeAdapter(PostgresAdapter):
         #
         # [0]: https://github.com/dbt-labs/dbt-core/blob/13b18654f03d92eab3f5a9113e526a2a844f145d/plugins/postgres/dbt/adapters/postgres/impl.py#L126-L133
         pass
+
+    def verify_database(self, database):
+        pass
+
+    def list_relations_without_caching(
+        self, schema_relation: MaterializeRelation
+    ) -> List[MaterializeRelation]:
+        # Adapted from: https://github.com/dbt-labs/dbt-snowflake/blob/main/dbt/adapters/snowflake/impl.py#L110
+        kwargs = {"schema_relation": schema_relation}
+        results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
+
+        relations = []
+        quote_policy = {"database": True, "schema": True, "identifier": True}
+
+        columns = ["database", "schema", "name", "type"]
+        for _database, _schema, _identifier, _type in results.select(columns):
+            try:
+                _type = self.Relation.get_relation_type(_type.lower())
+            except ValueError:
+                _type = self.Relation.get_relation_type.View
+            relations.append(
+                self.Relation.create(
+                    database=_database,
+                    schema=_schema,
+                    identifier=_identifier,
+                    quote_policy=quote_policy,
+                    type=_type,
+                )
+            )
+
+        return relations

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -15,10 +15,11 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Type
 
 from dbt.adapters.postgres import PostgresRelation
 from dbt.dataclass_schema import StrEnum
+from dbt.utils import classproperty
 
 
 class MaterializeRelationType(StrEnum):
@@ -38,3 +39,7 @@ class MaterializeRelationType(StrEnum):
 @dataclass(frozen=True, eq=False, repr=False)
 class MaterializeRelation(PostgresRelation):
     type: Optional[MaterializeRelationType] = None
+
+    @classproperty
+    def get_relation_type(cls) -> Type[MaterializeRelationType]:
+        return MaterializeRelationType

--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -16,82 +16,31 @@
 
 {% macro materialize__get_catalog(information_schema, schemas) -%}
 
+  {% set database = information_schema.database %}
+  {{ adapter.verify_database(database) }}
+
   {%- call statement('catalog', fetch_result=True) -%}
-    {#
-      If the user has multiple databases set and the first one is wrong, this will fail.
-      But we won't fail in the case where there are multiple quoting-difference-only dbs, which is better.
-    #}
-    {% set database = information_schema.database %}
-    {{ adapter.verify_database(database) }}
-
-    select
-        '{{ database }}' as table_database,
-        sch.nspname as table_schema,
-        tbl.relname as table_name,
-        case tbl.relkind
-            when 'v' then 'VIEW'
-            else 'BASE TABLE'
-        end as table_type,
-        tbl_desc.description as table_comment,
-        col.attname as column_name,
-        col.attnum as column_index,
-        col.type as column_type,
-        col_desc.description as column_comment,
-        pg_get_userbyid(tbl.relowner) as table_owner
-
-    from pg_catalog.pg_namespace sch
-    join pg_catalog.pg_class tbl on tbl.relnamespace = sch.oid
-    join (select mz_columns.name as attname, position as attnum, mz_relations.oid as attrelid, FALSE as attisdropped, mz_columns.type as type
-          from mz_columns join mz_relations on mz_columns.id = mz_relations.id)
-          as col on col.attrelid = tbl.oid
-    left outer join pg_catalog.pg_description tbl_desc on (tbl_desc.objoid = tbl.oid and tbl_desc.objsubid = 0)
-    left outer join pg_catalog.pg_description col_desc on (col_desc.objoid = tbl.oid and col_desc.objsubid = col.attnum)
-
-    where (
-        {%- for schema in schemas -%}
-          upper(sch.nspname) = upper('{{ schema }}'){%- if not loop.last %} or {% endif -%}
-        {%- endfor -%}
-      )
-      and tbl.relkind in ('r', 'v', 'f', 'p', 'm') -- o[r]dinary table, [v]iew, [f]oreign table, [p]artitioned table, [m]aterialized view. Other values are [i]ndex, [S]equence, [c]omposite type, [t]OAST table
-      and col.attnum > 0 -- negative numbers are used for system columns such as oid
-      and not col.attisdropped -- column as not been dropped
-
-    order by
-        sch.nspname,
-        tbl.relname,
-        col.attnum
-
+        select
+            d.name as table_database,
+            s.name as table_schema,
+            o.name as table_name,
+            case when o.type = 'materialized view' then 'materializedview' else o.type end as table_type,
+            '' as table_comment,
+            c.name as column_name,
+            c.position as column_index,
+            c.type as column_type,
+            '' as column_comment,
+            '' as table_owner
+        from mz_objects o
+        join mz_schemas s on o.schema_id = s.id
+        join mz_databases d on s.database_id = d.id and d.name = '{{ database }}'
+        join mz_columns c on c.id = o.id
+        where s.name in (
+            {%- for schema in schemas -%}
+                '{{ schema }}' {%- if not loop.last %}, {% endif -%}
+            {%- endfor -%}
+        )
   {%- endcall -%}
-
   {{ return(load_result('catalog').table) }}
-
 {%- endmacro %}
 
-{% macro postgres__list_relations_without_caching(schema_relation) %}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
-    select
-      '{{ schema_relation.database }}' as database,
-      tablename as name,
-      schemaname as schema,
-      'table' as type
-    from pg_tables
-    where schemaname ilike '{{ schema_relation.schema }}'
-    union all
-    select
-      '{{ schema_relation.database }}' as database,
-      viewname as name,
-      schemaname as schema,
-      'view' as type
-    from pg_views
-    where schemaname ilike '{{ schema_relation.schema }}'
-    union all
-    select
-      '{{ schema_relation.database }}' as database,
-      matviewname as name,
-      schemaname as schema,
-      'materializedview' as type
-    from pg_matviews
-    where schemaname ilike '{{ schema_relation.schema }}'
-  {% endcall %}
-  {{ return(load_result('list_relations_without_caching').table) }}
-{% endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -43,4 +43,3 @@
   {%- endcall -%}
   {{ return(load_result('catalog').table) }}
 {%- endmacro %}
-

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/index.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/index.sql
@@ -29,15 +29,17 @@
         """
     )}}
   {%- set identifier = model['alias'] -%}
+  {%- set old_relation = adapter.get_relation(identifier=identifier,
+                                              schema=schema,
+                                              database=database) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='index') -%}
 
-  {% set index_name %}
-      {{ mz_generate_name(identifier) }}
-  {% endset %}
-  {{ materialize__drop_index(index_name) }}
+  {% if old_relation %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/materialized_view.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/materialized_view.sql
@@ -25,7 +25,7 @@
                                                 type='materializedview') -%}
 
   {% if old_relation %}
-    {{ adapter.drop_relation(drop_relation) }}
+    {{ adapter.drop_relation(old_relation) }}
   {% endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/sink.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/sink.sql
@@ -15,15 +15,17 @@
 
 {% materialization sink, adapter='materialize' %}
   {%- set identifier = model['alias'] -%}
+  {%- set old_relation = adapter.get_relation(identifier=identifier,
+                                              schema=schema,
+                                              database=database) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='sink') -%}
 
-  {% set sink_name %}
-      {{ mz_generate_name(identifier) }}
-  {% endset %}
-  {{ materialize__drop_sink(sink_name) }}
+  {% if old_relation %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/source.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/source.sql
@@ -15,15 +15,17 @@
 
 {% materialization source, adapter='materialize' %}
   {%- set identifier = model['alias'] -%}
+  {%- set old_relation = adapter.get_relation(identifier=identifier,
+                                              schema=schema,
+                                              database=database) -%}
   {%- set target_relation = api.Relation.create(identifier=identifier,
                                                 schema=schema,
                                                 database=database,
                                                 type='source') -%}
 
-  {% set source_name %}
-      {{ mz_generate_name(identifier) }}
-  {% endset %}
-  {{ materialize__drop_source(source_name) }}
+  {% if old_relation %}
+    {{ adapter.drop_relation(old_relation) }}
+  {% endif %}
 
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/mz_generate_name.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/mz_generate_name.sql
@@ -14,5 +14,19 @@
 -- limitations under the License.
 
 {% macro mz_generate_name(identifier) -%}
+    {{ exceptions.warn(
+        """
+        The mz_generate_name macro is deprecated and will be removed in a future release of dbt-materialize.
+        Please use the {{ this }} jinja function to reference the relation instead:
+
+        e.g.
+        {{ config(materialized=''source'') }}
+
+        CREATE SOURCE {{ this }} ...
+
+        Will create a source using the filename as the identifier.
+        Documentation for {{ this }} can be found: https://docs.getdbt.com/reference/dbt-jinja-functions/this
+        """
+    )}}
   {{ return("{}.{}.{}".format(database, schema, identifier)) }}
 {% endmacro %}

--- a/misc/dbt-materialize/test/materialize.dbtspec
+++ b/misc/dbt-materialize/test/materialize.dbtspec
@@ -142,9 +142,9 @@ projects:
             SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse')) _ (a, b)
 
         models/test_source.sql: |
-            {{ config(materialized='source') }}
+            {{ config(materialized='source', database='materialize') }}
 
-            CREATE SOURCE {{ mz_generate_name('test_source') }}
+            CREATE SOURCE {{ this }}
             FROM KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-source'
             FORMAT BYTES
 
@@ -160,14 +160,14 @@ projects:
                 indexes=[{'columns': ['data']}]
             ) }}
 
-            CREATE SOURCE {{ mz_generate_name('test_source_index') }}
+            CREATE SOURCE {{ this }}
             FROM KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-source-index'
             FORMAT BYTES
 
         models/test_sink.sql: |
             {{ config(materialized='sink') }}
 
-            CREATE SINK {{ mz_generate_name('test_sink') }}
+            CREATE SINK {{ this }}
             FROM {{ ref('test_materialized_view') }}
             INTO KAFKA BROKER '{{ env_var('KAFKA_ADDR', 'localhost:9092') }}' TOPIC 'test-sink'
             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '{{ env_var('SCHEMA_REGISTRY_URL', 'http://localhost:8081') }}'


### PR DESCRIPTION
- Deprecate mz_generate_name function in favor of internal dbt functionality 
- Make dbt-materialize database aware
- Audit the way relations are dropped pre create
- Adjust catalog query to include materialize specific attributes

### Motivation

This PR fixes previously unreported bugs.

- This [PR](https://github.com/MaterializeInc/materialize/pull/13706/files) introduced cloud specific code into the adapter. Specifically in the `list_relations_without_caching` and `catalog` macros. I adjusted those macros to work with both the binary and cloud. This _might_ prolong the need for us to check the version of materialize we are running against.   

  A question: I diverged from using pg_catalog here because mz_catalog has a better representation of the resources (sources, sinks, indexes, (in the case of cloud) materialized views). Is this ok? Is there a better/different query we should be using? 

- Old Relations had different types than New Relations, and so were not getting correctly dropped in the custom materialization macros: for example, adding the below to the source custom [materialization](https://github.com/MaterializeInc/materialize/pull/14036/files#diff-bde408dfb29db5e4f97c46f1d4342c864168143043d78cc826d61dfc55611aa6) 
  ```
  {{ log("OLD Relation: " ~ old_relation.type, info=true) }}
  {{ log("NEW Relation: " ~ target_relation.type, info=true) }}
  ```
  And running a source model: 
  ```
  18:40:04  1 of 3 START source model public.market_orders_raw ............................. [RUN]
  CLASS TYPE <class 'dbt.adapters.materialize.relation.MaterializeRelation'>
  18:40:04  OLD Relation: table
  18:40:04  NEW Relation: source
  ```
  The [get_relation](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/adapters/base/impl.py#L745) function runs the `list_relations_without_caching` on first run, and caches the results for dbt to more quickly grab next time. The cached relations were getting stored with BaseRelation type value, not MaterializeRelationType specific values we need to correctly drop sources, sinks, etc.  Seeds were also not getting dropped correctly, but now should be. 

### Tips for reviewer

I've included @morsapaes work to use Redpanda instead of Kafka for testing. 
PR for removing mz_generate_name macro from demos/docs is next, should this get approved. 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
