### PR TITLE
storage: move start_offset and kafka_time_offset out of legacy with_options

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -818,6 +818,8 @@ pub enum KafkaConfigOptionName {
     StatisticsIntervalMs,
     TopicMetadataRefreshIntervalMs,
     TransactionTimeoutMs,
+    StartTimestamp,
+    StartOffset,
 }
 
 impl AstDisplay for KafkaConfigOptionName {
@@ -834,6 +836,8 @@ impl AstDisplay for KafkaConfigOptionName {
                 "TOPIC METADATA REFRESH INTERVAL MS"
             }
             KafkaConfigOptionName::TransactionTimeoutMs => "TRANSACTION TIMEOUT MS",
+            KafkaConfigOptionName::StartTimestamp => "START TIMESTAMP",
+            KafkaConfigOptionName::StartOffset => "START OFFSET",
         })
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2054,6 +2054,7 @@ impl<'a> Parser<'a> {
             STATISTICS,
             TOPIC,
             TRANSACTION,
+            START,
         ])? {
             ACKS => KafkaConfigOptionName::Acks,
             CLIENT => {
@@ -2088,6 +2089,11 @@ impl<'a> Parser<'a> {
                 self.expect_keywords(&[TIMEOUT, MS])?;
                 KafkaConfigOptionName::TransactionTimeoutMs
             }
+            START => match self.expect_one_of_keywords(&[OFFSET, TIMESTAMP])? {
+                OFFSET => KafkaConfigOptionName::StartOffset,
+                TIMESTAMP => KafkaConfigOptionName::StartTimestamp,
+                _ => unreachable!(),
+            },
             _ => unreachable!(),
         };
         let _ = self.consume_token(&Token::Eq);

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1399,6 +1399,22 @@ CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TR
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), with_options: [] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, key_constraint: None, with_options: [] })
 
