### PR TITLE
[storage] re-enable pg resumption tests that require reconciliation

### DIFF
--- a/test/pg-cdc-resumption/mzcompose.py
+++ b/test/pg-cdc-resumption/mzcompose.py
@@ -26,11 +26,9 @@ def workflow_default(c: Composition) -> None:
     initialize(c)
 
     for scenario in [
-        # TODO: re-enable these as part of
-        # <https://github.com/MaterializeInc/materialize/issues/13254>
-        # disconnect_pg_during_snapshot,
+        disconnect_pg_during_snapshot,
         disconnect_pg_during_replication,
-        # restart_pg_during_snapshot,
+        restart_pg_during_snapshot,
         restart_mz_during_snapshot,
         restart_pg_during_replication,
         restart_mz_during_replication,


### PR DESCRIPTION
These tests now work because storage reconciliation is working!

cc https://github.com/MaterializeInc/materialize/issues/12856

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
