### PR TITLE
Allow SELECT queries to execute on time-bounded dataflows

### DIFF
--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -84,6 +84,7 @@ message ProtoDataflowDescription {
     repeated ProtoIndexExport index_exports = 4;
     repeated ProtoSinkExport sink_exports = 5;
     optional mz_persist.gen.persist.ProtoU64Antichain as_of = 6;
+    mz_persist.gen.persist.ProtoU64Antichain until = 9;
     string debug_name = 7;
     mz_proto.ProtoU128 id = 8;
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -459,6 +459,7 @@ where
                 objects_to_build: d.objects_to_build,
                 index_exports: d.index_exports,
                 as_of: d.as_of,
+                until: d.until,
                 debug_name: d.debug_name,
                 id: d.id,
             });

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -1505,6 +1505,7 @@ This is not expected to cause incorrect results, but could indicate a performanc
             index_exports: desc.index_exports,
             sink_exports: desc.sink_exports,
             as_of: desc.as_of,
+            until: desc.until,
             debug_name: desc.debug_name,
             id: desc.id,
         })

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -207,6 +207,7 @@ where
                             index_exports: dataflow.index_exports.clone(),
                             sink_exports: dataflow.sink_exports.clone(),
                             as_of: dataflow.as_of.clone(),
+                            until: dataflow.until.clone(),
                             debug_name: dataflow.debug_name.clone(),
                             id: dataflow.id,
                         });

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -78,6 +78,9 @@ where
     /// imported traces, both because it improves performance, and because
     /// potentially incorrect results are visible in sinks.
     pub as_of_frontier: Antichain<T>,
+    /// Frontier after which updates should not be emitted.
+    /// Used to limit the amount of work done when appropriate.
+    pub until: Antichain<T>,
     /// Bindings of identifiers to collections.
     pub bindings: BTreeMap<Id, CollectionBundle<S, V, T>>,
 }
@@ -100,6 +103,7 @@ where
             debug_name: dataflow.debug_name.clone(),
             dataflow_id,
             as_of_frontier,
