### PR TITLE
ci,test: Make sure --workers 4 is used for all tests

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -200,21 +200,19 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          # TODO(benesch): set --workers=1 again.
-          args: [--aws-region=us-east-2]
+          args: [--workers 1, --aws-region=us-east-2]
 
-  # TODO(benesch): reenable.
-  # - id: testdrive-workers-32
-  #   label: ":racing_car: testdrive with --workers 32"
-  #   depends_on: build-x86_64
-  #   timeout_in_minutes: 120
-  #   plugins:
-  #     - ./ci/plugins/scratch-aws-access: ~
-  #     - ./ci/plugins/mzcompose:
-  #         composition: testdrive
-  #         args: [--aws-region=us-east-2, --workers=32]
-  #   agents:
-  #     queue: linux-x86_64-large
+   - id: testdrive-workers-32
+     label: ":racing_car: testdrive with --workers 32"
+     depends_on: build-x86_64
+     timeout_in_minutes: 120
+     plugins:
+       - ./ci/plugins/scratch-aws-access: ~
+       - ./ci/plugins/mzcompose:
+           composition: testdrive
+           args: [--workers 32, --aws-region=us-east-2]
+     agents:
+       queue: linux-x86_64-large
 
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -42,7 +42,7 @@ class Materialized(Service):
         extra_ports: List[int] = [],
         memory: Optional[str] = None,
         data_directory: str = "/mzdata",
-        workers: Optional[int] = None,
+        workers: Optional[int] = 4,
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         environment_extra: Optional[List[str]] = None,
@@ -70,6 +70,13 @@ class Materialized(Service):
                 "COMPUTED_LOG_FILTER",
                 "INTERNAL_SQL_LISTEN_ADDR=0.0.0.0:6877",
                 "INTERNAL_HTTP_LISTEN_ADDR=0.0.0.0:6878",
+            ]
+
+        if workers:
+            environment += [
+                f"MZ_WORKERS={workers}",
+                f"COMPUTED_WORKERS={workers}",
+                f"STORAGED_WORKERS={workers}",
             ]
 
         if forward_aws_credentials:
@@ -100,9 +107,6 @@ class Materialized(Service):
                 config_ports.pop()
 
         command_list = []
-
-        if workers:
-            command_list.append(f"--workers {workers}")
 
         if options:
             if isinstance(options, str):
@@ -147,7 +151,7 @@ class Computed(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        workers: Optional[int] = None,
+        workers: Optional[int] = 4,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:
@@ -214,7 +218,7 @@ class Storaged(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        workers: Optional[int] = None,
+        workers: Optional[int] = 4,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -22,6 +22,7 @@
 //! about each of these interfaces.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::env;
 use std::mem;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
@@ -349,10 +350,15 @@ where
                                         "--internal-http-listen-addr={}:{}",
                                         assigned.listen_host, assigned.ports["internal-http"]
                                     ),
-                                    format!("--workers={}", allocation.workers),
                                     format!("--opentelemetry-resource=instance_id={}", instance_id),
                                     format!("--opentelemetry-resource=replica_id={}", replica_id),
                                 ];
+
+                                // For testing purposes, give precedence to the COMPUTED_WORKERS env option
+                                if env::var("COMPUTED_WORKERS").is_err() {
+                                    compute_opts.push(format!("--workers={}", allocation.workers))
+                                }
+
                                 compute_opts.extend(
                                     assigned.peers.iter().map(|(host, ports)| {
                                         format!("{host}:{}", ports["compute"])

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -39,6 +39,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         action="store_true",
         help="run against Redpanda instead of the Confluent Platform",
     )
+
+    parser.add_argument("--workers", help="Specify number of workers to use")
+
     parser.add_argument(
         "--aws-region",
         help="run against the specified AWS region instead of localstack",
@@ -73,7 +76,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         validate_postgres_stash=True,
     )
 
-    with c.override(testdrive):
+    materialized = (
+        Materialized(workers=args.workers) if args.workers else Materialized()
+    )
+
+    with c.override(testdrive, materialized):
         c.start_and_wait_for_tcp(services=dependencies)
         c.wait_for_materialized("materialized")
         try:


### PR DESCRIPTION
Now that --workers 1 is the default in Platform, the tests have
become less stressful concurrency-wise. Set the default to be
--workers 4 for both computeds and storageds across the CI.

This mimics the behavior we had pre-Platform where --workers=4 was
used by default in the CI.

Also, restore the --workers option in test/tetsdrive/mzcompose.py and
restore previous Nightly CI jobs that used --workers 1 and --workers 32

### Motivation

  * This PR adds a feature that has not yet been specified.

The CI was not testing multi-worker computeds and storageds

### Tips for reviewer

@benesch this is unlikely to pass now, as there are blocking bugs. However, I wanted to get your opinion on the way I give preference to the env variable when determining the value of the `--workers` option that the orchestrator computes.