### PR TITLE
persist: return err rather than panic if compaction sees missing blob

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -218,7 +218,7 @@ impl Compactor {
                             updates.push(((k.to_vec(), v.to_vec()), t, d));
                         },
                     )
-                    .await;
+                    .await?;
                 }
             }
             consolidate_updates(&mut updates);

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -956,6 +956,7 @@ mod tests {
                                     },
                                 )
                                 .await
+                                .expect("invalid batch part");
                             }
                             if s.is_empty() {
                                 s.push_str("<empty>\n");


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR updates compaction to error rather than panic (or if you're the code on prod: get in an endless retry loop) if it encounters a missing blob. Since compaction does not use seqno holds, it can potentially race with itself and try to read a blob that's already been compacted+gc'd, given a sequence like:

1. transitioning from state s1 --> s2 produces compaction request c1 for batches [b0,b1]
1. transitioning from s2 --> s3 produces compaction request c2 for batches [b0,b1,2]. c2 generates new blob [b0_1_2] 
1. transitioning from s3 --> s4 produces gc request through s4, deleting all unreferenced blobs in s1/s2/s3, including b0 and b1
1. c1 finally gets scheduled and panics/gets stuck trying to find b0/b1


### Motivation

Part of the story for #14043

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
