### PR TITLE
[sinks] Add SinkConnectionState to indicate replacing temporary sink

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -539,7 +539,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     // Re-create the sink on the compute instance.
                     let builder = match &sink.connection {
                         SinkConnectionState::Pending(builder) => builder,
-                        SinkConnectionState::Ready(_) => {
+                        SinkConnectionState::Finalizing(_) | SinkConnectionState::Ready(_) => {
                             panic!("sink already initialized during catalog boot")
                         }
                     };


### PR DESCRIPTION
Currently when processing the `DropItem` in `catalog_transact`, because the catalog sees the temporary sink with state `SinkConnectionState::Pending`, we do the following:
- Do not drop it from the sinks system table.  This is the correct behavior! But also why just updating to Ready before calling `catalog_transact` won't work.  If it is dropped, the drop from the temp sink and the add from the permanent sink will cancel out and we will have no sinks in the system catalog (e.g. `SHOW SINKS`)
- We do not call `drop_sink` with the id -- which means we're not cleaning up the temporary sink properly.  This became more noticeable when writing #14009 because, in that PR, we create a storaged process for the temporary sink, kill it, and then recreate one for the permanent sink.

I added the `SinkConnectionState::Finalizing(_)` state to indicate that we should not drop the sink from the system table but also call `drop_sink` on the temporary sink.

### Motivation
Splitting out part of #14009 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