+# Note that this will error in planninf, as you cannot specify START OFFSET and START TIMESTAMP at the same time
+parse-statement
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET=1, START TIMESTAMP=2) TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+----
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET = 1, START TIMESTAMP = 2) TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), with_options: [KafkaConfigOption { name: StartOffset, value: Some(Value(Number("1"))) }, KafkaConfigOption { name: StartTimestamp, value: Some(Value(Number("2"))) }] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, key_constraint: None, with_options: [] })
+
+# Note that this will error in planning, as START OFFSET must be an array of nums
+parse-statement
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+----
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET = hmm) TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), with_options: [KafkaConfigOption { name: StartOffset, value: Some(Ident(Ident("hmm"))) }] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, key_constraint: None, with_options: [] })
+
 parse-statement
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah'
 ----

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -77,9 +77,9 @@ use crate::ast::{
     CsrConnectionOption, CsrConnectionOptionName, CsrConnectionProtobuf, CsrSeedProtobuf,
     CsvColumns, DbzMode, DbzTxMetadataOption, DropClusterReplicasStatement, DropClustersStatement,
     DropDatabaseStatement, DropObjectsStatement, DropRolesStatement, DropSchemaStatement, Envelope,
-    Expr, Format, Ident, IfExistsBehavior, IndexOption, IndexOptionName, KafkaConnectionOption,
-    KafkaConnectionOptionName, KafkaConsistency, KeyConstraint, LoadGeneratorOption,
-    LoadGeneratorOptionName, ObjectType, Op, PostgresConnectionOption,
+    Expr, Format, Ident, IfExistsBehavior, IndexOption, IndexOptionName, KafkaConfigOptionName,
+    KafkaConnectionOption, KafkaConnectionOptionName, KafkaConsistency, KeyConstraint,
+    LoadGeneratorOption, LoadGeneratorOptionName, ObjectType, Op, PostgresConnectionOption,
     PostgresConnectionOptionName, ProtobufSchema, QualifiedReplica, Query, ReplicaDefinition,
     ReplicaOption, ReplicaOptionName, Select, SelectItem, SetExpr, SourceIncludeMetadata,
     SourceIncludeMetadataType, SshConnectionOptionName, Statement, SubscriptPosition,
@@ -87,7 +87,7 @@ use crate::ast::{
     Value, ViewDefinition, WithOptionValue,
 };
 use crate::catalog::{CatalogItem, CatalogItemType, CatalogType, CatalogTypeDetails};
-use crate::kafka_util::{self, KafkaConfigOptionExtracted};
+use crate::kafka_util::{self, KafkaConfigOptionExtracted, KafkaStartOffsetType};
 use crate::names::{
     Aug, FullSchemaName, QualifiedObjectName, RawDatabaseSpecifier, ResolvedClusterName,
     ResolvedDataType, ResolvedDatabaseSpecifier, ResolvedObjectName, SchemaSpecifier,
@@ -371,7 +371,7 @@ pub fn plan_create_source(
 
     let (external_connection, encoding) = match connection {
         CreateSourceConnection::Kafka(kafka) => {
-            let (kafka_connection, options) = match &kafka.connection {
+            let (kafka_connection, options, optional_start_offset) = match &kafka.connection {
                 mz_sql_parser::ast::KafkaConnection::Inline { broker } => {
                     scx.require_unsafe_mode("creating Kafka sources with inline connections")?;
                     let mut options = BTreeMap::new();
@@ -383,7 +383,7 @@ pub fn plan_create_source(
                             .into(),
                     );
                     let connection = KafkaConnection::try_from(&mut options)?;
-                    (connection, options)
+                    (connection, options, None)
                 }
                 mz_sql_parser::ast::KafkaConnection::Reference {
                     connection,
@@ -395,15 +395,23 @@ pub fn plan_create_source(
                         _ => sql_bail!("{} is not a kafka connection", item.name()),
                     };
 
-                    if !with_options.is_empty() {
+                    // Starting offsets are allowed out unsafe mode, as they are a simple,
+                    // useful way to specify where to start reading a topic.
+                    if with_options.iter().any(|opt| {
+                        opt.name != KafkaConfigOptionName::StartOffset
+                            && opt.name != KafkaConfigOptionName::StartTimestamp
+                    }) {
                         scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
                     }
 
                     let with_options: KafkaConfigOptionExtracted =
                         with_options.clone().try_into()?;
-                    let with_options: BTreeMap<String, StringOrSecret> = with_options.try_into()?;
+                    let (optional_start_offset, with_options): (
+                        _,
+                        BTreeMap<String, StringOrSecret>,
+                    ) = with_options.try_into()?;
 
-                    (connection, with_options)
+                    (connection, with_options, optional_start_offset)
                 }
             };
 
@@ -413,44 +421,40 @@ pub fn plan_create_source(
                 Some(_) => sql_bail!("group_id_prefix must be a string"),
             };
 
-            let parse_offset = |s: &str| match s.parse::<i64>() {
+            let parse_offset = |s: i64| {
                 // we parse an i64 here, because we don't yet support u64's in
                 // sql, but put it into an internal MzOffset that holds a u64
                 // TODO: make this an native u64 when
                 // https://github.com/MaterializeInc/materialize/issues/7629 is
                 // resolved.
-                Ok(n) if n >= 0 => Ok(MzOffset {
-                    offset: n.try_into().unwrap(),
-                }),
-                _ => sql_bail!("start_offset must be a nonnegative integer"),
+                if s >= 0 {
+                    Ok(MzOffset {
+                        offset: s.try_into().unwrap(),
+                    })
+                } else {
+                    sql_bail!("START OFFSET must be a nonnegative integer")
+                }
             };
 
             let mut start_offsets = HashMap::new();
-            let has_nontrivial_start_offsets = match legacy_with_options.remove("start_offset") {
+            let has_nontrivial_start_offsets = match optional_start_offset {
                 None => {
                     start_offsets.insert(0, MzOffset::from(0));
                     false
                 }
-                Some(SqlValueOrSecret::Value(Value::Number(n))) => {
-                    start_offsets.insert(0, parse_offset(&n)?);
-                    true
-                }
-                Some(SqlValueOrSecret::Value(Value::Array(vs))) => {
-                    for (i, v) in vs.iter().enumerate() {
-                        match v {
-                            Value::Number(n) => {
-                                start_offsets.insert(i32::try_from(i)?, parse_offset(n)?);
-                            }
-                            _ => sql_bail!("start_offset value must be a number: {}", v),
-                        }
+                Some(KafkaStartOffsetType::StartOffset(vs)) => {
+                    for (i, v) in vs.0.iter().enumerate() {
+                        start_offsets.insert(i32::try_from(i)?, parse_offset(*v)?);
                     }
                     true
                 }
-                Some(v) => sql_bail!("invalid start_offset value: {}", v),
+                Some(KafkaStartOffsetType::StartTimestamp(_)) => {
+                    unreachable!("time offsets should be converted in purification")
+                }
             };
 
             if has_nontrivial_start_offsets && envelope.requires_all_input() {
-                sql_bail!("start_offset is not supported with ENVELOPE {}", envelope)
+                sql_bail!("START OFFSET is not supported with ENVELOPE {}", envelope)
             }
 
             let encoding = get_encoding(scx, format, &envelope, &connection)?;
@@ -1871,12 +1875,22 @@ fn kafka_sink_builder(
                 _ => sql_bail!("{} is not a kafka connection", item.name()),
             };
 
+            for option in with_options.iter() {
+                if matches!(
+                    option.name,
+                    KafkaConfigOptionName::StartOffset | KafkaConfigOptionName::StartTimestamp
+                ) {
+                    sql_bail!("Sinks do not support {}", option.name.to_ast_string());
+                }
+            }
+
             if !with_options.is_empty() {
                 scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
             }
 
             let with_options: KafkaConfigOptionExtracted = with_options.try_into()?;
-            let with_options: BTreeMap<String, StringOrSecret> = with_options.try_into()?;
+            let (_, with_options): (_, BTreeMap<String, StringOrSecret>) =
+                with_options.try_into()?;
             (connection, with_options)
         }
         mz_sql_parser::ast::KafkaConnection::Inline { .. } => unreachable!(),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -443,7 +443,7 @@ pub fn plan_create_source(
                     false
                 }
                 Some(KafkaStartOffsetType::StartOffset(vs)) => {
-                    for (i, v) in vs.0.iter().enumerate() {
+                    for (i, v) in vs.iter().enumerate() {
                         start_offsets.insert(i32::try_from(i)?, parse_offset(*v)?);
                     }
                     true

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -163,6 +163,23 @@ impl ImpliedValue for i32 {
     }
 }
 
+impl TryFromValue<Value> for i64 {
+    fn try_from_value(v: Value) -> Result<Self, PlanError> {
+        match v {
+            Value::Number(v) => v
+                .parse::<i64>()
+                .map_err(|e| sql_err!("invalid numeric value: {e}")),
+            _ => sql_bail!("cannot use value as number"),
+        }
+    }
+}
+
+impl ImpliedValue for i64 {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("must provide an integer value")
+    }
+}
+
 impl TryFromValue<Value> for u16 {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         match v {

--- a/test/persistence/kafka-sources/start-offset-before.td
+++ b/test/persistence/kafka-sources/start-offset-before.td
@@ -30,6 +30,9 @@ $ set schema={
         ]
     }
 
+> CREATE CONNECTION IF NOT EXISTS kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
 $ kafka-create-topic topic=offset
 
 $ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count} timestamp=1
@@ -42,14 +45,16 @@ $ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} 
 {"f1": "c${kafka-ingest.iteration}"} {"f2": "c${kafka-ingest.iteration}"}
 
 > CREATE SOURCE start_offset
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-offset-${testdrive.seed}'
-  WITH (start_offset = 100)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET = 100)
+  TOPIC 'testdrive-offset-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
 > CREATE SOURCE kafka_time_offset
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-offset-${testdrive.seed}'
-  WITH (kafka_time_offset=2)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=2)
+  TOPIC 'testdrive-offset-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 

--- a/test/persistence/kafka-sources/start-offset-before.td
+++ b/test/persistence/kafka-sources/start-offset-before.td
@@ -46,7 +46,7 @@ $ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} 
 
 > CREATE SOURCE start_offset
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET = 100)
+  WITH (START OFFSET = [100])
   TOPIC 'testdrive-offset-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -15,8 +15,11 @@ $ kafka-ingest format=bytes topic=bytes timestamp=1
 ©1
 ©2
 
+> CREATE CONNECTION kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
 > CREATE SOURCE data
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET
 
@@ -35,7 +38,7 @@ data           offset
 # Test that CREATE SOURCE can specify a custom name for the column.
 
 > CREATE SOURCE data_named_col (named_col)
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
 
 > SHOW COLUMNS FROM data_named_col
@@ -44,8 +47,9 @@ name       nullable  type
 named_col  false     bytea
 
 > CREATE SOURCE data_offset
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-${testdrive.seed}'
-  WITH (start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=1)
+  TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET
 
@@ -63,8 +67,9 @@ $ kafka-ingest format=bytes topic=bytes-partitions timestamp=1 partition=1
 ©2
 
 > CREATE SOURCE data_offset_2
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bytes-partitions-${testdrive.seed}'
-  WITH (start_offset=[0,1])
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=[0,1])
+  TOPIC 'testdrive-bytes-partitions-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET
 

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -48,7 +48,7 @@ named_col  false     bytea
 
 > CREATE SOURCE data_offset
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=1)
+  WITH (START OFFSET=[1])
   TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -143,11 +143,12 @@ a  b  json                     c            d             e                   f
 -1  7 "[1,2,3]"                FileNotFound True          <null>              <null>
 
 ! CREATE SOURCE fast_forwarded
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (start_offset=2)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=2)
+  TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
-contains:start_offset is not supported with ENVELOPE DEBEZIUM
+contains:START OFFSET is not supported with ENVELOPE DEBEZIUM
 
 # Check that repeated Debezium messages are skipped.
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
@@ -234,8 +235,9 @@ $ kafka-ingest format=avro topic=non-dbz-data-multi-partition schema=${non-dbz-s
 {"a": 1, "b": 2}
 
 > CREATE SOURCE non_dbz_data_multi_partition
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
-  WITH (start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=1)
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -245,8 +247,9 @@ a  b
 4  1
 
 > CREATE SOURCE non_dbz_data_multi_partition_2
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
-  WITH (start_offset=[0,0])
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=[0,0])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -257,8 +260,9 @@ a  b
 4  1
 
 > CREATE SOURCE non_dbz_data_multi_partition_fast_forwarded
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
-  WITH (start_offset=[0,1])
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=[0,1])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -268,8 +272,9 @@ a  b
 1  2
 
 > CREATE SOURCE non_dbz_data_multi_partition_fast_forwarded_2
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
-  WITH (start_offset=[1,0])
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=[1,0])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -287,20 +292,24 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 
 > CREATE SOURCE non_dbz_data_varying_partition
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START OFFSET=1
+    )
   TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