+            until: dataflow.until.clone(),
             bindings: BTreeMap::new(),
         }
     }

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -166,13 +166,23 @@ pub fn build_compute_dataflow<A: Allocate>(
             for (source_id, (source, _monotonic)) in dataflow.source_imports.iter() {
                 // Note: For correctness, we require that sources only emit times advanced by
                 // `dataflow.as_of`. `persist_source` is documented to provide this guarantee.
-                let (mut ok_stream, err_stream, token) = persist_source::persist_source(
+                let (mut ok_stream, mut err_stream, token) = persist_source::persist_source(
                     region,
                     *source_id,
                     Arc::clone(&compute_state.persist_clients),
                     source.storage_metadata.clone(),
                     dataflow.as_of.clone().unwrap(),
                 );
+
+                // Restrict updates by `dataflow.until`, retaining those at times not greater or equal to it.
+                // TODO: Teach `persist_source` to accept `until` and drop its capabilities when it passes.
+                if !dataflow.until.is_empty() {
+                    use timely::dataflow::operators::Filter;
+                    let until1 = dataflow.until.clone();
+                    let until2 = dataflow.until.clone();
+                    ok_stream = ok_stream.filter(move |(_, time, _)| !until1.less_equal(time));
+                    err_stream = err_stream.filter(move |(_, time, _)| !until2.less_equal(time));
+                }
 
                 // If logging is enabled, intercept frontier advancements coming from persist to track materialization lags.
                 // Note that we do this here instead of in the server.rs worker loop since we want to catch the wall-clock
@@ -303,13 +313,13 @@ where
                 scope,
                 &format!("Index({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
-                Default::default(),
+                self.until.clone(),
             );
             let (err_arranged, err_button) = traces.errs_mut().import_frontier_core(
                 scope,
                 &format!("ErrIndex({}, {:?})", idx.on_id, idx.key),
                 self.as_of_frontier.clone(),
-                Default::default(),
+                self.until.clone(),
             );
             let ok_arranged = ok_arranged.enter(region);
             let err_arranged = err_arranged.enter(region);
@@ -427,15 +437,20 @@ where
 
                 // We should advance times in constant collections to start from `as_of`.
                 let as_of_frontier = self.as_of_frontier.clone();
+                let until = self.until.clone();
                 let ok_collection = rows
                     .into_iter()
-                    .map(move |(row, mut time, diff)| {
+                    .filter_map(move |(row, mut time, diff)| {
                         time.advance_by(as_of_frontier.borrow());
-                        (
-                            row,
-                            <G::Timestamp as Refines<mz_repr::Timestamp>>::to_inner(time),
-                            diff,
-                        )
+                        if !until.less_equal(&time) {
+                            Some((
+                                row,
+                                <G::Timestamp as Refines<mz_repr::Timestamp>>::to_inner(time),
+                                diff,
+                            ))
+                        } else {
+                            None
+                        }
                     })
                     .to_stream(scope)
                     .as_collection();

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -492,11 +492,16 @@ where
                         collection
                     }
                     mz_compute_client::plan::GetPlan::Arrangement(key, row, mfp) => {
-                        let (oks, errs) = collection.as_collection_core(mfp, Some((key, row)));
+                        let (oks, errs) = collection.as_collection_core(
+                            mfp,
+                            Some((key, row)),
+                            self.until.clone(),
+                        );
                         CollectionBundle::from_collections(oks, errs)
                     }
                     mz_compute_client::plan::GetPlan::Collection(mfp) => {
-                        let (oks, errs) = collection.as_collection_core(mfp, None);
+                        let (oks, errs) =
+                            collection.as_collection_core(mfp, None, self.until.clone());
                         CollectionBundle::from_collections(oks, errs)
                     }
                 }
@@ -521,7 +526,8 @@ where
                 if mfp.is_identity() {
                     input
                 } else {
-                    let (oks, errs) = input.as_collection_core(mfp, input_key_val);
+                    let (oks, errs) =
+                        input.as_collection_core(mfp, input_key_val, self.until.clone());
                     CollectionBundle::from_collections(oks, errs)
                 }
             }
@@ -595,7 +601,7 @@ where
                 input_mfp,
             } => {
                 let input = self.render_plan(*input, scope, worker_index);
-                input.ensure_collections(keys, input_key, input_mfp)
+                input.ensure_collections(keys, input_key, input_mfp, self.until.clone())
             }
         }
     }

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -67,7 +67,7 @@ where
             let (permutation, thinning) = permutation_for_arrangement(&key, unthinned_arity);
             let mut mfp = MapFilterProject::new(unthinned_arity);
             mfp.permute(permutation, thinning.len() + key.len());
-            bundle.as_collection_core(mfp, Some((key.clone(), None)))
+            bundle.as_collection_core(mfp, Some((key.clone(), None)), self.until.clone())
         };
 
         let sink_token = sink_render.render_continuous_sink(

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -428,7 +428,14 @@ where
                 move |(input_row, time, diff)| {
                     let arena = mz_repr::RowArena::new();
                     let mut datums_local = datum_vec.borrow_with(&input_row);
-                    linear_op_mfp.evaluate(&mut datums_local, &arena, time, diff, &mut row_builder)
+                    linear_op_mfp.evaluate(
+                        &mut datums_local,
+                        &arena,
+                        time,
+                        diff,
+                        |_time| true,
+                        &mut row_builder,
+                    )
                 }
             });
 

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -185,7 +185,14 @@ where
             move |(row, time, diff)| {
                 let arena = mz_repr::RowArena::new();
                 let mut datums_local = datum_vec.borrow_with(&row);
-                plan.evaluate(&mut datums_local, &arena, time, diff, &mut row_builder)
+                plan.evaluate(
+                    &mut datums_local,
+                    &arena,
+                    time,
+                    diff,
+                    |_time| true,
+                    &mut row_builder,
+                )
             }
         });
 


### PR DESCRIPTION
This PR introduces an `until: Antichain<T>` member to `DataflowDescription`, which indicates through which time the dataflow should run. In particular, this is meant to be useful for dataflows that service `Peek` commands, which are only meant to execute at a single time. These dataflows should properly hydrate at that time, but will produce no further updates and (except for `persist_source`) drop their capabilities and shut down.

This is a bit of a draft at the moment, but it seemed to run ok locally. I have not yet exercised it as compared to `main` to observe any difference. It is possible that it will be nominal.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
