### PR TITLE
[avro] Use short names whenever possible

### DIFF
--- a/src/avro/src/reader.rs
+++ b/src/avro/src/reader.rs
@@ -858,7 +858,7 @@ impl<'a> SchemaResolver<'a> {
                         &writer.root.lookup(w_index).name,
                         &reader.root.lookup(r_index).name,
                     );
-                    return Err(SchemaResolutionError::new(format!("Attempted to resolve writer schema node named {} against reader schema node named {}", w_name, r_name)).into());
+                    return Err(SchemaResolutionError::new(format!("Attempted to resolve writer schema node named {:?} against reader schema node named {:?}", w_name, r_name)).into());
                 }
                 // Check if we have already resolved the name previously, and if so, return a reference to
                 // it (in the new schema's namespace).

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -142,7 +142,7 @@ impl SchemaPieceOrNamed {
     pub fn get_human_name(&self, root: &Schema) -> String {
         match self {
             Self::Piece(piece) => format!("{:?}", piece),
-            Self::Named(idx) => format!("{}", root.lookup(*idx).name),
+            Self::Named(idx) => format!("{:?}", root.lookup(*idx).name),
         }
     }
     #[inline(always)]
@@ -518,13 +518,14 @@ pub struct Name {
     pub aliases: Option<Vec<String>>,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Hash, PartialEq, Eq)]
 pub struct FullName {
     name: String,
     namespace: String,
 }
 
 impl FullName {
+    // [XXX] btv - what happens if `name` contains dots, _and_ `namespace` is `Some` ?
     pub fn from_parts(name: &str, namespace: Option<&str>, default_namespace: &str) -> FullName {
         if let Some(ns) = namespace {
             FullName {
@@ -551,9 +552,24 @@ impl FullName {
         }
         return format!("{}.{}", self.namespace, self.name);
     }
+    /// Get the shortest unambiguous synonym of this name
+    /// at a given point in the schema graph. If this name
+    /// is in the same namespace as the enclosing node, this
+    /// returns the short name; otherwise, it returns the fully qualified name.
+    pub fn short_name(&self, enclosing_ns: &str) -> Cow<'_, str> {
+        if enclosing_ns == &self.namespace {
+            Cow::Borrowed(&self.name)
+        } else {
+            Cow::Owned(format!("{}.{}", self.namespace, self.name))
+        }
+    }
+    /// Returns the namespace of the name
+    pub fn ns(&self) -> &str {
+        &self.namespace
+    }
 }
 
-impl fmt::Display for FullName {
+impl fmt::Debug for FullName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}.{}", self.namespace, self.name)
     }
@@ -827,7 +843,7 @@ impl SchemaParser {
             Entry::Vacant(ve) => *ve.insert(self.named.len()),
             Entry::Occupied(oe) => {
                 return Err(ParseSchemaError::new(format!(
-                    "Sub-schema with name {} encountered multiple times",
+                    "Sub-schema with name {:?} encountered multiple times",
                     oe.key()
                 ))
                 .into())
@@ -1372,7 +1388,7 @@ impl<'a> SchemaPieceRefOrNamed<'a> {
     pub fn get_human_name(&self, root: &Schema) -> String {
         match self {
             Self::Piece(piece) => format!("{:?}", piece),
-            Self::Named(idx) => format!("{}", root.lookup(*idx).name),
+            Self::Named(idx) => format!("{:?}", root.lookup(*idx).name),
         }
     }
 
@@ -1437,6 +1453,11 @@ impl<'a> SchemaNodeOrNamed<'a> {
             indices,
             top: piece,
         }
+    }
+
+    pub fn ns(self) -> Option<&'a str> {
+        let SchemaNode { name, .. } = self.lookup();
+        name.map(|FullName { namespace, .. }| namespace.as_str())
     }
 }
 
@@ -1781,7 +1802,9 @@ struct SchemaSerContext<'a> {
     // it is only ever mutated in one stack frame at a time.
     // But AFAICT serde doesn't expose a way to
     // provide some mutable context to every node in the tree...
