### PR TITLE
doc/user: fix documentation logo link

### DIFF
--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -24,7 +24,7 @@
 </nav>
 
 <header class="flex_wrap">
-  <a href="/" class="primary gradient_text">
+  <a href="{{.Site.BaseURL}}" class="primary gradient_text">
     Materialize Documentation
   </a>
   <div class="flex_grow relative search-wrap">


### PR DESCRIPTION
Fix the "Materialize Documentation" link so that it always redirects to
the root of the docs, even in previews.

Fixes MaterializeInc/www#39.
