### PR TITLE
persist: also update WriteHandle upper in fetch_recent_upper

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -932,8 +932,9 @@ mod tests {
         // The shard-global upper does advance, even if this writer didn't advance its local upper.
         assert_eq!(write2.fetch_recent_upper().await, Antichain::from_elem(3));
 
-        // The writer-local upper should not advance if another writer advances the frontier.
-        assert_eq!(write2.upper().clone(), Antichain::from_elem(0));
+        // The writer-local upper should advance, even if it was another writer
+        // that advanced the frontier.
+        assert_eq!(write2.upper().clone(), Antichain::from_elem(3));
     }
 
     #[tokio::test]

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -108,9 +108,9 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {
-    /// This handle's `upper` frontier.
+    /// A cached version of the shard-global `upper` frontier.
     ///
-    /// This will always be greater or equal to the shard-global `upper`.
+    /// This will always be less or equal to the shard-global `upper`.
     pub fn upper(&self) -> &Antichain<T> {
         &self.upper
     }
@@ -123,7 +123,11 @@ where
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn fetch_recent_upper(&mut self) -> Antichain<T> {
         trace!("WriteHandle::fetch_recent_upper");
-        self.machine.fetch_upper().await
+        // TODO: Do we even need to track self.upper on WriteHandle or could
+        // WriteHandle::upper just get the one out of machine?
+        let fresh_upper = self.machine.fetch_upper().await;
+        self.upper.clone_from(&fresh_upper);
+        fresh_upper
     }
 
     /// Applies `updates` to this shard and downgrades this handle's upper to


### PR DESCRIPTION
This fixes a bug where calling fetch_recent_upper didn't also advance
the self.upper field that powers `WriteHandle::upper`.

Also added a note that we might not even need to cache upper on
WriteHandle, since it should be redundant with info that's already in
machine+state. Didn't make that change here because I wanted to get this
fix out without having to think through the implications of making a
larger change.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