-    seen_named: Rc<RefCell<HashMap<usize, String>>>,
+    seen_named: Rc<RefCell<HashMap<usize, FullName>>>,
+    /// The namespace of this node's parent, or "" by default
+    enclosing_ns: &'a str,
 }
 
 #[derive(Clone)]
@@ -1792,9 +1815,11 @@ struct RecordFieldSerContext<'a> {
 
 impl<'a> SchemaSerContext<'a> {
     fn step(&'a self, next: SchemaPieceRefOrNamed<'a>) -> Self {
+        let ns = self.node.ns().unwrap_or(self.enclosing_ns);
         Self {
             node: self.node.step_ref(next),
             seen_named: Rc::clone(&self.seen_named),
+            enclosing_ns: ns,
         }
     }
 }
@@ -1904,18 +1929,21 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                 let mut map = self.seen_named.borrow_mut();
                 let named_piece = match map.get(&index) {
                     Some(name) => {
-                        return serializer.serialize_str(name.as_str());
+                        return serializer.serialize_str(&*name.short_name(self.enclosing_ns));
                     }
                     None => self.node.root.lookup(index),
                 };
-                let name = named_piece.name.to_string();
+                let name = &named_piece.name;
                 map.insert(index, name.clone());
                 std::mem::drop(map);
                 match &named_piece.piece {
                     SchemaPiece::Record { doc, fields, .. } => {
                         let mut map = serializer.serialize_map(None)?;
                         map.serialize_entry("type", "record")?;
-                        map.serialize_entry("name", &name)?;
+                        map.serialize_entry("name", &name.name)?;
+                        if self.enclosing_ns != &name.namespace {
+                            map.serialize_entry("namespace", &name.namespace)?;
+                        }
                         if let Some(ref docstr) = doc {
                             map.serialize_entry("doc", docstr)?;
                         }
@@ -1939,7 +1967,10 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                     } => {
                         let mut map = serializer.serialize_map(None)?;
                         map.serialize_entry("type", "enum")?;
-                        map.serialize_entry("name", &name)?;
+                        map.serialize_entry("name", &name.name)?;
+                        if self.enclosing_ns != &name.namespace {
+                            map.serialize_entry("namespace", &name.namespace)?;
+                        }
                         map.serialize_entry("symbols", symbols)?;
                         if let Some(default_idx) = *default_idx {
                             assert!(default_idx < symbols.len());
@@ -1950,7 +1981,10 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                     SchemaPiece::Fixed { size } => {
                         let mut map = serializer.serialize_map(None)?;
                         map.serialize_entry("type", "fixed")?;
-                        map.serialize_entry("name", &name)?;
+                        map.serialize_entry("name", &name.name)?;
+                        if self.enclosing_ns != &name.namespace {
+                            map.serialize_entry("namespace", &name.namespace)?;
+                        }
                         map.serialize_entry("size", size)?;
                         map.end()
                     }
@@ -1962,7 +1996,10 @@ impl<'a> Serialize for SchemaSerContext<'a> {
                         let mut map = serializer.serialize_map(Some(6))?;
                         map.serialize_entry("type", "fixed")?;
                         map.serialize_entry("logicalType", "decimal")?;
-                        map.serialize_entry("name", &name)?;
+                        map.serialize_entry("name", &name.name)?;
+                        if self.enclosing_ns != &name.namespace {
+                            map.serialize_entry("namespace", &name.namespace)?;
+                        }
                         map.serialize_entry("size", size)?;
                         map.serialize_entry("precision", precision)?;
                         map.serialize_entry("scale", scale)?;
@@ -2022,6 +2059,7 @@ impl Serialize for Schema {
                 inner: self.top.as_ref(),
             },
             seen_named: Rc::new(RefCell::new(Default::default())),
+            enclosing_ns: "",
         };
         ctx.serialize(serializer)
     }

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2861,7 +2861,6 @@ mod tests {
 
     #[test]
     fn test_schema_fingerprint() {
-        use md5::Md5;
         use sha2::Sha256;
 
         let raw_schema = r#"
@@ -2877,13 +2876,8 @@ mod tests {
 
         let schema = Schema::from_str(raw_schema).unwrap();
         assert_eq!(
-            "5ecb2d1f0eaa647d409e6adbd5d70cd274d85802aa9167f5fe3b73ba70b32c76",
+            "c4d97949770866dec733ae7afa3046757e901d0cfea32eb92a8faeadcc4de153",
             format!("{}", schema.fingerprint::<Sha256>())
-        );
-
-        assert_eq!(
-            "a2c99a3f40ea2eea32593d63b483e962",
-            format!("{}", schema.fingerprint::<Md5>())
         );
     }
 }

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -564,7 +564,7 @@ impl FullName {
         }
     }
     /// Returns the namespace of the name
-    pub fn ns(&self) -> &str {
+    pub fn namespace(&self) -> &str {
         &self.namespace
     }
 }
@@ -1455,7 +1455,7 @@ impl<'a> SchemaNodeOrNamed<'a> {
         }
     }
 
-    pub fn ns(self) -> Option<&'a str> {
+    pub fn namespace(self) -> Option<&'a str> {
         let SchemaNode { name, .. } = self.lookup();
         name.map(|FullName { namespace, .. }| namespace.as_str())
     }
