### PR TITLE
persist: split batch fetching from decoding

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -179,6 +179,8 @@ pub fn build_compute_dataflow<A: Allocate>(
                     dataflow.as_of.clone().unwrap(),
                     dataflow.until.clone(),
                     mfp.as_mut(),
+                    // Copy the logic in DeltaJoin/Get/Join to start.
+                    |_timer, count| count > 1_000_000,
                 );
 
                 // If `mfp` is non-identity, we need to apply what remains.

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -941,19 +941,19 @@ mod tests {
                                         continue;
                                     }
                                 };
-                                fetch_batch_part(
+                                let mut part = fetch_batch_part(
                                     &shard_id,
                                     client.blob.as_ref(),
                                     client.metrics.as_ref(),
                                     &part.key,
                                     &batch.desc,
-                                    |k, _v, t, d| {
-                                        let (k, d) = (String::decode(k).unwrap(), i64::decode(d));
-                                        write!(s, "{k} {t} {d}\n");
-                                    },
                                 )
                                 .await
                                 .expect("invalid batch part");
+                                while let Some((k, _v, t, d)) = part.next() {
+                                    let (k, d) = (String::decode(k).unwrap(), i64::decode(d));
+                                    write!(s, "{k} {t} {d}\n");
+                                }
                             }
                             if s.is_empty() {
                                 s.push_str("<empty>\n");

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -302,14 +302,15 @@ where
         let (parts, progress) = self.next_parts().await;
         let mut ret = Vec::with_capacity(parts.len() + 1);
         for part in parts {
-            let (part, updates) = fetch_leased_part(
+            let (part, fetched_part) = fetch_leased_part(
                 part,
                 self.handle.blob.as_ref(),
-                &self.handle.metrics,
+                Arc::clone(&self.handle.metrics),
                 Some(&self.handle.reader_id),
             )
             .await;
             self.handle.process_returned_leased_part(part);
+            let updates = fetched_part.collect::<Vec<_>>();
             if !updates.is_empty() {
                 ret.push(ListenEvent::Updates(updates));
             }
@@ -518,16 +519,16 @@ where
         let snap = self.snapshot(as_of).await?;
 
         let mut contents = Vec::new();
-        for batch in snap {
-            let (batch, mut r) = fetch_leased_part(
-                batch,
+        for part in snap {
+            let (part, fetched_part) = fetch_leased_part(
+                part,
                 self.blob.as_ref(),
-                &self.metrics,
+                Arc::clone(&self.metrics),
                 Some(&self.reader_id),
             )
             .await;
-            self.process_returned_leased_part(batch);
-            contents.append(&mut r);
+            self.process_returned_leased_part(part);
+            contents.extend(fetched_part);
         }
         Ok(contents)
     }

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -56,6 +56,8 @@ pub(crate) fn render_sink<G: Scope<Timestamp = Timestamp>>(
         sink.as_of.frontier.clone(),
         timely::progress::Antichain::new(),
         None,
+        // Copy the logic in DeltaJoin/Get/Join to start.
+        |_timer, count| count > 1_000_000,
     );
     needed_tokens.push(source_token);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -277,6 +277,8 @@ where
                                     as_of,
                                     Antichain::new(),
                                     None,
+                                    // Copy the logic in DeltaJoin/Get/Join to start.
+                                    |_timer, count| count > 1_000_000,
                                 );
                             let (tx_source_ok, tx_source_err) = (
                                 tx_source_ok_stream.as_collection(),
@@ -326,6 +328,8 @@ where
                                 Antichain::from_elem(previous_as_of),
                                 Antichain::new(),
                                 None,
+                                // Copy the logic in DeltaJoin/Get/Join to start.
+                                |_timer, count| count > 1_000_000,
                             );
                             (stream, Some(tok))
                         } else {


### PR DESCRIPTION
This will allow additional opportunities to yield in the persist_source
operator, making it play more nicely with timely.

Touches #13623

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
