### PR TITLE
expr: Have methods that calculate the type of scalar take the argument &[ColumnType].

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -505,10 +505,11 @@ impl CatalogState {
             let on_entry = self.get_entry(&index.on);
             let nullable = key
                 .typ(
-                    on_entry
+                    &on_entry
                         .desc(&self.resolve_full_name(on_entry.name(), on_entry.conn_id()))
                         .unwrap()
-                        .typ(),
+                        .typ()
+                        .column_types,
                 )
                 .nullable;
             let seq_in_index = i64::try_from(i + 1).expect("invalid index sequence number");

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -14,7 +14,7 @@ use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 
 use mz_compute_client::controller::ComputeInstanceId;
 use mz_repr::explain_new::ExprHumanizer;
-use mz_repr::{RelationType, RowArena, ScalarType, Timestamp};
+use mz_repr::{RowArena, ScalarType, Timestamp};
 use mz_sql::plan::QueryWhen;
 use mz_stash::Append;
 
@@ -64,7 +64,7 @@ impl<S: Append + 'static> Coordinator<S> {
             if evaled.is_null() {
                 coord_bail!("can't use {} as a timestamp for AS OF", evaled);
             }
-            let ty = timestamp.typ(&RelationType::empty());
+            let ty = timestamp.typ(&[]);
             let ts = match ty.scalar_type {
                 ScalarType::Numeric { .. } => {
                     let n = evaled.unwrap_numeric().0;

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -372,7 +372,7 @@ impl MirRelationExpr {
 
                 let mut remappings = Vec::new();
                 for (column, scalar) in scalars.iter().enumerate() {
-                    typ.column_types.push(scalar.typ(&typ));
+                    typ.column_types.push(scalar.typ(&typ.column_types));
                     // assess whether the scalar preserves uniqueness,
                     // and could participate in a key!
 
@@ -590,10 +590,10 @@ impl MirRelationExpr {
                 let input_typ = &input_types[0];
                 let mut column_types = group_key
                     .iter()
-                    .map(|e| e.typ(input_typ))
+                    .map(|e| e.typ(&input_typ.column_types))
                     .collect::<Vec<_>>();
                 for agg in aggregates {
-                    column_types.push(agg.typ(input_typ));
+                    column_types.push(agg.typ(&input_typ.column_types));
                 }
                 let mut result = RelationType::new(column_types);
                 // The group key should form a key, but we might already have
@@ -1513,8 +1513,8 @@ impl RustType<ProtoAggregateExpr> for AggregateExpr {
 
 impl AggregateExpr {
     /// Computes the type of this `AggregateExpr`.
-    pub fn typ(&self, relation_type: &RelationType) -> ColumnType {
-        self.func.output_type(self.expr.typ(relation_type))
+    pub fn typ(&self, column_types: &[ColumnType]) -> ColumnType {
+        self.func.output_type(self.expr.typ(column_types))
     }
 
     /// Returns whether the expression has a constant result.
@@ -1549,7 +1549,7 @@ impl AggregateExpr {
     }
 
     /// Extracts unique input from aggregate type
-    pub fn on_unique(&self, input_type: &RelationType) -> MirScalarExpr {
+    pub fn on_unique(&self, input_type: &[ColumnType]) -> MirScalarExpr {
         match &self.func {
             // Count is one if non-null, and zero if null.
             AggregateFunc::Count => self

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -14,7 +14,7 @@ mod test {
     use mz_lowertest::{deserialize, deserialize_optional, tokenize, MzReflect};
     use mz_ore::result::ResultExt;
     use mz_ore::str::separated;
-    use mz_repr::RelationType;
+    use mz_repr::ColumnType;
 
     use serde::{Deserialize, Serialize};
 
@@ -22,7 +22,7 @@ mod test {
         let mut input_stream = tokenize(&s)?.into_iter();
         let mut ctx = MirScalarExprDeserializeContext::default();
         let mut scalar: MirScalarExpr = deserialize(&mut input_stream, "MirScalarExpr", &mut ctx)?;
-        let typ: RelationType = deserialize(&mut input_stream, "RelationType", &mut ctx)?;
+        let typ: Vec<ColumnType> = deserialize(&mut input_stream, "Vec<ColumnType> ", &mut ctx)?;
         let before = scalar.typ(&typ);
         scalar.reduce(&typ);
         let after = scalar.typ(&typ);
@@ -41,7 +41,7 @@ mod test {
         let mut ctx = MirScalarExprDeserializeContext::default();
         let input_predicates: Vec<MirScalarExpr> =
             deserialize(&mut input_stream, "Vec<MirScalarExpr>", &mut ctx)?;
-        let typ: RelationType = deserialize(&mut input_stream, "RelationType", &mut ctx)?;
+        let typ: Vec<ColumnType> = deserialize(&mut input_stream, "Vec<ColumnType>", &mut ctx)?;
         // predicate canonicalization is meant to produce the same output regardless of the
         // order of the input predicates.
         let mut predicates1 = input_predicates.clone();
@@ -106,8 +106,9 @@ mod test {
         let mut ctx = MirScalarExprDeserializeContext::default();
         let mut equivalences: Vec<Vec<MirScalarExpr>> =
             deserialize(&mut input_stream, "Vec<Vec<MirScalarExpr>>", &mut ctx)?;
-        let input_type: RelationType = deserialize(&mut input_stream, "RelationType", &mut ctx)?;
-        canonicalize_equivalences(&mut equivalences, &[input_type]);
+        let input_type: Vec<ColumnType> =
+            deserialize(&mut input_stream, "Vec<ColumnType>", &mut ctx)?;
+        canonicalize_equivalences(&mut equivalences, std::iter::once(&input_type));
         Ok(equivalences)
     }
 

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -2603,7 +2603,7 @@ impl HirScalarExpr {
 
     fn simplify_to_literal(self) -> Option<Row> {
         let mut expr = self.lower_uncorrelated().ok()?;
-        expr.reduce(&mz_repr::RelationType::empty());
+        expr.reduce(&[]);
         match expr {
             mz_expr::MirScalarExpr::Literal(Ok(row), _) => Some(row),
             _ => None,

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -611,7 +611,12 @@ impl HirRelationExpr {
                     let input_type = input.typ();
                     let default = applied_aggregates
                         .iter()
-                        .map(|agg| (agg.func.default(), agg.typ(&input_type).scalar_type))
+                        .map(|agg| {
+                            (
+                                agg.func.default(),
+                                agg.typ(&input_type.column_types).scalar_type,
+                            )
+                        })
                         .collect();
                     // NOTE we don't need to remove any extra columns from aggregate.applied_to above because the reduce will do that anyway
                     let mut reduced =
@@ -1068,8 +1073,9 @@ impl HirScalarExpr {
                                             &mut get_inner,
                                             subquery_map,
                                         );
-                                        let mir_encoded_args_type =
-                                            mir_encoded_args.typ(&get_inner.typ()).scalar_type;
+                                        let mir_encoded_args_type = mir_encoded_args
+                                            .typ(&get_inner.typ().column_types)
+                                            .scalar_type;
 
                                         // Record input arity here so that any group_keys that need to mutate get_inner
                                         // don't add those columns to the aggregate input.

--- a/src/sql/src/query_model/mir.rs
+++ b/src/sql/src/query_model/mir.rs
@@ -250,7 +250,12 @@ impl<'a> Lowerer<'a> {
                     let input_type = input.typ();
                     let default = aggregates
                         .iter()
-                        .map(|agg| (agg.func.default(), agg.typ(&input_type).scalar_type))
+                        .map(|agg| {
+                            (
+                                agg.func.default(),
+                                agg.typ(&input_type.column_types).scalar_type,
+                            )
+                        })
                         .collect_vec();
 
                     input = SR::Reduce {

--- a/src/transform/src/demand.rs
+++ b/src/transform/src/demand.rs
@@ -241,7 +241,7 @@ impl Demand {
                     let input_type = input.typ();
                     for index in (0..aggregates.len()).rev() {
                         if !columns.contains(&(group_key.len() + index)) {
-                            let typ = aggregates[index].typ(&input_type);
+                            let typ = aggregates[index].typ(&input_type.column_types);
                             aggregates[index] = AggregateExpr {
                                 func: AggregateFunc::Dummy,
                                 expr: MirScalarExpr::literal_ok(Datum::Dummy, typ.scalar_type),

--- a/src/transform/src/fusion/filter.rs
+++ b/src/transform/src/fusion/filter.rs
@@ -76,7 +76,7 @@ impl Filter {
                 *input = Box::new(inner.take_dangerous());
             }
 
-            mz_expr::canonicalize::canonicalize_predicates(predicates, &input.typ());
+            mz_expr::canonicalize::canonicalize_predicates(predicates, &input.typ().column_types);
 
             // remove the Filter stage if empty.
             if predicates.is_empty() {

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -104,7 +104,10 @@ impl JoinImplementation {
             let input_types = inputs.iter().map(|i| i.typ()).collect::<Vec<_>>();
 
             // Canonicalize the equivalence classes
-            mz_expr::canonicalize::canonicalize_equivalences(equivalences, &input_types);
+            mz_expr::canonicalize::canonicalize_equivalences(
+                equivalences,
+                input_types.iter().map(|t| &t.column_types),
+            );
 
             // Common information of broad utility.
             let input_mapper = JoinInputMapper::new_from_input_types(&input_types);

--- a/src/transform/src/map_lifting.rs
+++ b/src/transform/src/map_lifting.rs
@@ -531,9 +531,7 @@ impl LiteralLifting {
                             eval,
                             // This type information should be available in the `a.expr` literal,
                             // but extracting it with pattern matching seems awkward.
-                            aggr.func
-                                .output_type(aggr.expr.typ(&mz_repr::RelationType::empty()))
-                                .scalar_type,
+                            aggr.func.output_type(aggr.expr.typ(&[])).scalar_type,
                         )
                     };
 

--- a/src/transform/src/nonnullable.rs
+++ b/src/transform/src/nonnullable.rs
@@ -47,7 +47,7 @@ impl NonNullable {
                     let mut metadata = input.typ();
                     for scalar in scalars.iter_mut() {
                         scalar_nonnullable(scalar, &metadata)?;
-                        let typ = scalar.typ(&metadata);
+                        let typ = scalar.typ(&metadata.column_types);
                         metadata.column_types.push(typ);
                     }
                 }

--- a/src/transform/src/reduce_elision.rs
+++ b/src/transform/src/reduce_elision.rs
@@ -50,7 +50,7 @@ impl ReduceElision {
             }) {
                 let map_scalars = aggregates
                     .iter()
-                    .map(|a| a.on_unique(&input_type))
+                    .map(|a| a.on_unique(&input_type.column_types))
                     .collect_vec();
 
                 let mut result = input.take_dangerous();

--- a/src/transform/src/redundant_join.rs
+++ b/src/transform/src/redundant_join.rs
@@ -180,7 +180,7 @@ impl RedundantJoin {
 
                         mz_expr::canonicalize::canonicalize_equivalences(
                             equivalences,
-                            &input_types,
+                            input_types.iter().map(|t| &t.column_types),
                         );
 
                         // Build a projection that leaves the binding expressions in the same


### PR DESCRIPTION
Change `MirScalarExpr::typ` and `AggregateExpr::typ` to accept `&[ColumnType]` as an argument instead of `RelationType`.

In turn, I changed methods that accept a `RelationType` for the sole purpose of passing it to `typ` to accept a `&[ColumnType]` instead, and so on. Affected methods:
* methods involving simplifying `MirScalarExpr`
* canonicalizing a collection of `MirScalarExpr`
* `AggregateExpr::on_unique`

### Motivation

* This PR is a precursor for a desirable feature.

Relates to #14315.

This PR will unblock the ability to display column types separately from unique keys in `EXPLAIN` by making it possible to calculate column types without also calculating unique keys.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

No user-facing behavior changes.