-  WITH (start_offset=1)
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
 > SELECT * FROM non_dbz_data_varying_partition
 
-# Erroneously adds start_offsets for non-existent partitions.
+# Erroneously adds START OFFSET for non-existent partitions.
 > CREATE SOURCE non_dbz_data_varying_partition_2
   FROM KAFKA CONNECTION kafka_conn
-    WITH(TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH(
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START OFFSET=[0,1]
+    )
   TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
-  WITH (start_offset=[0,1])
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -336,9 +345,11 @@ a  b
 
 > CREATE SOURCE non_dbz_data_varying_partition_3
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START OFFSET=[1,1]
+    )
   TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
-  WITH (start_offset=[1,1])
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -144,7 +144,7 @@ a  b  json                     c            d             e                   f
 
 ! CREATE SOURCE fast_forwarded
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=2)
+  WITH (START OFFSET=[2])
   TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
@@ -236,7 +236,7 @@ $ kafka-ingest format=avro topic=non-dbz-data-multi-partition schema=${non-dbz-s
 
 > CREATE SOURCE non_dbz_data_multi_partition
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=1)
+  WITH (START OFFSET=[1])
   TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
@@ -294,7 +294,7 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
   FROM KAFKA CONNECTION kafka_conn
     WITH (
       TOPIC METADATA REFRESH INTERVAL MS=10,
-      START OFFSET=1
+      START OFFSET=[1]
     )
   TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -11,8 +11,12 @@ $ kafka-create-topic topic=input_csv partitions=1
 $ kafka-create-topic topic=input_csv_partitioned partitions=2
 $ kafka-create-topic topic=input_proto
 
