### PR TITLE
platform checks: Run each Check and Scenario combination in isolation

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -36,6 +36,12 @@ steps:
           - { value: zippy-kafka-sources }
           - { value: zippy-user-tables }
           - { value: secrets }
+          - { value: checks-oneatatime-drop-create-default-replica }
+          - { value: checks-oneatatime-restart-computed }
+          - { value: checks-oneatatime-restart-entire-mz }
+          - { value: checks-oneatatime-restart-environmentd-storaged }
+          - { value: checks-oneatatime-kill-storaged }
+          - { value: checks-oneatatime-restart-postgres-backend }
           - { value: unused-deps }
         multiple: true
         required: false
@@ -261,56 +267,6 @@ steps:
           composition: zippy
           args: [--scenario=UserTables, --actions=1000]
 
-  - id: checks-drop-create-default-replica
-    label: "Checks + DROP/CREATE replica"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=DropCreateDefaultReplica]
-
-  - id: checks-restart-computed
-    label: "Checks + restart computed"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartComputed]
-
-  - id: checks-restart-entire-mz
-    label: "Checks + restart of the entire Mz"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartEntireMz]
-
-  - id: checks-restart-environmentd-storaged
-    label: "Checks + restart of environmentd & storaged"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartEnvironmentdStoraged]
-
-  - id: checks-kill-storaged
-    label: "Checks + kill storaged"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=KillStoraged]
-
   - id: secrets
     label: "Secrets"
     timeout_in_minutes: 30
@@ -319,6 +275,66 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: secrets
+
+  - id: checks-oneatatime-drop-create-default-replica
+    label: "Checks oneatatime + DROP/CREATE replica"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=DropCreateDefaultReplica, --execution-mode=oneatatime]
+
+  - id: checks-oneatatime-restart-computed
+    label: "Checks oneatatime + restart computed"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartComputed, --execution-mode=oneatatime]
+
+  - id: checks-oneatatime-restart-entire-mz
+    label: "Checks oneatatime + restart of the entire Mz"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEntireMz, --execution-mode=oneatatime]
+
+  - id: checks-oneatatime-restart-environmentd-storaged
+    label: "Checks oneatatime + restart of environmentd & storaged"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartEnvironmentdStoraged, --execution-mode=oneatatime]
+
+  - id: checks-oneatatime-kill-storaged
+    label: "Checks oneatatime + kill storaged"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=KillStoraged, --execution-mode=oneatatime]
+
+  - id: checks-oneatatime-restart-postgres-backend
+    label: "Checks oneatatime + restart Postgres backend"
+    timeout_in_minutes: 300
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: platform-checks
+          args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
 
   - id: persistence-failpoints
     label: Persistence failpoints

