### PR TITLE
ore: teach tracing about NO_COLOR

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -207,13 +207,15 @@ where
     let service_name = service_name.to_string();
 
     let config = config.into();
+    // See: https://no-color.org/
+    let no_color = std::env::var_os("NO_COLOR").unwrap_or_else(|| "".into()) != "";
     let stderr_log_layer = fmt::layer()
         .event_format(PrefixFormat {
             inner: format(),
             prefix: config.stderr_log.prefix,
         })
         .with_writer(io::stderr)
-        .with_ansi(atty::is(atty::Stream::Stderr))
+        .with_ansi(!no_color && atty::is(atty::Stream::Stderr))
         .with_filter(config.stderr_log.filter);
 
     let (otel_layer, otel_reloader) = if let Some(otel_config) = config.opentelemetry {


### PR DESCRIPTION
For those of us who prefer no colors or don't have terminals with support, teach tracing how to correctly disable ansi codes.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a