### PR TITLE
persist: use new state before expiring leases and reporting metrics

### DIFF
--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -518,6 +518,7 @@ where
                             new_state.seqno(),
                             new_state
                         );
+                        self.state = new_state;
 
                         self.shard_metrics.set_since(self.state.since());
                         self.shard_metrics.set_upper(&self.state.upper());
@@ -541,7 +542,6 @@ where
                             lease_expiration,
                         };
 
-                        self.state = new_state;
                         return Ok((self.state.seqno(), Ok(work_ret), maintenance));
                     }
                     Err(current) => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

After a successful `compare_and_set` op, we report metrics and calculate some maintenance work like which leases to expire. Currently we're calculating this state from _before_ the most recent transition, so leases could be incorrectly expired (e.g. a reader may need to heartbeat, it cas's a heartbeat, but then expires itself because it doesn't observe the new heartbeat timestamp in the pre-cas state it looks at).

Thinking more on it, I doubt this is the problem observed in https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660242935876619, but it helps close at least one bug.

### Motivation

  * This PR fixes a previously unreported bug.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
