### PR TITLE
ci: Add missing depends_on directives to the checks jobs

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -456,6 +456,7 @@ steps:
 
   - id: checks-drop-create-default-replica
     label: "Checks + DROP/CREATE replica"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -466,6 +467,7 @@ steps:
 
   - id: checks-restart-computed
     label: "Checks + restart computed"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -476,6 +478,7 @@ steps:
 
   - id: checks-restart-entire-mz
     label: "Checks + restart of the entire Mz"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -486,6 +489,7 @@ steps:
 
   - id: checks-restart-environmentd-storaged
     label: "Checks + restart of environmentd & storaged"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -496,6 +500,7 @@ steps:
 
   - id: checks-kill-storaged
     label: "Checks + kill storaged"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -506,6 +511,7 @@ steps:
 
   - id: checks-restart-postgres-backend
     label: "Checks + restart Postgres backend"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
@@ -516,6 +522,7 @@ steps:
 
   - id: checks-restart-source-postgres
     label: "Checks + restart source Postgres"
+    depends_on: build-x86_64
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64


### PR DESCRIPTION
The checks jobs were missing a depends_on: build-x86_64 directive
which caused them to all compile the entire product independently

### Motivation

  * This PR fixes a previously unreported bug.
CI slow because of unnecessary recompilations in the "checks" jobs.