### PR TITLE
persist: fix a sqllogictest test flake

### DIFF
--- a/src/persist-client/src/impl/compact.rs
+++ b/src/persist-client/src/impl/compact.rs
@@ -183,6 +183,7 @@ impl Compactor {
         T: Timestamp + Lattice + Codec64,
         D: Semigroup + Codec64 + Send + Sync,
     {
+        let parts_cpu_heavy_runtime = Arc::clone(&cpu_heavy_runtime);
         let compact_blocking = async move {
             let () = Self::validate_req(&req)?;
 
@@ -193,6 +194,7 @@ impl Compactor {
                 writer_id,
                 req.desc.lower().clone(),
                 Arc::clone(&blob),
+                parts_cpu_heavy_runtime,
                 &metrics.compaction.batch,
             );
 

--- a/src/persist-client/src/impl/machine.rs
+++ b/src/persist-client/src/impl/machine.rs
@@ -894,6 +894,7 @@ mod tests {
                                 0,
                                 Antichain::from_elem(lower),
                                 Arc::clone(&client.blob),
+                                Arc::clone(&cpu_heavy_runtime),
                                 shard_id.clone(),
                                 WriterId::new(),
                             );

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -423,6 +423,7 @@ impl PersistClient {
             gc,
             compact,
             blob: Arc::clone(&self.blob),
+            cpu_heavy_runtime: Arc::clone(&self.cpu_heavy_runtime),
             upper: shard_upper.0,
             explicitly_expired: false,
         };

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -27,6 +27,7 @@ use tokio::runtime::Handle;
 use tracing::{debug, debug_span, info, instrument, warn, Instrument};
 use uuid::Uuid;
 
+use crate::async_runtime::CpuHeavyRuntime;
 use crate::batch::{validate_truncate_batch, Batch, BatchBuilder};
 use crate::error::InvalidUsage;
 use crate::r#impl::compact::Compactor;
@@ -95,6 +96,7 @@ where
     pub(crate) gc: GarbageCollector,
     pub(crate) compact: Option<Compactor>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
+    pub(crate) cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
     pub(crate) writer_id: WriterId,
     pub(crate) explicitly_expired: bool,
 
@@ -486,6 +488,7 @@ where
             size_hint,
             lower,
             Arc::clone(&self.blob),
+            Arc::clone(&self.cpu_heavy_runtime),
             self.machine.shard_id().clone(),
             self.writer_id.clone(),
         )


### PR DESCRIPTION
We're now seeing the following flake in sqllogictest:

    thread 'tokio-runtime-worker' panicked at 'part encode task failed: JoinError::Cancelled(Id(122138))', /var/lib/buildkite-agent/builds/buildkite-builders-d43b1b5-i-04014543989fee453-1/materialize/tests/src/persist-client/src/batch.rs:433:18

This is the same issue as #13930 but a different location in the code,
so apply the same fix.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
