### PR TITLE
coord: ensure secrets' bytes can be cast to strings

### DIFF
--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -181,3 +181,7 @@ CREATE SECRET to_be_dropped.secret3 as 'text'
 
 statement OK
 DROP SCHEMA to_be_dropped CASCADE
+
+# Secret validation
+statement error secret value must be valid UTF-8
+CREATE SECRET invalid_cert AS '\x80';


### PR DESCRIPTION
Secrets' bytes weren't being validated before passing through to storage; now they are.

### Motivation

This PR fixes a recognized bug. Fixes #14281

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Require values used in `SECRET`s to be convertible to UTF-8 strings.
