### PR TITLE
sql: deprecate consistency_topic option for sinks

### DIFF
--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -67,7 +67,6 @@ Field                | Value type | Description
 `partition_count`    | `int`      | Set the sink Kafka topic's partition count. This defaults to -1 (use the broker default).
 `replication_factor` | `int`      | Set the sink Kafka topic's replication factor. This defaults to -1 (use the broker default).
 `reuse_topic`        | `bool`     | Use the existing Kafka topic after Materialize restarts, instead of creating a new one. The default is false. See [Enabling topic reuse after restart](/sql/create-sink/#exactly-once-sinks-with-topic-reuse-after-restart) for details.
-`consistency_topic`  | `text`     | This option is only available to support backwards-compatibility. Please use the new [`CONSISTENCY` syntax](/sql/create-sink/#sink_kafka_connector) to define a consistency topic for the sink.
 `security_protocol`  | `text`     | Use [`ssl`](#authentication) or, for [Kerberos](#authentication), `sasl_plaintext`, `sasl-scram-sha-256`, or `sasl-sha-512` to connect to the Kafka cluster.
 `acks`               | `text`     | Sets the number of Kafka replicas that must acknowledge Materialize writes. Accepts values [-1,1000]. `-1` (the default) specifies all replicas.
 `retention_ms`       | `long`     | Sets the maximum time Kafka will retain a log.  Accepts values [-1, ...]. `-1` specifics no time limit.  If not set, uses the broker default.

--- a/src/billing-demo/src/bin/billing-demo/mz.rs
+++ b/src/billing-demo/src/bin/billing-demo/mz.rs
@@ -69,7 +69,8 @@ pub async fn create_kafka_sink(
 
     let query = format!(
             "CREATE SINK {sink} FROM billing_monthly_statement INTO KAFKA CONNECTION {sink}_kafka_conn TOPIC '{topic}' \
-             WITH (consistency_topic = '{topic}-consistency') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '{schema_registry}'",
+             CONSISTENCY (TOPIC '{topic}-consistency' )
+             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '{schema_registry}'",
              sink = sink_name,
              topic = sink_topic_name,
              schema_registry = schema_registry_url

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -114,7 +114,7 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK non_keyed_sink FROM input
   INTO KAFKA CONNECTION kafka_conn TOPIC 'non-keyed-sink'
-  WITH (consistency_topic = 'non-keyed-sink-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'non-keyed-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE VIEW max_view AS SELECT a, MAX(b) as b FROM input GROUP BY a
@@ -123,22 +123,22 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK non_keyed_sink_of_keyed_relation FROM input
   INTO KAFKA CONNECTION kafka_conn TOPIC 'non-keyed-sink-of-keyed-relation'
-  WITH (consistency_topic = 'non-keyed-sink-of-keyed-relation-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'non-keyed-sink-of-keyed-relation-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK keyed_sink FROM input
   INTO KAFKA CONNECTION kafka_conn TOPIC 'keyed-sink' KEY (a)
-  WITH (consistency_topic = 'keyed-sink-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'keyed-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK keyed_sink_of_keyed_relation FROM input
   INTO KAFKA CONNECTION kafka_conn TOPIC 'keyed-sink-of-keyed-relation' KEY (b)
-  WITH (consistency_topic = 'keyed-sink-of-keyed-relation-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'keyed-sink-of-keyed-relation-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 > CREATE SINK multi_keyed_sink FROM input
   INTO KAFKA CONNECTION kafka_conn TOPIC 'multi-keyed-sink' KEY (b, a)
-  WITH (consistency_topic = 'multi-keyed-sink-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'multi-keyed-sink-consistency') FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-ingest format=avro topic=input schema=${schema}
@@ -173,14 +173,6 @@ $ kafka-verify format=avro sink=materialize.public.non_keyed_sink sort-messages=
 $ kafka-verify format=avro sink=materialize.public.non_keyed_sink sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
 
-$ kafka-verify format=avro sink=materialize.public.non_keyed_sink consistency=debezium
-{"id": "1", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "1", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "non-keyed-sink"}]}}
-{"id": "2", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "2", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "non-keyed-sink"}]}}
-{"id": "3", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "3", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "non-keyed-sink"}]}}
-
 # Again, compare split by transaction. See comment just above.
 
 $ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation sort-messages=true
@@ -193,14 +185,6 @@ $ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relat
 
 $ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
-
-$ kafka-verify format=avro sink=materialize.public.non_keyed_sink_of_keyed_relation consistency=debezium
-{"id": "1", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "1", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "non-keyed-sink-of-keyed-relation"}]}}}
-{"id": "2", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "2", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "non-keyed-sink-of-keyed-relation"}]}}}
-{"id": "3", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "3", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "non-keyed-sink-of-keyed-relation"}]}}}
 
 # Again, compare split by transaction. See comment just above.
 
