### PR TITLE
catalog: Add more columns to pg_roles

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1953,11 +1953,19 @@ pub const PG_ROLES: BuiltinView = BuiltinView {
     name: "pg_roles",
     schema: PG_CATALOG_SCHEMA,
     sql: "CREATE VIEW pg_catalog.pg_roles AS SELECT
-    r.name AS rolname,
+    r.rolname,
+    r.rolsuper,
+    r.rolinherit,
+    r.rolcreaterole,
+    r.rolcreatedb,
+    r.rolcanlogin,
+    r.rolreplication,
+    r.rolconnlimit,
     '********'::pg_catalog.text AS rolpassword,
+    r.rolvaliduntil,
+    r.rolbypassrls,
     r.oid AS oid
-FROM mz_catalog.mz_roles r
-JOIN mz_catalog.mz_databases d ON (d.id IS NULL OR d.name = pg_catalog.current_database())",
+FROM pg_catalog.pg_authid r",
 };
 
 pub const PG_VIEWS: BuiltinView = BuiltinView {
@@ -2103,7 +2111,8 @@ AS SELECT
     NULL::pg_catalog.text AS rolpassword,
     -- MZ doesn't have role passwords
     NULL::pg_catalog.timestamptz AS rolvaliduntil
-FROM mz_catalog.mz_roles r",
+FROM mz_catalog.mz_roles r
+JOIN mz_catalog.mz_databases d ON (d.id IS NULL OR d.name = pg_catalog.current_database())",
 };
 
 pub const MZ_SYSTEM: BuiltinRole = BuiltinRole { name: SYSTEM_USER };
@@ -2276,13 +2285,13 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&PG_CONSTRAINT),
         Builtin::View(&PG_TABLES),
         Builtin::View(&PG_ACCESS_METHODS),
+        Builtin::View(&PG_AUTHID),
         Builtin::View(&PG_ROLES),
         Builtin::View(&PG_VIEWS),
         Builtin::View(&PG_MATVIEWS),
         Builtin::View(&PG_COLLATION),
         Builtin::View(&PG_POLICY),
         Builtin::View(&PG_INHERITS),
-        Builtin::View(&PG_AUTHID),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
         Builtin::StorageCollection(&MZ_SOURCE_STATUS_HISTORY),

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import time
+from textwrap import dedent
 
 from pg8000.dbapi import ProgrammingError
 
@@ -73,6 +74,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-drop-default-cluster",
         "test-upsert",
         "test-resource-limits",
+        "test-builtin-migration",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -256,3 +258,60 @@ def workflow_test_resource_limits(c: Composition) -> None:
         c.wait_for_materialized()
 
         c.run("testdrive", "resources/resource-limits.td")
+
+
+# TODO: Would be nice to update this test to use a builtin table that can be materialized.
+#  pg_roles, and most postgres catalog views, cannot be materialized because they use
+#  pg_catalog.current_database(). So we can't test making indexes and materialized views.
+def workflow_test_builtin_migration(c: Composition) -> None:
+    """Exercise the builtin object migration code by upgrading between two versions
+    that will have a migration triggered between them. Create a materialized view
+    over the affected builtin object to confirm that the migration was successful
+    """
+
+    c.down(destroy_volumes=True)
+    with c.override(
+        # Random commit before pg_roles was updated.
+        Materialized(
+            image="materialize/materialized:devel-9efd269199b1510b3e8f90196cb4fa3072a548a1",
+        ),
+        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True)
+    ):
+        c.up("testdrive", persistent=True)
+        c.up("materialized")
+        c.wait_for_materialized()
+
+        c.testdrive(
+            input=dedent(
+                """
+        > CREATE VIEW v1 AS SELECT COUNT(*) FROM pg_roles;
+        > SELECT * FROM v1;
+        2
+        ! SELECT DISTINCT rolconnlimit FROM pg_roles;
+        contains:column "rolconnlimit" does not exist
+    """
+            )
+        )
+
+        c.kill("materialized")
+
+    with c.override(
+        # This will stop working if we introduce a breaking change.
+        Materialized(),
+        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True)
+    ):
+        c.up("testdrive", persistent=True)
+        c.up("materialized")
+        c.wait_for_materialized()
+
+        c.testdrive(
+            input=dedent(
+                """
+       > SELECT * FROM v1;
+       2
+       # This column is new after the migration
+       > SELECT DISTINCT rolconnlimit FROM pg_roles;
+       -1
+    """
+            )
+        )

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -275,7 +275,7 @@ def workflow_test_builtin_migration(c: Composition) -> None:
         Materialized(
             image="materialize/materialized:devel-9efd269199b1510b3e8f90196cb4fa3072a548a1",
         ),
-        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True)
+        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True),
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")
@@ -298,7 +298,7 @@ def workflow_test_builtin_migration(c: Composition) -> None:
     with c.override(
         # This will stop working if we introduce a breaking change.
         Materialized(),
-        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True)
+        Testdrive(default_timeout="15s", no_reset=True, consistent_seed=True),
     ):
         c.up("testdrive", persistent=True)
         c.up("materialized")


### PR DESCRIPTION
This commit adds some of the missing columns from Postgres catalog
view pg_roles. Also adds a migration test for the new columns.

### Motivation
Adds Postgres compatibility and migration tests.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds the following columns to `pg_roles`: 
    - rolname,
    - rolsuper,
    - rolinherit,
    - rolcreaterole,
    - rolcreatedb,
    - rolcanlogin,
    - rolreplication,
    - rolconnlimit,
    - rolvaliduntil,
    - rolbypassrls