### PR TITLE
compute: retain logging sinks during reconciliation

### DIFF
--- a/src/compute/src/logging/persist.rs
+++ b/src/compute/src/logging/persist.rs
@@ -42,8 +42,6 @@ pub(crate) fn persist_sink<G>(
         truncate,
     );
 
-    // We don't allow these dataflows to be dropped, so the tokens could
-    // be stored anywhere.
     compute_state.sink_tokens.insert(
         target_id,
         crate::compute_state::SinkToken {

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -456,6 +456,13 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     ComputeCommand::CreateInstance(new_config) => {
                         // Cluster creation should not be performed again!
                         assert_eq!(old_config, Some(new_config));
+
+                        // Ensure we retain the logging sink dataflows.
+                        if let Some(logging) = &new_config.logging {
+                            for (id, _) in logging.sink_logs.values() {
+                                retain_ids.insert(*id);
+                            }
+                        }
                     }
                     // All other commands we apply as requested.
                     command => {


### PR DESCRIPTION
This PR adjusts compute reconciliation to ensure logging sinks are not inadvertently dropped.

### Motivation

  * This PR fixes a recognized bug.

Fixes #14346.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
