### PR TITLE
adapter: process stash consolidations out of user request path

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -743,6 +743,10 @@ impl<S: Append> Connection<S> {
         Ok(self.stash.confirm_leadership().await?)
     }
 
+    pub async fn consolidate(&mut self, collections: &[mz_stash::Id]) -> Result<(), Error> {
+        Ok(self.stash.consolidate_batch(&collections).await?)
+    }
+
     pub fn cluster_id(&self) -> Uuid {
         self.cluster_id
     }
@@ -1234,6 +1238,13 @@ impl<'a, S: Append> Transaction<'a, S> {
 
     #[tracing::instrument(level = "debug", skip_all)]
     pub async fn commit(self) -> Result<(), Error> {
+        let (stash, collections) = self.commit_without_consolidate().await?;
+        stash.consolidate_batch(&collections).await?;
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn commit_without_consolidate(self) -> Result<(&'a mut S, Vec<mz_stash::Id>), Error> {
         let mut batches = Vec::new();
         async fn add_batch<K, V, S, I>(
             stash: &mut S,
@@ -1364,13 +1375,18 @@ impl<'a, S: Append> Transaction<'a, S> {
             self.storage_usage_updates,
         )
         .await?;
-        if batches.is_empty() {
-            return Ok(());
+
+        let ids = batches
+            .iter()
+            .map(|batch| batch.collection_id)
+            .collect::<Vec<_>>();
+        if !batches.is_empty() {
+            self.stash
+                .append_batch(&batches)
+                .await
+                .map_err(StashError::from)?;
         }
-        self.stash
-            .append_batch(&batches)
-            .await
-            .map_err(|e| e.into())
+        Ok((self.stash, ids))
     }
 }
 

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1367,7 +1367,10 @@ impl<'a, S: Append> Transaction<'a, S> {
         if batches.is_empty() {
             return Ok(());
         }
-        self.stash.append(batches).await.map_err(|e| e.into())
+        self.stash
+            .append_batch(&batches)
+            .await
+            .map_err(|e| e.into())
     }
 }
 
@@ -1424,7 +1427,7 @@ pub async fn initialize_stash<S: Append>(stash: &mut S) -> Result<(), Error> {
     add_batch(stash, &mut batches, &COLLECTION_SYSTEM_CONFIGURATION).await?;
     add_batch(stash, &mut batches, &COLLECTION_AUDIT_LOG).await?;
     add_batch(stash, &mut batches, &COLLECTION_STORAGE_USAGE).await?;
-    stash.append(batches).await.map_err(|e| e.into())
+    stash.append(&batches).await.map_err(|e| e.into())
 }
 
 macro_rules! impl_codec {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -169,7 +169,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .unwrap_or(SYSTEM_CONN_ID),
         )?;
 
-        let (builtin_table_updates, result) = self
+        let (builtin_table_updates, collections, result) = self
             .catalog
             .transact(session, ops, |catalog| {
                 f(CatalogTxn {
@@ -231,6 +231,9 @@ impl<S: Append + 'static> Coordinator<S> {
         }
         .await;
 
+        self.consolidations_tx
+            .send(collections)
+            .expect("sending on consolidations_tx must succeed");
         Ok(result)
     }
 

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -73,6 +73,16 @@ impl<S: Append + 'static> Coordinator<S> {
             Message::StorageUsageUpdate(sizes) => {
                 self.storage_usage_update(sizes).await;
             }
+            Message::Consolidate(collections) => {
+                self.consolidate(&collections).await;
+            }
+        }
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn consolidate(&mut self, collections: &[mz_stash::Id]) {
+        if let Err(err) = self.catalog.consolidate(collections).await {
+            warn!("consolidation error: {:?}", err);
         }
     }
 


### PR DESCRIPTION
Process stash consolidations in a low priority task. Multiple consolidations will be merged together.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/14018

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a