### PR TITLE
adapter: temporarily disable source status collection

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2285,7 +2285,10 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_AUTHID),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
-        Builtin::StorageCollection(&MZ_SOURCE_STATUS_HISTORY),
+        // This is disabled for the moment because it has unusual upper
+        // advancement behavior.
+        // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
+        // Builtin::StorageCollection(&MZ_SOURCE_STATUS_HISTORY),
     ]);
 
     builtins

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -455,9 +455,16 @@ impl<S: Append + 'static> Coordinator<S> {
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
         let mut policies_to_set: CollectionIdBundle = Default::default();
 
-        let source_status_collection_id = self
-            .catalog
-            .resolve_builtin_storage_collection(&crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY);
+        // This is disabled for the moment because it has unusual upper
+        // advancement behavior.
+        // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
+        let status_collection_id = if false {
+            Some(self.catalog.resolve_builtin_storage_collection(
+                &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
+            ))
+        } else {
+            None
+        };
 
         for entry in &entries {
             match entry.item() {
@@ -489,7 +496,7 @@ impl<S: Append + 'static> Coordinator<S> {
                                 desc: source.desc.clone(),
                                 ingestion: Some(ingestion),
                                 since: None,
-                                status_collection_id: Some(source_status_collection_id),
+                                status_collection_id,
                                 host_config: Some(source.host_config.clone()),
                             },
                         )])

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -450,9 +450,16 @@ impl<S: Append + 'static> Coordinator<S> {
                     }
                 }
 
-                let source_status_collection_id = self.catalog.resolve_builtin_storage_collection(
-                    &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
-                );
+                // This is disabled for the moment because it has unusual upper
+                // advancement behavior.
+                // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
+                let status_collection_id = if false {
+                    Some(self.catalog.resolve_builtin_storage_collection(
+                        &crate::catalog::builtin::MZ_SOURCE_STATUS_HISTORY,
+                    ))
+                } else {
+                    None
+                };
 
                 self.controller
                     .storage_mut()
@@ -462,7 +469,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             desc: source.desc.clone(),
                             ingestion: Some(ingestion),
                             since: None,
-                            status_collection_id: Some(source_status_collection_id),
+                            status_collection_id,
                             host_config: Some(source.host_config),
                         },
                     )])

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -21,7 +21,7 @@ mode cockroach
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1') - (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name LIKE '%_1');
 ----
-1
+0
 
 # This test checks if the views in mz_catalog are also present in a postfixed
 # way. If this test fails and you added new view that uses introspection

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -380,7 +380,6 @@ mz_scheduling_histogram_internal
 mz_scheduling_histogram_internal_1
 mz_scheduling_parks_internal
 mz_scheduling_parks_internal_1
-mz_source_status_history
 mz_worker_materialization_delays
 mz_worker_materialization_delays_1
 mz_worker_materialization_frontiers
@@ -423,7 +422,6 @@ mz_scheduling_histogram_internal              system log
 mz_scheduling_histogram_internal_1            system log
 mz_scheduling_parks_internal                  system log
 mz_scheduling_parks_internal_1                system log
-mz_source_status_history                      system "storage collection"
 mz_worker_materialization_delays              system log
 mz_worker_materialization_delays_1            system log
 mz_worker_materialization_frontiers           system log


### PR DESCRIPTION
As described in Slack and in the storage meeting, the source status
collection has unusual upper advancement behavior. Just disable it for
now, since the collection is not presently in use.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR works around a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
