### PR TITLE
cloudtest: remove CONNECTION references from SOURCEs

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -120,6 +120,7 @@ def trim_pipeline(pipeline: Any) -> None:
     no other untrimmed steps that depend on it.
     """
     repo = mzbuild.Repository(Path("."))
+    deps = repo.resolve_dependencies(image for image in repo)
 
     steps = OrderedDict()
     for config in pipeline["steps"]:
@@ -146,6 +147,10 @@ def trim_pipeline(pipeline: Any) -> None:
                         for dep in composition.dependencies:
                             step.image_dependencies.add(dep)
                         step.extra_inputs.add(str(repo.compositions[name]))
+                    elif plugin_name == "./ci/plugins/cloudtest":
+                        step.image_dependencies.add(deps["environmentd"])
+                        step.image_dependencies.add(deps["computed"])
+                        step.image_dependencies.add(deps["storaged"])
         steps[step.id] = step
 
     # Find all the steps whose inputs have changed with respect to main.

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -534,8 +534,12 @@ steps:
   - id: cloudtest
     label: Cloudtest
     depends_on: build-x86_64
+    timeout_in_minutes: 30
     artifact_paths: junit_cloudtest_*.xml
     inputs: [test/cloudtest]
+    # TODO: re-enable cloudtest.
+    # See: https://github.com/MaterializeInc/materialize/issues/14359
+    soft_fail: true
     plugins:
       - ./ci/plugins/cloudtest:
           args: [test/cloudtest/]

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -532,12 +532,13 @@ steps:
           args: [--scenario=RestartSourcePostgres, --check=DebeziumPostgres]
 
   - id: cloudtest
-    label: "Cloudtest"
+    label: Cloudtest
     depends_on: build-x86_64
     artifact_paths: junit_cloudtest_*.xml
+    inputs: [test/cloudtest]
     plugins:
       - ./ci/plugins/cloudtest:
-          args: ["test/cloudtest/"]
+          args: [test/cloudtest/]
 
   - id: lang-csharp
     label: ":csharp: tests"

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -27,10 +27,8 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
 
             > INSERT INTO t1 VALUES (234);
 
-            > CREATE CONNECTION kafka FOR KAFKA BROKER '${testdrive.kafka-addr}'
-
             > CREATE SOURCE s1
-              FROM KAFKA CONNECTION kafka
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
               TOPIC 'testdrive-crash-${testdrive.seed}'
               FORMAT BYTES
               ENVELOPE NONE;

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -20,15 +20,12 @@ def test_secrets(mz: MaterializeApplication) -> None:
             > CREATE SECRET username AS '123';
             > CREATE SECRET password AS '234';
 
-            # Our Redpanda instance is not configured for SASL, so we can not
-            # really establish a successful connection.
-
-            ! CREATE CONNECTION secrets_conn
-              FOR KAFKA
-              BROKER '${testdrive.kafka-addr}',
-              SASL MECHANISMS 'PLAIN',
-              SASL USERNAME = SECRET username,
-              SASL PASSWORD = SECRET password;
+            # Cloud test doesn't yet work with `CONNECTION`, so we cannot specify the necessary options to support complex auth.
+            ! CREATE SOURCE secrets_source
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
+              TOPIC 'testdrive-secrets-topic-${testdrive.seed}'
+              FORMAT BYTES
+              ENVELOPE NONE;
 
             contains: SSL handshake failed
             """

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -40,10 +40,8 @@ def test_testdrive(mz: MaterializeApplication) -> None:
                 > CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '2-2'));
                 > SET cluster=c1
 
-                > CREATE CONNECTION kafka FOR KAFKA BROKER '${testdrive.kafka-addr}'
-
                 > CREATE SOURCE s1
-                  FROM KAFKA CONNECTION kafka
+                  FROM KAFKA BROKER '${testdrive.kafka-addr}'
                   TOPIC'testdrive-test-${testdrive.seed}'
                   FORMAT BYTES
                   ENVELOPE NONE;

--- a/test/cloudtest/test_storaged.py
+++ b/test/cloudtest/test_storaged.py
@@ -23,16 +23,14 @@ def test_storaged_creation(mz: MaterializeApplication) -> None:
             $ kafka-ingest format=bytes topic=test
             ABC
 
-            > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
             > CREATE SOURCE source1
-              FROM KAFKA CONNECTION kafka_conn
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
               TOPIC 'testdrive-test-${testdrive.seed}'
               FORMAT BYTES
               ENVELOPE NONE;
 
             > CREATE SOURCE source2
-              FROM KAFKA CONNECTION kafka_conn
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
               TOPIC 'testdrive-test-${testdrive.seed}'
               FORMAT BYTES
               ENVELOPE NONE;
@@ -60,10 +58,8 @@ def test_storaged_shutdown(mz: MaterializeApplication) -> None:
             $ kafka-ingest format=bytes topic=test
             ABC
 
-            > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
             > CREATE SOURCE source1
-              FROM KAFKA CONNECTION kafka_conn
+              FROM KAFKA BROKER '${testdrive.kafka-addr}'
               TOPIC 'testdrive-test-${testdrive.seed}'
               FORMAT BYTES
               ENVELOPE NONE;


### PR DESCRIPTION
I recently converted all inline broker references in sources to use `CONNECTION`; that was possibly ill-advised and is breaking cloudtest

### Motivation

This PR fixes a recognized bug. See [Slack](https://materializeinc.slack.com/archives/CTESPM7FU/p1661273963621729)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes.
