### PR TITLE
COORD: Add a new unexpected-type error to improve messages

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -44,8 +44,8 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Expr;
 use mz_sql::catalog::{
     CatalogDatabase, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
-    CatalogItemType as SqlCatalogItemType, CatalogSchema, CatalogType, CatalogTypeDetails,
-    IdReference, NameReference, SessionCatalog, TypeReference,
+    CatalogItemType as SqlCatalogItemType, CatalogItemType, CatalogSchema, CatalogType,
+    CatalogTypeDetails, IdReference, NameReference, SessionCatalog, TypeReference,
 };
 use mz_sql::names::{
     Aug, DatabaseId, FullObjectName, ObjectQualifiers, PartialObjectName, QualifiedObjectName,
@@ -1251,14 +1251,20 @@ impl CatalogItem {
     ) -> Result<&'static mz_sql::func::Func, SqlCatalogError> {
         match &self {
             CatalogItem::Func(func) => Ok(func.inner),
-            _ => Err(SqlCatalogError::UnknownFunction(name.item.to_string())),
+            _ => Err(SqlCatalogError::UnexpectedType(
+                name.item.to_string(),
+                CatalogItemType::Func,
+            )),
         }
     }
 
     pub fn source_desc(&self, name: &QualifiedObjectName) -> Result<&SourceDesc, SqlCatalogError> {
         match &self {
             CatalogItem::Source(source) => Ok(&source.source_desc),
-            _ => Err(SqlCatalogError::UnknownSource(name.item.clone())),
+            _ => Err(SqlCatalogError::UnexpectedType(
+                name.item.clone(),
+                CatalogItemType::Source,
+            )),
         }
     }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -569,8 +569,8 @@ impl fmt::Display for CatalogError {
                 write!(f, "unknown cluster replica '{}'", name)
             }
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
-            Self::UnexpectedType(name, cit) => {
-                write!(f, "\"{name}\" is not of type {cit}")
+            Self::UnexpectedType(name, item_type) => {
+                write!(f, "\"{name}\" is not of type {item_type}")
             }
             Self::InvalidDependency { name, typ } => write!(
                 f,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -543,10 +543,10 @@ pub enum CatalogError {
     UnknownItem(String),
     /// Unknown function.
     UnknownFunction(String),
-    /// Unknown source.
-    UnknownSource(String),
     /// Unknown connection.
     UnknownConnection(String),
+    /// Expected the catalog item to have the given type, but it did not.
+    UnexpectedType(String, CatalogItemType),
     /// Invalid attempt to depend on a non-dependable item.
     InvalidDependency {
         /// The invalid item's name.
@@ -561,7 +561,9 @@ impl fmt::Display for CatalogError {
         match self {
             Self::UnknownDatabase(name) => write!(f, "unknown database '{}'", name),
             Self::UnknownFunction(name) => write!(f, "function \"{}\" does not exist", name),
-            Self::UnknownSource(name) => write!(f, "source \"{}\" does not exist", name),
+            Self::UnexpectedType(name, cit) => {
+                write!(f, "\"{name}\" is not of type {cit}")
+            }
             Self::UnknownConnection(name) => write!(f, "connection \"{}\" does not exist", name),
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -561,9 +561,6 @@ impl fmt::Display for CatalogError {
         match self {
             Self::UnknownDatabase(name) => write!(f, "unknown database '{}'", name),
             Self::UnknownFunction(name) => write!(f, "function \"{}\" does not exist", name),
-            Self::UnexpectedType(name, cit) => {
-                write!(f, "\"{name}\" is not of type {cit}")
-            }
             Self::UnknownConnection(name) => write!(f, "connection \"{}\" does not exist", name),
             Self::UnknownSchema(name) => write!(f, "unknown schema '{}'", name),
             Self::UnknownRole(name) => write!(f, "unknown role '{}'", name),
@@ -572,6 +569,9 @@ impl fmt::Display for CatalogError {
                 write!(f, "unknown cluster replica '{}'", name)
             }
             Self::UnknownItem(name) => write!(f, "unknown catalog item '{}'", name),
+            Self::UnexpectedType(name, cit) => {
+                write!(f, "\"{name}\" is not of type {cit}")
+            }
             Self::InvalidDependency { name, typ } => write!(
                 f,
                 "catalog item '{}' is {} {} and so cannot be depended upon",


### PR DESCRIPTION
In #13682, we spotted an incorrect error message -- the error said a
particular name did not exist, where in fact it did but just had an
unexpected type. Add a new error type to represent this, convert
a couple methods that ought to be using it, and remove the old type.

### Motivation

This doesn't fix the core issue in #13682, but ought to improve the user's experience in general and make similar things easier to diagnose.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

(This is technically user-visible, but I suspect does not require a release note. Happy to add one on request!)