### PR TITLE
Assert that only single node replicas use reconciliation

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -69,6 +69,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     for name in [
         "test-cluster",
         "test-github-12251",
+        "test-github-13603",
         "test-remote-storaged",
         "test-drop-default-cluster",
         "test-upsert",
@@ -121,6 +122,29 @@ def workflow_test_cluster(c: Composition, parser: WorkflowArgumentParser) -> Non
     # Leave only replica 2 up and verify that tests still pass.
     c.sql("DROP CLUSTER REPLICA cluster1.replica1")
     c.run("testdrive", *args.glob)
+
+
+def workflow_test_github_13603(c: Composition) -> None:
+    """Test that multi woker replicas terminate eagerly upon rehydration"""
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+    c.wait_for_materialized()
+
+    c.up("computed_1")
+    c.up("computed_2")
+    c.sql(
+        "CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ['computed_1:2100', 'computed_2:2100']));"
+    )
+
+    c.kill("materialized")
+    c.up("materialized")
+    c.wait_for_materialized()
+
+    # Ensure the computeds have crashed
+    c1 = c.invoke("logs", "computed_1", capture=True)
+    assert "panicked" in c1.stdout
+    c2 = c.invoke("logs", "computed_2", capture=True)
+    assert "panicked" in c2.stdout
 
 
 def workflow_test_github_12251(c: Composition) -> None:


### PR DESCRIPTION
Reconciliation in multi node clusters is not working correctly, see #13603.

This PR adds as a stop-gap an assertion that reconciliation in multi-node replicas crashes early and loudly. In production the instance will be restarted by kubernetes.

A future PR will implement suggestion 2 outlined in #13603 and revert this change.


### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No release notes
