### PR TITLE
platform checks: Add a scenario that restarts Redpanda

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -45,6 +45,7 @@ steps:
           - { value: checks-oneatatime-restart-environmentd-storaged }
           - { value: checks-oneatatime-kill-storaged }
           - { value: checks-oneatatime-restart-postgres-backend }
+          - { value: checks-oneatatime-restart-redpanda }
           - { value: checks-upgrade-entire-mz }
           - { value: checks-upgrade-computed-first }
           - { value: checks-upgrade-computed-last }
@@ -380,6 +381,16 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
+
+  - id: checks-oneatatime-restart-redpanda
+    label: "Checks oneatatime + restart Redpanda"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartRedpanda, --execution-mode=oneatatime]
 
   - id: checks-upgrade-entire-mz
     label: "Upgrade entire Mz from v0.27.0-alpha.23"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -541,6 +541,16 @@ steps:
       - ./ci/plugins/cloudtest:
           args: [-m, "not long", test/cloudtest/]
 
+  - id: checks-restart-redpanda
+    label: "Checks + restart Redpanda"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartRedpanda]
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build-x86_64

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -105,6 +105,14 @@ class StartComputed(MzcomposeAction):
             c.up("computed_1")
 
 
+class RestartRedpanda(MzcomposeAction):
+    def execute(self, e: Executor) -> None:
+        c = e.mzcompose_composition()
+
+        c.kill("redpanda")
+        c.start_and_wait_for_tcp(services=["redpanda"])
+
+
 class RestartPostgresBackend(MzcomposeAction):
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -29,6 +29,9 @@ from materialize.checks.mzcompose_actions import (
     RestartPostgresBackend as RestartPostgresBackendAction,
 )
 from materialize.checks.mzcompose_actions import (
+    RestartRedpanda as RestartRedpandaAction,
+)
+from materialize.checks.mzcompose_actions import (
     RestartSourcePostgres as RestartSourcePostgresAction,
 )
 from materialize.checks.mzcompose_actions import StartComputed, StartMz, UseComputed
@@ -169,5 +172,19 @@ class RestartSourcePostgres(Scenario):
             RestartSourcePostgresAction(),
             Manipulate(self.checks, phase=2),
             RestartSourcePostgresAction(),
+            Validate(self.checks),
+        ]
+
+
+class RestartRedpanda(Scenario):
+    def actions(self) -> List[Action]:
+        return [
+            StartMz(),
+            Initialize(self.checks),
+            RestartRedpandaAction(),
+            Manipulate(self.checks, phase=1),
+            RestartRedpandaAction(),
+            Manipulate(self.checks, phase=2),
+            RestartRedpandaAction(),
             Validate(self.checks),
         ]

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -544,8 +544,8 @@ impl KafkaSinkState {
                     Ok(result) => Ok(result),
                     Err(KafkaError::Transaction(e)) if e.txn_requires_abort() => {
                         info!("error requiring txn abort in kafka sink: {:?}", e);
-                        self.abort_active_txn().await;
-                        Err(KafkaError::Transaction(e))
+                        let () = self.abort_active_txn().await;
+                        panic!("shutting down due error requiring txn abort in kafka sink: {e:?}");
                     }
                     Err(KafkaError::Transaction(e)) if e.is_retriable() => {
                         info!("retriable error in kafka sink: {e:?}; will retry");

--- a/src/storage/src/sink/sink_connection.rs
+++ b/src/storage/src/sink/sink_connection.rs
@@ -264,7 +264,6 @@ async fn build_kafka(
         value_desc: builder.value_desc,
         published_schema_info,
         progress,
-        exactly_once: true,
         fuel: builder.fuel,
     }))
 }

--- a/src/storage/src/types/sinks.proto
+++ b/src/storage/src/types/sinks.proto
@@ -62,11 +62,7 @@ message ProtoKafkaSinkConnection {
         repeated uint64 relation_key_indices = 1;
     }
 
-
-    // Fields of previous versions:
-    //  - string topic_prefix = 3;
-    //  - repeated mz_repr.global_id.ProtoGlobalId transitive_source_dependencies = 10;
-    reserved 3, 10;
+    reserved 3, 9, 10;
 
     mz_repr.global_id.ProtoGlobalId connection_id = 13;
     mz_storage.types.connections.ProtoKafkaConnection connection = 1;
@@ -76,7 +72,6 @@ message ProtoKafkaSinkConnection {
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
     optional ProtoPublishedSchemaInfo published_schema_info = 7;
     ProtoKafkaSinkProgressConnection progress = 8;
-    bool exactly_once = 9;
     uint64 fuel = 11;
     map<string, mz_storage.types.connections.ProtoStringOrSecret> options = 12;
 }

--- a/src/storage/src/types/sinks.rs
+++ b/src/storage/src/types/sinks.rs
@@ -247,7 +247,6 @@ pub struct KafkaSinkConnection {
     pub value_desc: RelationDesc,
     pub published_schema_info: Option<PublishedSchemaInfo>,
     pub progress: KafkaSinkProgressConnection,
-    pub exactly_once: bool,
     // Maximum number of records the sink will attempt to send each time it is
     // invoked
     pub fuel: usize,
@@ -276,7 +275,6 @@ proptest::prop_compose! {
         value_desc in any::<RelationDesc>(),
         published_schema_info in any::<Option<PublishedSchemaInfo>>(),
         progress in any::<KafkaSinkProgressConnection>(),
-        exactly_once in any::<bool>(),
         fuel in any::<usize>(),
     ) -> KafkaSinkConnection {
         KafkaSinkConnection {
@@ -289,7 +287,6 @@ proptest::prop_compose! {
             value_desc,
             published_schema_info,
             progress,
-            exactly_once,
             fuel,
         }
     }
@@ -354,7 +351,6 @@ impl RustType<ProtoKafkaSinkConnection> for KafkaSinkConnection {
             value_desc: Some(self.value_desc.into_proto()),
             published_schema_info: self.published_schema_info.into_proto(),
             progress: Some(self.progress.into_proto()),
-            exactly_once: self.exactly_once,
             fuel: self.fuel.into_proto(),
         }
     }
@@ -384,7 +380,6 @@ impl RustType<ProtoKafkaSinkConnection> for KafkaSinkConnection {
             progress: proto
                 .progress
                 .into_rust_if_some("ProtoKafkaSinkConnection::progress")?,
-            exactly_once: proto.exactly_once,
             fuel: proto.fuel.into_rust()?,
         })
     }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
