### PR TITLE
persist: track per-writer compare_and_append idempotency token

### DIFF
--- a/src/persist-client/src/internal/maintenance.rs
+++ b/src/persist-client/src/internal/maintenance.rs
@@ -170,10 +170,19 @@ impl RoutineMaintenance {
 /// routine maintenance common to all handles. It is expected that
 /// writers always perform maintenance.
 #[must_use]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct WriterMaintenance<T> {
     pub(crate) routine: RoutineMaintenance,
     pub(crate) compaction: Vec<CompactReq<T>>,
+}
+
+impl<T> Default for WriterMaintenance<T> {
+    fn default() -> Self {
+        Self {
+            routine: RoutineMaintenance::default(),
+            compaction: Vec::default(),
+        }
+    }
 }
 
 impl<T> WriterMaintenance<T>

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -56,6 +56,8 @@ message ProtoCriticalReaderState {
 message ProtoWriterState {
     uint64 last_heartbeat_timestamp_ms = 1;
     uint64 lease_duration_ms = 2;
+    string most_recent_write_token = 3;
+    ProtoU64Antichain most_recent_write_upper = 4;
 }
 
 message ProtoStateRollup {

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -71,7 +71,7 @@ pub struct StateDiff<T> {
     pub(crate) last_gc_req: Vec<StateFieldDiff<(), SeqNo>>,
     pub(crate) leased_readers: Vec<StateFieldDiff<LeasedReaderId, LeasedReaderState<T>>>,
     pub(crate) critical_readers: Vec<StateFieldDiff<CriticalReaderId, CriticalReaderState<T>>>,
-    pub(crate) writers: Vec<StateFieldDiff<WriterId, WriterState>>,
+    pub(crate) writers: Vec<StateFieldDiff<WriterId, WriterState<T>>>,
     pub(crate) since: Vec<StateFieldDiff<(), Antichain<T>>>,
     pub(crate) spine: Vec<StateFieldDiff<HollowBatch<T>, ()>>,
 }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -521,7 +521,7 @@ where
                 &self.writer_id,
                 heartbeat_timestamp,
             )
-            .await?;
+            .await;
 
         let maintenance = match res {
             Ok(Ok((_seqno, maintenance))) => {
@@ -532,13 +532,13 @@ where
                 }
                 maintenance
             }
-            Ok(Err(current_upper)) => {
+            Ok(Err(invalid_usage)) => return Ok(Err(invalid_usage)),
+            Err(current_upper) => {
                 // We tried to to a compare_and_append with the wrong expected upper, that
                 // won't work. Update the cached upper to the current upper.
                 self.upper = current_upper.0.clone();
                 return Ok(Ok(Err(current_upper)));
             }
-            Err(err) => return Ok(Err(err)),
         };
 
         maintenance.start_performing(&self.machine, &self.gc, self.compact.as_ref());

--- a/src/persist-client/tests/machine/caa_idempotent
+++ b/src/persist-client/tests/machine/caa_idempotent
@@ -1,0 +1,114 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for the various edge cases of retrying compare_and_append in the
+# presence of indeterminate errors.
+
+# Write some batches we'll need later and register some writers
+
+write-batch output=b0w1 lower=0 upper=1
+zero 0 1
+----
+parts=1 len=1
+
+write-batch output=b1w1 lower=1 upper=2
+one 1 1
+----
+parts=1 len=1
+
+write-batch output=b2w1 lower=2 upper=3
+w1 2 1
+----
+parts=1 len=1
+
+write-batch output=b2w2 lower=2 upper=3
+w2 2 1
+----
+parts=1 len=1
+
+write-batch output=b3w1 lower=3 upper=4
+w1 3 1
+----
+parts=1 len=1
+
+write-batch output=b4w2 lower=4 upper=5
+w2 4 1
+----
+parts=1 len=1
+
+register-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [0]
+
+register-writer writer_id=w22222222-2222-2222-2222-222222222222
+----
+v3 [0]
+
+# Case 1: A compare_and_append receives an indeterminate error, but _doesn't_
+# actually commit. On retry it commits.
+
+# Imagine the first attempt getting an indeterminate error, but not committing
+# here.
+
+# Okay and pretend this is a retry.
+compare-and-append input=b0w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i33333333-3333-3333-3333-333333333333 prev_indeterminate=timeout
+----
+v4 [1]
+
+# Case 2: A compare_and_append receives an indeterminate error, but _does_
+# actually commit. On retry it is a no-op.
+compare-and-append input=b1w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i44444444-4444-4444-4444-444444444444
+----
+v5 [2]
+
+compare-and-append input=b1w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i44444444-4444-4444-4444-444444444444 prev_indeterminate=timeout
+----
+v5 [2]
+
+# Case 1B: A compare_and_append receives an indeterminate error, but _doesn't_
+# actually commit. Another writer advances the upper in between retries. On
+# retry it discovers the upper mismatch and also that it didn't commit before.
+
+# Imagine the first attempt getting an indeterminate error, but not committing
+# here.
+
+compare-and-append input=b2w2 writer_id=w22222222-2222-2222-2222-222222222222
+----
+v6 [3]
+
+compare-and-append input=b2w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i55555555-5555-5555-5555-555555555555 prev_indeterminate=timeout
+----
+error: Upper(Antichain { elements: [3] })
+
+# Case 2B: A compare_and_append receives an indeterminate error, but _does_
+# actually commit. Another writer advances the upper in between retries. On
+# retry it discovers the upper mismatch and also that it did commit before and
+# so is now a no-op.
+
+compare-and-append input=b3w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i66666666-6666-6666-6666-666666666666
+----
+v7 [4]
+
+compare-and-append input=b4w2 writer_id=w22222222-2222-2222-2222-222222222222
+----
+v8 [5]
+
+compare-and-append input=b3w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i66666666-6666-6666-6666-666666666666 prev_indeterminate=timeout
+----
+v8 [5]
+
+# Case 3: We expect that writers generally move "forward" in time and the
+# technique we use to make compare_and_append idempotent depends on this.
+# However, we don't just totally punt on the case. We're able to handle this as
+# long as we don't see an Indeterminate error the first time through (otherwise
+# we'll hit a panic). The combination of two rare (hopefully independent?)
+# events means we expect to ~never see the panic in practice.
+compare-and-append input=b0w1 writer_id=w11111111-1111-1111-1111-111111111111 token=i77777777-7777-7777-7777-777777777777
+----
+error: Upper(Antichain { elements: [5] })

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -117,6 +117,15 @@ pub struct Indeterminate {
     pub(crate) inner: anyhow::Error,
 }
 
+impl Indeterminate {
+    /// Return a new Indeterminate wrapping the given error.
+    ///
+    /// Exposed for testing.
+    pub fn new(inner: anyhow::Error) -> Self {
+        Indeterminate { inner }
+    }
+}
+
 impl std::fmt::Display for Indeterminate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "indeterminate: ")?;


