### PR TITLE
adapter,compute: remove undocumented mz_perf views

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1437,62 +1437,6 @@ GROUP BY
     mz_records_per_dataflow.name",
 };
 
-pub const MZ_PERF_ARRANGEMENT_RECORDS: BuiltinView = BuiltinView {
-    name: "mz_perf_arrangement_records",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_perf_arrangement_records AS
-WITH records_cte AS (
-    SELECT
-        operator,
-        worker,
-        pg_catalog.count(*) AS records
-    FROM
-        mz_catalog.mz_arrangement_records_internal
-    GROUP BY
-        operator, worker
-)
-SELECT mas.worker, name, records, operator
-FROM
-    records_cte mas LEFT JOIN mz_catalog.mz_dataflow_operators mdo
-        ON mdo.id = mas.operator AND mdo.worker = mas.worker",
-};
-
-pub const MZ_PERF_PEEK_DURATIONS_CORE: BuiltinView = BuiltinView {
-    name: "mz_perf_peek_durations_core",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_perf_peek_durations_core AS SELECT
-    d_upper.worker,
-    d_upper.duration_ns::pg_catalog.text AS le,
-    pg_catalog.sum(d_summed.count) AS count
-FROM
-    mz_catalog.mz_peek_durations AS d_upper,
-    mz_catalog.mz_peek_durations AS d_summed
-WHERE
-    d_upper.worker = d_summed.worker AND
-    d_upper.duration_ns >= d_summed.duration_ns
-GROUP BY d_upper.worker, d_upper.duration_ns",
-};
-
-pub const MZ_PERF_PEEK_DURATIONS_BUCKET: BuiltinView = BuiltinView {
-    name: "mz_perf_peek_durations_bucket",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_perf_peek_durations_bucket AS
-(
-    SELECT * FROM mz_catalog.mz_perf_peek_durations_core
-) UNION (
-    SELECT worker, '+Inf', pg_catalog.max(count) AS count FROM mz_catalog.mz_perf_peek_durations_core
-    GROUP BY worker
-)",
-};
-
-pub const MZ_PERF_PEEK_DURATIONS_AGGREGATES: BuiltinView = BuiltinView {
-    name: "mz_perf_peek_durations_aggregates",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_perf_peek_durations_aggregates AS SELECT worker, pg_catalog.sum(duration_ns * count) AS sum, pg_catalog.sum(count) AS count
-FROM mz_catalog.mz_peek_durations lpd
-GROUP BY worker",
-};
-
 pub const PG_NAMESPACE: BuiltinView = BuiltinView {
     name: "pg_namespace",
     schema: PG_CATALOG_SCHEMA,
@@ -2260,10 +2204,6 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&MZ_MATERIALIZATION_FRONTIERS),
         Builtin::View(&MZ_MATERIALIZATION_SOURCE_FRONTIERS),
         Builtin::View(&MZ_MESSAGE_COUNTS),
