### PR TITLE
Change SSL KEY in CONNECTION to SSL KEY PEM

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -31,18 +31,18 @@ Field                       | Value            | Required | Description
 `BROKERS`                   | `text[]`         |          | A comma-separated list of Kafka bootstrap servers. Exclusive with `BROKER`.
 `SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
 `SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate. Required for SSL client authentication.
-`SSL KEY`                   | secret           | ✓        | Your SSL certificate's key. Required for SSL client authentication.
+`SSL KEY PEM`               | secret           | ✓        | Your SSL certificate's key. Required for SSL client authentication.
 
 ##### Example
 
 ```sql
 CREATE SECRET kafka_ssl_crt AS '<BROKER_SSL_CRT>';
-CREATE SECRET kafka_ssl_key AS '<BROKER_SSL_KEY>';
+CREATE SECRET kafka_ssl_key_pem AS '<BROKER_SSL_KEY_PEM>';
 
 CREATE CONNECTION kafka_connection
   FOR KAFKA
     BROKER 'rp-f00000bar.data.vectorized.cloud:30365',
-    SSL KEY = SECRET kafka_ssl_key,
+    SSL KEY PEM = SECRET kafka_ssl_key_pem,
     SSL CERTIFICATE = SECRET kafka_ssl_crt;
 ```
 
@@ -53,7 +53,7 @@ Field                       | Value            | Required | Description
 `URL`                       | `text`           | ✓        | The schema registry URL.
 `SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
 `SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate. Required for SSL client authentication.
-`SSL KEY`                   | secret           | ✓        | Your SSL certificate's key. Required for SSL client authentication.
+`SSL KEY PEM`               | secret           | ✓        | Your SSL certificate's key. Required for SSL client authentication.
 `PASSWORD`                  | secret           |          | The password used to connect to the schema registry with basic HTTP authentication. This is compatible with the `ssl` options, which control the transport between Materialize and the CSR.
 `USERNAME`                  | secret or `text` |          | The username used to connect to the schema registry with basic HTTP authentication. This is compatible with the `ssl` options, which control the transport between Materialize and the CSR.
 
@@ -61,13 +61,13 @@ Field                       | Value            | Required | Description
 
 ```sql
 CREATE SECRET csr_ssl_crt AS '<CSR_SSL_CRT>';
-CREATE SECRET csr_ssl_key AS '<CSR_SSL_KEY>';
+CREATE SECRET csr_ssl_key_pem AS '<CSR_SSL_KEY_PEM>';
 CREATE SECRET csr_password AS '<CSR_PASSWORD>';
 
 CREATE CONNECTION csr_ssl
   FOR CONFLUENT SCHEMA REGISTRY
     URL 'rp-f00000bar.data.vectorized.cloud:30993',
-    SSL KEY = SECRET csr_ssl_key,
+    SSL KEY PEM = SECRET csr_ssl_key_pem,
     SSL CERTIFICATE = SECRET csr_ssl_crt,
     USERNAME = 'foo',
     PASSWORD = SECRET csr_password;
@@ -113,7 +113,7 @@ Field                       | Value            | Required | Description
 `SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
 `SSL MODE`                  | `text`           |          | Default: `disable`. Enables SSL connections if set to `require`, `verify_ca`, or `verify_full`.
 `SSL CERTIFICATE`           | secret or `text` |          | Client SSL certificate.
-`SSL KEY`                   | secret           |          | Client SSL key.
+`SSL KEY PEM`               | secret           |          | Client SSL key.
 `USER`                      | `text`           | ✓        | Database username.
 
 ##### Example

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -282,13 +282,13 @@ Once created, a connection is **reusable** across multiple `CREATE SOURCE` state
 {{< tabs tabID="1" >}}
 {{< tab "SSL">}}
 ```sql
-CREATE SECRET kafka_ssl_key AS '<BROKER_SSL_KEY>';
+CREATE SECRET kafka_ssl_key_pem AS '<BROKER_SSL_KEY_PEM>';
 CREATE SECRET kafka_ssl_crt AS '<BROKER_SSL_CRT>';
 
 CREATE CONNECTION kafka_connection
   FOR KAFKA
     BROKER 'rp-f00000bar.data.vectorized.cloud:30365',
-    SSL KEY = SECRET kafka_ssl_key,
+    SSL KEY PEM = SECRET kafka_ssl_key_pem,
     SSL CERTIFICATE = SECRET kafka_ssl_crt;
 ```
 {{< /tab >}}
