### PR TITLE
sql: remove unsafe_mode from KAFKA..CONNECTION

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -395,13 +395,13 @@ pub fn plan_create_source(
                         _ => sql_bail!("{} is not a kafka connection", item.name()),
                     };
 
-                    let with_options: KafkaConfigOptionExtracted =
-                        with_options.clone().try_into()?;
-                    let with_options: BTreeMap<String, StringOrSecret> = with_options.try_into()?;
-
                     if !with_options.is_empty() {
                         scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
                     }
+
+                    let with_options: KafkaConfigOptionExtracted =
+                        with_options.clone().try_into()?;
+                    let with_options: BTreeMap<String, StringOrSecret> = with_options.try_into()?;
 
                     (connection, with_options)
                 }
@@ -1871,11 +1871,12 @@ fn kafka_sink_builder(
                 _ => sql_bail!("{} is not a kafka connection", item.name()),
             };
 
-            let with_options: KafkaConfigOptionExtracted = with_options.try_into()?;
-            let with_options: BTreeMap<String, StringOrSecret> = with_options.try_into()?;
             if !with_options.is_empty() {
                 scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
             }
+
+            let with_options: KafkaConfigOptionExtracted = with_options.try_into()?;
+            let with_options: BTreeMap<String, StringOrSecret> = with_options.try_into()?;
             (connection, with_options)
         }
         mz_sql_parser::ast::KafkaConnection::Inline { .. } => unreachable!(),


### PR DESCRIPTION
The KAFKA CONNECTION WITH options have default values, so cannot
be gated behind unsafe mode.

@benesch Sorry I overlooked this earlier! If you have any other suggestions, very open.

### Motivation

This PR fixes a recognized bug. [Slack](https://materializeinc.slack.com/archives/CTESPM7FU/p1661285996741329)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
