### PR TITLE
cloudtest: Move to the default CI pipeline

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -18,7 +18,6 @@ steps:
         key: tests
         options:
           - { value: coverage }
-          - { value: cloudtest }
           - { value: kafka-matrix }
           - { value: kafka-multi-broker }
           - { value: redpanda-testdrive }
@@ -62,13 +61,6 @@ steps:
       queue: linux
 
   - wait: ~
-
-  - id: cloudtest
-    label: "Cloudtest"
-    artifact_paths: junit_cloudtest_*.xml
-    plugins:
-      - ./ci/plugins/cloudtest:
-          args: ["test/cloudtest/"]
 
   - id: feature-benchmark-single-node
     label: "Feature benchmark (single node)"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -531,6 +531,14 @@ steps:
           composition: platform-checks
           args: [--scenario=RestartSourcePostgres, --check=DebeziumPostgres]
 
+  - id: cloudtest
+    label: "Cloudtest"
+    depends_on: build-x86_64
+    artifact_paths: junit_cloudtest_*.xml
+    plugins:
+      - ./ci/plugins/cloudtest:
+          args: ["test/cloudtest/"]
+
   - id: lang-csharp
     label: ":csharp: tests"
     depends_on: build-x86_64


### PR DESCRIPTION
The cloudtest job is short, stable and provides value to various
projects currently in progress such as ALTER SOURCE. So, move it
to the default CI pipline so that it runs for every push.
### Motivation

  * This PR adds a feature that has not yet been specified.
The cloudtest CI job was only running in Nightly even though there is a lot of new development in the area it covers.