### PR TITLE
testdrive: use a useful Postgres default image

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -459,13 +459,12 @@ class Postgres(Service):
     def __init__(
         self,
         name: str = "postgres",
-        mzbuild: str = "postgres",
-        image: Optional[str] = None,
+        image: str = "postgres:14.4",
         port: int = 5432,
         command: str = "postgres -c wal_level=logical -c max_wal_senders=20 -c max_replication_slots=20 -c max_connections=5000",
         environment: List[str] = ["POSTGRESDB=postgres", "POSTGRES_PASSWORD=postgres"],
     ) -> None:
-        config: ServiceConfig = {"image": image} if image else {"mzbuild": mzbuild}
+        config: ServiceConfig = {"image": image}
         config.update(
             {
                 "command": command,

--- a/test/pg-cdc/mzcompose.py
+++ b/test/pg-cdc/mzcompose.py
@@ -14,7 +14,8 @@ SERVICES = [
     Materialized(volumes_extra=["secrets:/share/secrets"]),
     Testdrive(),
     TestCerts(),
-    Postgres(),
+    # TODO: Use the default Postgres image.
+    Postgres(image="postgres:10.21"),
 ]
 
 

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -17,15 +17,12 @@ from materialize.mzcompose.services import (
     Zookeeper,
 )
 
-testdrive_no_reset = Testdrive(name="testdrive_no_reset", no_reset=True)
-
 SERVICES = [
     Zookeeper(),
     Kafka(auto_create_topics=True),
     SchemaRegistry(),
     Materialized(),
     Testdrive(),
-    testdrive_no_reset,
     Postgres(),
 ]
 

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -99,9 +99,8 @@ def workflow_stash(c: Composition) -> None:
     materialized = Materialized(
         options=["--adapter-stash-url", "postgres://postgres:postgres@postgres"],
     )
-    postgres = Postgres(image="postgres:14.4")
 
-    with c.override(materialized, postgres):
+    with c.override(materialized):
         c.up("postgres")
         c.wait_for_postgres()
         c.start_and_wait_for_tcp(services=["materialized"])


### PR DESCRIPTION
mzcompose's default Postgres image uses postgres 10 due to some mzbuild stuff that seems unused now. Remove the mzbuild stuff for Postgres and just make it always use a recent version.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a