### PR TITLE
Explain: Add arity and column type attributes.

### DIFF
--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -87,7 +87,7 @@ pub struct Attributes {
     non_negative: Option<bool>,
     subtree_size: Option<usize>,
     arity: Option<usize>,
-    column_types: Option<Vec<String>>,
+    types: Option<String>,
 }
 
 impl fmt::Display for Attributes {
@@ -102,8 +102,8 @@ impl fmt::Display for Attributes {
         if let Some(arity) = &self.arity {
             builder.field("arity", arity);
         }
-        if let Some(column_types) = &self.column_types {
-            builder.field("column_types", column_types);
+        if let Some(types) = &self.types {
+            builder.field("types", types);
         }
         builder.finish()
     }

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -86,6 +86,8 @@ pub(crate) struct AnnotatedPlan<'a, T> {
 pub struct Attributes {
     non_negative: Option<bool>,
     subtree_size: Option<usize>,
+    arity: Option<usize>,
+    column_types: Option<Vec<String>>,
 }
 
 impl fmt::Display for Attributes {
@@ -96,6 +98,12 @@ impl fmt::Display for Attributes {
         }
         if let Some(non_negative) = &self.non_negative {
             builder.field("non_negative", non_negative);
+        }
+        if let Some(arity) = &self.arity {
+            builder.field("arity", arity);
+        }
+        if let Some(column_types) = &self.column_types {
+            builder.field("column_types", column_types);
         }
         builder.finish()
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -300,79 +300,211 @@ impl MirRelationExpr {
     /// It is meant to be used during post-order traversals to compute relation
     /// schemas incrementally.
     pub fn typ_with_input_types(&self, input_types: &[RelationType]) -> RelationType {
-        assert_eq!(self.num_inputs(), input_types.len());
+        let column_types = self.col_with_input_cols(input_types.iter().map(|i| &i.column_types));
+        let unique_keys = self.keys_with_input_keys(
+            input_types.iter().map(|i| i.arity()),
+            input_types.iter().map(|i| &i.keys),
+        );
+        RelationType::new(column_types).with_keys(unique_keys)
+    }
+
+    /// Reports the column types of the relation given the column types of the input relations.
+    ///
+    /// `input_types` is required to contain the column types for the input relations of
+    /// the current relation in the same order as they are visited by `try_visit1`
+    /// method, even though not all may be used for computing the schema of the
+    /// current relation. For example, `Let` expects two input types, one for the
+    /// value relation and one for the body, in that order, but only the one for the
+    /// body is used to determine the type of the `Let` relation.
+    ///
+    /// It is meant to be used during post-order traversals to compute column types
+    /// incrementally.
+    pub fn col_with_input_cols<'a, I>(&self, mut input_types: I) -> Vec<ColumnType>
+    where
+        I: Iterator<Item = &'a Vec<ColumnType>>,
+    {
+        use MirRelationExpr::*;
+
         match self {
-            MirRelationExpr::Constant { rows, typ } => {
-                if let Ok(rows) = rows {
-                    let n_cols = typ.arity();
-                    // If the `i`th entry is `Some`, then we have not yet observed non-uniqueness in the `i`th column.
-                    let mut unique_values_per_col = vec![Some(HashSet::<Datum>::default()); n_cols];
-                    for (row, diff) in rows {
-                        for (i, (datum, column_typ)) in
-                            row.iter().zip(typ.column_types.iter()).enumerate()
+            Constant { typ, .. } | Get { typ, .. } => typ.column_types.clone(),
+            Project { outputs, .. } => {
+                let input = input_types.next().unwrap();
+                outputs.iter().map(|&i| input[i].clone()).collect()
+            }
+            Map { scalars, .. } => {
+                let mut result = input_types.next().unwrap().clone();
+                for scalar in scalars.iter() {
+                    result.push(scalar.typ(&result))
+                }
+                result
+            }
+            FlatMap { func, .. } => {
+                let mut result = input_types.next().unwrap().clone();
+                result.extend(func.output_type().column_types);
+                result
+            }
+            Filter { predicates, .. } => {
+                let mut result = input_types.next().unwrap().clone();
+                // Augment non-nullability of columns, by observing either
+                // 1. Predicates that explicitly test for null values, and
+                // 2. Columns that if null would make a predicate be null.
+                let mut nonnull_required_columns = HashSet::new();
+                for predicate in predicates {
+                    // Add any columns that being null would force the predicate to be null.
+                    // Should that happen, the row would be discarded.
+                    predicate.non_null_requirements(&mut nonnull_required_columns);
+                    // Test for explicit checks that a column is non-null.
+                    if let MirScalarExpr::CallUnary {
+                        func: UnaryFunc::Not(scalar_func::Not),
+                        expr,
+                    } = predicate
+                    {
+                        if let MirScalarExpr::CallUnary {
+                            func: UnaryFunc::IsNull(scalar_func::IsNull),
+                            expr,
+                        } = &**expr
                         {
-                            // If the record will be observed, we should validate its type.
-                            if datum != Datum::Dummy {
-                                assert!(
-                                    datum.is_instance_of(column_typ),
-                                    "Expected datum of type {:?}, got value {:?}",
-                                    column_typ,
-                                    datum
-                                );
-                                if let Some(unique_vals) = &mut unique_values_per_col[i] {
-                                    let is_dupe = *diff != 1 || !unique_vals.insert(datum);
-                                    if is_dupe {
-                                        unique_values_per_col[i] = None;
-                                    }
+                            if let MirScalarExpr::Column(c) = &**expr {
+                                result[*c].nullable = false;
+                            }
+                        }
+                    }
+                }
+                // Set as nonnull any columns where null values would cause
+                // any predicate to evaluate to null.
+                for column in nonnull_required_columns.into_iter() {
+                    result[column].nullable = false;
+                }
+                result
+            }
+            // Iterating and cloning types inside the flat_map() avoids allocating Vec<>,
+            // as clones are directly added to column_types Vec<>.
+            Join { .. } => input_types.flat_map(|cols| cols.to_owned()).collect(),
+            Reduce {
+                group_key,
+                aggregates,
+                ..
+            } => {
+                let input = input_types.next().unwrap();
+                group_key
+                    .iter()
+                    .map(|e| e.typ(&input))
+                    .chain(aggregates.iter().map(|agg| agg.typ(&input)))
+                    .collect()
+            }
+            TopK { .. } | Negate { .. } | Threshold { .. } | ArrangeBy { .. } => {
+                input_types.next().unwrap().clone()
+            }
+            Let { .. } => {
+                // skip over the unique keys for value
+                input_types.next();
+                input_types.next().unwrap().clone()
+            }
+            Union { .. } => {
+                let mut result = input_types.next().unwrap().clone();
+                for input_col_types in input_types {
+                    for (base_col, col) in result.iter_mut().zip_eq(input_col_types) {
+                        *base_col = base_col
+                            .union(&col)
+                            .map_err(|e| format!("{}\nIn {:#?}", e, self))
+                            .unwrap();
+                    }
+                }
+                result
+            }
+        }
+    }
+
+    /// Reports the unique keys of the relation given the arities and the unique
+    /// keys of the input relations.
+    ///
+    /// `input_arities` and `input_keys` are required to contain the
+    /// corresponding info for the input relations of
+    /// the current relation in the same order as they are visited by `try_visit1`
+    /// method, even though not all may be used for computing the schema of the
+    /// current relation. For example, `Let` expects two input types, one for the
+    /// value relation and one for the body, in that order, but only the one for the
+    /// body is used to determine the type of the `Let` relation.
+    ///
+    /// It is meant to be used during post-order traversals to compute unique keys
+    /// incrementally.
+    pub fn keys_with_input_keys<'a, I, J>(
+        &self,
+        mut input_arities: I,
+        mut input_keys: J,
+    ) -> Vec<Vec<usize>>
+    where
+        I: Iterator<Item = usize>,
+        J: Iterator<Item = &'a Vec<Vec<usize>>>,
+    {
+        use MirRelationExpr::*;
+
+        match self {
+            Constant {
+                rows: Ok(rows),
+                typ,
+            } => {
+                let n_cols = typ.arity();
+                // If the `i`th entry is `Some`, then we have not yet observed non-uniqueness in the `i`th column.
+                let mut unique_values_per_col = vec![Some(HashSet::<Datum>::default()); n_cols];
+                for (row, diff) in rows {
+                    for (i, datum) in row.iter().enumerate() {
+                        if datum != Datum::Dummy {
+                            if let Some(unique_vals) = &mut unique_values_per_col[i] {
+                                let is_dupe = *diff != 1 || !unique_vals.insert(datum);
+                                if is_dupe {
+                                    unique_values_per_col[i] = None;
                                 }
                             }
                         }
                     }
-                    if rows.len() == 0 || (rows.len() == 1 && rows[0].1 == 1) {
-                        RelationType::new(typ.column_types.clone()).with_key(vec![])
-                    } else {
-                        // XXX - Multi-column keys are not detected.
-                        typ.clone().with_keys(
+                }
+                if rows.len() == 0 || (rows.len() == 1 && rows[0].1 == 1) {
+                    vec![vec![]]
+                } else {
+                    // XXX - Multi-column keys are not detected.
+                    typ.keys
+                        .iter()
+                        .cloned()
+                        .chain(
                             unique_values_per_col
                                 .into_iter()
                                 .enumerate()
                                 .filter(|(_idx, unique_vals)| unique_vals.is_some())
-                                .map(|(idx, _)| vec![idx])
-                                .collect(),
+                                .map(|(idx, _)| vec![idx]),
                         )
-                    }
-                } else {
-                    typ.clone()
+                        .collect()
                 }
             }
-            MirRelationExpr::Get { typ, .. } => typ.clone(),
-            MirRelationExpr::Let { .. } => input_types.last().unwrap().clone(),
-            MirRelationExpr::Project { input: _, outputs } => {
-                let input_typ = &input_types[0];
-                let mut output_typ = RelationType::new(
-                    outputs
-                        .iter()
-                        .map(|&i| input_typ.column_types[i].clone())
-                        .collect(),
-                );
-                for keys in input_typ.keys.iter() {
-                    if keys.iter().all(|k| outputs.contains(k)) {
-                        output_typ = output_typ.with_key(
-                            keys.iter()
-                                .map(|c| outputs.iter().position(|o| o == c).unwrap())
-                                .collect(),
-                        );
-                    }
-                }
-                output_typ
+            Constant { rows: Err(_), typ } | Get { typ, .. } => typ.keys.clone(),
+            Threshold { .. } | ArrangeBy { .. } => input_keys.next().unwrap().clone(),
+            Let { .. } => {
+                // skip over the unique keys for value
+                input_keys.next();
+                input_keys.next().unwrap().clone()
             }
-            MirRelationExpr::Map { scalars, .. } => {
-                let mut typ = input_types[0].clone();
-                let arity = typ.column_types.len();
-
+            Project { outputs, .. } => {
+                let input = input_keys.next().unwrap();
+                input
+                    .iter()
+                    .filter_map(|key_set| {
+                        if key_set.iter().all(|k| outputs.contains(k)) {
+                            Some(
+                                key_set
+                                    .iter()
+                                    .map(|c| outputs.iter().position(|o| o == c).unwrap())
+                                    .collect(),
+                            )
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            }
+            Map { scalars, .. } => {
                 let mut remappings = Vec::new();
+                let arity = input_arities.next().unwrap();
                 for (column, scalar) in scalars.iter().enumerate() {
-                    typ.column_types.push(scalar.typ(&typ.column_types));
                     // assess whether the scalar preserves uniqueness,
                     // and could participate in a key!
 
@@ -395,14 +527,15 @@ impl MirRelationExpr {
                     }
                 }
 
+                let mut result = input_keys.next().unwrap().clone();
+                let mut new_keys = Vec::new();
                 // Any column in `remappings` could be replaced in a key
                 // by the corresponding c. This could lead to combinatorial
                 // explosion using our current representation, so we wont
                 // do that. Instead, we'll handle the case of one remapping.
                 if remappings.len() == 1 {
                     let (old, new) = remappings.pop().unwrap();
-                    let mut new_keys = Vec::new();
-                    for key in typ.keys.iter() {
+                    for key in &result {
                         if key.contains(&old) {
                             let mut new_key: Vec<usize> =
                                 key.iter().cloned().filter(|k| k != &old).collect();
@@ -411,27 +544,26 @@ impl MirRelationExpr {
                             new_keys.push(new_key);
                         }
                     }
-                    for new_key in new_keys {
-                        typ = typ.with_key(new_key);
-                    }
+                    result.append(&mut new_keys);
                 }
-
-                typ
+                result
             }
-            MirRelationExpr::FlatMap { func, .. } => {
-                let mut input_typ = input_types[0].clone();
-                input_typ
-                    .column_types
-                    .extend(func.output_type().column_types);
-                // FlatMap can add duplicate rows, so input keys are no longer valid
-                let typ = RelationType::new(input_typ.column_types);
-                typ
+            FlatMap { .. } => {
+                // FlatMap can add duplicate rows, so input keys are no longer
+                // valid
+                vec![]
             }
-            MirRelationExpr::Filter { predicates, .. } => {
+            Negate { .. } => {
+                // Although negate may have distinct records for each key,
+                // the multiplicity is -1 rather than 1. This breaks many
+                // of the optimization uses of "keys".
+                vec![]
+            }
+            Filter { predicates, .. } => {
                 // A filter inherits the keys of its input unless the filters
                 // have reduced the input to a single row, in which case the
                 // keys of the input are `()`.
-                let mut input_typ = input_types[0].clone();
+                let mut input = input_keys.next().unwrap().clone();
                 let cols_equal_to_literal = predicates
                     .iter()
                     .filter_map(|p| {
@@ -450,10 +582,10 @@ impl MirRelationExpr {
                         None
                     })
                     .collect::<Vec<_>>();
-                for key_set in &mut input_typ.keys {
+                for key_set in &mut input {
                     key_set.retain(|k| !cols_equal_to_literal.contains(&k));
                 }
-                if !input_typ.keys.is_empty() {
+                if !input.is_empty() {
                     // If `[0 1]` is an input key and there `#0 = #1` exists as a
                     // predicate, we should present both `[0]` and `[1]` as keys
                     // of the output. Also, if there is a key involving X column
@@ -481,7 +613,7 @@ impl MirRelationExpr {
                     });
 
                     // Keep doing replacements until the number of keys settles
-                    let mut prev_keys: HashSet<_> = input_typ.keys.drain(..).collect();
+                    let mut prev_keys: HashSet<_> = input.drain(..).collect();
                     let mut prev_keys_size = 0;
                     while prev_keys_size != prev_keys.len() {
                         prev_keys_size = prev_keys.len();
@@ -520,93 +652,32 @@ impl MirRelationExpr {
                         }
                     }
 
-                    input_typ.keys = prev_keys.into_iter().sorted().collect_vec();
+                    prev_keys.into_iter().sorted().collect()
+                } else {
+                    input
                 }
-                // Augment non-nullability of columns, by observing either
-                // 1. Predicates that explicitly test for null values, and
-                // 2. Columns that if null would make a predicate be null.
-                let mut nonnull_required_columns = HashSet::new();
-                for predicate in predicates {
-                    // Add any columns that being null would force the predicate to be null.
-                    // Should that happen, the row would be discarded.
-                    predicate.non_null_requirements(&mut nonnull_required_columns);
-                    // Test for explicit checks that a column is non-null.
-                    if let MirScalarExpr::CallUnary {
-                        func: UnaryFunc::Not(scalar_func::Not),
-                        expr,
-                    } = predicate
-                    {
-                        if let MirScalarExpr::CallUnary {
-                            func: UnaryFunc::IsNull(scalar_func::IsNull),
-                            expr,
-                        } = &**expr
-                        {
-                            if let MirScalarExpr::Column(c) = &**expr {
-                                input_typ.column_types[*c].nullable = false;
-                            }
-                        }
-                    }
-                }
-                // Set as nonnull any columns where null values would cause
-                // any predicate to evaluate to null.
-                for column in nonnull_required_columns.into_iter() {
-                    input_typ.column_types[column].nullable = false;
-                }
-                input_typ
             }
-            MirRelationExpr::Join { equivalences, .. } => {
-                // Iterating and cloning types inside the flat_map() avoids allocating Vec<>,
-                // as clones are directly added to column_types Vec<>.
-                let column_types = input_types
-                    .iter()
-                    .flat_map(|i| i.column_types.iter().cloned())
-                    .collect::<Vec<_>>();
-                let mut typ = RelationType::new(column_types);
-
-                // It is important the `new_from_input_types` constructor is
+            Join { equivalences, .. } => {
+                // It is important the `new_from_input_arities` constructor is
                 // used. Otherwise, Materialize may potentially end up in an
                 // infinite loop.
-                let input_mapper =
-                    join_input_mapper::JoinInputMapper::new_from_input_types(input_types);
+                let input_mapper = crate::JoinInputMapper::new_from_input_arities(input_arities);
 
-                let global_keys = input_mapper.global_keys(
-                    &input_types
-                        .iter()
-                        .map(|t| t.keys.clone())
-                        .collect::<Vec<_>>(),
-                    equivalences,
-                );
-
-                for keys in global_keys {
-                    typ = typ.with_key(keys.clone());
-                }
-                typ
+                input_mapper.global_keys(input_keys, equivalences)
             }
-            MirRelationExpr::Reduce {
-                group_key,
-                aggregates,
-                ..
-            } => {
-                let input_typ = &input_types[0];
-                let mut column_types = group_key
-                    .iter()
-                    .map(|e| e.typ(&input_typ.column_types))
-                    .collect::<Vec<_>>();
-                for agg in aggregates {
-                    column_types.push(agg.typ(&input_typ.column_types));
-                }
-                let mut result = RelationType::new(column_types);
+            Reduce { group_key, .. } => {
                 // The group key should form a key, but we might already have
                 // keys that are subsets of the group key, and should retain
                 // those instead, if so.
-                let mut keys = Vec::new();
-                for key in input_typ.keys.iter() {
-                    if key
+                let mut result = Vec::new();
+                for key_set in input_keys.next().unwrap() {
+                    if key_set
                         .iter()
                         .all(|k| group_key.contains(&MirScalarExpr::Column(*k)))
                     {
-                        keys.push(
-                            key.iter()
+                        result.push(
+                            key_set
+                                .iter()
                                 .map(|i| {
                                     group_key
                                         .iter()
@@ -617,47 +688,23 @@ impl MirRelationExpr {
                         );
                     }
                 }
-                if keys.is_empty() {
-                    keys.push((0..group_key.len()).collect());
-                }
-                for key in keys {
-                    result = result.with_key(key);
+                if result.is_empty() {
+                    result.push((0..group_key.len()).collect());
                 }
                 result
             }
-            MirRelationExpr::TopK {
+            TopK {
                 group_key, limit, ..
             } => {
                 // If `limit` is `Some(1)` then the group key will become
                 // a unique key, as there will be only one record with that key.
-                let mut typ = input_types[0].clone();
+                let mut result = input_keys.next().unwrap().clone();
                 if limit == &Some(1) {
-                    typ = typ.with_key(group_key.clone())
+                    result.push(group_key.clone())
                 }
-                typ
+                result
             }
-            MirRelationExpr::Negate { input: _ } => {
-                // Although negate may have distinct records for each key,
-                // the multiplicity is -1 rather than 1. This breaks many
-                // of the optimization uses of "keys".
-                let mut typ = input_types[0].clone();
-                typ.keys.clear();
-                typ
-            }
-            MirRelationExpr::Threshold { .. } => input_types[0].clone(),
-            MirRelationExpr::Union { base, inputs } => {
-                let mut base_cols = input_types[0].column_types.clone();
-                for input_type in input_types.iter().skip(1) {
-                    for (base_col, col) in
-                        base_cols.iter_mut().zip_eq(input_type.column_types.iter())
-                    {
-                        *base_col = base_col
-                            .union(&col)
-                            .map_err(|e| format!("{}\nIn {:#?}", e, self))
-                            .unwrap();
-                    }
-                }
-
+            Union { base, inputs } => {
                 // Generally, unions do not have any unique keys, because
                 // each input might duplicate some. However, there is at
                 // least one idiomatic structure that does preserve keys,
@@ -681,15 +728,16 @@ impl MirRelationExpr {
                 // and who knows what is true (not expected, but again
                 // who knows what the query plan might look like).
 
+                let arity = input_arities.next().unwrap();
                 let (base_projection, base_with_project_stripped) =
                     if let MirRelationExpr::Project { input, outputs } = &**base {
                         (outputs.clone(), &**input)
                     } else {
                         // A input without a project is equivalent to an input
                         // with the project being all columns in the input in order.
-                        ((0..base_cols.len()).collect::<Vec<_>>(), &**base)
+                        ((0..arity).collect::<Vec<_>>(), &**base)
                     };
-                let mut keys = Vec::new();
+                let mut result = Vec::new();
                 if let MirRelationExpr::Get {
                     id: first_id,
                     typ: _,
@@ -707,7 +755,7 @@ impl MirRelationExpr {
                                             } = &**input
                                             {
                                                 if first_id == second_id {
-                                                    keys.extend(
+                                                    result.extend(
                                                         inputs[0].typ().keys.drain(..).filter(
                                                             |key| {
                                                                 key.iter().all(|c| {
@@ -727,11 +775,9 @@ impl MirRelationExpr {
                         }
                     }
                 }
-
-                RelationType::new(base_cols).with_keys(keys)
                 // Important: do not inherit keys of either input, as not unique.
+                result
             }
-            MirRelationExpr::ArrangeBy { .. } => input_types[0].clone(),
         }
     }
 
@@ -739,29 +785,82 @@ impl MirRelationExpr {
     ///
     /// This number is determined from the type, which is determined recursively
     /// at non-trivial cost.
+    ///
+    /// The arity is computed incrementally with a recursive post-order
+    /// traversal, that accumulates the arities for the relations yet to be
+    /// visited in `arity_stack`.
     pub fn arity(&self) -> usize {
+        let mut arity_stack = Vec::new();
+        #[allow(deprecated)]
+        self.visit_pre_post_nolimit(
+            &mut |e: &MirRelationExpr| -> Option<Vec<&MirRelationExpr>> {
+                if let MirRelationExpr::Let { body, .. } = &e {
+                    // Do not traverse the value sub-graph, since it's not relevant for
+                    // determining the arity of Let operators.
+                    Some(vec![&*body])
+                } else {
+                    None
+                }
+            },
+            &mut |e: &MirRelationExpr| {
+                if let MirRelationExpr::Let { .. } = &e {
+                    let body_arity = arity_stack.pop().unwrap();
+                    arity_stack.push(0);
+                    arity_stack.push(body_arity);
+                }
+                let num_inputs = e.num_inputs();
+                let arity = e
+                    .arity_with_input_arities(arity_stack[arity_stack.len() - num_inputs..].iter());
+                arity_stack.truncate(arity_stack.len() - num_inputs);
+                arity_stack.push(arity);
+            },
+        );
+        assert_eq!(arity_stack.len(), 1);
+        arity_stack.pop().unwrap()
+    }
+
+    /// Reports the arity of the relation given the schema of the input relations.
+    ///
+    /// `input_arities` is required to contain the arities for the input relations of
+    /// the current relation in the same order as they are visited by `try_visit1`
+    /// method, even though not all may be used for computing the schema of the
+    /// current relation. For example, `Let` expects two input types, one for the
+    /// value relation and one for the body, in that order, but only the one for the
+    /// body is used to determine the type of the `Let` relation.
+    ///
+    /// It is meant to be used during post-order traversals to compute arities
+    /// incrementally.
+    pub fn arity_with_input_arities<'a, I>(&self, mut input_arities: I) -> usize
+    where
+        I: Iterator<Item = &'a usize>,
+    {
+        use MirRelationExpr::*;
+
         match self {
-            MirRelationExpr::Constant { rows: _, typ } => typ.arity(),
-            MirRelationExpr::Get { typ, .. } => typ.arity(),
-            MirRelationExpr::Let { body, .. } => body.arity(),
-            MirRelationExpr::Project { input: _, outputs } => outputs.len(),
-            MirRelationExpr::Map { input, scalars } => input.arity() + scalars.len(),
-            MirRelationExpr::FlatMap { input, func, .. } => {
-                input.arity() + func.output_type().column_types.len()
+            Constant { rows: _, typ } => typ.arity(),
+            Get { typ, .. } => typ.arity(),
+            Let { .. } => {
+                input_arities.next();
+                *input_arities.next().unwrap()
             }
-            MirRelationExpr::Filter { input, .. } => input.arity(),
-            MirRelationExpr::Join { inputs, .. } => inputs.iter().map(|i| i.arity()).sum(),
-            MirRelationExpr::Reduce {
+            Project { outputs, .. } => outputs.len(),
+            Map { scalars, .. } => *input_arities.next().unwrap() + scalars.len(),
+            FlatMap { func, .. } => {
+                *input_arities.next().unwrap() + func.output_type().column_types.len()
+            }
+            Join { .. } => input_arities.map(|a| *a).sum(),
+            Reduce {
                 input: _,
                 group_key,
                 aggregates,
                 ..
             } => group_key.len() + aggregates.len(),
-            MirRelationExpr::TopK { input, .. } => input.arity(),
-            MirRelationExpr::Negate { input } => input.arity(),
-            MirRelationExpr::Threshold { input } => input.arity(),
-            MirRelationExpr::Union { base, inputs: _ } => base.arity(),
-            MirRelationExpr::ArrangeBy { input, .. } => input.arity(),
+            Filter { .. }
+            | TopK { .. }
+            | Negate { .. }
+            | Threshold { .. }
+            | Union { .. }
+            | ArrangeBy { .. } => *input_arities.next().unwrap(),
         }
     }
 

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -291,7 +291,7 @@ impl MirRelationExpr {
     /// Reports the schema of the relation given the schema of the input relations.
     ///
     /// `input_types` is required to contain the schemas for the input relations of
-    /// the current relation in the same order as they are visited by `try_visit1`
+    /// the current relation in the same order as they are visited by `try_visit_children`
     /// method, even though not all may be used for computing the schema of the
     /// current relation. For example, `Let` expects two input types, one for the
     /// value relation and one for the body, in that order, but only the one for the
@@ -311,7 +311,7 @@ impl MirRelationExpr {
     /// Reports the column types of the relation given the column types of the input relations.
     ///
     /// `input_types` is required to contain the column types for the input relations of
-    /// the current relation in the same order as they are visited by `try_visit1`
+    /// the current relation in the same order as they are visited by `try_visit_children`
     /// method, even though not all may be used for computing the schema of the
     /// current relation. For example, `Let` expects two input types, one for the
     /// value relation and one for the body, in that order, but only the one for the
@@ -420,7 +420,7 @@ impl MirRelationExpr {
     ///
     /// `input_arities` and `input_keys` are required to contain the
     /// corresponding info for the input relations of
-    /// the current relation in the same order as they are visited by `try_visit1`
+    /// the current relation in the same order as they are visited by `try_visit_children`
     /// method, even though not all may be used for computing the schema of the
     /// current relation. For example, `Let` expects two input types, one for the
     /// value relation and one for the body, in that order, but only the one for the
@@ -822,7 +822,7 @@ impl MirRelationExpr {
     /// Reports the arity of the relation given the schema of the input relations.
     ///
     /// `input_arities` is required to contain the arities for the input relations of
-    /// the current relation in the same order as they are visited by `try_visit1`
+    /// the current relation in the same order as they are visited by `try_visit_children`
     /// method, even though not all may be used for computing the schema of the
     /// current relation. For example, `Let` expects two input types, one for the
     /// value relation and one for the body, in that order, but only the one for the

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -359,6 +359,10 @@ impl From<RecursionLimitError> for ExplainError {
 /// A set of options for controlling the output of [`Explain`] implementations.
 #[derive(Debug)]
 pub struct ExplainConfig {
+    /// Show the number of columns.
+    pub arity: bool,
+    /// For each column, show the scalar type and whether the column is nullable
+    pub column_types: bool,
     /// Render implemented MIR `Join` nodes in a way which reflects the implementation.
     pub join_impls: bool,
     /// Show the `non_negative` in the explanation if it is supported by the backing IR.
@@ -379,7 +383,7 @@ pub struct ExplainConfig {
 
 impl ExplainConfig {
     pub fn requires_attributes(&self) -> bool {
-        self.subtree_size || self.non_negative
+        self.subtree_size || self.non_negative || self.arity || self.column_types
     }
 }
 
@@ -393,6 +397,8 @@ impl TryFrom<HashSet<String>> for ExplainConfig {
             config_flags.insert("raw_syntax".into());
         }
         let result = ExplainConfig {
+            arity: config_flags.remove("arity"),
+            column_types: config_flags.remove("column_types"),
             join_impls: config_flags.remove("join_impls"),
             non_negative: config_flags.remove("non_negative"),
             no_fast_path: config_flags.remove("no_fast_path"),
@@ -754,6 +760,8 @@ mod tests {
 
         let format = ExplainFormat::Text;
         let config = ExplainConfig {
+            arity: false,
+            column_types: false,
             join_impls: false,
             non_negative: false,
             no_fast_path: false,

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -361,8 +361,6 @@ impl From<RecursionLimitError> for ExplainError {
 pub struct ExplainConfig {
     /// Show the number of columns.
     pub arity: bool,
-    /// For each column, show the scalar type and whether the column is nullable
-    pub column_types: bool,
     /// Render implemented MIR `Join` nodes in a way which reflects the implementation.
     pub join_impls: bool,
     /// Show the `non_negative` in the explanation if it is supported by the backing IR.
@@ -377,13 +375,13 @@ pub struct ExplainConfig {
     pub subtree_size: bool,
     /// Print optimization timings (currently unsupported).
     pub timing: bool,
-    /// Show the `type` attribute in the explanation (currently unsupported by all IRs).
+    /// Show the `type` attribute in the explanation.
     pub types: bool,
 }
 
 impl ExplainConfig {
     pub fn requires_attributes(&self) -> bool {
-        self.subtree_size || self.non_negative || self.arity || self.column_types
+        self.subtree_size || self.non_negative || self.arity || self.types
     }
 }
 
@@ -398,7 +396,6 @@ impl TryFrom<HashSet<String>> for ExplainConfig {
         }
         let result = ExplainConfig {
             arity: config_flags.remove("arity"),
-            column_types: config_flags.remove("column_types"),
             join_impls: config_flags.remove("join_impls"),
             non_negative: config_flags.remove("non_negative"),
             no_fast_path: config_flags.remove("no_fast_path"),
@@ -761,7 +758,6 @@ mod tests {
         let format = ExplainFormat::Text;
         let config = ExplainConfig {
             arity: false,
-            column_types: false,
             join_impls: false,
             non_negative: false,
             no_fast_path: false,

--- a/src/transform/src/attribute/arity.rs
+++ b/src/transform/src/attribute/arity.rs
@@ -1,0 +1,42 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Definition and helper structs for the [`Arity`] attribute.
+
+use mz_expr::MirRelationExpr;
+
+use super::{subtree_size::SubtreeSize, Attribute};
+
+/// Compute the column types of each subtree of a [MirRelationExpr] from the
+/// bottom-up.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct Arity {
+    /// A vector of results for all nodes in the visited tree in
+    /// post-visit order.
+    pub results: Vec<usize>,
+}
+
+impl Attribute for Arity {
+    type Value = Vec<usize>;
+    type Dependencies = SubtreeSize;
+
+    fn derive(&mut self, expr: &MirRelationExpr, subtree_size: &SubtreeSize) {
+        let n = self.results.len();
+        let mut offsets = Vec::new();
+        let mut offset = 1;
+        for _ in 0..expr.num_inputs() {
+            offsets.push(n - offset);
+            offset += &subtree_size.results[n - offset];
+        }
+        let subtree_arity =
+            expr.arity_with_input_arities(offsets.into_iter().rev().map(|o| &self.results[o]));
+        self.results.push(subtree_arity);
+    }
+}

--- a/src/transform/src/attribute/column_types.rs
+++ b/src/transform/src/attribute/column_types.rs
@@ -1,0 +1,44 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Definition and helper structs for the [`ColumnTypes`] attribute.
+
+use mz_expr::MirRelationExpr;
+use mz_repr::ColumnType;
+
+use super::subtree_size::SubtreeSize;
+use super::Attribute;
+
+/// Compute the column types of each subtree of a [MirRelationExpr] from the
+/// bottom-up.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct ColumnTypes {
+    /// A vector of results for all nodes in the visited tree in
+    /// post-visit order.
+    pub results: Vec<Vec<ColumnType>>,
+}
+
+impl Attribute for ColumnTypes {
+    type Value = Vec<ColumnType>;
+    type Dependencies = SubtreeSize;
+
+    fn derive(&mut self, expr: &MirRelationExpr, subtree_size: &SubtreeSize) {
+        let n = self.results.len();
+        let mut offsets = Vec::new();
+        let mut offset = 1;
+        for _ in 0..expr.num_inputs() {
+            offsets.push(n - offset);
+            offset += &subtree_size.results[n - offset];
+        }
+        let subtree_column_types =
+            expr.col_with_input_cols(offsets.into_iter().rev().map(|o| &self.results[o]));
+        self.results.push(subtree_column_types);
+    }
+}

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -13,6 +13,8 @@ use std::collections::HashMap;
 
 use mz_expr::{LocalId, MirRelationExpr};
 
+pub mod arity;
+pub mod column_types;
 pub mod non_negative;
 pub mod subtree_size;
 

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 use mz_expr::{LocalId, MirRelationExpr};
 
 pub mod arity;
-pub mod column_types;
 pub mod non_negative;
+pub mod relation_type;
 pub mod subtree_size;
 
 /// A common interface to be implemented by all derived attributes.

--- a/src/transform/src/attribute/relation_type.rs
+++ b/src/transform/src/attribute/relation_type.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! Definition and helper structs for the [`ColumnTypes`] attribute.
+//! Definition and helper structs for the [`RelationType`] attribute.
 
 use mz_expr::MirRelationExpr;
 use mz_repr::ColumnType;
@@ -19,13 +19,13 @@ use super::Attribute;
 /// bottom-up.
 #[derive(Default)]
 #[allow(missing_debug_implementations)]
-pub struct ColumnTypes {
+pub struct RelationType {
     /// A vector of results for all nodes in the visited tree in
     /// post-visit order.
     pub results: Vec<Vec<ColumnType>>,
 }
 
-impl Attribute for ColumnTypes {
+impl Attribute for RelationType {
     type Value = Vec<ColumnType>;
     type Dependencies = SubtreeSize;
 

--- a/test/sqllogictest/explain/attributes/mir_arity.slt
+++ b/test/sqllogictest/explain/attributes/mir_arity.slt
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b int
+)
+
+statement ok
+CREATE TABLE u (
+  c int,
+  d int
+)
+
+statement ok
+CREATE TABLE v (
+  e int,
+  f int
+)
+
+statement ok
+CREATE INDEX t_a_idx ON T(a);
+
+statement ok
+CREATE INDEX u_d_idx ON U(d);
+
+# Constant EXCEPT (<outer join> order by ..) will return at least one instance
+# of each flavor of MirRelationExpr.
+
+statement ok
+CREATE VIEW test1 AS
+(SELECT 1 as a, 2 as b, 11 as h, 12 as g) EXCEPT (SELECT t.*, u.c + 1 as g FROM (SELECT a, b, generate_series(a, b) as h FROM t) t LEFT OUTER JOIN u on t.a = u.d
+ORDER BY t.b LIMIT 10 OFFSET 1);
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR VIEW test1
+----
+Explained Query
+  Let // { arity: 4 }
+    Threshold // { arity: 4 }
+      Union // { arity: 4 }
+        Negate // { arity: 4 }
+          Distinct group_by=[#0, #1, #2, #3] // { arity: 4 }
+            TopK order_by=[#1 asc nulls_last] limit=10 offset=1 monotonic=false // { arity: 4 }
+              Project (#0..=#2, #4) // { arity: 4 }
+                Map ((#3 + 1)) // { arity: 5 }
+                  Union // { arity: 4 }
+                    Map (null) // { arity: 4 }
+                      Union // { arity: 3 }
+                        Negate // { arity: 3 }
+                          Project (#0..=#2) // { arity: 3 }
+                            Join on=(#0 = #3) type=differential // { arity: 4 }
+                              Get l0 // { arity: 3 }
+                              ArrangeBy keys=[[#0]] // { arity: 1 }
+                                Distinct group_by=[#0] // { arity: 1 }
+                                  Project (#0) // { arity: 1 }
+                                    Get l1 // { arity: 4 }
+                        Get l0 // { arity: 3 }
+                    Get l1 // { arity: 4 }
+        Constant // { arity: 4 }
+          - (1, 2, 11, 12)
+    Where
+      l1 =
+        Project (#0..=#3) // { arity: 4 }
+          Join on=(#0 = #4) type=differential // { arity: 5 }
+            Filter (#0) IS NOT NULL // { arity: 3 }
+              Get l0 // { arity: 3 }
+            ArrangeBy keys=[[#1]] // { arity: 2 }
+              Get materialize.public.u // { arity: 2 }
+      l0 =
+        FlatMap generate_series(#0, #1, 1) // { arity: 3 }
+          Get materialize.public.t // { arity: 2 }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+  - materialize.public.u_d_idx
+
+EOF
+
+# a reduce with an aggregation.
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
+SELECT sum(e * f), max(f) FROM v GROUP BY mod(e, 5)
+----
+Explained Query
+  Project (#1, #2) // { arity: 2 }
+    Reduce group_by=[(#0 % 5)] aggregates=[sum((#0 * #1)), max(#1)] // { arity: 3 }
+      Get materialize.public.v // { arity: 2 }
+
+Source materialize.public.v
+  Demand (#0, #1)
+
+EOF
+
+# A let where the value has a different arity from the body
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
+WITH u AS (select u.c + 1 as g from u)
+SELECT u.g as g, w.g as h FROM u, u as w WHERE u.g = w.g
+----
+Explained Query
+  Let // { arity: 2 }
+    Project (#0, #0) // { arity: 2 }
+      Join on=(#0 = #1) type=differential // { arity: 2 }
+        ArrangeBy keys=[[#0]] // { arity: 1 }
+          Get l0 // { arity: 1 }
+        Get l0 // { arity: 1 }
+    Where
+      l0 =
+        Project (#2) // { arity: 1 }
+          Filter (#0) IS NOT NULL // { arity: 3 }
+            Map ((#0 + 1)) // { arity: 3 }
+              Get materialize.public.u // { arity: 2 }
+
+Used Indexes:
+  - materialize.public.u_d_idx
+
+EOF
+
+# a constant error
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
+SELECT * FROM u WHERE (SELECT f FROM v WHERE v.e = u.d)
+----
+EOF

--- a/test/sqllogictest/explain/attributes/mir_column_types.slt
+++ b/test/sqllogictest/explain/attributes/mir_column_types.slt
@@ -1,0 +1,160 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b text,
+  c date
+)
+
+statement ok
+CREATE TABLE u (
+  d int
+)
+
+statement ok
+CREATE TABLE v (
+  e double,
+  f bool
+)
+
+#### NULL propagation ####
+
+# Union that does not propagate a null
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(column_types) AS TEXT FOR (SELECT * FROM v WHERE f) UNION ALL (SELECT * FROM v WHERE e IS NOT NULL)
+----
+Explained Query
+  Union // { column_types: ["double precision?", "boolean?"] }
+    Filter #1 // { column_types: ["double precision?", "boolean"] }
+      Get materialize.public.v // { column_types: ["double precision?", "boolean?"] }
+    Filter (#0) IS NOT NULL // { column_types: ["double precision", "boolean?"] }
+      Get materialize.public.v // { column_types: ["double precision?", "boolean?"] }
+
+Source materialize.public.v
+  Demand (#0, #1)
+
+EOF
+
+# Union that does propagate a null
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(column_types) AS TEXT FOR (SELECT * FROM v WHERE e = 1.25) UNION ALL (SELECT * FROM v WHERE e IS NOT NULL)
+----
+Explained Query
+  Union // { column_types: ["double precision", "boolean?"] }
+    Filter (#0 = 1.25) // { column_types: ["double precision", "boolean?"] }
+      Get materialize.public.v // { column_types: ["double precision?", "boolean?"] }
+    Filter (#0) IS NOT NULL // { column_types: ["double precision", "boolean?"] }
+      Get materialize.public.v // { column_types: ["double precision?", "boolean?"] }
+
+Source materialize.public.v
+  Demand (#0, #1)
+
+EOF
+
+# Constant + reduce
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(column_types) AS TEXT FOR
+(SELECT 1 as a, 'hello' as b, null::date as c)
+EXCEPT
+(SELECT sum(a) as a, max(b) as b, c FROM t GROUP BY c)
+----
+Explained Query
+  Threshold // { column_types: ["bigint?", "text?", "date?"] }
+    Union // { column_types: ["bigint?", "text?", "date?"] }
+      Negate // { column_types: ["bigint?", "text?", "date?"] }
+        Project (#1, #2, #0) // { column_types: ["bigint?", "text?", "date?"] }
+          Reduce group_by=[#2] aggregates=[sum(#0), max(#1)] // { column_types: ["date?", "bigint?", "text?"] }
+            Get materialize.public.t // { column_types: ["integer?", "text?", "date?"] }
+      Constant // { column_types: ["bigint?", "text?", "date?"] }
+        - (1, "hello", null)
+
+Source materialize.public.t
+  Demand (#0..=#2)
+
+EOF
+
+#### Correct column scalar type ####
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(column_types) AS TEXT FOR
+SELECT t.* FROM u LEFT OUTER JOIN t on t.a = u.d
+----
+Explained Query
+  Let // { column_types: ["integer?", "text?", "date?"] }
+    Union // { column_types: ["integer?", "text?", "date?"] }
+      Map (null, null, null) // { column_types: ["integer?", "text?", "date?"] }
+        Union // { column_types: [] }
+          Negate // { column_types: [] }
+            Project () // { column_types: [] }
+              Join on=(#0 = #1) type=differential // { column_types: ["integer?", "integer"] }
+                Get materialize.public.u // { column_types: ["integer?"] }
+                ArrangeBy keys=[[#0]] // { column_types: ["integer"] }
+                  Distinct group_by=[#0] // { column_types: ["integer"] }
+                    Project (#0) // { column_types: ["integer"] }
+                      Get l0 // { column_types: ["integer", "text?", "date?"] }
+          Project () // { column_types: [] }
+            Get materialize.public.u // { column_types: ["integer?"] }
+      Get l0 // { column_types: ["integer", "text?", "date?"] }
+    Where
+      l0 =
+        Project (#0, #2, #3) // { column_types: ["integer", "text?", "date?"] }
+          Join on=(#0 = #1) type=differential // { column_types: ["integer", "integer", "text?", "date?"] }
+            ArrangeBy keys=[[#0]] // { column_types: ["integer"] }
+              Filter (#0) IS NOT NULL // { column_types: ["integer"] }
+                Get materialize.public.u // { column_types: ["integer?"] }
+            Filter (#0) IS NOT NULL // { column_types: ["integer", "text?", "date?"] }
+              Get materialize.public.t // { column_types: ["integer?", "text?", "date?"] }
+
+Source materialize.public.t
+  Demand (#0..=#2)
+  Filter (#0) IS NOT NULL
+Source materialize.public.u
+  Demand (#0)
+
+EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(column_types) AS TEXT FOR
+(SELECT null::boolean as f1, 10 as f2) EXCEPT (SELECT min(f), count(*) FROM v WHERE (select d::double FROM u) = v.e GROUP BY e LIMIT 1)
+----
+Explained Query
+  Threshold // { column_types: ["boolean?", "bigint"] }
+    Union // { column_types: ["boolean?", "bigint"] }
+      Negate // { column_types: ["boolean?", "bigint"] }
+        TopK limit=1 monotonic=false // { column_types: ["boolean?", "bigint"] }
+          Project (#1, #2) // { column_types: ["boolean?", "bigint"] }
+            Reduce group_by=[#0] aggregates=[min(#1), count(true)] // { column_types: ["double precision", "boolean?", "bigint"] }
+              Project (#0, #1) // { column_types: ["double precision", "boolean?"] }
+                Join on=(#0 = #2) type=differential // { column_types: ["double precision", "boolean?", "double precision"] }
+                  ArrangeBy keys=[[#0]] // { column_types: ["double precision", "boolean?"] }
+                    Filter (#0) IS NOT NULL // { column_types: ["double precision", "boolean?"] }
+                      Get materialize.public.v // { column_types: ["double precision?", "boolean?"] }
+                  Union // { column_types: ["double precision"] }
+                    Project (#1) // { column_types: ["double precision"] }
+                      Filter (#1) IS NOT NULL // { column_types: ["integer?", "double precision"] }
+                        Map (integer_to_double(#0)) // { column_types: ["integer?", "double precision?"] }
+                          Get materialize.public.u // { column_types: ["integer?"] }
+                    Map (error("more than one record produced in subquery")) // { column_types: ["double precision"] }
+                      Project () // { column_types: [] }
+                        Filter error("more than one record produced in subquery") AND (#0 > 1) // { column_types: ["bigint"] }
+                          Reduce aggregates=[count(true)] // { column_types: ["bigint"] }
+                            Project () // { column_types: [] }
+                              Get materialize.public.u // { column_types: ["integer?"] }
+      Constant // { column_types: ["boolean?", "bigint"] }
+        - (null, 10)
+
+Source materialize.public.u
+  Demand (#0)
+Source materialize.public.v
+  Demand (#0, #1)
+  Filter (#0) IS NOT NULL
+
+EOF


### PR DESCRIPTION
Allows new explain plans to display arities and column types.

In order to allow the arity attribute to share code with `MirRelationExpr::arity`, there is a new helper method `arity_with_input_arities` that incrementally calculates arities. 
The method `typ_with_input_types` has been split into two methods: `col_with_input_cols` and `keys_with_input_keys` so that the column type attribute can share code with `MirRelationExpr::typ`. The future unique keys attribute will call `keys_with_input_keys`.

### Motivation

  * This PR adds a known-desirable feature.

Part of #14315. Ticks off the arity and column types.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
