### PR TITLE
sql: Fix overflow when negating min ints

### DIFF
--- a/src/expr/src/scalar/func/impls/int16.rs
+++ b/src/expr/src/scalar/func/impls/int16.rs
@@ -20,8 +20,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "-"]
-    fn neg_int16(a: i16) -> i16 {
-        -a
+    fn neg_int16(a: i16) -> Result<i16, EvalError> {
+        a.checked_neg().ok_or(EvalError::Int16OutOfRange)
     }
 );
 
@@ -34,8 +34,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "abs"]
-    fn abs_int16(a: i16) -> i16 {
-        a.abs()
+    fn abs_int16(a: i16) -> Result<i16, EvalError> {
+        a.checked_abs().ok_or(EvalError::Int16OutOfRange)
     }
 );
 

--- a/src/expr/src/scalar/func/impls/int32.rs
+++ b/src/expr/src/scalar/func/impls/int32.rs
@@ -21,8 +21,8 @@ use crate::EvalError;
 
 sqlfunc!(
     #[sqlname = "-"]
-    fn neg_int32(a: i32) -> i32 {
-        -a
+    fn neg_int32(a: i32) -> Result<i32, EvalError> {
+        a.checked_neg().ok_or(EvalError::Int32OutOfRange)
     }
 );
 
@@ -35,8 +35,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "abs"]
-    fn abs_int32(a: i32) -> i32 {
-        a.abs()
+    fn abs_int32(a: i32) -> Result<i32, EvalError> {
+        a.checked_abs().ok_or(EvalError::Int32OutOfRange)
     }
 );
 

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -22,8 +22,8 @@ use crate::EvalError;
 sqlfunc!(
     #[sqlname = "-"]
     #[preserves_uniqueness = true]
-    fn neg_int64(a: i64) -> i64 {
-        -a
+    fn neg_int64(a: i64) -> Result<i64, EvalError> {
+        a.checked_neg().ok_or(EvalError::Int64OutOfRange)
     }
 );
 
@@ -37,8 +37,8 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "abs"]
-    fn abs_int64(a: i64) -> i64 {
-        a.abs()
+    fn abs_int64(a: i64) -> Result<i64, EvalError> {
+        a.checked_abs().ok_or(EvalError::Int64OutOfRange)
     }
 );
 

--- a/test/sqllogictest/arithmetic.slt
+++ b/test/sqllogictest/arithmetic.slt
@@ -1130,3 +1130,23 @@ SELECT
    ~1 - 2  as def_sub, ~(1 - 2)  as l_prec_sub, (~1) - 2  as h_prec_sub
 ----
 -3 -3 -1 0 0 -4
+
+# overflow for negating minimum integers
+
+query error smallint out of range
+SELECT - '-32768'::int2
+
+query error smallint out of range
+SELECT  ABS('-32768'::int2)
+
+query error integer out of range
+SELECT - '-2147483648'::int4
+
+query error integer out of range
+SELECT  ABS('-2147483648'::int4)
+
+query error bigint out of range
+SELECT - '-9223372036854775808'::int8
+
+query error bigint out of range
+SELECT  ABS('-9223372036854775808'::int8)


### PR DESCRIPTION
This commit fixes a panic when trying to negate the minimum value of
some integer type. Integer types are not symmetric with respect to
their positive and negative ranges. There is one more negative number
than positive numbers. Therefore, negating the minimum value of an
integer type will fail.

Fixes #14291

### Motivation
This PR fixes a recognized bug.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
