### PR TITLE
Clean up string interpolation in pyactivate script

### DIFF
--- a/bin/pyactivate
+++ b/bin/pyactivate
@@ -25,7 +25,7 @@ logger = logging.getLogger("bootstrap")
 
 def main(args: List[str]) -> int:
     logging.basicConfig(level=os.environ.get("MZ_DEV_LOG", "WARNING").upper())
-    logger.debug("args={}".format(args))
+    logger.debug("args=%s", args)
 
     # Validate Python version.
     if sys.hexversion < 0x03090000:
@@ -40,7 +40,7 @@ def main(args: List[str]) -> int:
 
     root_dir = Path(__file__).parent.parent
     py_dir = root_dir / "misc" / "python"
-    logger.debug("root_dir={} py_dir={}".format(root_dir, py_dir))
+    logger.debug("root_dir=%s py_dir=%s", root_dir, py_dir)
 
     # If we're not in the CI builder container, activate a virtualenv with the
     # necessary dependencies.
@@ -48,7 +48,7 @@ def main(args: List[str]) -> int:
         python = "python3"
     else:
         python = str(activate_venv(py_dir))
-    logger.debug("python={}".format(python))
+    logger.debug("python=%s", python)
 
     # Reinvoke with the interpreter from the virtualenv.
     py_path = str(py_dir.resolve())
@@ -64,7 +64,7 @@ def activate_venv(py_dir: Path) -> Path:
     stamp_path = venv_dir / "dep_stamp"
     bin_dir = venv_dir / "bin"
     python = bin_dir / "python"
-    logger.debug("venv_dir={} python={}".format(venv_dir, python))
+    logger.debug("venv_dir=%s python=%s", venv_dir, python)
 
     # Create a virtualenv, if necessary. virtualenv creation is not atomic, so
     # we don't want to assume the presence of a `venv` directory means that we
@@ -87,8 +87,8 @@ def activate_venv(py_dir: Path) -> Path:
                 "warning: existing virtualenv is unable to execute python; will recreate",
                 file=sys.stderr
             )
-            logger.info(f"python exec error: {e}")
-        print("==> Initializing virtualenv in {}".format(venv_dir), file=sys.stderr)
+            logger.info("python exec error: %s", e)
+        print(f"==> Initializing virtualenv in {venv_dir}", file=sys.stderr)
         # Install Python into the virtualenv via a symlink rather than copying,
         # except on Windows. This matches the behavior of the `python -m venv`
         # command line tool. This is important on macOS, where the default
@@ -152,22 +152,18 @@ def acquire_deps(venv_dir: Path, variant: Optional[str] = None, use_pep517: bool
         stamp_mtime = os.path.getmtime(stamp_path)
     except FileNotFoundError:
         stamp_mtime = 0
-    logger.debug("stamp_path={} stamp_mtime={}".format(stamp_path, stamp_mtime))
+    logger.debug("stamp_path=%s stamp_mtime=%s", stamp_path, stamp_mtime)
 
     # Check when the requirements file was last modified.
     requirements_path = venv_dir.parent / (
         f"requirements-{variant}.txt" if variant else "requirements.txt"
     )
     requirements_mtime = os.path.getmtime(requirements_path)
-    logger.debug(
-        "requirements_path={} requirements_mtime={}".format(
-            requirements_path, requirements_mtime
-        )
-    )
+    logger.debug("requirements_path=%s requirements_mtime=%s", requirements_path, requirements_mtime)
 
     # Update dependencies, if necessary.
     if stamp_mtime <= requirements_mtime:
-        print("==> Updating {}dependencies with pip".format(variant + " " if variant else ""), file=sys.stderr)
+        print(f"==> Updating {variant + ' ' if variant else ''}dependencies with pip", file=sys.stderr)
         subprocess.check_call([
             venv_dir / "bin" / "pip", "install", "-r", requirements_path,
             "--disable-pip-version-check",


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

This updates the script to use logging's built-in support for
interpolation. This is beneficial because the interpolation will only be
performed when the log level matches the log statement's level.

This additionally updates all uses of `str.format` to be f-strings,
except in the case where we encounter a Python distribution < 3.9, where
we'll want to support the old style.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
