### PR TITLE
Prepare for mz-avro bump on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2952,7 +2952,7 @@ dependencies = [
 
 [[package]]
 name = "mz-avro"
-version = "0.6.5"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/src/avro/Cargo.toml
+++ b/src/avro/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
 name = "mz-avro"
 description = "Library for working with Apache Avro in Rust"
-version = "0.6.5"
+version = "0.7.0"
 authors = [
-    "Brennan Vincent <brennan@materialize.io>",
-    "Jessica Laughlin <jessica@materialize.io>",
+    "Brennan Vincent <brennan@materialize.com>",
 ]
 license = "Apache-2.0"
 repository = "https://github.com/MaterializeInc/materialize"


### PR DESCRIPTION
Bump the version number so we can put something on crates.io to replace the ancient 0.6.5

### Motivation

The old version of the published crate can technically cause UB: https://github.com/MaterializeInc/materialize/issues/8669

Thus, I have yanked it. I'm not sure if anyone out there is actually using the published version of the crate, but just in case, we might as well publish a new one with a new version number.

I have also removed @JLDLaughlin from the list of maintainers as she has no longer been working on the Avro decoder for some years, and probably doesn't want more jobs than she already has :) 
