### PR TITLE
dbt-materialize: release v1.1.3

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,15 +1,35 @@
 # dbt-materialize Changelog
 
+## 1.1.3 - 2022-08-17
+
+* Deprecate the `mz_generate_name` macro. The native Jinja function [`{
+  { this }}`]
+  (https://docs.getdbt.com/reference/dbt-jinja-functions/this) should be used
+  to reference the relation instead.
+
+  ```sql
+  {{ config(materialized='source') }}
+    CREATE SOURCE {{ this }} ...
+  ```
+
+* Fix a bug that prevented old relations from being correctly dropped on
+  re-creation.
+
+* Make custom materialization types available to dbt docs by swapping
+  `pg_catalog` with `mz_catalog` metadata.
+
+* Migrate to new `pytest` testing framework.
+
 ## 1.1.2 - 2022-06-15
 
 * Mark the adapter as not supporting query cancellation, as Materialize does not
-  support the `pg_terminate_backend` function that dbt uses to cancel
-  queries.
+  support the `pg_terminate_backend` function that dbt uses to cancel queries.
 
 ## 1.1.1 - 2022-05-04
 
-* Provide support for storing the results of a test query in a `materializedview`
-  using the [`store_failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures).
+* Provide support for storing the results of a test query in a
+  `materializedview` using the [`store_failures` config]
+  (https://docs.getdbt.com/reference/resource-configs/store_failures).
 
 ## 1.1.0 - 2022-05-02
 
@@ -18,11 +38,12 @@
 ## 1.0.5 - 2022-04-26
 
 * Deprecate support for custom index materialization.
-* Enable defining indexes when creating a `materializedview`, `view`, or `source` using the `indexes` config.
+* Enable defining indexes when creating a `materializedview`, `view`, or
+  `source` using the `indexes` config.
 
   ```sql
   {{ config(materialized='view',
-          indexes=[{'columns': ['symbol']}]) }}
+    indexes=[{'columns':['symbol']}]) }}
   ```
 
 ## 1.0.4 - 2022-03-27
@@ -32,7 +53,7 @@
 ## 1.0.3.post1 - 2022-03-16
 
 * Produce a proper error message when attempting to use an incremental
-materialization.
+  materialization.
 
 ## 1.0.3 - 2022-02-27
 
@@ -48,10 +69,10 @@ materialization.
 * Execute hooks that specify `transaction: true` ([#7675]). In particular, this
   includes hooks that are configured as a simple string.
 
-  Previously, dbt-materialize would only execute hooks that specified
-  `transaction: false`. The new behavior matches the other non-transactional dbt
-  adapters, which simply execute all hooks outside of a transaction regardless
-  of their configured `transaction` behavior.
+  Previously, `dbt-materialize` would only execute hooks that specified
+  `transaction: false`. The new behavior matches the other non-transactional
+  dbt adapters, which simply execute all hooks outside of a transaction
+  regardless of their configured `transaction` behavior.
 
 [#7675]: https://github.com/MaterializeInc/materialize/issues/7675
 
@@ -90,8 +111,8 @@ materialization.
 ## 0.20.1.post1 - 2021-08-18
 
 * **Breaking change.** Remove the `mz_create_source`, `mz_drop_source`,
-  `mz_create_sink`, `mz_drop_sink`, `mz_create_index`, and `mz_drop_index`
-  macros as they caused incorrect behavior in `dbt docs` ([#7810]).
+    `mz_create_sink`, `mz_drop_sink`, `mz_create_index`, and `mz_drop_index`
+    macros as they caused incorrect behavior in `dbt docs` ([#7810]).
 
 * Add three new custom materialization types: `source`, `index`, and `sink`.
   These replace the aforementioned macros that were removed in this release.
@@ -109,19 +130,21 @@ materialization.
 * Add the `mz_create_index` and `mz_drop_index` macros to manage the creation
   and deletion of indexes.
 
-* Add the `mz_create_sink` and `mz_drop_sink` macros to manage the creation
-  and deletion of sinks.
+* Add the `mz_create_sink` and `mz_drop_sink` macros to manage the creation and
+  deletion of sinks.
 
 ## 0.18.1.post4 - 2021-07-14
 
-* Add the `mz_create_source` and `mz_drop_source` macros to manage the
-  creation and deletion of sources, respectively.
+* Add the `mz_create_source` and `mz_drop_source` macros to manage the creation
+  and deletion of sources, respectively.
 
 ## 0.18.1.post3 - 2021-06-17
 
-* Support the `sslcert`, `sslkey`, and `sslrootcert` parameters for
-  specifying a TLS client certificate. Notably, this permits using
-  dbt-materialize with [Materialize Cloud].
+* Support the `sslcert`, `sslkey`, and `sslrootcert` parameters for specifying a
+  TLS client certificate. Notably, this permits using dbt-materialize with
+  [Materialize Cloud].
+
+[Materialize Cloud]: https://cloud.materialize.com
 
 ## 0.18.1.post2 - 2021-04-21
 
@@ -139,5 +162,3 @@ materialization.
 ## 0.18.1 - 2021-02-25
 
 Initial release.
-
-[Materialize Cloud]: https://cloud.materialize.com

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -53,7 +53,7 @@ Type               | Supported? | Details
 `view`             | YES        | Creates a [view].
 `materializedview` | YES        | Creates a [materialized view].
 `table`            | YES        | Creates a [materialized view]. (Actual table support pending [#5266].)
-`index`            | YES         | (Deprecated) Creates an index. Use the `indexes` config to create indexes on `materializedview`, `view` or `source` relations instead.
+`index`            | YES        | (Deprecated) Creates an index. Use the `indexes` config to create indexes on `materializedview`, `view` or `source` relations instead.
 `sink`             | YES        | Creates a [sink].
 `ephemeral`        | YES        | Executes queries using CTEs.
 `incremental`      | NO         | Use the `materializedview` materialization instead! dbt's incremental models are valuable because they only spend your time and money transforming your new data as it arrives. Luckily, this is exactly what Materialize's materialized views were built to do! Better yet, our materialized views will always return up-to-date results without manual or configured refreshes. For more information, check out [our documentation](https://materialize.com/docs/).
@@ -62,7 +62,7 @@ Type               | Supported? | Details
 
 Macro | Purpose
 ------|----------
-`mz_generate_name(identifier)` | Generates a fully-qualified name (including the database and schema) given an object name.
+`mz_generate_name(identifier)` | (Deprecated) Generates a fully-qualified name given an object name. Use the native Jinja function [`{{ this }}`](https://docs.getdbt.com/reference/dbt-jinja-functions/this) to reference relations instead.
 
 We provide a `materialize-dbt-utils` package with Materialize-specific implementations of dispatched macros from `dbt-utils`. To use this package in your dbt project, check the latest installation instructions in [dbt Hub](https://hub.getdbt.com/materializeinc/materialize_dbt_utils/latest/).
 

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.1.2"
+version = "1.1.3"

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -24,7 +24,7 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.1.2",
+    version="1.1.3",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Cut a new release of `dbt-materialize` while we work through blockers for the `v1.2.0` upgrade and some cloud-specific changes. 

There's at least one user waiting on the improvements in #14036, which is enough of a reason to cut a new patch!