### PR TITLE
persist: remove pub from maybe_heartbeat_reader

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -471,7 +471,8 @@ where
     /// promising that no more data will ever be read by this handle.
     ///
     /// This also acts as a heartbeat for the reader lease (including if called
-    /// with `new_since` equal to `self.since()`, making the call a no-op).
+    /// with `new_since` equal to something like `self.since()` or the minimum
+    /// timestamp, making the call a no-op).
     #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
     pub async fn downgrade_since(&mut self, new_since: &Antichain<T>) {
         let (_seqno, current_reader_since, maintenance) = self
@@ -690,11 +691,11 @@ where
     ///
     /// This is an internally rate limited helper, designed to allow users to
     /// call it as frequently as they like. Call this [Self::downgrade_since],
-    /// or [Self::maybe_heartbeat_reader] on some interval that is "frequent"
+    /// or Self::maybe_heartbeat_reader on some interval that is "frequent"
     /// compared to PersistConfig::FAKE_READ_LEASE_DURATION.
     ///
     /// This is communicating actual progress information, so is given
-    /// preferential treatment compared to [Self::maybe_heartbeat_reader].
+    /// preferential treatment compared to Self::maybe_heartbeat_reader.
     pub async fn maybe_downgrade_since(&mut self, new_since: &Antichain<T>) {
         // NB: min_elapsed is intentionally smaller than the one in
         // maybe_heartbeat_reader (this is the preferential treatment mentioned
@@ -712,7 +713,7 @@ where
     /// call it as frequently as they like. Call this [Self::downgrade_since],
     /// or [Self::maybe_downgrade_since] on some interval that is "frequent"
     /// compared to PersistConfig::FAKE_READ_LEASE_DURATION.
-    pub async fn maybe_heartbeat_reader(&mut self) {
+    async fn maybe_heartbeat_reader(&mut self) {
         let min_elapsed = PersistConfig::FAKE_READ_LEASE_DURATION / 2;
         let elapsed_since_last_heartbeat = self.last_heartbeat.elapsed();
         if elapsed_since_last_heartbeat >= min_elapsed {


### PR DESCRIPTION
The semantics of maybe_heartbeat_reader come from snapshots, which want
to keep a capability on seqno. The only thing that needs a seqno hold is
snapshot, so this PR revisits the publicly available combos of
"downgrade since" vs "downgrade seqno" vs "heartbeat reader_id" (the
concepts, not corresponding to methods in code).

Active listens want all three, active snapshots want only heartbeat,
read handles in environmentd want all three (possibly with a no-op
downgrade_since for the tick loop in persist_read_handles).

The "only heartbeat" one for snapshots (currently called
maybe_heartbeat_reader) is the dangerous one because it holds back the
seqno, so I've changed this method to be private to persist. Instead,
use the idempotence of downgrade_since to make a no-op call for
persist_read_handles's tick loop.

Fixes #14265

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