### PR DESCRIPTION
SUBTLE: Retries of compare_and_append with Indeterminate errors are
tricky (more discussion of this in #12797):

- (1) We compare_and_append and get an Indeterminate error back from
  CRDB/Consensus. This means we don't know if it committed or not.
- (2) We retry it.
- (3) We get back an upper mismatch. The tricky bit is deciding if we
  conflicted with some other writer OR if the write in (1) actually
  went through and we're "conflicting" with ourself.

A number of scenarios can be distinguished with per-writer
idempotency tokens, so I'll jump straight to the hardest one:

- (1) A compare_and_append is issued for e.g. `[5,7)`, the consensus
  call makes it onto the network before the operation is cancelled
  (by dropping the future).
- (2) A compare_and_append is issued from the same WriteHandle for
  `[3,5)`, it uses a different conn from the consensus pool and gets
  an Indeterminate error.
- (3) The call in (1) is received by consensus and commits.
- (4) The retry of (2) receives an upper mismatch with an upper of 7.

At this point, how do we determine whether (2) committed or not and
thus whether we should return success or upper mismatch? Getting this
right is very important for correctness (imagine this is a table
write and we either return success or failure to the client).

- If we use per-writer IdempotencyTokens but only store the latest
  one in state, then the `[5,7)` one will have clobbered whatever our
  `[3,5)` one was.
- We could store every IdempotencyToken that ever committed, but that
  would require unbounded storage in state (non-starter).
- We could require that IdempotencyTokens are comparable and that
  each call issued by a WriteHandle uses one that is strictly greater
  than every call before it. A previous version of this PR tried this
  and it's remarkably subtle. As a result, I (Dan) have developed
  strong feels that our correctness protocol _should not depend on
  WriteHandle, only Machine_.
- We could require a new WriterId if a request is ever cancelled by
  making `compare_and_append` take ownership of `self` and then
  handing it back for any call polled to completion. The ergonomics
  of this are quite awkward and, like the previous idea, it depends
  on the WriteHandle impl for correctness.
- Any ideas that involve reading back the data are foiled by a step
  `(0) set the since to 100` (plus the latency and memory usage would
  be too unpredictable).

The technique used here derives from the following observations:

- In practice, we don't use compare_and_append with the sort of
  "regressing frontiers" described above.
- In practice, Indeterminate errors are rare-ish. They happen enough
  that we don't want to always panic on them, but this is still a
  useful property to build on.

At a high level, we do just enough to be able to distinguish the
cases that we think will happen in practice and then leave the rest
for a panic! that we think we'll never see. Concretely:

- Run compare_and_append in a loop, retrying on Indeterminate errors
  but noting if we've ever done that.
- If we haven't seen an Indeterminate error (i.e. this is the first
  time though the loop) then the result we got is guaranteed to be
  correct, so pass it up.
- Otherwise, any result other than an expected upper mismatch is
  guaranteed to be correct, so just pass it up.
- Otherwise examine the writer's most recent upper and break it into
  two cases:
- Case 1 `expected_upper.less_than(writer_most_recent_upper)`: it's
  impossible that we committed on a previous iteration because the
  overall upper of the shard is less_than what this call would have
  advanced it to. Pass up the expectation mismatch.
- Case 2 `!Case1`: First note that this means our IdempotencyToken
  didn't match, otherwise we would have gotten `AlreadyCommitted`. It
  also means some previous write from _this writer_ has committed an
  upper that is beyond the one in this call, which is a weird usage
  (NB can't be a future write because that would mean someone is
  still polling us, but `&mut self` prevents that).

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
