### PR TITLE
catalog: Move migration comment

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -262,24 +262,6 @@ async fn migrate<S: Append>(
             })?;
             Ok(())
         },
-        // Add new migrations here.
-        //
-        // Migrations should be preceded with a comment of the following form:
-        //
-        //     > Short summary of migration's purpose.
-        //     >
-        //     > Introduced in <VERSION>.
-        //     >
-        //     > Optional additional commentary about safety or approach.
-        //
-        // Please include @mjibson and @jkosh44 on any code reviews that add or
-        // edit migrations.
-        // Migrations must preserve backwards compatibility with all past releases
-        // of Materialize. Migrations can be edited up until they ship in a
-        // release, after which they must never be removed, only patched by future
-        // migrations. Migrations must be transactional or idempotent (in case of
-        // midway failure).
-
         // Fill in non-optional availability zone
         // Introduced in alpha.4
         |txn: &mut Transaction<'_, S>, bootstrap_args| {
@@ -337,6 +319,23 @@ async fn migrate<S: Append>(
             })?;
             Ok(())
         },
+        // Add new migrations here.
+        //
+        // Migrations should be preceded with a comment of the following form:
+        //
+        //     > Short summary of migration's purpose.
+        //     >
+        //     > Introduced in <VERSION>.
+        //     >
+        //     > Optional additional commentary about safety or approach.
+        //
+        // Please include @mjibson and @jkosh44 on any code reviews that add or
+        // edit migrations.
+        // Migrations must preserve backwards compatibility with all past releases
+        // of Materialize. Migrations can be edited up until they ship in a
+        // release, after which they must never be removed, only patched by future
+        // migrations. Migrations must be transactional or idempotent (in case of
+        // midway failure).
     ];
 
     let mut txn = transaction(stash).await?;


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