@@ -313,13 +313,13 @@ CREATE CONNECTION kafka_connection
 {{< tab "SSL">}}
 ```sql
 CREATE SECRET csr_ssl_crt AS '<CSR_SSL_CRT>';
-CREATE SECRET csr_ssl_key AS '<CSR_SSL_KEY>';
+CREATE SECRET csr_ssl_key_pem AS '<CSR_SSL_KEY_PEM>';
 CREATE SECRET csr_password AS '<CSR_PASSWORD>';
 
 CREATE CONNECTION csr_ssl
   FOR CONFLUENT SCHEMA REGISTRY
     URL 'rp-f00000bar.data.vectorized.cloud:30993',
-    SSL KEY = SECRET csr_ssl_key,
+    SSL KEY PEM = SECRET csr_ssl_key_pem,
     SSL CERTIFICATE = SECRET csr_ssl_crt,
     USERNAME = 'foo',
     PASSWORD = SECRET csr_password;

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -540,7 +540,7 @@ impl_display_t!(DbzTxMetadataOption);
 pub enum KafkaConnectionOptionName {
     Broker,
     Brokers,
-    SslKey,
+    SslKeyPem,
     SslCertificate,
     SslCertificateAuthority,
     SaslMechanisms,
@@ -553,7 +553,7 @@ impl AstDisplay for KafkaConnectionOptionName {
         f.write_str(match self {
             KafkaConnectionOptionName::Broker => "BROKER",
             KafkaConnectionOptionName::Brokers => "BROKERS",
-            KafkaConnectionOptionName::SslKey => "SSL KEY",
+            KafkaConnectionOptionName::SslKeyPem => "SSL KEY PEM",
             KafkaConnectionOptionName::SslCertificate => "SSL CERTIFICATE",
             KafkaConnectionOptionName::SslCertificateAuthority => "SSL CERTIFICATE AUTHORITY",
             KafkaConnectionOptionName::SaslMechanisms => "SASL MECHANISMS",
@@ -585,7 +585,7 @@ impl_display_t!(KafkaConnectionOption);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CsrConnectionOptionName {
     Url,
-    SslKey,
+    SslKeyPem,
     SslCertificate,
     SslCertificateAuthority,
     Username,
@@ -596,7 +596,7 @@ impl AstDisplay for CsrConnectionOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             CsrConnectionOptionName::Url => "URL",
-            CsrConnectionOptionName::SslKey => "SSL KEY",
+            CsrConnectionOptionName::SslKeyPem => "SSL KEY PEM",
             CsrConnectionOptionName::SslCertificate => "SSL CERTIFICATE",
             CsrConnectionOptionName::SslCertificateAuthority => "SSL CERTIFICATE AUTHORITY",
             CsrConnectionOptionName::Username => "USERNAME",
@@ -633,7 +633,7 @@ pub enum PostgresConnectionOptionName {
     SshTunnel,
     SslCertificate,
     SslCertificateAuthority,
-    SslKey,
+    SslKeyPem,
     SslMode,
     User,
 }
@@ -648,7 +648,7 @@ impl AstDisplay for PostgresConnectionOptionName {
             PostgresConnectionOptionName::SshTunnel => "SSH TUNNEL",
             PostgresConnectionOptionName::SslCertificate => "SSL CERTIFICATE",
             PostgresConnectionOptionName::SslCertificateAuthority => "SSL CERTIFICATE AUTHORITY",
-            PostgresConnectionOptionName::SslKey => "SSL KEY",
+            PostgresConnectionOptionName::SslKeyPem => "SSL KEY PEM",
             PostgresConnectionOptionName::SslMode => "SSL MODE",
             PostgresConnectionOptionName::User => "USER",
         })

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -225,6 +225,7 @@ Outer
 Over
 Partition
 Password
+Pem
 Physical
 Plan
 Plans

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -1984,7 +1984,10 @@ impl<'a> Parser<'a> {
                 _ => unreachable!(),
             },
             SSL => match self.expect_one_of_keywords(&[KEY, CERTIFICATE])? {
-                KEY => KafkaConnectionOptionName::SslKey,
+                KEY => {
+                    self.expect_keyword(PEM)?;
+                    KafkaConnectionOptionName::SslKeyPem
+                }
                 CERTIFICATE => {
                     if self.parse_keyword(AUTHORITY) {
                         KafkaConnectionOptionName::SslCertificateAuthority
@@ -2007,7 +2010,10 @@ impl<'a> Parser<'a> {
     fn parse_csr_connection_options(&mut self) -> Result<CsrConnectionOption<Raw>, ParserError> {
         let name = match self.expect_one_of_keywords(&[SSL, URL, USERNAME, PASSWORD])? {
             SSL => match self.expect_one_of_keywords(&[KEY, CERTIFICATE])? {
-                KEY => CsrConnectionOptionName::SslKey,
+                KEY => {
+                    self.expect_keyword(PEM)?;
+                    CsrConnectionOptionName::SslKeyPem
+                }
                 CERTIFICATE => {
                     if self.parse_keyword(AUTHORITY) {
                         CsrConnectionOptionName::SslCertificateAuthority
@@ -2052,7 +2058,10 @@ impl<'a> Parser<'a> {
                         PostgresConnectionOptionName::SslCertificate
                     }
                 }
-                KEY => PostgresConnectionOptionName::SslKey,
+                KEY => {
+                    self.expect_keyword(PEM)?;
+                    PostgresConnectionOptionName::SslKeyPem
+                }
                 MODE => PostgresConnectionOptionName::SslMode,
                 _ => unreachable!(),
             },

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1312,11 +1312,11 @@ ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 AlterSecret(AlterSecretStatement { name: UnresolvedObjectName([Ident("secret")]), if_exists: false, value: Function(Function { name: UnresolvedObjectName([Ident("decode")]), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
-CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux';
+CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY PEM = 'foo', SSL CERTIFICATE = 'qux';
 ----
-CREATE CONNECTION conn1 FOR KAFKA BROKER = 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux'
+CREATE CONNECTION conn1 FOR KAFKA BROKER = 'kafka:1234', SSL KEY PEM = 'foo', SSL CERTIFICATE = 'qux'
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(Value(String("kafka:1234"))) }, KafkaConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
+CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Kafka { with_options: [KafkaConnectionOption { name: Broker, value: Some(Value(String("kafka:1234"))) }, KafkaConnectionOption { name: SslKeyPem, value: Some(Value(String("foo"))) }, KafkaConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }] }, if_not_exists: false })
 
 parse-statement
 DROP CONNECTION conn1

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -216,7 +216,7 @@ impl ConfigKey for KafkaConnectionOptionName {
         use KafkaConnectionOptionName::*;
         match self {
             Broker | Brokers => "bootstrap.servers",
-            SslKey => "ssl.key.pem",
+            SslKeyPem => "ssl.key.pem",
             SslCertificate => "ssl.certificate.pem",
             SslCertificateAuthority => "ssl.ca.pem",
             SaslMechanisms => "sasl.mechanisms",
@@ -248,7 +248,7 @@ impl From<KafkaConnection> for BTreeMap<String, StringOrSecret> {
                     r.insert(SslCertificateAuthority.config_key(), root_cert);
                 }
                 if let Some(identity) = identity {
-                    r.insert(SslKey.config_key(), StringOrSecret::Secret(identity.key));
+                    r.insert(SslKeyPem.config_key(), StringOrSecret::Secret(identity.key));
                     r.insert(SslCertificate.config_key(), identity.cert);
                 }
             }
@@ -306,7 +306,7 @@ impl TryFrom<&mut BTreeMap<String, StringOrSecret>> for KafkaConnection {
             match v.unwrap_string().to_lowercase().as_str() {
                 config @ "ssl" => Some(KafkaSecurity::Tls(KafkaTlsConfig {
                     identity: Some(TlsIdentity {
-                        key: key_or_err(config, map, SslKey)?.unwrap_secret(),
+                        key: key_or_err(config, map, SslKeyPem)?.unwrap_secret(),
                         cert: key_or_err(config, map, SslCertificate)?,
                     }),
                     root_cert: map.remove(&SslCertificateAuthority.config_key()),

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
 > CREATE CONNECTION kafka_ssl
   FOR KAFKA
     BROKER 'kafka:9092',
-    SSL KEY = SECRET ssl_key_kafka,
+    SSL KEY PEM = SECRET ssl_key_kafka,
     SSL CERTIFICATE = '${arg.materialized-kafka-crt}',
     SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}';
 
@@ -160,7 +160,7 @@ contains:self signed certificate in certificate chain
       ssl_ca_pem = '${arg.ca-crt}'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:missing SSL KEY (ssl.key.pem)
+contains:missing SSL KEY PEM (ssl.key.pem)
 
 > CREATE SOURCE kafka_connector_source
   FROM KAFKA CONNECTION kafka_ssl
@@ -183,7 +183,7 @@ a
 > CREATE CONNECTION csr_ssl
   FOR CONFLUENT SCHEMA REGISTRY
     URL '${testdrive.schema-registry-url}',
-    SSL KEY = SECRET ssl_key_csr,
+    SSL KEY PEM = SECRET ssl_key_csr,
     SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
     SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}',
     USERNAME = 'materialize',
@@ -225,13 +225,13 @@ contains:cannot set option security.protocol for SOURCE using CONNECTION materia
 > CREATE CONNECTION kafka_sasl_no_ca
   FOR KAFKA
     BROKER 'kafka:9092',
-    SSL KEY = SECRET ssl_key_kafka,
+    SSL KEY PEM = SECRET ssl_key_kafka,
     SSL CERTIFICATE = '${arg.materialized-kafka-crt}';
 
 >  CREATE CONNECTION csr_ssl_no_ca
   FOR CONFLUENT SCHEMA REGISTRY
     URL '${testdrive.schema-registry-url}',
-    SSL KEY = SECRET ssl_key_csr,
+    SSL KEY PEM = SECRET ssl_key_csr,
     SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
     USERNAME = 'materialize',
     PASSWORD = SECRET password_csr;

--- a/test/pg-cdc/pg-cdc-ssl.td.gh14037
+++ b/test/pg-cdc/pg-cdc-ssl.td.gh14037
@@ -278,7 +278,7 @@ contains:self signed certificate in certificate chain
   USER certuser,
   SSL MODE require,
   SSL CERTIFICATE SECRET ssl_cert,
-  SSL KEY SECRET ssl_key,
+  SSL KEY PEM SECRET ssl_key,
   SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
   DATABASE postgres;
 > CREATE SOURCE "mz_source"
@@ -317,7 +317,7 @@ contains:db error: FATAL: connection requires a valid client certificate
   USER certuser,
   SSL MODE verify_ca,
   SSL CERTIFICATE SECRET ssl_wrong_cert,
-  SSL KEY SECRET ssl_wrong_key,
+  SSL KEY PEM SECRET ssl_wrong_key,
   SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
   DATABASE postgres;
 ! CREATE SOURCE "mz_source"
@@ -332,7 +332,7 @@ contains:db error: FATAL: certificate authentication failed for user "certuser"
   USER certuser,
   SSL MODE verify_ca,
   SSL CERTIFICATE SECRET ssl_cert,
-  SSL KEY SECRET ssl_key,
+  SSL KEY PEM SECRET ssl_key,
   SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
   DATABASE postgres;
 > CREATE SOURCE "mz_source"
@@ -358,7 +358,7 @@ DELETE FROM numbers WHERE number = 2;
   USER certuser,
   SSL MODE verify_full,
   SSL CERTIFICATE SECRET ssl_cert,
-  SSL KEY SECRET ssl_key,
+  SSL KEY PEM SECRET ssl_key,
   SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
   DATABASE postgres;
 > CREATE SOURCE "mz_source"
@@ -384,7 +384,7 @@ DELETE FROM numbers WHERE number = 2;
   USER certuser,
   SSL MODE verify_full,
   SSL CERTIFICATE SECRET noexist,
-  SSL KEY SECRET ssl_key,
+  SSL KEY PEM SECRET ssl_key,
   SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
   DATABASE postgres;
 contains:unknown catalog item 'noexist'
@@ -395,7 +395,7 @@ contains:unknown catalog item 'noexist'
   USER certuser,
   SSL MODE verify_full,
   SSL CERTIFICATE SECRET ssl_cert,
-  SSL KEY SECRET noexist,
+  SSL KEY PEM SECRET noexist,
   SSL CERTIFICATE AUTHORITY SECRET ssl_ca,
   DATABASE postgres;
 contains:unknown catalog item 'noexist'
@@ -406,7 +406,7 @@ contains:unknown catalog item 'noexist'
   USER certuser,
   SSL MODE verify_full,
   SSL CERTIFICATE SECRET ssl_cert,
-  SSL KEY SECRET ssl_key,
+  SSL KEY PEM SECRET ssl_key,
   SSL CERTIFICATE AUTHORITY SECRET noexist,
   DATABASE postgres;
 contains:unknown catalog item 'noexist'
@@ -418,12 +418,12 @@ contains:unknown catalog item 'noexist'
   SSL MODE verify_full,
   SSL CERTIFICATE SECRET ssl_cert,
   DATABASE postgres;
-contains:invalid CONNECTION: both SSL KEY and SSL CERTIFICATE are required
+contains:invalid CONNECTION: both SSL KEY PEM and SSL CERTIFICATE are required
 
 ! CREATE CONNECTION pgconn FOR POSTGRES
   HOST postgres,
   USER certuser,
   SSL MODE verify_full,
-  SSL KEY SECRET ssl_cert,
+  SSL KEY PEM SECRET ssl_cert,
   DATABASE postgres;
-contains:invalid CONNECTION: both SSL KEY and SSL CERTIFICATE are required
+contains:invalid CONNECTION: both SSL KEY PEM and SSL CERTIFICATE are required

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -274,8 +274,8 @@ contains:invalid SASL PASSWORD: must provide a secret value
 ! CREATE CONNECTION not_a_secret
   FOR KAFKA
     BROKER '',
-    SSL KEY = ''
-contains:invalid SSL KEY: must provide a secret value
+    SSL KEY PEM = ''
+contains:invalid SSL KEY PEM: must provide a secret value
 
 ! CREATE CONNECTION duplicate_option
   FOR KAFKA
@@ -327,14 +327,14 @@ contains: must specify URL
 ! CREATE CONNECTION missing_cert
     FOR CONFLUENT SCHEMA REGISTRY
     URL 'http://localhost',
-    SSL KEY = SECRET s
-contains: requires both SSL KEY and SSL CERTIFICATE
+    SSL KEY PEM = SECRET s
+contains: requires both SSL KEY PEM and SSL CERTIFICATE
 
 ! CREATE CONNECTION missing_key
     FOR CONFLUENT SCHEMA REGISTRY
      URL 'http://localhost',
     SSL CERTIFICATE = ''
-contains: requires both SSL KEY and SSL CERTIFICATE
+contains: requires both SSL KEY PEM and SSL CERTIFICATE
 
 ## SSH
 ! CREATE CONNECTION missing_user


### PR DESCRIPTION
Addressing issue https://github.com/MaterializeInc/materialize/issues/13500. This change renames the existing query field `SSL KEY` to `SSL KEY PEM` in `CONNECTION`.

### Motivation
This PR adds a known-desirable feature.
  * Make explicit the fact that we expect the ssl key in PEM format.

### Tips for reviewer
This is my first PR at Materialize!
I appreciate all feedback.
Please confirm whether a catalog migration, any additional testing beyond CI, or a release note is needed.
Note: this passed CI without a catalog migration - does that mean no migration is necessary, or should there be tests in place to catch changes like this if they don't have a migration?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

###  Release notes

This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
This release will rename the field `SSL KEY` to `SSL KEY PEM` in  `CREATE CONNECTION` command.