### PR TITLE
limits test: Tone down the 'instance size' workflow

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1218,7 +1218,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
         "--clusters",
         type=int,
         metavar="N",
-        default=16,
+        default=8,
         help="set the number of clusters to create",
     )
     parser.add_argument(


### PR DESCRIPTION
Creating 16 clusters at a time was problematic for many reasons:
- docker-compose had trouble managing that many containers
- the OOM killer was killing either cockroach or environmentd
- too many TCP ports are being opened

So, tone down the workflow to 8 clusters and see if this will make
it more stable.


### Motivation

  * This PR fixes a previously unreported bug.
The "Instance size" Nightly CI job was failing.