### PR TITLE
stash: remove timestamps and diffs

### DIFF
--- a/src/stash/src/sqlite.rs
+++ b/src/stash/src/sqlite.rs
@@ -9,21 +9,18 @@
 
 //! Durable metadata storage.
 
-use std::cmp;
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 use std::path::Path;
 
 use async_trait::async_trait;
+use mz_ore::collections::CollectionExt;
 use rusqlite::{named_params, params, Connection, OptionalExtension, Transaction};
-use timely::progress::Antichain;
-use timely::PartialOrder;
 
 use mz_persist_types::Codec;
-use timely::progress::frontier::AntichainRef;
 
 use crate::{
-    AntichainFormatter, Append, AppendBatch, Data, Diff, Id, InternalStashError, Stash,
-    StashCollection, StashError, Timestamp,
+    Append, AppendBatch, Data, Diff, Id, InternalStashError, Stash, StashCollection, StashError,
 };
 
 const APPLICATION_ID: i32 = 0x0872_e898; // chosen randomly
@@ -38,20 +35,7 @@ CREATE TABLE data (
     collection_id integer NOT NULL REFERENCES collections (collection_id),
     key blob NOT NULL,
     value blob NOT NULL,
-    time integer NOT NULL,
-    diff integer NOT NULL
-);
-
-CREATE INDEX data_time_idx ON data (collection_id, time);
-
-CREATE TABLE sinces (
-    collection_id NOT NULL UNIQUE REFERENCES collections (collection_id),
-    since integer
-);
-
-CREATE TABLE uppers (
-    collection_id NOT NULL UNIQUE REFERENCES collections (collection_id),
-    upper integer
+    PRIMARY KEY (collection_id, key)
 );
 ";
 
@@ -90,159 +74,43 @@ impl Sqlite {
         Ok(Sqlite { conn })
     }
 
