### PR TITLE
environmentd: bump retry time in test_auth_expiry

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -533,7 +533,7 @@ fn test_auth_expiry() -> Result<(), Box<dyn Error>> {
         let expected = *frontegg_server.refreshes.lock().unwrap() + 1;
         Retry::default()
             .factor(1.0)
-            .max_duration(Duration::from_secs(EXPIRES_IN_SECS + 1))
+            .max_duration(Duration::from_secs(EXPIRES_IN_SECS + 10))
             .retry(|_| {
                 let refreshes = *frontegg_server.refreshes.lock().unwrap();
                 if refreshes >= expected {


### PR DESCRIPTION
Increase time we wait for a refresh.

Fixes #14238

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/14238

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a