### PR TITLE
adapter: align fast and slow path output for `EXPLAIN ... AS TEXT`

### DIFF
--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -167,10 +167,9 @@ where
         where
             Displayable<'a, T>: DisplayText<PlanRenderingContext<'a, T>>,
         {
-            if let Some(fast_path_plan) = fast_path_plan {
-                fast_path_plan.fmt_text(f, ctx)
-            } else {
-                Displayable::from(plan).fmt_text(f, ctx)
+            match fast_path_plan {
+                Some(fast_path_plan) if !ctx.config.no_fast_path => fast_path_plan.fmt_text(f, ctx),
+                _ => Displayable::from(plan).fmt_text(f, ctx),
             }
         }
 
@@ -212,54 +211,57 @@ where
     fn fmt_text(&self, f: &mut fmt::Formatter<'_>, _ctx: &mut ()) -> fmt::Result {
         let mut ctx = RenderingContext::new(Indent::default(), self.context.humanizer);
 
-        if let Some(fast_path_plan) = &self.context.fast_path_plan {
-            writeln!(f, "{}{} (fast path)", ctx.indent, GlobalId::Explain)?;
-            ctx.indented(|ctx| {
-                // if present, a RowSetFinishing is applied on top of the fast path plan
-                match &self.context.finishing {
-                    Some(finishing) => {
-                        finishing.fmt_text(f, &mut ctx.indent)?;
-                        ctx.indented(|ctx| fast_path_plan.fmt_text(f, ctx))?;
-                    }
-                    _ => {
-                        fast_path_plan.fmt_text(f, ctx)?;
-                    }
-                }
-                Ok(())
-            })?;
-        } else {
-            // render plans
-            for (no, (id, plan)) in self.plans.iter().enumerate() {
-                let mut ctx = PlanRenderingContext::new(
-                    ctx.indent.clone(),
-                    ctx.humanizer,
-                    plan.annotations.clone(),
-                    self.context.config,
-                );
-
-                writeln!(f, "{}{}", ctx.indent, id)?;
+        match &self.context.fast_path_plan {
+            Some(fast_path_plan) if !self.context.config.no_fast_path => {
+                writeln!(f, "{}{} (fast path)", ctx.indent, GlobalId::Explain)?;
                 ctx.indented(|ctx| {
+                    // if present, a RowSetFinishing is applied on top of the fast path plan
                     match &self.context.finishing {
-                        // if present, a RowSetFinishing always applies to the first rendered plan
-                        Some(finishing) if no == 0 => {
+                        Some(finishing) => {
                             finishing.fmt_text(f, &mut ctx.indent)?;
-                            ctx.indented(|ctx| Displayable(plan.plan).fmt_text(f, ctx))?;
+                            ctx.indented(|ctx| fast_path_plan.fmt_text(f, ctx))?;
                         }
-                        // all other plans are rendered without a RowSetFinishing
                         _ => {
-                            Displayable(plan.plan).fmt_text(f, ctx)?;
+                            fast_path_plan.fmt_text(f, ctx)?;
                         }
                     }
                     Ok(())
                 })?;
             }
-            if !self.sources.is_empty() {
-                // render one blank line between the plans and sources
-                writeln!(f, "")?;
-                // render sources
-                for (id, operator) in self.sources.iter() {
-                    writeln!(f, "{}Source {}", ctx.indent, id)?;
-                    ctx.indented(|ctx| Displayable(*operator).fmt_text(f, ctx))?;
+            _ => {
+                // render plans
+                for (no, (id, plan)) in self.plans.iter().enumerate() {
+                    let mut ctx = PlanRenderingContext::new(
+                        ctx.indent.clone(),
+                        ctx.humanizer,
+                        plan.annotations.clone(),
+                        self.context.config,
+                    );
+
+                    writeln!(f, "{}{}", ctx.indent, id)?;
+                    ctx.indented(|ctx| {
+                        match &self.context.finishing {
+                            // if present, a RowSetFinishing always applies to the first rendered plan
+                            Some(finishing) if no == 0 => {
+                                finishing.fmt_text(f, &mut ctx.indent)?;
+                                ctx.indented(|ctx| Displayable(plan.plan).fmt_text(f, ctx))?;
+                            }
+                            // all other plans are rendered without a RowSetFinishing
+                            _ => {
+                                Displayable(plan.plan).fmt_text(f, ctx)?;
+                            }
+                        }
+                        Ok(())
+                    })?;
+                }
+                if !self.sources.is_empty() {
+                    // render one blank line between the plans and sources
+                    writeln!(f, "")?;
+                    // render sources
+                    for (id, operator) in self.sources.iter() {
+                        writeln!(f, "{}Source {}", ctx.indent, id)?;
+                        ctx.indented(|ctx| Displayable(*operator).fmt_text(f, ctx))?;
+                    }
                 }
             }
         }

--- a/src/ore/src/str.rs
+++ b/src/ore/src/str.rs
@@ -154,6 +154,7 @@ where
 pub struct Indent {
     unit: String,
     buff: String,
+    mark: Vec<usize>,
 }
 
 impl Indent {
@@ -163,6 +164,7 @@ impl Indent {
         Indent {
             unit: std::iter::repeat(unit).take(step).collect::<String>(),
             buff: String::with_capacity(unit.len_utf8()),
+            mark: vec![],
         }
     }
 
@@ -176,6 +178,21 @@ impl Indent {
         let tail = rhs.saturating_mul(self.unit.len());
         let head = self.buff.len().saturating_sub(tail);
         self.buff.truncate(head);
+    }
+
+    /// Remember the current state.
+    pub fn set(&mut self) {
+        self.mark.push(self.buff.len());
+    }
+
+    /// Reset `buff` to the last marked state.
+    pub fn reset(&mut self) {
+        if let Some(len) = self.mark.pop() {
+            while self.buff.len() < len {
+                self.buff += &self.unit;
+            }
+            self.buff.truncate(len);
+        }
     }
 }
 

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -363,6 +363,8 @@ pub struct ExplainConfig {
     pub join_impls: bool,
     /// Show the `non_negative` in the explanation if it is supported by the backing IR.
     pub non_negative: bool,
+    /// Show the slow path plan even if a fast path plan was created. Useful for debugging.
+    pub no_fast_path: bool,
     /// Don't normalize plans before explaining them.
     pub raw_plans: bool,
     /// Disable virtual syntax in the explanation.
@@ -393,6 +395,7 @@ impl TryFrom<HashSet<String>> for ExplainConfig {
         let result = ExplainConfig {
             join_impls: config_flags.remove("join_impls"),
             non_negative: config_flags.remove("non_negative"),
+            no_fast_path: config_flags.remove("no_fast_path"),
             raw_plans: config_flags.remove("raw_plans"),
             raw_syntax: config_flags.remove("raw_syntax"),
             subtree_size: config_flags.remove("subtree_size"),
@@ -753,6 +756,7 @@ mod tests {
         let config = ExplainConfig {
             join_impls: false,
             non_negative: false,
+            no_fast_path: false,
             raw_plans: false,
             raw_syntax: false,
             subtree_size: false,

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -50,7 +50,8 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
 SELECT 1 / 0
 ----
-Error "division by zero"
+Explained Query (fast path)
+  Error "division by zero"
 
 EOF
 
@@ -59,9 +60,10 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
 (SELECT 1, 2) UNION ALL (SELECT 1, 2) UNION ALL (SELECT 3, 4)
 ----
-Constant
-  - ((1, 2) x 2)
-  - (3, 4)
+Explained Query (fast path)
+  Constant
+    - ((1, 2) x 2)
+    - (3, 4)
 
 EOF
 
@@ -70,10 +72,11 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
 SELECT 1, a + b as c FROM t WHERE a > 0 and b < 0 and a + b > 0
 ----
-Project (#3, #2)
-  Filter (#0 > 0) AND (#1 < 0) AND (#2 > 0)
-    Map ((#0 + #1), 1)
-      ReadExistingIndex materialize.public.t_a_idx
+Explained Query (fast path)
+  Project (#3, #2)
+    Filter (#0 > 0) AND (#1 < 0) AND (#2 > 0)
+      Map ((#0 + #1), 1)
+        ReadExistingIndex materialize.public.t_a_idx
 
 Used Indexes:
   - materialize.public.t_a_idx
@@ -177,7 +180,9 @@ query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
-ReadExistingIndex materialize.public.t_a_idx
+Explained Query (fast path)
+  Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
+    ReadExistingIndex materialize.public.t_a_idx
 
 Used Indexes:
   - materialize.public.t_a_idx

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -65,7 +65,22 @@ Constant
 
 EOF
 
-# Test basic linear chains.
+# Test basic linear chains (fast path).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
+SELECT 1, a + b as c FROM t WHERE a > 0 and b < 0 and a + b > 0
+----
+Project (#3, #2)
+  Filter (#0 > 0) AND (#1 < 0) AND (#2 > 0)
+    Map ((#0 + #1), 1)
+      ReadExistingIndex materialize.public.t_a_idx
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Test basic linear chains (slow path).
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(non_negative) AS TEXT FOR
 SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0


### PR DESCRIPTION
Addresses some issues with fast path rendering on the new `EXPLAIN ... AS TEXT` code path.

### Motivation

  * This PR fixes a previously unreported bug.

The fast path output should include a `Finish` operator if present and it should be rendered identically to a slow path. I've added the test to cover that (grep "# Test basic linear chains (fast path)." and compare the output to the next test).

### Tips for reviewer

- 075576ca6 adds `set` and `reset` to `Indent` so one can memoize the indentation to some level and then reset back to it (I've seen this pattern a number of times now).
- decef1b05 fixes some `TODO` comment in `DisplayText` for `FastPathPlan` and employs the above methods.
- 90a77e102 fixes some issues in the fast path rendering for `EXPLAIN ... AS TEXT` outputs (the main point for doing this PR). See the diff of the `*.slt` files in this commit for an overview of what changed.
- ca58a623c implements `ExplainConfig::no_fast_path` as a config option (as discussed offline, I find it useful to have this in order to explore the slow path for some simple plans, as opposed to putting in a `GROUP BY` or something similar to the query).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes since the new `EXPLAIN ... AS TEXT` code path is not public yet.
