### PR TITLE
persist-client: Avoid cloning upper frontier

### DIFF
--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -366,7 +366,7 @@ mod api {
         async fn snapshot(&mut self, as_of: Antichain<T>)
             -> Result<Vec<((K, V), T)>, Antichain<T>>;
 
-        async fn current_upper(&mut self) -> Antichain<T>;
+        async fn current_upper(&mut self) -> &Antichain<T>;
 
         /// Tries to append the given updates to the maintained collection. If the current
         /// upper is not `expected_upper` this will return an `Err` containing the current
@@ -888,7 +888,7 @@ mod impls {
             + Sync
             + Copy,
     {
-        async fn current_upper(&mut self) -> Antichain<T> {
+        async fn current_upper(&mut self) -> &Antichain<T> {
             self.write.fetch_recent_upper().await
         }
 

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -102,12 +102,12 @@ where
         self.state.shard_id()
     }
 
-    pub async fn fetch_upper(&mut self) -> Antichain<T> {
+    pub async fn fetch_upper(&mut self) -> &Antichain<T> {
         self.fetch_and_update_state().await;
         self.state.upper()
     }
 
-    pub fn upper(&self) -> Antichain<T> {
+    pub fn upper(&self) -> &Antichain<T> {
         self.state.upper()
     }
 
@@ -200,8 +200,8 @@ where
 
                     // We tried to to a compare_and_append with the wrong
                     // expected upper, that won't work.
-                    if &current_upper != batch.desc.lower() {
-                        return Ok(Ok(Err(Upper(current_upper))));
+                    if current_upper != batch.desc.lower() {
+                        return Ok(Ok(Err(Upper(current_upper.clone()))));
                     } else {
                         // The upper stored in state was outdated. Retry after
                         // updating.

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -309,8 +309,8 @@ where
         self.collections.trace.since()
     }
 
-    pub fn upper(&self) -> Antichain<T> {
-        self.collections.trace.upper().clone()
+    pub fn upper(&self) -> &Antichain<T> {
+        self.collections.trace.upper()
     }
 
     pub fn batch_count(&self) -> usize {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -930,11 +930,11 @@ mod tests {
             .await;
 
         // The shard-global upper does advance, even if this writer didn't advance its local upper.
-        assert_eq!(write2.fetch_recent_upper().await, Antichain::from_elem(3));
+        assert_eq!(write2.fetch_recent_upper().await, &Antichain::from_elem(3));
 
         // The writer-local upper should advance, even if it was another writer
         // that advanced the frontier.
-        assert_eq!(write2.upper().clone(), Antichain::from_elem(3));
+        assert_eq!(write2.upper(), &Antichain::from_elem(3));
     }
 
     #[tokio::test]

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -121,7 +121,7 @@ where
     /// This requires fetching the latest state from consensus and is therefore a potentially
     /// expensive operation.
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
-    pub async fn fetch_recent_upper(&mut self) -> Antichain<T> {
+    pub async fn fetch_recent_upper(&mut self) -> &Antichain<T> {
         trace!("WriteHandle::fetch_recent_upper");
         // TODO: Do we even need to track self.upper on WriteHandle or could
         // WriteHandle::upper just get the one out of machine?


### PR DESCRIPTION
This avoids several allocations by returning a reference instead of owned
data.

Signed-off-by: Moritz Hoffmann <mh@materialize.com>

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
