### PR TITLE
transform: handle more cases in `ThresholdElision`

### DIFF
--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -1,0 +1,154 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Derived attributes framework and definitions.
+
+use std::collections::HashMap;
+
+use mz_expr::{LocalId, MirRelationExpr};
+
+pub mod non_negative;
+pub mod subtree_size;
+
+/// A common interface to be implemented by all derived attributes.
+pub trait Attribute {
+    /// The domain of the attribute values.
+    type Value: Clone + Eq + PartialEq;
+    /// The domain of the dependencies.
+    type Dependencies;
+
+    /// Derive an attribute.
+    fn derive(&mut self, expr: &MirRelationExpr, deps: &Self::Dependencies);
+
+    /// Schedule environment maintenance tasks.
+    ///
+    /// Deletate to [`Env::schedule_tasks`] if this attribute has an [`Env`] field.
+    fn schedule_env_tasks(&mut self, _expr: &MirRelationExpr) {}
+
+    /// Handle scheduled environment maintenance tasks.
+    ///
+    /// Deletate to [`Env::handle_tasks`] if this attribute has an [`Env`] field.
+    fn handle_env_tasks(&mut self) {}
+}
+
+/// A map that keeps the computed `A` values for all `LocalId`
+/// bindings in the current environment.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct Env<A: Attribute> {
+    /// The [`HashMap`] backing this environment.
+    env: HashMap<LocalId, A::Value>,
+    // A stack of tasks to maintain the `env` map.
+    env_tasks: Vec<EnvTask<A::Value>>,
+}
+
+impl<A: Attribute> Env<A> {
+    pub(crate) fn get(&self, id: &LocalId) -> Option<&A::Value> {
+        self.env.get(id)
+    }
+}
+
+impl<A: Attribute> Env<A> {
+    /// Schedules evinronment maintenance tasks.
+    ///
+    /// Should be called from a `Visitor<MirRelationExpr>::pre_visit` implementaion.
+    pub fn schedule_tasks(&mut self, expr: &MirRelationExpr) {
+        match expr {
+            MirRelationExpr::Let { id, .. } => {
+                // Add an Extend task to be handled in the post_visit the node children.
+                self.env_tasks.push(EnvTask::Extend(id.clone()));
+            }
+            _ => {
+                // Don not do anything with the environment in this node's children.
+                self.env_tasks.push(EnvTask::NoOp);
+            }
+        }
+    }
+
+    /// Handles scheduled evinronment maintenance tasks.
+    ///
+    /// Should be called from a `Visitor<MirRelationExpr>::post_visit` implementaion.
+    pub fn handle_tasks(&mut self, results: &Vec<A::Value>) {
+        // Pop the env task for this element's children.
+        let parent = self.env_tasks.pop();
+        // This should be always be NoOp, as this is either the original value or the
+        // terminal state of the state machine that Let children implement (see the
+        // code at the end of this method).
+        debug_assert!(parent.is_some() && parent.unwrap() == EnvTask::NoOp);
+
+        // Handle EnvTask initiated by the parent.
+        if let Some(env_task) = self.env_tasks.pop() {
+            // Compute a task to represent the next state of the state machine associated with
+            // this task.
+            let env_task = match env_task {
+                // An Extend indicates that the parent of the current node is a Let binding
+                // and we are about to leave a Let binding value.
+                EnvTask::Extend(id) => {
+                    // Before descending to the next sibling (the Let binding body), do as follows:
+                    // 1. Update the env map with the attribute derived for the Let binding value.
+                    let result = results.last().expect("unexpected empty results vector");
+                    let oldval = self.env.insert(id, result.clone());
+                    // 2. Create a task to be handled after visiting the Let binding body.
+                    match oldval {
+                        Some(val) => EnvTask::Reset(id, val), // reset old value if present
+                        None => EnvTask::Remove(id),          // remove key otherwise
+                    }
+                }
+                // An Reset task indicates that we are about to leave the Let binding body
+                // and the id of the Let parent shadowed another `id` in the environment.
+                EnvTask::Reset(id, val) => {
+                    // Before moving to the post_visit of the enclosing Let parent, do as follows:
+                    // 1. Reset the entry in the env map with the shadowed value.
+                    self.env.insert(id, val);
+                    // 2. Create a NoOp task indicating that there is nothing more to be done.
+                    EnvTask::NoOp
+                }
+                // An Remove task indicates that we are about to leave the Let binding body
+                // and the id of the Let parent did not shadow another `id` in the environment.
+                EnvTask::Remove(id) => {
+                    // Before moving to the post_visit of the enclosing Let parent, do as follows:
+                    // 1. Remove the value assciated with the given `id` from the environment.
+                    self.env.remove(&id);
+                    // 2. Create a NoOp task indicating that there is nothing more to be done.
+                    EnvTask::NoOp
+                }
+                // A NoOp task indicates that we don't need to do anyting.
+                EnvTask::NoOp => EnvTask::NoOp,
+            };
+            // Advance the state machine.
+            self.env_tasks.push(env_task);
+        };
+    }
+}
+
+/// Models an environment maintenence task that needs to be executed
+/// after visiting a [`MirRelationExpr`].
+///
+/// The [`Env::schedule_tasks`] hook installs such a task for each node,
+/// and the [`Env::handle_tasks`] hook removes it.
+///
+/// In addition, the [`Env::handle_tasks`] looks at the task installed
+/// by its parent and modifies it if needed, advancing it through the
+/// following state machinge from left to right:
+/// ```text
+/// Set --- Reset ---- NoOp
+///     \            /
+///      -- Remove --
+/// ```
+#[derive(Eq, PartialEq, Debug)]
+enum EnvTask<T> {
+    /// Add the latest attribute to the environment under the given key.
+    Extend(LocalId),
+    /// Reset value of an environment entry.
+    Reset(LocalId, T),
+    /// Remove an entry from the environment.
+    Remove(LocalId),
+    /// Do not do anything.
+    NoOp,
+}

