### PR TITLE
[process orchestrator] harden local file deletes

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -180,14 +180,15 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                 self.data_dir.join(format!("{}.ports", process_file_name));
             port_metadata_file_locations[i] = Some(port_metadata_file_location.clone());
 
-            if pid_file_location.exists() && port_metadata_file_location.exists() {
+            if let (Ok(pid), Ok(port_metadata)) = (
+                PidFile::read(&pid_file_location),
+                PortMetadataFile::read(&port_metadata_file_location),
+            ) {
                 let system = system.get_or_insert_with(|| {
                     sysinfo::System::new_with_specifics(
                         RefreshKind::new().with_processes(Default::default()),
                     )
                 });
-                let pid = PidFile::read(&pid_file_location)?;
-                let port_metadata = PortMetadataFile::read(&port_metadata_file_location)?;
                 if let Some(process) = system.process(pid.into()) {
                     if process.exe() == path {
                         if process.status() == ProcessStatus::Dead

--- a/src/orchestrator-process/src/port_metadata_file.rs
+++ b/src/orchestrator-process/src/port_metadata_file.rs
@@ -68,6 +68,10 @@ impl<P: AsRef<Path>> PortMetadataFile<P> {
 impl<P: AsRef<Path>> Drop for PortMetadataFile<P> {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);
+        // Best effort attempt to fsync the delete.
+        if let Some(parent_path) = self.path.as_ref().parent() {
+            let _ = std::fs::File::open(parent_path).and_then(|h| h.sync_all());
+        }
     }
 }
 


### PR DESCRIPTION
Make a couple changes to harden the use of the temporary files for the ProcessOrchestrator:
- `fsync` the parent directory after deleting the port metadata file.  This will ensure that we will not be able to read it again in the future.  (the std lib finally uses `F_FULLFSYNC` on osx!)
- Remove the ability for a race between checking for file existence and opening them
- Explicitly drop the process handles in `drop_service` to make it clear that we need this to remove the temp files before the service is fully dropped

I'm pretty sure the `fsync` fix is the one that actually acutely fixes my issue but I threw the other ones in just for thoroughness sake

### Motivation
I ran into this while writing up #14009 where we stop a storaged process and immediately turn it back on again

### Checklist
existing tests should be fine.  testing fsync is basically impossible