### PR TITLE
feat(doc/user) TTL Pattern

### DIFF
--- a/doc/user/content/sql/patterns/ttl.md
+++ b/doc/user/content/sql/patterns/ttl.md
@@ -1,0 +1,81 @@
+---
+title: "Time-To-Live"
+description: "Use the time-to-live pattern and assign an expiration time for a particular row."
+draft: true
+menu:
+  main:
+    parent: 'sql-patterns'
+---
+
+The TTL pattern helps assign an expiration time for a particular row. Before you dive in, make sure you understand how [temporal filters](/guides/temporal-filters/) work.
+
+A few examples of the use cases that you can achieve:
+
+- Free up memory
+- Schedule events, like emails or messages
+- Temporal offers for a store
+- Spam counters and blockers
+
+## How-to
+
+1. Identify the row, its initial time, and the time to live. The sum of these two values, `event_time` and `event_ttl`, returns the **expiry date**.
+    ```sql
+      CREATE TABLE events (event_name TEXT, event_time TIMESTAMP, event_ttl INTERVAL);
+
+      -- Sample (One minute time to live):
+      INSERT INTO events VALUES ('send_email', now(), INTERVAL '1 minute');
+    ```
+
+1. Create a view with a temporal filter filtering by the expiring date. Only **rows with a expiry date greater than** `mz_logical_timestamp()` **are made available**; otherwise, they get discarded.
+    ```sql
+      CREATE MATERIALIZED VIEW ttl_view AS
+      SELECT *
+      FROM events
+      WHERE mz_logical_timestamp() < extract(epoch from (event_time + event_ttl)) * 1000;
+    ```
+
+1. Use it in the way that best fits your use case.
+
+Here are some examples:
+
+- Run a query to know the remaining living time:
+  ```sql
+    SELECT
+      (extract(epoch from (event_time + event_ttl))) -
+      (mz_logical_timestamp() / 1000) AS remaining_block_time
+    FROM TTL_VIEW
+    WHERE event_name = 'send_email';
+  ```
+
+- Check if a particular row is still available:
+  ```sql
+  SELECT event_name as email_offer_is_available
+  FROM TTL_VIEW
+  WHERE event_name = 'special_offer';
+  ```
+
+- Run a tail and listen when the time to live is over:
+  ```sql
+    INSERT INTO events VALUES ('send_email', now(), INTERVAL '10 seconds');
+    COPY( TAIL TTL_VIEW WITH (SNAPSHOT = false) ) TO STDOUT;
+
+    -- It is time to send the email when:
+  ```
+  ```nofmt
+  mz_timestamp | mz_diff | event_name | event_time | event_ttl |
+  -------------|---------|------------|------------|-----------|
+  ...          | -1      | send_email | ...        | 00:00:10  |
+  ```
+
+## Expiring time
+
+One can simplify the case by summing the `event_time` and `event_ttl` to get the expiry date at the beginning:
+
+```sql
+  CREATE TABLE events (event_name TEXT, event_expiration TIMESTAMP);
+
+  -- Sample (One minute time to live):
+  INSERT INTO events VALUES ('send_email', now() + INTERVAL '1 minute');
+```
+
+But if there is a need in the future for more details, then **it will be a disadvantage**. Granularity is absent.

--- a/doc/user/content/sql/patterns/ttl.md
+++ b/doc/user/content/sql/patterns/ttl.md
@@ -6,33 +6,56 @@ menu:
     parent: 'sql-patterns'
 ---
 
-The time-to-live (TTL) pattern helps assign expiration times to rows while processing. Before continuing, make sure to understand how [temporal filters](/guides/temporal-filters/) work.
+The time to live (TTL) pattern helps to remove rows in views or tails using expiration times. You can use it to keep rows in views or tails until they are no longer useful or to trigger certain use cases.
 
-A few examples of the use cases that you can achieve are:
+The following examples are possible TTL use cases that you could achieve:
 
-- Free-up memory
-- Schedule tasks, like emails or messages
-- Assign temporal offers for an e-commerce
-- Run time-sensitive security blockers
+- Trigger schedule tasks, like emails or messages
+- Store temporal offers for an e-commerce
+- Maintain time-sensitive security blockers
+- Saving-up memory
 
-## How-to
+Before continuing, make sure to understand how [temporal filters](/guides/temporal-filters/) work.
 