-    fn since_tx(tx: &Transaction, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
-        let since: Option<Timestamp> = tx.query_row(
-            "SELECT since FROM sinces WHERE collection_id = $collection_id",
-            named_params! {"$collection_id": collection_id},
-            |row| row.get("since"),
-        )?;
-        Ok(Antichain::from_iter(since))
-    }
-
-    fn upper_tx(tx: &Transaction, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
-        let upper: Option<Timestamp> = tx.query_row(
-            "SELECT upper FROM uppers WHERE collection_id = $collection_id",
-            named_params! {"$collection_id": collection_id},
-            |row| row.get("upper"),
-        )?;
-        Ok(Antichain::from_iter(upper))
-    }
-
-    fn seal_batch_tx<'a, I>(tx: &Transaction, seals: I) -> Result<(), StashError>
-    where
-        I: Iterator<Item = (Id, &'a Antichain<Timestamp>)>,
-    {
-        let mut update_stmt =
-            tx.prepare("UPDATE uppers SET upper = $upper WHERE collection_id = $collection_id")?;
-        for (collection_id, new_upper) in seals {
-            let upper = Self::upper_tx(&tx, collection_id)?;
-            if PartialOrder::less_than(new_upper, &upper) {
-                return Err(StashError::from(format!(
-                    "seal request {} is less than the current upper frontier {}",
-                    AntichainFormatter(new_upper),
-                    AntichainFormatter(&upper),
-                )));
-            }
-            update_stmt.execute(
-                named_params! {"$upper": new_upper.as_option(), "$collection_id": collection_id},
-            )?;
-        }
-        drop(update_stmt);
-        Ok(())
-    }
-
     fn update_many_tx<I>(tx: &Transaction, collection_id: Id, entries: I) -> Result<(), StashError>
     where
-        I: Iterator<Item = ((Vec<u8>, Vec<u8>), Timestamp, Diff)>,
+        I: Iterator<Item = ((Vec<u8>, Vec<u8>), Diff)>,
     {
-        let upper = Self::upper_tx(&tx, collection_id)?;
         let mut insert_stmt = tx.prepare(
-            "INSERT INTO data (collection_id, key, value, time, diff)
-             VALUES ($collection_id, $key, $value, $time, $diff)",
+            "INSERT OR IGNORE
+             INTO data (collection_id, key, value)
+             VALUES ($collection_id, $key, $value)",
         )?;
-        for ((key, value), time, diff) in entries {
-            if !upper.less_equal(&time) {
-                return Err(StashError::from(format!(
-                    "entry time {} is less than the current upper frontier {}",
-                    time,
-                    AntichainFormatter(&upper)
-                )));
-            }
-            insert_stmt.execute(named_params! {
-                "$collection_id": collection_id,
-                "$key": key,
-                "$value": value,
-                "$time": time,
-                "$diff": diff,
-            })?;
-        }
-        drop(insert_stmt);
-        Ok(())
-    }
-
-    fn compact_batch_tx<'a, I>(tx: &Transaction, compactions: I) -> Result<(), StashError>
-    where
-        I: Iterator<Item = (Id, &'a Antichain<Timestamp>)>,
-    {
-        let mut compact_stmt =
-            tx.prepare("UPDATE sinces SET since = $since WHERE collection_id = $collection_id")?;
-        for (collection_id, new_since) in compactions {
-            let since = Self::since_tx(&tx, collection_id)?;
-            let upper = Self::upper_tx(&tx, collection_id)?;
-            if PartialOrder::less_than(&upper, new_since) {
-                return Err(StashError::from(format!(
-                    "compact request {} is greater than the current upper frontier {}",
-                    AntichainFormatter(new_since),
-                    AntichainFormatter(&upper)
-                )));
-            }
-            if PartialOrder::less_than(new_since, &since) {
-                return Err(StashError::from(format!(
-                    "compact request {} is less than the current since frontier {}",
-                    AntichainFormatter(new_since),
-                    AntichainFormatter(&since)
-                )));
-            }
-            compact_stmt.execute(
-                named_params! {"$since": new_since.as_option(), "$collection_id": collection_id},
-            )?;
-        }
-        drop(compact_stmt);
-        Ok(())
-    }
-
-    fn consolidate_batch_tx<'a, I>(tx: &Transaction<'a>, collections: I) -> Result<(), StashError>
-    where
-        I: Iterator<Item = Id>,
-    {
-        let mut consolidation_stmt = tx.prepare(
+        let mut delete_stmt = tx.prepare(
             "DELETE FROM data
-             WHERE collection_id = $collection_id AND time <= $since
-             RETURNING key, value, diff",
+              WHERE collection_id = $collection_id AND key = $key",
         )?;
-        let mut insert_stmt = tx.prepare(
-            "INSERT INTO data (collection_id, key, value, time, diff)
-             VALUES ($collection_id, $key, $value, $time, $diff)",
-        )?;
-        let mut drop_stmt = tx.prepare("DELETE FROM data WHERE collection_id = $collection_id")?;
-
-        for collection_id in collections {
-            let since = Self::since_tx(&tx, collection_id)?.into_option();
-            match since {
-                Some(since) => {
-                    let mut updates = consolidation_stmt
-                        .query_and_then(
-                            named_params! {
-                                "$collection_id": collection_id,
-                                "$since": since,
-                            },
-                            |row| {
-                                let key = row.get("key")?;
-                                let value = row.get("value")?;
-                                let diff = row.get("diff")?;
-                                Ok::<_, StashError>(((key, value), since, diff))
-                            },
-                        )?
-                        .collect::<Result<Vec<((Vec<u8>, Vec<u8>), i64, i64)>, _>>()?;
-                    differential_dataflow::consolidation::consolidate_updates(&mut updates);
-                    for ((key, value), time, diff) in updates {
-                        insert_stmt.execute(named_params! {
-                            "$collection_id": collection_id,
-                            "$key": key,
-                            "$value": value,
-                            "$time": time,
-                            "$diff": diff,
-                        })?;
+        for ((key, value), diff) in entries {
+            match diff {
+                Diff::Insert => {
+                    let count = insert_stmt.execute(named_params! {
+                        "$collection_id": collection_id,
+                        "$key": key,
+                        "$value": value,
+                    })?;
+                    if count == 0 {
+                        return Err(StashError::from(InternalStashError::InsertDuplicateKey));
                     }
                 }
-                None => {
-                    drop_stmt.execute(named_params! {
+                Diff::Delete => {
+                    let count = delete_stmt.execute(named_params! {
                         "$collection_id": collection_id,
+                        "$key": key,
                     })?;
+                    if count == 0 {
+                        return Err(StashError::from(InternalStashError::DeleteNotFound));
+                    }
                 }
-            }
+            };
         }
-        drop((consolidation_stmt, insert_stmt, drop_stmt));
+        drop(insert_stmt);
         Ok(())
     }
 }
@@ -272,14 +140,6 @@ impl Stash for Sqlite {
                     named_params! {"$name": name},
                     |row| row.get("collection_id"),
                 )?;
-                tx.execute(
-                    "INSERT INTO sinces (collection_id, since) VALUES ($collection_id, $since)",
-                    named_params! {"$collection_id": collection_id, "$since": Timestamp::MIN},
-                )?;
-                tx.execute(
-                    "INSERT INTO uppers (collection_id, upper) VALUES ($collection_id, $upper)",
-                    named_params! {"$collection_id": collection_id, "$upper": Timestamp::MIN},
-                )?;
                 collection_id
             }
         };
@@ -294,23 +154,15 @@ impl Stash for Sqlite {
     async fn iter<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
-    ) -> Result<Vec<((K, V), Timestamp, Diff)>, StashError>
+    ) -> Result<BTreeMap<K, V>, StashError>
     where
         K: Data,
         V: Data,
     {
         let tx = self.conn.transaction()?;
-        let since = match Self::since_tx(&tx, collection.id)?.into_option() {
-            Some(since) => since,
-            None => {
-                return Err(StashError::from(
-                    "cannot iterate collection with empty since frontier",
-                ));
-            }
-        };
-        let mut rows = tx
+        let rows = tx
             .prepare(
-                "SELECT key, value, time, diff FROM data
+                "SELECT key, value FROM data
                  WHERE collection_id = $collection_id",
             )?
             .query_and_then(named_params! {"$collection_id": collection.id}, |row| {
@@ -318,20 +170,17 @@ impl Stash for Sqlite {
                 let value_buf: Vec<_> = row.get("value")?;
                 let key = K::decode(&key_buf)?;
                 let value = V::decode(&value_buf)?;
-                let time = row.get("time")?;
-                let diff = row.get("diff")?;
-                Ok::<_, StashError>(((key, value), cmp::max(time, since), diff))
+                Ok::<_, StashError>((key, value))
             })?
-            .collect::<Result<Vec<_>, _>>()?;
-        differential_dataflow::consolidation::consolidate_updates(&mut rows);
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
         Ok(rows)
     }
 
-    async fn iter_key<K, V>(
+    async fn get_key<K, V>(
         &mut self,
         collection: StashCollection<K, V>,
         key: &K,
-    ) -> Result<Vec<(V, Timestamp, Diff)>, StashError>
+    ) -> Result<Option<V>, StashError>
     where
         K: Data,
         V: Data,
@@ -339,17 +188,9 @@ impl Stash for Sqlite {
         let mut key_buf = vec![];
         key.encode(&mut key_buf);
         let tx = self.conn.transaction()?;
-        let since = match Self::since_tx(&tx, collection.id)?.into_option() {
-            Some(since) => since,
-            None => {
-                return Err(StashError::from(
-                    "cannot iterate collection with empty since frontier",
-                ));
-            }
-        };
-        let mut rows = tx
+        let rows = tx
             .prepare(
-                "SELECT value, time, diff FROM data
+                "SELECT value FROM data
                  WHERE collection_id = $collection_id AND key = $key",
             )?
             .query_and_then(
@@ -360,14 +201,15 @@ impl Stash for Sqlite {
                 |row| {
                     let value_buf: Vec<_> = row.get("value")?;
                     let value = V::decode(&value_buf)?;
-                    let time = row.get("time")?;
-                    let diff = row.get("diff")?;
-                    Ok::<_, StashError>((value, cmp::max(time, since), diff))
+                    Ok::<_, StashError>(value)
                 },
             )?
             .collect::<Result<Vec<_>, _>>()?;
-        differential_dataflow::consolidation::consolidate_updates(&mut rows);
-        Ok(rows)
+        if rows.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(rows.into_element()))
+        }
     }
 
     async fn update_many<K: Codec, V: Codec, I>(
@@ -378,136 +220,20 @@ impl Stash for Sqlite {
     where
         K: Data,
         V: Data,
-        I: IntoIterator<Item = ((K, V), Timestamp, Diff)> + Send,
+        I: IntoIterator<Item = ((K, V), Diff)> + Send,
         I::IntoIter: Send,
     {
-        let entries = entries.into_iter().map(|((key, value), time, diff)| {
+        let entries = entries.into_iter().map(|((key, value), diff)| {
             let mut key_buf = vec![];
             let mut value_buf = vec![];
             key.encode(&mut key_buf);
             value.encode(&mut value_buf);
-            ((key_buf, value_buf), time, diff)
+            ((key_buf, value_buf), diff)
         });
         let tx = self.conn.transaction()?;
         Self::update_many_tx(&tx, collection.id, entries)?;
         tx.commit()?;
         Ok(())
-    }
-
-    async fn seal<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-        new_upper: AntichainRef<'_, Timestamp>,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.seal_batch(&[(collection, new_upper.to_owned())]).await
-    }
-
-    async fn seal_batch<K, V>(
-        &mut self,
-        seals: &[(StashCollection<K, V>, Antichain<Timestamp>)],
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let seals = seals
-            .iter()
-            .map(|(collection, frontier)| (collection.id, frontier));
-        let tx = self.conn.transaction()?;
-        Self::seal_batch_tx(&tx, seals)?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    async fn compact<'a, K, V>(
-        &'a mut self,
-        collection: StashCollection<K, V>,
-        new_since: AntichainRef<'a, Timestamp>,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.compact_batch(&[(collection, new_since.to_owned())])
-            .await
-    }
-
-    async fn compact_batch<K, V>(
-        &mut self,
-        compactions: &[(StashCollection<K, V>, Antichain<Timestamp>)],
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let tx = self.conn.transaction()?;
-        Self::compact_batch_tx(
-            &tx,
-            compactions
-                .iter()
-                .map(|(collection, since)| (collection.id, since)),
-        )?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    async fn consolidate<'a, K, V>(
-        &'a mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        self.consolidate_batch(&[collection]).await
-    }
-
-    async fn consolidate_batch<K, V>(
-        &mut self,
-        collections: &[StashCollection<K, V>],
-    ) -> Result<(), StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let tx = self.conn.transaction()?;
-        Self::consolidate_batch_tx(&tx, collections.iter().map(|collection| collection.id))?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    /// Reports the current since frontier.
-    async fn since<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Antichain<Timestamp>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let tx = self.conn.transaction()?;
-        let since = Self::since_tx(&tx, collection.id)?;
-        tx.commit()?;
-        Ok(since)
-    }
-
-    /// Reports the current upper frontier.
-    async fn upper<K, V>(
-        &mut self,
-        collection: StashCollection<K, V>,
-    ) -> Result<Antichain<Timestamp>, StashError>
-    where
-        K: Data,
-        V: Data,
-    {
-        let tx = self.conn.transaction()?;
-        let upper = Self::upper_tx(&tx, collection.id)?;
-        tx.commit()?;
-        Ok(upper)
     }
 
     async fn confirm_leadership(&mut self) -> Result<(), StashError> {
@@ -532,18 +258,9 @@ impl Append for Sqlite {
         I::IntoIter: Send,
     {
         let tx = self.conn.transaction()?;
-        let mut consolidate = Vec::new();
         for batch in batches {
-            consolidate.push(batch.collection_id);
-            let upper = Self::upper_tx(&tx, batch.collection_id)?;
-            if upper != batch.lower {
-                return Err("unexpected lower".into());
-            }
             Self::update_many_tx(&tx, batch.collection_id, batch.entries.into_iter())?;
-            Self::seal_batch_tx(&tx, std::iter::once((batch.collection_id, &batch.upper)))?;
-            Self::compact_batch_tx(&tx, std::iter::once((batch.collection_id, &batch.compact)))?;
         }
-        Self::consolidate_batch_tx(&tx, consolidate.iter().map(|id| *id))?;
         tx.commit()?;
         Ok(())
     }

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -746,7 +746,7 @@ where
             {
                 Some(
                     METADATA_COLLECTION
-                        .peek_key_one(&mut self.state.stash, &status_collection_id)
+                        .get_key(&mut self.state.stash, &status_collection_id)
                         .await?
                         .ok_or(StorageError::IdentifierMissing(status_collection_id))?
                         .data_shard,

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -213,8 +213,6 @@ impl State {
                     CREATE TABLE fence AS SELECT * FROM {0}.fence;
                     CREATE TABLE collections AS SELECT * FROM {0}.collections;
                     CREATE TABLE data AS SELECT * FROM {0}.data;
-                    CREATE TABLE sinces AS SELECT * FROM {0}.sinces;
-                    CREATE TABLE uppers AS SELECT * FROM {0}.uppers;
                     ",
                     current_schema,
                 ))


### PR DESCRIPTION
Timestamps and diffs are not used by any users of the stash, and they add
complication and work when processing data. Remove timestamps, diffs,
seal, compact, uppers, and sinces from all APIs. Simplify the API for
the single value per key expectation that all current callers have.

This should greatly reduce the number of remote SQL queries the postgres
backend does.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a