+> CREATE CONNECTION kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
 > CREATE SOURCE input_csv (first, second)
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_csv-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-input_csv-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS;
 
 $ kafka-ingest format=bytes topic=input_csv
@@ -32,8 +36,9 @@ $ kafka-ingest format=bytes topic=input_csv_partitioned partition=1
 2,3
 
 > CREATE SOURCE input_csv_partitioned (first, second)
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input_csv_partitioned-${testdrive.seed}'
-  WITH (start_offset=[1,0])
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=[1,0])
+  TOPIC 'testdrive-input_csv_partitioned-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS;
 
 > SELECT * FROM input_csv_partitioned

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -29,7 +29,7 @@ contains:topic missing_topic does not exist
 
 ! CREATE SOURCE pick_one
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START TIMESTAMP=1, START OFFSET=1)
+  WITH (START TIMESTAMP=1, START OFFSET=[1])
   TOPIC 'testdrive-t0-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Tests for `kafka_time_offset` configuration which resolves a `start_offset`
+# Tests for `START TIMESTAMP` configuration which resolves a start offset
 # during creation of the source.
 
 #
@@ -20,25 +20,29 @@ $ kafka-create-topic topic=t0
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 ! CREATE SOURCE missing_topic
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'missing_topic'
-  WITH (kafka_time_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=1)
+  TOPIC 'missing_topic'
   FORMAT TEXT
   INCLUDE OFFSET
 contains:topic missing_topic does not exist
 
 ! CREATE SOURCE pick_one
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t0-${testdrive.seed}'
-  WITH (kafka_time_offset=1, start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=1, START OFFSET=1)
+  TOPIC 'testdrive-t0-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
-contains:`start_offset` and `kafka_time_offset` cannot be set at the same time.
+contains:cannot specify START TIMESTAMP and START OFFSET at same time
+
 
 ! CREATE SOURCE not_a_number
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t0-${testdrive.seed}'
-  WITH (kafka_time_offset="not_a_number")
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP="not_a_number")
+  TOPIC 'testdrive-t0-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
-contains:`kafka_time_offset` must be a number
+contains:invalid START TIMESTAMP: cannot use value as number
 
 #
 # Append-Only
