### PR TITLE
persist: panic on missing blob

### DIFF
--- a/src/persist-client/examples/maelstrom/services.rs
+++ b/src/persist-client/examples/maelstrom/services.rs
@@ -153,7 +153,10 @@ impl Consensus for MaelstromConsensus {
     }
 
     async fn scan(&self, _key: &str, _from: SeqNo) -> Result<Vec<VersionedData>, ExternalError> {
-        unimplemented!("not yet used")
+        // TODO: Implement this. This placeholder unblocks getting maelstrom
+        // working in CI again, but it prevents us from getting coverage of gc
+        // correctness.
+        Ok(vec![])
     }
 
     async fn truncate(&self, _key: &str, _seqno: SeqNo) -> Result<usize, ExternalError> {

--- a/src/persist-client/examples/persistcli.rs
+++ b/src/persist-client/examples/persistcli.rs
@@ -67,6 +67,14 @@ fn main() {
     let root_span = info_span!("persistcli");
     let res = match args.command {
         Command::Maelstrom(args) => runtime.block_on(async move {
+            // Persist internally has a bunch of sanity check assertions. If
+            // maelstrom tickles one of these, we very much want to bubble this
+            // up into a process exit with non-0 status. It's surprisingly
+            // tricky to be confident that we're not accidentally swallowing
+            // panics in async tasks (in fact there was a bug that did exactly
+            // this at one point), so abort on any panics to be extra sure.
+            mz_ore::panic::set_abort_on_panic();
+
             // Run the maelstrom stuff in a spawn_blocking because it internally
             // spawns tasks, so the runtime needs to be in the TLC.
             Handle::current()

--- a/src/persist-client/src/impl/metrics.rs
+++ b/src/persist-client/src/impl/metrics.rs
@@ -281,7 +281,6 @@ impl MetricsVecs {
                 storage_usage_shard_size: self.retry_metrics("storage_usage::shard_size"),
             },
             append_batch: self.retry_metrics("append_batch"),
-            fetch_batch_part: self.retry_metrics("fetch_batch_part"),
             idempotent_cmd: self.retry_metrics("idempotent_cmd"),
             next_listen_batch: self.retry_metrics("next_listen_batch"),
             snapshot: self.retry_metrics("snapshot"),
@@ -433,7 +432,6 @@ pub struct RetriesMetrics {
     pub(crate) external: RetryExternal,
 
     pub(crate) append_batch: RetryMetrics,
-    pub(crate) fetch_batch_part: RetryMetrics,
     pub(crate) idempotent_cmd: RetryMetrics,
     pub(crate) next_listen_batch: RetryMetrics,
     pub(crate) snapshot: RetryMetrics,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Seeing a log line of `INFO mz_persist_client::read: unexpected missing blob, trying again in 16s` is one of the scariest sights, and we should panic when they occur. All of our blob implementations are linearizable, so retrying will not help, and we'll want to bubble this error up in a Sentry to catch when it crops up.

This also updates Maelstrom (which found a previous bug that could lead to this symptom) to abort on panic, to more clearly identify when the issue occurs if we're able to repro locally

### Motivation

Part of https://github.com/MaterializeInc/materialize/pull/14101

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
