### PR TITLE
persist: slightly more efficient insert to CRDB

### DIFF
--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -26,7 +26,7 @@ use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use openssl::x509::X509;
 use postgres_openssl::MakeTlsConnector;
 use std::time::Instant;
-use tracing::{debug, info};
+use tracing::debug;
 
 use crate::error::Error;
 use crate::location::{Consensus, ExternalError, SeqNo, VersionedData};
@@ -340,64 +340,27 @@ impl Consensus for PostgresConsensus {
         }
 
         let result = if let Some(expected) = expected {
-            // This PR uses a few tricks to execute in a single network round-trip:
-            // - It conditionally UPSERTs[0] a new row into consensus iff the greatest sequence
-            //   number is of the expected value, and then uses UPSERT ... RETURNING to indicate
-            //   whether the upsert succeeded
-            // - The SELECT statement with the greatest sequence number (and its data) is unioned
-            //   with the results of the conditional UPSERT, allowing the client to read whether
-            //   it succeeded, and if not, the latest state so it can retry without having to
-            //   refetch state in a separate query.
-            // [0]: https://www.cockroachlabs.com/docs/stable/upsert.html
-            //
-            // WIP: there are open questions about the linearizability of the
-            //      `SELECT ... ORDER BY sequence_number DESC LIMIT` use on CRDB
+            // This query has been written to execute within a single
+            // network round-trip. The insert performance has been tuned
+            // against CockroachDB, ensuring it goes through the fast-path
+            // 1-phase commit of CRDB. Any changes to this query should
+            // confirm an EXPLAIN ANALYZE (VERBOSE) query plan contains
+            // `auto commit`
             let q = r#"
-                WITH
-                    greatest_seqno AS (
-                        SELECT sequence_number, data FROM consensus WHERE shard = $1 ORDER BY sequence_number DESC LIMIT 1
-                    ),
-                    inserted AS (
-                        UPSERT INTO consensus (shard, sequence_number, data)
-                        SELECT $1, $2, $3
-                        WHERE EXISTS (SELECT 1 FROM greatest_seqno WHERE sequence_number = $4)
-                        RETURNING sequence_number
-                    )
-                    SELECT true as was_inserted, sequence_number, NULL as data FROM inserted
-                    UNION ALL
-                    SELECT false as was_inserted, sequence_number, data FROM greatest_seqno
+                INSERT INTO consensus (shard, sequence_number, data)
+                SELECT $1, $2, $3
+                WHERE (SELECT sequence_number FROM consensus
+                       WHERE shard = $1
+                       ORDER BY sequence_number DESC LIMIT 1) = $4;
             "#;
-            let result = {
-                let client = self.get_connection().await?;
-                let statement = client.prepare_cached(q).await?;
-                client
-                    .query(
-                        &statement,
-                        &[&key, &new.seqno, &new.data.as_ref(), &expected],
-                    )
-                    .await?
-            };
-            for row in result {
-                let was_inserted: bool = row.try_get("was_inserted")?;
-
-                if was_inserted {
-                    debug!("Upserted: {:?}", new.seqno);
-                    return Ok(Ok(()));
-                }
-
-                let seqno: SeqNo = row.try_get("sequence_number")?;
-                let data: Vec<u8> = row.try_get("data")?;
-                debug!(
-                    "Did not upsert row: tried {:?} and got {:?}",
-                    new.seqno, seqno
-                );
-                return Ok(Err(Some(VersionedData {
-                    seqno,
-                    data: Bytes::from(data),
-                })));
-            }
-            // no-op, we'd want to refactor how the initial insert works here
-            1
+            let client = self.get_connection().await?;
+            let statement = client.prepare_cached(q).await?;
+            client
+                .execute(
+                    &statement,
+                    &[&key, &new.seqno, &new.data.as_ref(), &expected],
+                )
+                .await?
         } else {
             // Insert the new row as long as no other row exists for the same shard.
             let q = "INSERT INTO consensus SELECT $1, $2, $3 WHERE


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
Saw that we're getting cas mismatches on ~40-50% of our `compare_and_set` calls steady-state. This updates our query to reduce the # of rows it needs to read on insert, and confirms that the query goes through the 1PC `auto commit` path of CRDB to minimize contention (the existing query did this as well).

The query structure should be compatible with Postgres, though that isn't the specific target for optimizing performance.

---

For reference, the explain plan for the updated query, showing that the select reads only 1 row and the insert goes through `auto commit`

```
                                                        info
--------------------------------------------------------------------------------------------------------------------
  planning time: 742µs
  execution time: 2ms
  distribution: local
  vectorized: true
  rows read from KV: 1 (437 B)
  cumulative time spent in KV: 968µs
  maximum memory usage: 30 KiB
  network usage: 0 B (0 messages)
  regions: aws-us-east-1

  • root
  │ columns: ()
  │
  ├── • insert
  │   │ columns: ()
  │   │ nodes: n3
  │   │ regions: aws-us-east-1
  │   │ actual row count: 1
  │   │ vectorized batch count: 1
  │   │ estimated row count: 0 (missing stats)
  │   │ into: consensus(shard, sequence_number, data)
  │   │ auto commit
  │   │
  │   └── • render
  │       │ columns: ("?column?", "?column?", "?column?")
  │       │ nodes: n3
  │       │ regions: aws-us-east-1
  │       │ actual row count: 0
  │       │ vectorized batch count: 0
  │       │ estimated row count: 0
  │       │ render ?column?: 'sfef24112-7698-4776-b89d-ecfb419f3e77'
  │       │ render ?column?: 10
  │       │ render ?column?: '\x616263'
  │       │
  │       └── • filter
  │           │ columns: ()
  │           │ nodes: n3
  │           │ regions: aws-us-east-1
  │           │ actual row count: 0
  │           │ vectorized batch count: 0
  │           │ estimated row count: 0
  │           │ filter: @S1 = 9
  │           │
  │           └── • emptyrow
  │                 columns: ()
  │                 nodes: n3
  │                 regions: aws-us-east-1
  │                 actual row count: 1
  │                 vectorized batch count: 1
  │
  └── • subquery
      │ id: @S1
      │ original sql: (SELECT * FROM greatest_seqno)
      │ exec mode: one row
      │
      └── • render
          │ columns: (sequence_number)
          │ nodes: n3
          │ regions: aws-us-east-1
          │ actual row count: 1
          │ vectorized batch count: 1
          │ KV time: 968µs
          │ KV contention time: 0µs
          │ KV rows read: 1
          │ KV bytes read: 437 B
          │ estimated max memory allocated: 20 KiB
          │ MVCC step count (ext/int): 2/3
          │ MVCC seek count (ext/int): 2/2
          │ estimated row count: 1
          │ render sequence_number: sequence_number
          │
          └── • revscan
                columns: (shard, sequence_number)
                nodes: n3
                regions: aws-us-east-1
                actual row count: 1
                vectorized batch count: 1
                KV time: 968µs
                KV contention time: 0µs
                KV rows read: 1
                KV bytes read: 437 B
                estimated max memory allocated: 20 KiB
                MVCC step count (ext/int): 2/3
                MVCC seek count (ext/int): 2/2
                estimated row count: 1 (0.18% of the table; stats collected 1 minute ago)
                table: consensus@consensus_pkey
                spans: /"sfef24112-7698-4776-b89d-ecfb419f3e77"-/"sfef24112-7698-4776-b89d-ecfb419f3e77"/PrefixEnd
                limit: 1
```

### Motivation

Works towards https://github.com/MaterializeInc/materialize/issues/12992

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
