### PR TITLE
persist: cli tools for viewing and comparing states

### DIFF
--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -73,3 +73,4 @@ tempfile = "3.2.0"
 
 [build-dependencies]
 prost-build = { version = "0.10.3", features = ["vendored"] }
+serde = { version = "1.0.140", features = ["derive"] }

--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -9,6 +9,7 @@
 
 fn main() {
     prost_build::Config::new()
+        .type_attribute(".", "#[derive(serde::Serialize)]")
         .compile_protos(&["persist-client/src/impl/state.proto"], &[".."])
         .unwrap();
 }

--- a/src/persist-client/examples/inspect.rs
+++ b/src/persist-client/examples/inspect.rs
@@ -1,0 +1,106 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Persist command-line utilities
+
+use mz_persist_client::ShardId;
+
+use serde_json::json;
+use std::str::FromStr;
+
+/// Commands for inspecting current persist state
+#[derive(Debug, clap::Args)]
+pub struct InspectArgs {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+/// Individual subcommands of inspect
+#[derive(Debug, clap::Subcommand)]
+pub(crate) enum Command {
+    /// Prints latest consensus state as JSON
+    State(StateArgs),
+
+    /// Prints each consensus state change as JSON. Output includes the full consensus state
+    /// before and after each state transitions:
+    ///
+    ///     {
+    ///         "previous": previous_consensus_state,
+    ///         "new": new_consensus_state,
+    ///     }
+    ///
+    /// This is most helpfully consumed using a JSON diff tool like `jd`. A useful incantation
+    /// to show only the changed fields between state transitions:
+    ///
+    ///     persistcli inspect state-diff --shard-id <shard> --consensus-uri <consensus_uri> |
+    ///         while read diff; do
+    ///             echo $diff | jq '.new' > temp_new
+    ///             echo $diff | jq '.previous' > temp_previous
+    ///             echo $diff | jq '.new.seqno'
+    ///             jd -color -set temp_previous temp_new
+    ///         done
+    ///
+    #[clap(verbatim_doc_comment)]
+    StateDiff(StateArgs),
+}
+
+/// Arguments for viewing the current state of a given shard
+#[derive(Debug, Clone, clap::Parser)]
+pub struct StateArgs {
+    /// Shard to view
+    #[clap(long)]
+    shard_id: String,
+
+    /// Consensus to use.
+    ///
+    /// When connecting to a deployed environment's consensus table, the Postgres/CRDB connection
+    /// string must contain the database name and `options=--search_path=consensus`.
+    ///
+    /// When connecting to Cockroach Cloud, use the following format:
+    ///
+    ///   postgresql://<user>:$COCKROACH_PW@<hostname>:<port>/environment_<environment-id>
+    ///     ?sslmode=verify-full
+    ///     &sslrootcert=/path/to/cockroach-cloud/certs/cluster-ca.crt
+    ///     &options=--search_path=consensus
+    ///
+    #[clap(long, verbatim_doc_comment)]
+    consensus_uri: String,
+}
+
+pub async fn run(command: InspectArgs) -> Result<(), anyhow::Error> {
+    match command.command {
+        Command::State(args) => {
+            let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
+            let state =
+                mz_persist_client::inspect::fetch_current_state(shard_id, &args.consensus_uri)
+                    .await?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&state).expect("unserializable state")
+            );
+        }
+        Command::StateDiff(args) => {
+            let shard_id = ShardId::from_str(&args.shard_id).expect("invalid shard id");
+            let states =
+                mz_persist_client::inspect::fetch_state_diffs(shard_id, &args.consensus_uri)
+                    .await?;
+            for window in states.windows(2) {
+                println!(
+                    "{}",
+                    json!({
+                        "previous": window[0],
+                        "new": window[1]
+                    })
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -23,6 +23,7 @@ use mz_ore::tracing::TracingConfig;
 use tokio::runtime::Handle;
 use tracing::{info_span, Instrument};
 
+pub mod inspect;
 pub mod maelstrom;
 pub mod open_loop;
 pub mod source_example;
@@ -42,6 +43,7 @@ enum Command {
     Maelstrom(crate::maelstrom::Args),
     OpenLoop(crate::open_loop::Args),
     SourceExample(crate::source_example::Args),
+    Inspect(crate::inspect::InspectArgs),
 }
 
 fn main() {
@@ -80,6 +82,9 @@ fn main() {
         }
         Command::SourceExample(args) => {
             runtime.block_on(crate::source_example::run(args).instrument(root_span))
+        }
+        Command::Inspect(command) => {
+            runtime.block_on(crate::inspect::run(command).instrument(root_span))
         }
     };
 

--- a/src/persist-client/src/inspect.rs
+++ b/src/persist-client/src/inspect.rs
@@ -1,0 +1,57 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! CLI introspection tools for persist
+
+use crate::r#impl::state::ProtoStateRollup;
+use crate::{Metrics, ShardId};
+use anyhow::anyhow;
+use mz_ore::metrics::MetricsRegistry;
+use mz_persist::cfg::ConsensusConfig;
+use mz_persist::location::SeqNo;
+use prost::Message;
+
+/// Fetches the current state of a given shard
+pub async fn fetch_current_state(
+    shard_id: ShardId,
+    consensus_uri: &str,
+) -> Result<impl serde::Serialize, anyhow::Error> {
+    let metrics = Metrics::new(&MetricsRegistry::new());
+    let consensus =
+        ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus).await?;
+    let consensus = consensus.clone().open().await?;
+
+    if let Some(data) = consensus.head(&shard_id.to_string()).await? {
+        let proto = ProtoStateRollup::decode(data.data).expect("invalid encoded state");
+        return Ok(proto);
+    }
+
+    Err(anyhow!("unknown shard"))
+}
+
+/// Fetches each state in a shard
+pub async fn fetch_state_diffs(
+    shard_id: ShardId,
+    consensus_uri: &str,
+) -> Result<Vec<impl serde::Serialize>, anyhow::Error> {
+    let metrics = Metrics::new(&MetricsRegistry::new());
+    let consensus =
+        ConsensusConfig::try_from(&consensus_uri, 1, metrics.postgres_consensus).await?;
+    let consensus = consensus.clone().open().await?;
+
+    let mut states = vec![];
+    for state in consensus
+        .scan(&shard_id.to_string(), SeqNo::minimum())
+        .await?
+    {
+        states.push(ProtoStateRollup::decode(state.data).expect("invalid encoded state"));
+    }
+
+    Ok(states)
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -48,6 +48,7 @@ pub mod async_runtime;
 pub mod batch;
 pub mod cache;
 pub mod error;
+pub mod inspect;
 pub mod read;
 pub mod usage;
 pub mod write;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

As part of investigating https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660242935876619 I wanted to be able to view the current state stored in CRDB for problematic shards.

This PR adds in some new features to `persistcli` to pull down this information from any consensus datasource. For instance, to view the current state of a problematic shard:

```
persistcli inspect state --shard-id sf65e5a6f-fff8-4e5e-945d-6b44955776ac --consensus-uri $COCKROACH_PROD_URI
```

```json
{
  "applier_version": "",
  "shard_id": "sf65e5a6f-fff8-4e5e-945d-6b44955776ac",
  "key_codec": "protobuf[SourceData]",
  "val_codec": "()",
  "ts_codec": "u64",
  "diff_codec": "i64",
  "seqno": 300353,
  "last_gc_req": 187826,
  "trace": {
    "since": {
      "elements": [
        1660340952000
      ]
    },
    "spine": [
        ...
     ]
  "readers": [
    {
      "reader_id": "rabc06b14-149b-4c08-ad05-ef0f6652190b",
      "since": {
        "elements": [
          1660340952000
        ]
      },
      "seqno": 187826,
      "last_heartbeat_timestamp_ms": 1660576504035
    },
    ...
  ]
  "writers": [
    {
      "writer_id": "wde231585-8022-4667-bbc4-d11284f64d8d",
      "last_heartbeat_timestamp_ms": 1660520157513
    },
    {
      "writer_id": "w70ba7475-503e-4c8a-b5ae-a654a77f50f5",
      "last_heartbeat_timestamp_ms": 1660548570549
    },
    ...
    ]
}
```

---

The `state-diff` command lets us view the partial changes between state transitions (when combined with `jd`):

```
persistcli inspect state-diff --shard-id sf152c413-bafa-48a0-85ab-ca9ea4c80528 --consensus-uri $COCKROACH_PROD_URI
```

<img width="1516" alt="Screen Shot 2022-08-15 at 11 18 50 AM" src="https://user-images.githubusercontent.com/785446/184663577-c5dbe05f-ef1a-4ba1-b73a-2f3feb053baa.png">



### Motivation

  * This PR adds a known-desirable feature.

Related to https://github.com/MaterializeInc/materialize/issues/13918 / M2 goals

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