@@ -215,14 +199,6 @@ $ kafka-verify format=avro sink=materialize.public.keyed_sink sort-messages=true
 $ kafka-verify format=avro sink=materialize.public.keyed_sink sort-messages=true
 {"a": 1} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
 
-$ kafka-verify format=avro sink=materialize.public.keyed_sink consistency=debezium
-{"id": "1", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "1", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "keyed-sink"}]}}}
-{"id": "2", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "2", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "keyed-sink"}]}}}
-{"id": "3", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "3", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "keyed-sink"}]}}}
-
 # Again, compare split by transaction. See comment just above.
 
 $ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation sort-messages=true
@@ -236,14 +212,6 @@ $ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation 
 $ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation sort-messages=true
 {"b": 7} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
 
-$ kafka-verify format=avro sink=materialize.public.keyed_sink_of_keyed_relation consistency=debezium
-{"id": "1", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "1", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "keyed-sink-of-keyed-relation"}]}}}
-{"id": "2", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "2", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "keyed-sink-of-keyed-relation"}]}}}
-{"id": "3", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "3", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "keyed-sink-of-keyed-relation"}]}}}
-
 # Again, compare split by transaction. See comment just above.
 
 $ kafka-verify format=avro sink=materialize.public.multi_keyed_sink sort-messages=true
@@ -256,11 +224,3 @@ $ kafka-verify format=avro sink=materialize.public.multi_keyed_sink sort-message
 
 $ kafka-verify format=avro sink=materialize.public.multi_keyed_sink sort-messages=true
 {"b": 7, "a": 1} {"before": null, "after": {"row": {"a": 1, "b": 7}}, "transaction": {"id": "3"}}
-
-$ kafka-verify format=avro sink=materialize.public.multi_keyed_sink consistency=debezium
-{"id": "1", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "1", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "multi-keyed-sink"}]}}}
-{"id": "2", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "2", "status": "END", "event_count": {"long": 2}, "data_collections": {"array": [{"event_count": 2, "data_collection": "multi-keyed-sink"}]}}}
-{"id": "3", "status": "BEGIN", "event_count": null, "data_collections": null}
-{"id": "3", "status": "END", "event_count": {"long": 1}, "data_collections": {"array": [{"event_count": 1, "data_collection": "multi-keyed-sink"}]}}}

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -144,14 +144,16 @@ $ kafka-create-topic topic=input
 
 > CREATE SINK input_sink FROM input_keyed
   INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (a)
-  WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'input-sink-consistency')
+  FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 # requesting to key by (a, b) is fine when (a) is a unique key
 
 > CREATE SINK input_sink_multiple_keys FROM input_keyed
   INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (b, a)
-  WITH (consistency_topic = 'input-sink-consistency') FORMAT AVRO
+  CONSISTENCY (TOPIC 'input-sink-consistency')
+  FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 
 $ kafka-ingest format=avro topic=input schema=${schema}
@@ -185,14 +187,6 @@ $ kafka-verify format=avro sink=materialize.public.input_sink sort-messages=true
 
 $ kafka-verify format=avro sink=materialize.public.input_sink sort-messages=true
 {"a": 1} {"a": 1, "b": 7, "transaction": {"id": "3"}}
