### PR TITLE
sql: parse non-legacy source WITH options correctly

### DIFF
--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1485,6 +1485,13 @@ CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }, CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
 
 parse-statement
+CREATE SOURCE gus FROM POSTGRES CONNECTION pgconn PUBLICATION 'red' WITH (REMOTE 'johto:42');
+----
+error: Expected equals sign, found string literal "johto:42"
+CREATE SOURCE gus FROM POSTGRES CONNECTION pgconn PUBLICATION 'red' WITH (REMOTE 'johto:42');
+                                                                                 ^
+
+parse-statement
 ALTER SYSTEM SET wal_level TO logical
 ----
 ALTER SYSTEM SET wal_level = logical


### PR DESCRIPTION
When parsing non-legacy `WITH` options when you don't have a `FORMAT` or other type of option, we currently unconditionally parse them as legacy-with options.

This means things like `WITH (REMOTE ...` are not possible with sources like pg sources.

This pr attempts to fix this problem. Unfortunately, disambiguating between these cases is pretty hard. The most subtle piece is how we detect "that we are at the end of the statement". I am not sure if my logic of checking if the next token is `None` or a `;` is right in general (are there ways to have multiple statements one after the other without a semi-colon?), or of it should be `!self.peek_keywords(&[KEY, FORMAT, INCLUDE, ENVELOPE])`...

One thing is for sure: the errors here in edge cases like: "you DID write a correct `REMOTE` pg source but forgot a semi-colon before the next statement are going to be _terrible_. In fact, the error message that I got that revealed this bugf was not great. Resolving this fact seems non-trivial if not impossible without dis-ambiguating the grammar,  by removing legacy with options. My understanding is that this is the plan.

### Motivation

  * This PR fixes a previously unreported bug.

See above


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
