### PR TITLE
Optimization: fix unique key calculation error

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -470,7 +470,9 @@ impl MirRelationExpr {
                         {
                             if let Some(c1) = expr1.as_column() {
                                 if let Some(c2) = expr2.as_column() {
-                                    return Some((c1, c2));
+                                    if c1 != c2 {
+                                        return Some((c1, c2));
+                                    }
                                 }
                             }
                         }

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -259,9 +259,11 @@ mod tests {
             "ReductionPushdown" => Ok(Box::new(
                 mz_transform::reduction_pushdown::ReductionPushdown,
             )),
+            "ReduceElision" => Ok(Box::new(mz_transform::reduce_elision::ReduceElision)),
             "RedundantJoin" => Ok(Box::new(
                 mz_transform::redundant_join::RedundantJoin::default(),
             )),
+            "RelationCSE" => Ok(Box::new(mz_transform::cse::relation_cse::RelationCSE)),
             "TopKFusion" => Ok(Box::new(mz_transform::fusion::top_k::TopK)),
             "ThresholdElision" => Ok(Box::new(mz_transform::threshold_elision::ThresholdElision)),
             "UnionBranchCancellation" => Ok(Box::new(

--- a/src/transform/tests/testdata/typ
+++ b/src/transform/tests/testdata/typ
@@ -204,3 +204,20 @@ build format=types
 | Filter (#0 = #2)
 | | types = (Int32, Int32?, Int32, Int32?)
 | | keys = ((#0, #1), (#0, #3), (#1, #2), (#2, #3))
+
+# Regression test for #14146. The keys at the end should be [#0]
+
+build format=types
+(filter (reduce (get x) [#0] [(count true false)])[(call_binary eq #0 #0)])
+----
+%0 =
+| Get x (u0)
+| | types = (Int32?, Int64?, Int32?)
+| | keys = ()
+| Reduce group=(#0)
+| | agg count(true)
+| | types = (Int32?, Int64)
+| | keys = ((#0))
+| Filter (#0 = #0)
+| | types = (Int32, Int64)
+| | keys = ((#0))

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -1,0 +1,84 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+statement ok
+create table test1 (a int, b int);
+
+statement ok
+create table test2 (a int, b int);
+
+statement ok
+create view test3 as select a, b, count(*) as c from test2 group by a, b;
+
+statement ok
+insert into test1 values (1, 3);
+
+statement ok
+insert into test2 values (1, 2), (1, 3);
+
+statement error more than one record produced in subquery
+select a, b, ( select c from test3 where a = test3.a and b = test3.b) from test1;
+
+query T multiline
+explain select a, b, ( select c from test3 where a = test3.a and b = test3.b) from test1;
+----
+Source materialize.public.test1 (u1):
+| Project (#0, #1)
+
+Source materialize.public.test2 (u2):
+| Filter (#0 = #0), (#1 = #1)
+| Project (#0, #1)
+
+Query:
+%0 = Let l0 =
+| Get materialize.public.test2 (u2)
+| Filter (#0 = #0), (#1 = #1)
+| Reduce group=(#0, #1)
+| | agg count(true)
+| Project (#2)
+
+%1 =
+| Get %0 (l0)
+| Project ()
+| Reduce group=()
+| | agg count(true)
+| Filter (#0 > 1)
+| Project ()
+| Map (err: more than one record produced in subquery)
+
+%2 = Let l1 =
+| Union %0 %1
+
+%3 =
+| Get materialize.public.test1 (u1)
+| ArrangeBy ()
+
+%4 =
+| Get %2 (l1)
+| Project ()
+| Distinct group=()
+| Negate
+
+%5 =
+| Constant ()
+
+%6 =
+| Union %4 %5
+| Map null
+
+%7 =
+| Union %2 %6
+
+%8 =
+| Join %3 %7
+| | implementation = Differential %7 %3.()
+
+EOF


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

Closes #14146

In our unique key calculation code:
* if the input considers the set `[#0, #1]` as a unique key
* and the input is being filtered on `#0 = #1`.
* then the output has the sets `[#0]` and `[#1]` as unique keys.

This code incorrectly got triggered in the case where the input is being filtered on `#0 = #0`, resulting in the deletion of `#0` from all unique keys of the input. So if the input considers the set `[#0]` as a unique key, the resulting output has the empty set as a unique key. If the input considers the set `[#0, #1]` as a unique key, the resulting output has the set `[#1]` as a unique key. 

One reason we haven't encountered this problem earlier is that filters normally get pushed below the reduces that would result in an input having unique keys.

### Tips for reviewer

Second commit just adds more transforms to the unit test runner. I added them while trying to debug the issue, and I figured we might as well merge the change.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Created a regression test in the `MirRelationExpr::typ` unit tests.

- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  -  Fixes a wrong result that may occur if a query contains a predicate of the form `samecolumn = samecolumn`.

TODO: figure out if this release note needs to go somewhere.
