### PR TITLE
environmentd: Fix connection ID allocation

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4229,7 +4229,7 @@ impl<S: Append> Catalog<S> {
     }
 }
 
-fn is_reserved_name(name: &str) -> bool {
+pub fn is_reserved_name(name: &str) -> bool {
     BUILTIN_ROLE_PREFIXES
         .iter()
         .any(|prefix| name.starts_with(prefix))

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -68,15 +68,6 @@ impl Handle {
     }
 }
 
-/// Distinguishes between external and internal clients.
-#[derive(Debug, Clone)]
-pub enum ClientType {
-    /// Client that has connected over an external port.
-    External,
-    /// Client that has connected over an internal port.
-    Internal,
-}
-
 /// A coordinator client.
 ///
 /// A coordinator client is a simple handle to a communication channel with the
@@ -88,15 +79,13 @@ pub enum ClientType {
 pub struct Client {
     cmd_tx: mpsc::UnboundedSender<Command>,
     id_alloc: Arc<IdAllocator<ConnectionId>>,
-    client_type: ClientType,
 }
 
 impl Client {
-    pub(crate) fn new(cmd_tx: mpsc::UnboundedSender<Command>, client_type: ClientType) -> Client {
+    pub(crate) fn new(cmd_tx: mpsc::UnboundedSender<Command>) -> Client {
         Client {
             cmd_tx,
             id_alloc: Arc::new(IdAllocator::new(1, 1 << 16)),
-            client_type,
         }
     }
 
@@ -130,11 +119,6 @@ impl Client {
         let response = self.system_execute(stmt).await?;
         Ok(response.results.into_element())
     }
-
-    /// Returns the `ClientType` associated with this client.
-    pub fn client_type(&self) -> &ClientType {
-        &self.client_type
-    }
 }
 
 /// A coordinator client that is bound to a connection.
@@ -153,11 +137,6 @@ impl ConnClient {
     /// Returns the ID of the connection associated with this client.
     pub fn conn_id(&self) -> ConnectionId {
         self.conn_id
-    }
-
-    /// Returns the `ClientType` associated with this client.
-    pub fn client_type(&self) -> &ClientType {
-        self.inner.client_type()
     }
 
     /// Upgrades this connection client to a session client.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -114,7 +114,7 @@ use crate::catalog::{
     self, storage, BuiltinMigrationMetadata, BuiltinTableUpdate, Catalog, CatalogItem,
     ClusterReplicaSizeMap, StorageHostSizeMap, StorageSinkConnectionState,
 };
-use crate::client::{Client, ClientType, ConnectionId, Handle};
+use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
 use crate::coord::appends::{BuiltinTableUpdateSource, Deferred, PendingWriteTxn};
 use crate::coord::id_bundle::CollectionIdBundle;
@@ -815,7 +815,7 @@ pub async fn serve<S: Append + 'static>(
         connection_context,
         storage_usage_client,
     }: Config<S>,
-) -> Result<(Handle, Client, Client), AdapterError> {
+) -> Result<(Handle, Client), AdapterError> {
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
     let (internal_cmd_tx, internal_cmd_rx) = mpsc::unbounded_channel();
     let (strict_serializable_reads_tx, strict_serializable_reads_rx) = mpsc::unbounded_channel();
@@ -933,9 +933,8 @@ pub async fn serve<S: Append + 'static>(
                 start_instant,
                 _thread: thread.join_on_drop(),
             };
-            let external_client = Client::new(cmd_tx.clone(), ClientType::External);
-            let internal_client = Client::new(cmd_tx, ClientType::Internal);
-            Ok((handle, external_client, internal_client))
+            let client = Client::new(cmd_tx.clone());
+            Ok((handle, client))
         }
         Err(e) => Err(e),
     }

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -250,23 +250,22 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let controller = mz_controller::Controller::new(config.controller).await;
 
     // Initialize adapter.
