### PR TITLE
Remove redundant remote struct field

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1135,7 +1135,6 @@ pub struct Source {
     pub desc: RelationDesc,
     pub timeline: Timeline,
     pub depends_on: Vec<GlobalId>,
-    pub remote_addr: Option<String>,
     pub host_config: StorageHostConfig,
 }
 
@@ -3906,7 +3905,6 @@ impl<S: Append> Catalog<S> {
             }),
             Plan::CreateSource(CreateSourcePlan {
                 source,
-                remote,
                 timeline,
                 host_config,
                 ..
@@ -3916,7 +3914,6 @@ impl<S: Append> Catalog<S> {
                 desc: source.desc,
                 timeline,
                 depends_on,
-                remote_addr: remote,
                 host_config: self.resolve_storage_host_config(host_config)?,
             }),
             Plan::CreateView(CreateViewPlan { view, .. }) => {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -395,7 +395,6 @@ impl<S: Append + 'static> Coordinator<S> {
             desc: plan.source.desc,
             timeline: plan.timeline,
             depends_on,
-            remote_addr: plan.remote,
             host_config,
         };
         ops.push(catalog::Op::CreateItem {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -207,7 +207,6 @@ pub struct CreateSourcePlan {
     pub source: Source,
     pub if_not_exists: bool,
     pub timeline: Timeline,
-    pub remote: Option<String>,
     pub host_config: StorageHostConfig,
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -818,7 +818,7 @@ pub fn plan_create_source(
     let CreateSourceOptionExtracted { size, remote, .. } =
         CreateSourceOptionExtracted::try_from(with_options.clone())?;
 
-    let host_config = match (remote.clone(), size) {
+    let host_config = match (remote, size) {
         (None, None) => StorageHostConfig::Undefined,
         (None, Some(size)) => StorageHostConfig::Managed { size },
         (Some(addr), None) => StorageHostConfig::Remote { addr },
@@ -865,7 +865,6 @@ pub fn plan_create_source(
         source,
         if_not_exists,
         timeline,
-        remote,
         host_config,
     }))
 }


### PR DESCRIPTION
The `remote` address is now redundant with our host config, which stores this info and more. Let's remove it.

### Motivation

This is a refactor; just tidying up a small redundancy.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None.