-
-$ kafka-verify format=avro sink=materialize.public.input_sink consistency=debezium
-{"status":"BEGIN","id":"1","event_count":null,"data_collections":null}
-{"status":"END","id":"1","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "input-sink"}]}}
-{"status":"BEGIN","id":"2","event_count":null,"data_collections":null}
-{"status":"END","id":"2","event_count":{"long": 2},"data_collections":{"array": [{"event_count": 2, "data_collection": "input-sink"}]}}
-{"status":"BEGIN","id":"3","event_count":null,"data_collections":null}
-{"status":"END","id":"3","event_count":{"long": 1},"data_collections":{"array": [{"event_count": 1, "data_collection": "input-sink"}]}}
 
 # Again, compare split by transaction. See comment just above.
 
@@ -286,13 +280,13 @@ $ kafka-create-topic topic=non-keyed-input
 
 ! CREATE SINK invalid_key FROM input
   INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (a)
-  WITH (consistency_topic = true) FORMAT AVRO
+  FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 contains:Invalid upsert key: (a), there are no valid keys
 
 ! CREATE SINK another_invalid_key FROM input_keyed
   INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (b)
-  WITH (consistency_topic = true) FORMAT AVRO
+  FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 contains:Invalid upsert key: (b), valid keys are: (a)
 
@@ -300,13 +294,13 @@ contains:Invalid upsert key: (b), valid keys are: (a)
 
 ! CREATE SINK invalid_sub_key FROM input_keyed_ab
   INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (a)
-  WITH (consistency_topic = true) FORMAT AVRO
+  FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 contains:Invalid upsert key: (a), valid keys are: (a, b)
 
 ! CREATE SINK another_invalid_sub_key FROM input_keyed_ab
   INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (b)
-  WITH (consistency_topic = true) FORMAT AVRO
+  FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}' ENVELOPE UPSERT
 contains:Invalid upsert key: (b), valid keys are: (a, b)
 

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -248,7 +248,8 @@ contains:collection identifier is not present
 
 > CREATE SINK output14_custom_consistency_topic FROM input_kafka_cdcv2
   INTO KAFKA CONNECTION kafka_conn TOPIC 'output14-view-${testdrive.seed}'
-  WITH (reuse_topic=true, consistency_topic='output14-custom-consistency-${testdrive.seed}')
+  CONSISTENCY (TOPIC 'output14-custom-consistency-${testdrive.seed}')
+  WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 # We need some data -- any data -- to start creating timestamp bindings
@@ -322,14 +323,6 @@ $ kafka-verify format=avro sink=materialize.public.rt_binding_consistency_test_s
 
 > CREATE MATERIALIZED VIEW simple_view AS SELECT 1 AS a, 2 AS b, 3 AS c;
 
-# Can't provide CONSISTENCY FORMAT and consistency_topic WITH option
-! CREATE SINK double_avro FROM simple_view
-  INTO KAFKA CONNECTION kafka_conn TOPIC 'double-avro'
-    CONSISTENCY (TOPIC 'topicname')
-    WITH (consistency_topic='willfail')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:Cannot specify consistency_topic and CONSISTENCY options simultaneously
-
 # Can't create sinks with JSON-encoded consistency topics
 ! CREATE SINK double_avro FROM simple_view
   INTO KAFKA CONNECTION kafka_conn TOPIC 'double-avro'
@@ -389,7 +382,7 @@ contains:For FORMAT JSON, you need to manually specify an Avro consistency topic
 # Default consistency format is Avro if consistency_topic is used
 > CREATE SINK default_avro_2 FROM simple_view
   INTO KAFKA CONNECTION kafka_conn TOPIC 'default-avro-2'
-    WITH (consistency_topic='default-consistency-avro')
+  CONSISTENCY (TOPIC 'default-consistency-avro')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 
 $ kafka-verify format=avro sink=materialize.public.default_avro sort-messages=true

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -57,13 +57,6 @@ contains:replication factor for sink topics must be an integer
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
 contains:replication factor for sink topics must be a positive integer or -1 for broker default
 
-! CREATE SINK invalid_consistency FROM v1
-  INTO KAFKA CONNECTION kafka_conn
-  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
-  WITH (consistency_topic = -2)
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
-contains:consistency_topic must be a string
-
 ! CREATE SINK invalid_acks FROM v1
   INTO KAFKA CONNECTION kafka_conn
   TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'


### PR DESCRIPTION
While sinks are behind unsafe mode, we should take this opportunity to deprecate `consistency_topic` in favor of the new dedicated `CONSISTENCY` syntax.

Apologies for the review request spam--not sure who has ever meaningfully touched this.

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Deprecate the `consistency_topic` option when creating `SINK`s in favor of the dedicated `CONSISTENCY` syntax.
