### PR TITLE
[DRAFT] Change DataflowError type

### DIFF
--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Handle as TokioHandle;
 use mz_interchange::avro::Decoder;
 use mz_repr::Row;
 
-use crate::types::errors::DecodeError;
+use crate::types::errors::DecodeErrorInner;
 
 #[derive(Debug)]
 pub struct AvroDecoderState {
@@ -35,13 +35,13 @@ impl AvroDecoderState {
         })
     }
 
-    pub fn decode(&mut self, bytes: &mut &[u8]) -> Result<Option<Row>, DecodeError> {
+    pub fn decode(&mut self, bytes: &mut &[u8]) -> Result<Option<Row>, DecodeErrorInner> {
         match self.tokio_handle.block_on(self.decoder.decode(bytes)) {
             Ok(row) => {
                 self.events_success += 1;
                 Ok(Some(row))
             }
-            Err(err) => Err(DecodeError::Text(format!(
+            Err(err) => Err(DecodeErrorInner::Text(format!(
                 "avro deserialization error: {:#}",
                 err
             ))),

--- a/src/storage/src/decode/csv.rs
+++ b/src/storage/src/decode/csv.rs
@@ -9,7 +9,7 @@
 
 use mz_repr::{Datum, Row};
 
-use crate::types::errors::DecodeError;
+use crate::types::errors::DecodeErrorInner;
 use crate::types::sources::encoding::CsvEncoding;
 use crate::types::transforms::LinearOperator;
 
@@ -71,7 +71,7 @@ impl CsvDecoderState {
         }
     }
 
-    pub fn decode(&mut self, chunk: &mut &[u8]) -> Result<Option<Row>, DecodeError> {
+    pub fn decode(&mut self, chunk: &mut &[u8]) -> Result<Option<Row>, DecodeErrorInner> {
         loop {
             let (result, n_input, n_output, n_ends) = self.csv_reader.read_record(
                 *chunk,
@@ -101,7 +101,7 @@ impl CsvDecoderState {
                         }
                         if ends_valid != self.n_cols {
                             self.events_error += 1;
-                            Err(DecodeError::Text(format!(
+                            Err(DecodeErrorInner::Text(format!(
                                 "CSV error at record number {}: expected {} columns, got {}.",
                                 self.total_events(),
                                 self.n_cols,
@@ -127,7 +127,7 @@ impl CsvDecoderState {
                                 }
                                 Err(e) => {
                                     self.events_error += 1;
-                                    Err(DecodeError::Text(format!(
+                                    Err(DecodeErrorInner::Text(format!(
                                         "CSV error at record number {}: invalid UTF-8 ({})",
                                         self.total_events(),
                                         e
@@ -148,7 +148,7 @@ impl CsvDecoderState {
                                 .enumerate()
                                 .find(|(_, (actual, expected))| actual.unwrap_str() != &**expected);
                             if let Some((i, (actual, expected))) = mismatched {
-                                break Err(DecodeError::Text(format!(
+                                break Err(DecodeErrorInner::Text(format!(
                                     "source file contains incorrect columns '{:?}', \
                                      first mismatched column at index {} expected={} actual={}",
                                     row,

--- a/src/storage/src/decode/protobuf.rs
+++ b/src/storage/src/decode/protobuf.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Handle as TokioHandle;
 use mz_interchange::protobuf::{DecodedDescriptors, Decoder};
 use mz_repr::Row;
 
-use crate::types::errors::DecodeError;
+use crate::types::errors::DecodeErrorInner;
 use crate::types::sources::encoding::ProtobufEncoding;
 
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl ProtobufDecoderState {
             events_error: 0,
         })
     }
-    pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DecodeError>> {
+    pub fn get_value(&mut self, bytes: &[u8]) -> Option<Result<Row, DecodeErrorInner>> {
         match self.tokio_handle.block_on(self.decoder.decode(bytes)) {
             Ok(row) => {
                 if let Some(row) = row {
@@ -48,14 +48,14 @@ impl ProtobufDecoderState {
                     Some(Ok(row))
                 } else {
                     self.events_error += 1;
-                    Some(Err(DecodeError::Text(format!(
+                    Some(Err(DecodeErrorInner::Text(format!(
                         "protobuf deserialization returned None"
                     ))))
                 }
             }
             Err(err) => {
                 self.events_error += 1;
-                Some(Err(DecodeError::Text(format!(
+                Some(Err(DecodeErrorInner::Text(format!(
                     "protobuf deserialization error: {:#}",
                     err
                 ))))

--- a/src/storage/src/types/errors.proto
+++ b/src/storage/src/types/errors.proto
@@ -14,10 +14,15 @@ import "repr/src/global_id.proto";
 
 package mz_storage.types.errors;
 
-message ProtoDecodeError {
+message ProtoDecodeErrorInner {
     oneof kind {
         string text = 1;
     }
+}
+
+message ProtoDecodeError {
+    ProtoDecodeErrorInner inner = 1;
+    optional bytes original_bytes = 2;
 }
 
 message ProtoSourceErrorDetails {
@@ -34,10 +39,18 @@ message ProtoSourceError {
     ProtoSourceErrorDetails error = 2;
 }
 
+message ProtoEnvelopeError {
+    oneof kind {
+        string text = 1;
+    }
+}
+
 message ProtoDataflowError {
     oneof kind {
-        ProtoDecodeError decode_error = 1;
-        mz_expr.scalar.ProtoEvalError eval_error = 2;
-        ProtoSourceError source_error = 3;
+        ProtoDecodeError key_decode_error = 1;
+	ProtoDecodeError value_decode_error = 2;
+        mz_expr.scalar.ProtoEvalError eval_error = 3;
+        ProtoSourceError source_error = 4;
+	ProtoEnvelopeError envelope_error = 5;
     }
 }


### PR DESCRIPTION
Motivation: include enough information in errors to allow
them to be retracted from upsert sources.

The way we will eventually allow retraction (coming soon, in a
follow-up to this PR) will be `"bad key bytes", null` for an
undecodable key error, and `"good key", null` for an undecodable value
that was inserted for `"good key"`.

Thus, our error type needs the following properties:

1. It must contain the original bytes associated with a decoding error
2. It must distinguish between key decoding errors and value decoding
errors
3. It must clearly separate decoding errors from random other errors in
the source pipeline. (Because decoding errors are the only ones that
it makes meaningful sense to correct via retraction to an upsert source; other errors
either occur later in the pipeline or are non-definite.)

In the service of these goals, we make the following changes:

1. We add an `original_bytes` field to the `DecodeError` type, which
is populated whenever the concept of original bytes makes sense.
2. We split `DataflowError::DecodeError` into `KeyDecodeError` and
`ValueDecodeError`.
3. We move some random non-decoding-related things that had crept into `DecodeError`
over the years out into a new variant `EnvelopeError`.

CAVEAT (and why this is still draft): This changes Protobuf types in
non-backwards-compatible ways. I would very much like to land this
before we get real customers in Platform and ignore the compatibility
issues, rather than having to leave around a bunch of deprecated
fields in protobuf and have to add logic to deal with them on
conversion.

I think this is fine, because there is no real pedagogical value to
doing the proper migration, and we're still (barely!) still in the
window where it's okay to blow everything away, but I thought it might
be controversial so I'm giving people the chance to respond.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
