### PR TITLE
pgtest: test invalid param binding

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -28,7 +28,7 @@ use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
 
 use mz_ore::collections::CollectionExt;
-use mz_ore::{assert_contains, task};
+use mz_ore::task;
 use mz_pgrepr::{Numeric, Record};
 
 use crate::util::PostgresErrorExt;
@@ -42,11 +42,6 @@ fn test_bind_params() -> Result<(), Box<dyn Error>> {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config)?;
     let mut client = server.connect(postgres::NoTls)?;
-
-    match client.query("SELECT ROW(1, 2) = $1", &[&42_i32]) {
-        Ok(_) => panic!("query with invalid parameters executed successfully"),
-        Err(err) => assert_contains!(format!("{:?}", err.source()), "WrongType"),
-    }
 
     match client.query("SELECT ROW(1, 2) = $1", &[&"(1,2)"]) {
         Ok(_) => panic!("query with invalid parameters executed successfully"),

--- a/test/pgtest/params.pt
+++ b/test/pgtest/params.pt
@@ -1,0 +1,14 @@
+# Test that invalid query params are rejected.
+
+send
+Parse {"query": "SELECT $1 + 1"}
+Bind {"values": ["a"]}
+Sync
+----
+
+until err_field_typs=S
+ReadyForQuery
+----
+ParseComplete
+ErrorResponse {"fields":[{"typ":"S","value":"ERROR"}]}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
This fixes the test_bind_params flake.

Testing this with tokio_postgres as the driver causes the *driver*
to return the WrongType error message. Wireshark showed that the bind
request was never issued to the server. The test flake must be happening
because the driver's type cache either is or isn't yet populated, and
so it does end up issuing the bind request to the server which returns
the no overload error.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a