### PR TITLE
sqllogictest: fix postgres image version

### DIFF
--- a/test/sqllogictest/mzcompose.py
+++ b/test/sqllogictest/mzcompose.py
@@ -11,7 +11,7 @@ from materialize import ROOT, ci_util
 from materialize.mzcompose import Composition
 from materialize.mzcompose.services import Postgres, SqlLogicTest
 
-SERVICES = [Postgres(), SqlLogicTest()]
+SERVICES = [Postgres(image="postgres:14.4"), SqlLogicTest()]
 
 
 def workflow_default(c: Composition) -> None:


### PR DESCRIPTION
mzcompose's default Postgres image uses postgres 10. That's probably a
latent mzcompose bug and deviates greatly from all the cloud stuff that
has happened recently, and should be fixed in mzcompose more generally.

For now, bump slt tests to use a recent postgres version. Maybe this
will help the recent postgres stash flakes.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a