### PR TITLE
[environmentd] add curl to the envd container

### DIFF
--- a/src/environmentd/ci/Dockerfile
+++ b/src/environmentd/ci/Dockerfile
@@ -10,7 +10,7 @@
 MZFROM ubuntu-base
 
 RUN apt-get update \
-    && apt-get -qy install ca-certificates tini \
+    && apt-get -qy install ca-certificates curl tini \
     && groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize \
     && mkdir /mzdata \


### PR DESCRIPTION
### Motivation

Its nice to have curl access in each pod, to be able to hit the internal http port, without setting up port forwards! This now match computed and storaged.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
