### PR TITLE
Minor changes to run TPC-H queries with tables in Materialize

### DIFF
--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -73,6 +73,7 @@ class Database:
     ) -> None:
         logging.debug(f"Initialize Database with host={host} port={port}, user={user}")
         self.conn = pg8000.connect(host=host, port=port, user=user)
+        self.conn.autocommit = True
 
     def mz_version(self) -> str:
         result = self.query_one("SELECT mz_version()")

--- a/misc/python/materialize/optbench/workload/tpch.sql
+++ b/misc/python/materialize/optbench/workload/tpch.sql
@@ -24,7 +24,7 @@ SELECT
 FROM
 	lineitem
 WHERE
-	l_shipdate <= DATE '1998-12-01' -- - INTERVAL '60' day (fails with an error)
+	l_shipdate <= DATE '1998-12-01' - INTERVAL '60' day
 GROUP BY
 	l_returnflag,
 	l_linestatus


### PR DESCRIPTION
This PR fixes two minor issues to enable us to run TPC-H queries with tables in Materialize by following the playbook: https://www.notion.so/materialize/Running-TPC-H-with-Tables-in-Materialize-205028a7d4fa45a2ba8e2823913b93d3

The changes included are:

- Enabling of `autocommit` in `optbench` to avoid transaction errors to be raised from `environmentd`
- Including interval subtraction in the filter of TPC-H query 1, since it is part of the standard query. 

### Motivation

  * This PR fixes a previously unreported bug.

Without autocommit enabled in the connection created by `optbench`, an error is returned when running the initialization command as in the following:

````
$ bin/optbench init tpch
Initializing "tpch" as the DB under test
Error: init command failed: {'S': 'ERROR', 'C': '25001', 'M': 'DROP DATABASE IF EXISTS tpch cannot be run inside a transaction block'}
````

Additionally, Q1 in TPC-H has an interval subtraction in its filter, which had been previously commented out. 

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A

