### PR TITLE
stash: switch serialization to JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,6 +4055,8 @@ dependencies = [
  "postgres-openssl",
  "rand",
  "rusqlite",
+ "serde",
+ "serde_json",
  "tempfile",
  "timely",
  "tokio",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::bail;
-use chrono::{DateTime, TimeZone, Utc};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -2141,13 +2140,11 @@ impl<S: Append> Catalog<S> {
         }
         let audit_logs = catalog.storage().await.load_audit_log().await?;
         for event in audit_logs {
-            let event = VersionedEvent::deserialize(&event).unwrap();
             builtin_table_updates.push(catalog.state.pack_audit_log_update(&event)?);
         }
 
         let storage_usage_events = catalog.storage().await.storage_usage().await?;
         for event in storage_usage_events {
-            let event = VersionedStorageUsage::deserialize(&event).unwrap();
             builtin_table_updates.push(catalog.state.pack_storage_usage_update(&event)?);
         }
 
@@ -2484,7 +2481,7 @@ impl<S: Append> Catalog<S> {
         for (id, schema_id, name) in migration_metadata.user_create_ops.drain(..) {
             let item = self.get_entry(&id).item();
             let serialized_item = self.serialize_item(item);
-            tx.insert_item(id, schema_id, &name, &serialized_item)?;
+            tx.insert_item(id, schema_id, &name, serialized_item)?;
         }
         tx.update_system_object_mappings(
             &migration_metadata
@@ -3440,7 +3437,7 @@ impl<S: Append> Catalog<S> {
                         }
                         let schema_id = name.qualifiers.schema_spec.clone().into();
                         let serialized_item = self.serialize_item(&item);
-                        tx.insert_item(id, schema_id, &name.item, &serialized_item)?;
+                        tx.insert_item(id, schema_id, &name.item, serialized_item)?;
                     }
 
                     if Self::should_audit_log_item(&item) {
@@ -3999,58 +3996,47 @@ impl<S: Append> Catalog<S> {
         Ok(self.storage().await.confirm_leadership().await?)
     }
 
-    fn serialize_item(&self, item: &CatalogItem) -> Vec<u8> {
-        let item = match item {
+    fn serialize_item(&self, item: &CatalogItem) -> SerializedCatalogItem {
+        match item {
             CatalogItem::Table(table) => SerializedCatalogItem::V1 {
                 create_sql: table.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Log(_) => unreachable!("builtin logs cannot be serialized"),
             CatalogItem::Source(source) => SerializedCatalogItem::V1 {
                 create_sql: source.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::View(view) => SerializedCatalogItem::V1 {
                 create_sql: view.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::MaterializedView(mview) => SerializedCatalogItem::V1 {
                 create_sql: mview.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Index(index) => SerializedCatalogItem::V1 {
                 create_sql: index.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Sink(sink) => SerializedCatalogItem::V1 {
                 create_sql: sink.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Type(typ) => SerializedCatalogItem::V1 {
                 create_sql: typ.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Secret(secret) => SerializedCatalogItem::V1 {
                 create_sql: secret.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Connection(connection) => SerializedCatalogItem::V1 {
                 create_sql: connection.create_sql.clone(),
-                eval_env: None,
             },
             CatalogItem::Func(_) => unreachable!("cannot serialize functions yet"),
             CatalogItem::StorageCollection(_) => {
                 unreachable!("builtin storage collections cannot be serialized")
             }
-        };
-        serde_json::to_vec(&item).expect("catalog serialization cannot fail")
+        }
     }
 
-    fn deserialize_item(&self, bytes: Vec<u8>) -> Result<CatalogItem, anyhow::Error> {
-        let SerializedCatalogItem::V1 {
-            create_sql,
-            eval_env: _,
-        } = serde_json::from_slice(&bytes)?;
+    fn deserialize_item(
+        &self,
+        SerializedCatalogItem::V1 { create_sql }: SerializedCatalogItem,
+    ) -> Result<CatalogItem, anyhow::Error> {
         self.parse_item(create_sql, Some(&PlanContext::zero()))
     }
 
@@ -4374,42 +4360,14 @@ pub enum Op {
     ResetAllSystemConfiguration {},
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-enum SerializedCatalogItem {
-    V1 {
-        create_sql: String,
-        // The name "eval_env" is historical.
-        eval_env: Option<SerializedPlanContext>,
-    },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct SerializedPlanContext {
-    pub logical_time: Option<u64>,
-    pub wall_time: Option<DateTime<Utc>>,
-}
-
-impl From<SerializedPlanContext> for PlanContext {
-    fn from(cx: SerializedPlanContext) -> PlanContext {
-        PlanContext {
-            wall_time: cx.wall_time.unwrap_or_else(|| Utc.timestamp(0, 0)),
-            qgm_optimizations: false,
-        }
-    }
-}
-
-impl From<PlanContext> for SerializedPlanContext {
-    fn from(cx: PlanContext) -> SerializedPlanContext {
-        SerializedPlanContext {
-            logical_time: None,
-            wall_time: Some(cx.wall_time),
-        }
-    }
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SerializedCatalogItem {
+    V1 { create_sql: String },
 }
 
 /// Serialized (stored alongside the replica) logging configuration of
 /// a replica. Serialized variant of ConcreteComputeInstanceReplicaLogging.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SerializedComputeInstanceReplicaLogging {
     /// Instantiate default logging configuration upon system start.
     /// To configure a replica without logging, ConcreteViews(vec![],vec![]) should be used.
@@ -4430,7 +4388,7 @@ impl From<ConcreteComputeInstanceReplicaLogging> for SerializedComputeInstanceRe
 /// A [`mz_sql::plan::ComputeInstanceReplicaConfig`] that is serialized as JSON and persisted
 /// to the catalog stash. This is a separate type to allow us to evolve the
 /// on-disk format independently from the SQL layer.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct SerializedComputeInstanceReplicaConfig {
     pub persisted_logs: SerializedComputeInstanceReplicaLogging,
     pub location: SerializedComputeInstanceReplicaLocation,
@@ -4450,7 +4408,7 @@ impl From<ConcreteComputeInstanceReplicaConfig> for SerializedComputeInstanceRep
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SerializedComputeInstanceReplicaLocation {
     Remote {
         addrs: BTreeSet<String>,

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use mz_ore::now::EpochMillis;
 
 /// New version variants should be added if fields need to be added, changed, or removed.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub enum VersionedEvent {
     V1(EventV1),
 }
@@ -74,7 +74,7 @@ impl VersionedEvent {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum EventType {
     Create,
@@ -84,7 +84,7 @@ pub enum EventType {
 
 serde_plain::derive_display_from_serialize!(EventType);
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ObjectType {
     Cluster,
@@ -98,7 +98,7 @@ pub enum ObjectType {
 
 serde_plain::derive_display_from_serialize!(ObjectType);
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub enum EventDetails {
     CreateComputeInstanceReplicaV1(CreateComputeInstanceReplicaV1),
     DropComputeInstanceReplicaV1(DropComputeInstanceReplicaV1),
@@ -107,31 +107,31 @@ pub enum EventDetails {
     RenameItemV1(RenameItemV1),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct FullNameV1 {
     pub database: String,
     pub schema: String,
     pub item: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct NameV1 {
     pub name: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct RenameItemV1 {
     pub previous_name: FullNameV1,
     pub new_name: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct DropComputeInstanceReplicaV1 {
     pub cluster_name: String,
     pub replica_name: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct CreateComputeInstanceReplicaV1 {
     pub cluster_name: String,
     pub replica_name: String,
@@ -154,7 +154,7 @@ impl EventDetails {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct EventV1 {
     pub id: u64,
     pub event_type: EventType,
@@ -221,12 +221,12 @@ fn test_audit_log() -> Result<(), anyhow::Error> {
 ///
 /// This type is persisted in the catalog across restarts, so any updates to the
 /// schema will require a new version.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub enum VersionedStorageUsage {
     V1(StorageUsageV1),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct StorageUsageV1 {
     pub id: u64,
     pub object_id: Option<String>,

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -285,7 +285,7 @@ pub static DEFAULT_LOG_VARIANTS: Lazy<Vec<LogVariant>> = Lazy::new(|| {
 
 /// Create a VIEW over the postfixed introspection sources. These views are created and torn down
 /// with replicas.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd)]
 pub enum LogView {
     MzArrangementSharing,
     MzArrangementSizes,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -174,7 +174,7 @@ pub struct CreateComputeInstanceReplicaPlan {
 }
 
 /// Configuration of introspection for a compute instance.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
 pub struct ComputeInstanceIntrospectionConfig {
     /// Whether to introspect the introspection.
     pub debugging: bool,

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -23,9 +23,11 @@ mz-persist-types = { path = "../persist-types" }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 rand = "0.8.5"
 rusqlite = { version = "0.28.0", features = ["bundled"] }
+serde = "1.0.140"
+serde_json = "1.0.82"
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false }
 tokio = "1.19.2"
-tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = [ "with-serde_json-1" ] }
 tracing = "0.1.36"
 
 [dev-dependencies]

--- a/src/stash/tests/stash.rs
+++ b/src/stash/tests/stash.rs
@@ -48,6 +48,8 @@ async fn test_stash_sqlite() -> Result<(), anyhow::Error> {
 
 #[tokio::test]
 async fn test_stash_postgres() -> Result<(), anyhow::Error> {
+    mz_ore::test::init_logging();
+
     let tls = mz_postgres_util::make_tls(&Config::new()).unwrap();
 
     {


### PR DESCRIPTION
This makes introspection in the backing cockroach databases possible with merely a SQL connection. This PR contains **no migration** code and must not be merged until there is migration code (which would be added as another commit into this PR) or we have another flag day where we start all instances over from scratch (in which case this PR can be merged as is).

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/14264

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a