### PR TITLE
Maintain introspection upper frontiers across restarts

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -294,7 +294,9 @@ where
             .collect();
 
         // Add the replica
-        self.compute.replicas.add_replica(id, addrs, persisted_logs);
+        self.compute
+            .replicas
+            .add_replica(id, addrs, persisted_logs, None);
     }
 
     pub fn get_replica_ids(&self) -> impl Iterator<Item = ReplicaId> + '_ {


### PR DESCRIPTION
Introspection collections report the `upper` frontiers they have committed to storage. These have not historically been tracked in active replication, and instead were just echoed back. This resulted in confusion for the storage controller, who relies on this information to correctly present `upper` information and to drive compaction (which is a function of `upper`). Although the upper frontiers were advancing, the storage controller was not learning this correctly.

This PR changes the active replication logic to have per-replica uppers tracked for their introspection shards.

I think there are better fixes for the future. 
1. The storage controller could receive `upper` information directly from `persist` (e.g. a table that contains effected `upper` changes, which it could drain).
2. The frontier communication between the controllers could be in terms of `Antichain<T>` rather than `ChangeBatch`. The latter is valuable when you have multiple contributors whose result must be accumulated, but that was not the case here.

### Motivation

  * This PR fixes #14261 .

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
