### PR TITLE
persist: properly return Since errors from ReadHandle::snapshot

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -537,10 +537,7 @@ where
     ) -> Result<Vec<ReaderEnrichedHollowBatch<T>>, Since<T>> {
         let mut machine = self.machine.clone();
 
-        let batches = machine
-            .snapshot(&as_of)
-            .await
-            .expect("ReadHandle should validate `as_of` valid before generating Subscribe");
+        let batches = machine.snapshot(&as_of).await?;
 
         let r = batches
             .into_iter()


### PR DESCRIPTION
Bad copy/paste job lead to placing an expect in a spot that should have returned an error instead.

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
