### PR TITLE
Use a unique producer ID

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -445,7 +445,13 @@ impl KafkaSinkState {
         metrics: &KafkaBaseMetrics,
         connection_context: &ConnectionContext,
     ) -> Self {
-        let config = Self::create_producer_config(&connection, connection_context);
+        let transactional_id = if connection.exactly_once {
+            Some(format!("mz-producer-{sink_id}-{worker_id}"))
+        } else {
+            None
+        };
+        let config =
+            Self::create_producer_config(&connection, connection_context, transactional_id);
         let consistency_client_config =
             Self::create_consistency_client_config(&connection, connection_context);
 
@@ -500,6 +506,7 @@ impl KafkaSinkState {
     fn create_producer_config(
         connection: &KafkaSinkConnection,
         connection_context: &ConnectionContext,
+        transactional_id: Option<String>,
     ) -> ClientConfig {
         let mut config = create_new_client_config(connection_context.librdkafka_log_level);
         TokioHandle::current().block_on(
@@ -530,13 +537,9 @@ impl KafkaSinkState {
         // if it makes a big difference
         config.set("queue.buffering.max.ms", &format!("{}", 10));
 
-        if connection.exactly_once {
-            // TODO(aljoscha): this only works for now, once there's an actual
-            // Kafka producer on each worker they would step on each others toes
-            let transactional_id = format!("mz-producer-{}", connection.topic);
-            config.set("transactional.id", transactional_id);
+        if let Some(id) = transactional_id {
+            config.set("transactional.id", id);
         }
-
         config
     }
 

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -1,0 +1,36 @@
+$ set schema={"type" : "record", "name" : "test", "fields": [ { "name": "f2", "type": "long" } ] }
+
+$ kafka-create-topic topic=topic0
+
+$ kafka-create-topic topic=topic1
+
+$ kafka-ingest format=avro topic=topic0 schema=${schema} publish=true repeat=1
+{"f2": 1}
+
+$ kafka-ingest format=avro topic=topic1 schema=${schema} publish=true repeat=1
+{"f2": 1}
+
+> CREATE CONNECTION kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+> CREATE SOURCE source0
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-topic0-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+> CREATE SOURCE source1
+  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-topic1-${testdrive.seed}'
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+  ENVELOPE NONE
+
+> CREATE SINK sink0 FROM source0
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-sink-output-${testdrive.seed}'
+  KEY (f2)
+  WITH (reuse_topic=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+> CREATE SINK sink1 FROM source1
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-sink-output-${testdrive.seed}'
+  KEY (f2)
+  WITH (reuse_topic=true)
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -17,7 +17,7 @@ $ kafka-ingest format=avro topic=topic0 schema=${schema} publish=true repeat=1
 {"f2": 1}
 
 $ kafka-ingest format=avro topic=topic1 schema=${schema} publish=true repeat=1
-{"f2": 1}
+{"f2": 7}
 
 > CREATE CONNECTION kafka_conn
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -46,6 +46,6 @@ $ kafka-ingest format=avro topic=topic1 schema=${schema} publish=true repeat=1
 
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
-$ kafka-verify format=avro sink=materialize.public.sink1
+$ kafka-verify format=avro sort-messages=true sink=materialize.public.sink1
 {"f2": 1} {"before": null, "after": {"row": {"f2": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
-{"f2": 1} {"before": null, "after": {"row": {"f2": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
+{"f2": 7} {"before": null, "after": {"row": {"f2": 7}}, "transaction": {"id": "<TIMESTAMP>"}}

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -34,3 +34,9 @@ $ kafka-ingest format=avro topic=topic1 schema=${schema} publish=true repeat=1
   KEY (f2)
   WITH (reuse_topic=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ kafka-verify format=avro sink=materialize.public.sink1
+{"f2": 1} {"before": null, "after": {"row": {"f2": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
+{"f2": 1} {"before": null, "after": {"row": {"f2": 1}}, "transaction": {"id": "<TIMESTAMP>"}}

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -1,3 +1,12 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
 $ set schema={"type" : "record", "name" : "test", "fields": [ { "name": "f2", "type": "long" } ] }
 
 $ kafka-create-topic topic=topic0


### PR DESCRIPTION
This uses the combination of sink and worker ID to uniquely identify a Kafka sink producer, instead of the topic name.

### Motivation

The TODO below mentions that using the topic is unsafe for multiple workers in the Kafka sink. As it happens, #11334 is caused by effectively the same issue: we treat the topic as a unique identifier.

Using the sink id resolves the bug, and using the worker id is meant to future-proof a bit for the world where we run multiple workers in the sink that publish concurrently.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - This uses @philip-stoev's test from the linked issue, updated for recent changes to the syntax.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a user-facing bug.
