### PR TITLE
[developer/guide] mention m1 mac postgresql.conf location

### DIFF
--- a/doc/developer/guide.md
+++ b/doc/developer/guide.md
@@ -67,7 +67,8 @@ issue `createdb` without any arguments, a database with your username will be
 created.
 
 To also run `bin/cargo-test`, you'll need to add the following to your
-Postgres config (e.g., `/var/lib/postgres/data/postgresql.conf`),
+Postgres config (e.g., `/var/lib/postgres/data/postgresql.conf`,
+or `/opt/homebrew/var/postgres/postgresql.conf` when using brew on an M1 mac),
 and then restart Postgres:
 
 ```


### PR DESCRIPTION
This is a really confusing location to find when using an m1 mac, so I figured we could mention it!


### Motivation
docs

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
