### PR TITLE
images: support arm cockroach

### DIFF
--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -7,6 +7,37 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# 22.1.2 community images with amd and arm variants. Used here so we can copy
+# the cockroach binary if this is an arm host. We are temporarily using this
+# image from the community until an official image is published.
+FROM juliuszaromskis/cockroachdb:22.1.2 AS crdb-arm
+
+# Create an image that determines the cockroach binary (so we don't have two
+# copies in the final image).
+MZFROM ubuntu-base AS crdb-bin
+
+RUN apt-get update \
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        ca-certificates \
+        curl
+
+COPY --from=crdb-arm /cockroach/cockroach /cockroach-arm
+
+ARG COCKROACH_VERSION=22.1.5
+
+RUN set -eux; \
+	arch="$(dpkg --print-architecture)"; arch="${arch##*-}"; \
+	case "$arch" in \
+		'amd64') \
+		         curl https://binaries.cockroachdb.com/cockroach-v${COCKROACH_VERSION}.linux-amd64.tgz | tar -xz;  \
+		         cp cockroach-v${COCKROACH_VERSION}.linux-amd64/cockroach /cockroach; \
+			;; \
+		'arm64') \
+			mv /cockroach-arm /cockroach; \
+			;; \
+		*) echo >&2 "error: unsupported architecture '$arch'"; exit 1 ;; \
+	esac;
+
 MZFROM ubuntu-base
 
 RUN apt-get update \
@@ -21,10 +52,7 @@ RUN apt-get update \
     && mkdir /cockroach-data \
     && chown materialize /mzdata /cockroach-data
 
-ARG COCKROACH_VERSION=22.1.5
-
-RUN curl https://binaries.cockroachdb.com/cockroach-v${COCKROACH_VERSION}.linux-amd64.tgz | tar -xz \
-    && cp cockroach-v${COCKROACH_VERSION}.linux-amd64/cockroach /usr/local/bin/
+COPY --from=crdb-bin /cockroach /usr/local/bin/cockroach
 
 COPY storaged computed environmentd entrypoint.sh /usr/local/bin/
 


### PR DESCRIPTION
Try to get the materialized image to work on m1 macs.

### Motivation

  * This PR fixes a previously unreported bug.m

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a