### PR TITLE
zippy: Add sinks over user tables

### DIFF
--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -48,6 +48,7 @@ class UserTables(Scenario):
             KillComputed: 15,
             CreateTable: 10,
             CreateView: 10,
+            CreateSink: 10,
             ValidateTable: 20,
             ValidateView: 20,
             DML: 30,

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -19,7 +19,7 @@ from materialize.zippy.view_capabilities import ViewExists
 
 
 class CreateSink(Action):
-    """Creates a view that is a join over one or more sources or tables"""
+    """Creates a sink over an existing view. Then creates a source over that sink and a view over that source."""
 
     @classmethod
     def requires(self) -> List[Set[Type[Capability]]]:


### PR DESCRIPTION
Now that it is possible to create sinks over user tables,
add CreateSink to the UserTables scenario.

### Motivation

* This PR adds a feature that has not yet been specified.

Zippy was missing sinks in the UserTables scenario.