### PR TITLE
github: add assignee to notify workflow

### DIFF
--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (https://github.com/MaterializeInc/materialize/issues/${{ github.event.issue.number }}).
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}).
           channel: github-p1
           color: red
           verbose: false
@@ -44,7 +44,7 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (https://github.com/MaterializeInc/materialize/issues/${{ github.event.issue.number }}).
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}).
           channel: github-triage
           color: red
           verbose: false

--- a/.github/workflows/slack_notify.yml
+++ b/.github/workflows/slack_notify.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}).
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
           channel: github-p1
           color: red
           verbose: false
@@ -44,7 +44,7 @@ jobs:
         with:
           slack_token: ${{ secrets.SLACK_TOKEN }}
           message: |
-            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}).
+            `${{ github.event.label.name }}` label has been added to "${{ github.event.issue.title }}" (${{ github.event.issue.html_url }}) (assigned to: ${{ github.event.issue.assignee.login || 'unassigned' }}).
           channel: github-triage
           color: red
           verbose: false


### PR DESCRIPTION
### Motivation

Per request of the product team, add the assignee to the Slack message.

### Checklist

  - No user-facing behavior changes
