### PR TITLE
Convert missing-id error to something more helpful

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -53,7 +53,7 @@ use mz_sql::plan::{
     SendDiffsPlan, SetVariablePlan, ShowVariablePlan, TailFrom, TailPlan, View,
 };
 use mz_stash::Append;
-use mz_storage::controller::{CollectionDescription, ReadPolicy};
+use mz_storage::controller::{CollectionDescription, ReadPolicy, StorageError};
 use mz_storage::types::sinks::{
     ComputeSinkConnection, ComputeSinkDesc, SinkAsOf, StorageSinkConnectionBuilder,
     TailSinkConnection,
@@ -1032,10 +1032,24 @@ impl<S: Append + 'static> Coordinator<S> {
             item: CatalogItem::Sink(catalog_sink.clone()),
         }];
 
+        let from_name = self
+            .catalog
+            .get_entry(&catalog_sink.from)
+            .name()
+            .item
+            .clone();
         let result = self
             .catalog_transact(Some(&session), ops, move |txn| {
                 // Validate that the from collection is in fact a persist collection we can export.
-                txn.dataflow_client.storage().collection(sink.from)?;
+                txn.dataflow_client
+                    .storage()
+                    .collection(sink.from)
+                    .map_err(|e| match e {
+                        StorageError::IdentifierMissing(_) => AdapterError::Unstructured(anyhow!(
+                            "{from_name} is not a persistent collection, and cannot be exported as a sink"
+                        )),
+                        e => AdapterError::Storage(e),
+                    })?;
                 Ok(())
             })
             .await;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1032,12 +1032,9 @@ impl<S: Append + 'static> Coordinator<S> {
             item: CatalogItem::Sink(catalog_sink.clone()),
         }];
 
-        let from_name = self
-            .catalog
-            .get_entry(&catalog_sink.from)
-            .name()
-            .item
-            .clone();
+        let from = self.catalog.get_entry(&catalog_sink.from);
+        let from_name = from.name().item.clone();
+        let from_type = from.item().typ().to_string();
         let result = self
             .catalog_transact(Some(&session), ops, move |txn| {
                 // Validate that the from collection is in fact a persist collection we can export.
@@ -1046,7 +1043,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .collection(sink.from)
                     .map_err(|e| match e {
                         StorageError::IdentifierMissing(_) => AdapterError::Unstructured(anyhow!(
-                            "{from_name} is not a persistent collection, and cannot be exported as a sink"
+                            "{from_name} is a {from_type}, which cannot be exported as a sink"
                         )),
                         e => AdapterError::Storage(e),
                     })?;

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -204,12 +204,11 @@ New York,NY,10004
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-# TODO(14221): Better error message!
 ! CREATE SINK output5 FROM input_kafka_dbz_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:collection identifier is not present
+contains:input_kafka_dbz_view is not a persistent collection, and cannot be exported as a sink
 
 > CREATE SINK output5_view FROM input_kafka_dbz_view_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5b-view-${testdrive.seed}'
@@ -221,12 +220,11 @@ contains:collection identifier is not present
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
-# TODO(14221): Better error message!
 ! CREATE SINK output7 FROM input_values_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output7-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:collection identifier is not present
+contains:input_values_view is not a persistent collection, and cannot be exported as a sink
 
 > CREATE SINK output8 FROM input_values_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output8-view-${testdrive.seed}'

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -208,7 +208,7 @@ New York,NY,10004
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:input_kafka_dbz_view is not a persistent collection, and cannot be exported as a sink
+contains:input_kafka_dbz_view is a view, which cannot be exported as a sink
 
 > CREATE SINK output5_view FROM input_kafka_dbz_view_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output5b-view-${testdrive.seed}'
@@ -224,7 +224,7 @@ contains:input_kafka_dbz_view is not a persistent collection, and cannot be expo
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output7-view-${testdrive.seed}'
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:input_values_view is not a persistent collection, and cannot be exported as a sink
+contains:input_values_view is a view, which cannot be exported as a sink
 
 > CREATE SINK output8 FROM input_values_mview
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'output8-view-${testdrive.seed}'

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -143,7 +143,7 @@ a  b
 ! CREATE SINK not_mat_sink2 FROM data_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-view2-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:data_view is not a persistent collection, and cannot be exported as a sink
+contains:data_view is a view, which cannot be exported as a sink
 
 # Can create indexed view from unmaterialized view.
 > CREATE VIEW test5 AS
@@ -154,7 +154,7 @@ contains:data_view is not a persistent collection, and cannot be exported as a s
 ! CREATE SINK not_mat_sink2 FROM test5
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-view2-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:test5 is not a persistent collection, and cannot be exported as a sink
+contains:test5 is a view, which cannot be exported as a sink
 
 $ set-regex match=(\s\(u\d+\)|\n) replacement=
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -139,24 +139,22 @@ a  b
 3  1
 1  2
 
-# TODO(14221): Better error message!
 # Cannot create sink from unmaterialized view.
 ! CREATE SINK not_mat_sink2 FROM data_view
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-view2-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:collection identifier is not present
+contains:data_view is not a persistent collection, and cannot be exported as a sink
 
 # Can create indexed view from unmaterialized view.
 > CREATE VIEW test5 AS
   SELECT b, max(a) AS c FROM data_view GROUP BY b
 > CREATE DEFAULT INDEX ON test5
 
-# TODO(14221): Better error message!
 # or from an indexed unmaterialized view
 ! CREATE SINK not_mat_sink2 FROM test5
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-view2-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:collection identifier is not present
+contains:test5 is not a persistent collection, and cannot be exported as a sink
 
 $ set-regex match=(\s\(u\d+\)|\n) replacement=
 

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -65,20 +65,17 @@ contains:unable to publish value schema to registry in kafka sink
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialized:6875'
 contains:unable to publish value schema to registry in kafka sink
 
-# TODO(14221): Better error message!
-# Cannot create a sink from an unmaterialized view ...
 ! CREATE SINK bad_view FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:collection identifier is not present
+contains:v1 is not a persistent collection, and cannot be exported as a sink
 
-# TODO(14221): Better error message!
 # ...Even if that view is based on a materialized source
 ! CREATE SINK bad_view2 FROM v2
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   WITH (retention_ms=1000000)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:collection identifier is not present
+contains:v2 is not a persistent collection, and cannot be exported as a sink
 
 > SHOW SINKS
 name

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -68,14 +68,14 @@ contains:unable to publish value schema to registry in kafka sink
 ! CREATE SINK bad_view FROM v1
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:v1 is not a persistent collection, and cannot be exported as a sink
+contains:v1 is a view, which cannot be exported as a sink
 
 # ...Even if that view is based on a materialized source
 ! CREATE SINK bad_view2 FROM v2
   INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'snk1'
   WITH (retention_ms=1000000)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:v2 is not a persistent collection, and cannot be exported as a sink
+contains:v2 is a view, which cannot be exported as a sink
 
 > SHOW SINKS
 name


### PR DESCRIPTION
> Currently we use StorageError::IdentifierMissing when looking up the from_collection to signify that you're trying to create a sink based on something that isn't a persisted collection. That prints as "collection identifier is not present" which isn't super helpful to the user!

This PR changes that error to something hopefully more specific.

### Motivation

Known-valuable enhancement: #14221.
 
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - User-facing error messages are slightly improved.