### PR TITLE
pgtest: increase default timeout

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -466,7 +466,7 @@ fn pg_test_inner(dir: PathBuf) -> Result<(), Box<dyn Error>> {
             _ => panic!("only tcp connections supported"),
         };
         let user = config.get_user().unwrap();
-        let timeout = Duration::from_secs(5);
+        let timeout = Duration::from_secs(30);
 
         mz_pgtest::run_test(tf, addr, user.to_string(), timeout);
     });

--- a/src/pgtest/src/main.rs
+++ b/src/pgtest/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     mz_pgtest::walk(
         args.addr,
         args.user,
-        std::time::Duration::from_secs(5),
+        std::time::Duration::from_secs(30),
         &args.directory,
     );
 }


### PR DESCRIPTION
Testing locally yielded unexplained, rare pgtest failures. There were
no crashes, just the timeout message. I think this just means sometimes
things take longer than 5 seconds? I'm not sure why that is happening,
but we can bump the timeout to see if it fixes the flakes.

Fixes #14160

### Motivation

  * This PR fixes a recognized bug. #14160

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a