@@ -62,48 +66,59 @@ $ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp
 grape:grape
 
 > CREATE SOURCE append_time_offset_0
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t1-${testdrive.seed}'
-  WITH (kafka_time_offset=0)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=0)
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_1
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START TIMESTAMP=1
+    )
   TOPIC 'testdrive-t1-${testdrive.seed}'
-  WITH (kafka_time_offset=1)
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_2
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START TIMESTAMP=2
+    )
   TOPIC 'testdrive-t1-${testdrive.seed}'
-  WITH (kafka_time_offset=2)
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_3
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START TIMESTAMP=3
+    )
   TOPIC 'testdrive-t1-${testdrive.seed}'
-  WITH (kafka_time_offset=3)
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_4
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START TIMESTAMP=4
+    )
   TOPIC 'testdrive-t1-${testdrive.seed}'
-  WITH (kafka_time_offset=4)
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_5
   FROM KAFKA CONNECTION kafka_conn
-    WITH (TOPIC METADATA REFRESH INTERVAL MS=10)
+    WITH (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START TIMESTAMP=5
+    )
   TOPIC 'testdrive-t1-${testdrive.seed}'
-  WITH (kafka_time_offset=5)
   FORMAT TEXT
   INCLUDE OFFSET
 
@@ -191,43 +206,49 @@ $ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp
 grape:grape
 
 > CREATE SOURCE upsert_time_offset_0
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t2-${testdrive.seed}'
-  WITH (kafka_time_offset=0)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=0)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_1
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t2-${testdrive.seed}'
-  WITH (kafka_time_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=1)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_2
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t2-${testdrive.seed}'
-  WITH (kafka_time_offset=2)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=2)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_3
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t2-${testdrive.seed}'
-  WITH (kafka_time_offset=3)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=3)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_4
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t2-${testdrive.seed}'
-  WITH (kafka_time_offset=4)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=4)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_5
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t2-${testdrive.seed}'
-  WITH (kafka_time_offset=5)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=5)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
@@ -307,14 +328,16 @@ $ kafka-ingest format=bytes topic=t3 timestamp=4084108700000
 cherry
 
 > CREATE SOURCE relative_time_offset_30_years_ago
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t3-${testdrive.seed}'
-  WITH (kafka_time_offset=-946100000000)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=-946100000000)
+  TOPIC 'testdrive-t3-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE relative_time_offset_today
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t3-${testdrive.seed}'
-  WITH (kafka_time_offset=-1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=-1)
+  TOPIC 'testdrive-t3-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
@@ -340,8 +363,9 @@ pie
 # A time offset of -1 specifies that we want to start from the end of the topic
 # (negative offsets are relative from the end).
 > CREATE SOURCE verify_no_fetch
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-t4-${testdrive.seed}'
-  WITH (kafka_time_offset = -1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=-1)
+  TOPIC 'testdrive-t4-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
@@ -418,8 +442,9 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": {"row": {"id": 4, "creature": "chicken"}}}
 
 > CREATE SOURCE upsert_time_skip
