### PR TITLE
sql: guard fallible cast expression

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1691,16 +1691,27 @@ pub fn plan_create_views(
                     let data_type = scx.resolve_type(ty)?;
                     projection.push(SelectItem::Expr {
                         expr: Expr::Cast {
-                            expr: Box::new(Expr::Subscript {
-                                expr: Box::new(Expr::Identifier(vec![Ident::new("row_data")])),
-                                positions: vec![SubscriptPosition {
-                                    start: Some(Expr::Value(Value::Number(
-                                        // LIST is one based
-                                        (i + 1).to_string(),
-                                    ))),
-                                    end: None,
-                                    explicit_slice: false,
+                            expr: Box::new(Expr::Case {
+                                operand: None,
+                                conditions: vec![Expr::Op {
+                                    op: Op::bare("="),
+                                    expr1: Box::new(Expr::Identifier(vec![Ident::new("oid")])),
+                                    expr2: Some(Box::new(Expr::Value(Value::Number(
+                                        table_desc.oid.to_string(),
+                                    )))),
                                 }],
+                                results: vec![Expr::Subscript {
+                                    expr: Box::new(Expr::Identifier(vec![Ident::new("row_data")])),
+                                    positions: vec![SubscriptPosition {
+                                        start: Some(Expr::Value(Value::Number(
+                                            // LIST is one based
+                                            (i + 1).to_string(),
+                                        ))),
+                                        end: None,
+                                        explicit_slice: false,
+                                    }],
+                                }],
+                                else_result: Some(Box::new(Expr::null())),
                             }),
                             data_type,
                         },


### PR DESCRIPTION
SQL doesn't guarantee the order of execution of expressions in the
SELECT part of query and the WHERE part of a query.

It can happen that the optimizer chooses to run the SELECT expressions
*before* applying the WHERE clause, even if that particular row would be
filtered out in the opposite case. This has the bad sideeffect of an
error being produced from a row that would have participated in the
output.

This PR changes the SELECT project of postgres CREATE VIEWS such that it
only evaluates the CAST expressions if the WHERE condition is true by
wrapping each CAST expression in a CASE statement.

### Checklist

- [χ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):