### PR TITLE
catalog: dynamically generate role ids

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -112,9 +112,13 @@ pub struct BuiltinFunc {
     pub inner: &'static mz_sql::func::Func,
 }
 
+pub static BUILTIN_ROLE_PREFIXES: Lazy<Vec<&str>> = Lazy::new(|| vec!["mz_", "pg_"]);
+
 pub struct BuiltinRole {
+    /// Name of the builtin role.
+    ///
+    /// IMPORTANT: Must start with a prefix from [`BUILTIN_ROLE_PREFIXES`].
     pub name: &'static str,
-    pub id: u64,
 }
 
 pub trait Fingerprint {
@@ -2101,9 +2105,10 @@ AS SELECT
 FROM mz_catalog.mz_roles r",
 };
 
-pub const MZ_SYSTEM: BuiltinRole = BuiltinRole {
-    name: "mz_system",
-    id: 0,
+pub const MZ_SYSTEM: BuiltinRole = BuiltinRole { name: "mz_system" };
+
+pub const MZ_SYSTEM_EXTERNAL: BuiltinRole = BuiltinRole {
+    name: "mz_system_external",
 };
 
 pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
@@ -2288,7 +2293,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
 
     builtins
 });
-pub static BUILTIN_ROLES: Lazy<Vec<BuiltinRole>> = Lazy::new(|| vec![MZ_SYSTEM]);
+pub static BUILTIN_ROLES: Lazy<Vec<BuiltinRole>> =
+    Lazy::new(|| vec![MZ_SYSTEM, MZ_SYSTEM_EXTERNAL]);
 
 #[allow(non_snake_case)]
 pub mod BUILTINS {

--- a/test/sqllogictest/id_reuse.slt
+++ b/test/sqllogictest/id_reuse.slt
@@ -69,7 +69,8 @@ SELECT id, name FROM mz_roles
 ----
 0 mz_system
 1 materialize
-2 foo
+2 mz_system_external
+3 foo
 
 statement ok
 DROP ROLE foo
@@ -82,7 +83,8 @@ SELECT id, name FROM mz_roles
 ----
 0 mz_system
 1 materialize
-3 bar
+2 mz_system_external
+4 bar
 
 statement ok
 CREATE CLUSTER foo REPLICAS (r1 (size '1'))

--- a/test/sqllogictest/pg_catalog_roles.slt
+++ b/test/sqllogictest/pg_catalog_roles.slt
@@ -12,5 +12,6 @@ mode cockroach
 query IT
 SELECT oid, rolname FROM pg_roles ORDER BY oid
 ----
-20007  materialize
-20008  mz_system
+20007  mz_system
+20008  materialize
+20009  mz_system_external

--- a/test/testdrive/roles.td
+++ b/test/testdrive/roles.td
@@ -13,6 +13,7 @@ $ set-sql-timeout duration=1s
 > SELECT id, name FROM mz_roles
 0 mz_system
 1 materialize
+2 mz_system_external
 
 # Verify that invalid options are rejected.
 ! CREATE ROLE foo
@@ -30,8 +31,9 @@ contains:conflicting or redundant options
 > SELECT id, name FROM mz_roles
 0 mz_system
 1 materialize
-2 rj
-3 fms
+2 mz_system_external
+3 rj
+4 fms
 
 # Dropping multiple roles should not have any effect if one of the role names
 # is bad...
@@ -40,25 +42,29 @@ contains:unknown role 'bad'
 > SELECT id, name FROM mz_roles
 0 mz_system
 1 materialize
-2 rj
-3 fms
+2 mz_system_external
+3 rj
+4 fms
 
 # ...unless IF EXISTS is specified.
 > DROP ROLE IF EXISTS rj, fms, bad
 > SELECT id, name FROM mz_roles
 0 mz_system
 1 materialize
+2 mz_system_external
 
 # Verify that the single name version of DROP ROLE works too.
 > CREATE ROLE nlb LOGIN SUPERUSER
 > SELECT id, name FROM mz_roles
 0 mz_system
 1 materialize
-4 nlb
+2 mz_system_external
+5 nlb
 > DROP ROLE nlb
 > SELECT id, name FROM mz_roles
 0 mz_system
 1 materialize
+2 mz_system_external
 > DROP ROLE IF EXISTS nlb
 
 # No dropping the current role.
@@ -74,3 +80,7 @@ contains:role 'materialize' already exists
 contains:role name "mz_system" is reserved
 ! CREATE ROLE mz_foo LOGIN SUPERUSER
 contains:role name "mz_foo" is reserved
+
+# No dropping roles that look like system roles.
+! DROP ROLE mz_system
+contains:role name "mz_system" is reserved

--- a/test/upgrade/check-from-current_source-role.td
+++ b/test/upgrade/check-from-current_source-role.td
@@ -9,6 +9,7 @@
 
 > SELECT name FROM mz_roles;
 mz_system
+mz_system_external
 materialize
 superuser_login
 "space role"


### PR DESCRIPTION
Previously, role ids for builtin roles were hardcoded into the binary.
This made it impossible to add new builtin roles because we didn't
reserve any ids for additional roles.

This commit modifies built in roles, so that whenever we add a new one,
their id is dynamically allocated to the next available id.

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