-        Builtin::View(&MZ_PERF_ARRANGEMENT_RECORDS),
-        Builtin::View(&MZ_PERF_PEEK_DURATIONS_AGGREGATES),
-        Builtin::View(&MZ_PERF_PEEK_DURATIONS_CORE),
-        Builtin::View(&MZ_PERF_PEEK_DURATIONS_BUCKET),
         Builtin::View(&MZ_RECORDS_PER_DATAFLOW_OPERATOR),
         Builtin::View(&MZ_RECORDS_PER_DATAFLOW),
         Builtin::View(&MZ_RECORDS_PER_DATAFLOW_GLOBAL),

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -294,10 +294,6 @@ pub enum LogView {
     MzDataflowOperatorReachability,
     MzMaterializationFrontiers,
     MzMessageCounts,
-    MzPerfArrangementRecords,
-    MzPerfPeekDurationsAggregates,
-    MzPerfPeekDurationsCore,
-    MzPerfPeekDurationsBucket,
     MzRecordsPerDataflowOperator,
     MzRecordsPerDataflow,
     MzRecordsPerDataflowGlobal,
@@ -316,10 +312,6 @@ pub static DEFAULT_LOG_VIEWS: Lazy<Vec<LogView>> = Lazy::new(|| {
         LogView::MzDataflowOperatorReachability,
         LogView::MzMaterializationFrontiers,
         LogView::MzMessageCounts,
-        LogView::MzPerfArrangementRecords,
-        LogView::MzPerfPeekDurationsAggregates,
-        LogView::MzPerfPeekDurationsCore,
-        LogView::MzPerfPeekDurationsBucket,
         LogView::MzRecordsPerDataflowOperator,
         LogView::MzRecordsPerDataflow,
         LogView::MzRecordsPerDataflowGlobal,
@@ -339,7 +331,8 @@ impl LogView {
                     pg_catalog.count(*) AS count
                 FROM mz_catalog.mz_arrangement_sharing_internal_{}
                 GROUP BY operator, worker",
-                "mz_arrangement_sharing_{}"),
+                "mz_arrangement_sharing_{}",
+            ),
 
             LogView::MzArrangementSizes => (
                 "WITH batches_cte AS (
@@ -368,7 +361,8 @@ impl LogView {
                     records_cte.records,
                     batches_cte.batches
                 FROM batches_cte JOIN records_cte USING (operator, worker)",
-                "mz_arrangement_sizes_{}"),
+                "mz_arrangement_sizes_{}",
+            ),
 
             LogView::MzDataflowNames => (
                 "SELECT mz_dataflow_addresses_{}.id,
@@ -382,7 +376,8 @@ impl LogView {
                         mz_dataflow_addresses_{}.id = mz_dataflow_operators_{}.id AND
                         mz_dataflow_addresses_{}.worker = mz_dataflow_operators_{}.worker AND
                         mz_catalog.list_length(mz_dataflow_addresses_{}.address) = 1",
-                "mz_dataflow_names_{}"),
+                "mz_dataflow_names_{}",
+            ),
 
             LogView::MzDataflowOperatorDataflows => (
                 "SELECT
@@ -400,7 +395,8 @@ impl LogView {
                     mz_dataflow_operators_{}.worker = mz_dataflow_addresses_{}.worker AND
                     mz_dataflow_names_{}.local_id = mz_dataflow_addresses_{}.address[1] AND
                     mz_dataflow_names_{}.worker = mz_dataflow_addresses_{}.worker",
-                "mz_dataflow_operator_dataflows_{}"),
+                "mz_dataflow_operator_dataflows_{}",
+            ),
 
             LogView::MzDataflowOperatorReachability => (
                 "SELECT
@@ -413,14 +409,16 @@ impl LogView {
                  FROM
                     mz_catalog.mz_dataflow_operator_reachability_internal_{}
                  GROUP BY address, port, worker, update_type, timestamp",
-                "mz_dataflow_operator_reachability_{}"),
+                "mz_dataflow_operator_reachability_{}",
+            ),
 
             LogView::MzMaterializationFrontiers => (
                 "SELECT
                     global_id, pg_catalog.min(time) AS time
                 FROM mz_catalog.mz_worker_materialization_frontiers_{}
                 GROUP BY global_id",
-                "mz_materialization_frontiers_{}"),
+                "mz_materialization_frontiers_{}",
+            ),
 
             LogView::MzMessageCounts => (
                 "WITH sent_cte AS (
@@ -452,53 +450,8 @@ impl LogView {
                     sent_cte.sent,
                     received_cte.received
                 FROM sent_cte JOIN received_cte USING (channel, source_worker, target_worker)",
-                "mz_message_counts_{}"),
-
-            LogView::MzPerfArrangementRecords => (
-                "WITH records_cte AS (
-                    SELECT
-                        operator,
-                        worker,
-                        pg_catalog.count(*) AS records
-                    FROM
-                        mz_catalog.mz_arrangement_records_internal_{}
-                    GROUP BY
-                        operator, worker
-                )
-                SELECT mas.worker, name, records, operator
-                FROM
-                    records_cte mas LEFT JOIN mz_catalog.mz_dataflow_operators_{} mdo
-                        ON mdo.id = mas.operator AND mdo.worker = mas.worker",
-                "mz_perf_arrangement_records_{}"),
-
-            LogView::MzPerfPeekDurationsAggregates => (
-                "SELECT worker, pg_catalog.sum(duration_ns * count) AS sum, pg_catalog.sum(count) AS count
-                 FROM mz_catalog.mz_peek_durations_{} lpd
-                 GROUP BY worker",
-                 "mz_perf_peek_durations_aggregates_{}"),
-
-            LogView::MzPerfPeekDurationsCore =>  (
-                "SELECT
-                    d_upper.worker,
-                    d_upper.duration_ns::pg_catalog.text AS le,
-                    pg_catalog.sum(d_summed.count) AS count
-                FROM
-                    mz_catalog.mz_peek_durations_{} AS d_upper,
-                    mz_catalog.mz_peek_durations_{} AS d_summed
-                WHERE
-                    d_upper.worker = d_summed.worker AND
-                    d_upper.duration_ns >= d_summed.duration_ns
-                GROUP BY d_upper.worker, d_upper.duration_ns",
-                "mz_perf_peek_durations_core_{}"),
-
-            LogView::MzPerfPeekDurationsBucket => (
-                "(
-                    SELECT * FROM mz_catalog.mz_perf_peek_durations_core_{}
-                ) UNION (
-                    SELECT worker, '+Inf', pg_catalog.max(count) AS count FROM mz_catalog.mz_perf_peek_durations_core_{}
-                    GROUP BY worker
-                )",
-                "mz_perf_peek_durations_bucket_{}"),
+                "mz_message_counts_{}",
+            ),
 
             LogView::MzRecordsPerDataflowOperator => (
                 "WITH records_cte AS (
@@ -523,9 +476,10 @@ impl LogView {
                 WHERE
                     mz_dataflow_operator_dataflows_{}.id = records_cte.operator AND
                     mz_dataflow_operator_dataflows_{}.worker = records_cte.worker",
-                "mz_records_per_dataflow_operator_{}"),
+                "mz_records_per_dataflow_operator_{}",
+            ),
 
