### PR TITLE
persist: add metric to track number of live updates in a shard

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -540,6 +540,8 @@ where
                         self.shard_metrics.set_upper(&self.state.upper());
                         self.shard_metrics.set_encoded_state_size(payload_len);
                         self.shard_metrics.set_batch_count(self.state.batch_count());
+                        self.shard_metrics
+                            .set_update_count(self.state.num_updates());
                         self.shard_metrics.set_seqnos_held(self.state.seqnos_held());
 
                         let (expired_readers, expired_writers) =

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -651,6 +651,7 @@ pub struct ShardsMetrics {
     // see directly as we're getting started, perhaps we're able to drop it
     // later in favor of only having the latter.
     batch_count: mz_ore::metrics::UIntGaugeVec,
+    update_count: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
     // We hand out `Arc<ShardMetrics>` to read and write handles, but store it
     // here as `Weak`. This allows us to discover if it's no longer in use and
@@ -699,6 +700,13 @@ impl ShardsMetrics {
                 metric!(
                     name: "mz_persist_shard_batch_count",
                     help: "count of batches in all active shards on this process",
+                    var_labels: ["shard"],
+                ),
+            ),
+            update_count: registry.register(
+                metric!(
+                    name: "mz_persist_shard_update_count",
+                    help: "count of updates in all active shards on this process",
                     var_labels: ["shard"],
                 ),
             ),
@@ -754,6 +762,7 @@ pub struct ShardMetrics {
     upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     encoded_state_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     batch_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    update_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
@@ -772,6 +781,9 @@ impl ShardMetrics {
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             batch_count: shards_metrics
                 .batch_count
+                .get_delete_on_drop_gauge(vec![shard.clone()]),
+            update_count: shards_metrics
+                .update_count
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             seqnos_held: shards_metrics
                 .seqnos_held
@@ -810,6 +822,10 @@ impl ShardMetrics {
 
     pub fn set_batch_count(&self, batch_count: usize) {
         self.batch_count.set(u64::cast_from(batch_count))
+    }
+
+    pub fn set_update_count(&self, update_count: usize) {
+        self.update_count.set(u64::cast_from(update_count))
     }
 
     pub fn set_seqnos_held(&self, seqnos_held: usize) {

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -355,6 +355,10 @@ where
         self.collections.trace.num_hollow_batches()
     }
 
+    pub fn num_updates(&self) -> usize {
+        self.collections.trace.num_updates()
+    }
+
     fn seqno_since(&self) -> SeqNo {
         let mut seqno_since = self.seqno;
         for cap in self.collections.readers.values() {

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -203,7 +203,6 @@ impl<T: Timestamp + Lattice> Trace<T> {
         ret
     }
 
-    #[cfg(test)]
     pub fn num_updates(&self) -> usize {
         let mut ret = 0;
         self.map_batches(|b| ret += b.len);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.


### Tips for reviewer

Sneaking this into tomorrow's release

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