-  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
-  WITH (kafka_time_offset = 6)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START TIMESTAMP=6)
+  TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -81,6 +81,9 @@ $ set schema={
     ]
   }
 
+> CREATE CONNECTION kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
 $ kafka-create-topic topic=dbzupsert partitions=1
 
 $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
@@ -89,13 +92,13 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 ! CREATE SOURCE doin_upsert
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM UPSERT
 contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
 
 > CREATE SOURCE doin_upsert
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 
@@ -142,14 +145,14 @@ creature
 moros
 
 ! CREATE SOURCE doin_upsert_metadata
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE OFFSET
   ENVELOPE DEBEZIUM
 contains:INCLUDE OFFSET with Debezium requires UPSERT semantics
 
 > CREATE SOURCE doin_upsert_metadata
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE PARTITION, OFFSET AS test_kafka_offset
   ENVELOPE DEBEZIUM UPSERT
@@ -179,10 +182,11 @@ id creature
 -----------
 3  triceratops
 
-# Test that `WITH (start_offset=<whatever>)` works
+# Test that `WITH (START OFFSET=<whatever>)` works
 > CREATE SOURCE upsert_fast_forward
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
-  WITH (start_offset = 6)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET = 6)
+  TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 
@@ -193,7 +197,7 @@ id creature
 
 # Test that it doesn't work with full deduplication
 ! CREATE SOURCE upsert_full_dedupe
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   WITH (deduplication = 'full')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
@@ -202,7 +206,7 @@ contains:unexpected parameters for CREATE SOURCE: deduplication
 
 # test include metadata
 > CREATE SOURCE upsert_metadata
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE OFFSET, PARTITION
   ENVELOPE DEBEZIUM UPSERT
@@ -217,7 +221,7 @@ id   creature      offset  partition
 
 # test include metadata respects metadata order
 > CREATE SOURCE upsert_metadata_reordered
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE PARTITION, OFFSET
   ENVELOPE DEBEZIUM UPSERT

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -185,7 +185,7 @@ id creature
 # Test that `WITH (START OFFSET=<whatever>)` works
 > CREATE SOURCE upsert_fast_forward
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET = 6)
+  WITH (START OFFSET = [6])
   TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -310,7 +310,7 @@ water     <null>  crocodile      7
 # Ensure that Upsert sources work with START OFFSET
 > CREATE SOURCE realtimeavroavro_ff
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=1)
+  WITH (START OFFSET=[1])
   TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -518,7 +518,7 @@ librairie 10
 
 > CREATE SOURCE include_metadata
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=1)
+  WITH (START OFFSET=[1])
   TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
