### PR TITLE
adapter,stash: add various tracing

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2991,6 +2991,7 @@ impl<S: Append> Catalog<S> {
         Ok(storage_host_config)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn transact<F, T>(
         &mut self,
         session: Option<&Session>,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -765,6 +765,7 @@ impl<S: Append> Connection<S> {
     }
 }
 
+#[tracing::instrument(level = "trace", skip_all)]
 pub async fn transaction<'a, S: Append>(stash: &'a mut S) -> Result<Transaction<'a, S>, Error> {
     let databases = COLLECTION_DATABASE.peek_one(stash).await?;
     let schemas = COLLECTION_SCHEMA.peek_one(stash).await?;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -201,6 +201,7 @@ pub trait Stash: std::fmt::Debug + Send {
     ///
     /// Sealed entries are those with timestamps less than the collection's upper
     /// frontier.
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn peek_key_one<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
@@ -637,6 +638,7 @@ where
         stash.peek_one(collection).await
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     pub async fn peek_key_one(
         &self,
         stash: &mut impl Stash,

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -210,6 +210,7 @@ impl Postgres {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn transact_inner<F, T>(&mut self, f: &F) -> Result<T, StashError>
     where
         F: for<'a> Fn(&'a mut Transaction) -> BoxFuture<'a, Result<T, StashError>>,
@@ -504,6 +505,7 @@ impl Stash for Postgres {
         .await
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn iter_key<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
@@ -679,6 +681,7 @@ impl Stash for Postgres {
     }
 
     /// Reports the current since frontier.
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn since<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
@@ -692,6 +695,7 @@ impl Stash for Postgres {
     }
 
     /// Reports the current upper frontier.
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn upper<K, V>(
         &mut self,
         collection: StashCollection<K, V>,


### PR DESCRIPTION
Adds some useful stash tracing.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a