### PR TITLE
doc/user: unstable docs more apparent, less threatening

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -312,7 +312,7 @@ header {
 }
 
 .navbar {
-    background: $darkest-purple-v2;
+    background-image: linear-gradient( 90deg, hsl(313deg, 93%, 55%) 0%, hsl(309deg, 84%, 52%) 11%, hsl(304deg, 76%, 49%) 22%, hsl(298deg, 73%, 48%) 33%, hsl(292deg, 71%, 49%) 44%, hsl(286deg, 72%, 51%) 56%, hsl(279deg, 73%, 52%) 67%, hsl(271deg, 75%, 53%) 78%, hsl(262deg, 76%, 55%) 89%, hsl(252deg, 77%, 56%) 100% );
     color: $white-v2;
     font-weight: 600;
     font-size: 14px;
@@ -382,32 +382,25 @@ header {
         background-position: 0% 100%;
         background-size: 200% 300%;
         transition: background-position 0.3s ease-out;
+
+        &:hover {
+            background-position: 100% 100%;
+            text-decoration: none;
+        }
+
+        &.featured {
+            background: $medium-purple-v2;
+        }
+
+        &.featured:hover {
+            background: $dark-purple-v2;
+        }
     }
 
-    &:hover {
-        background-position: 100% 100%;
-        text-decoration: none;
-    }
 
-    &:featured {
-        background-size: 200% 200%;
-        background-image: linear-gradient(
-            300deg,
-            #c13aff 0%,
-            #7e52ff 31.36%,
-            #5c29f1 43.94%,
-            #e37ac2 76.56%,
-            #ff9067 85.53%
-        );
-        transition: all 0.2s ease-out;
-    }
-
-    &:featured:hover {
-        color: #fff;
-    }
 
     .secondary {
-        opacity: 0.5;
+        opacity: 0.85;
     }
 }
 

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -11,10 +11,8 @@
         <path class="logo--mark-4" d="M25.0888 19.7874C24.1549 18.8714 23.2122 17.9642 22.2872 17.0392C21.0287 15.7852 19.7836 14.5178 18.534 13.2593C18.534 12.281 18.534 11.3071 18.534 10.3288C18.5242 10.2288 18.5367 10.1279 18.5705 10.0334C18.6043 9.9388 18.6587 9.85289 18.7297 9.78181L24.8531 3.68951C24.902 3.64059 24.9643 3.60057 25.0087 3.56055C25.1466 3.60946 25.1066 3.71174 25.1066 3.78734C25.1066 9.04955 25.1066 14.3103 25.1066 19.5695C25.1052 19.6425 25.0993 19.7152 25.0888 19.7874V19.7874Z" fill="white" fill-opacity="0.5"></path>
       </svg>
     </a>
-    <a role="menuitem" href="https://materialize.com/">Materialize</a>
-    <div class="flex_grow text_center">
-      <div style="background: #FBE2D9; border: 1px solid #be4519; max-width:65ch; margin:0 auto; color:#be4519; font-weight:normal;"><strong>Warning: </strong>This documentation is for an unreleased version of Materialize. Please check <a href="https://materialize.com/docs/">https://materialize.com/docs/</a></a> for the latest stable version.</div>
-    </div>
+    <div class="flex_grow"><a role="menuitem" href="https://materialize.com/">Materialize</a>/ Early Access</div>
+    <a class="secondary" role="menuitem" href="https://materialize.com/docs">Back to Stable Docs ➟</a>
     <a class="secondary" role="menuitem" href="https://cloud.materialize.com/">Log In</a>
     <a class="btn featured" role="menuitem"  href="https://materialize.com/materialize-cloud-access/">Register for Cloud</a>
   </div>


### PR DESCRIPTION

### Motivation

Temporarily make it super clear which version of docs you are in, make unstable warning less dangerous sounding.

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/11527560/184768495-1079ee26-6b15-4c6e-ad30-5a0273247904.png">
