### PR TITLE
Make `ComputeCommandHistory` self-compacting

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -357,7 +357,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // Importantly, act as if all peeks may have been retired (as we cannot know otherwise).
             compute_state
                 .command_history
-                .reduce(&HashMap::<_, ()>::default());
+                .retain_peeks(&HashMap::<_, ()>::default());
+            compute_state.command_history.reduce();
 
             // At this point, we need to sort out which of the *certainly installed* dataflows are
             // suitable replacements for the requested dataflows. A dataflow is "certainly installed"


### PR DESCRIPTION
This PR makes `ComputeCommandHistory` self-compacting, so that insertions into it (via `push(command)`) will compact the representation as it grows in length. The intended behavior is that compaction is only triggered if the effective length of the command history doubles, complicated slightly by the fact that many commands are *composite* commands containing multiple instructions. This should have the property that it maintains a bounded footprint, as a function of the number of live dataflow, and performs idk bounded-ish total work.

### Motivation

  * This PR fixes a previously unreported bug.

Compute instances left running indefinitely would have memory increase without bound, due to a new use of `ComputeCommandHistory` that did not apply the optional compaction. The compaction is no longer optional.

### Tips for reviewer

This has not been tested, and I think we do not have a test that would exercise whether compaction is happening effectively. Ideally, we turn this on for a day or so and see what happens, potentially concurrent with merging if we otherwise like the work.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