--- a/src/transform/src/attribute/non_negative.rs
+++ b/src/transform/src/attribute/non_negative.rs
@@ -1,0 +1,135 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Definition and helper structs for the [`NonNegative`] attribute.
+
+use mz_expr::Id;
+use mz_expr::MirRelationExpr;
+
+use super::subtree_size::SubtreeSize;
+use super::{Attribute, Env};
+
+/// Traverses a [`MirRelationExpr`] tree and figures out whether for subtree
+/// the sum of all diffs up to a specific time for any record can be a
+/// negative value.
+///
+/// The sresult for each subtree are accumulated in a bottom-up order
+/// in [`NonNegative::results`].
+///
+/// This method is a conservative approximation and is known to miss not-hard
+/// cases.
+///
+/// It assumes that all `Get` bindings correspond to collections without negative
+/// multiplicities. Local let bindings present in `safe_lets` are relied on to have
+/// no non-negative multiplicities by the `env` field.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct NonNegative {
+    /// Environment of computed values for this attribute.
+    env: Env<Self>,
+    /// A vector of results for all nodes in the visited tree in
+    /// post-visit order.
+    pub results: Vec<bool>,
+}
+
+impl Attribute for NonNegative {
+    type Value = bool;
+    type Dependencies = SubtreeSize;
+
+    fn derive(&mut self, expr: &MirRelationExpr, subtree_size: &SubtreeSize) {
+        use MirRelationExpr::*;
+        let n = self.results.len();
+        match expr {
+            Constant { rows, .. } => {
+                if let Ok(rows) = rows {
+                    let has_negative_rows = rows.iter().any(|(_data, diff)| diff < &0);
+                    self.results.push(has_negative_rows);
+                } else {
+                    self.results.push(true); // constant errors are considered "non-negative"
+                }
+            }
+            Get { id, .. } => match id {
+                Id::Local(id) => match self.env.get(id) {
+                    Some(value) => self.results.push(value.clone()),
+                    None => self.results.push(false),
+                },
+                Id::Global(_) => {
+                    self.results.push(true);
+                }
+            },
+            Let {
+                value: _, body: _, ..
+            } => {
+                let body = self.results[n - 1];
+                self.results.push(body);
+            }
+            Project { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+            Map { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+            FlatMap { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+            Filter { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+            Join { inputs, .. } => {
+                let mut result = true;
+                let mut offset = 1;
+                for _ in 0..inputs.len() {
+                    result &= &self.results[n - offset];
+                    offset += &subtree_size.results[n - offset];
+                }
+                self.results.push(result); // can be refined
+            }
+            Reduce { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+            TopK { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+            Negate { input: _ } => {
+                self.results.push(false); // can be refined
+            }
+            Threshold { input: _ } => {
+                self.results.push(true);
+            }
+            Union { base: _, inputs } => {
+                let mut result = true;
+                let mut offset = 1;
+                for _ in 0..inputs.len() {
+                    result &= &self.results[n - offset];
+                    offset += &subtree_size.results[n - offset];
+                }
+                result &= &self.results[n - offset]; // include the base result
+                self.results.push(result); // can be refined
+            }
+            ArrangeBy { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input);
+            }
+        }
+    }
+
+    fn schedule_env_tasks(&mut self, expr: &MirRelationExpr) {
+        self.env.schedule_tasks(expr);
+    }
+
+    fn handle_env_tasks(&mut self) {
+        self.env.handle_tasks(&self.results);
+    }
+}

--- a/src/transform/src/attribute/subtree_size.rs
+++ b/src/transform/src/attribute/subtree_size.rs
@@ -1,0 +1,99 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Definition and helper structs for the [`SubtreeSize`] attribute.
+
+use mz_expr::MirRelationExpr;
+
+use super::Attribute;
+
+/// Compute the number of MirRelationExpr in each subtree in a bottom-up manner.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct SubtreeSize {
+    /// A vector of results for all nodes in the visited tree in
+    /// post-visit order.
+    pub results: Vec<usize>,
+}
+
+impl Attribute for SubtreeSize {
+    type Value = usize;
+    type Dependencies = ();
+
+    fn derive(&mut self, expr: &MirRelationExpr, _deps: &()) {
+        use MirRelationExpr::*;
+        let n = self.results.len();
+        match expr {
+            Constant { .. } => {
+                self.results.push(1);
+            }
+            Get { .. } => {
+                self.results.push(1);
+            }
+            Let {
+                value: _, body: _, ..
+            } => {
+                let body = self.results[n - 1];
+                let value = self.results[n - 1 - body];
+                self.results.push(body + value + 1);
+            }
+            Project { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            Map { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            FlatMap { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            Filter { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            Join { inputs, .. } => {
+                let mut offset = 1;
+                for _ in 0..inputs.len() {
+                    offset += &self.results[n - offset];
+                }
+                self.results.push(offset);
+            }
+            Reduce { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            TopK { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            Negate { input: _ } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            Threshold { input: _ } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+            Union { base: _, inputs } => {
+                let mut offset = 1;
+                for _ in 0..inputs.len() {
+                    offset += &self.results[n - offset];
+                }
+                offset += &self.results[n - offset]; // add base size
+                self.results.push(offset);
+            }
+            ArrangeBy { input: _, .. } => {
+                let input = self.results[n - 1];
+                self.results.push(input + 1);
+            }
+        }
+    }
+}

--- a/src/transform/src/column_knowledge.rs
+++ b/src/transform/src/column_knowledge.rs
@@ -393,6 +393,7 @@ pub fn optimize(
     // `DatumKnowledge` in the stack are the `DatumKnowledge` corresponding to
     // the children.
 
+    #[allow(deprecated)]
     expr.visit_mut_pre_post(
         &mut |e| {
             // We should not eagerly memoize `if` branches that might not be taken.

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -529,6 +529,7 @@ fn install_lifted_mfp(
                     expr.permute(&project);
                     // if column references refer to mapped expressions that have been
                     // lifted, replace the column reference with the mapped expression.
+                    #[allow(deprecated)]
                     expr.visit_mut_pre_post(
                         &mut |e| {
                             if let MirScalarExpr::Column(c) = e {

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -30,6 +30,7 @@ use mz_expr::{MirRelationExpr, MirScalarExpr};
 use mz_ore::id_gen::IdGen;
 use mz_repr::GlobalId;
 
+pub mod attribute;
 pub mod canonicalize_mfp;
 pub mod column_knowledge;
 pub mod cse;

--- a/src/transform/tests/testdata/threshold_elision
+++ b/src/transform/tests/testdata/threshold_elision
@@ -14,7 +14,7 @@ cat
 ok
 
 # simple positive test
-# (select * from x) except all (select * from x where a > 7)
+# (select * from x) except all (select * from x where a < 7)
 build apply=ThresholdElision
 (threshold
   (union [
@@ -37,7 +37,7 @@ build apply=ThresholdElision
 ----
 
 # simple positive test
-# (select * from x) except all (select * from x where a > 7)
+# (select * from x) except all (select * from x where a < 7)
 build apply=ThresholdElision
 (threshold
   (union [
@@ -61,7 +61,7 @@ build apply=ThresholdElision
 
 
 # simple negative test: EXCEPT ALL
-# (select * from x) except all (select * from y where a > 7)
+# (select * from x) except all (select * from y where a < 7)
 build apply=ThresholdElision
 (threshold
   (union [
@@ -85,7 +85,7 @@ build apply=ThresholdElision
 ----
 
 # simple positive test: EXCEPT
-# (select * from x) except (select * from x where a > 7)
+# (select * from x) except (select * from x where a < 7)
 build apply=ThresholdElision
 (threshold
   (union [
@@ -109,6 +109,44 @@ build apply=ThresholdElision
 ----
 ----
 
+# simple positive test: EXCEPT where the lhs has a Negate
+# with r as (select * from x except select * from x where a < 7)
+# select * from r except all select * from r where a > 9;
+build apply=ThresholdElision
+(let z
+    (threshold
+      (union [
+        (get x)
+        (negate
+          (filter (get x) [(call_binary lt #0 (7 Int64))])) ]))
+    (threshold
+      (union [
+        (get z)
+        (negate
+          (filter (get z) [(call_binary gt #0 (9 Int64))])) ])))
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+| Filter (#0 < 7)
+| Negate
+
+%2 = Let l0 =
+| Union %0 %1
+
+%3 =
+| Get %2 (l0)
+| Filter (#0 > 9)
+| Negate
+
+%4 =
+| Union %2 %3
+| Threshold
+----
+----
 
 # simple negative test: EXCEPT
 # (select * from x) except (select * from y where a > 7)
@@ -132,6 +170,45 @@ build apply=ThresholdElision
 
 %2 =
 | Union %0 %1
+| Threshold
+----
+----
+
+# (unsupported) positive test: EXCEPT where the lhs has a Negate
+# with r as (select * from x except select * from x where a < 7)
+# select * from r except all select * from r where a > 9;
+build apply=ThresholdElision
+(let z
+    (threshold
+      (union [
+        (get x)
+        (negate
+          (filter (get x) [(call_binary lt #0 (7 Int64))])) ]))
+    (threshold
+      (union [
+        (get z)
+        (negate
+          (filter (get z) [(call_binary gt #0 (9 Int64))])) ])))
+----
+----
+%0 =
+| Get x (u0)
+
+%1 =
+| Get x (u0)
+| Filter (#0 < 7)
+| Negate
+
+%2 = Let l0 =
+| Union %0 %1
+
+%3 =
+| Get %2 (l0)
+| Filter (#0 > 9)
+| Negate
+
+%4 =
+| Union %2 %3
 | Threshold
 ----
 ----

--- a/src/transform/tests/testdata/threshold_elision
+++ b/src/transform/tests/testdata/threshold_elision
@@ -144,7 +144,6 @@ build apply=ThresholdElision
 
 %4 =
 | Union %2 %3
-| Threshold
 ----
 ----
 
@@ -174,7 +173,7 @@ build apply=ThresholdElision
 ----
 ----
 
-# (unsupported) positive test: EXCEPT where the lhs has a Negate
+# positive test: EXCEPT where the lhs has a Negate
 # with r as (select * from x except select * from x where a < 7)
 # select * from r except all select * from r where a > 9;
 build apply=ThresholdElision
@@ -209,6 +208,5 @@ build apply=ThresholdElision
 
 %4 =
 | Union %2 %3
-| Threshold
 ----
 ----

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -265,7 +265,7 @@ Query:
 
 EOF
 
-# Complex example (unsupported): CTE with a join.
+# Complex example: CTE with a join.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 WITH cte AS (SELECT people.id FROM people, bands)
@@ -298,11 +298,10 @@ Query:
 
 %4 =
 | Union %2 %3
-| Threshold
 
 EOF
 
-# Complex example (unsupported): CTE with a DISTINCT.
+# Complex example: CTE with a DISTINCT.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 WITH cte AS (SELECT DISTINCT name FROM people)
@@ -324,11 +323,10 @@ Query:
 
 %2 =
 | Union %0 %1
-| Threshold
 
 EOF
 
-# Complex example (unsupported): CTE with a GROUP BY.
+# Complex example: CTE with a GROUP BY.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 WITH a(birth_year, no_people_born) AS (
@@ -355,11 +353,10 @@ Query:
 
 %2 =
 | Union %0 %1
-| Threshold
 
 EOF
 
-# Complex example (unsupported): a chain of CTEs with:
+# Complex example: a chain of CTEs with:
 # (1) an EXCEPT ALL in cte1 (that is, a plan containing Negate),
 # (2) a non-pushable operation (Distinct) in the cte2,
 # (3) an EXCEPT in the final result,
@@ -402,7 +399,6 @@ Query:
 
 %4 =
 | Union %2 %3
-| Threshold
 
 EOF
 

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -56,7 +56,7 @@ INSERT INTO band_members VALUES
     (1, 3),
     (1, 4)
 
-# simple case: EXCEPT ALL with a const literal constraint
+# Simple case: EXCEPT ALL with a const literal constraint.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 (
@@ -87,7 +87,7 @@ Query:
 
 EOF
 
-# simple case: EXCEPT ALL with an IS NOT NULL filter
+# Simple case: EXCEPT ALL with an IS NOT NULL filter.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 (
@@ -117,7 +117,7 @@ Query:
 
 EOF
 
-# simple case: EXCEPT
+# Simple case: EXCEPT.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 SELECT name FROM people
@@ -145,8 +145,8 @@ Query:
 
 EOF
 
-# negative example: EXCEPT ALL that should not be confused for an EXCEPT
-# the two inputs have a Reduce *with aggregates*
+# Negative example: EXCEPT ALL that should not be confused for an EXCEPT
+# the two inputs have a Reduce *with aggregates*.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 SELECT MAX(id) FROM people GROUP BY name
@@ -179,10 +179,10 @@ Query:
 
 EOF
 
-# complex example: EXCEPT ALL
-# here ThresholdElision can only match in after some prior simplifications
-# and for some reason (TBD later) this means that we need to run it ad the
-# end of the physical pass
+# Complex example: EXCEPT ALL.
+# Here ThresholdElision can only match in after some prior simplifications
+# and for some reason (TBD later) this means that we need to run it at the
+# end of the physical pass.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 (
@@ -222,10 +222,10 @@ Query:
 
 EOF
 
-# complex example: EXCEPT
-# here ThresholdElision can only match in after some prior simplifications
-# and for some reason (TBD later) this means that we need to run it ad the
-# end of the physical pass
+# Complex example: EXCEPT.
+# Here ThresholdElision can only match in after some prior simplifications
+# and for some reason (TBD later) this means that we need to run it at the
+# end of the physical pass.
 query T multiline
 EXPLAIN OPTIMIZED PLAN FOR
 (
@@ -262,5 +262,183 @@ Query:
 
 %2 =
 | Union %0 %1
+
+EOF
+
+# Complex example (unsupported): CTE with a join.
+query T multiline
+EXPLAIN OPTIMIZED PLAN FOR
+WITH cte AS (SELECT people.id FROM people, bands)
+SELECT * FROM cte EXCEPT ALL SELECT * FROM cte where id > 5;
+----
+Source materialize.public.bands (u1):
+| Project ()
+
+Source materialize.public.people (u2):
+| Project (#0)
+
+Query:
+%0 =
+| Get materialize.public.people (u2)
+| Project (#0)
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.bands (u1)
+| Project ()
+
+%2 = Let l0 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+
+%3 =
+| Get %2 (l0)
+| Filter (#0 > 5)
+| Negate
+
+%4 =
+| Union %2 %3
+| Threshold
+
+EOF
+
+# Complex example (unsupported): CTE with a DISTINCT.
+query T multiline
+EXPLAIN OPTIMIZED PLAN FOR
+WITH cte AS (SELECT DISTINCT name FROM people)
+SELECT * FROM cte EXCEPT ALL SELECT * FROM cte WHERE name LIKE 'J%'
+----
+Source materialize.public.people (u2):
+| Project (#1)
+
+Query:
+%0 = Let l0 =
+| Get materialize.public.people (u2)
+| Project (#1)
+| Distinct group=(#0)
+
+%1 =
+| Get %0 (l0)
+| Filter "J%" ~~(#0)
+| Negate
+
+%2 =
+| Union %0 %1
+| Threshold
+
+EOF
+
+# Complex example (unsupported): CTE with a GROUP BY.
+query T multiline
+EXPLAIN OPTIMIZED PLAN FOR
+WITH a(birth_year, no_people_born) AS (
+    SELECT EXTRACT(year from born), COUNT(*)
+    FROM people
+    GROUP BY EXTRACT(year from born)
+)
+SELECT * FROM a EXCEPT (SELECT * FROM a WHERE birth_year > 1940);
+----
+Source materialize.public.people (u2):
+| Project (#2)
+
+Query:
+%0 = Let l0 =
+| Get materialize.public.people (u2)
+| Project (#2)
+| Reduce group=(extract_year_d(#0))
+| | agg count(true)
+
+%1 =
+| Get %0 (l0)
+| Filter (#0 > 1940)
+| Negate
+
+%2 =
+| Union %0 %1
+| Threshold
+
+EOF
+
+# Complex example (unsupported): a chain of CTEs with:
+# (1) an EXCEPT ALL in cte1 (that is, a plan containing Negate),
+# (2) a non-pushable operation (Distinct) in the cte2,
+# (3) an EXCEPT in the final result,
+# The optimization still removes the Threshold operators in both
+# (1) and (3) because the non_negative value inferred for cte1
+# prior to the rewrite is maintained for downstream rewrites.
+query T multiline
+EXPLAIN OPTIMIZED PLAN FOR
+WITH cte1 AS (
+    SELECT * FROM people
+    EXCEPT ALL
+    SELECT * FROM people WHERE name LIKE 'J%'
+), cte2 AS (
+    SELECT DISTINCT * FROM cte1
+)
+SELECT * FROM cte2
+EXCEPT
+SELECT * FROM cte2 WHERE name LIKE 'P%';
+----
+Source materialize.public.people (u2):
+| Project (#0..=#3)
+
+Query:
+%0 =
+| Get materialize.public.people (u2)
+
+%1 =
+| Get materialize.public.people (u2)
+| Filter "J%" ~~(#1)
+| Negate
+
+%2 = Let l0 =
+| Union %0 %1
+| Distinct group=(#0, #1, #2, #3)
+
+%3 =
+| Get %2 (l0)
+| Filter "P%" ~~(#1)
+| Negate
+
+%4 =
+| Union %2 %3
+| Threshold
+
+EOF
+
+# Complex example (unsupported): A - (σ(p)(A) ⊎ σ(q)(A)).
+query T multiline
+EXPLAIN OPTIMIZED PLAN FOR
+SELECT name FROM people
+EXCEPT ALL
+(
+    SELECT name FROM people WHERE id = 1
+    UNION ALL
+    SELECT name FROM people WHERE id = 2
+)
+----
+Source materialize.public.people (u2):
+| Project (#0, #1)
+
+Query:
+%0 =
+| Get materialize.public.people (u2)
+| Project (#1)
+
+%1 =
+| Get materialize.public.people (u2)
+| Filter (#0 = 1)
+| Project (#1)
+| Negate
+
+%2 =
+| Get materialize.public.people (u2)
+| Filter (#0 = 2)
+| Project (#1)
+| Negate
+
+%3 =
+| Union %0 %1 %2
+| Threshold
 
 EOF


### PR DESCRIPTION
This PR addresses some of the limitations of  `ThresholdElision` that were discovered by @philip-stoev while testing #14085. This is important because these limitations affect some anticipated customer workloads.

### Motivation

  * This PR fixes a recognized bug.

  Resolves some of the issues limitations tracked in #14142.

### Tips for reviewer

- The first commit introduces changes in the `visit.rs` module that are necessary to resolve this issue. See the commit message for details.
- The second commit extends `threshold_elision.slt` with some test cases that demonstrate it's current limitations around CTEs.
- The third commit addresses these test cases by introducing several changes in `threshold_elision.rs`, described in more detail below.

First, non-negativity as now modeled as a `NonNegative` struct rather than a function. `NonNegative` implements `Attribute` in order to:
- define `NonNegative::derive` in order to derive attribute values in a bottom-up manner, and
- maintain an environment of derived outcomes for each `LocalId` in scope.

The state machine required to implement the latter is bit clunky, but (1) it allows us to piggy back on an externally driven recursion scheme, and (2) it only needs to be written once. In fact, I can demonstrate this almost immediately in a separate PR if requested.

Second, I introduce a new struct `ThresholdElisionAction` which wraps a `NonNegative` instance and itself implements `VisitorMut` in order to:
- delegate attribute derivation to `NonNegative` (a form of chain of responsibility),
- call the transform `action` (now moved to this new type) after the `NonNegative` attribute has been
  derived.

This ensures that non-negative `LocalId` values that fall outside of the scope of the `Threshold` that is matched at the root of the transform `action` method are correctly classified.

Also, because both attribute derivation and transformation attempts work in a single pass, the implementation improves the runtime behavior (sadly the asymptotic complexity is still `O(n^2)` because of the `is_superset_of` call).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The optimizer now includes a transformation that will attempt to remove `Threshold` operators in certain cases where this is safe, thereby reducing the memory footprint of queries of the form `A EXCEPT B` or `A EXCEPT ALL B`, where `B` can be shown to be a subset of `A`.
