### PR TITLE
[persist]: Modify `downgrade_since` to take a ref Antichain

### DIFF
--- a/src/persist-client/examples/maelstrom/txn.rs
+++ b/src/persist-client/examples/maelstrom/txn.rs
@@ -376,7 +376,7 @@ impl Transactor {
         let new_since = self.read_ts.saturating_sub(SINCE_LAG);
         debug!("downgrading since to {}", new_since);
         self.read
-            .downgrade_since(Antichain::from_elem(new_since))
+            .downgrade_since(&Antichain::from_elem(new_since))
             .await;
         self.since_ts = new_since;
     }

--- a/src/persist-client/examples/source_example.rs
+++ b/src/persist-client/examples/source_example.rs
@@ -1400,7 +1400,7 @@ mod reader {
                                 break 'outer;
                             }
 
-                            read.downgrade_since(p).await;
+                            read.downgrade_since(&p).await;
                         }
                         ListenEvent::Updates(updates) => {
                             println!("instance {}: got updates from listen: {:?}", name, updates);

--- a/src/persist-client/src/impl/encoding.rs
+++ b/src/persist-client/src/impl/encoding.rs
@@ -262,7 +262,7 @@ impl<T: Timestamp + Lattice + Codec64> RustType<ProtoTrace> for Trace<T> {
 
     fn from_proto(proto: ProtoTrace) -> Result<Self, TryFromProtoError> {
         let mut ret = Trace::default();
-        ret.downgrade_since(proto.since.into_rust_if_some("since")?);
+        ret.downgrade_since(&proto.since.into_rust_if_some("since")?);
         for batch in proto.spine.into_iter() {
             let batch: HollowBatch<T> = batch.into_rust()?;
             if PartialOrder::less_than(ret.since(), batch.desc.since()) {

--- a/src/persist-client/src/impl/state.rs
+++ b/src/persist-client/src/impl/state.rs
@@ -242,7 +242,7 @@ where
         while let Some(reader) = readers.next() {
             since.meet_assign(&reader.since);
         }
-        self.trace.downgrade_since(since);
+        self.trace.downgrade_since(&since);
     }
 }
 

--- a/src/persist-client/src/impl/trace.rs
+++ b/src/persist-client/src/impl/trace.rs
@@ -99,8 +99,8 @@ impl<T: Timestamp + Lattice> Trace<T> {
         &self.spine.upper
     }
 
-    pub fn downgrade_since(&mut self, since: Antichain<T>) {
-        self.spine.since = since;
+    pub fn downgrade_since(&mut self, since: &Antichain<T>) {
+        self.spine.since.clone_from(since);
     }
 
     pub fn push_batch(&mut self, batch: HollowBatch<T>) {

--- a/src/persist-client/src/impl/trace.rs
+++ b/src/persist-client/src/impl/trace.rs
@@ -1112,7 +1112,7 @@ mod tests {
                     }
                     "downgrade-since" => {
                         let since = tc.input.trim().parse().expect("invalid since");
-                        trace.downgrade_since(Antichain::from_elem(since));
+                        trace.downgrade_since(&Antichain::from_elem(since));
                         "ok\n".to_owned()
                     }
                     "take-merge-reqs" => {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -604,7 +604,7 @@ mod tests {
         );
 
         // Downgrading the since is tracked locally (but otherwise is a no-op).
-        read.downgrade_since(Antichain::from_elem(2)).await;
+        read.downgrade_since(&Antichain::from_elem(2)).await;
         assert_eq!(read.since(), &Antichain::from_elem(2));
     }
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -250,7 +250,7 @@ where
         // This listen only needs to distinguish things after its frontier
         // (initially as_of although the frontier is inclusive and the as_of
         // isn't). Be a good citizen and downgrade early.
-        ret.handle.downgrade_since(ret.since.clone()).await;
+        ret.handle.downgrade_since(&ret.since).await;
         ret
     }
 
@@ -480,11 +480,11 @@ where
     /// This also acts as a heartbeat for the reader lease (including if called
     /// with `new_since` equal to `self.since()`, making the call a no-op).
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
-    pub async fn downgrade_since(&mut self, new_since: Antichain<T>) {
+    pub async fn downgrade_since(&mut self, new_since: &Antichain<T>) {
         trace!("ReadHandle::downgrade_since new_since={:?}", new_since);
         let (_seqno, current_reader_since, maintenance) = self
             .machine
-            .downgrade_since(&self.reader_id, &new_since, (self.cfg.now)())
+            .downgrade_since(&self.reader_id, new_since, (self.cfg.now)())
             .await;
         self.since = current_reader_since.0;
         // A heartbeat is just any downgrade_since traffic, so update the
@@ -702,7 +702,7 @@ where
         let min_elapsed = PersistConfig::FAKE_READ_LEASE_DURATION / 4;
         let elapsed_since_last_heartbeat = self.last_heartbeat.elapsed();
         if elapsed_since_last_heartbeat >= min_elapsed {
-            self.downgrade_since(new_since.clone()).await;
+            self.downgrade_since(&new_since).await;
         }
     }
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -432,7 +432,7 @@ where
 /// # let timeout: std::time::Duration = unimplemented!();
 /// # let new_since: timely::progress::Antichain<u64> = unimplemented!();
 /// # async {
-/// tokio::time::timeout(timeout, read.downgrade_since(new_since)).await
+/// tokio::time::timeout(timeout, read.downgrade_since(&new_since)).await
 /// # };
 /// ```
 #[derive(Debug)]

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -653,7 +653,7 @@ where
 
             // Advance the collection's `since` as requested.
             if let Some(since) = &description.since {
-                read.downgrade_since(since.clone()).await;
+                read.downgrade_since(&since).await;
             }
 
             let collection_state =
@@ -1208,7 +1208,7 @@ mod persist_read_handles {
                                     for (id, read) in read_handles.iter_mut() {
                                         if let Some((span, since)) = downgrades.remove(id) {
                                             let fut = async move {
-                                                read.downgrade_since(since).instrument(span).await;
+                                                read.downgrade_since(&since).instrument(span).await;
                                             };
 
                                             futs.push(fut);


### PR DESCRIPTION
Some of the `downgrade_since` methods take a `new_since: Antichain` and others `new_since: &Antichain`. It seems all can take the reference, as those that take ownership use it in assignment and can use `clone_from` on the reference instead.

No strong feels about the urgency of doing this, but @antiguru noticed a bunch of `Antichain::clone` churn in a recent memory profile, and we were tracking down places to tidy that might be contributors!

### Motivation

  * This PR replaces calls to `Antichain::clone` with calls to `Antichain::clone_from`, which may avoid allocations.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
