### PR TITLE
Update CONNECTION docs to specify PEM format for SSL query options

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -29,9 +29,9 @@ Field                       | Value            | Required | Description
 ----------------------------|------------------|:--------:|------------------
 `BROKER`                    | `text`           | ✓        | The Kafka bootstrap server. Exclusive with `BROKERS`.
 `BROKERS`                   | `text[]`         |          | A comma-separated list of Kafka bootstrap servers. Exclusive with `BROKER`.
-`SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
-`SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate. Required for SSL client authentication.
-`SSL KEY`                   | secret           | ✓        | Your SSL certificate's key. Required for SSL client authentication.
+`SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate in PEM format. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
+`SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate in PEM format. Required for SSL client authentication.
+`SSL KEY`                   | secret           | ✓        | Your SSL certificate's key in PEM format. Required for SSL client authentication.
 
 ##### Example
 
@@ -51,9 +51,9 @@ CREATE CONNECTION kafka_connection
 Field                       | Value            | Required | Description
 ----------------------------|------------------|:--------:| ------------
 `URL`                       | `text`           | ✓        | The schema registry URL.
-`SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
-`SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate. Required for SSL client authentication.
-`SSL KEY`                   | secret           | ✓        | Your SSL certificate's key. Required for SSL client authentication.
+`SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate in PEM format. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
+`SSL CERTIFICATE`           | secret or `text` | ✓        | Your SSL certificate in PEM format. Required for SSL client authentication.
+`SSL KEY`                   | secret           | ✓        | Your SSL certificate's key in PEM format. Required for SSL client authentication.
 `PASSWORD`                  | secret           |          | The password used to connect to the schema registry with basic HTTP authentication. This is compatible with the `ssl` options, which control the transport between Materialize and the CSR.
 `USERNAME`                  | secret or `text` |          | The username used to connect to the schema registry with basic HTTP authentication. This is compatible with the `ssl` options, which control the transport between Materialize and the CSR.
 
@@ -110,10 +110,10 @@ Field                       | Value            | Required | Description
 `PORT`                      | `int4`           |          | Default: `5432`. Port number to connect to at the server host.
 `PASSWORD`                  | secret           |          | Password for the connection
 `SSH TUNNEL`                | `text`           |          | `SSH TUNNEL` connection name. See [SSH tunneling](#postgres-ssh).
-`SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
+`SSL CERTIFICATE AUTHORITY` | secret or `text` |          | The absolute path to the certificate authority (CA) certificate in PEM format. Used for both SSL client and server authentication. If unspecified, uses the system's default CA certificates.
 `SSL MODE`                  | `text`           |          | Default: `disable`. Enables SSL connections if set to `require`, `verify_ca`, or `verify_full`.
-`SSL CERTIFICATE`           | secret or `text` |          | Client SSL certificate.
-`SSL KEY`                   | secret           |          | Client SSL key.
+`SSL CERTIFICATE`           | secret or `text` |          | Client SSL certificate in PEM format.
+`SSL KEY`                   | secret           |          | Client SSL key in PEM format.
 `USER`                      | `text`           | ✓        | Database username.
 
 ##### Example


### PR DESCRIPTION
Addressing issue https://github.com/MaterializeInc/materialize/issues/13500. This change updates docs to make required format more clear for all `SSL` query options in `CONNECTION`. 

### Motivation

This PR adds a known-desirable feature.

### Tips for reviewer

This is a purely docs change.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

No user-facing behavior changes, only user-facing docs changes.