### PR TITLE
adapter: consolidate migrations

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1996,22 +1996,6 @@ impl<S: Append> Catalog<S> {
                     catalog.allocate_persisted_introspection_items().await
                 }
 
-                SerializedComputeInstanceReplicaLogging::Concrete(x) => {
-                    ConcreteComputeInstanceReplicaLogging::ConcreteViews(x.clone(), {
-                        // Build the views only if the cluster is configured with logging
-                        let inst = catalog
-                            .state
-                            .compute_instances_by_id
-                            .get(&instance_id)
-                            .unwrap();
-                        if inst.logging.is_some() {
-                            catalog.allocate_persisted_introspection_views().await
-                        } else {
-                            vec![]
-                        }
-                    })
-                }
-
                 SerializedComputeInstanceReplicaLogging::ConcreteViews(x, y) => {
                     ConcreteComputeInstanceReplicaLogging::ConcreteViews(x.clone(), y.clone())
                 }
@@ -4356,8 +4340,6 @@ pub enum SerializedComputeInstanceReplicaLogging {
     /// Instantiate default logging configuration upon system start.
     /// To configure a replica without logging, ConcreteViews(vec![],vec![]) should be used.
     Default,
-    /// Logging sources have been built for this replica.
-    Concrete(Vec<(LogVariant, GlobalId)>),
     /// Logging sources and views have been built for this replica.
     ConcreteViews(Vec<(LogVariant, GlobalId)>, Vec<(LogView, GlobalId)>),
 }
@@ -4366,7 +4348,6 @@ impl From<ConcreteComputeInstanceReplicaLogging> for SerializedComputeInstanceRe
     fn from(conc: ConcreteComputeInstanceReplicaLogging) -> Self {
         match conc {
             ConcreteComputeInstanceReplicaLogging::Default => Self::Default,
-            ConcreteComputeInstanceReplicaLogging::Concrete(x) => Self::Concrete(x),
             ConcreteComputeInstanceReplicaLogging::ConcreteViews(x, y) => Self::ConcreteViews(x, y),
         }
     }

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -142,9 +142,6 @@ pub enum ConcreteComputeInstanceReplicaLogging {
     /// Instantiate default logging configuration upon system start.
     /// To configure a replica without logging, ConcreteViews(vec![],vec![]) should be used.
     Default,
-    /// Logging sources have been built for this replica. Upon system restart,
-    /// this will be replaced with ConcreteViews.
-    Concrete(Vec<(LogVariant, GlobalId)>),
     /// Logging sources and views have been built for this replica.
     ConcreteViews(Vec<(LogVariant, GlobalId)>, Vec<(LogView, GlobalId)>),
 }
@@ -154,7 +151,6 @@ impl ConcreteComputeInstanceReplicaLogging {
     pub fn get_sources(&self) -> Vec<(LogVariant, GlobalId)> {
         match self {
             ConcreteComputeInstanceReplicaLogging::Default => vec![],
-            ConcreteComputeInstanceReplicaLogging::Concrete(logs) => logs.clone(),
             ConcreteComputeInstanceReplicaLogging::ConcreteViews(logs, _) => logs.clone(),
         }
     }
@@ -163,7 +159,6 @@ impl ConcreteComputeInstanceReplicaLogging {
     pub fn get_views(&self) -> Vec<(LogView, GlobalId)> {
         match self {
             ConcreteComputeInstanceReplicaLogging::Default => vec![],
-            ConcreteComputeInstanceReplicaLogging::Concrete(_) => vec![],
             ConcreteComputeInstanceReplicaLogging::ConcreteViews(_, views) => views.clone(),
         }
     }


### PR DESCRIPTION
We are removing everything in a few days, so can consolidate the
migrations.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
