### PR TITLE
doc/user: switch algolia index to materialize_unstable

### DIFF
--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -45,7 +45,7 @@
 <script defer>
 addEventListener("DOMContentLoaded", () => {
   docsearch({
-    apiKey: "cf315153e0b62d66538a2f8b86bfb93f",
+    apiKey: "5fb0a95d60e603d3c83c2506e1de4a64",
     appId: "9LF5B9GMOF",
     indexName: "materialize_unstable",
     inputSelector: '#search-input',

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -47,7 +47,7 @@ addEventListener("DOMContentLoaded", () => {
   docsearch({
     apiKey: "cf315153e0b62d66538a2f8b86bfb93f",
     appId: "9LF5B9GMOF",
-    indexName: "materialize",
+    indexName: "materialize_unstable",
     inputSelector: '#search-input',
     debug: true,
   });


### PR DESCRIPTION

### Motivation

Fixes #14184 

I created a new index in algolia crawler console (crawler.algolia.com) copied the settings from the default index and added the unstable path

### Tips for reviewer

Check in preview that:

1. Docs that are only in unstable are findable
2. Clicking on a result keeps you in unstable