-1. Identify the row, its initial timestamp, and the TTL. In the example, the `event_timestamp` and `event_ttl` represent those times. The sum of these values is when the row needs to drop, known as **expiring time**.
+## Pattern
+
+The pattern uses a temporal filter over a row’s **expiring time**.
+This time indicates when the query should drop the row.
+
+```sql
+  CREATE VIEW TTL_VIEW
+  SELECT *
+  FROM events
+  WHERE mz_logical_timestamp() < expiring_time;
+```
+
+To know the remaining time to live:
+
+```sql
+  SELECT (expiring_time - mz_logical_timestamp()) AS remaining_ttl
+  FROM TTL_VIEW;
+```
+
+## Example
+
+To have a crystal clear understanding of the pattern, let's build a task scheduling system. It will consist on a view filtering rows from a table. Each row in the table represents a task, and it contains its name, creation time, and TTL.
+
+1.  First, we need to set up the table with its corresponding fields.
     ```sql
-      CREATE TABLE events (event_name TEXT, event_timestamp TIMESTAMP, event_ttl INTERVAL);
-
-      -- Sample (One minute TTL):
-      INSERT INTO events VALUES ('send_email', now(), INTERVAL '5 minutes');
+      CREATE TABLE tasks (name TEXT, created_date TIMESTAMP, ttl INTERVAL);
     ```
-
-    The fields of `event_timestamp` and `event_ttl`, or the resulting expiring time, could come from sources or views building them on the fly. The table is just one of the many options.
-
-1. Create a view with a temporal filter **filtering by the expiring time**.
+1.  Add a task to send an email in the next five minutes:
     ```sql
-      CREATE MATERIALIZED VIEW ttl_view AS
+      INSERT INTO tasks VALUES ('send_email', now(), INTERVAL '5 minutes');
+      INSERT INTO tasks VALUES ('time_to_eat', now(), INTERVAL '1 hour');
+      INSERT INTO tasks VALUES ('security_block', now(), INTERVAL '1 day');
+    ```
+1. Create a view using a temporal filter **over the expiring time**. For our example, the expiring time represents the sum between the task's `created_date` and its `ttl`.
+    ```sql
+      CREATE MATERIALIZED VIEW tasks_scheduling AS
       SELECT *
-      FROM events
-      WHERE mz_logical_timestamp() < extract(epoch from (event_timestamp + event_ttl)) * 1000;
+      FROM tasks
+      WHERE mz_logical_timestamp() < extract(epoch from (created_date + ttl)) * 1000;
     ```
 
     The filter clause will discard any row with an **expiring time** less or equal to `mz_logical_timestamp()`.
@@ -43,40 +66,27 @@ A few examples of the use cases that you can achieve are:
 - Run a query to know the time to live for a row:
   ```sql
     SELECT
-      (extract(epoch from (event_timestamp + event_ttl))) -
-      (mz_logical_timestamp() / 1000) AS remaining_time
-    FROM TTL_VIEW
-    WHERE event_name = 'send_email';
+      extract(epoch from (created_date + ttl)) -
+      (mz_logical_timestamp() / 1000) AS remaining_ttl
+    FROM tasks_scheduling
+    WHERE name = 'time_to_eat';
   ```
 
-- Just check if a particular row is still available:
+- Check if a particular row is still available:
   ```sql
-  SELECT event_name
-  FROM TTL_VIEW
-  WHERE event_name = 'ban_over_ip_address';
+  SELECT true
+  FROM tasks_scheduling
+  WHERE name = 'security_block';
   ```
 
-- Run a tail and react over any expiring row:
+- Trigger an external process when a row expires:
   ```sql
-    INSERT INTO events VALUES ('send_email', now(), INTERVAL '5 seconds');
-    COPY( TAIL TTL_VIEW WITH (SNAPSHOT = false) ) TO STDOUT;
+    INSERT INTO tasks VALUES ('send_email', now(), INTERVAL '5 seconds');
+    COPY( TAIL tasks_scheduling WITH (SNAPSHOT = false) ) TO STDOUT;
 
   ```
   ```nofmt
   mz_timestamp | mz_diff | event_name | event_timestamp | event_ttl |
   -------------|---------|------------|-----------------|-----------|
-  ...          | -1      | send_email | ...             | 00:00:10  | <-- Time to send the email!
+  ...          | -1      | send_email | ...             | ...       | <-- Time to send the email!
   ```
-
-<!-- ## Expiring time
-
-One can simplify the case by summing the `event_time` and `event_ttl` to get the expiry date at the beginning:
-
-```sql
-  CREATE TABLE events (event_name TEXT, event_expiration TIMESTAMP);
-
-  -- Sample (One minute time to live):
-  INSERT INTO events VALUES ('send_email', now() + INTERVAL '1 minute');
-```
-
-But if there is a need in the future for more details, then **it will be a disadvantage**. Granularity is absent. -->

--- a/doc/user/content/sql/patterns/ttl.md
+++ b/doc/user/content/sql/patterns/ttl.md
@@ -15,16 +15,16 @@ The following examples are possible TTL use cases:
 - Maintain time-sensitive security blockers
 - Saving-up memory
 
-Before continuing, make sure to understand how [temporal filters](/guides/temporal-filters/) work.
+Before continuing, make sure to understand how [temporal filters](/sql/patterns/temporal-filters/) work.
 
 ## Pattern
 
