### PR TITLE
Refresh read leases in storage controller

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1156,91 +1156,116 @@ mod persist_read_handles {
                 let mut read_handles: BTreeMap<GlobalId, ReadHandle<SourceData, (), T, Diff>> =
                     BTreeMap::new();
 
-                while let Some(cmd) = rx.recv().await {
-                    // Peel off all available commands.
-                    // This allows us to catch up if we fall behind on downgrade commands.
-                    let mut commands = vec![cmd];
-                    while let Ok(cmd) = rx.try_recv() {
-                        commands.push(cmd);
-                    }
-                    // Collect all downgrade requests and apply them last.
-                    let mut downgrades = BTreeMap::default();
-                    let mut shutdown = false;
+                let mut shutdown = false;
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+                while !shutdown {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            // Ideally we would use the code below, but the `since`
+                            // lifetime expires to early for the future, or somesuch.
 
-                    for (span, command) in commands {
-                        match command {
-                            PersistWorkerCmd::Register(id, read_handle) => {
-                                let previous = read_handles.insert(id, read_handle);
-                                if previous.is_some() {
-                                    panic!(
-                                        "already registered a ReadHandle for collection {:?}",
-                                        id
-                                    );
-                                }
+                            // let futs = FuturesUnordered::new();
+                            // for (_id, read) in read_handles.iter_mut() {
+                            //     let since = read.since().clone();
+                            //     futs.push(read.maybe_downgrade_since(&since));
+                            // }
+                            // futs.collect::<Vec<_>>().await;
+
+                            // Instead we use this code, which has a longer critical path.
+                            let mut since = Antichain::new();
+                            for (_id, read) in read_handles.iter_mut() {
+                                since.clone_from(read.since());
+                                read.maybe_downgrade_since(&since).await;
                             }
-                            PersistWorkerCmd::Downgrade(since_frontiers) => {
-                                for (id, frontier) in since_frontiers {
-                                    downgrades.insert(id, (span.clone(), frontier));
+                        },
+                        cmd = rx.recv() => {
+                            if let Some(cmd) = cmd {
+                                // Peel off all available commands.
+                                // This allows us to catch up if we fall behind on downgrade commands.
+                                let mut commands = vec![cmd];
+                                while let Ok(cmd) = rx.try_recv() {
+                                    commands.push(cmd);
                                 }
-                            }
-                            PersistWorkerCmd::Snapshot(id, as_of, oneshot) => {
-                                async fn snapshot<T2: Timestamp + Lattice + Codec64>(
-                                    read_handle: &mut ReadHandle<SourceData, (), T2, Diff>,
-                                    id: GlobalId,
-                                    as_of: Antichain<T2>,
-                                ) -> Result<Vec<(Row, Diff)>, StorageError>
-                                {
-                                    let mut contents = Vec::new();
-                                    for ((source_data, _pid), _ts, diff) in read_handle
-                                        .snapshot_and_fetch(as_of)
-                                        .await
-                                        .map_err(|_| StorageError::ReadBeforeSince(id))?
-                                    {
-                                        let row = source_data.expect("cannot read snapshot").0?;
-                                        contents.push((row, diff));
+                                // Collect all downgrade requests and apply them last.
+                                let mut downgrades = BTreeMap::default();
+
+                                for (span, command) in commands {
+                                    match command {
+                                        PersistWorkerCmd::Register(id, read_handle) => {
+                                            let previous = read_handles.insert(id, read_handle);
+                                            if previous.is_some() {
+                                                panic!(
+                                                    "already registered a ReadHandle for collection {:?}",
+                                                    id
+                                                );
+                                            }
+                                        }
+                                        PersistWorkerCmd::Downgrade(since_frontiers) => {
+                                            for (id, frontier) in since_frontiers {
+                                                downgrades.insert(id, (span.clone(), frontier));
+                                            }
+                                        }
+                                        PersistWorkerCmd::Snapshot(id, as_of, oneshot) => {
+                                            async fn snapshot<T2: Timestamp + Lattice + Codec64>(
+                                                read_handle: &mut ReadHandle<SourceData, (), T2, Diff>,
+                                                id: GlobalId,
+                                                as_of: Antichain<T2>,
+                                            ) -> Result<Vec<(Row, Diff)>, StorageError>
+                                            {
+                                                let mut contents = Vec::new();
+                                                for ((source_data, _pid), _ts, diff) in read_handle
+                                                    .snapshot_and_fetch(as_of)
+                                                    .await
+                                                    .map_err(|_| StorageError::ReadBeforeSince(id))?
+                                                {
+                                                    let row = source_data.expect("cannot read snapshot").0?;
+                                                    contents.push((row, diff));
+                                                }
+
+                                                Ok(contents)
+                                            }
+
+                                            if let Some(read_handle) = read_handles.get_mut(&id) {
+                                                let result = snapshot(read_handle, id, as_of)
+                                                    .instrument(span.clone())
+                                                    .await;
+                                                oneshot.send(result).expect("Oneshot should not fail");
+                                            } else {
+                                                oneshot
+                                                    .send(Err(StorageError::IdentifierMissing(id)))
+                                                    .expect("Oneshot should not fail");
+                                            }
+                                        }
+                                        PersistWorkerCmd::Shutdown => {
+                                            shutdown = true;
+                                        }
+                                    }
+                                }
+
+
+                                if !downgrades.is_empty() {
+                                    let futs = FuturesUnordered::new();
+
+                                    for (id, read) in read_handles.iter_mut() {
+                                        if let Some((span, since)) = downgrades.remove(id) {
+                                            let fut = async move {
+                                                read.downgrade_since(since).instrument(span).await;
+                                            };
+
+                                            futs.push(fut);
+                                        }
                                     }
 
-                                    Ok(contents)
+                                    assert!(downgrades.is_empty());
+                                    futs.collect::<Vec<_>>().await;
                                 }
-
-                                if let Some(read_handle) = read_handles.get_mut(&id) {
-                                    let result = snapshot(read_handle, id, as_of)
-                                        .instrument(span.clone())
-                                        .await;
-                                    oneshot.send(result).expect("Oneshot should not fail");
-                                } else {
-                                    oneshot
-                                        .send(Err(StorageError::IdentifierMissing(id)))
-                                        .expect("Oneshot should not fail");
-                                }
-                            }
-                            PersistWorkerCmd::Shutdown => {
+                            } else {
                                 shutdown = true;
                             }
                         }
                     }
-
-                    if !downgrades.is_empty() {
-                        let futs = FuturesUnordered::new();
-
-                        for (id, read) in read_handles.iter_mut() {
-                            if let Some((span, since)) = downgrades.remove(id) {
-                                let fut = async move {
-                                    read.downgrade_since(since).instrument(span).await;
-                                };
-
-                                futs.push(fut);
-                            }
-                        }
-
-                        assert!(downgrades.is_empty());
-                        futs.collect::<Vec<_>>().await;
-                    }
-                    if shutdown {
-                        tracing::trace!("shutting down persist since downgrade task");
-                        break;
-                    }
                 }
+                tracing::trace!("shutting down persist since downgrade task");
             });
 
             Self { tx }


### PR DESCRIPTION
The `ReadHandle`s held by the storage controller would lose their leases if they did not experience changes for 15 minutes. That can happen, because loading data is slow. For example, loading TPCH can take 30+ minutes, and if in that time one creates a MV based on the source, and then drops the MV later on, this will "unblock" compaction of the source, but in fact just causes a crash.

It seems plausible that there are other issues related to read handles that do not experience a change in `since` frontier, and so do not communicate with `persist`.

This PR adds a periodic wake up to the task managing the collections, in which it performs a no-op `maybe_downgrade_since` operation to refresh its leases on all read handles. 

tyvm to @pH14 for pointing out the lease expiration issue!

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

This code is not well written, and should be cleaned up! In particular, there is an example of better code we might use to perform the lease refresh concurrently, but the lifetimes were annoying and I wanted to head to bed. Someone else should pick this up! :D

Ignore whitespace to simplify the diff.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
