### PR TITLE
Compiling a literal constraint into a join

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -303,8 +303,7 @@ pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
                     }
                 }
                 mz_expr::MirRelationExpr::Join { implementation, .. } => {
-                    if let mz_expr::JoinImplementation::PredicateIndex(id, key, val) =
-                        implementation
+                    if let mz_expr::JoinImplementation::IndexedFilter(id, key, val) = implementation
                     {
                         // We should only get excited if we can track down an index for `id`.
                         // If `keys` is non-empty, that means we think one exists.

--- a/src/expr/src/explain.rs
+++ b/src/expr/src/explain.rs
@@ -411,7 +411,7 @@ impl<'a> ViewExplanation<'a> {
                 }
                 Ok(())
             }
-            JoinImplementation::PredicateIndex(_, key, val) => {
+            JoinImplementation::IndexedFilter(_, key, val) => {
                 writeln!(
                     f,
                     "IndexedFilter {}",

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1909,10 +1909,13 @@ pub enum JoinImplementation {
     /// Each plan starts from the corresponding index, and then in sequence joins
     /// against collections identified by index and with the specified arrangement key.
     DeltaQuery(Vec<Vec<(usize, Vec<MirScalarExpr>)>>),
-    /// Join a constant to a user-created index to speed up evaluation of a predicate
+    /// Join a user-created index with a constant collection to speed up the evaluation of a
+    /// predicate such as `f1 = 3 AND f2 = 5`.
+    /// This gets translated to a Differential join during MIR -> LIR lowering, but we still want
+    /// to represent it in MIR, because the fast path detection wants to match on this.
     ///
-    /// Consists of (<view id>, <keys of index>, <constant>)
-    PredicateIndex(GlobalId, Vec<MirScalarExpr>, #[mzreflect(ignore)] Row),
+    /// Consists of (<view id>, <keys of index>, <constant>, and then the same as Differential)
+    IndexedFilter(GlobalId, Vec<MirScalarExpr>, #[mzreflect(ignore)] Row),
     /// No implementation yet selected.
     Unimplemented,
 }

--- a/test/sqllogictest/in_list.slt
+++ b/test/sqllogictest/in_list.slt
@@ -13,6 +13,9 @@ statement ok
 CREATE TABLE t1 (a int, b text)
 
 statement ok
+CREATE DEFAULT INDEX ON t1
+
+statement ok
 INSERT INTO t1 VALUES (1, 'l1'), (2, 'l2'), (3, 'l3'), (1234, 'xxx'), (3456, 'yyy'), (12345, 'zzz')
 
 # A very large IN list shouldn't cause a stack overflow or other issue in the optimizer, see
@@ -23,3 +26,85 @@ SELECT b FROM t1 WHERE a IN (3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,2
 l3
 xxx
 yyy
+
+# IN list translated to ReadExistingIndex
+
+query T multiline
+EXPLAIN SELECT * FROM t1 WHERE a IN (1, 1+1)
+----
+%0 =
+| ReadExistingIndex materialize.public.t1_primary_idx
+| Filter ((#0 = 1) OR (#0 = 2))
+
+EOF
+
+query IT rowsort
+SELECT * FROM t1 WHERE a IN (1, 1+1)
+----
+1  l1
+2  l2
+
+# IndexedFilter join executed in fast path
+
+query T multiline
+EXPLAIN SELECT a, b FROM t1
+WHERE a = 2 AND b = 'l2'
+----
+%0 =
+| ReadExistingIndex materialize.public.t1_primary_idx
+| | Lookup value (2, "l2")
+| Filter (#0 = 2), (#1 = "l2")
+| Project (#0, #1)
+
+EOF
+
+query IT rowsort
+SELECT a, b FROM t1
+WHERE a = 2 AND b = 'l2'
+----
+2  l2
+
+# IndexedFilter join executed in a dataflow
+
+query T multiline
+EXPLAIN SELECT count(*) FROM t1
+WHERE a = 2 AND b = 'l2'
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#0, #1)
+
+%1 =
+| Constant (2, "l2")
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2) (= #1 #3)
+| | implementation = IndexedFilter #0 = 2 AND #1 = "l2"
+| Project (#0, #1)
+| Filter (#0 = 2), (#1 = "l2")
+| Project ()
+| Reduce group=()
+| | agg count(true)
+
+%3 =
+| Get %2 (l0)
+| Project ()
+| Negate
+
+%4 =
+| Constant ()
+
+%5 =
+| Union %3 %4
+| Map 0
+
+%6 =
+| Union %2 %5
+
+EOF
+
+query I rowsort
+SELECT count(*) FROM t1
+WHERE a = 2 AND b = 'l2'
+----
+1

--- a/test/sqllogictest/relation-cse.slt
+++ b/test/sqllogictest/relation-cse.slt
@@ -69,18 +69,22 @@ EXPLAIN SELECT * FROM t1 AS a1 , t1 AS a2 WHERE a1.f1 = 1 AND a2.f1 = 1;
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | ArrangeBy ()
 
-%3 =
-| Join %2 %1
-| | implementation = Differential %1 %2.()
+%4 =
+| Join %3 %2
+| | implementation = Differential %2 %3.()
 
 EOF
 
@@ -91,18 +95,22 @@ EXPLAIN SELECT * FROM t1 AS a1 , t1 AS a2, t1 AS a3 WHERE a1.f1 = 1 AND a2.f1 = 
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 = Let l1 =
-| Get %1 (l0)
+%3 = Let l1 =
+| Get %2 (l0)
 | ArrangeBy ()
 
-%3 =
-| Join %2 %2 %1
-| | implementation = Differential %1 %2.() %2.()
+%4 =
+| Join %3 %3 %2
+| | implementation = Differential %2 %3.() %3.()
 
 EOF
 
@@ -117,22 +125,26 @@ EXPLAIN SELECT * FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1) WHERE a1.f1 = 1 AND
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | ArrangeBy ()
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
 | Project (#1)
 
-%4 =
-| Join %2 %3
-| | implementation = Differential %3 %2.()
+%5 =
+| Join %3 %4
+| | implementation = Differential %4 %3.()
 
 EOF
 
@@ -183,17 +195,21 @@ EXPLAIN SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1) AND f2 = (S
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | Project (#0)
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -201,21 +217,21 @@ EXPLAIN SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1) AND f2 = (S
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%4 = Let l1 =
-| Union %2 %3
+%5 = Let l1 =
+| Union %3 %4
 
-%5 =
+%6 =
 | Get materialize.public.t1 (u1)
 | Filter (#0) IS NOT NULL, (#1) IS NOT NULL
 | ArrangeBy (#1)
 
-%6 =
-| Get %4 (l1)
+%7 =
+| Get %5 (l1)
 | ArrangeBy (#0)
 
-%7 =
-| Join %5 %6 %4 (= #0 #2) (= #1 #3)
-| | implementation = Differential %4 %5.(#1) %6.(#0)
+%8 =
+| Join %6 %7 %5 (= #0 #2) (= #1 #3)
+| | implementation = Differential %5 %6.(#1) %7.(#0)
 | Project (#0, #1)
 
 EOF
@@ -316,18 +332,22 @@ ON TRUE
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | ArrangeBy ()
 
-%3 =
-| Join %2 %1
-| | implementation = Differential %1 %2.()
+%4 =
+| Join %3 %2
+| | implementation = Differential %2 %3.()
 
 EOF
 
@@ -342,18 +362,22 @@ AND a2.f2 = 2
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1), (#1 = 2)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | ArrangeBy ()
 
-%3 =
-| Join %2 %1
-| | implementation = Differential %1 %2.()
+%4 =
+| Join %3 %2
+| | implementation = Differential %2 %3.()
 
 EOF
 
@@ -369,22 +393,26 @@ AND a2.f2 = 3
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
-| | implementation = IndexedFilter #0 = 1
+%1 =
+| Constant (1)
 
-%2 =
-| Get %1 (l0)
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
+
+%3 =
+| Get %2 (l0)
 | Filter (#0 = 1), (#1 = 2)
 | ArrangeBy ()
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
 | Filter (#0 = 1), (#1 = 3)
 
-%4 =
-| Join %2 %3
-| | implementation = Differential %3 %2.()
+%5 =
+| Join %3 %4
+| | implementation = Differential %4 %3.()
 
 EOF
 
@@ -399,13 +427,17 @@ EXPLAIN SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1 UN
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Union %1 %1 %1
+%3 =
+| Union %2 %2 %2
 
 EOF
 
@@ -416,14 +448,18 @@ EXPLAIN SELECT * FROM t1 WHERE f1 = 1 UNION ALL SELECT * FROM t1 WHERE f1 = 1 UN
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | Project (#1)
 
-%2 =
-| Union %1 %1 %1
+%3 =
+| Union %2 %2 %2
 | Distinct group=(#0)
 | Map 1
 | Project (#1, #0)
@@ -441,17 +477,21 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | Project (#0)
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -459,33 +499,33 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) , (SELECT f1 FROM t1 WHERE f1 = 
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%4 = Let l1 =
-| Union %2 %3
+%5 = Let l1 =
+| Union %3 %4
 
-%5 =
+%6 =
 | Get materialize.public.t1 (u1)
 | Project ()
 | ArrangeBy ()
 
-%6 =
-| Get %4 (l1)
+%7 =
+| Get %5 (l1)
 | Project ()
 | Distinct group=()
 | Negate
 
-%7 =
+%8 =
 | Constant ()
 
-%8 =
-| Union %6 %7
+%9 =
+| Union %7 %8
 | Map null
 
-%9 =
-| Union %4 %8
-
 %10 =
-| Join %5 %9
-| | implementation = Differential %9 %5.()
+| Union %5 %9
+
+%11 =
+| Join %6 %10
+| | implementation = Differential %10 %6.()
 | Project (#0, #0)
 
 EOF
@@ -497,17 +537,21 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHE
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | Project (#0)
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -515,55 +559,55 @@ EXPLAIN SELECT MIN((SELECT f1 FROM t1 WHERE f1 = 1)), MAX((SELECT f1 FROM t1 WHE
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%4 = Let l1 =
-| Union %2 %3
+%5 = Let l1 =
+| Union %3 %4
 
-%5 =
-| Get %4 (l1)
+%6 =
+| Get %5 (l1)
 | Project ()
 | Distinct group=()
 | Negate
 
-%6 =
+%7 =
 | Constant ()
 
-%7 =
-| Union %5 %6
+%8 =
+| Union %6 %7
 | Map null
 
-%8 = Let l2 =
-| Union %4 %7
+%9 = Let l2 =
+| Union %5 %8
 
-%9 =
+%10 =
 | Get materialize.public.t1 (u1)
 | Project ()
 | ArrangeBy ()
 
-%10 =
-| Get %8 (l2)
+%11 =
+| Get %9 (l2)
 | ArrangeBy ()
 
-%11 = Let l3 =
-| Join %9 %10 %8
-| | implementation = Differential %8 %9.() %10.()
+%12 = Let l3 =
+| Join %10 %11 %9
+| | implementation = Differential %9 %10.() %11.()
 | Reduce group=()
 | | agg min(#0)
 | | agg max(#1)
 
-%12 =
-| Get %11 (l3)
+%13 =
+| Get %12 (l3)
 | Project ()
 | Negate
 
-%13 =
+%14 =
 | Constant ()
 
-%14 =
-| Union %12 %13
+%15 =
+| Union %13 %14
 | Map null, null
 
-%15 =
-| Union %11 %14
+%16 =
+| Union %12 %15
 
 EOF
 
@@ -578,21 +622,91 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1 WHERE EXISTS (SELECT f1 
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 = Let l1 =
-| Get %1 (l0)
+%3 = Let l1 =
+| Get %2 (l0)
 | Project ()
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
+| Project (#0)
+
+%5 =
+| Get %3 (l1)
+| Reduce group=()
+| | agg count(true)
+| Filter (#0 > 1)
+| Project ()
+| Map (err: more than one record produced in subquery)
+
+%6 = Let l2 =
+| Union %4 %5
+
+%7 =
+| Get materialize.public.t1 (u1)
+| Project ()
+| ArrangeBy ()
+
+%8 =
+| Get %3 (l1)
+| Distinct group=()
+| ArrangeBy ()
+
+%9 =
+| Get %6 (l2)
+| Project ()
+| Distinct group=()
+| Negate
+
+%10 =
+| Constant ()
+
+%11 =
+| Union %9 %10
+| Map null
+
+%12 =
+| Union %6 %11
+
+%13 =
+| Join %7 %8 %12
+| | implementation = Differential %12 %8.() %7.()
+
+EOF
+
+query T multiline
+EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1
+UNION ALL
+SELECT f1 FROM t1 WHERE f1 = 1
+----
+%0 =
+| Get materialize.public.t1 (u1)
+| ArrangeBy (#0)
+
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
+| | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
+| Filter (#0 = 1)
+
+%3 = Let l1 =
+| Get %2 (l0)
 | Project (#0)
 
 %4 =
-| Get %2 (l1)
+| Get %2 (l0)
+| Project ()
 | Reduce group=()
 | | agg count(true)
 | Filter (#0 > 1)
@@ -608,89 +722,27 @@ EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1 WHERE EXISTS (SELECT f1 
 | ArrangeBy ()
 
 %7 =
-| Get %2 (l1)
-| Distinct group=()
-| ArrangeBy ()
-
-%8 =
 | Get %5 (l2)
 | Project ()
 | Distinct group=()
 | Negate
 
-%9 =
+%8 =
 | Constant ()
 
-%10 =
-| Union %8 %9
+%9 =
+| Union %7 %8
 | Map null
 
+%10 =
+| Union %5 %9
+
 %11 =
-| Union %5 %10
+| Join %6 %10
+| | implementation = Differential %10 %6.()
 
 %12 =
-| Join %6 %7 %11
-| | implementation = Differential %11 %7.() %6.()
-
-EOF
-
-query T multiline
-EXPLAIN SELECT (SELECT f1 FROM t1 WHERE f1 = 1) FROM t1
-UNION ALL
-SELECT f1 FROM t1 WHERE f1 = 1
-----
-%0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
-
-%1 = Let l0 =
-| Join %0
-| | implementation = IndexedFilter #0 = 1
-| Filter (#0 = 1)
-
-%2 = Let l1 =
-| Get %1 (l0)
-| Project (#0)
-
-%3 =
-| Get %1 (l0)
-| Project ()
-| Reduce group=()
-| | agg count(true)
-| Filter (#0 > 1)
-| Project ()
-| Map (err: more than one record produced in subquery)
-
-%4 = Let l2 =
-| Union %2 %3
-
-%5 =
-| Get materialize.public.t1 (u1)
-| Project ()
-| ArrangeBy ()
-
-%6 =
-| Get %4 (l2)
-| Project ()
-| Distinct group=()
-| Negate
-
-%7 =
-| Constant ()
-
-%8 =
-| Union %6 %7
-| Map null
-
-%9 =
-| Union %4 %8
-
-%10 =
-| Join %5 %9
-| | implementation = Differential %9 %5.()
-
-%11 =
-| Union %10 %2
+| Union %11 %3
 
 EOF
 
@@ -780,44 +832,52 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 LEFT JOIN t1 AS a2 USING (f1)) W
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l1 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l1 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 = Let l2 =
-| Join %0
+%3 =
+| Constant (2)
+
+%4 = Let l2 =
+| Join %0 %3 (= #0 #2)
 | | implementation = IndexedFilter #0 = 2
+| Project (#0, #1)
 | Filter (#0 = 2)
 
-%3 =
-| Get %1 (l1)
+%5 =
+| Get %2 (l1)
 | Project ()
 | ArrangeBy ()
-
-%4 =
-| Get %1 (l1)
-| Project (#0)
-
-%5 =
-| Join %3 %4
-| | implementation = Differential %4 %3.()
 
 %6 =
-| Get %2 (l2)
+| Get %2 (l1)
+| Project (#0)
+
+%7 =
+| Join %5 %6
+| | implementation = Differential %6 %5.()
+
+%8 =
+| Get %4 (l2)
 | Project ()
 | ArrangeBy ()
 
-%7 =
-| Get %2 (l2)
+%9 =
+| Get %4 (l2)
 | Project (#0)
 
-%8 =
-| Join %6 %7
-| | implementation = Differential %7 %6.()
+%10 =
+| Join %8 %9
+| | implementation = Differential %9 %8.()
 
-%9 =
-| Union %5 %8
+%11 =
+| Union %7 %10
 
 EOF
 
@@ -832,27 +892,31 @@ WHERE s1.f1 = 1 AND s2.f1 = 1
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 = Let l1 =
-| Get %1 (l0)
+%3 = Let l1 =
+| Get %2 (l0)
 | Project (#0)
 | ArrangeBy ()
 
-%3 = Let l2 =
-| Get %1 (l0)
+%4 = Let l2 =
+| Get %2 (l0)
 | Project ()
 
-%4 =
-| Get %3 (l2)
+%5 =
+| Get %4 (l2)
 | ArrangeBy ()
 
-%5 =
-| Join %2 %4 %2 %3
-| | implementation = Differential %3 %2.() %4.() %2.()
+%6 =
+| Join %3 %5 %3 %4
+| | implementation = Differential %4 %3.() %5.() %3.()
 
 EOF
 
@@ -867,38 +931,46 @@ WHERE s1.f1 = 1 AND s2.f1 = 2
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l1 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l1 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 = Let l2 =
-| Join %0
+%3 =
+| Constant (2)
+
+%4 = Let l2 =
+| Join %0 %3 (= #0 #2)
 | | implementation = IndexedFilter #0 = 2
+| Project (#0, #1)
 | Filter (#0 = 2)
 
-%3 =
-| Get %1 (l1)
-| Project (#0)
-| ArrangeBy ()
-
-%4 =
-| Get %1 (l1)
-| Project ()
-| ArrangeBy ()
-
 %5 =
-| Get %2 (l2)
+| Get %2 (l1)
 | Project (#0)
 | ArrangeBy ()
 
 %6 =
-| Get %2 (l2)
+| Get %2 (l1)
 | Project ()
+| ArrangeBy ()
 
 %7 =
-| Join %3 %4 %5 %6
-| | implementation = Differential %6 %3.() %4.() %5.()
+| Get %4 (l2)
+| Project (#0)
+| ArrangeBy ()
+
+%8 =
+| Get %4 (l2)
+| Project ()
+
+%9 =
+| Join %5 %6 %7 %8
+| | implementation = Differential %8 %5.() %6.() %7.()
 
 EOF
 
@@ -916,13 +988,17 @@ SELECT * FROM t1 WHERE f1 = 1 AND f2 = 2
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1), (#1 = 2)
 
-%2 =
-| Union %1 %1
+%3 =
+| Union %2 %2
 
 EOF
 
@@ -963,19 +1039,23 @@ SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t1 WHERE f1 = 1)
 | ArrangeBy (#0)
 
 %2 =
-| Join %1
+| Constant (1)
+
+%3 =
+| Join %1 %2 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%3 = Let l0 =
-| Join %0 %2
-| | implementation = Differential %0 %2.()
+%4 = Let l0 =
+| Join %0 %3
+| | implementation = Differential %0 %3.()
 
-%4 =
-| Union %3 %3
+%5 =
+| Union %4 %4
 
 EOF
 
@@ -989,17 +1069,21 @@ SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1)
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l1 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l1 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l1)
+%3 =
+| Get %2 (l1)
 | Project (#0)
 
-%3 =
-| Get %1 (l1)
+%4 =
+| Get %2 (l1)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -1007,16 +1091,16 @@ SELECT * FROM t1 WHERE f1 = (SELECT f1 FROM t1 WHERE f1 = 1)
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%4 =
-| Union %2 %3
+%5 =
+| Union %3 %4
 
-%5 = Let l2 =
-| Join %0 %4 (= #0 #2)
-| | implementation = Differential %4 %0.(#0)
+%6 = Let l2 =
+| Join %0 %5 (= #0 #2)
+| | implementation = Differential %5 %0.(#0)
 | Project (#0, #1)
 
-%6 =
-| Union %5 %5
+%7 =
+| Union %6 %6
 
 EOF
 
@@ -1155,13 +1239,17 @@ UNION ALL
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Union %1 %1 %1 %1
+%3 =
+| Union %2 %2 %2 %2
 
 EOF
 
@@ -1179,19 +1267,23 @@ UNION ALL
 | ArrangeBy (#0)
 
 %2 =
-| Join %1
+| Constant (1)
+
+%3 =
+| Join %1 %2 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%3 = Let l0 =
-| Join %0 %2
-| | implementation = Differential %0 %2.()
+%4 = Let l0 =
+| Join %0 %3
+| | implementation = Differential %0 %3.()
 
-%4 =
-| Union %3 %3
+%5 =
+| Union %4 %4
 
 EOF
 
@@ -1213,27 +1305,31 @@ UNION ALL
 | ArrangeBy (#0)
 
 %2 =
-| Join %1
+| Constant (1)
+
+%3 =
+| Join %1 %2 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%3 = Let l0 =
-| Join %0 %2
-| | implementation = Differential %0 %2.()
-
-%4 =
-| Get %3 (l0)
-| Project (#0)
+%4 = Let l0 =
+| Join %0 %3
+| | implementation = Differential %0 %3.()
 
 %5 =
-| Get %3 (l0)
-| Project (#1)
+| Get %4 (l0)
+| Project (#0)
 
 %6 =
-| Union %4 %5
+| Get %4 (l0)
+| Project (#1)
+
+%7 =
+| Union %5 %6
 
 EOF
 
@@ -1251,30 +1347,34 @@ Query:
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | Project ()
 | Distinct group=()
 | ArrangeBy ()
 
-%2 =
+%3 =
 | Get materialize.public.t1 (u1)
 
-%3 =
-| Join %2 %1
-| | implementation = Differential %2 %1.()
-
 %4 =
-| Get materialize.public.t2 (u3)
+| Join %3 %2
+| | implementation = Differential %3 %2.()
 
 %5 =
-| Join %4 %1
-| | implementation = Differential %4 %1.()
+| Get materialize.public.t2 (u3)
 
 %6 =
-| Union %3 %5
+| Join %5 %2
+| | implementation = Differential %5 %2.()
+
+%7 =
+| Union %4 %6
 
 EOF
 
@@ -1291,30 +1391,34 @@ Query:
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | Project (#0)
 
-%2 =
+%3 =
 | Get materialize.public.t2 (u3)
 | Project (#0)
 
-%3 =
-| Union %2 %1
+%4 =
+| Union %3 %2
 | ArrangeBy ()
 
-%4 =
+%5 =
 | Get materialize.public.t2 (u3)
 | Project (#1)
 
-%5 =
-| Union %4 %1
-
 %6 =
-| Join %3 %5
-| | implementation = Differential %5 %3.()
+| Union %5 %2
+
+%7 =
+| Join %4 %6
+| | implementation = Differential %6 %4.()
 
 EOF
 
@@ -1329,21 +1433,25 @@ SELECT f2 FROM t1 WHERE f1 = 1
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 =
-| Get %1 (l0)
+%3 =
+| Get %2 (l0)
 | Project (#0)
 
-%3 =
-| Get %1 (l0)
+%4 =
+| Get %2 (l0)
 | Project (#1)
 
-%4 =
-| Union %2 %3
+%5 =
+| Union %3 %4
 
 EOF
 
@@ -1360,19 +1468,27 @@ EXPLAIN SELECT * FROM t1 AS a1, t1 AS a2 WHERE a1.f1 = 1 AND a2.f1 = 2
 | ArrangeBy (#0)
 
 %1 =
-| Join %0
+| Constant (1)
+
+%2 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 | ArrangeBy ()
 
-%2 =
-| Join %0
+%3 =
+| Constant (2)
+
+%4 =
+| Join %0 %3 (= #0 #2)
 | | implementation = IndexedFilter #0 = 2
+| Project (#0, #1)
 | Filter (#0 = 2)
 
-%3 =
-| Join %1 %2
-| | implementation = Differential %2 %1.()
+%5 =
+| Join %2 %4
+| | implementation = Differential %4 %2.()
 
 EOF
 
@@ -1386,44 +1502,52 @@ SELECT * FROM (SELECT a2.f1 AS f1 FROM t1 AS a1 JOIN t1 AS a2 USING (f1)) WHERE 
 | Get materialize.public.t1 (u1)
 | ArrangeBy (#0)
 
-%1 = Let l1 =
-| Join %0
+%1 =
+| Constant (1)
+
+%2 = Let l1 =
+| Join %0 %1 (= #0 #2)
 | | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
 | Filter (#0 = 1)
 
-%2 = Let l2 =
-| Join %0
+%3 =
+| Constant (2)
+
+%4 = Let l2 =
+| Join %0 %3 (= #0 #2)
 | | implementation = IndexedFilter #0 = 2
+| Project (#0, #1)
 | Filter (#0 = 2)
 
-%3 =
-| Get %1 (l1)
+%5 =
+| Get %2 (l1)
 | Project ()
 | ArrangeBy ()
-
-%4 =
-| Get %1 (l1)
-| Project (#0)
-
-%5 =
-| Join %3 %4
-| | implementation = Differential %4 %3.()
 
 %6 =
-| Get %2 (l2)
+| Get %2 (l1)
+| Project (#0)
+
+%7 =
+| Join %5 %6
+| | implementation = Differential %6 %5.()
+
+%8 =
+| Get %4 (l2)
 | Project ()
 | ArrangeBy ()
 
-%7 =
-| Get %2 (l2)
+%9 =
+| Get %4 (l2)
 | Project (#0)
 
-%8 =
-| Join %6 %7
-| | implementation = Differential %7 %6.()
+%10 =
+| Join %8 %9
+| | implementation = Differential %9 %8.()
 
-%9 =
-| Union %5 %8
+%11 =
+| Union %7 %10
 
 EOF
 
@@ -1438,17 +1562,25 @@ SELECT * FROM t1 WHERE f1 = 2
 | ArrangeBy (#0)
 
 %1 =
-| Join %0
-| | implementation = IndexedFilter #0 = 1
-| Filter (#0 = 1)
+| Constant (1)
 
 %2 =
-| Join %0
-| | implementation = IndexedFilter #0 = 2
-| Filter (#0 = 2)
+| Join %0 %1 (= #0 #2)
+| | implementation = IndexedFilter #0 = 1
+| Project (#0, #1)
+| Filter (#0 = 1)
 
 %3 =
-| Union %1 %2
+| Constant (2)
+
+%4 =
+| Join %0 %3 (= #0 #2)
+| | implementation = IndexedFilter #0 = 2
+| Project (#0, #1)
+| Filter (#0 = 2)
+
+%5 =
+| Union %2 %4
 
 EOF
 

--- a/test/sqllogictest/transform/dataflow.slt
+++ b/test/sqllogictest/transform/dataflow.slt
@@ -62,8 +62,12 @@ EXPLAIN PLAN FOR VIEW foo3
 | ArrangeBy (#0)
 
 %1 =
-| Join %0
+| Constant (6)
+
+%2 =
+| Join %0 %1 (= #0 #1)
 | | implementation = IndexedFilter #0 = 6
+| Project (#0)
 | Filter (#0 = 6)
 
 EOF
@@ -75,5 +79,6 @@ EXPLAIN PLAN FOR SELECT * from foo3
 | ReadExistingIndex materialize.public.foo2_primary_idx
 | | Lookup value (6)
 | Filter (#0 = 6)
+| Project (#0)
 
 EOF

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -153,27 +153,31 @@ EXPLAIN SELECT  MIN( o_orderkey  )
 | Get materialize.public.lineitem (u10)
 | ArrangeBy (#0)
 
-%1 = Let l0 =
-| Join %0
+%1 =
+| Constant (38)
+
+%2 = Let l0 =
+| Join %0 %1 (= #0 #8)
 | | implementation = IndexedFilter #0 = 38
+| Project (#0..=#7)
 | Filter (#0 = 38)
 
-%2 =
+%3 =
 | Get materialize.public.lineitem (u10)
 | Filter (#6 = 1997-01-25)
 | Project (#4)
 | ArrangeBy (#0)
 
-%3 =
+%4 =
 | Get materialize.public.orders (u7)
 | ArrangeBy (#0)
 
-%4 =
-| Get %1 (l0)
+%5 =
+| Get %2 (l0)
 | Project (#0)
 
-%5 =
-| Get %1 (l0)
+%6 =
+| Get %2 (l0)
 | Project ()
 | Reduce group=()
 | | agg count(true)
@@ -181,31 +185,31 @@ EXPLAIN SELECT  MIN( o_orderkey  )
 | Project ()
 | Map (err: more than one record produced in subquery)
 
-%6 =
-| Union %4 %5
+%7 =
+| Union %5 %6
 
-%7 = Let l1 =
-| Join %2 %3 %6 (= #0 #3) (= #1 #5)
-| | implementation = Differential %6 %3.(#0) %2.(#0)
+%8 = Let l1 =
+| Join %3 %4 %7 (= #0 #3) (= #1 #5)
+| | implementation = Differential %7 %4.(#0) %3.(#0)
 | Filter (#1 <= 195), (#1 >= 38), (1997-08-25 00:00:00 = date_to_timestamp(#4))
 | Project (#1)
 | Reduce group=()
 | | agg min(#0)
 
-%8 =
-| Get %7 (l1)
+%9 =
+| Get %8 (l1)
 | Project ()
 | Negate
 
-%9 =
+%10 =
 | Constant ()
 
-%10 =
-| Union %8 %9
+%11 =
+| Union %9 %10
 | Map null
 
-%11 =
-| Union %7 %10
+%12 =
+| Union %8 %11
 
 EOF
 
@@ -228,25 +232,33 @@ EXPLAIN SELECT l_partkey AS col24843 , l_orderkey AS col24844 , l_partkey AS col
 | ArrangeBy (#1)
 
 %2 =
-| Join %1
+| Constant (134)
+
+%3 =
+| Join %1 %2 (= #1 #4)
 | | implementation = IndexedFilter #1 = 134
+| Project (#0..=#3)
 | Filter (#1 = 134), (#2 = (#2 % 5))
 | Project (#2, #3)
 | ArrangeBy (#0, #1)
 
-%3 =
+%4 =
 | Get materialize.public.customer (u4)
 | ArrangeBy (#0)
 
-%4 =
-| Join %3
+%5 =
+| Constant (134)
+
+%6 =
+| Join %4 %5 (= #0 #3)
 | | implementation = IndexedFilter #0 = 134
+| Project (#0..=#2)
 | Filter (#0 = 134)
 | Project ()
 
-%5 =
-| Join %0 %2 %4 (= #2 #4) (= #3 #5)
-| | implementation = Differential %4 %0.() %2.(#0, #1)
+%7 =
+| Join %0 %3 %6 (= #2 #4) (= #3 #5)
+| | implementation = Differential %6 %0.() %3.(#0, #1)
 | Project (#1, #0, #1)
 
 EOF
@@ -269,23 +281,31 @@ EXPLAIN SELECT *
 | ArrangeBy (#1)
 
 %2 =
-| Join %1
+| Constant (229)
+
+%3 =
+| Join %1 %2 (= #1 #4)
 | | implementation = IndexedFilter #1 = 229
+| Project (#0..=#3)
 | Filter (#1 = 229)
 | ArrangeBy (#2, #3)
 
-%3 =
+%4 =
 | Get materialize.public.customer (u4)
 | ArrangeBy (#0)
 
-%4 =
-| Join %3
+%5 =
+| Constant (229)
+
+%6 =
+| Join %4 %5 (= #0 #3)
 | | implementation = IndexedFilter #0 = 229
+| Project (#0..=#2)
 | Filter (#0 = 229)
 
-%5 =
-| Join %0 %2 %4 (= #4 #10) (= #5 #11)
-| | implementation = Differential %4 %0.() %2.(#2, #3)
+%7 =
+| Join %0 %3 %6 (= #4 #10) (= #5 #11)
+| | implementation = Differential %6 %0.() %3.(#2, #3)
 | Project (#0..=#9, #4, #5, #12..=#14)
 
 EOF

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -28,11 +28,11 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 "%0 =| ReadExistingIndex t1_primary_idx| Filter (#0) IS NULL, (#1 = 5)"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
-"%0 =| ReadExistingIndex t1_primary_idx| | Lookup value (5, 1)| Filter (#0 = 5), (#1 = 1)"
+"%0 =| ReadExistingIndex t1_primary_idx| | Lookup value (5, 1)| Filter (#0 = 5), (#1 = 1)| Project (#0, #1)"
 
 # NULL-able expressions are dedupped
 > EXPLAIN SELECT * FROM t1 WHERE col_null = 1 AND (col_null = 1 AND col_not_null = 5);
-"%0 =| ReadExistingIndex t1_primary_idx| | Lookup value (1, 5)| Filter (#0 = 1), (#1 = 5)"
+"%0 =| ReadExistingIndex t1_primary_idx| | Lookup value (1, 5)| Filter (#0 = 1), (#1 = 5)| Project (#0, #1)"
 
 # OR/disjunction at the top level
 


### PR DESCRIPTION
### Motivation

  * This PR refactors existing code: This is the next step for compiling IN lists with multiple literals into a join https://github.com/MaterializeInc/materialize/issues/13151
    * This PR just changes `PredicateIndex` to use a join with a constant collection, instead of the old code that builds a `Get` that seeks into the index. For now, the constant collection always has only 1 element, so we are using the index in exactly the same cases as before. But the point of the join is that the join will be able to handle multiple elements in the constant collection, while the old code in `Get` can handle only one seek into the index. (I updated the task list in the epic with my plan for the follow-up steps, e.g. to actually feed the join with multiple elements.)

### Tips for reviewer

It's better to view the PR with hiding of whitespace changes.

There would be several alternative ways to do this transformation:
- We could already create a `Differential` join in `CanonicalizeMfp` instead of introducing `PredicateIndex`. However, then the fast path detection would be harder, because it would need to recognize this join pattern instead of just matching on `PredicateIndex`.
- We could introduce a LIR join during the MIR->LIR lowering, but that is harder to construct.

Note that the earlier code in `CanonicalizeMfp` was introducing a `PredicateIndex` join in a way that the join results could not be determined without looking at the join implementation, as pointed out by @frankmcsherry:
https://materializeinc.slack.com/archives/C01BE3RN82F/p1660316046340199
I'm also fixing this issue in this PR by already adding the constant collection as a join input and the `equivalences` in `CanonicalizeMfp`.

(I will later open a separate PR for adding back the literal constraints detection during the lowering of a `Get`, which was discussed in https://materializeinc.slack.com/archives/C02PPB50ZHS/p1660314866840339?thread_ts=1660310528.321199&cid=C02PPB50ZHS)

(Currently, the `PredicateIndex` join variant has more fields than necessary. The first 3 are used by the fast path, and the last 2 are used by the translation into a differential join. Some of the information in the first 3 fields are also in the last 2, but I didn't want to touch the fast path code in this PR. In a follow-up PR I will tend to the fast path anyway, when handling more than one lookup records.)

The performance seems to be the same for the new and old code. For example:
```
\timing
create view v1 as select generate_series(1, 10000000) as f1;
select count(f1) from v1 where f1=5; --0.95s
create index i1 on v1(f1);
select count(f1) from v1 where f1=5;
```
The time of the last statement is around 8ms on my laptop with both the old and new code. (Just `select 1;` takes around 2ms on my laptop.)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - There are many existing tests mentioning `IndexedFilter`, but all of them have a constraint only on 1 field. So I added some tests in `in_list.slt`.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No output change or significant run time change, only plans change a bit.
