### PR TITLE
Remove panics due to async shutdown

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -679,7 +679,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .append(appends)
             .expect("invalid updates")
             .await
-            .expect("One-shot shouldn't fail")
+            .expect("One-shot shouldn't be dropped during bootstrap")
             .unwrap();
 
         // Add builtin table updates the clear the contents of all system tables

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -426,19 +426,21 @@ impl<S: Append + 'static> Coordinator<S> {
                 let otel_ctx = OpenTelemetryContext::obtain();
                 task::spawn(|| format!("purify:{conn_id}"), async move {
                     let result = purify_fut.await.map_err(|e| e.into());
-                    internal_cmd_tx
-                        .send(Message::CreateSourceStatementReady(
-                            CreateSourceStatementReady {
-                                session,
-                                tx,
-                                result,
-                                params,
-                                depends_on,
-                                original_stmt,
-                                otel_ctx,
-                            },
-                        ))
-                        .expect("sending to internal_cmd_tx cannot fail");
+                    // It is not an error for purification to complete after `internal_cmd_rx` is dropped.
+                    let result = internal_cmd_tx.send(Message::CreateSourceStatementReady(
+                        CreateSourceStatementReady {
+                            session,
+                            tx,
+                            result,
+                            params,
+                            depends_on,
+                            original_stmt,
+                            otel_ctx,
+                        },
+                    ));
+                    if let Err(e) = result {
+                        tracing::warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+                    }
                 });
             }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -374,7 +374,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 tx: tx.take(),
                                 span: tracing::Span::none(),
                             }))
-                            .expect("sending to internal_cmd_tx cannot fail");
+                            .expect("sending to self.internal_cmd_tx cannot fail");
                     }
                     Err(err) => tx.send(Err(err), session),
                 };
@@ -1075,8 +1075,9 @@ impl<S: Append + 'static> Coordinator<S> {
         task::spawn(
             || format!("sink_connection_ready:{}", sink.from),
             async move {
-                internal_cmd_tx
-                    .send(Message::SinkConnectionReady(SinkConnectionReady {
+                // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
+                let result =
+                    internal_cmd_tx.send(Message::SinkConnectionReady(SinkConnectionReady {
                         session,
                         tx,
                         id,
@@ -1084,8 +1085,10 @@ impl<S: Append + 'static> Coordinator<S> {
                         result: sink_connection::build(connection_builder, id, connection_context)
                             .await,
                         compute_instance,
-                    }))
-                    .expect("sending to internal_cmd_tx cannot fail");
+                    }));
+                if let Err(e) = result {
+                    warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+                }
             },
         );
     }
@@ -2968,11 +2971,13 @@ impl<S: Append + 'static> Coordinator<S> {
                             // We timed out, so remove the pending peek. This is
                             // best-effort and doesn't guarantee we won't
                             // receive a response.
-                            internal_cmd_tx
-                                .send(Message::RemovePendingPeeks {
-                                    conn_id: session.conn_id(),
-                                })
-                                .expect("sending to internal_cmd_tx cannot fail");
+                            // It is not an error for this timeout to occur after `internal_cmd_rx` has been dropped.
+                            let result = internal_cmd_tx.send(Message::RemovePendingPeeks {
+                                conn_id: session.conn_id(),
+                            });
+                            if let Err(e) = result {
+                                warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+                            }
                             Err(AdapterError::StatementTimeout)
                         }
                     }
@@ -3020,16 +3025,18 @@ impl<S: Append + 'static> Coordinator<S> {
             } else {
                 diffs
             };
-            internal_cmd_tx
-                .send(Message::SendDiffs(SendDiffs {
-                    session,
-                    tx,
-                    id,
-                    diffs,
-                    kind,
-                    returning: returning_rows,
-                }))
-                .expect("sending to internal_cmd_tx cannot fail");
+            // It is not an error for these results to be ready after `internal_cmd_rx` has been dropped.
+            let result = internal_cmd_tx.send(Message::SendDiffs(SendDiffs {
+                session,
+                tx,
+                id,
+                diffs,
+                kind,
+                returning: returning_rows,
+            }));
+            if let Err(e) = result {
+                warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+            }
         });
     }
 


### PR DESCRIPTION
Several forms of channel communication throughout `environmentd` will panic if they are interrupted. For example, if sends or receives find the other end of their connection dropped. This is not always an error. Especially with asynchronous tasks, one side can shutdown (usually as part of winding down) while the other still thinks it has work. If that occurs, it doesn't mean that anything is wrong, and is not itself a reason to panic. Perhaps to take note, if we like.

At the same time, there are also moments where we shouldn't just ignore this and act as if all is well. For example, we use one-shots to stand in for asynchronous futures, and if they error that doesn't mean "continue ahead" so much as "better behave as if hung". These cases seemed to be pretty clear though.

cc: @jkosh44, @mjibson, @danhhz 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
