### PR TITLE
opentelemetry: increase largest trace we can collect into jaeger

### DIFF
--- a/misc/opentelemetry/mzcompose.py
+++ b/misc/opentelemetry/mzcompose.py
@@ -15,6 +15,7 @@ SERVICES = [
         {
             "image": "jaegertracing/all-in-one:1.36",
             "ports": ["16686:16686", 14268, 14250],
+            "command": "--collector.grpc-server.max-message-size=16777216",
             "allow_host_ports": True,
         },
     ),

--- a/misc/opentelemetry/otel-collector-config.yaml
+++ b/misc/opentelemetry/otel-collector-config.yaml
@@ -14,6 +14,7 @@ receivers:
     protocols:
       http:
       grpc:
+        max_recv_msg_size_mib: 16777216
 
 exporters:
   logging:


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

When running Jaeger locally, we're limited to traces that total to 4MB, the default grpc max message size. I found it easy to hit this limit when running various modules with `trace` level logging, so let's try increasing it.

### Motivation

* This PR refactors existing code.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
