### PR TITLE
storage: assert on Sink as_of/gate timestamp correctness

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -1154,6 +1154,14 @@ where
                         .map(|init| init.to_running(Rc::clone(&shared_gate_ts)));
 
                     if let Some(gate) = latest_ts {
+                        assert!(
+                            as_of.frontier.iter().all(|ts| *ts <= gate),
+                            "some element of the Sink as_of frontier is too \
+                                far advanced for our output-gating timestamp: \
+                                as_of {:?}, gate_ts: {:?}",
+                            as_of.frontier,
+                            gate
+                        );
                         s.maybe_update_progress(&gate);
                     }
 

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -174,7 +174,13 @@ t1
 
 # Sources
 
-> CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+# Explicitly set a progress topic to ensure multiple runs (which the
+# mzcompose.py driver does) do not clash.
+# TODO: remove this once we add some form of nonce to the default progress
+# topic name.
+> CREATE CONNECTION IF NOT EXISTS kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}',
+  PROGRESS TOPIC 'testdrive-progress-${testdrive.seed}';
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
   FOR CONFLUENT SCHEMA REGISTRY


### PR DESCRIPTION
We use the gate timestamp to figure out which updates we still need to
write to the sink, and which we have already written. If the as_of
frontier were past the gate timestamp, we could not differentiate, and
would potentially write duplicate updates.

Cross fingers and hope this actually passes CI. 🤞 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
