### PR TITLE
Decompose record in `Literal(record(c1, c2)) = record_create(e1, e2)`

### DIFF
--- a/test/sqllogictest/record.slt
+++ b/test/sqllogictest/record.slt
@@ -59,3 +59,26 @@ query T
 SELECT abc FROM (VALUES (1, 2, (3,4), ROW(5, 6, 7))) as abc;
 ----
 (1,2,"(3,4)","(5,6,7)")
+
+# MirScalarExpr::reduce() should transform
+# Literal([c1, c2]) = record_create(e1, e2)
+# into
+# c1 = e1 AND c2 = e2
+#
+# If this test fails in the future, one possible reason is the canonical ordering having been changed between
+# MirScalarExpr::Literal and MirScalarExpr::CallVariadic, because then the argument ordering of the `Eq` changes, so
+# reduce() doesn't recognize the pattern anymore.
+
+query T multiline
+EXPLAIN PLAN FOR SELECT * FROM t1 WHERE (t1.a, t1.b) IN ((1,2))
+----
+Source materialize.public.t1 (u1):
+| Filter (#0 = 1), (#1 = 2)
+| Project (#0, #1)
+
+Query:
+%0 =
+| Get materialize.public.t1 (u1)
+| Filter (#0 = 1), (#1 = 2)
+
+EOF


### PR DESCRIPTION
This transforms
```Literal(record(c1, c2)) = record_create(e1, e2)```
to
```c1 = e1 AND c2 = e2```.

### Motivation

  * This PR adds a known-desirable feature: Part of https://github.com/MaterializeInc/materialize/issues/13151:
  `(e1,e2) IN ((1,2))` is desugared using a `record_create`, so we need this transform to be able to work with such queries in `literal_constraints`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This is just a very minor optimization by itself. I'd say we should tend to the release notes once https://github.com/MaterializeInc/materialize/issues/13151 is completely done.