-    let (adapter_handle, external_adapter_client, internal_adapter_client) =
-        mz_adapter::serve(mz_adapter::Config {
-            dataflow_client: controller,
-            storage: adapter_storage,
-            unsafe_mode: config.unsafe_mode,
-            build_info: &BUILD_INFO,
-            metrics_registry: config.metrics_registry.clone(),
-            now: config.now,
-            secrets_controller: config.secrets_controller,
-            cluster_replica_sizes: config.cluster_replica_sizes,
-            storage_host_sizes: config.storage_host_sizes,
-            default_storage_host_size: config.default_storage_host_size,
-            availability_zones: config.availability_zones,
-            connection_context: config.connection_context,
-            storage_usage_client,
-        })
-        .await?;
+    let (adapter_handle, adapter_client) = mz_adapter::serve(mz_adapter::Config {
+        dataflow_client: controller,
+        storage: adapter_storage,
+        unsafe_mode: config.unsafe_mode,
+        build_info: &BUILD_INFO,
+        metrics_registry: config.metrics_registry.clone(),
+        now: config.now,
+        secrets_controller: config.secrets_controller,
+        cluster_replica_sizes: config.cluster_replica_sizes,
+        storage_host_sizes: config.storage_host_sizes,
+        default_storage_host_size: config.default_storage_host_size,
+        availability_zones: config.availability_zones,
+        connection_context: config.connection_context,
+        storage_usage_client,
+    })
+    .await?;
 
     // TODO(benesch): replace both `TCPListenerStream`s below with
     // `<type>_listener.incoming()` if that is
@@ -283,8 +282,9 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     task::spawn(|| "pgwire_server", {
         let pgwire_server = mz_pgwire::Server::new(mz_pgwire::Config {
             tls: pgwire_tls,
-            adapter_client: external_adapter_client.clone(),
+            adapter_client: adapter_client.clone(),
             frontegg: config.frontegg.clone(),
+            internal: false,
         });
 
         async move {
@@ -303,8 +303,9 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
         task::spawn(|| "internal_pgwire_server", {
             let internal_pgwire_server = mz_pgwire::Server::new(mz_pgwire::Config {
                 tls: None,
-                adapter_client: internal_adapter_client,
+                adapter_client: adapter_client.clone(),
                 frontegg: None,
+                internal: true,
             });
             let mut incoming = TcpListenerStream::new(internal_sql_listener);
             async move {
@@ -322,7 +323,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
             let http_server = http::Server::new(http::Config {
                 tls: http_tls,
                 frontegg: config.frontegg,
-                adapter_client: external_adapter_client,
+                adapter_client,
                 allowed_origin: config.cors_allowed_origin,
             });
             let mut incoming = TcpListenerStream::new(http_listener);

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -40,6 +40,9 @@ pub struct Config {
     /// a valid Frontegg API token as a password to authenticate. Otherwise,
     /// password authentication is disabled.
     pub frontegg: Option<FronteggAuthentication>,
+    /// Whether this is an internal server that permits access to restricted
+    /// system resources.
+    pub internal: bool,
 }
 
 /// Configures a server's TLS encryption and authentication.
@@ -66,6 +69,7 @@ pub struct Server {
     tls: Option<TlsConfig>,
     adapter_client: mz_adapter::Client,
     frontegg: Option<FronteggAuthentication>,
+    internal: bool,
 }
 
 impl Server {
@@ -75,6 +79,7 @@ impl Server {
             tls: config.tls,
             adapter_client: config.adapter_client,
             frontegg: config.frontegg,
+            internal: config.internal,
         }
     }
 
@@ -109,6 +114,7 @@ impl Server {
                         version,
                         params,
                         frontegg: self.frontegg.as_ref(),
+                        internal: self.internal,
                     })
                     .await?;
                     conn.flush().await?;


### PR DESCRIPTION
Previously, internal ports and external ports used separate
IDAllocators to allocate connection IDs. This caused connection IDs
on internal and external ports to collide. This commit fixes this issue
by having internal and external ports share an IDAllocator. This fixes
a regression caused by 041f326fdea44508fb80b22246a9815f2d3548a6.


### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
