### PR TITLE
limits test: Adjust the timeout for the ViewsMaterializedNested scenario

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -631,6 +631,7 @@ class ViewsMaterializedNested(Generator):
 
     @classmethod
     def body(cls) -> None:
+        print("$ set-sql-timeout duration=300s")
         print("$ postgres-execute connection=mz_system")
         print(
             f"ALTER SYSTEM SET max_materialized_views = {ViewsMaterializedNested.COUNT * 10};"


### PR DESCRIPTION
Apparently 120 seconds are not enough to process 25 levels of nested
materialized views.

Relates to #13840

### Motivation

  * This PR fixes a previously unreported bug.

Nightly Limits CI job was timing out due to:
- #13840