-            LogView::MzRecordsPerDataflow =>  (
+            LogView::MzRecordsPerDataflow => (
                 "SELECT
                     mz_records_per_dataflow_operator_{}.dataflow_id as id,
                     mz_dataflow_names_{}.name,
@@ -541,9 +495,10 @@ impl LogView {
                     mz_records_per_dataflow_operator_{}.dataflow_id,
                     mz_dataflow_names_{}.name,
                     mz_records_per_dataflow_operator_{}.worker",
-                "mz_records_per_dataflow_{}"),
+                "mz_records_per_dataflow_{}",
+            ),
 
-            LogView::MzRecordsPerDataflowGlobal =>  (
+            LogView::MzRecordsPerDataflowGlobal => (
                 "SELECT
                     mz_records_per_dataflow_{}.id,
                     mz_records_per_dataflow_{}.name,
@@ -553,16 +508,18 @@ impl LogView {
                 GROUP BY
                     mz_records_per_dataflow_{}.id,
                     mz_records_per_dataflow_{}.name",
-                "mz_records_per_dataflow_global_{}"),
+                "mz_records_per_dataflow_global_{}",
+            ),
 
-            LogView::MzSchedulingElapsed =>  (
+            LogView::MzSchedulingElapsed => (
                 "SELECT
                     id, worker, pg_catalog.count(*) AS elapsed_ns
                 FROM
                     mz_catalog.mz_scheduling_elapsed_internal_{}
                 GROUP BY
                     id, worker",
-                "mz_scheduling_elapsed_{}"),
+                "mz_scheduling_elapsed_{}",
+            ),
 
             LogView::MzSchedulingHistogram => (
                 "SELECT
@@ -571,18 +528,18 @@ impl LogView {
                     mz_catalog.mz_scheduling_histogram_internal_{}
                 GROUP BY
                     id, worker, duration_ns",
-                "mz_scheduling_histogram_{}"),
+                "mz_scheduling_histogram_{}",
+            ),
 
-
-            LogView::MzSchedulingParks =>  (
+            LogView::MzSchedulingParks => (
                 "SELECT
                     worker, slept_for, requested, pg_catalog.count(*) AS count
                 FROM
                     mz_catalog.mz_scheduling_parks_internal_{}
                 GROUP BY
                     worker, slept_for, requested",
-                "mz_scheduling_parks_{}"),
-
+                "mz_scheduling_parks_{}",
+            ),
         }
     }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -75,7 +75,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-drop-default-cluster",
         "test-upsert",
         "test-resource-limits",
-        "test-builtin-migration",
+        # Disabled to permit a breaking change.
+        # See: https://materializeinc.slack.com/archives/C02FWJ94HME/p1661288774456699?thread_ts=1661288684.301649&cid=C02FWJ94HME
+        # "test-builtin-migration",
     ]:
         with c.test_case(name):
             c.workflow(name)

--- a/test/sqllogictest/cluster_log_sinks.slt
+++ b/test/sqllogictest/cluster_log_sinks.slt
@@ -28,10 +28,6 @@
 ###   "mz_scheduling_parks_internal",
 ###   "mz_worker_materialization_frontiers"
 ###    "mz_message_counts",
-###    "mz_perf_arrangement_records",
-###    "mz_perf_peek_durations_aggregates",
-###    "mz_perf_peek_durations_bucket",
-###    "mz_perf_peek_durations_core",
 ###    "mz_records_per_dataflow",
 ###    "mz_records_per_dataflow_global",
 ###    "mz_records_per_dataflow_operator",
@@ -322,38 +318,6 @@ SELECT * FROM ((SELECT * FROM mz_message_counts_1) EXCEPT (SELECT * FROM mz_mess
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_perf_arrangement_records) EXCEPT (SELECT * FROM mz_perf_arrangement_records_1));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_arrangement_records_1) EXCEPT (SELECT * FROM mz_perf_arrangement_records));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_aggregates) EXCEPT (SELECT * FROM mz_perf_peek_durations_aggregates_1));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_aggregates_1) EXCEPT (SELECT * FROM mz_perf_peek_durations_aggregates));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_bucket) EXCEPT (SELECT * FROM mz_perf_peek_durations_bucket_1));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_bucket_1) EXCEPT (SELECT * FROM mz_perf_peek_durations_bucket));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_core) EXCEPT (SELECT * FROM mz_perf_peek_durations_core_1));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_core_1) EXCEPT (SELECT * FROM mz_perf_peek_durations_core));
-----
-
-query T
 SELECT * FROM ((SELECT * FROM mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_records_per_dataflow_1));
 ----
 
