### PR TITLE
coord: Advance timelines when creating new obj

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1261,13 +1261,13 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
 
+                self.ship_dataflow(df, compute_instance).await;
+
                 self.initialize_storage_read_policies(
                     vec![id],
                     DEFAULT_LOGICAL_COMPACTION_WINDOW_MS,
                 )
                 .await;
-
-                self.ship_dataflow(df, compute_instance).await;
 
                 Ok(ExecuteResponse::CreatedMaterializedView { existed: false })
             }

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -422,6 +422,17 @@ impl<S: Append + 'static> Coordinator<S> {
             .expect("inserted above")
     }
 
+    /// Ensures that a global timeline state exists for `timeline`.
+    pub(crate) async fn ensure_and_take_timeline_state(
+        &mut self,
+        timeline: Timeline,
+    ) -> TimelineState<Timestamp> {
+        self.ensure_timeline_state(timeline.clone()).await;
+        self.global_timelines
+            .remove(&timeline)
+            .expect("inserted above")
+    }
+
     pub(crate) fn remove_storage_ids_from_timeline<I>(&mut self, ids: I) -> Vec<Timeline>
     where
         I: IntoIterator<Item = GlobalId>,


### PR DESCRIPTION
If an object is created with an initial read frontier that is larger
than the current timestamp of the timeline that object belongs to, then
we must advance that timeline to the frontier of that object. This
commit updates the code to do that.

The alternative would be to wait until the timeline catches up to the
object and then add the object to the timeline.

Fixes #14136

### Motivation

This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
