### PR TITLE
storage: pass relock operator frontiers to the storage controller

### DIFF
--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -51,8 +51,14 @@ message ProtoExportSinks {
     repeated ProtoExportSinkCommand exports = 1;
 }
 
+// TODO: move this to compute
 message ProtoFrontierUppersKind {
     repeated ProtoTrace traces = 1;
+}
+
+message ProtoStorageFrontierUppersKind {
+    repeated ProtoTrace traces = 1;
+    repeated ProtoTrace remap_traces = 2;
 }
 
 message ProtoTrace {
@@ -76,6 +82,6 @@ message ProtoStorageCommand {
 
 message ProtoStorageResponse {
     oneof kind {
-        ProtoFrontierUppersKind frontier_uppers = 1;
+        ProtoStorageFrontierUppersKind frontier_uppers = 1;
     }
 }

--- a/src/storage/src/protocol/server.rs
+++ b/src/storage/src/protocol/server.rs
@@ -26,7 +26,7 @@ use mz_service::local::LocalClient;
 use crate::protocol::client::StorageClient;
 use crate::sink::SinkBaseMetrics;
 use crate::source::metrics::SourceBaseMetrics;
-use crate::storage_state::{StorageState, Worker};
+use crate::storage_state::{StorageFrontierState, StorageState, Worker};
 use crate::types::connections::ConnectionContext;
 use crate::DecodeMetrics;
 
@@ -95,10 +95,15 @@ pub fn serve(
             timely_worker,
             client_rx,
             storage_state: StorageState {
-                source_uppers: HashMap::new(),
+                frontiers: StorageFrontierState {
+                    source_uppers: HashMap::new(),
+                    source_remap_uppers: HashMap::new(),
+                    reported_frontiers: HashMap::new(),
+                    reported_remap_frontiers: HashMap::new(),
+                    sink_write_frontiers: HashMap::new(),
+                },
                 source_tokens: HashMap::new(),
                 decode_metrics,
-                reported_frontiers: HashMap::new(),
                 ingestions: HashMap::new(),
                 exports: HashMap::new(),
                 now: now.clone(),
@@ -109,7 +114,6 @@ pub fn serve(
                 connection_context: config.connection_context.clone(),
                 persist_clients,
                 sink_tokens: HashMap::new(),
-                sink_write_frontiers: HashMap::new(),
             },
         }
         .run()

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -54,7 +54,7 @@ pub fn render<G>(
 
     let mut input = persist_op.new_input(&source_data.inner, Exchange::new(move |_| hashed_id));
 
-    let current_upper = Rc::clone(&storage_state.source_uppers[&src_id]);
+    let current_upper = Rc::clone(&storage_state.frontiers.source_uppers[&src_id]);
 
     let weak_token = Rc::downgrade(&token);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -145,6 +145,7 @@ where
         resume_upper: resume_upper.clone(),
         storage_metadata: description.storage_metadata.clone(),
         persist_clients: Arc::clone(&storage_state.persist_clients),
+        current_remap_upper: Rc::clone(&storage_state.frontiers.source_remap_uppers[&id]),
     };
 
     // Build the _raw_ ok and error sources using `create_raw_source` and the

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -150,6 +150,7 @@ where
         );
 
         storage_state
+            .frontiers
             .sink_write_frontiers
             .insert(sink_id, shared_frontier);
 

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -221,13 +221,14 @@ impl ReclockOperator {
     }
 
     /// Advances the upper of the reclock operator if appropriate
-    pub async fn advance(&mut self) {
+    pub async fn advance(&mut self) -> &Antichain<Timestamp> {
         if self.next_mint_timestamp().is_ok() {
             let empty: Vec<(PartitionId, MzOffset)> = Vec::new();
             while let Err(Upper(actual_upper)) = self.append(&empty).await {
                 self.sync(&actual_upper).await;
             }
         }
+        &self.upper
     }
 
     /// Calculates the source upper frontier at a particular timestamp

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -25,7 +25,7 @@ use mz_ore::now::NowFn;
 use mz_repr::{GlobalId, Timestamp};
 
 use crate::controller::CollectionMetadata;
-use crate::protocol::client::{StorageCommand, StorageResponse};
+use crate::protocol::client::{StorageCommand, StorageFrontierUppers, StorageResponse};
 use crate::sink::SinkBaseMetrics;
 use crate::types::connections::ConnectionContext;
 use crate::types::sinks::StorageSinkDesc;
@@ -293,8 +293,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
             &mut self.storage_state.frontiers.reported_remap_frontiers,
         );
 
-        if !data_changes.is_empty() {
-            self.send_storage_response(response_tx, StorageResponse::FrontierUppers(data_changes));
+        if !data_changes.is_empty() || !remap_changes.is_empty() {
+            self.send_storage_response(
+                response_tx,
+                StorageResponse::FrontierUppers(StorageFrontierUppers {
+                    data: data_changes,
+                    remap: remap_changes,
+                }),
+            );
         }
     }
 


### PR DESCRIPTION
This pr is the first step to implementing https://github.com/MaterializeInc/materialize/issues/13534. It sets up the requisite data for _calculating a resumption frontier_ in the storage controller. This is managed by 1. adding a way for the source operator to write the remap upper back into storage state and 2. passing this information to the controller in `StorageResponse::FrontierUppers`. This pr implements both those changes.

This pr does not cause the controller to do anything with this information, it simple drops it. Additionally, this doubles the `FrontierUppers` traffic from `storaged` -> `storage controller`, as the current way we step timely workers causes the remap and data frontiers to be updated on different steps. This could be reduced, as a later optimization. Existing tests should cover that the changes don't break anything.



### Motivation

  * This PR adds a known-desirable feature.


### Tips for reviewer

The bottom pr adds adds a way for the source operator to update the
The top pr communicates these changes

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