-The pattern uses a temporal filter over a row's creation timestamp plus a TTL. The sum represents the row's **expiring time**. After reaching the expiring time, the query will drop the row.
+The pattern uses a temporal filter over a row's creation timestamp plus a TTL. The sum represents the row's **expiration time**. After reaching the expiration time, the query will drop the row.
 
 Pattern example:
 ```sql
   CREATE VIEW TTL_VIEW
-  SELECT (created_ts + ttl) as expiring_time
+  SELECT (created_ts + ttl) as expiration_time
   FROM events
   WHERE mz_logical_timestamp() < (created_ts + ttl);
 ```
@@ -32,13 +32,13 @@ Pattern example:
 To know the remaining time to live:
 
 ```sql
-  SELECT (expiring_time - mz_logical_timestamp()) AS remaining_ttl
+  SELECT (expiration_time - mz_logical_timestamp()) AS remaining_ttl
   FROM TTL_VIEW;
 ```
 
 ## Example
 
-To have a crystal clear understanding of the pattern, let's build a task tracking system. It will consist on a view filtering rows from a table. Each row in the table contains the name, creation timestamp, and TTL of a task.
+For a real-world example of the pattern, let's build a task tracking system. It will consist on a view filtering rows from a table. Each row in the table contains a name, creation timestamp, and TTL of a task.
 
 1.  First, we need to set up the table:
     ```sql
@@ -50,24 +50,24 @@ To have a crystal clear understanding of the pattern, let's build a task trackin
       INSERT INTO tasks VALUES ('time_to_eat', now(), INTERVAL '1 hour');
       INSERT INTO tasks VALUES ('security_block', now(), INTERVAL '1 day');
     ```
-1. Create a view using a temporal filter **over the expiring time**. For our example, the expiring time represents the sum between the task's `created_ts` and its `ttl`.
+1. Create a view using a temporal filter **over the expiration time**. For our example, the expiration time represents the sum between the task's `created_ts` and its `ttl`.
     ```sql
       CREATE MATERIALIZED VIEW tracking_tasks AS
       SELECT
         name,
-        extract(epoch from (created_ts + ttl)) * 1000 as expiring_time
+        extract(epoch from (created_ts + ttl)) * 1000 as expiration_time
       FROM tasks
       WHERE mz_logical_timestamp() < extract(epoch from (created_ts + ttl)) * 1000;
     ```
 
-    The filter clause will discard any row with an **expiring time** less or equal to `mz_logical_timestamp()`.
+    The filter clause will discard any row with an **expiration time** less than or equal to `mz_logical_timestamp()`.
 1. That's it! Use it in the way that best fits your use case.
 
 ### Usage examples
 
 - Run a query to know the time to live for a row:
   ```sql
-    SELECT expiring_time - mz_logical_timestamp() AS remaining_ttl
+    SELECT expiration_time - mz_logical_timestamp() AS remaining_ttl
     FROM tracking_tasks
     WHERE name = 'time_to_eat';
   ```
@@ -86,7 +86,7 @@ To have a crystal clear understanding of the pattern, let's build a task trackin
 
   ```
   ```nofmt
-  mz_timestamp | mz_diff | name       | expiring_time   |
+  mz_timestamp | mz_diff | name       | expiration_time   |
   -------------|---------|------------|-----------------|
   ...          | -1      | send_email | ...             | <-- Time to send the email!
   ```

--- a/doc/user/content/sql/patterns/ttl.md
+++ b/doc/user/content/sql/patterns/ttl.md
@@ -1,7 +1,6 @@
 ---
 title: "Time-To-Live"
 description: "Use the time-to-live pattern and assign an expiration time for a particular row."
-draft: true
 menu:
   main:
     parent: 'sql-patterns'
@@ -18,7 +17,7 @@ A few examples of the use cases that you can achieve are:
 
 ## How-to
 
-1. Identify the row, its initial time, and the TTL. In the example, the `event_time` and `event_ttl` represent those times. The sum of these values represents the **expiring time**.
+1. Identify the row, its initial timestamp, and the TTL. In the example, the `event_time` and `event_ttl` represent those times. The sum of these values is the **expiring time**.
     ```sql
       CREATE TABLE events (event_name TEXT, event_time TIMESTAMP, event_ttl INTERVAL);
 
@@ -26,7 +25,7 @@ A few examples of the use cases that you can achieve are:
       INSERT INTO events VALUES ('send_email', now(), INTERVAL '1 minute');
     ```
 
-    For the example, we use a table, but the time fields could come from a source or views building them on the fly.
+    The time fields or expiring time could come from sources or views building them on the fly. The table is just one of the many options.
 
 1. Create a view with a temporal filter **filtering by the expiring time**.
     ```sql


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

[Preview](https://preview.materialize.com/14130/sql/patterns/ttl/)

Create a documentation page for the TTL pattern.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I'm not completely happy with the introduction. Before, it was:
- The time-to-live pattern (TTL) helps you to build expiration times mechanisms using SQL

The thing is that the TTL is not over a row in a table or a source but in a view, query, or tail. They are dynamic environments, not in the "static world".

Issue reference:
https://github.com/MaterializeInc/developer-experience/issues/163

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
