### PR TITLE
Un-unsafify `CREATE SOURCE ... SIZE`

### DIFF
--- a/src/sql-parser/src/ast/display.rs
+++ b/src/sql-parser/src/ast/display.rs
@@ -42,6 +42,16 @@ where
     }
 }
 
+impl<'a, T> std::fmt::Display for DisplaySeparated<'a, T>
+where
+    T: AstDisplay,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        AstFormatter::new(f, FormatMode::Simple).write_node(self);
+        Ok(())
+    }
+}
+
 pub fn separated<'a, T>(slice: &'a [T], sep: &'static str) -> DisplaySeparated<'a, T>
 where
     T: AstDisplay,


### PR DESCRIPTION
Fully explained by title. (Assuming you accept "un-unsafify" as an English word)

### Motivation

We want people to be able to use this!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - The `SIZE` parameter can now be specified when creating a source.
