### PR TITLE
frontegg-auth: retry exchange_client_secret_for_token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,6 +3307,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -16,4 +16,5 @@ reqwest = "0.11.11"
 serde = { version = "1.0.140", features = ["derive"] }
 thiserror = "1.0.31"
 tokio = "1.19.2"
+tracing = "0.1.35"
 uuid = "1.1.2"


### PR DESCRIPTION
This may fix a hung login attempt we observed. Timeout and log if
it happens.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a