### PR TITLE
cloudtest: Tests around computed and storaged startup/shutdown

### DIFF
--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -151,3 +151,6 @@ nodes:
         hostPort: 32062
       - containerPort: 32063
         hostPort: 32063
+
+  - role: worker
+  - role: worker

--- a/misc/python/materialize/cloudtest/application.py
+++ b/misc/python/materialize/cloudtest/application.py
@@ -77,13 +77,14 @@ class MaterializeApplication(Application):
 
         self.images = ["environmentd", "computed", "storaged", "testdrive"]
 
-        # Label the minicube node in a way that mimics Materialize cloud
-        self.kubectl(
-            "label",
-            "--overwrite",
-            "node/kind-control-plane",
-            "materialize.cloud/availability-zone=",
-        )
+        # Label the minicube nodes in a way that mimics Materialize cloud
+        for node in ["kind-control-plane", "kind-worker", "kind-worker2"]:
+            self.kubectl(
+                "label",
+                "--overwrite",
+                f"node/{node}",
+                "materialize.cloud/availability-zone=",
+            )
 
         super().__init__()
 

--- a/misc/python/materialize/cloudtest/k8s/postgres.py
+++ b/misc/python/materialize/cloudtest/k8s/postgres.py
@@ -41,13 +41,18 @@ class PostgresConfigMap(K8sConfigMap):
                 name="postgres-init",
             ),
             data={
+                "connections.sql": dedent(
+                    """
+                    ALTER SYSTEM SET max_connections = 5000;
+                    """
+                ),
                 "schemas.sql": dedent(
                     """
                 CREATE SCHEMA consensus;
                 CREATE SCHEMA catalog;
                 CREATE SCHEMA storage;
             """
-                )
+                ),
             },
         )
 

--- a/test/cloudtest/test_computed.py
+++ b/test/cloudtest/test_computed.py
@@ -1,0 +1,67 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.wait import wait
+
+
+def test_computed_sizing(mz: MaterializeApplication) -> None:
+    """Test that a SIZE N cluster indeed creates N computed instances."""
+    SIZE = 2
+
+    mz.environmentd.sql(
+        f"CREATE CLUSTER sized1 REPLICAS (sized_replica1 (SIZE '{SIZE}-1'))"
+    )
+    cluster_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_clusters WHERE name = 'sized1'"
+    )[0][0]
+    assert cluster_id is not None
+
+    replica_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_cluster_replicas WHERE name = 'sized_replica1'"
+    )[0][0]
+    assert replica_id is not None
+
+    for compute_id in range(0, SIZE):
+        compute_pod = (
+            f"pod/compute-cluster-{cluster_id}-replica-{replica_id}-{compute_id}"
+        )
+        wait(condition="condition=Ready", resource=compute_pod)
+
+    mz.environmentd.sql("DROP CLUSTER sized1 CASCADE")
+
+
+def test_computed_shutdown(mz: MaterializeApplication) -> None:
+    """Test that dropping a cluster or replica causes the associated computeds to shut down."""
+
+    mz.environmentd.sql(
+        "CREATE CLUSTER shutdown1 REPLICAS (shutdown_replica1 (SIZE '1'), shutdown_replica2 (SIZE '1'))"
+    )
+
+    cluster_id = mz.environmentd.sql_query(
+        "SELECT id FROM mz_clusters WHERE name = 'shutdown1'"
+    )[0][0]
+    assert cluster_id is not None
+
+    compute_pods = {}
+    for replica_name in ["shutdown_replica1", "shutdown_replica2"]:
+        replica_id = mz.environmentd.sql_query(
+            f"SELECT id FROM mz_cluster_replicas WHERE name = '{replica_name}'"
+        )[0][0]
+        assert replica_id is not None
+
+        compute_pod = f"pod/compute-cluster-{cluster_id}-replica-{replica_id}-0"
+        compute_pods[replica_name] = compute_pod
+        wait(condition="condition=Ready", resource=compute_pod)
+
+    mz.environmentd.sql("DROP CLUSTER REPLICA shutdown1.shutdown_replica1")
+    wait(condition="delete", resource=compute_pods["shutdown_replica1"])
+
+    mz.environmentd.sql("DROP CLUSTER shutdown1 CASCADE")
+    wait(condition="delete", resource=compute_pods["shutdown_replica2"])

--- a/test/cloudtest/test_storaged.py
+++ b/test/cloudtest/test_storaged.py
@@ -1,0 +1,90 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+
+from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.wait import wait
+
+
+def test_storaged_creation(mz: MaterializeApplication) -> None:
+    """Test that creating multiple sources causes multiple storageds to be spawned."""
+    mz.testdrive.run_string(
+        dedent(
+            """
+            $ kafka-create-topic topic=test
+
+            $ kafka-ingest format=bytes topic=test
+            ABC
+
+            > CREATE SOURCE source1
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
+              TOPIC 'testdrive-test-${testdrive.seed}'
+              FORMAT BYTES
+              ENVELOPE NONE;
+
+            > CREATE SOURCE source2
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
+              TOPIC 'testdrive-test-${testdrive.seed}'
+              FORMAT BYTES
+              ENVELOPE NONE;
+            """
+        )
+    )
+
+    for source in ["source1", "source2"]:
+        id = mz.environmentd.sql_query(
+            f"SELECT id FROM mz_sources WHERE name = '{source}'"
+        )[0][0]
+        assert id is not None
+
+        storaged = f"pod/storage-{id}-0"
+        wait(condition="condition=Ready", resource=storaged)
+
+
+def test_storaged_shutdown(mz: MaterializeApplication) -> None:
+    """Test that dropping a source causes its respective storaged to shut down."""
+    mz.testdrive.run_string(
+        dedent(
+            """
+            $ kafka-create-topic topic=test
+
+            $ kafka-ingest format=bytes topic=test
+            ABC
+
+            > CREATE SOURCE source1
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
+              TOPIC 'testdrive-test-${testdrive.seed}'
+              FORMAT BYTES
+              ENVELOPE NONE;
+
+            # Those two objects do not currenly create storaged instances
+            # > CREATE MATERIALIZED VIEW view1 AS SELECT COUNT(*) FROM source1;
+
+            # > CREATE SINK sink1
+            #  FROM view1
+            #  INTO KAFKA BROKER '${testdrive.kafka-addr}'
+            #  TOPIC 'testdrive-sink1-${testdrive.seed}'
+            #  FORMAT JSON;
+            """
+        )
+    )
+
+    id = mz.environmentd.sql_query("SELECT id FROM mz_sources WHERE name = 'source1'")[
+        0
+    ][0]
+    assert id is not None
+
+    storaged = f"pod/storage-{id}-0"
+
+    wait(condition="condition=Ready", resource=storaged)
+
+    mz.environmentd.sql("DROP SOURCE source1")
+
+    wait(condition="delete", resource=storaged)


### PR DESCRIPTION
Tests that confirm that storageds and computeds are spawned in
response to CREATE commands and removed in response to DROP commands.

Relates to #13580

### Motivation

  * This PR fixes a previously unreported bug.
We were missing tests if the K8s orchestrator properly spawns, and more importantly, cleans up, storageds and computeds.