@@ -1815,7 +1815,7 @@ struct RecordFieldSerContext<'a> {
 
 impl<'a> SchemaSerContext<'a> {
     fn step(&'a self, next: SchemaPieceRefOrNamed<'a>) -> Self {
-        let ns = self.node.ns().unwrap_or(self.enclosing_ns);
+        let ns = self.node.namespace().unwrap_or(self.enclosing_ns);
         Self {
             node: self.node.step_ref(next),
             seen_named: Rc::clone(&self.seen_named),

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -535,26 +535,38 @@ fn test_ignored_logical_types() {
 fn test_namespace_serialization() {
     let input = r#"
 {
-    "type": "record",
-    "name": ".r1",
-    "fields": [{
-	"name": "f1",
-	"type": {
-	    "type": "record",
-	    "name": "r2",
-	    "namespace": "ns1",
-	    "fields": [{
-		"name": "f1",
-		"type": ["null", "ns1.r2"]
-	    }, {
-		"name": "f2",
-		"type": ["null", ".r1"]
-	    }]
-	}
-    }, {
-	"name": "f2",
-	"type": "ns1.r2"
-    }]
+  "type": "record",
+  "name": ".r1",
+  "fields": [
+    {
+      "name": "f1",
+      "type": {
+        "type": "record",
+        "name": "r2",
+        "namespace": "ns1",
+        "fields": [
+          {
+            "name": "f1",
+            "type": [
+              "null",
+              "ns1.r2"
+            ]
+          },
+          {
+            "name": "f2",
+            "type": [
+              "null",
+              ".r1"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "f2",
+      "type": "ns1.r2"
+    }
+  ]
 }
 "#;
     let expected_output = r#"{

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -530,3 +530,68 @@ fn test_ignored_logical_types() {
         );
     }
 }
+
+#[test]
+fn test_namespace_serialization() {
+    let input = r#"
+{
+    "type": "record",
+    "name": ".r1",
+    "fields": [{
+	"name": "f1",
+	"type": {
+	    "type": "record",
+	    "name": "r2",
+	    "namespace": "ns1",
+	    "fields": [{
+		"name": "f1",
+		"type": ["null", "ns1.r2"]
+	    }, {
+		"name": "f2",
+		"type": ["null", ".r1"]
+	    }]
+	}
+    }, {
+	"name": "f2",
+	"type": "ns1.r2"
+    }]
+}
+"#;
+    let expected_output = r#"{
+  "type": "record",
+  "name": "r1",
+  "fields": [
+    {
+      "name": "f1",
+      "type": {
+        "type": "record",
+        "name": "r2",
+        "namespace": "ns1",
+        "fields": [
+          {
+            "name": "f1",
+            "type": [
+              "null",
+              "r2"
+            ]
+          },
+          {
+            "name": "f2",
+            "type": [
+              "null",
+              ".r1"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "f2",
+      "type": "ns1.r2"
+    }
+  ]
+}"#;
+    let schema = Schema::from_str(input).unwrap();
+    let json = serde_json::to_string_pretty(&schema).unwrap();
+    assert_eq!(expected_output, json);
+}

--- a/src/interchange/src/avro/envelope_cdc_v2.rs
+++ b/src/interchange/src/avro/envelope_cdc_v2.rs
@@ -30,7 +30,7 @@ pub fn extract_data_columns<'a>(schema: &'a Schema) -> anyhow::Result<SchemaNode
     let data_name = FullName::from_parts("data", Some("com.materialize.cdc"), "");
     let data_schema = &schema
         .try_lookup_name(&data_name)
-        .ok_or_else(|| anyhow!("record not found: {}", data_name))?
+        .ok_or_else(|| anyhow!("record not found: {:?}", data_name))?
         .piece;
     Ok(SchemaNode {
         root: &schema,

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -387,7 +387,7 @@ impl<'a> RandomAvroGenerator<'a> {
             } => {
                 let name = node.name.unwrap();
                 for f in fields {
-                    let fn_ = format!("{}::{}", name, f.name);
+                    let fn_ = format!("{}.{}::{}", name.ns(), name.base_name(), f.name);
                     self.new_inner(node.step(&f.schema), annotations, Some(&fn_));
                 }
             }

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -387,7 +387,7 @@ impl<'a> RandomAvroGenerator<'a> {
             } => {
                 let name = node.name.unwrap();
                 for f in fields {
-                    let fn_ = format!("{}.{}::{}", name.ns(), name.base_name(), f.name);
+                    let fn_ = format!("{}.{}::{}", name.namespace(), name.base_name(), f.name);
                     self.new_inner(node.step(&f.schema), annotations, Some(&fn_));
                 }
             }

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -186,7 +186,7 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, anyhow::
                     SchemaPieceOrNamed::Named(idx) => {
                         let schema_name = &schema.root.lookup(*idx).name;
                         if name.chars().any(|ch| ch == '.') {
-                            name == &schema_name.to_string()
+                            name == &format!("{}.{}", schema_name.ns(), schema_name.base_name())
                         } else {
                             name == schema_name.base_name()
                         }

--- a/src/testdrive/src/format/avro.rs
+++ b/src/testdrive/src/format/avro.rs
@@ -186,7 +186,11 @@ pub fn from_json(json: &JsonValue, schema: SchemaNode) -> Result<Value, anyhow::
                     SchemaPieceOrNamed::Named(idx) => {
                         let schema_name = &schema.root.lookup(*idx).name;
                         if name.chars().any(|ch| ch == '.') {
-                            name == &format!("{}.{}", schema_name.ns(), schema_name.base_name())
+                            name == &format!(
+                                "{}.{}",
+                                schema_name.namespace(),
+                                schema_name.base_name()
+                            )
                         } else {
                             name == schema_name.base_name()
                         }


### PR DESCRIPTION
Certain Avro implementations choke on fullnames with the null namespace (e.g. `".foo"`).

This seems to (maybe?) match the spec, but the spec is confusing and, under the interpretation that it does indeed prohibit leading dots in fullnames, makes it impossible to serialize a large class of logically valid schemas (#14333).

Thus, pending upstream resolution of the questions about the spec, we do _not_ avoid emitting such fullnames in the case where they're indispensable for expressing the schema. But in this PR, we do avoid emitting fullnames _whenever possible_, making a wider class of our schemas interpretable by downstream tools.

### Motivation

Fixes #14333.

### Tips for reviewer

`test_schema_fingerprint` now matches Python:

```
>>> import avro.schema
>>> schema = avro.schema.parse(open("test_schema.json", "rb").read())
>>> import hashlib
>>> hashlib.sha256(schema.canonical_form.encode()).hexdigest()
'c4d97949770866dec733ae7afa3046757e901d0cfea32eb92a8faeadcc4de153'
```

However, I think PCF might still be broken, since it will not fully-qualify anything that doesn't need to be (which seems to violate the spec). I'll look into that as a follow-up.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Avro schema namespaces are now encoded only when necessary
