### PR TITLE
persist: shoring up missing blobs from FileBlob

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -490,7 +490,6 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                 .await
             {
                 Ok(()) => (),
-                Err(err) if err.is_cancelled() => (),
                 Err(err) => panic!("part upload task failed: {}", err),
             };
             self.finished_parts.push(key);
@@ -503,7 +502,6 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         for (key, handle) in self.writing_parts {
             let () = match handle.await {
                 Ok(()) => (),
-                Err(err) if err.is_cancelled() => (),
                 Err(err) => panic!("part upload task failed: {}", err),
             };
             keys.push(key);

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -490,6 +490,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
                 .await
             {
                 Ok(()) => (),
+                Err(err) if err.is_cancelled() => (),
                 Err(err) => panic!("part upload task failed: {}", err),
             };
             self.finished_parts.push(key);
@@ -502,6 +503,7 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         for (key, handle) in self.writing_parts {
             let () = match handle.await {
                 Ok(()) => (),
+                Err(err) if err.is_cancelled() => (),
                 Err(err) => panic!("part upload task failed: {}", err),
             };
             keys.push(key);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Since [replacing our missing blob retry loop with a panic](https://github.com/MaterializeInc/materialize/pull/14254), we've started to see CI fail sporadically on missing blobs. After playing with this today, the issue seems to be the missing `fsync` on the blob directory after a write. 

~~Additionally while reading through the code to find any possibility of committing a write for a blob that does not exist, I changed our `Batch` to panic if one of its batch part upload tasks is cancelled, rather than the potential of it continuing to `compare_and_append` when one of its batch parts did not make it to Blob.~~ Edit: this one is harder to do, can be a separate PR


### Motivation

  * This PR fixes a recognized bug.

I believe this will fix https://github.com/MaterializeInc/materialize/issues/14275. I still saw `unexpected missing blob` errors, which might be a result of a shutdown race between a persist handle and the temp directory being removed underneath it. When I saw this, it was only at shutdown and the SLT tests were still passing.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
