### PR TITLE
adapter: use "storage usage" rather than "storage metrics" everywhere

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -75,9 +75,7 @@ use crate::catalog::builtin::{
     MZ_TEMP_SCHEMA, PG_CATALOG_SCHEMA,
 };
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
-pub use crate::catalog::config::{
-    ClusterReplicaSizeMap, Config, StorageHostSizeMap, DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL,
-};
+pub use crate::catalog::config::{ClusterReplicaSizeMap, Config, StorageHostSizeMap};
 pub use crate::catalog::error::{AmbiguousRename, Error, ErrorKind};
 use crate::catalog::storage::BootstrapArgs;
 use crate::client::ConnectionId;
@@ -1746,7 +1744,6 @@ impl<S: Append> Catalog<S> {
                     session_id: Uuid::new_v4(),
                     build_info: config.build_info,
                     timestamp_frequency: Duration::from_secs(1),
-                    storage_usage_collection_interval: DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL,
                     now: config.now.clone(),
                 },
                 oid_counter: FIRST_USER_OID,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -25,7 +25,7 @@ use tracing::{info, trace};
 use uuid::Uuid;
 
 use mz_audit_log::{
-    EventDetails, EventType, FullNameV1, ObjectType, VersionedEvent, VersionedStorageMetrics,
+    EventDetails, EventType, FullNameV1, ObjectType, VersionedEvent, VersionedStorageUsage,
 };
 use mz_build_info::DUMMY_BUILD_INFO;
 use mz_compute_client::command::{ProcessId, ReplicaId};
@@ -76,7 +76,7 @@ use crate::catalog::builtin::{
 };
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
 pub use crate::catalog::config::{
-    ClusterReplicaSizeMap, Config, StorageHostSizeMap, DEFAULT_STORAGE_METRIC_INTERVAL_SECONDS,
+    ClusterReplicaSizeMap, Config, StorageHostSizeMap, DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL,
 };
 pub use crate::catalog::error::{AmbiguousRename, Error, ErrorKind};
 use crate::catalog::storage::BootstrapArgs;
@@ -1746,9 +1746,7 @@ impl<S: Append> Catalog<S> {
                     session_id: Uuid::new_v4(),
                     build_info: config.build_info,
                     timestamp_frequency: Duration::from_secs(1),
-                    storage_metrics_collection_interval: Duration::from_secs(
-                        DEFAULT_STORAGE_METRIC_INTERVAL_SECONDS,
-                    ),
+                    storage_usage_collection_interval: DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL,
                     now: config.now.clone(),
                 },
                 oid_counter: FIRST_USER_OID,
@@ -2128,9 +2126,9 @@ impl<S: Append> Catalog<S> {
             builtin_table_updates.push(catalog.state.pack_audit_log_update(&event)?);
         }
 