@@ -592,38 +556,6 @@ SELECT * FROM ((SELECT * FROM mz_message_counts) EXCEPT (SELECT * FROM mz_messag
 
 query T
 SELECT * FROM ((SELECT * FROM mz_message_counts_2) EXCEPT (SELECT * FROM mz_message_counts));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_arrangement_records) EXCEPT (SELECT * FROM mz_perf_arrangement_records_2));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_arrangement_records_2) EXCEPT (SELECT * FROM mz_perf_arrangement_records));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_aggregates) EXCEPT (SELECT * FROM mz_perf_peek_durations_aggregates_2));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_aggregates_2) EXCEPT (SELECT * FROM mz_perf_peek_durations_aggregates));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_bucket) EXCEPT (SELECT * FROM mz_perf_peek_durations_bucket_2));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_bucket_2) EXCEPT (SELECT * FROM mz_perf_peek_durations_bucket));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_core) EXCEPT (SELECT * FROM mz_perf_peek_durations_core_2));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_core_2) EXCEPT (SELECT * FROM mz_perf_peek_durations_core));
 ----
 
 query T
@@ -875,38 +807,6 @@ SELECT * FROM ((SELECT * FROM mz_message_counts) EXCEPT (SELECT * FROM mz_messag
 
 query T
 SELECT * FROM ((SELECT * FROM mz_message_counts_3) EXCEPT (SELECT * FROM mz_message_counts));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_arrangement_records) EXCEPT (SELECT * FROM mz_perf_arrangement_records_3));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_arrangement_records_3) EXCEPT (SELECT * FROM mz_perf_arrangement_records));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_aggregates) EXCEPT (SELECT * FROM mz_perf_peek_durations_aggregates_3));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_aggregates_3) EXCEPT (SELECT * FROM mz_perf_peek_durations_aggregates));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_bucket) EXCEPT (SELECT * FROM mz_perf_peek_durations_bucket_3));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_bucket_3) EXCEPT (SELECT * FROM mz_perf_peek_durations_bucket));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_core) EXCEPT (SELECT * FROM mz_perf_peek_durations_core_3));
-----
-
-query T
-SELECT * FROM ((SELECT * FROM mz_perf_peek_durations_core_3) EXCEPT (SELECT * FROM mz_perf_peek_durations_core));
 ----
 
 query T

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -596,14 +596,6 @@ mz_materialization_source_frontiers
 mz_message_counts
 mz_message_counts_1
 mz_objects
-mz_perf_arrangement_records
-mz_perf_arrangement_records_1
-mz_perf_peek_durations_aggregates
-mz_perf_peek_durations_aggregates_1
-mz_perf_peek_durations_bucket
-mz_perf_peek_durations_bucket_1
-mz_perf_peek_durations_core
-mz_perf_peek_durations_core_1
 mz_records_per_dataflow
 mz_records_per_dataflow_1
 mz_records_per_dataflow_global
@@ -639,14 +631,6 @@ mz_materialization_source_frontiers  system
 mz_message_counts                    system
 mz_message_counts_1                  system
 mz_objects                           system
-mz_perf_arrangement_records          system
-mz_perf_arrangement_records_1        system
-mz_perf_peek_durations_aggregates    system
-mz_perf_peek_durations_aggregates_1  system
-mz_perf_peek_durations_bucket        system
-mz_perf_peek_durations_bucket_1      system
-mz_perf_peek_durations_core          system
-mz_perf_peek_durations_core_1        system
 mz_records_per_dataflow              system
 mz_records_per_dataflow_1            system
 mz_records_per_dataflow_global       system
@@ -666,14 +650,6 @@ mz_peek_active
 mz_peek_active_1
 mz_peek_durations
 mz_peek_durations_1
-
-> SHOW VIEWS FROM mz_catalog LIKE '%peek%';
-mz_perf_peek_durations_aggregates
-mz_perf_peek_durations_aggregates_1
-mz_perf_peek_durations_bucket
-mz_perf_peek_durations_bucket_1
-mz_perf_peek_durations_core
-mz_perf_peek_durations_core_1
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2


### PR DESCRIPTION
These views were used by a now-obsolete Grafana dashboard. They're not
documented and not used by anyone, as far as I can tell, so just remove
them. One less thing to worry about in #7174.

Touches #7174.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR removes obsolete system catalog tables.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - This is a breaking change. Sneaking it in before the window closes.
