### PR TITLE
test: fix syntax errors in test/cloudtest/test_secrets.py

### DIFF
--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -25,10 +25,10 @@ def test_secrets(mz: MaterializeApplication) -> None:
 
             ! CREATE CONNECTION secrets_conn
               FOR KAFKA
-              BROKER BROKER '${testdrive.kafka-addr}',
+              BROKER '${testdrive.kafka-addr}',
               SASL MECHANISMS 'PLAIN',
               SASL USERNAME = SECRET username,
-              SASL PASSWORD = SECRET passsword;
+              SASL PASSWORD = SECRET password;
 
             contains: SSL handshake failed
             """


### PR DESCRIPTION
There were some syntax errors in this test, which caused it to fail. However, I cannot run the test locally so am not sure if there is some larger issue.

### Motivation

This PR fixes a recognized bug. Caused CI failures.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