--- a/doc/developer/platform-checks.md
+++ b/doc/developer/platform-checks.md
@@ -14,7 +14,7 @@ In the context of this framework:
 # Running
 
 ```
-bin/mzcompose --find platform-checks run default --scenario=SCENARIO [--check=CHECK]
+bin/mzcompose --find platform-checks run default --scenario=SCENARIO [--check=CHECK] [--execution-mode= [--execution-mode={alltogether,oneatatime}]
 ```
 
 The list of Checks available can be found [here](https://dev.materialize.com/api/python/materialize/checks/checks.html#materialize.checks.checks.Check)
@@ -22,6 +22,13 @@ The list of Checks available can be found [here](https://dev.materialize.com/api
 The list of Scenarios is [here](https://dev.materialize.com/api/python/materialize/checks/scenarios.html#materialize.checks.scenarios.Scenario)
 
 The list of available Actions for use in Scenarios is [here](https://dev.materialize.com/api/python/materialize/checks/actions.html)
+
+In execution mode `altogether` (the defauklt), all Checks are run against a single Mz instance. This means more "stuff" happens
+against that single instance, which has the potential for exposing various bugs that do not happen in isolation. At the same time,
+a smaller number of adverse events can be injected in the test per unit of time.
+
+In execution mode `oneatatime`, each Check is run in isolation against a completely fresh Mz instance. This allows more events to happen
+per unit of time, but any issues that require greater load or variety of database objects will not show up.
 
 # Debugging CI failures
 

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from enum import Enum
+
 from materialize.checks.aggregation import *  # noqa: F401 F403
 from materialize.checks.alter_index import *  # noqa: F401 F403
 from materialize.checks.boolean_type import *  # noqa: F401 F403
@@ -54,7 +56,13 @@ from materialize.checks.upsert import *  # noqa: F401 F403
 from materialize.checks.users import *  # noqa: F401 F403
 from materialize.checks.window_functions import *  # noqa: F401 F403
 from materialize.mzcompose import Composition, WorkflowArgumentParser
-from materialize.mzcompose.services import Debezium, Materialized, Postgres, Redpanda
+from materialize.mzcompose.services import (
+    Computed,
+    Debezium,
+    Materialized,
+    Postgres,
+    Redpanda,
+)
 from materialize.mzcompose.services import Testdrive as TestdriveService
 
 SERVICES = [
@@ -62,6 +70,9 @@ SERVICES = [
     Postgres(name="postgres-source"),
     Redpanda(auto_create_topics=True),
     Debezium(),
+    Computed(
+        name="computed_1"
+    ),  # Started by some Scenarios, defined here only for the teardown
     Materialized(
         options=" ".join(
             [
@@ -75,19 +86,15 @@ SERVICES = [
 ]
 
 
-def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    # c.silent = True
+class ExecutionMode(Enum):
+    ALLTOGETHER = "alltogether"
+    ONEATATIME = "oneatatime"
 
-    parser.add_argument(
-        "--scenario", metavar="SCENARIO", type=str, help="Scenario to run."
-    )
+    def __str__(self) -> str:
+        return self.value
 
-    parser.add_argument(
-        "--check", metavar="CHECK", type=str, action="append", help="Check(s) to run."
-    )
 
-    args = parser.parse_args()
-
+def setup(c: Composition) -> None:
     c.up("testdrive", persistent=True)
 
     c.start_and_wait_for_tcp(
@@ -107,6 +114,32 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         password="postgres",
     )
 
+
+def teardown(c: Composition) -> None:
+    c.rm(*[s.name for s in SERVICES], stop=True, destroy_volumes=True)
+    c.rm_volumes("mzdata", "pgdata", "tmp", force=True)
+
+
+def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
+    # c.silent = True
+
+    parser.add_argument(
+        "--scenario", metavar="SCENARIO", type=str, help="Scenario to run."
+    )
+
+    parser.add_argument(
+        "--check", metavar="CHECK", type=str, action="append", help="Check(s) to run."
+    )
+
+    parser.add_argument(
+        "--execution-mode",
+        type=ExecutionMode,
+        choices=list(ExecutionMode),
+        default=ExecutionMode.ALLTOGETHER,
+    )
+
+    args = parser.parse_args()
+
     scenarios = (
         [globals()[args.scenario]] if args.scenario else Scenario.__subclasses__()
     )
@@ -116,6 +149,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     for scenario_class in scenarios:
-        print(f"Testing upgrade scenario {scenario_class}")
-        scenario = scenario_class(checks=checks)
-        scenario.run(c)
+        print(f"Testing scenario {scenario_class}...")
+        if args.execution_mode is ExecutionMode.ALLTOGETHER:
+            setup(c)
+            scenario = scenario_class(checks=checks)
+            scenario.run(c)
+            teardown(c)
+        elif args.execution_mode is ExecutionMode.ONEATATIME:
+            for check in checks:
+                print(f"Running individual check {check}, scenario {scenario_class}")
+                setup(c)
+                scenario = scenario_class(checks=[check])
+                scenario.run(c)
+                teardown(c)
+        else:
+            assert False


### PR DESCRIPTION
Introduce a new option that allows the Platform Checks framework to
run each Check + Scenario combination in isolation.

This allows more reconciliation events to happen while the test is running.

Add a Nightly CI job that runs the complete matrix, replacing all existing
Nightly CI jobs. The per-push CI jobs will run all the Checks together, as before.

### Motivation

  * This PR adds a feature that has not yet been specified.
We need more reconciliation tests in CI. One way to achieve that is to restart the various pieces of Mz more times during a Platform Checks test, that is, for every Check individually.