### PR TITLE
environmentd: change test assertion to print the error

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -28,7 +28,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
 use mz_ore::collections::CollectionExt;
-use mz_ore::task;
+use mz_ore::{assert_contains, task};
 use mz_pgrepr::{Numeric, Record};
 
 use crate::util::PostgresErrorExt;
@@ -45,9 +45,7 @@ fn test_bind_params() -> Result<(), Box<dyn Error>> {
 
     match client.query("SELECT ROW(1, 2) = $1", &[&42_i32]) {
         Ok(_) => panic!("query with invalid parameters executed successfully"),
-        Err(err) => {
-            assert!(format!("{:?}", err.source()).contains("WrongType"));
-        }
+        Err(err) => assert_contains!(format!("{:?}", err.source()), "WrongType"),
     }
 
     match client.query("SELECT ROW(1, 2) = $1", &[&"(1,2)"]) {


### PR DESCRIPTION
Should help track down test_bind_params flake.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a