-        let storage_metric_events = catalog.storage().await.load_storage_metrics().await?;
-        for event in storage_metric_events {
-            let event = VersionedStorageMetrics::deserialize(&event).unwrap();
+        let storage_usage_events = catalog.storage().await.storage_usage().await?;
+        for event in storage_usage_events {
+            let event = VersionedStorageUsage::deserialize(&event).unwrap();
             builtin_table_updates.push(catalog.state.pack_storage_usage_update(&event)?);
         }
 
@@ -3010,7 +3008,7 @@ impl<S: Append> Catalog<S> {
         Ok(())
     }
 
-    fn add_to_storage_metrics(
+    fn add_to_storage_usage(
         &self,
         tx: &mut storage::Transaction<S>,
         builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
@@ -3018,12 +3016,12 @@ impl<S: Append> Catalog<S> {
         size_bytes: u64,
     ) -> Result<(), Error> {
         let collection_timestamp = (self.state.config.now)();
-        let id = tx.get_and_increment_id(storage::STORAGE_METRICS_ID_ALLOC_KEY.to_string())?;
+        let id = tx.get_and_increment_id(storage::STORAGE_USAGE_ID_ALLOC_KEY.to_string())?;
 
         let event_details =
-            VersionedStorageMetrics::new(id, object_id, size_bytes, collection_timestamp);
+            VersionedStorageUsage::new(id, object_id, size_bytes, collection_timestamp);
         builtin_table_updates.push(self.state.pack_storage_usage_update(&event_details)?);
-        tx.insert_storage_metrics_event(event_details);
+        tx.insert_storage_usage_event(event_details);
         Ok(())
     }
 
@@ -3687,11 +3685,11 @@ impl<S: Append> Catalog<S> {
 
                     vec![Action::UpdateComputeInstanceStatus { event }]
                 }
-                Op::UpdateStorageMetrics {
+                Op::UpdateStorageUsage {
                     object_id,
                     size_bytes,
                 } => {
-                    self.add_to_storage_metrics(
+                    self.add_to_storage_usage(
                         &mut tx,
                         &mut builtin_table_updates,
                         object_id,
@@ -4307,7 +4305,7 @@ pub enum Op {
     UpdateComputeInstanceStatus {
         event: ComputeInstanceEvent,
     },
-    UpdateStorageMetrics {
+    UpdateStorageUsage {
         object_id: Option<String>,
         size_bytes: u64,
     },

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -9,7 +9,7 @@
 
 use chrono::{DateTime, Utc};
 
-use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageMetrics};
+use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
 use mz_compute_client::command::{ProcessId, ReplicaId};
 use mz_compute_client::controller::ComputeInstanceId;
 use mz_controller::{ComputeInstanceStatus, ConcreteComputeInstanceReplicaLocation};
@@ -746,11 +746,11 @@ impl CatalogState {
 
     pub fn pack_storage_usage_update(
         &self,
-        event: &VersionedStorageMetrics,
+        event: &VersionedStorageUsage,
     ) -> Result<BuiltinTableUpdate, Error> {
         let (id, object_id, size_bytes, collection_timestamp): (u64, &Option<String>, u64, u64) =
             match event {
-                VersionedStorageMetrics::V1(ev) => {
+                VersionedStorageUsage::V1(ev) => {
                     (ev.id, &ev.object_id, ev.size_bytes, ev.collection_timestamp)
                 }
             };

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -9,7 +9,6 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
-use std::time::Duration;
 
 use serde::Deserialize;
 
@@ -19,9 +18,6 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_storage::types::hosts::StorageHostResourceAllocation;
 
 use crate::catalog::storage;
-
-/// The default interval at which to collect storage usage information.
-pub const DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL: Duration = Duration::from_secs(3600);
 
 /// Configures a catalog.
 #[derive(Debug)]

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -9,6 +9,7 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
+use std::time::Duration;
 
 use serde::Deserialize;
 
@@ -19,8 +20,8 @@ use mz_storage::types::hosts::StorageHostResourceAllocation;
 
 use crate::catalog::storage;
 
-/// The default interval to collect storage usage information in seconds
-pub const DEFAULT_STORAGE_METRIC_INTERVAL_SECONDS: u64 = 3600;
+/// The default interval at which to collect storage usage information.
+pub const DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL: Duration = Duration::from_secs(3600);
 
 /// Configures a catalog.
 #[derive(Debug)]

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -733,7 +733,7 @@ impl<S: Append + 'static> Coordinator<S> {
 
         // Trigger a storage usage metric collection on configured interval
         let mut storage_usage_update_interval =
-            tokio::time::interval(self.catalog.config().storage_metrics_collection_interval);
+            tokio::time::interval(self.catalog.config().storage_usage_collection_interval);
 
         loop {
             // Before adding a branch to this select loop, please ensure that the branch is

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -110,7 +110,7 @@ impl<S: Append + 'static> Coordinator<S> {
         if let Err(err) = self
             .catalog_transact(
                 None,
-                vec![catalog::Op::UpdateStorageMetrics {
+                vec![catalog::Op::UpdateStorageUsage {
                     object_id,
                     size_bytes: known_storage,
                 }],

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -217,31 +217,31 @@ fn test_audit_log() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// VersionedStorageMetrics describes the state of storage
-/// for the environment, such as storage used, at a point in time.
-/// These metrics are persisted in the catalog across restarts,
-/// so any updates to the schema will require a new version.
+/// Describes the environment's storage usage at a point in time.
+///
+/// This type is persisted in the catalog across restarts, so any updates to the
+/// schema will require a new version.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum VersionedStorageMetrics {
-    V1(StorageMetricsV1),
+pub enum VersionedStorageUsage {
+    V1(StorageUsageV1),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StorageMetricsV1 {
+pub struct StorageUsageV1 {
     pub id: u64,
     pub object_id: Option<String>,
     pub size_bytes: u64,
     pub collection_timestamp: EpochMillis,
 }
 
-impl StorageMetricsV1 {
+impl StorageUsageV1 {
     pub fn new(
         id: u64,
         object_id: Option<String>,
         size_bytes: u64,
         collection_timestamp: EpochMillis,
-    ) -> StorageMetricsV1 {
-        StorageMetricsV1 {
+    ) -> StorageUsageV1 {
+        StorageUsageV1 {
             id,
             object_id,
             size_bytes,
@@ -250,7 +250,7 @@ impl StorageMetricsV1 {
     }
 }
 
-impl VersionedStorageMetrics {
+impl VersionedStorageUsage {
     /// Create a new metric snapshot.
     /// This function must always require and produce the most
     /// recent variant of VersionedStorageMetrics.
@@ -260,7 +260,7 @@ impl VersionedStorageMetrics {
         size_bytes: u64,
         collection_timestamp: EpochMillis,
     ) -> Self {
-        Self::V1(StorageMetricsV1::new(
+        Self::V1(StorageUsageV1::new(
             id,
             object_id,
             size_bytes,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -39,7 +39,7 @@ use mz_ore::tracing::OpenTelemetryEnableCallback;
 use mz_persist_client::usage::StorageUsageClient;
 use mz_secrets::SecretsController;
 use mz_storage::types::connections::ConnectionContext;
-use tracing::{error, info};
+use tracing::error;
 
 use crate::tcp_connection::ConnectionHandler;
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -249,7 +249,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     };
     info!(
         "collecting storage metrics every {:?} seconds",
-        mz_adapter::catalog::DEFAULT_STORAGE_METRIC_INTERVAL_SECONDS
+        mz_adapter::catalog::DEFAULT_STORAGE_USAGE_COLLECTION_INTERVAL
     );
 
     let storage_usage_client = match storage_usage_response {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -216,7 +216,7 @@ pub struct CatalogConfig {
     /// Default timestamp frequency for CREATE SOURCE
     pub timestamp_frequency: Duration,
     /// How often to collect storage metrics (in seconds).
-    pub storage_metrics_collection_interval: Duration,
+    pub storage_usage_collection_interval: Duration,
     /// Function that returns a wall clock now time; can safely be mocked to return
     /// 0.
     pub now: NowFn,
@@ -607,7 +607,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     unsafe_mode: true,
     build_info: &DUMMY_BUILD_INFO,
     timestamp_frequency: Duration::from_secs(1),
-    storage_metrics_collection_interval: Duration::from_secs(5),
+    storage_usage_collection_interval: Duration::from_secs(5),
     now: NOW_ZERO.clone(),
 });
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -215,8 +215,6 @@ pub struct CatalogConfig {
     pub build_info: &'static BuildInfo,
     /// Default timestamp frequency for CREATE SOURCE
     pub timestamp_frequency: Duration,
-    /// How often to collect storage metrics (in seconds).
-    pub storage_usage_collection_interval: Duration,
     /// Function that returns a wall clock now time; can safely be mocked to return
     /// 0.
     pub now: NowFn,
@@ -607,7 +605,6 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     unsafe_mode: true,
     build_info: &DUMMY_BUILD_INFO,
     timestamp_frequency: Duration::from_secs(1),
-    storage_usage_collection_interval: Duration::from_secs(5),
     now: NOW_ZERO.clone(),
 });
 

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -49,7 +49,6 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     build_info: &DUMMY_BUILD_INFO,
     timestamp_frequency: Duration::from_secs(1),
     now: NOW_ZERO.clone(),
-    storage_usage_collection_interval: Duration::from_secs(5),
 });
 
 /// A dummy [`CatalogItem`] implementation.

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -49,7 +49,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     build_info: &DUMMY_BUILD_INFO,
     timestamp_frequency: Duration::from_secs(1),
     now: NOW_ZERO.clone(),
-    storage_metrics_collection_interval: Duration::from_secs(5),
+    storage_usage_collection_interval: Duration::from_secs(5),
 });
 
 /// A dummy [`CatalogItem`] implementation.


### PR DESCRIPTION
And a few other assorted changes. See commit messages for details. I didn't want this to linger given e.g. https://github.com/MaterializeInc/materialize/pull/14204#pullrequestreview-1070557581.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
