### PR TITLE
storage: use maybe_downgrade_since for tables

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1208,7 +1208,11 @@ mod persist_read_handles {
                                     for (id, read) in read_handles.iter_mut() {
                                         if let Some((span, since)) = downgrades.remove(id) {
                                             let fut = async move {
-                                                read.downgrade_since(&since).instrument(span).await;
+                                                // Use maybe_downgrade_since here so that we opt
+                                                // into rate-limiting. It's okay for the since to
+                                                // lag behind a bit and this _greatly_ reduces the
+                                                // persist traffic.
+                                                read.maybe_downgrade_since(&since).instrument(span).await;
                                             };
 
                                             futs.push(fut);


### PR DESCRIPTION
In the storage controller, use maybe_downgrade_since for tables so that
we opt into rate-limiting. It's okay for the since to lag behind a bit
and this _greatly_ reduces the persist traffic.


### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
