### PR TITLE
[avro] Fix busted PCF logic

### DIFF
--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2165,11 +2165,7 @@ fn pcf_map(schema: &Map<String, serde_json::Value>, enclosing_ns: &str, in_field
         deferred_values.push((k, v));
     }
 
-    let next_ns = if !in_fields {
-        found_next_ns.expect("`name` must be specified at least once")
-    } else {
-        default_ns
-    };
+    let next_ns = found_next_ns.unwrap_or(default_ns);
     for (k, v) in deferred_values {
         fields.push((
             k,

--- a/src/avro/src/schema.rs
+++ b/src/avro/src/schema.rs
@@ -2083,19 +2083,28 @@ impl<'a> Serialize for RecordFieldSerContext<'a> {
 /// Parses a **valid** avro schema into the Parsing Canonical Form.
 /// <https://avro.apache.org/docs/1.8.2/spec.html#Parsing+Canonical+Form+for+Schemas>
 fn parsing_canonical_form(schema: &serde_json::Value) -> String {
+    pcf(schema, "", false)
+}
+
+fn pcf(schema: &serde_json::Value, enclosing_ns: &str, in_fields: bool) -> String {
     match schema {
-        serde_json::Value::Object(map) => pcf_map(map),
+        serde_json::Value::Object(map) => pcf_map(map, enclosing_ns, in_fields),
         serde_json::Value::String(s) => pcf_string(s),
-        serde_json::Value::Array(v) => pcf_array(v),
+        serde_json::Value::Array(v) => pcf_array(v, enclosing_ns, in_fields),
         serde_json::Value::Number(n) => n.to_string(),
         _ => unreachable!("{:?} cannot yet be printed in canonical form", schema),
     }
 }
 
-fn pcf_map(schema: &Map<String, serde_json::Value>) -> String {
+fn pcf_map(schema: &Map<String, serde_json::Value>, enclosing_ns: &str, in_fields: bool) -> String {
     // Look for the namespace variant up front.
-    let ns = schema.get("namespace").and_then(|v| v.as_str());
+    let default_ns = schema
+        .get("namespace")
+        .and_then(|v| v.as_str())
+        .unwrap_or(enclosing_ns);
     let mut fields = Vec::new();
+    let mut found_next_ns = None;
+    let mut deferred_values = vec![];
     for (k, v) in schema {
         // Reduce primitive types to their simple form. ([PRIMITIVE] rule)
         if schema.len() == 1 && k == "type" {
@@ -2112,15 +2121,31 @@ fn pcf_map(schema: &Map<String, serde_json::Value>) -> String {
 
         // Fully qualify the name, if it isn't already ([FULLNAMES] rule).
         if k == "name" {
+            // The `fields` stanza needs special handling, as it has "name"
+            // fields that don't get canonicalized (since they are not type names).
+            if in_fields {
+                fields.push((
+                    k,
+                    format!("{}:{}", pcf_string(k), pcf_string(v.as_str().unwrap())),
+                ));
+                continue;
+            }
             // Invariant: Only valid schemas. Must be a string.
             let name = v.as_str().unwrap();
-            let n = match ns {
-                Some(namespace) if !name.contains('.') => {
-                    Cow::Owned(format!("{}.{}", namespace, name))
-                }
-                _ => Cow::Borrowed(name),
+            assert!(
+                found_next_ns.is_none(),
+                "`name` must not be specified multiple times"
+            );
+            let next_ns = match name.rsplit_once('.') {
+                None => default_ns,
+                Some((ns, _name)) => ns,
             };
-
+            found_next_ns = Some(next_ns);
+            let n = if next_ns.is_empty() {
+                Cow::Borrowed(name)
+            } else {
+                Cow::Owned(format!("{next_ns}.{name}"))
+            };
             fields.push((k, format!("{}:{}", pcf_string(k), pcf_string(&*n))));
             continue;
         }
@@ -2135,10 +2160,20 @@ fn pcf_map(schema: &Map<String, serde_json::Value>) -> String {
             continue;
         }
 
-        // For anything else, recursively process the result.
+        // For anything else, recursively process the result
+        // (deferred until we know the namespace)
+        deferred_values.push((k, v));
+    }
+
+    let next_ns = if !in_fields {
+        found_next_ns.expect("`name` must be specified at least once")
+    } else {
+        default_ns
+    };
+    for (k, v) in deferred_values {
         fields.push((
             k,
-            format!("{}:{}", pcf_string(k), parsing_canonical_form(v)),
+            format!("{}:{}", pcf_string(k), pcf(v, next_ns, &*k == "fields")),
         ));
     }
 
@@ -2152,10 +2187,10 @@ fn pcf_map(schema: &Map<String, serde_json::Value>) -> String {
     format!("{{{}}}", inter)
 }
 
-fn pcf_array(arr: &[serde_json::Value]) -> String {
+fn pcf_array(arr: &[serde_json::Value], enclosing_ns: &str, in_fields: bool) -> String {
     let inter = arr
         .iter()
-        .map(parsing_canonical_form)
+        .map(|s| pcf(s, enclosing_ns, in_fields))
         .collect::<Vec<String>>()
         .join(",");
     format!("[{}]", inter)
@@ -2873,11 +2908,39 @@ mod tests {
             ]
         }
     "#;
-
+        let expected_canonical = r#"{"name":"test","type":"record","fields":[{"name":"a","type":"long"},{"name":"b","type":"string"}]}"#;
         let schema = Schema::from_str(raw_schema).unwrap();
+        assert_eq!(&schema.canonical_form(), expected_canonical);
+        let expected_fingerprint = format!("{:02x}", Sha256::digest(expected_canonical));
         assert_eq!(
-            "c4d97949770866dec733ae7afa3046757e901d0cfea32eb92a8faeadcc4de153",
-            format!("{}", schema.fingerprint::<Sha256>())
+            format!("{}", schema.fingerprint::<Sha256>()),
+            expected_fingerprint
+        );
+
+        let raw_schema = r#"
+{
+  "type": "record",
+  "name": "ns.r1",
+  "namespace": "ignored",
+  "fields": [
+    {
+      "name": "f1",
+      "type": {
+        "type": "fixed",
+        "name": "r2",
+        "size": 1
+      }
+    }
+  ]
+}
+"#;
+        let expected_canonical = r#"{"name":"ns.r1","type":"record","fields":[{"name":"f1","type":{"name":"ns.r2","type":"fixed","size":1}}]}"#;
+        let schema = Schema::from_str(raw_schema).unwrap();
+        assert_eq!(&schema.canonical_form(), expected_canonical);
+        let expected_fingerprint = format!("{:02x}", Sha256::digest(expected_canonical));
+        assert_eq!(
+            format!("{}", schema.fingerprint::<Sha256>()),
+            expected_fingerprint
         );
     }
 }


### PR DESCRIPTION

### Motivation

The PCF logic was not filling in fullnames for nodes where the namespace is implicit (i.e., where it comes from an enclosing node)

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