@@ -534,7 +534,7 @@ earth     dao       rhinoceros   211   0         12
 
 > CREATE SOURCE include_metadata_ts
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=1)
+  WITH (START OFFSET=[1])
   TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -28,6 +28,9 @@ $ set schema={
 
 $ kafka-create-topic topic=avroavro
 
+> CREATE CONNECTION kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
 $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true
 {"key": "fish"} {"f1": "fish", "f2": 1000}
 {"key": "bird1"} {"f1":"goose", "f2": 1}
@@ -40,7 +43,8 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
 {"key": "mammalmore"} {"f1":"moose", "f2": 2}
 
 > CREATE SOURCE avroavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-avroavro-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
 
@@ -60,13 +64,15 @@ birdmore: {"f1":"geese", "f2": 2}
 mammal1: {"f1": "moose", "f2": 1}
 
 > CREATE SOURCE bytesavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textavro-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT AVRO USING SCHEMA  '${schema}'
   ENVELOPE UPSERT
 
 > CREATE SOURCE textavro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textavro-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textavro-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE UPSERT
@@ -102,24 +108,28 @@ mammal1:moose
 bìrd1:
 
 > CREATE SOURCE texttext
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   ENVELOPE UPSERT
 
 > CREATE SOURCE textbytes
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytesbytes
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytestext
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textbytes-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT TEXT
   ENVELOPE UPSERT
@@ -179,13 +189,15 @@ $ protobuf-compile-descriptors inputs=test.proto output=test.pb
 $ kafka-create-topic topic=textproto partitions=1
 
 > CREATE SOURCE textproto
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textproto-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textproto-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA FILE '${testdrive.temp-dir}/test.pb'
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytesproto
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-textproto-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textproto-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA FILE '${testdrive.temp-dir}/test.pb'
   ENVELOPE UPSERT
@@ -245,7 +257,8 @@ mammalmore:moose
 mammal1:
 
 > CREATE SOURCE nullkey
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-nullkey-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-nullkey-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT TEXT
   ENVELOPE UPSERT
@@ -279,7 +292,8 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 {"f3": {"string": "earth"}, "f4":{"string": "dao"}}
 
 > CREATE SOURCE realtimeavroavro (f3, f4, f1, f2)
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
@@ -293,11 +307,11 @@ fire      yang    dog            42
 <null>    yin     sheep          54
 water     <null>  crocodile      7
 
-# Ensure that Upsert sources work with `start_offset`
+# Ensure that Upsert sources work with START OFFSET
 > CREATE SOURCE realtimeavroavro_ff
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC
-  'testdrive-realtimeavroavro-${testdrive.seed}'
-  WITH (start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=1)
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
@@ -358,7 +372,8 @@ $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=$
 {"k1": {"string": "boucherie"}, "k2": {"long": 5}} {"f1": {"string": "apple"}, "f2": {"long": 3}}
 
 > CREATE SOURCE realtimefilteravro
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimefilteravro-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-realtimefilteravro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE UPSERT
@@ -502,8 +517,9 @@ k1        k2
 librairie 10
 
 > CREATE SOURCE include_metadata
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
-  WITH (start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=1)
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE PARTITION, OFFSET
@@ -517,8 +533,9 @@ air       qi        chicken      47    0         13
 earth     dao       rhinoceros   211   0         12
 
 > CREATE SOURCE include_metadata_ts
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
-  WITH (start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=1)
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   INCLUDE PARTITION, OFFSET, TIMESTAMP as ts

--- a/test/testdrive/zstd-kafka-compression.td
+++ b/test/testdrive/zstd-kafka-compression.td
@@ -15,16 +15,21 @@ $ kafka-ingest format=bytes topic=zstd timestamp=1
 hello
 world
 
+> CREATE CONNECTION kafka_conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
 > CREATE SOURCE zstd
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-zstd-${testdrive.seed}'
   FORMAT TEXT
 > SELECT text FROM zstd
 hello
 world
 
 > CREATE SOURCE zstd_fast_forwarded
-  FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-zstd-${testdrive.seed}'
-  WITH (start_offset=1)
+  FROM KAFKA CONNECTION kafka_conn
+  WITH (START OFFSET=1)
+  TOPIC 'testdrive-zstd-${testdrive.seed}'
   FORMAT TEXT
 > SELECT text FROM zstd_fast_forwarded
 world

--- a/test/testdrive/zstd-kafka-compression.td
+++ b/test/testdrive/zstd-kafka-compression.td
@@ -28,7 +28,7 @@ world
 
 > CREATE SOURCE zstd_fast_forwarded
   FROM KAFKA CONNECTION kafka_conn
-  WITH (START OFFSET=1)
+  WITH (START OFFSET=[1])
   TOPIC 'testdrive-zstd-${testdrive.seed}'
   FORMAT TEXT
 > SELECT text FROM zstd_fast_forwarded


### PR DESCRIPTION
After this approach is approved, I can update the docs! Also, this will need a migration, I think, so I will look into doing that as well.

**Note that these options are no longer available if using `KAFKA BROKER` over `KAFKA CONNECTION`.** Fixing this would require a pretty nasty parser change.



### Motivation
  * This PR adds a known-desirable feature.

part of https://github.com/MaterializeInc/materialize/issues/14341

### Tips for reviewer


The implementation is a bit confusing, with some back and forthing, but the way we do purification is somewhat complex, so I did my best.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - `start_offset` and `kafka_time_offset` are now in the `KAFKA CONNECTION` `WITH` block, as `START OFFSET` and `START TIME OFFSET`. They are no longer available for old-style `KAFKA BROKER` sources
