### PR TITLE
persist: commit state updates to durable storage incrementally

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -532,7 +532,7 @@ pub(crate) fn validate_truncate_batch<T: Timestamp>(
 #[cfg(test)]
 mod tests {
     use crate::cache::PersistClientCache;
-    use crate::internal::paths::BlobKey;
+    use crate::internal::paths::{BlobKey, PartialBlobKey};
     use crate::tests::all_ok;
     use crate::PersistLocation;
 
@@ -645,7 +645,7 @@ mod tests {
         assert_eq!(batch.blob_keys.len(), 3);
         for key in &batch.blob_keys {
             match BlobKey::parse_ids(&key.complete(&shard_id)) {
-                Ok((Some((shard, writer)), _)) => {
+                Ok((shard, PartialBlobKey::Batch(writer, _))) => {
                     assert_eq!(shard.to_string(), shard_id.to_string());
                     assert_eq!(writer.to_string(), write.writer_id.to_string());
                 }

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 use mz_persist::location::{Determinate, ExternalError, Indeterminate};
 use timely::progress::Antichain;
 
-use crate::internal::paths::PartialBlobKey;
+use crate::internal::paths::PartialBatchKey;
 use crate::{ShardId, WriterId};
 
 /// An indication of whether the given error type indicates an operation
@@ -66,7 +66,7 @@ pub enum InvalidUsage<T> {
         /// The given upper bound
         upper: Antichain<T>,
         /// Set of keys containing updates.
-        keys: Vec<PartialBlobKey>,
+        keys: Vec<PartialBatchKey>,
     },
     /// Bounds of a [crate::batch::Batch] are not valid for the attempted append call
     InvalidBatchBounds {

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -32,7 +32,7 @@ use crate::error::InvalidUsage;
 use crate::internal::encoding::ProtoLeasedBatch;
 use crate::internal::machine::retry_external;
 use crate::internal::metrics::Metrics;
-use crate::internal::paths::PartialBlobKey;
+use crate::internal::paths::PartialBatchKey;
 use crate::internal::state::HollowBatch;
 use crate::read::{ReadHandle, ReaderId};
 use crate::ShardId;
@@ -189,7 +189,7 @@ pub(crate) async fn fetch_batch_part<T, UpdateFn>(
     shard_id: &ShardId,
     blob: &(dyn Blob + Send + Sync),
     metrics: &Metrics,
-    key: &PartialBlobKey,
+    key: &PartialBatchKey,
     registered_desc: &Description<T>,
     mut update_fn: UpdateFn,
 ) -> Result<(), anyhow::Error>

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -29,11 +29,10 @@ use mz_persist_types::{Codec, Codec64};
 use mz_proto::{ProtoType, RustType};
 
 use crate::error::InvalidUsage;
-use crate::internal::encoding::ProtoLeasedBatch;
 use crate::internal::machine::retry_external;
 use crate::internal::metrics::Metrics;
 use crate::internal::paths::PartialBatchKey;
-use crate::internal::state::HollowBatch;
+use crate::internal::state::{HollowBatch, ProtoLeasedBatch};
 use crate::read::{ReadHandle, ReaderId};
 use crate::ShardId;
 

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -7,30 +7,30 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
+use mz_persist_types::{Codec, Codec64};
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use prost::Message;
 use semver::Version;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use uuid::Uuid;
 
-use mz_persist_types::{Codec, Codec64};
-use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
-
 use crate::error::CodecMismatch;
 use crate::fetch::{LeasedBatch, LeasedBatchMetadata};
-use crate::internal::paths::PartialBatchKey;
+use crate::internal::paths::{PartialBatchKey, PartialRollupKey};
 use crate::internal::state::proto_leased_batch_metadata;
 use crate::internal::state::{
     HollowBatch, ProtoHollowBatch, ProtoLeasedBatch, ProtoLeasedBatchMetadata, ProtoReaderState,
-    ProtoStateRollup, ProtoTrace, ProtoU64Antichain, ProtoU64Description, ProtoWriterState,
-    ReaderState, State, StateCollections, WriterState,
+    ProtoStateDiff, ProtoStateFieldDiff, ProtoStateFieldDiffType, ProtoStateRollup, ProtoTrace,
+    ProtoU64Antichain, ProtoU64Description, ProtoWriterState, ReaderState, State, StateCollections,
+    WriterState,
 };
-
+use crate::internal::state_diff::{StateDiff, StateFieldDiff, StateFieldValDiff};
 use crate::internal::trace::Trace;
 use crate::read::ReaderId;
 use crate::{ShardId, WriterId};
@@ -43,6 +43,41 @@ pub(crate) fn parse_id(id_prefix: char, id_type: &str, encoded: &str) -> Result<
     let uuid = Uuid::parse_str(&uuid_encoded)
         .map_err(|err| format!("invalid {} {}: {}", id_type, encoded, err))?;
     Ok(*uuid.as_bytes())
+}
+
+// If persist gets some encoded ProtoState from the future (e.g. two versions of
+// code are running simultaneously against the same shard), it might have a
+// field that the current code doesn't know about. This would be silently
+// discarded at proto decode time. Unknown Fields [1] are a tool we can use in
+// the future to help deal with this, but in the short-term, it's best to keep
+// the persist read-modify-CaS loop simple for as long as we can get away with
+// it (i.e. until we have to offer the ability to do rollbacks).
+//
+// [1]: https://developers.google.com/protocol-buffers/docs/proto3#unknowns
+//
+// To detect the bad situation and disallow it, we tag every version of state
+// written to consensus with the version of code used to encode it. Then at
+// decode time, we're able to compare the current version against any we receive
+// and assert as necessary.
+//
+// Initially we reject any version from the future (no forward compatibility,
+// most conservative but easiest to reason about) but allow any from the past
+// (permanent backward compatibility). If/when we support deploy rollbacks and
+// rolling upgrades, we can adjust this assert as necessary to reflect the
+// policy (e.g. by adding some window of X allowed versions of forward
+// compatibility, computed by comparing semvers).
+//
+// We could do the same for blob data, but it shouldn't be necessary. Any blob
+// data we read is going to be because we fetched it using a pointer stored in
+// some persist state. If we can handle the state, we can handle the blobs it
+// references, too.
+fn check_applier_version(build_version: &Version, applier_version: &Version) {
+    if build_version < applier_version {
+        panic!(
+            "{} received persist state from the future {}",
+            build_version, applier_version
+        );
+    }
 }
 
 impl RustType<String> for ShardId {
@@ -94,71 +129,36 @@ impl RustType<String> for PartialBatchKey {
     }
 }
 
-impl<K, V, T, D> State<K, V, T, D>
-where
-    K: Codec,
-    V: Codec,
-    T: Timestamp + Lattice + Codec64,
-    D: Codec64,
-{
-    pub fn decode(build_version: &Version, buf: &[u8]) -> Result<Self, CodecMismatch> {
-        let proto = ProtoStateRollup::decode(buf)
+impl RustType<String> for PartialRollupKey {
+    fn into_proto(&self) -> String {
+        self.0.clone()
+    }
+
+    fn from_proto(proto: String) -> Result<Self, TryFromProtoError> {
+        Ok(PartialRollupKey(proto))
+    }
+}
+
+impl<T: Timestamp + Lattice + Codec64> StateDiff<T> {
+    pub fn decode(build_version: &Version, buf: &[u8]) -> Self {
+        let proto = ProtoStateDiff::decode(buf)
             // We received a State that we couldn't decode. This could happen if
             // persist messes up backward/forward compatibility, if the durable
             // data was corrupted, or if operations messes up deployment. In any
             // case, fail loudly.
             .expect("internal error: invalid encoded state");
-        let state = Self::try_from(proto).expect("internal error: invalid encoded state")?;
-
-        // If persist gets some encoded ProtoState from the future (e.g. two
-        // versions of code are running simultaneously against the same shard),
-        // it might have a field that the current code doesn't know about. This
-        // would be silently discarded at proto decode time. Unknown Fields [1]
-        // are a tool we can use in the future to help deal with this, but in
-        // the short-term, it's best to keep the persist read-modify-CaS loop
-        // simple for as long as we can get away with it (i.e. until we have to
-        // offer the ability to do rollbacks).
-        //
-        // [1]:
-        //     https://developers.google.com/protocol-buffers/docs/proto3#unknowns
-        //
-        // To detect the bad situation and disallow it, we tag every version of
-        // state written to consensus with the version of code used to encode
-        // it. Then at decode time, we're able to compare the current version
-        // against any we receive and assert as necessary.
-        //
-        // Initially we reject any version from the future (no forward
-        // compatibility, most conservative but easiest to reason about) but
-        // allow any from the past (permanent backward compatibility). If/when
-        // we support deploy rollbacks and rolling upgrades, we can adjust this
-        // assert as necessary to reflect the policy (e.g. by adding some window
-        // of X allowed versions of forward compatibility, computed by comparing
-        // semvers).
-        //
-        // We could do the same for blob data, but it shouldn't be necessary.
-        // Any blob data we read is going to be because we fetched it using a
-        // pointer stored in some persist state. If we can handle the state, we
-        // can handle the blobs it references, too.
-        if build_version < &state.applier_version {
-            panic!(
-                "{} received persist state from the future {}",
-                build_version, state.applier_version
-            );
-        }
-
-        Ok(state)
+        let diff = Self::from_proto(proto).expect("internal error: invalid encoded state");
+        check_applier_version(build_version, &diff.applier_version);
+        diff
     }
 }
 
-impl<K, V, T, D> Codec for State<K, V, T, D>
+impl<T> Codec for StateDiff<T>
 where
-    K: Codec,
-    V: Codec,
     T: Timestamp + Lattice + Codec64,
-    D: Codec64,
 {
     fn codec_name() -> String {
-        "proto[State]".into()
+        "proto[StateDiff]".into()
     }
 
     fn encode<B>(&self, buf: &mut B)
@@ -171,13 +171,242 @@ where
     }
 
     fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
-        let proto = ProtoStateRollup::decode(buf).map_err(|err| err.to_string())?;
-        // This match goes away when we do incremental state.
-        match State::try_from(proto) {
-            Ok(Ok(x)) => Ok(x),
-            Ok(Err(err)) => Err(err.to_string()),
-            Err(err) => Err(err.to_string()),
+        let proto = ProtoStateDiff::decode(buf).map_err(|err| err.to_string())?;
+        proto.into_rust().map_err(|err| err.to_string())
+    }
+}
+
+impl<T: Timestamp + Codec64> RustType<ProtoStateDiff> for StateDiff<T> {
+    fn into_proto(&self) -> ProtoStateDiff {
+        ProtoStateDiff {
+            applier_version: self.applier_version.to_string(),
+            seqno_from: self.seqno_from.into_proto(),
+            seqno_to: self.seqno_to.into_proto(),
+            latest_rollup_key: self.latest_rollup_key.into_proto(),
+            rollups: field_diffs_into_proto(
+                &self.rollups,
+                |k| k.into_proto().encode_to_vec(),
+                |v| v.into_proto().encode_to_vec(),
+            ),
+            last_gc_req: field_diffs_into_proto(
+                &self.last_gc_req,
+                |()| Vec::new(),
+                |v| v.into_proto().encode_to_vec(),
+            ),
+            readers: field_diffs_into_proto(
+                &self.readers,
+                |k| k.into_proto().encode_to_vec(),
+                |v| {
+                    ProtoReaderState {
+                        since: Some(v.since.into_proto()),
+                        seqno: v.seqno.into_proto(),
+                        last_heartbeat_timestamp_ms: v.last_heartbeat_timestamp_ms,
+                    }
+                    .encode_to_vec()
+                },
+            ),
+            writers: field_diffs_into_proto(
+                &self.writers,
+                |k| k.into_proto().encode_to_vec(),
+                |v| {
+                    ProtoWriterState {
+                        last_heartbeat_timestamp_ms: v.last_heartbeat_timestamp_ms,
+                        lease_duration_ms: v.lease_duration_ms,
+                    }
+                    .encode_to_vec()
+                },
+            ),
+            since: field_diffs_into_proto(
+                &self.since,
+                |()| Vec::new(),
+                |v| v.into_proto().encode_to_vec(),
+            ),
+            spine: field_diffs_into_proto(
+                &self.spine,
+                |k| k.into_proto().encode_to_vec(),
+                |()| Vec::new(),
+            ),
         }
+    }
+
+    fn from_proto(proto: ProtoStateDiff) -> Result<Self, TryFromProtoError> {
+        let applier_version = if proto.applier_version.is_empty() {
+            // Backward compatibility with versions of ProtoState before we set
+            // this field: if it's missing (empty), assume an infinitely old
+            // version.
+            semver::Version::new(0, 0, 0)
+        } else {
+            semver::Version::parse(&proto.applier_version).map_err(|err| {
+                TryFromProtoError::InvalidSemverVersion(format!(
+                    "invalid applier_version {}: {}",
+                    proto.applier_version, err
+                ))
+            })?
+        };
+        Ok(StateDiff {
+            applier_version,
+            seqno_from: proto.seqno_from.into_rust()?,
+            seqno_to: proto.seqno_to.into_rust()?,
+            latest_rollup_key: proto.latest_rollup_key.into_rust()?,
+            rollups: field_diffs_into_rust::<u64, String, _, _, _, _>(
+                proto.rollups,
+                |k| k.into_rust(),
+                |v| v.into_rust(),
+            )?
+            .into_iter()
+            .collect(),
+            last_gc_req: field_diffs_into_rust::<(), u64, _, _, _, _>(
+                proto.last_gc_req,
+                |()| Ok(()),
+                |v| v.into_rust(),
+            )?,
+            readers: field_diffs_into_rust::<String, ProtoReaderState, _, _, _, _>(
+                proto.readers,
+                |k| k.into_rust(),
+                |v| {
+                    Ok(ReaderState {
+                        since: v.since.into_rust_if_some("since")?,
+                        seqno: v.seqno.into_rust()?,
+                        last_heartbeat_timestamp_ms: v.last_heartbeat_timestamp_ms,
+                    })
+                },
+            )?
+            .into_iter()
+            .collect(),
+            writers: field_diffs_into_rust::<String, ProtoWriterState, _, _, _, _>(
+                proto.writers,
+                |k| k.into_rust(),
+                |v| {
+                    Ok(WriterState {
+                        last_heartbeat_timestamp_ms: v.last_heartbeat_timestamp_ms,
+                        lease_duration_ms: v.lease_duration_ms,
+                    })
+                },
+            )?
+            .into_iter()
+            .collect(),
+            since: field_diffs_into_rust::<(), ProtoU64Antichain, _, _, _, _>(
+                proto.since,
+                |()| Ok(()),
+                |v| v.into_rust(),
+            )?,
+            spine: field_diffs_into_rust::<ProtoHollowBatch, (), _, _, _, _>(
+                proto.spine,
+                |k| k.into_rust(),
+                |()| Ok(()),
+            )?,
+        })
+    }
+}
+
+fn field_diffs_into_proto<K, V, KFn, VFn>(
+    diffs: &[StateFieldDiff<K, V>],
+    k_fn: KFn,
+    v_fn: VFn,
+) -> Vec<ProtoStateFieldDiff>
+where
+    KFn: Fn(&K) -> Vec<u8>,
+    VFn: Fn(&V) -> Vec<u8>,
+{
+    diffs
+        .iter()
+        .map(|diff| {
+            let (diff_type, from, to) = match &diff.val {
+                StateFieldValDiff::Insert(to) => {
+                    (ProtoStateFieldDiffType::Insert, Vec::new(), v_fn(to))
+                }
+                StateFieldValDiff::Update(from, to) => {
+                    (ProtoStateFieldDiffType::Update, v_fn(from), v_fn(to))
+                }
+                StateFieldValDiff::Delete(from) => {
+                    (ProtoStateFieldDiffType::Delete, v_fn(from), Vec::new())
+                }
+            };
+            ProtoStateFieldDiff {
+                key: k_fn(&diff.key),
+                diff_type: i32::from(diff_type),
+                from,
+                to,
+            }
+        })
+        .collect()
+}
+
+fn field_diffs_into_rust<KP, VP, K, V, KFn, VFn>(
+    protos: Vec<ProtoStateFieldDiff>,
+    k_fn: KFn,
+    v_fn: VFn,
+) -> Result<Vec<StateFieldDiff<K, V>>, TryFromProtoError>
+where
+    KP: prost::Message + Default,
+    VP: prost::Message + Default,
+    KFn: Fn(KP) -> Result<K, TryFromProtoError>,
+    VFn: Fn(VP) -> Result<V, TryFromProtoError>,
+{
+    let mut diffs = Vec::new();
+    for proto in protos {
+        let val = match ProtoStateFieldDiffType::from_i32(proto.diff_type) {
+            Some(ProtoStateFieldDiffType::Insert) => {
+                let to = VP::decode(proto.to.as_slice())
+                    .map_err(|err| TryFromProtoError::InvalidPersistState(err.to_string()))?;
+                StateFieldValDiff::Insert(v_fn(to)?)
+            }
+            Some(ProtoStateFieldDiffType::Update) => {
+                let from = VP::decode(proto.from.as_slice())
+                    .map_err(|err| TryFromProtoError::InvalidPersistState(err.to_string()))?;
+                let to = VP::decode(proto.to.as_slice())
+                    .map_err(|err| TryFromProtoError::InvalidPersistState(err.to_string()))?;
+
+                StateFieldValDiff::Update(v_fn(from)?, v_fn(to)?)
+            }
+            Some(ProtoStateFieldDiffType::Delete) => {
+                let from = VP::decode(proto.from.as_slice())
+                    .map_err(|err| TryFromProtoError::InvalidPersistState(err.to_string()))?;
+                StateFieldValDiff::Delete(v_fn(from)?)
+            }
+            None => {
+                return Err(TryFromProtoError::unknown_enum_variant(format!(
+                    "ProtoStateFieldDiffType {}",
+                    proto.diff_type,
+                )))
+            }
+        };
+        let key = KP::decode(proto.key.as_slice())
+            .map_err(|err| TryFromProtoError::InvalidPersistState(err.to_string()))?;
+        diffs.push(StateFieldDiff {
+            key: k_fn(key)?,
+            val,
+        });
+    }
+    Ok(diffs)
+}
+
+impl<K, V, T, D> State<K, V, T, D>
+where
+    K: Codec,
+    V: Codec,
+    T: Timestamp + Lattice + Codec64,
+    D: Codec64,
+{
+    pub fn encode<B>(&self, buf: &mut B)
+    where
+        B: bytes::BufMut,
+    {
+        self.into_proto()
+            .encode(buf)
+            .expect("no required fields means no initialization errors");
+    }
+
+    pub fn decode(build_version: &Version, buf: &[u8]) -> Result<Self, CodecMismatch> {
+        let proto = ProtoStateRollup::decode(buf)
+            // We received a State that we couldn't decode. This could happen if
+            // persist messes up backward/forward compatibility, if the durable
+            // data was corrupted, or if operations messes up deployment. In any
+            // case, fail loudly.
+            .expect("internal error: invalid encoded state");
+        let state = Self::try_from(proto).expect("internal error: invalid encoded state")?;
+        check_applier_version(build_version, &state.applier_version);
+        Ok(state)
     }
 }
 
@@ -198,26 +427,23 @@ where
             ts_codec: T::codec_name(),
             diff_codec: D::codec_name(),
             last_gc_req: self.collections.last_gc_req.into_proto(),
+            rollups: self
+                .collections
+                .rollups
+                .iter()
+                .map(|(seqno, key)| (seqno.into_proto(), key.into_proto()))
+                .collect(),
             readers: self
                 .collections
                 .readers
                 .iter()
-                .map(|(id, cap)| ProtoReaderState {
-                    reader_id: id.into_proto(),
-                    since: Some(cap.since.into_proto()),
-                    seqno: cap.seqno.into_proto(),
-                    last_heartbeat_timestamp_ms: cap.last_heartbeat_timestamp_ms,
-                })
+                .map(|(id, state)| (id.into_proto(), state.into_proto()))
                 .collect(),
             writers: self
                 .collections
                 .writers
                 .iter()
-                .map(|(id, writer)| ProtoWriterState {
-                    writer_id: id.into_proto(),
-                    last_heartbeat_timestamp_ms: writer.last_heartbeat_timestamp_ms,
-                    lease_duration_ms: writer.lease_duration_ms,
-                })
+                .map(|(id, state)| (id.into_proto(), state.into_proto()))
                 .collect(),
             trace: Some(self.collections.trace.into_proto()),
         }
@@ -270,28 +496,20 @@ where
             })?
         };
 
-        let mut readers = HashMap::with_capacity(x.readers.len());
-        for proto in x.readers {
-            let reader_id = proto.reader_id.into_rust()?;
-            let cap = ReaderState {
-                since: proto.since.into_rust_if_some("since")?,
-                seqno: proto.seqno.into_rust()?,
-                last_heartbeat_timestamp_ms: proto.last_heartbeat_timestamp_ms,
-            };
-            readers.insert(reader_id, cap);
+        let mut rollups = BTreeMap::new();
+        for (seqno, key) in x.rollups {
+            rollups.insert(seqno.into_rust()?, key.into_rust()?);
         }
-        let mut writers = HashMap::with_capacity(x.writers.len());
-        for proto in x.writers {
-            let writer_id = proto.writer_id.into_rust()?;
-            writers.insert(
-                writer_id,
-                WriterState {
-                    last_heartbeat_timestamp_ms: proto.last_heartbeat_timestamp_ms,
-                    lease_duration_ms: proto.lease_duration_ms,
-                },
-            );
+        let mut readers = BTreeMap::new();
+        for (id, state) in x.readers {
+            readers.insert(id.into_rust()?, state.into_rust()?);
+        }
+        let mut writers = BTreeMap::new();
+        for (id, state) in x.writers {
+            writers.insert(id.into_rust()?, state.into_rust()?);
         }
         let collections = StateCollections {
+            rollups,
             last_gc_req: x.last_gc_req.into_rust()?,
             readers,
             writers,
@@ -343,6 +561,40 @@ impl<T: Timestamp + Lattice + Codec64> RustType<ProtoTrace> for Trace<T> {
             let _merge_reqs = ret.push_batch(batch);
         }
         Ok(ret)
+    }
+}
+
+impl<T: Timestamp + Codec64> RustType<ProtoReaderState> for ReaderState<T> {
+    fn into_proto(&self) -> ProtoReaderState {
+        ProtoReaderState {
+            seqno: self.seqno.into_proto(),
+            since: Some(self.since.into_proto()),
+            last_heartbeat_timestamp_ms: self.last_heartbeat_timestamp_ms.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoReaderState) -> Result<Self, TryFromProtoError> {
+        Ok(ReaderState {
+            seqno: proto.seqno.into_rust()?,
+            since: proto.since.into_rust_if_some("ProtoReaderState::since")?,
+            last_heartbeat_timestamp_ms: proto.last_heartbeat_timestamp_ms.into_rust()?,
+        })
+    }
+}
+
+impl RustType<ProtoWriterState> for WriterState {
+    fn into_proto(&self) -> ProtoWriterState {
+        ProtoWriterState {
+            last_heartbeat_timestamp_ms: self.last_heartbeat_timestamp_ms.into_proto(),
+            lease_duration_ms: self.lease_duration_ms.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoWriterState) -> Result<Self, TryFromProtoError> {
+        Ok(WriterState {
+            last_heartbeat_timestamp_ms: proto.last_heartbeat_timestamp_ms.into_rust()?,
+            lease_duration_ms: proto.lease_duration_ms.into_rust()?,
+        })
     }
 }
 
@@ -476,13 +728,16 @@ impl<T: Timestamp + Codec64> RustType<ProtoLeasedBatch> for LeasedBatch<T> {
 
 #[cfg(test)]
 mod tests {
+    use mz_persist::location::SeqNo;
     use mz_persist_types::Codec;
 
+    use crate::internal::paths::PartialRollupKey;
     use crate::internal::state::State;
+    use crate::internal::state_diff::StateDiff;
     use crate::ShardId;
 
     #[test]
-    fn applier_version() {
+    fn applier_version_state() {
         let v1 = semver::Version::new(1, 0, 0);
         let v2 = semver::Version::new(2, 0, 0);
         let v3 = semver::Version::new(3, 0, 0);
@@ -500,6 +755,33 @@ mod tests {
         // losing or misinterpreting something written out by a future version
         // of code.
         let v1_res = std::panic::catch_unwind(|| State::<(), (), u64, i64>::decode(&v1, &buf));
+        assert!(v1_res.is_err());
+    }
+
+    #[test]
+    fn applier_version_state_diff() {
+        let v1 = semver::Version::new(1, 0, 0);
+        let v2 = semver::Version::new(2, 0, 0);
+        let v3 = semver::Version::new(3, 0, 0);
+
+        // Code version v2 evaluates and writes out some State.
+        let diff = StateDiff::<u64>::new(
+            v2.clone(),
+            SeqNo(0),
+            SeqNo(1),
+            PartialRollupKey("rollup".into()),
+        );
+        let mut buf = Vec::new();
+        diff.encode(&mut buf);
+
+        // We can read it back using persist code v2 and v3.
+        assert_eq!(StateDiff::decode(&v2, &buf), diff);
+        assert_eq!(StateDiff::decode(&v3, &buf), diff);
+
+        // But we can't read it back using v1 because v1 might corrupt it by
+        // losing or misinterpreting something written out by a future version
+        // of code.
+        let v1_res = std::panic::catch_unwind(|| StateDiff::<u64>::decode(&v1, &buf));
         assert!(v1_res.is_err());
     }
 }

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -23,7 +23,7 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 
 use crate::error::CodecMismatch;
 use crate::fetch::{LeasedBatch, LeasedBatchMetadata};
-use crate::internal::paths::PartialBlobKey;
+use crate::internal::paths::PartialBatchKey;
 use crate::internal::state::proto_leased_batch_metadata;
 use crate::internal::state::{
     HollowBatch, ProtoHollowBatch, ProtoLeasedBatchMetadata, ProtoReaderState, ProtoStateRollup,
@@ -88,13 +88,13 @@ impl RustType<String> for WriterId {
     }
 }
 
-impl RustType<String> for PartialBlobKey {
+impl RustType<String> for PartialBatchKey {
     fn into_proto(&self) -> String {
         self.0.clone()
     }
 
     fn from_proto(proto: String) -> Result<Self, TryFromProtoError> {
-        Ok(PartialBlobKey(proto))
+        Ok(PartialBatchKey(proto))
     }
 }
 

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -19,7 +19,7 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, debug_span, warn, Instrument, Span};
 
 use crate::internal::machine::retry_external;
-use crate::internal::paths::PartialBlobKey;
+use crate::internal::paths::PartialBatchKey;
 use crate::internal::state::ProtoStateRollup;
 use crate::{Metrics, ShardId};
 
@@ -242,7 +242,7 @@ impl GarbageCollector {
         // concurrently, but this requires a bunch of Arc cloning, so wait to
         // see if it's worth it.
         for key in deleteable_blobs {
-            let key = PartialBlobKey(key).complete(&req.shard_id);
+            let key = PartialBatchKey(key).complete(&req.shard_id);
             retry_external(&metrics.retries.external.gc_delete, || async {
                 blob.delete(&key).await
             })

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -578,7 +578,8 @@ where
 
                         return Ok((self.state.seqno(), Ok(work_ret), maintenance));
                     }
-                    Err(current) => {
+                    Err(mut current) => {
+                        let current = current.pop();
                         debug!(
                             "apply_unbatched_cmd {} {} lost the CaS race, retrying: {} vs {:?}",
                             self.shard_id(),
@@ -643,10 +644,11 @@ where
                     );
                     return Ok(state);
                 }
-                Err(x) => {
+                Err(mut x) => {
                     // We lost a CaS race, use the value included in the CaS
                     // expectation error. Because we used None for expected,
                     // this should never be None.
+                    let x = x.pop();
                     debug!(
                         "maybe_init_state lost the CaS race, using current value: {:?}",
                         x.as_ref().map(|x| x.seqno)

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -19,11 +19,11 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::cast::CastFrom;
 use timely::progress::{Antichain, Timestamp};
-use tracing::{debug, debug_span, info, trace, trace_span, Instrument};
+use tracing::{debug, info, trace_span, Instrument};
 
 #[allow(unused_imports)] // False positive.
 use mz_ore::fmt::FormatBuffer;
-use mz_persist::location::{Consensus, ExternalError, Indeterminate, SeqNo, VersionedData};
+use mz_persist::location::{ExternalError, Indeterminate, SeqNo};
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
 
@@ -32,11 +32,14 @@ use crate::internal::compact::CompactReq;
 use crate::internal::gc::GcReq;
 use crate::internal::maintenance::{LeaseExpiration, RoutineMaintenance, WriterMaintenance};
 use crate::internal::metrics::{
-    CmdMetrics, Metrics, MetricsRetryStream, RetriesMetrics, RetryMetrics, ShardMetrics,
+    CmdMetrics, Metrics, MetricsRetryStream, RetryMetrics, ShardMetrics,
 };
+use crate::internal::paths::{PartialRollupKey, RollupId};
 use crate::internal::state::{
     HollowBatch, ReaderState, Since, State, StateCollections, Upper, WriterState,
 };
+use crate::internal::state_diff::StateDiff;
+use crate::internal::state_versions::StateVersions;
 use crate::internal::trace::FueledMergeRes;
 use crate::read::ReaderId;
 use crate::write::WriterId;
@@ -44,11 +47,10 @@ use crate::{PersistConfig, ShardId};
 
 #[derive(Debug)]
 pub struct Machine<K, V, T, D> {
-    // TODO: Remove cfg after we remove the read lease expiry hack.
-    cfg: PersistConfig,
-    consensus: Arc<dyn Consensus + Send + Sync>,
-    metrics: Arc<Metrics>,
-    shard_metrics: Arc<ShardMetrics>,
+    pub(crate) cfg: PersistConfig,
+    pub(crate) metrics: Arc<Metrics>,
+    pub(crate) shard_metrics: Arc<ShardMetrics>,
+    pub(crate) state_versions: Arc<StateVersions>,
 
     state: State<K, V, T, D>,
 }
@@ -58,9 +60,9 @@ impl<K, V, T: Clone, D> Clone for Machine<K, V, T, D> {
     fn clone(&self) -> Self {
         Self {
             cfg: self.cfg.clone(),
-            consensus: Arc::clone(&self.consensus),
             metrics: Arc::clone(&self.metrics),
             shard_metrics: Arc::clone(&self.shard_metrics),
+            state_versions: Arc::clone(&self.state_versions),
             state: self.state.clone(self.cfg.build_version.clone()),
         }
     }
@@ -76,8 +78,8 @@ where
     pub async fn new(
         cfg: PersistConfig,
         shard_id: ShardId,
-        consensus: Arc<dyn Consensus + Send + Sync>,
         metrics: Arc<Metrics>,
+        state_versions: Arc<StateVersions>,
     ) -> Result<Self, CodecMismatch> {
         let shard_metrics = metrics.shards.shard(&shard_id);
         let state = metrics
@@ -86,14 +88,14 @@ where
             .run_cmd(|_cas_mismatch_metric| {
                 // No cas_mismatch retries because we just use the returned
                 // state on a mismatch.
-                Self::maybe_init_state(&cfg, consensus.as_ref(), &metrics.retries, shard_id)
+                state_versions.maybe_init_shard(&shard_metrics)
             })
             .await?;
         Ok(Machine {
             cfg,
-            consensus,
             metrics,
             shard_metrics,
+            state_versions,
             state,
         })
     }
@@ -118,6 +120,46 @@ where
     #[cfg(test)]
     pub fn seqno_since(&self) -> SeqNo {
         self.state.seqno_since()
+    }
+
+    pub async fn add_rollup_for_current_seqno(&mut self) {
+        let rollup_seqno = self.state.seqno;
+        let rollup_key = PartialRollupKey::new(rollup_seqno, &RollupId::new());
+        let () = self
+            .state_versions
+            .write_rollup_blob(&self.shard_metrics, &self.state, &rollup_key)
+            .await;
+        let applied = self
+            .add_and_remove_rollups((rollup_seqno, &rollup_key), &[])
+            .await;
+        if !applied {
+            // Someone else already wrote a rollup at this seqno, so ours didn't
+            // get added. Delete it.
+            self.state_versions
+                .delete_rollup(&self.state.shard_id, &rollup_key)
+                .await;
+        }
+    }
+
+    pub async fn add_and_remove_rollups(
+        &mut self,
+        add_rollup: (SeqNo, &PartialRollupKey),
+        remove_rollups: &[(SeqNo, PartialRollupKey)],
+    ) -> bool {
+        // See the big SUBTLE comment in [Self::merge_res] for what's going on
+        // here.
+        let mut applied_ever_true = false;
+        let metrics = Arc::clone(&self.metrics);
+        let (_seqno, _applied, _maintenance) = self
+            .apply_unbatched_idempotent_cmd(&metrics.cmds.add_and_remove_rollups, |_, state| {
+                let ret = state.add_and_remove_rollups(add_rollup, remove_rollups);
+                if let Continue(applied) = ret {
+                    applied_ever_true = applied_ever_true || applied;
+                }
+                ret
+            })
+            .await;
+        applied_ever_true
     }
 
     pub async fn register_reader(
@@ -477,7 +519,6 @@ where
     ) -> Result<(SeqNo, Result<R, E>, RoutineMaintenance), Indeterminate> {
         let is_write = cmd.name == self.metrics.cmds.compare_and_append.name;
         cmd.run_cmd(|cas_mismatch_metric| async move {
-            let path = self.shard_id().to_string();
             let mut garbage_collection;
 
             loop {
@@ -490,6 +531,18 @@ where
                         return Ok((self.state.seqno(), Err(err), RoutineMaintenance::default()))
                     }
                 };
+
+                let diff = StateDiff::from_diff(&self.state, &new_state);
+                // Sanity check that our diff logic roundtrips and adds back up
+                // correctly.
+                #[cfg(any(test, debug_assertions))]
+                {
+                    if let Err(err) =
+                        StateDiff::validate_roundtrip(&self.metrics, &self.state, &diff, &new_state)
+                    {
+                        panic!("validate_roundtrips failed: {}", err);
+                    }
+                }
 
                 // Find out if this command has been selected to perform gc, so
                 // that it will fire off a background request to the
@@ -510,55 +563,31 @@ where
                             new_seqno_since,
                         });
 
-                trace!(
-                    "apply_unbatched_cmd {} attempting {}\n  new_state={:?}",
-                    cmd.name,
-                    self.state.seqno(),
-                    new_state
-                );
-                let new = self
-                    .metrics
-                    .codecs
-                    .state
-                    .encode(|| VersionedData::from((new_state.seqno(), &new_state)));
-
                 // SUBTLE! Unlike the other consensus and blob uses, we can't
                 // automatically retry indeterminate ExternalErrors here. However,
                 // if the state change itself is _idempotent_, then we're free to
                 // retry even indeterminate errors. See
                 // [Self::apply_unbatched_idempotent_cmd].
-                let payload_len = new.data.len();
-                let cas_res = retry_determinate(
-                    &self.metrics.retries.determinate.apply_unbatched_cmd_cas,
-                    || async {
-                        self.consensus
-                            .compare_and_set(&path, Some(self.state.seqno()), new.clone())
-                            .await
-                    },
-                )
-                .instrument(debug_span!("apply_unbatched_cmd::cas", payload_len))
-                .await
-                .map_err(|err| {
-                    debug!("apply_unbatched_cmd {} errored: {}", cmd.name, err);
-                    err
-                })?;
+                let expected = self.state.seqno();
+                let cas_res = self
+                    .state_versions
+                    .try_compare_and_set_current(
+                        &cmd.name,
+                        &self.shard_metrics,
+                        Some(expected),
+                        &new_state,
+                        &diff,
+                    )
+                    .await?;
                 match cas_res {
                     Ok(()) => {
-                        trace!(
-                            "apply_unbatched_cmd {} succeeded {}\n  new_state={:?}",
-                            cmd.name,
-                            new_state.seqno(),
-                            new_state
+                        assert!(
+                            self.state.seqno <= new_state.seqno,
+                            "state seqno regressed: {} vs {}",
+                            self.state.seqno,
+                            new_state.seqno
                         );
                         self.state = new_state;
-
-                        self.shard_metrics.set_since(self.state.since());
-                        self.shard_metrics.set_upper(&self.state.upper());
-                        self.shard_metrics.set_encoded_state_size(payload_len);
-                        self.shard_metrics.set_batch_count(self.state.batch_count());
-                        self.shard_metrics
-                            .set_update_count(self.state.num_updates());
-                        self.shard_metrics.set_seqnos_held(self.state.seqnos_held());
 
                         let (expired_readers, expired_writers) =
                             self.state.handles_needing_expiration((self.cfg.now)());
@@ -574,21 +603,60 @@ where
                         let maintenance = RoutineMaintenance {
                             garbage_collection,
                             lease_expiration,
+                            write_rollup: self.state.need_rollup(),
                         };
 
                         return Ok((self.state.seqno(), Ok(work_ret), maintenance));
                     }
-                    Err(mut current) => {
-                        let current = current.pop();
-                        debug!(
-                            "apply_unbatched_cmd {} {} lost the CaS race, retrying: {} vs {:?}",
-                            self.shard_id(),
-                            cmd.name,
-                            self.state.seqno(),
-                            current.as_ref().map(|x| x.seqno)
-                        );
+                    Err(diffs_to_current) => {
                         cas_mismatch_metric.0.inc();
-                        self.update_state(current).await;
+
+                        let seqno_before = self.state.seqno;
+                        let diffs_apply = diffs_to_current
+                            .first()
+                            .map_or(true, |x| x.seqno == seqno_before.next());
+                        if diffs_apply {
+                            self.metrics.state.update_state_fast_path.inc();
+                            self.state.apply_encoded_diffs(
+                                &self.cfg,
+                                &self.metrics,
+                                &diffs_to_current,
+                            )
+                        } else {
+                            // Otherwise, we've gc'd the diffs we'd need to
+                            // advance self.state to where diffs_to_current
+                            // starts so we need a new rollup.
+                            self.metrics.state.update_state_slow_path.inc();
+                            debug!(
+                                "update_state didn't hit update_state fast path {} {:?}",
+                                self.state.seqno,
+                                diffs_to_current.first().map(|x| x.seqno),
+                            );
+
+                            // SUBTLE: Consensus::compare_and_set guarantees
+                            // that we get back everything in
+                            // `[max(expected.next(),earliest),current]` on
+                            // expectation mismatch. If `diffs_apply` is false
+                            // (this branch), then we know `earliest >
+                            // expected.next()` and so `diffs_to_current` is
+                            // already the full set of all live diffs. Sanity
+                            // check this deduction with an assert and then use
+                            // it to `fetch_current_state`.
+                            assert!(
+                                diffs_to_current
+                                    .first()
+                                    .map_or(false, |x| x.seqno > expected.next()),
+                                "{:?} vs {}",
+                                diffs_to_current.first(),
+                                expected.next()
+                            );
+                            let all_live_diffs = diffs_to_current;
+                            self.state = self
+                                .state_versions
+                                .fetch_current_state(&self.state.shard_id, all_live_diffs)
+                                .await
+                                .expect("shard codecs should not change");
+                        }
 
                         // Intentionally don't backoff here. It would only make
                         // starvation issues even worse.
@@ -600,99 +668,18 @@ where
         .await
     }
 
-    async fn maybe_init_state(
-        cfg: &PersistConfig,
-        consensus: &(dyn Consensus + Send + Sync),
-        retry_metrics: &RetriesMetrics,
-        shard_id: ShardId,
-    ) -> Result<State<K, V, T, D>, CodecMismatch> {
-        let path = shard_id.to_string();
-        let mut current = retry_external(&retry_metrics.external.maybe_init_state_head, || async {
-            consensus.head(&path).await
-        })
-        .await;
-
-        loop {
-            // First, check if the shard has already been initialized.
-            if let Some(current) = current.as_ref() {
-                let current_state = match State::decode(&cfg.build_version, &current.data) {
-                    Ok(x) => x,
-                    Err(err) => return Err(err),
-                };
-                debug_assert_eq!(current.seqno, current_state.seqno());
-                return Ok(current_state);
-            }
-
-            // It hasn't been initialized, try initializing it.
-            let state = State::new(cfg.build_version.clone(), shard_id);
-            let new = VersionedData::from((state.seqno(), &state));
-            trace!(
-                "maybe_init_state attempting {}\n  state={:?}",
-                new.seqno,
-                state
-            );
-            let cas_res = retry_external(&retry_metrics.external.maybe_init_state_cas, || async {
-                consensus.compare_and_set(&path, None, new.clone()).await
-            })
-            .await;
-            match cas_res {
-                Ok(()) => {
-                    trace!(
-                        "maybe_init_state succeeded {}\n  state={:?}",
-                        state.seqno(),
-                        state
-                    );
-                    return Ok(state);
-                }
-                Err(mut x) => {
-                    // We lost a CaS race, use the value included in the CaS
-                    // expectation error. Because we used None for expected,
-                    // this should never be None.
-                    let x = x.pop();
-                    debug!(
-                        "maybe_init_state lost the CaS race, using current value: {:?}",
-                        x.as_ref().map(|x| x.seqno)
-                    );
-                    debug_assert!(x.is_some());
-                    current = x
-                }
-            }
-        }
-    }
-
     pub async fn fetch_and_update_state(&mut self) {
-        let shard_id = self.shard_id();
-        let current = retry_external(
-            &self.metrics.retries.external.fetch_and_update_state_head,
-            || async { self.consensus.head(&shard_id.to_string()).await },
-        )
-        .instrument(trace_span!("fetch_and_update_state::head"))
-        .await;
-        self.update_state(current).await;
-    }
-
-    async fn update_state(&mut self, current: Option<VersionedData>) {
-        let current = match current {
-            Some(x) => x,
-            None => {
-                // Machine is only constructed once, we've successfully
-                // retrieved state from durable storage, but now it's gone? In
-                // the future, maybe this means the shard was deleted or
-                // something, but for now it's entirely unexpected.
-                panic!("internal error: missing state {}", self.state.shard_id());
-            }
-        };
-        let current_state = self
-            .metrics
-            .codecs
-            .state
-            .decode(|| State::decode(&self.cfg.build_version, &current.data))
-            // We received a State with different declared codecs than a
-            // previous SeqNo of the same State. Fail loudly.
-            .expect("internal error: new durable state disagreed with old durable state");
-        debug_assert_eq!(current.seqno, current_state.seqno());
-        debug_assert!(self.state.seqno() <= current.seqno);
-        self.state = current_state;
+        let seqno_before = self.state.seqno;
+        self.state_versions
+            .fetch_and_update_to_current(&mut self.state)
+            .await
+            .expect("shard codecs should not change");
+        assert!(
+            seqno_before <= self.state.seqno,
+            "state seqno regressed: {} vs {}",
+            seqno_before,
+            self.state.seqno
+        );
     }
 }
 
@@ -794,8 +781,6 @@ mod tests {
     use crate::batch::{validate_truncate_batch, BatchBuilder};
     use crate::fetch::fetch_batch_part;
     use crate::internal::compact::{CompactReq, Compactor};
-    use crate::internal::paths::PartialBatchKey;
-    use crate::internal::state::ProtoStateRollup;
     use crate::read::{Listen, ListenEvent};
     use crate::tests::new_test_client;
     use crate::{GarbageCollector, PersistConfig, ShardId};
@@ -859,43 +844,31 @@ mod tests {
                         "consensus-scan" => {
                             let from =
                                 SeqNo(get_u64(&tc.args, "from_seqno").expect("missing from_seqno"));
-                            let res = client.consensus.scan(&shard_id.to_string(), from).await;
 
                             let mut s = String::new();
-                            let states = match res {
-                                Ok(states) => states,
-                                Err(err) => {
-                                    write!(s, "error: {}\n", err);
-                                    return s;
-                                }
-                            };
-                            for persisted_state in states {
-                                let persisted_state: ProtoStateRollup =
-                                    prost::Message::decode(&*persisted_state.data)
-                                        .expect("internal error: invalid encoded state");
-                                let mut batches = vec![];
-                                if let Some(trace) = persisted_state.trace.as_ref() {
-                                    for batch in trace.spine.iter() {
-                                        let part_keys: Vec<PartialBatchKey> = batch
-                                            .keys
-                                            .iter()
-                                            .map(|k| PartialBatchKey(k.to_owned()))
-                                            .collect();
 
-                                        for (batch_name, original_batch) in &state.batches {
-                                            if original_batch.keys == part_keys {
-                                                batches.push(batch_name.to_owned());
-                                                break;
-                                            }
+                            let mut states = write
+                                .lock()
+                                .await
+                                .machine
+                                .state_versions
+                                .fetch_live_states::<String, (), u64, i64>(&shard_id)
+                                .await
+                                .expect("shard codecs should not change");
+                            while let Some(x) = states.next() {
+                                if x.seqno < from {
+                                    continue;
+                                }
+                                let mut batches = vec![];
+                                x.collections.trace.map_batches(|b| {
+                                    for (batch_name, original_batch) in &state.batches {
+                                        if original_batch.keys == b.keys {
+                                            batches.push(batch_name.to_owned());
+                                            break;
                                         }
                                     }
-                                }
-                                write!(
-                                    s,
-                                    "seqno={} batches={}\n",
-                                    persisted_state.seqno,
-                                    batches.join(",")
-                                );
+                                });
+                                write!(s, "seqno={} batches={}\n", x.seqno, batches.join(","));
                             }
                             s
                         }
@@ -1061,9 +1034,7 @@ mod tests {
                                 SeqNo(get_u64(&tc.args, "to_seqno").expect("missing to_seqno"));
 
                             GarbageCollector::gc_and_truncate(
-                                Arc::clone(&client.consensus),
-                                Arc::clone(&client.blob),
-                                &client.metrics,
+                                &mut write.lock().await.machine,
                                 GcReq {
                                     shard_id,
                                     old_seqno_since,
@@ -1155,7 +1126,6 @@ mod tests {
             .await
             .expect_open::<String, (), u64, i64>(ShardId::new())
             .await;
-        let consensus = Arc::clone(&write.machine.consensus);
 
         // Write a bunch of batches. This should result in a bounded number of
         // live entries in consensus.
@@ -1179,17 +1149,22 @@ mod tests {
                 .perform(&write.machine, &write.gc, write.compact.as_ref())
                 .await;
         }
-        let key = write.machine.shard_id().to_string();
-        let consensus_entries = consensus
-            .scan(&key, SeqNo::minimum())
-            .await
-            .expect("scan failed");
+        let live_diffs = write
+            .machine
+            .state_versions
+            .fetch_live_diffs(&write.machine.shard_id())
+            .await;
         // Make sure we constructed the key correctly.
-        assert!(consensus_entries.len() > 0);
+        assert!(live_diffs.len() > 0);
         // Make sure the number of entries is bounded. (I think we could work
         // out a tighter bound than this, but the point is only that it's
         // bounded).
-        let max_entries = 2 * usize::cast_from(NUM_BATCHES.next_power_of_two().trailing_zeros());
-        assert!(consensus_entries.len() < max_entries);
+        let max_live_diffs = 2 * usize::cast_from(NUM_BATCHES.next_power_of_two().trailing_zeros());
+        assert!(
+            live_diffs.len() < max_live_diffs,
+            "{} vs {}",
+            live_diffs.len(),
+            max_live_diffs
+        );
     }
 }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -794,7 +794,7 @@ mod tests {
     use crate::batch::{validate_truncate_batch, BatchBuilder};
     use crate::fetch::fetch_batch_part;
     use crate::internal::compact::{CompactReq, Compactor};
-    use crate::internal::paths::PartialBlobKey;
+    use crate::internal::paths::PartialBatchKey;
     use crate::internal::state::ProtoStateRollup;
     use crate::read::{Listen, ListenEvent};
     use crate::tests::new_test_client;
@@ -876,10 +876,10 @@ mod tests {
                                 let mut batches = vec![];
                                 if let Some(trace) = persisted_state.trace.as_ref() {
                                     for batch in trace.spine.iter() {
-                                        let part_keys: Vec<PartialBlobKey> = batch
+                                        let part_keys: Vec<PartialBatchKey> = batch
                                             .keys
                                             .iter()
-                                            .map(|k| PartialBlobKey(k.to_owned()))
+                                            .map(|k| PartialBatchKey(k.to_owned()))
                                             .collect();
 
                                         for (batch_name, original_batch) in &state.batches {

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use mz_persist::location::SeqNo;
 use std::ops::Deref;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -14,7 +15,8 @@ use uuid::Uuid;
 use crate::internal::encoding::parse_id;
 use crate::{ShardId, WriterId};
 
-/// An opaque identifier for an individual blob of a persist durable TVC (aka shard).
+/// An opaque identifier for an individual batch of a persist durable TVC (aka
+/// shard).
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct PartId(pub(crate) [u8; 16]);
 
@@ -51,25 +53,16 @@ impl PartId {
 /// Used to reduce the bytes needed to refer to a blob key in memory and in
 /// persistent state, all access to blobs are always within the context of an
 /// individual shard.
-#[derive(Clone, Debug, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PartialBatchKey(pub(crate) String);
 
 impl PartialBatchKey {
-    pub fn new(writer_id: &WriterId, part_id: &PartId) -> PartialBatchKey {
+    pub fn new(writer_id: &WriterId, part_id: &PartId) -> Self {
         PartialBatchKey(format!("{}/{}", writer_id, part_id))
     }
 
     pub fn complete(&self, shard_id: &ShardId) -> BlobKey {
-        if self.starts_with('w') {
-            BlobKey(format!("{}/{}", shard_id, self))
-        } else {
-            // the legacy key format is a plain UUID (which cannot start with
-            // 'w') so it should not be prepended with the shard id.
-            //
-            // TODO: this can be removed when there are no more legacy keys. see
-            // [BlobKey::parse_ids] for more details
-            BlobKey(self.0.to_owned())
-        }
+        BlobKey(format!("{}/{}", shard_id, self))
     }
 }
 
@@ -87,12 +80,87 @@ impl Deref for PartialBatchKey {
     }
 }
 
+/// An opaque identifier for an individual blob of a persist durable TVC (aka shard).
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct RollupId(pub(crate) [u8; 16]);
+
+impl std::fmt::Display for RollupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "r{}", Uuid::from_bytes(self.0))
+    }
+}
+
+impl std::fmt::Debug for RollupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RollupId({})", Uuid::from_bytes(self.0))
+    }
+}
+
+impl FromStr for RollupId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_id('r', "RollupId", s).map(RollupId)
+    }
+}
+
+impl RollupId {
+    pub(crate) fn new() -> Self {
+        RollupId(*Uuid::new_v4().as_bytes())
+    }
+}
+
+/// Partially encoded path used in [mz_persist::location::Blob] storage.
+/// Composed of a [SeqNo] and [RollupId]. Can be completed with a [ShardId] to
+/// form a full [BlobKey].
+///
+/// Used to reduce the bytes needed to refer to a blob key in memory and in
+/// persistent state, all access to blobs are always within the context of an
+/// individual shard.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PartialRollupKey(pub(crate) String);
+
+impl PartialRollupKey {
+    pub fn new(seqno: SeqNo, rollup_id: &RollupId) -> Self {
+        PartialRollupKey(format!("{}/{}", seqno, rollup_id))
+    }
+
+    pub fn complete(&self, shard_id: &ShardId) -> BlobKey {
+        BlobKey(format!("{}/{}", shard_id, self))
+    }
+}
+
+impl std::fmt::Display for PartialRollupKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl Deref for PartialRollupKey {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// A parsed, partial path used in [mz_persist::location::Blob] storage.
+///
+/// This enumerates all types of partial blob keys used in persist.
+#[derive(Debug, PartialEq)]
+pub enum PartialBlobKey {
+    /// A parsed [PartialBatchKey].
+    Batch(WriterId, PartId),
+    /// A parsed [PartialRollupKey].
+    Rollup(SeqNo, RollupId),
+}
+
 /// Fully encoded path used in [mz_persist::location::Blob] storage. Composed of
 /// a [ShardId], [WriterId] and [PartId].
 ///
 /// Use when directly interacting with a [mz_persist::location::Blob], otherwise
-/// use [PartialBatchKey] to refer to a blob without needing to copy the
-/// [ShardId].
+/// use [PartialBatchKey] or [PartialRollupKey] to refer to a blob without
+/// needing to copy the [ShardId].
 #[derive(Clone, Debug, PartialEq)]
 pub struct BlobKey(String);
 
@@ -111,19 +179,17 @@ impl Deref for BlobKey {
 }
 
 impl BlobKey {
-    pub fn parse_ids(key: &str) -> Result<(Option<(ShardId, WriterId)>, PartId), String> {
+    pub fn parse_ids(key: &str) -> Result<(ShardId, PartialBlobKey), String> {
         let ids = key.split('/').collect::<Vec<_>>();
 
         match ids[..] {
-            [shard, writer, part] => Ok((
-                Some((ShardId::from_str(shard)?, WriterId::from_str(writer)?)),
-                PartId::from_str(part)?,
-            )),
-            // TODO: this blob key format can be removed (and return type updated to not include
-            //       Option) once all deployed environments have been wiped clean after
-            //       https://github.com/MaterializeInc/materialize/pull/13617 has been merged
-            [part] => Ok((None, PartId::from_str(part)?)),
-            _ => Err(format!("invalid blob key format. expected either <shard_id>/<writer_id>/<part_id> or legacy <part_id> format. got: {}", key)),
+            [shard, writer, part] if writer.starts_with('w') => Ok(
+                (ShardId::from_str(shard)?, PartialBlobKey::Batch(WriterId::from_str(writer)?, PartId::from_str(part)?))
+            ),
+            [shard, seqno, rollup] if seqno.starts_with('v') => Ok(
+                (ShardId::from_str(shard)?, PartialBlobKey::Rollup(SeqNo::from_str(seqno)?, RollupId::from_str(rollup)?))
+            ),
+            _ => Err(format!("invalid blob key format. expected either <shard_id>/<writer_id>/<part_id> or <shard_id>/<seqno>/<rollup_id>. got: {}", key)),
         }
     }
 }
@@ -132,13 +198,15 @@ impl BlobKey {
 #[derive(Debug)]
 pub enum BlobKeyPrefix<'a> {
     /// For accessing all blobs
-    #[allow(dead_code)]
     All,
-    /// Scoped to the blobs of an individual shard
+    /// Scoped to the batch and state rollup blobs of an individual shard
     Shard(&'a ShardId),
-    /// Scoped to the blobs of an individual writer
-    #[allow(dead_code)]
+    /// Scoped to the batch blobs of an individual writer
+    #[cfg(test)]
     Writer(&'a ShardId, &'a WriterId),
+    /// Scoped to all state rollup blobs  of an individual shard
+    #[cfg(test)]
+    Rollups(&'a ShardId),
 }
 
 impl std::fmt::Display for BlobKeyPrefix<'_> {
@@ -146,7 +214,10 @@ impl std::fmt::Display for BlobKeyPrefix<'_> {
         let s = match self {
             BlobKeyPrefix::All => "".into(),
             BlobKeyPrefix::Shard(shard) => format!("{}", shard),
+            #[cfg(test)]
             BlobKeyPrefix::Writer(shard, writer) => format!("{}/{}", shard, writer),
+            #[cfg(test)]
+            BlobKeyPrefix::Rollups(shard) => format!("{}/v", shard),
         };
         f.write_str(&s)
     }
@@ -164,12 +235,6 @@ mod tests {
             partial_key.complete(&shard_id),
             BlobKey(format!("{}/{}/{}", shard_id, writer_id, part_id))
         );
-
-        let partial_key = PartialBatchKey("random-legacy-key".to_string());
-        assert_eq!(
-            partial_key.complete(&shard_id),
-            BlobKey("random-legacy-key".to_string())
-        );
     }
 
     #[test]
@@ -179,13 +244,7 @@ mod tests {
         // can parse full blob key
         assert_eq!(
             BlobKey::parse_ids(&format!("{}/{}/{}", shard_id, writer_id, part_id)),
-            Ok((Some((shard_id, writer_id)), part_id.clone()))
-        );
-
-        // can parse legacy blob key
-        assert_eq!(
-            BlobKey::parse_ids(&format!("{}", part_id)),
-            Ok((None, part_id))
+            Ok((shard_id, PartialBlobKey::Batch(writer_id, part_id)))
         );
 
         // fails on invalid blob key formats

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -52,11 +52,11 @@ impl PartId {
 /// persistent state, all access to blobs are always within the context of an
 /// individual shard.
 #[derive(Clone, Debug, PartialEq, Hash, Eq)]
-pub struct PartialBlobKey(pub(crate) String);
+pub struct PartialBatchKey(pub(crate) String);
 
-impl PartialBlobKey {
-    pub fn new(writer_id: &WriterId, part_id: &PartId) -> PartialBlobKey {
-        PartialBlobKey(format!("{}/{}", writer_id, part_id))
+impl PartialBatchKey {
+    pub fn new(writer_id: &WriterId, part_id: &PartId) -> PartialBatchKey {
+        PartialBatchKey(format!("{}/{}", writer_id, part_id))
     }
 
     pub fn complete(&self, shard_id: &ShardId) -> BlobKey {
@@ -73,13 +73,13 @@ impl PartialBlobKey {
     }
 }
 
-impl std::fmt::Display for PartialBlobKey {
+impl std::fmt::Display for PartialBatchKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
     }
 }
 
-impl Deref for PartialBlobKey {
+impl Deref for PartialBatchKey {
     type Target = String;
 
     fn deref(&self) -> &Self::Target {
@@ -91,7 +91,7 @@ impl Deref for PartialBlobKey {
 /// a [ShardId], [WriterId] and [PartId].
 ///
 /// Use when directly interacting with a [mz_persist::location::Blob], otherwise
-/// use [PartialBlobKey] to refer to a blob without needing to copy the
+/// use [PartialBatchKey] to refer to a blob without needing to copy the
 /// [ShardId].
 #[derive(Clone, Debug, PartialEq)]
 pub struct BlobKey(String);
@@ -159,13 +159,13 @@ mod tests {
     #[test]
     fn partial_blob_key_completion() {
         let (shard_id, writer_id, part_id) = (ShardId::new(), WriterId::new(), PartId::new());
-        let partial_key = PartialBlobKey::new(&writer_id, &part_id);
+        let partial_key = PartialBatchKey::new(&writer_id, &part_id);
         assert_eq!(
             partial_key.complete(&shard_id),
             BlobKey(format!("{}/{}/{}", shard_id, writer_id, part_id))
         );
 
-        let partial_key = PartialBlobKey("random-legacy-key".to_string());
+        let partial_key = PartialBatchKey("random-legacy-key".to_string());
         assert_eq!(
             partial_key.complete(&shard_id),
             BlobKey("random-legacy-key".to_string())

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -38,16 +38,14 @@ message ProtoTrace {
 }
 
 message ProtoReaderState {
-    string reader_id = 1;
-    ProtoU64Antichain since = 2;
-    uint64 seqno = 3;
-    uint64 last_heartbeat_timestamp_ms = 4;
+    ProtoU64Antichain since = 1;
+    uint64 seqno = 2;
+    uint64 last_heartbeat_timestamp_ms = 3;
 }
 
 message ProtoWriterState {
-    string writer_id = 1;
-    uint64 last_heartbeat_timestamp_ms = 2;
-    uint64 lease_duration_ms = 3;
+    uint64 last_heartbeat_timestamp_ms = 1;
+    uint64 lease_duration_ms = 2;
 }
 
 message ProtoStateRollup {
@@ -60,9 +58,40 @@ message ProtoStateRollup {
     string diff_codec = 5;
     uint64 seqno = 6;
     uint64 last_gc_req = 10;
+    map<uint64, string> rollups = 12;
+
     ProtoTrace trace = 7;
-    repeated ProtoReaderState readers = 8;
-    repeated ProtoWriterState writers = 9;
+    map<string, ProtoReaderState> readers = 8;
+    map<string, ProtoWriterState> writers = 9;
+}
+
+enum ProtoStateFieldDiffType {
+    INSERT = 0;
+    UPDATE = 1;
+    DELETE = 2;
+}
+
+message ProtoStateFieldDiff {
+    bytes key = 1;
+    ProtoStateFieldDiffType diff_type = 2;
+    bytes from = 3;
+    bytes to = 4;
+}
+
+message ProtoStateDiff {
+    string applier_version = 1;
+
+    uint64 seqno_from = 2;
+    uint64 seqno_to = 3;
+    string latest_rollup_key = 4;
+
+    // TODO: columnar encoding of these just in case?
+    repeated ProtoStateFieldDiff rollups = 5;
+    repeated ProtoStateFieldDiff last_gc_req = 6;
+    repeated ProtoStateFieldDiff readers = 7;
+    repeated ProtoStateFieldDiff writers = 8;
+    repeated ProtoStateFieldDiff since = 9;
+    repeated ProtoStateFieldDiff spine = 10;
 }
 
 message ProtoLeasedBatchMetadata {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -24,7 +24,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 
 use crate::error::{Determinacy, InvalidUsage};
-use crate::internal::paths::PartialBlobKey;
+use crate::internal::paths::PartialBatchKey;
 use crate::internal::trace::{FueledMergeReq, FueledMergeRes, Trace};
 use crate::read::ReaderId;
 use crate::write::WriterId;
@@ -60,7 +60,7 @@ pub struct HollowBatch<T> {
     /// Describes the times of the updates in the batch.
     pub desc: Description<T>,
     /// Pointers usable to retrieve the updates.
-    pub keys: Vec<PartialBlobKey>,
+    pub keys: Vec<PartialBatchKey>,
     /// The number of updates in the batch.
     pub len: usize,
 }
@@ -562,7 +562,7 @@ mod tests {
             ),
             keys: keys
                 .iter()
-                .map(|x| PartialBlobKey((*x).to_owned()))
+                .map(|x| PartialBatchKey((*x).to_owned()))
                 .collect(),
             len,
         }
@@ -720,7 +720,7 @@ mod tests {
             Break(Err(InvalidEmptyTimeInterval {
                 lower: Antichain::from_elem(5),
                 upper: Antichain::from_elem(5),
-                keys: vec![PartialBlobKey("key1".to_owned())],
+                keys: vec![PartialBatchKey("key1".to_owned())],
             }))
         );
 

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -161,15 +161,17 @@ where
             return Break(Ok(Upper(shard_upper.clone())));
         }
 
-        if batch.desc.upper() != batch.desc.lower() {
-            self.trace.push_batch(batch.clone());
-        }
+        let merge_reqs = if batch.desc.upper() != batch.desc.lower() {
+            self.trace.push_batch(batch.clone())
+        } else {
+            Vec::new()
+        };
         debug_assert_eq!(self.trace.upper(), batch.desc.upper());
 
         // Also use this as an opportunity to heartbeat the writer
         self.writer(writer_id).last_heartbeat_timestamp_ms = heartbeat_timestamp_ms;
 
-        Continue(self.trace.take_merge_reqs())
+        Continue(merge_reqs)
     }
 
     pub fn apply_merge_res(&mut self, res: &FueledMergeRes<T>) -> ControlFlow<Infallible, bool> {

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -1,0 +1,597 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
+use mz_persist::location::{SeqNo, VersionedData};
+use mz_persist_types::Codec64;
+use timely::progress::{Antichain, Timestamp};
+use timely::PartialOrder;
+use tracing::debug;
+
+use crate::internal::paths::PartialRollupKey;
+use crate::internal::state::{HollowBatch, ReaderState, State, StateCollections, WriterState};
+use crate::internal::trace::Trace;
+use crate::read::ReaderId;
+use crate::write::WriterId;
+use crate::{Metrics, PersistConfig};
+
+use self::StateFieldValDiff::*;
+
+#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Clone, PartialEq))]
+pub enum StateFieldValDiff<V> {
+    Insert(V),
+    Update(V, V),
+    Delete(V),
+}
+
+#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Clone, PartialEq))]
+pub struct StateFieldDiff<K, V> {
+    pub key: K,
+    pub val: StateFieldValDiff<V>,
+}
+
+#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(Clone, PartialEq))]
+pub struct StateDiff<T> {
+    pub(crate) applier_version: semver::Version,
+    pub(crate) seqno_from: SeqNo,
+    pub(crate) seqno_to: SeqNo,
+    pub(crate) latest_rollup_key: PartialRollupKey,
+    pub(crate) rollups: Vec<StateFieldDiff<SeqNo, PartialRollupKey>>,
+    pub(crate) last_gc_req: Vec<StateFieldDiff<(), SeqNo>>,
+    pub(crate) readers: Vec<StateFieldDiff<ReaderId, ReaderState<T>>>,
+    pub(crate) writers: Vec<StateFieldDiff<WriterId, WriterState>>,
+    pub(crate) since: Vec<StateFieldDiff<(), Antichain<T>>>,
+    pub(crate) spine: Vec<StateFieldDiff<HollowBatch<T>, ()>>,
+}
+
+impl<T: Timestamp + Lattice + Codec64> StateDiff<T> {
+    pub fn new(
+        applier_version: semver::Version,
+        seqno_from: SeqNo,
+        seqno_to: SeqNo,
+        latest_rollup_key: PartialRollupKey,
+    ) -> Self {
+        StateDiff {
+            applier_version,
+            seqno_from,
+            seqno_to,
+            latest_rollup_key,
+            rollups: Vec::default(),
+            last_gc_req: Vec::default(),
+            readers: Vec::default(),
+            writers: Vec::default(),
+            since: Vec::default(),
+            spine: Vec::default(),
+        }
+    }
+
+    pub fn from_diff<K, V, D>(from: &State<K, V, T, D>, to: &State<K, V, T, D>) -> Self {
+        // Deconstruct from and to so we get a compile failure if new
+        // fields are added.
+        let State {
+            applier_version: _,
+            shard_id: from_shard_id,
+            seqno: from_seqno,
+            collections:
+                StateCollections {
+                    last_gc_req: from_last_gc_req,
+                    rollups: from_rollups,
+                    readers: from_readers,
+                    writers: from_writers,
+                    trace: from_trace,
+                },
+            _phantom: _,
+        } = from;
+        let State {
+            applier_version: to_applier_version,
+            shard_id: to_shard_id,
+            seqno: to_seqno,
+            collections:
+                StateCollections {
+                    last_gc_req: to_last_gc_req,
+                    rollups: to_rollups,
+                    readers: to_readers,
+                    writers: to_writers,
+                    trace: to_trace,
+                },
+            _phantom: _,
+        } = to;
+        assert_eq!(from_shard_id, to_shard_id);
+
+        let (_, latest_rollup_key) = to.latest_rollup();
+        let mut diffs = Self::new(
+            to_applier_version.clone(),
+            *from_seqno,
+            *to_seqno,
+            latest_rollup_key.clone(),
+        );
+        diff_field_single(from_last_gc_req, to_last_gc_req, &mut diffs.last_gc_req);
+        diff_field_sorted_iter(from_rollups.iter(), to_rollups, &mut diffs.rollups);
+        diff_field_sorted_iter(from_readers.iter(), to_readers, &mut diffs.readers);
+        diff_field_sorted_iter(from_writers.iter(), to_writers, &mut diffs.writers);
+        diff_field_single(from_trace.since(), to_trace.since(), &mut diffs.since);
+        diff_field_spine(from_trace, to_trace, &mut diffs.spine);
+        diffs
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub fn validate_roundtrip<K, V, D>(
+        metrics: &Metrics,
+        from_state: &State<K, V, T, D>,
+        diff: &Self,
+        to_state: &State<K, V, T, D>,
+    ) -> Result<(), String>
+    where
+        K: mz_persist_types::Codec + std::fmt::Debug,
+        V: mz_persist_types::Codec + std::fmt::Debug,
+        D: differential_dataflow::difference::Semigroup + Codec64,
+    {
+        use crate::internal::state::ProtoStateDiff;
+        use mz_proto::RustType;
+        use prost::Message;
+
+        let mut roundtrip_state = from_state.clone(to_state.applier_version.clone());
+        roundtrip_state.apply_diff(metrics, diff.clone())?;
+
+        if &roundtrip_state != to_state {
+            // The weird spacing in this format string is so they all line up
+            // when printed out.
+            return Err(format!("state didn't roundtrip\n  from_state {:?}\n  to_state   {:?}\n  rt_state   {:?}\n  diff       {:?}\n", from_state, to_state, roundtrip_state, diff));
+        }
+
+        let encoded_diff = diff.into_proto().encode_to_vec();
+        let roundtrip_diff = Self::from_proto(
+            ProtoStateDiff::decode(encoded_diff.as_slice()).map_err(|err| err.to_string())?,
+        )
+        .map_err(|err| err.to_string())?;
+
+        if &roundtrip_diff != diff {
+            // The weird spacing in this format string is so they all line up
+            // when printed out.
+            return Err(format!(
+                "diff didn't roundtrip\n  diff    {:?}\n  rt_diff {:?}",
+                diff, roundtrip_diff
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl<K, V, T: Timestamp + Lattice + Codec64, D> State<K, V, T, D> {
+    pub fn apply_encoded_diffs<'a, I: IntoIterator<Item = &'a VersionedData>>(
+        &mut self,
+        cfg: &PersistConfig,
+        metrics: &Metrics,
+        diffs: I,
+    ) {
+        let mut state_seqno = self.seqno;
+        let diffs = diffs.into_iter().filter_map(move |x| {
+            if x.seqno == state_seqno {
+                // No-op.
+                return None;
+            }
+            let diff = metrics
+                .codecs
+                .state_diff
+                .decode(|| StateDiff::decode(&cfg.build_version, &x.data));
+            assert_eq!(diff.seqno_from, state_seqno);
+            state_seqno = diff.seqno_to;
+            Some(diff)
+        });
+        self.apply_diffs(metrics, diffs)
+            .expect("state diff should apply cleanly");
+    }
+}
+
+impl<K, V, T: Timestamp + Lattice, D> State<K, V, T, D> {
+    // This might leave state in an invalid (umm) state when returning an error.
+    // The caller is responsible for handling this.
+    pub fn apply_diffs<I: IntoIterator<Item = StateDiff<T>>>(
+        &mut self,
+        metrics: &Metrics,
+        diffs: I,
+    ) -> Result<(), String> {
+        for diff in diffs {
+            // TODO: This could special-case batch apply for diffs where it's
+            // more efficient (in particular, spine batches that hit the slow
+            // path).
+            self.apply_diff(metrics, diff)?;
+        }
+        Ok(())
+    }
+
+    // Intentionally not even pub(crate) because all callers should use
+    // [Self::apply_diffs].
+    fn apply_diff(&mut self, metrics: &Metrics, diff: StateDiff<T>) -> Result<(), String> {
+        if self.seqno == diff.seqno_to {
+            return Ok(());
+        }
+        if self.seqno != diff.seqno_from {
+            return Err(format!(
+                "could not apply diff {} -> {} to state {}",
+                diff.seqno_from, diff.seqno_to, self.seqno
+            ));
+        }
+        self.seqno = diff.seqno_to;
+
+        apply_diffs_map("rollups", diff.rollups, &mut self.collections.rollups)?;
+        apply_diffs_single(
+            "last_gc_req",
+            diff.last_gc_req,
+            &mut self.collections.last_gc_req,
+        )?;
+        apply_diffs_map("readers", diff.readers, &mut self.collections.readers)?;
+        apply_diffs_map("writers", diff.writers, &mut self.collections.writers)?;
+
+        for x in diff.since {
+            match x.val {
+                Update(from, to) => {
+                    if self.collections.trace.since() != &from {
+                        return Err(format!(
+                            "since update didn't match: {:?} vs {:?}",
+                            self.collections.trace.since(),
+                            &from
+                        ));
+                    }
+                    self.collections.trace.downgrade_since(&to);
+                }
+                Insert(_) => return Err(format!("cannot insert since field")),
+                Delete(_) => return Err(format!("cannot delete since field")),
+            }
+        }
+        apply_diffs_spine(metrics, diff.spine, &mut self.collections.trace)?;
+
+        // There's various sanity checks that this method could run (e.g. since,
+        // upper, seqno_since, etc don't regress or that diff.latest_rollup ==
+        // state.rollups.last()), are they a good idea? On one hand, I like
+        // sanity checks, other the other, one of the goals here is to keep
+        // apply logic as straightforward and unchanging as possible.
+        Ok(())
+    }
+}
+
+fn diff_field_single<T: PartialEq + Clone>(
+    from: &T,
+    to: &T,
+    diffs: &mut Vec<StateFieldDiff<(), T>>,
+) {
+    // This could use the `diff_field_sorted_iter(once(from), once(to), diffs)`
+    // general impl, but we just do the obvious thing.
+    if from != to {
+        diffs.push(StateFieldDiff {
+            key: (),
+            val: Update(from.clone(), to.clone()),
+        })
+    }
+}
+
+fn apply_diffs_single<X: PartialEq + Debug>(
+    name: &str,
+    diffs: Vec<StateFieldDiff<(), X>>,
+    single: &mut X,
+) -> Result<(), String> {
+    for diff in diffs {
+        apply_diff_single(name, diff, single)?;
+    }
+    Ok(())
+}
+
+fn apply_diff_single<X: PartialEq + Debug>(
+    name: &str,
+    diff: StateFieldDiff<(), X>,
+    single: &mut X,
+) -> Result<(), String> {
+    match diff.val {
+        Update(from, to) => {
+            if single != &from {
+                return Err(format!(
+                    "{} update didn't match: {:?} vs {:?}",
+                    name, single, &from
+                ));
+            }
+            *single = to
+        }
+        Insert(_) => return Err(format!("cannot insert {} field", name)),
+        Delete(_) => return Err(format!("cannot delete {} field", name)),
+    }
+    Ok(())
+}
+
+fn diff_field_sorted_iter<'a, K, V, IF, IT>(from: IF, to: IT, diffs: &mut Vec<StateFieldDiff<K, V>>)
+where
+    K: Ord + Clone + 'a,
+    V: PartialEq + Clone + 'a,
+    IF: IntoIterator<Item = (&'a K, &'a V)>,
+    IT: IntoIterator<Item = (&'a K, &'a V)>,
+{
+    let (mut from, mut to) = (from.into_iter(), to.into_iter());
+    let (mut f, mut t) = (from.next(), to.next());
+    loop {
+        match (f, t) {
+            (None, None) => break,
+            (Some((fk, fv)), Some((tk, tv))) => match fk.cmp(tk) {
+                Ordering::Less => {
+                    diffs.push(StateFieldDiff {
+                        key: fk.clone(),
+                        val: Delete(fv.clone()),
+                    });
+                    let f_next = from.next();
+                    debug_assert!(f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk));
+                    f = f_next;
+                }
+                Ordering::Greater => {
+                    diffs.push(StateFieldDiff {
+                        key: tk.clone(),
+                        val: Insert(tv.clone()),
+                    });
+                    let t_next = to.next();
+                    debug_assert!(t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk));
+                    t = t_next;
+                }
+                Ordering::Equal => {
+                    // TODO: regression test for this if, I missed it in the
+                    // original impl :)
+                    if fv != tv {
+                        diffs.push(StateFieldDiff {
+                            key: fk.clone(),
+                            val: Update(fv.clone(), tv.clone()),
+                        });
+                    }
+                    let f_next = from.next();
+                    debug_assert!(f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk));
+                    f = f_next;
+                    let t_next = to.next();
+                    debug_assert!(t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk));
+                    t = t_next;
+                }
+            },
+            (None, Some((tk, tv))) => {
+                diffs.push(StateFieldDiff {
+                    key: tk.clone(),
+                    val: Insert(tv.clone()),
+                });
+                let t_next = to.next();
+                debug_assert!(t_next.as_ref().map_or(true, |(tk_next, _)| tk_next > &tk));
+                t = t_next;
+            }
+            (Some((fk, fv)), None) => {
+                diffs.push(StateFieldDiff {
+                    key: fk.clone(),
+                    val: Delete(fv.clone()),
+                });
+                let f_next = from.next();
+                debug_assert!(f_next.as_ref().map_or(true, |(fk_next, _)| fk_next > &fk));
+                f = f_next;
+            }
+        }
+    }
+}
+
+fn apply_diffs_map<K: Ord, V: PartialEq + Debug>(
+    name: &str,
+    diffs: Vec<StateFieldDiff<K, V>>,
+    map: &mut BTreeMap<K, V>,
+) -> Result<(), String> {
+    for diff in diffs {
+        apply_diff_map(name, diff, map)?;
+    }
+    Ok(())
+}
+
+// This might leave state in an invalid (umm) state when returning an error. The
+// caller ultimately ends up panic'ing on error, but if that changes, we might
+// want to revisit this.
+fn apply_diff_map<K: Ord, V: PartialEq + Debug>(
+    name: &str,
+    diff: StateFieldDiff<K, V>,
+    map: &mut BTreeMap<K, V>,
+) -> Result<(), String> {
+    match diff.val {
+        Insert(to) => {
+            let prev = map.insert(diff.key, to);
+            if prev != None {
+                return Err(format!("{} insert found existing value: {:?}", name, prev));
+            }
+        }
+        Update(from, to) => {
+            let prev = map.insert(diff.key, to);
+            if prev.as_ref() != Some(&from) {
+                return Err(format!(
+                    "{} update didn't match: {:?} vs {:?}",
+                    name,
+                    prev,
+                    Some(from),
+                ));
+            }
+        }
+        Delete(from) => {
+            let prev = map.remove(&diff.key);
+            if prev.as_ref() != Some(&from) {
+                return Err(format!(
+                    "{} delete didn't match: {:?} vs {:?}",
+                    name,
+                    prev,
+                    Some(from),
+                ));
+            }
+        }
+    };
+    Ok(())
+}
+
+fn diff_field_spine<T: Timestamp + Lattice>(
+    from: &Trace<T>,
+    to: &Trace<T>,
+    diffs: &mut Vec<StateFieldDiff<HollowBatch<T>, ()>>,
+) {
+    let from_batches = from.batches().into_iter().map(|b| (b, &()));
+    let to_batches = to.batches().into_iter().map(|b| (b, &()));
+    diff_field_sorted_iter(from_batches, to_batches, diffs);
+}
+
+// This might leave state in an invalid (umm) state when returning an error. The
+// caller ultimately ends up panic'ing on error, but if that changes, we might
+// want to revisit this.
+fn apply_diffs_spine<T: Timestamp + Lattice>(
+    metrics: &Metrics,
+    diffs: Vec<StateFieldDiff<HollowBatch<T>, ()>>,
+    trace: &mut Trace<T>,
+) -> Result<(), String> {
+    match &diffs[..] {
+        // Fast-path: no diffs.
+        [] => return Ok(()),
+
+        // Fast-path: batch insert.
+        [StateFieldDiff {
+            key,
+            val: StateFieldValDiff::Insert(()),
+        }] => {
+            // Ignore merge_reqs because whichever process generated this diff is
+            // assigned the work.
+            let _merge_reqs = trace.push_batch(key.clone());
+            metrics.state.apply_spine_fast_path.inc();
+            return Ok(());
+        }
+
+        // Fast-path: batch insert with both new and most recent batch empty.
+        // Spine will happily merge these empty batches together without a call
+        // out to compaction.
+        [StateFieldDiff {
+            key: del,
+            val: StateFieldValDiff::Delete(()),
+        }, StateFieldDiff {
+            key: ins,
+            val: StateFieldValDiff::Insert(()),
+        }] => {
+            if del.keys.len() == 0
+                && ins.keys.len() == 0
+                && del.desc.lower() == ins.desc.lower()
+                && PartialOrder::less_than(del.desc.upper(), ins.desc.upper())
+            {
+                // Ignore merge_reqs because whichever process generated this diff is
+                // assigned the work.
+                let _merge_reqs = trace.push_batch(HollowBatch {
+                    desc: Description::new(
+                        del.desc.upper().clone(),
+                        ins.desc.upper().clone(),
+                        // `keys.len() == 0` for both `del` and `ins` means we
+                        // don't have to think about what the compaction
+                        // frontier is for these batches (nothing in them, so nothing could have been compacted.
+                        Antichain::from_elem(T::minimum()),
+                    ),
+                    keys: vec![],
+                    len: 0,
+                });
+                metrics.state.apply_spine_fast_path.inc();
+                return Ok(());
+            }
+        }
+        // Fall-through
+        _ => {}
+    }
+
+    // Fast-path: compaction
+    //
+    // TODO: This seems to tickle some existing bugs that we haven't been
+    // hitting because, before incremental state, we were reconstructing Spine
+    // from scratch whenever we deserialized a new version of state. Losing it
+    // is unfortunate, but no worse than where we were before and we're getting
+    // down to the wire with getting inc state (and its backward
+    // incompatibility) into the desired release. Revisit as time permits to
+    // shake out the bugs (they repro readily in CI) and re-enable.
+    #[cfg(TODO)]
+    if let Some((_inputs, output)) = sniff_compaction(&diffs) {
+        let res = FueledMergeRes { output };
+        // We can't predict how spine will arrange the batches when it's
+        // hydrated. This means that something that is maintaining a Spine
+        // starting at some seqno may not exactly match something else
+        // maintaining the same spine starting at a different seqno. (Plus,
+        // maybe these aren't even on the same version of the code and we've
+        // changed the spine logic.) Because apply_merge_res is strict,
+        // we're not _guaranteed_ that we can apply a compaction response
+        // that was generated elsewhere. Most of the time we can, though, so
+        // count the good ones and fall back to the slow path below when we
+        // can't.
+        if trace.apply_merge_res(&res) {
+            // Maybe return the replaced batches from apply_merge_res and verify
+            // that they match _inputs?
+            metrics.state.apply_spine_fast_path.inc();
+            return Ok(());
+        }
+    }
+
+    // Something complicated is going on, so reconstruct the Trace from scratch.
+    metrics.state.apply_spine_slow_path.inc();
+    debug!(
+        "apply_diffs_spine didn't hit a fast-path diffs={:?} trace={:?}",
+        diffs, trace
+    );
+
+    let mut batches = BTreeMap::new();
+    trace.map_batches(|b| assert!(batches.insert(b.clone(), ()).is_none()));
+    apply_diffs_map("spine", diffs, &mut batches)?;
+
+    let mut new_trace = Trace::default();
+    new_trace.downgrade_since(trace.since());
+    for (batch, ()) in batches {
+        // Ignore merge_reqs because whichever process generated this diff is
+        // assigned the work.
+        let _merge_reqs = new_trace.push_batch(batch);
+    }
+    *trace = new_trace;
+    Ok(())
+}
+
+// TODO: Instead of trying to sniff out a compaction from diffs, should we just
+// be explicit?
+#[allow(dead_code)]
+fn sniff_compaction<'a, T: Timestamp + Lattice>(
+    diffs: &'a [StateFieldDiff<HollowBatch<T>, ()>],
+) -> Option<(Vec<&'a HollowBatch<T>>, HollowBatch<T>)> {
+    // Compaction always produces exactly one output batch (with possibly many
+    // parts, but we get one Insert for the whole batch.
+    let mut inserts = diffs.iter().flat_map(|x| match x.val {
+        StateFieldValDiff::Insert(()) => Some(&x.key),
+        _ => None,
+    });
+    let compaction_output = match inserts.next() {
+        Some(x) => x,
+        None => return None,
+    };
+    if let Some(_) = inserts.next() {
+        return None;
+    }
+
+    // Grab all deletes and sanity check that there are no updates.
+    let mut compaction_inputs = Vec::with_capacity(diffs.len() - 1);
+    for diff in diffs.iter() {
+        match diff.val {
+            StateFieldValDiff::Delete(()) => {
+                compaction_inputs.push(&diff.key);
+            }
+            StateFieldValDiff::Insert(()) => {}
+            StateFieldValDiff::Update((), ()) => {
+                // Fall through to let the general case create the error
+                // message.
+                return None;
+            }
+        }
+    }
+
+    Some((compaction_inputs, compaction_output.clone()))
+}

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1,0 +1,578 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! A durable, truncatable log of versions of [State].
+
+use std::fmt::Debug;
+use std::ops::ControlFlow::{Break, Continue};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use bytes::Bytes;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist::location::{Atomicity, Blob, Consensus, Indeterminate, SeqNo, VersionedData};
+use mz_persist::retry::Retry;
+use mz_persist_types::{Codec, Codec64};
+use timely::progress::Timestamp;
+use tracing::{debug, debug_span, trace, Instrument};
+
+use crate::error::CodecMismatch;
+use crate::internal::machine::{retry_determinate, retry_external};
+use crate::internal::metrics::ShardMetrics;
+use crate::internal::paths::{PartialRollupKey, RollupId};
+use crate::internal::state::State;
+use crate::internal::state_diff::StateDiff;
+use crate::{Metrics, PersistConfig, ShardId};
+
+/// A durable, truncatable log of versions of [State].
+///
+/// As persist metadata changes over time, we make its versions (each identified
+/// by a [SeqNo]) durable in two ways:
+/// - `rollups`: Periodic copies of the entirety of [State], written to [Blob].
+/// - `diffs`: Incremental [StateDiff]s, written to [Consensus].
+///
+/// The following invariants are maintained at all times:
+/// - A shard is initialized iff there is at least one version of it in
+///   Consensus.
+/// - The first version of state is written to `SeqNo(1)`. Each successive state
+///   version is assigned its predecessor's SeqNo +1.
+/// - `current`: The latest version of state. By definition, the largest SeqNo
+///   present in Consensus.
+/// - As state changes over time, we keep a range of consecutive versions
+///   available. These are periodically `truncated` to prune old versions that
+///   are no longer necessary.
+/// - `earliest`: The first version of state that it is possible to reconstruct.
+///   - Invariant: `earliest <= current.seqno_since()` (we don't garbage collect
+///     versions still being used by some reader).
+///   - Invariant: `earliest` is always the smallest Seqno present in Consensus.
+///     - This doesn't have to be true, but we select to enforce it.
+///     - Because the data stored at that smallest Seqno is an incremental diff,
+///       to make this invariant work, there needs to be a rollup at either
+///       `earliest-1` or `earliest`. We choose `earliest` because it seems to
+///       make the code easier to reason about in practice.
+///     - A consequence of the above is when we garbage collect old versions of
+///       state, we're only free to truncate ones that are `<` the latest rollup
+///       that is `<= current.seqno_since`.
+/// - `live diffs`: The set of SeqNos present in Consensus at any given time.
+/// - `live states`: The range of state versions that it is possible to
+///   reconstruct: `[earliest,current]`.
+///   - Because of earliest and current invariants above, the range of `live
+///     diffs` and `live states` are the same.
+/// - The set of known rollups are tracked in the shard state itself.
+///   - For efficiency of common operations, the most recent rollup's Blob key
+///     is always denormalized in each StateDiff written to Consensus. (As
+///     described above, there is always a rollup at earliest, so we're
+///     guaranteed that there is always at least one live rollup.)
+///   - Invariant: The rollups in `current` exist in Blob.
+///     - A consequence is that, if a rollup in a state you believe is `current`
+///       doesn't exist, it's a guarantee that `current` has changed (or it's a
+///       bug).
+///   - Any rollup at a version `< earliest-1` is useless (we've lost the
+///     incremental diffs between it and the live states). GC is tasked with
+///     deleting these rollups from Blob before truncating diffs from Consensus.
+///     Thus, any rollup at a seqno < earliest can be considered "leaked" and
+///     deleted by the leaked blob detector.
+///   - Note that this means, while `current`'s rollups exist, it will be common
+///     for other live states to reference rollups that no longer exist.
+#[derive(Debug)]
+pub struct StateVersions {
+    cfg: PersistConfig,
+    pub(crate) consensus: Arc<dyn Consensus + Send + Sync>,
+    pub(crate) blob: Arc<dyn Blob + Send + Sync>,
+    metrics: Arc<Metrics>,
+}
+
+impl StateVersions {
+    pub fn new(
+        cfg: PersistConfig,
+        consensus: Arc<dyn Consensus + Send + Sync>,
+        blob: Arc<dyn Blob + Send + Sync>,
+        metrics: Arc<Metrics>,
+    ) -> Self {
+        StateVersions {
+            cfg,
+            consensus,
+            blob,
+            metrics,
+        }
+    }
+
+    /// Fetches the `current` state of the requested shard, or creates it if
+    /// uninitialized.
+    pub async fn maybe_init_shard<K, V, T, D>(
+        &self,
+        shard_metrics: &ShardMetrics,
+    ) -> Result<State<K, V, T, D>, CodecMismatch>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let shard_id = shard_metrics.shard_id;
+
+        // The common case is that the shard is initialized, so try that first
+        let live_diffs = self.fetch_live_diffs(&shard_id).await;
+        if !live_diffs.is_empty() {
+            return self.fetch_current_state(&shard_id, live_diffs).await;
+        }
+
+        // Shard is not initialized, try initializing it.
+        let (initial_state, initial_diff) = self.write_initial_rollup(shard_metrics).await;
+        let cas_res = retry_external(&self.metrics.retries.external.maybe_init_cas, || async {
+            self.try_compare_and_set_current(
+                "maybe_init_shard",
+                shard_metrics,
+                None,
+                &initial_state,
+                &initial_diff,
+            )
+            .await
+            .map_err(|err| err.into())
+        })
+        .await;
+        match cas_res {
+            Ok(()) => {
+                return Ok(initial_state);
+            }
+            Err(live_diffs) => {
+                // We lost a CaS race and someone else initialized the shard,
+                // use the value included in the CaS expectation error.
+
+                // Clean up the rollup blob that we were trying to reference.
+                let (_, rollup_key) = initial_state.latest_rollup();
+                self.delete_rollup(&shard_id, rollup_key).await;
+
+                return self.fetch_current_state(&shard_id, live_diffs).await;
+            }
+        }
+    }
+
+    /// Updates the state of a shard to a new `current` iff `expected` matches
+    /// `current`.
+    ///
+    /// May be called on uninitialized shards.
+    pub async fn try_compare_and_set_current<K, V, T, D>(
+        &self,
+        cmd_name: &str,
+        shard_metrics: &ShardMetrics,
+        expected: Option<SeqNo>,
+        new_state: &State<K, V, T, D>,
+        diff: &StateDiff<T>,
+    ) -> Result<Result<(), Vec<VersionedData>>, Indeterminate>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        assert_eq!(shard_metrics.shard_id, new_state.shard_id);
+        let path = new_state.shard_id.to_string();
+
+        trace!(
+            "apply_unbatched_cmd {} attempting {}\n  new_state={:?}",
+            cmd_name,
+            new_state.seqno(),
+            new_state
+        );
+        let new = self
+            .metrics
+            .codecs
+            .state_diff
+            .encode(|| VersionedData::from((new_state.seqno(), diff)));
+        assert_eq!(new.seqno, diff.seqno_to);
+
+        let payload_len = new.data.len();
+        let cas_res = retry_determinate(
+            &self.metrics.retries.determinate.apply_unbatched_cmd_cas,
+            || async {
+                self.consensus
+                    .compare_and_set(&path, expected, new.clone())
+                    .await
+            },
+        )
+        .instrument(debug_span!("apply_unbatched_cmd::cas", payload_len))
+        .await
+        .map_err(|err| {
+            debug!("apply_unbatched_cmd {} errored: {}", cmd_name, err);
+            err
+        })?;
+
+        match cas_res {
+            Ok(()) => {
+                trace!(
+                    "apply_unbatched_cmd {} succeeded {}\n  new_state={:?}",
+                    cmd_name,
+                    new_state.seqno(),
+                    new_state
+                );
+
+                shard_metrics.set_since(new_state.since());
+                shard_metrics.set_upper(&new_state.upper());
+                shard_metrics.set_batch_count(new_state.batch_count());
+                shard_metrics.set_update_count(new_state.num_updates());
+                shard_metrics.set_seqnos_held(new_state.seqnos_held());
+                shard_metrics.inc_encoded_diff_size(payload_len);
+                Ok(Ok(()))
+            }
+            Err(live_diffs) => {
+                debug!(
+                    "apply_unbatched_cmd {} {} lost the CaS race, retrying: {} vs {:?}",
+                    new_state.shard_id(),
+                    cmd_name,
+                    new_state.seqno(),
+                    live_diffs.last().map(|x| x.seqno)
+                );
+                Ok(Err(live_diffs))
+            }
+        }
+    }
+
+    /// Fetches the `current` state of the requested shard.
+    ///
+    /// Uses the provided hint (all_live_diffs), which is a possibly outdated
+    /// copy of all live diffs, to avoid fetches where possible.
+    ///
+    /// Panics if called on an uninitialized shard.
+    pub async fn fetch_current_state<K, V, T, D>(
+        &self,
+        shard_id: &ShardId,
+        mut all_live_diffs: Vec<VersionedData>,
+    ) -> Result<State<K, V, T, D>, CodecMismatch>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let retry = self
+            .metrics
+            .retries
+            .fetch_latest_state
+            .stream(Retry::persist_defaults(SystemTime::now()).into_retry_stream());
+        loop {
+            let latest_diff = all_live_diffs
+                .last()
+                .expect("initialized shard should have at least one diff");
+            let latest_diff = self
+                .metrics
+                .codecs
+                .state_diff
+                .decode(|| StateDiff::<T>::decode(&self.cfg.build_version, &latest_diff.data));
+            let mut state = match self
+                .fetch_rollup_at_key(shard_id, &latest_diff.latest_rollup_key)
+                .await
+            {
+                Some(x) => x?,
+                None => {
+                    // The rollup that this diff referenced is gone, so the diff
+                    // must be out of date. Try again.
+                    all_live_diffs = self.fetch_live_diffs(shard_id).await;
+                    // Intentionally don't sleep on retry.
+                    retry.retries.inc();
+                    continue;
+                }
+            };
+
+            let rollup_seqno = state.seqno;
+            let diffs = all_live_diffs.iter().filter(|x| x.seqno > rollup_seqno);
+            state.apply_encoded_diffs(&self.cfg, &self.metrics, diffs);
+            return Ok(state);
+        }
+    }
+
+    /// Updates the provided state to current.
+    ///
+    /// This method differs from [Self::fetch_current_state] in that it
+    /// optimistically fetches only the diffs since state.seqno and only falls
+    /// back to fetching all of them when necessary.
+    pub async fn fetch_and_update_to_current<K, V, T, D>(
+        &self,
+        state: &mut State<K, V, T, D>,
+    ) -> Result<(), CodecMismatch>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let path = state.shard_id.to_string();
+        let diffs_to_current =
+            retry_external(&self.metrics.retries.external.fetch_state_scan, || async {
+                self.consensus.scan(&path, state.seqno.next()).await
+            })
+            .instrument(debug_span!("fetch_state::scan"))
+            .await;
+        let seqno_before = state.seqno;
+        let diffs_apply = diffs_to_current
+            .first()
+            .map_or(true, |x| x.seqno == seqno_before.next());
+        if diffs_apply {
+            state.apply_encoded_diffs(&self.cfg, &self.metrics, &diffs_to_current);
+            Ok(())
+        } else {
+            let all_live_diffs = self.fetch_live_diffs(&state.shard_id).await;
+            *state = self
+                .fetch_current_state(&state.shard_id, all_live_diffs)
+                .await?;
+            Ok(())
+        }
+    }
+
+    /// Returns an iterator over all live states for the requested shard.
+    ///
+    /// Panics if called on an uninitialized shard.
+    pub async fn fetch_live_states<K, V, T, D>(
+        &self,
+        shard_id: &ShardId,
+    ) -> Result<StateVersionsIter<K, V, T, D>, CodecMismatch>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let retry = self
+            .metrics
+            .retries
+            .fetch_live_states
+            .stream(Retry::persist_defaults(SystemTime::now()).into_retry_stream());
+        loop {
+            let live_diffs = self.fetch_live_diffs(&shard_id).await;
+            let earliest_live_diff = match live_diffs.first() {
+                Some(x) => x,
+                None => panic!("fetch_live_states should only be called on an initialized shard"),
+            };
+            let state = match self
+                .fetch_rollup_at_seqno(shard_id, live_diffs.clone(), earliest_live_diff.seqno)
+                .await
+            {
+                Some(x) => x?,
+                None => {
+                    // We maintain an invariant that a rollup always exists for
+                    // the earliest live diff. Since we didn't find out, that
+                    // can only mean that the live_diffs we just fetched are
+                    // obsolete (there's a race condition with gc). This should
+                    // be rare in practice, so inc a counter and try again.
+                    // Intentionally don't sleep on retry.
+                    retry.retries.inc();
+                    continue;
+                }
+            };
+            assert_eq!(earliest_live_diff.seqno, state.seqno);
+            return Ok(StateVersionsIter::new(
+                self.cfg.clone(),
+                Arc::clone(&self.metrics),
+                state,
+                live_diffs,
+            ));
+        }
+    }
+
+    /// Fetches the live_diffs for a shard.
+    ///
+    /// Returns an empty Vec iff called on an uninitialized shard.
+    pub async fn fetch_live_diffs(&self, shard_id: &ShardId) -> Vec<VersionedData> {
+        let path = shard_id.to_string();
+        retry_external(&self.metrics.retries.external.fetch_state_scan, || async {
+            self.consensus.scan(&path, SeqNo::minimum()).await
+        })
+        .instrument(debug_span!("fetch_state::scan"))
+        .await
+    }
+
+    /// Truncates any diffs in consensus less than the given seqno.
+    pub async fn truncate_diffs(&self, shard_id: &ShardId, seqno: SeqNo) {
+        let path = shard_id.to_string();
+        let _deleted_count = retry_external(&self.metrics.retries.external.gc_truncate, || async {
+            self.consensus.truncate(&path, seqno).await
+        })
+        .instrument(debug_span!("gc::truncate"))
+        .await;
+    }
+
+    // Writes a self-referential rollup to blob storage and returns the diff
+    // that should be compare_and_set into consensus to finish initializing the
+    // shard.
+    async fn write_initial_rollup<K, V, T, D>(
+        &self,
+        shard_metrics: &ShardMetrics,
+    ) -> (State<K, V, T, D>, StateDiff<T>)
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let empty_state = State::new(self.cfg.build_version.clone(), shard_metrics.shard_id);
+        let rollup_seqno = empty_state.seqno.next();
+        let rollup_key = PartialRollupKey::new(rollup_seqno, &RollupId::new());
+        let (applied, initial_state) = match empty_state
+            .clone_apply(&self.cfg.build_version, &mut |_, state| {
+                state.add_and_remove_rollups((rollup_seqno, &rollup_key), &[])
+            }) {
+            Continue(x) => x,
+            Break(x) => match x {},
+        };
+        assert!(
+            applied,
+            "add_and_remove_rollups should apply to the empty state"
+        );
+
+        let () = self
+            .write_rollup_blob(shard_metrics, &initial_state, &rollup_key)
+            .await;
+        assert_eq!(initial_state.seqno, rollup_seqno);
+
+        let diff = StateDiff::from_diff(&empty_state, &initial_state);
+        (initial_state, diff)
+    }
+
+    /// Writes the given state as a rollup to the specified key.
+    pub async fn write_rollup_blob<K, V, T, D>(
+        &self,
+        shard_metrics: &ShardMetrics,
+        state: &State<K, V, T, D>,
+        key: &PartialRollupKey,
+    ) where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let buf = self.metrics.codecs.state.encode(|| {
+            let mut buf = Vec::new();
+            state.encode(&mut buf);
+            Bytes::from(buf)
+        });
+        let payload_len = buf.len();
+        retry_external(&self.metrics.retries.external.rollup_set, || async {
+            self.blob
+                .set(
+                    &key.complete(&state.shard_id),
+                    Bytes::clone(&buf),
+                    Atomicity::RequireAtomic,
+                )
+                .await
+        })
+        .instrument(debug_span!("rollup::set", payload_len))
+        .await;
+        shard_metrics.set_encoded_rollup_size(payload_len);
+    }
+
+    /// Fetches a rollup for the given SeqNo, if it exists.
+    ///
+    /// Uses the provided hint, which is a possibly outdated copy of all live
+    /// diffs, to avoid fetches where possible.
+    ///
+    /// Panics if called on an uninitialized shard.
+    async fn fetch_rollup_at_seqno<K, V, T, D>(
+        &self,
+        shard_id: &ShardId,
+        all_live_diffs: Vec<VersionedData>,
+        seqno: SeqNo,
+    ) -> Option<Result<State<K, V, T, D>, CodecMismatch>>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        let state = match self
+            .fetch_current_state::<K, V, T, D>(shard_id, all_live_diffs)
+            .await
+        {
+            Ok(x) => x,
+            Err(err) => return Some(Err(err)),
+        };
+        let rollup_key = state.collections.rollups.get(&seqno)?;
+        self.fetch_rollup_at_key(shard_id, rollup_key).await
+    }
+
+    /// Fetches the rollup at the given key, if it exists.
+    async fn fetch_rollup_at_key<K, V, T, D>(
+        &self,
+        shard_id: &ShardId,
+        rollup_key: &PartialRollupKey,
+    ) -> Option<Result<State<K, V, T, D>, CodecMismatch>>
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + Codec64,
+        D: Semigroup + Codec64,
+    {
+        retry_external(&self.metrics.retries.external.rollup_get, || async {
+            self.blob.get(&rollup_key.complete(&shard_id)).await
+        })
+        .instrument(debug_span!("rollup::get"))
+        .await
+        .map(|buf| {
+            self.metrics
+                .codecs
+                .state
+                .decode(|| State::decode(&self.cfg.build_version, &buf))
+        })
+    }
+
+    /// Deletes the rollup at the given key, if it exists.
+    pub async fn delete_rollup(&self, shard_id: &ShardId, key: &PartialRollupKey) {
+        let _ = retry_external(&self.metrics.retries.external.rollup_delete, || async {
+            self.blob.delete(&key.complete(shard_id)).await
+        })
+        .await
+        .instrument(debug_span!("rollup::delete"));
+    }
+}
+
+/// An iterator over consecutive versions of [State].
+pub struct StateVersionsIter<K, V, T, D> {
+    cfg: PersistConfig,
+    metrics: Arc<Metrics>,
+    state: State<K, V, T, D>,
+    diffs: Vec<VersionedData>,
+}
+
+impl<K, V, T: Timestamp + Lattice + Codec64, D> StateVersionsIter<K, V, T, D> {
+    fn new(
+        cfg: PersistConfig,
+        metrics: Arc<Metrics>,
+        state: State<K, V, T, D>,
+        // diffs is stored reversed so we can efficiently pop off the Vec.
+        mut diffs: Vec<VersionedData>,
+    ) -> Self {
+        assert!(diffs.first().map_or(true, |x| x.seqno == state.seqno));
+        diffs.reverse();
+        StateVersionsIter {
+            cfg,
+            metrics,
+            state,
+            diffs,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.diffs.len()
+    }
+
+    pub fn next(&mut self) -> Option<&State<K, V, T, D>> {
+        let diff = match self.diffs.pop() {
+            Some(x) => x,
+            None => return None,
+        };
+        self.state
+            .apply_encoded_diffs(&self.cfg, &self.metrics, std::iter::once(&diff));
+        assert_eq!(self.state.seqno, diff.seqno);
+        Some(&self.state)
+    }
+
+    pub fn into_inner(self) -> State<K, V, T, D> {
+        self.state
+    }
+}

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1050,7 +1050,7 @@ impl<T: Timestamp + Lattice> MergeVariant<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::internal::paths::PartialBlobKey;
+    use crate::internal::paths::PartialBatchKey;
 
     #[test]
     fn trace_datadriven() {
@@ -1075,7 +1075,7 @@ mod tests {
                 len,
                 keys: keys
                     .iter()
-                    .map(|x| PartialBlobKey((*x).to_owned()))
+                    .map(|x| PartialBatchKey((*x).to_owned()))
                     .collect(),
             }
         }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -34,7 +34,7 @@ use crate::internal::state::Since;
 use crate::{GarbageCollector, PersistConfig};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReaderId(pub(crate) [u8; 16]);
 
 impl std::fmt::Display for ReaderId {
@@ -367,7 +367,7 @@ where
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) reader_id: ReaderId,
     pub(crate) machine: Machine<K, V, T, D>,
-    pub(crate) gc: GarbageCollector,
+    pub(crate) gc: GarbageCollector<K, V, T, D>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
 
     pub(crate) since: Antichain<T>,

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -37,7 +37,7 @@ use crate::internal::state::{HollowBatch, Upper};
 use crate::{parse_id, CpuHeavyRuntime, GarbageCollector, PersistConfig};
 
 /// An opaque identifier for a writer of a persist durable TVC (aka shard).
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WriterId(pub(crate) [u8; 16]);
 
 impl std::fmt::Display for WriterId {
@@ -93,7 +93,7 @@ where
     pub(crate) cfg: PersistConfig,
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) machine: Machine<K, V, T, D>,
-    pub(crate) gc: GarbageCollector,
+    pub(crate) gc: GarbageCollector<K, V, T, D>,
     pub(crate) compact: Option<Compactor>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
     pub(crate) cpu_heavy_runtime: Arc<CpuHeavyRuntime>,

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -39,13 +39,13 @@ ok
 # that add or subtract linearized operations from Machine
 # setup could throw off the indexing here.
 #
-# at the time of writing here, seqno 2 refers to the compare-
+# at the time of writing here, seqno 3 refers to the compare-
 # and-append batch written above
 
 # verify we have a new state that references the latest batch
-consensus-scan from_seqno=2
+consensus-scan from_seqno=3
 ----
-seqno=2 batches=b0
+seqno=v3 batches=b0
 
 # insert a second batch into state
 compare-and-append input=b1
@@ -53,30 +53,33 @@ compare-and-append input=b1
 ok
 
 # verify we have a new state that references both batches
-consensus-scan from_seqno=2
+consensus-scan from_seqno=3
 ----
-seqno=2 batches=b0
-seqno=3 batches=b0,b1
+seqno=v3 batches=b0
+seqno=v4 batches=b0,b1
 
 # run gc up to our latest seqno
-gc from_seqno=0 to_seqno=3
+gc from_seqno=0 to_seqno=4
 ----
 ok
 
-# verify that gc removed all seqno less than the latest
+# verify that gc removed all seqno less than the latest. (NB: gc introduces a
+# seqno of its own to add a rollup)
 consensus-scan from_seqno=0
 ----
-seqno=3 batches=b0,b1
+seqno=v4 batches=b0,b1
+seqno=v5 batches=b0,b1
 
 # insert another batch
 compare-and-append input=b2
 ----
 ok
 
-consensus-scan from_seqno=2
+consensus-scan from_seqno=0
 ----
-seqno=3 batches=b0,b1
-seqno=4 batches=b0,b1,b2
+seqno=v4 batches=b0,b1
+seqno=v5 batches=b0,b1
+seqno=v6 batches=b0,b1,b2
 
 # compact and merge b0 and b1 into b0_1
 compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
@@ -90,21 +93,23 @@ true
 # verify that we b0_1 has replaced b0 and b1 in latest state
 consensus-scan from_seqno=0
 ----
-seqno=3 batches=b0,b1
-seqno=4 batches=b0,b1,b2
-seqno=5 batches=b0_1,b2
+seqno=v4 batches=b0,b1
+seqno=v5 batches=b0,b1
+seqno=v6 batches=b0,b1,b2
+seqno=v7 batches=b0_1,b2
 
-# run gc to clear only the oldest seqno
-gc from_seqno=0 to_seqno=4
+# run gc to clear only the b0,b1 seqnos
+gc from_seqno=0 to_seqno=6
 ----
 ok
 
 consensus-scan from_seqno=0
 ----
-seqno=4 batches=b0,b1,b2
-seqno=5 batches=b0_1,b2
+seqno=v6 batches=b0,b1,b2
+seqno=v7 batches=b0_1,b2
+seqno=v8 batches=b0_1,b2
 
-# verify that b0 and b1 still exist, because they're referenced in seqno 4
+# verify that b0 and b1 still exist, because they're referenced in seqno 6
 fetch-batch input=b0
 ----
 <part 0>
@@ -117,14 +122,15 @@ k2 1 -1
 k3 1 1
 
 # run gc to clear up to the latest state.
-gc from_seqno=4 to_seqno=5
+gc from_seqno=6 to_seqno=8
 ----
 ok
 
-# we should only have the latest state now
+# we should only have b0_1,b2 now
 consensus-scan from_seqno=0
 ----
-seqno=5 batches=b0_1,b2
+seqno=v8 batches=b0_1,b2
+seqno=v9 batches=b0_1,b2
 
 # and b0 and b1 should no longer exist in the blob store, as no states still reference them
 fetch-batch input=b0

--- a/src/persist-client/tests/trace/compaction_regression_size_reduction
+++ b/src/persist-client/tests/trace/compaction_regression_size_reduction
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for a bug in FuelingMerge. We previously tracked how much
+# total fuel a FuelingBatch had received, calling it progress. Whenever it
+# received new fuel, we compared progress against self.b1.len() + self.b2.len()
+# to see how much work remained. However, because we (quite surprisingly) swap
+# out the innards of a batch when applying a compaction response, if the
+# compaction resulted in consolication of updates, a batch len could become
+# smaller. This could lead to a situation where progress was greater than the
+# sum of the two batch lengths. In debug, this would present as a subtraction
+# underflow panic. In release, it would actually underflow and result in a batch
+# that would not complete given any amount of fuel, which then presented as a
+# "Attempted to insert batch into incomplete merge" panic.
+
+# Insert two batches and then a big batch so that 0-1 and 1-2 are fueled to
+# merge. This also creates a FuelingMerge(0-2,2-3).
+insert
+0 1 0 500 k0
+1 2 0 500 k1
+2 3 0 1000 k2
+----
+ok
+
+batches
+----
+[0][2][0] 2/1000 k0 k1
+[2][3][0] 1000 k2
+
+take-merge-reqs
+----
+[0][2][0] k0 k1
+
+# Give the FuelingMerge(0-2,2-3) some fuel, but not enough to finish.
+insert
+3 4 0 100 k3
+----
+ok
+
+# Now swap in the result of the 0-1 1-2 compaction with far fewer updates than
+# the pre compacted version (1000 vs 1). This creates a scenario where
+# FuelingMerge(0-2,2-3) suddenly has more fuel than it needs.
+apply-merge-res
+0 2 0 1 k0-1
+----
+applied
+
+# Insert a batch that would force FuelingMerge(0-2,2-3) to finish and move up a
+# few levels. In the regression, this would panic.
+insert
+4 5 0 10000 k4
+----
+ok

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -48,6 +48,20 @@ impl timely::PartialOrder for SeqNo {
     }
 }
 
+impl std::str::FromStr for SeqNo {
+    type Err = String;
+
+    fn from_str(encoded: &str) -> Result<Self, Self::Err> {
+        let encoded = match encoded.strip_prefix('v') {
+            Some(x) => x,
+            None => return Err(format!("invalid SeqNo {}: incorrect prefix", encoded)),
+        };
+        let seqno =
+            u64::from_str(&encoded).map_err(|err| format!("invalid SeqNo {}: {}", encoded, err))?;
+        Ok(SeqNo(seqno))
+    }
+}
+
 impl SeqNo {
     /// Returns the next SeqNo in the sequence.
     pub fn next(self) -> SeqNo {

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -314,33 +314,34 @@ impl<T: Codec> TryFrom<&VersionedData> for (SeqNo, T) {
 pub trait Consensus: std::fmt::Debug {
     /// Returns a recent version of `data`, and the corresponding sequence number, if
     /// one exists at this location.
+    ///
+    /// TODO: This is no longer used. Remove it?
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError>;
 
-    /// Update the [VersionedData] stored at this location to `new`, iff the current
-    /// sequence number is exactly `expected` and `new`'s sequence number > the current
-    /// sequence number.
+    /// Update the [VersionedData] stored at this location to `new`, iff the
+    /// current sequence number is exactly `expected` and `new`'s sequence
+    /// number > the current sequence number.
     ///
-    /// Returns a recent version and data from this location iff the current sequence
-    /// number does not equal `expected` or if `new`'s sequence number is less than or
-    /// equal to the current sequence number. It is invalid to call this function with
-    /// a `new` and `expected` such that `new`'s sequence number is <= `expected`.
-    /// It is invalid to call this function with a sequence number outside of the range
-    /// [0, i64::MAX].
+    /// If the current seqno does not equal `expected`, returns all versions >
+    /// `expected` and <= current. It is invalid to call this function with a
+    /// `new` and `expected` such that `new`'s sequence number is <= `expected`.
+    /// It is invalid to call this function with a sequence number outside of
+    /// the range `[0, i64::MAX]`.
     ///
-    /// This data is initialized to None, and the first call to compare_and_set needs to
-    /// happen with None as the expected value to set the state.
+    /// This data is initialized to None, and the first call to compare_and_set
+    /// needs to happen with None as the expected value to set the state.
     async fn compare_and_set(
         &self,
         key: &str,
         expected: Option<SeqNo>,
         new: VersionedData,
-    ) -> Result<Result<(), Option<VersionedData>>, ExternalError>;
+    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError>;
 
     /// Return all versions of data stored for this `key` at sequence numbers
     /// >= `from`, in ascending order of sequence number.
     ///
-    /// Returns an error if `from` is greater than the current sequence number
-    /// or if there is no data at this key.
+    /// Returns an empty vec if `from` is greater than the current sequence
+    /// number or if there is no data at this key.
     async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError>;
 
     /// Deletes all historical versions of the data stored at `key` that are <
@@ -590,8 +591,8 @@ pub mod tests {
         // Starting value of consensus data is None.
         assert_eq!(consensus.head(&key).await, Ok(None));
 
-        // Cannot scan a key that has no data.
-        assert!(consensus.scan(&key, SeqNo(0)).await.is_err());
+        // Can scan a key that has no data.
+        assert_eq!(consensus.scan(&key, SeqNo(0)).await, Ok(vec![]));
 
         // Cannot truncate data from a key that doesn't have any data
         assert!(consensus.truncate(&key, SeqNo(0)).await.is_err(),);
@@ -606,7 +607,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(SeqNo(0)), state.clone())
                 .await,
-            Ok(Err(None))
+            Ok(Err(vec![]))
         );
 
         // Correctly updating the state with the correct expected value should succeed.
@@ -630,8 +631,9 @@ pub mod tests {
             Ok(vec![state.clone()])
         );
 
-        // Cannot scan a key that has data with a lower bound sequence number > head.
-        assert!(consensus.scan(&key, SeqNo(6)).await.is_err());
+        // Can scan a key that has data with a lower bound sequence number >
+        // head.
+        assert_eq!(consensus.scan(&key, SeqNo(6)).await, Ok(vec![]));
 
         // Can truncate data with an upper bound <= head, even if there is no data in the
         // range [0, upper).
@@ -651,7 +653,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(SeqNo(7)), new_state.clone())
                 .await,
-            Ok(Err(Some(state.clone())))
+            Ok(Err(vec![]))
         );
 
         // Trying to update without the correct expected seqno fails, (even if expected < current)
@@ -659,7 +661,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(SeqNo(3)), new_state.clone())
                 .await,
-            Ok(Err(Some(state.clone())))
+            Ok(Err(vec![state.clone()]))
         );
 
         let invalid_constant_seqno = VersionedData {
@@ -701,6 +703,36 @@ pub mod tests {
         // We can observe the a recent value on successful update.
         assert_eq!(consensus.head(&key).await, Ok(Some(new_state.clone())));
 
+        // We get both versions back if our expected is < both of them
+        assert_eq!(
+            consensus
+                .compare_and_set(
+                    &key,
+                    Some(SeqNo(0)),
+                    VersionedData {
+                        seqno: SeqNo(3),
+                        data: Bytes::from(""),
+                    }
+                )
+                .await,
+            Ok(Err(vec![state.clone(), new_state.clone()]))
+        );
+
+        // We only get the greater back if our expected == the lesser one
+        assert_eq!(
+            consensus
+                .compare_and_set(
+                    &key,
+                    Some(state.seqno),
+                    VersionedData {
+                        seqno: SeqNo(20),
+                        data: Bytes::from(""),
+                    }
+                )
+                .await,
+            Ok(Err(vec![new_state.clone()]))
+        );
+
         // We can observe both states in the correct order with scan if pass
         // in a suitable lower bound.
         assert_eq!(
@@ -722,8 +754,8 @@ pub mod tests {
             Ok(vec![new_state.clone()])
         );
 
-        // We cannot scan if the provided lower bound > head's sequence number.
-        assert!(consensus.scan(&key, SeqNo(11)).await.is_err());
+        // We can scan if the provided lower bound > head's sequence number.
+        assert_eq!(consensus.scan(&key, SeqNo(11)).await, Ok(vec![]));
 
         // Can remove the previous write with the appropriate truncation.
         assert_eq!(consensus.truncate(&key, SeqNo(6)).await, Ok(1));
@@ -769,7 +801,7 @@ pub mod tests {
             consensus
                 .compare_and_set(&key, Some(state.seqno), invalid_jump_forward)
                 .await,
-            Ok(Err(Some(new_state.clone())))
+            Ok(Err(vec![new_state.clone()]))
         );
 
         // Writing a large (~10 KiB) amount of data works fine.

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -162,16 +162,12 @@ impl MemConsensus {
         key: &str,
         from: SeqNo,
     ) -> Result<Vec<VersionedData>, ExternalError> {
-        let mut results = vec![];
-        if let Some(values) = store.get(key) {
-            // TODO: we could instead binary search to find the first valid
-            // key and then binary search the rest.
-            for value in values {
-                if value.seqno >= from {
-                    results.push(value.clone());
-                }
-            }
-        }
+        let results = if let Some(values) = store.get(key) {
+            let from_idx = values.partition_point(|x| x.seqno < from);
+            values[from_idx..].to_vec()
+        } else {
+            Vec::new()
+        };
         Ok(results)
     }
 }

--- a/src/persist/src/mem.rs
+++ b/src/persist/src/mem.rs
@@ -156,6 +156,26 @@ impl Default for MemConsensus {
     }
 }
 
+impl MemConsensus {
+    fn scan_store(
+        store: &HashMap<String, Vec<VersionedData>>,
+        key: &str,
+        from: SeqNo,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
+        let mut results = vec![];
+        if let Some(values) = store.get(key) {
+            // TODO: we could instead binary search to find the first valid
+            // key and then binary search the rest.
+            for value in values {
+                if value.seqno >= from {
+                    results.push(value.clone());
+                }
+            }
+        }
+        Ok(results)
+    }
+}
+
 #[async_trait]
 impl Consensus for MemConsensus {
     async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
@@ -173,7 +193,7 @@ impl Consensus for MemConsensus {
         key: &str,
         expected: Option<SeqNo>,
         new: VersionedData,
-    ) -> Result<Result<(), Option<VersionedData>>, ExternalError> {
+    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError> {
         if let Some(expected) = expected {
             if new.seqno <= expected {
                 return Err(ExternalError::from(
@@ -198,7 +218,8 @@ impl Consensus for MemConsensus {
         let seqno = data.as_ref().map(|data| data.seqno);
 
         if seqno != expected {
-            return Ok(Err(data.cloned()));
+            let from = expected.map_or_else(SeqNo::minimum, |x| x.next());
+            return Ok(Err(Self::scan_store(&store, key, from)?));
         }
 
         store.entry(key.to_string()).or_default().push(new);
@@ -208,25 +229,7 @@ impl Consensus for MemConsensus {
 
     async fn scan(&self, key: &str, from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
         let store = self.data.lock().map_err(Error::from)?;
-        let mut results = vec![];
-        if let Some(values) = store.get(key) {
-            // TODO: we could instead binary search to find the first valid
-            // key and then binary search the rest.
-            for value in values {
-                if value.seqno >= from {
-                    results.push(value.clone());
-                }
-            }
-        }
-
-        if results.is_empty() {
-            Err(ExternalError::from(anyhow!(
-                "sequence number lower bound too high for scan: {:?}",
-                from
-            )))
-        } else {
-            Ok(results)
-        }
+        Self::scan_store(&store, key, from)
     }
 
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError> {

--- a/src/persist/src/unreliable.rs
+++ b/src/persist/src/unreliable.rs
@@ -193,7 +193,7 @@ impl Consensus for UnreliableConsensus {
         key: &str,
         expected: Option<SeqNo>,
         new: VersionedData,
-    ) -> Result<Result<(), Option<VersionedData>>, ExternalError> {
+    ) -> Result<Result<(), Vec<VersionedData>>, ExternalError> {
         self.handle
             .run_op("compare_and_set", || {
                 self.consensus.compare_and_set(key, expected, new)

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -346,6 +346,16 @@ where
     }
 }
 
+impl RustType<()> for () {
+    fn into_proto(&self) -> () {
+        *self
+    }
+
+    fn from_proto(proto: ()) -> Result<Self, TryFromProtoError> {
+        Ok(proto)
+    }
+}
+
 impl RustType<u64> for usize {
     fn into_proto(&self) -> u64 {
         u64::cast_from(*self)

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -20,4 +20,16 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     """Run the nemesis for 5 seconds as a smoke test."""
-    c.run("maelstrom-persist", "--time-limit=5", "--", "maelstrom")
+    c.run(
+        "maelstrom-persist",
+        "--time-limit=5",
+        "--node-count=1",
+        "--concurrency=2",
+        "--rate=100",
+        "--",
+        "maelstrom",
+        "--blob-uri=mem://",
+        "--consensus-uri=mem://",
+    )
+    # TODO: Reenable this when we un-break MaelstromConsensus
+    # c.run("maelstrom-persist", "--time-limit=5", "--", "maelstrom")


### PR DESCRIPTION
Before, there was pressure to keep the size of state down, because it
was rewritten entirely on each command application. In particular, this
created a tension in compaction tuning between being aggressive about
fewer batches (smaller state) and compacting small batches lazily
(smaller write amplification).

Writing state updates as incremental diffs means that size of a
Consensus writes for each command is independent of the total size of
state. We should be able leverage this to make the entire
`WriteHandle::compare_and_append_batch` latency constant w.r.t. the size
of state and thus independent of compaction. This lets us tune
compaction entirely for where we want to be in its more intrinsic
tradeoff between read, write, and space amplification.

(NB: This commit doesn't quite get us to constant latencies, there's
some elbow grease left. I've proven concretely that it can get down to
`O(log(num state batches))`, but that included some hacks that didn't
make this PR. This would be lovely followup work once we get a chance.)

As persist metadata changes over time, we make its versions (each
identified by a [SeqNo]) durable in two ways:
- `rollups`: Periodic copies of the entirety of [State], written to
  [Blob].
- `diffs`: Incremental [StateDiff]s, written to [Consensus]. The
following invariants are maintained at all times:
- A shard is initialized iff there is at least one version of it in
  Consensus.
- The first version of state is written to `SeqNo(1)`. Each successive
  state version is assigned its predecessor's SeqNo +1.
- `current`: The latest version of state. By definition, the largest
  SeqNo present in Consensus.
- As state changes over time, we keep a range of consecutive versions
  available. These are periodically `truncated` to prune old versions
  that are no longer necessary.
- `earliest`: The first version of state that it is possible to
  reconstruct.
  - Invariant: `earliest <= current.seqno_since()` (we don't garbage
    collect versions still being used by some reader).
  - Invariant: `earliest` is always the smallest Seqno present in
    Consensus.
    - This doesn't have to be true, but we select to enforce it.
    - Because the data stored at that smallest Seqno is an incremental
      diff, to make this invariant work, there needs to be a rollup at
      either `earliest-1` or `earliest`. We choose `earliest` because it
      seems to make the code easier to reason about in practice.
    - A consequence of the above is when we garbage collect old versions
      of state, we're only free to truncate ones that are `<` the latest
      rollup that is `<= current.seqno_since`.
- `live diffs`: The set of SeqNos present in Consensus at any given
  time.
- `live states`: The range of state versions that it is possible to
  reconstruct: `[earliest,current]`.
  - Because of earliest and current invariants above, the range of `live
    diffs` and `live states` are the same.
- The set of known rollups are tracked in the shard state itself.
  - For efficiency of common operations, the most recent rollup's Blob
    key is always denormalized in each StateDiff written to Consensus.
    (As described above, there is always a rollup at earliest, so we're
    guaranteed that there is always at least one live rollup.)
  - Invariant: The rollups in `current` exist in Blob.
    - A consequence is that, if a rollup in a state you believe is
      `current` doesn't exist, it's a guarantee that `current` has
      changed (or it's a bug).
  - Any rollup at a version `< earliest-1` is useless (we've lost the
    incremental diffs between it and the live states). GC is tasked with
    deleting these rollups from Blob before truncating diffs from
    Consensus. Thus, any rollup at a seqno < earliest can be considered
    "leaked" and deleted by the leaked blob detector.
  - Note that this means, while `current`'s rollups exist, it will be
    common for other live states to reference rollups that no longer
    exist.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
