### PR TITLE
storage: thread worker count config through to K8s command

### DIFF
--- a/src/storage/src/controller/hosts.rs
+++ b/src/storage/src/controller/hosts.rs
@@ -255,7 +255,7 @@ where
                     image: self.storaged_image.clone(),
                     args: &|assigned| {
                         vec![
-                            format!("--workers=1"),
+                            format!("--workers={}", allocation.workers),
                             format!(
                                 "--controller-listen-addr={}:{}",
                                 assigned.listen_host, assigned.ports["controller"]


### PR DESCRIPTION
This simply passes the storage worker count on to Kubernetes, so the pod
is started up with the right number of workers.

Note that this has nothing to do with the "scale" -- ie. the number of
pods that will be spun up. We're keeping that fixed at 1 for now for
simplicity.

### Motivation

This PR fixes a previously unreported bug.

Or at least it seems like it might be a bug! It's unclear why we'd allow folks to configure increased worker counts if this information is never passed to `storaged`. But feel free to push back on this PR if you disagree.
 
### Checklist

This shouldn't have any user-facing impact aside from fixing up the (purported) bug.