### PR TITLE
Non-differential FrontierUppers

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2503,12 +2503,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         sources.push(TimestampSource {
                             name: format!("{name} ({id}, storage)"),
                             read_frontier: state.implied_capability.elements().to_vec(),
-                            write_frontier: state
-                                .write_frontier
-                                .frontier()
-                                .to_owned()
-                                .elements()
-                                .to_vec(),
+                            write_frontier: state.write_frontier.elements().to_vec(),
                         });
                     }
                 }
@@ -2530,12 +2525,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             sources.push(TimestampSource {
                                 name: format!("{name} ({id}, compute)"),
                                 read_frontier: state.implied_capability.elements().to_vec(),
-                                write_frontier: state
-                                    .write_frontier
-                                    .frontier()
-                                    .to_owned()
-                                    .elements()
-                                    .to_vec(),
+                                write_frontier: state.write_frontier.elements().to_vec(),
                             });
                         }
                     }

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -210,7 +210,6 @@ impl<S: Append + 'static> Coordinator<S> {
                         .collection(*id)
                         .unwrap()
                         .write_frontier
-                        .frontier()
                         .iter()
                         .cloned(),
                 );
@@ -225,7 +224,6 @@ impl<S: Append + 'static> Coordinator<S> {
                             .collection(*id)
                             .unwrap()
                             .write_frontier
-                            .frontier()
                             .iter()
                             .cloned(),
                     );

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -294,9 +294,7 @@ where
             .collect();
 
         // Add the replica
-        self.compute
-            .replicas
-            .add_replica(id, addrs, persisted_logs, None);
+        self.compute.replicas.add_replica(id, addrs, persisted_logs);
     }
 
     pub fn get_replica_ids(&self) -> impl Iterator<Item = ReplicaId> + '_ {
@@ -653,7 +651,7 @@ where
         let mut read_capability_changes = BTreeMap::default();
         for (id, policy) in policies.into_iter() {
             if let Ok(collection) = self.collection_mut(id) {
-                let mut new_read_capability = policy.frontier(collection.write_frontier.frontier());
+                let mut new_read_capability = policy.frontier(collection.write_frontier.borrow());
 
                 if timely::order::PartialOrder::less_equal(
                     &collection.implied_capability,
@@ -704,19 +702,14 @@ where
                     )))
                 }
                 ComputeResponse::TailResponse(global_id, response) => {
-                    let mut changes = timely::progress::ChangeBatch::new();
-                    match &response {
-                        TailResponse::Batch(TailBatch { lower, upper, .. }) => {
-                            changes.extend(upper.iter().map(|time| (time.clone(), 1)));
-                            changes.extend(lower.iter().map(|time| (time.clone(), -1)));
-                        }
-                        TailResponse::DroppedAt(frontier) => {
-                            // The tail will not be written to again, but we should not confuse that
-                            // with the source of the TAIL being complete through this time.
-                            changes.extend(frontier.iter().map(|time| (time.clone(), -1)));
-                        }
-                    }
-                    self.update_write_frontiers(&[(global_id, changes)]).await?;
+                    let new_upper = match &response {
+                        TailResponse::Batch(TailBatch { upper, .. }) => upper.clone(),
+                        // The tail will not be written to again, but we should not confuse that
+                        // with the source of the TAIL being complete through this time.
+                        TailResponse::DroppedAt(_) => Antichain::new(),
+                    };
+                    self.update_write_frontiers(&[(global_id, new_upper)])
+                        .await?;
                     Ok(Some(ComputeControllerResponse::TailResponse(
                         global_id, response,
                     )))
@@ -772,26 +765,23 @@ where
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn update_write_frontiers(
         &mut self,
-        updates: &[(GlobalId, ChangeBatch<T>)],
+        updates: &[(GlobalId, Antichain<T>)],
     ) -> Result<(), ComputeError> {
         let mut read_capability_changes = BTreeMap::default();
-        for (id, changes) in updates.iter() {
+        for (id, new_upper) in updates.iter() {
             let collection = self
                 .collection_mut(*id)
                 .expect("Reference to absent collection");
 
-            collection
-                .write_frontier
-                .update_iter(changes.clone().drain());
+            collection.write_frontier.join_assign(new_upper);
 
             let mut new_read_capability = collection
                 .read_policy
-                .frontier(collection.write_frontier.frontier());
+                .frontier(collection.write_frontier.borrow());
             if timely::order::PartialOrder::less_equal(
                 &collection.implied_capability,
                 &new_read_capability,
             ) {
-                // TODO: reuse change batch above?
                 let mut update = ChangeBatch::new();
                 update.extend(new_read_capability.iter().map(|time| (time.clone(), 1)));
                 std::mem::swap(&mut collection.implied_capability, &mut new_read_capability);
@@ -926,11 +916,7 @@ pub struct CollectionState<T> {
     pub compute_dependencies: Vec<GlobalId>,
 
     /// Reported progress in the write capabilities.
-    ///
-    /// Importantly, this is not a write capability, but what we have heard about the
-    /// write capabilities of others. All future writes will have times greater than or
-    /// equal to `write_frontier.frontier()`.
-    pub write_frontier: MutableAntichain<T>,
+    pub write_frontier: Antichain<T>,
 }
 
 impl<T: Timestamp> CollectionState<T> {
@@ -948,7 +934,7 @@ impl<T: Timestamp> CollectionState<T> {
             read_policy: ReadPolicy::ValidFrom(since),
             storage_dependencies,
             compute_dependencies,
-            write_frontier: MutableAntichain::new_bottom(Timestamp::minimum()),
+            write_frontier: Antichain::from_elem(Timestamp::minimum()),
         }
     }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -920,7 +920,7 @@ pub struct CollectionState<T> {
     /// Compute identifiers on which this collection depends.
     pub compute_dependencies: Vec<GlobalId>,
 
-    /// Reported progress in the write capabilities.
+    /// Reported write frontier.
     pub write_frontier: Antichain<T>,
 }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -703,7 +703,12 @@ where
                 }
                 ComputeResponse::TailResponse(global_id, response) => {
                     let new_upper = match &response {
-                        TailResponse::Batch(TailBatch { upper, .. }) => upper.clone(),
+                        TailResponse::Batch(TailBatch { lower, upper, .. }) => {
+                            // Ensure there are no gaps in the tail stream we receive.
+                            assert_eq!(lower, &self.compute.collections[&global_id].write_frontier);
+
+                            upper.clone()
+                        }
                         // The tail will not be written to again, but we should not confuse that
                         // with the source of the TAIL being complete through this time.
                         TailResponse::DroppedAt(_) => Antichain::new(),

--- a/src/compute-client/src/response.rs
+++ b/src/compute-client/src/response.rs
@@ -20,21 +20,20 @@ use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
-use timely::progress::ChangeBatch;
 use uuid::Uuid;
 
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_proto::{any_uuid, IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, Row};
-use mz_timely_util::progress::any_change_batch;
+use mz_timely_util::progress::any_antichain;
 
 include!(concat!(env!("OUT_DIR"), "/mz_compute_client.response.rs"));
 
 /// Responses that the compute nature of a worker/dataflow can provide back to the coordinator.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
-    /// A list of identifiers of traces, with prior and new upper frontiers.
-    FrontierUppers(Vec<(GlobalId, ChangeBatch<T>)>),
+    /// A list of identifiers of traces, with new upper frontiers.
+    FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
     /// The worker's response to a specified (by connection id) peek.
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
     /// The worker's next response to a specified tail.
@@ -91,7 +90,7 @@ impl Arbitrary for ComputeResponse<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         prop_oneof![
-            proptest::collection::vec((any::<GlobalId>(), any_change_batch()), 1..4)
+            proptest::collection::vec((any::<GlobalId>(), any_antichain()), 1..4)
                 .prop_map(ComputeResponse::FrontierUppers),
             (any_uuid(), any::<PeekResponse>()).prop_map(|(id, resp)| {
                 ComputeResponse::PeekResponse(id, resp, OpenTelemetryContext::empty())
@@ -324,25 +323,7 @@ mod tests {
         fn compute_response_protobuf_roundtrip(expect in any::<ComputeResponse<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoComputeResponse>(&expect);
             assert!(actual.is_ok());
-            let actual = actual.unwrap();
-            if let ComputeResponse::FrontierUppers(expected_traces) = expect {
-                if let ComputeResponse::FrontierUppers(actual_traces) = actual {
-                    assert_eq!(actual_traces.len(), expected_traces.len());
-                    for ((actual_id, mut actual_changes), (expected_id, mut expected_changes)) in actual_traces.into_iter().zip(expected_traces.into_iter()) {
-                        assert_eq!(actual_id, expected_id);
-                        // `ChangeBatch`es representing equivalent sets of
-                        // changes could have different internal
-                        // representations, so they need to be compacted before comparing.
-                        actual_changes.compact();
-                        expected_changes.compact();
-                        assert_eq!(actual_changes, expected_changes);
-                    }
-                } else {
-                    assert_eq!(actual, ComputeResponse::FrontierUppers(expected_traces));
-                }
-            } else {
-                assert_eq!(actual, expect);
-            }
+            assert_eq!(actual.unwrap(), expect);
         }
     }
 }

--- a/src/compute-client/src/response.rs
+++ b/src/compute-client/src/response.rs
@@ -33,6 +33,9 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.response.rs"));
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// A list of identifiers of traces, with new upper frontiers.
+    ///
+    /// TODO(teskje): Consider also reporting the previous upper frontier and using that
+    /// information to assert the correct implementation of our protocols at various places.
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
     /// The worker's response to a specified (by connection id) peek.
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -22,7 +22,6 @@ use timely::logging::Logger;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::progress::reachability::logging::TrackerEvent;
-use timely::progress::ChangeBatch;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::{mpsc, Mutex};
 
@@ -532,65 +531,43 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
     /// Send progress information to the coordinator.
     pub fn report_compute_frontiers(&mut self) {
-        fn add_progress(
-            id: GlobalId,
-            new_frontier: &Antichain<Timestamp>,
-            prev_frontier: &Antichain<Timestamp>,
-            progress: &mut Vec<(GlobalId, ChangeBatch<Timestamp>)>,
-        ) {
-            let mut changes = ChangeBatch::new();
-            for time in prev_frontier.elements().iter() {
-                changes.update(time.clone(), -1);
+        let mut new_uppers = Vec::new();
+
+        let mut update_frontier = |id, new_frontier: &Antichain<Timestamp>| {
+            let prev_frontier = self.compute_state.reported_frontiers.get_mut(&id);
+            let prev_frontier = prev_frontier
+                .unwrap_or_else(|| panic!("Frontier update for untracked identifier: {id}"));
+
+            assert!(PartialOrder::less_equal(prev_frontier, new_frontier));
+            if prev_frontier == new_frontier {
+                return; // nothing new to report
             }
-            for time in new_frontier.elements().iter() {
-                changes.update(time.clone(), 1);
+
+            if let Some(logger) = self.compute_state.compute_logger.as_mut() {
+                if let Some(time) = prev_frontier.get(0) {
+                    logger.log(ComputeEvent::Frontier(id, *time, -1));
+                }
+                if let Some(time) = new_frontier.get(0) {
+                    logger.log(ComputeEvent::Frontier(id, *time, 1));
+                }
             }
-            changes.compact();
-            if !changes.is_empty() {
-                progress.push((id, changes));
-            }
-        }
+
+            new_uppers.push((id, new_frontier.clone()));
+            prev_frontier.clone_from(&new_frontier);
+        };
 
         let mut new_frontier = Antichain::new();
-        let mut progress = Vec::new();
         for (id, traces) in self.compute_state.traces.traces.iter_mut() {
-            // Read the upper frontier and compare to what we've reported.
             traces.oks_mut().read_upper(&mut new_frontier);
-            if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&id) {
-                assert!(PartialOrder::less_equal(prev_frontier, &new_frontier));
-                if prev_frontier != &new_frontier {
-                    add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
-                    prev_frontier.clone_from(&new_frontier);
-                }
-            } else {
-                panic!("Frontier update for untracked identifier: {:?}", id);
-            }
+            update_frontier(*id, &new_frontier);
         }
-
         for (id, frontier) in self.compute_state.sink_write_frontiers.iter() {
             new_frontier.clone_from(&frontier.borrow());
-            if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&id) {
-                assert!(PartialOrder::less_equal(prev_frontier, &new_frontier));
-                if prev_frontier != &new_frontier {
-                    add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
-                    prev_frontier.clone_from(&new_frontier);
-                }
-            } else {
-                panic!("Frontier update for untracked identifier: {:?}", id);
-            }
+            update_frontier(*id, &new_frontier);
         }
 
-        // Log index and sink frontier changes
-        if let Some(logger) = self.compute_state.compute_logger.as_mut() {
-            for (id, changes) in &mut progress {
-                for (time, diff) in changes.iter() {
-                    logger.log(ComputeEvent::Frontier(*id, *time, *diff));
-                }
-            }
-        }
-
-        if !progress.is_empty() {
-            self.send_compute_response(ComputeResponse::FrontierUppers(progress));
+        if !new_uppers.is_empty() {
+            self.send_compute_response(ComputeResponse::FrontierUppers(new_uppers));
         }
     }
 

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -1323,7 +1323,7 @@ pub struct CollectionState<T> {
     /// The policy to use to downgrade `self.implied_capability`.
     pub read_policy: ReadPolicy<T>,
 
-    /// Reported progress in the write capabilities.
+    /// Reported write frontier.
     pub write_frontier: Antichain<T>,
 
     pub collection_metadata: CollectionMetadata,
@@ -1355,7 +1355,7 @@ pub struct ExportState<T> {
     /// Description with which the export was created
     pub description: ExportDescription<T>,
 
-    /// Reported progress in the write capabilities.
+    /// Reported write frontier.
     pub write_frontier: Antichain<T>,
 }
 impl<T: Timestamp> ExportState<T> {

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -251,7 +251,7 @@ pub trait StorageController: Debug + Send {
     /// Accept write frontier updates from the compute layer.
     async fn update_write_frontiers(
         &mut self,
-        updates: &[(GlobalId, ChangeBatch<Self::Timestamp>)],
+        updates: &[(GlobalId, Antichain<Self::Timestamp>)],
     ) -> Result<(), StorageError>;
 
     /// Applies `updates` and sends any appropriate compaction command.
@@ -972,7 +972,6 @@ where
                 Err(_) => continue,
             };
             let from = export.from();
-            let old_frontier = export.write_frontier.frontier().to_owned();
 
             self.state
                 .exported_collections
@@ -982,9 +981,8 @@ where
                 .retain(|from_export_id| *from_export_id != id);
 
             // Remove sink by removing its write frontier and then deprovisioning.
-            let mut update = ChangeBatch::new();
-            update.extend(old_frontier.iter().map(|time| (time.clone(), -1)));
-            self.update_write_frontiers(&[(id, update)]).await?;
+            self.update_write_frontiers(&[(id, Antichain::new())])
+                .await?;
             self.hosts.deprovision(id).await?;
         }
         Ok(())
@@ -1049,36 +1047,36 @@ where
     #[tracing::instrument(level = "debug", skip(self))]
     async fn update_write_frontiers(
         &mut self,
-        updates: &[(GlobalId, ChangeBatch<Self::Timestamp>)],
+        updates: &[(GlobalId, Antichain<Self::Timestamp>)],
     ) -> Result<(), StorageError> {
         let mut read_capability_changes = BTreeMap::default();
         let mut collections = BTreeMap::new();
         let mut exports = vec![];
 
-        for (id, changes) in updates.iter() {
+        for (id, new_upper) in updates.iter() {
             if let Ok(_) = self.collection(*id) {
-                collections.insert(*id, Some(changes));
+                collections.insert(*id, Some(new_upper));
             } else if let Ok(_) = self.export(*id) {
-                exports.push((id, changes));
+                exports.push((id, new_upper));
             } else {
                 panic!("Reference to absent collection");
             }
         }
 
         // Exports come first so we can update the collections below based on any new export write frontiers
-        for (id, changes) in exports {
+        for (id, new_upper) in exports {
             let export = self
                 .export_mut(*id)
                 .expect("Export previously validated to exist");
-            export.write_frontier.update_iter(changes.clone().drain());
+            export.write_frontier.join_assign(new_upper);
             collections.entry(export.from()).or_insert(None);
         }
 
-        for (id, changes) in collections {
+        for (id, new_upper) in collections {
             let mut update = self
                 .generate_new_capability_for_collection(id, |c| {
-                    if let Some(changes) = changes {
-                        c.write_frontier.update_iter(changes.clone().drain());
+                    if let Some(new_upper) = new_upper {
+                        c.write_frontier.join_assign(new_upper);
                     }
                 })
                 .expect("Collection previously validated to exist");
@@ -1270,7 +1268,7 @@ where
         // Get read policy sent from the coordinator
         let mut new_read_capability = collection
             .read_policy
-            .frontier(collection.write_frontier.frontier());
+            .frontier(collection.write_frontier.borrow());
 
         // Also consider the write frontier of any exports.  It's worth adding a quick note on write frontiers here.
         //
@@ -1294,9 +1292,7 @@ where
                     .exports
                     .get(&export_id)
                     .expect("Dangling export reference")
-                    .write_frontier
-                    .frontier()
-                    .to_owned(),
+                    .write_frontier,
             );
         }
 
@@ -1328,11 +1324,7 @@ pub struct CollectionState<T> {
     pub read_policy: ReadPolicy<T>,
 
     /// Reported progress in the write capabilities.
-    ///
-    /// Importantly, this is not a write capability, but what we have heard about the
-    /// write capabilities of others. All future writes will have times greater than or
-    /// equal to `write_frontier.frontier()`.
-    pub write_frontier: MutableAntichain<T>,
+    pub write_frontier: Antichain<T>,
 
     pub collection_metadata: CollectionMetadata,
 }
@@ -1351,7 +1343,7 @@ impl<T: Timestamp> CollectionState<T> {
             read_capabilities,
             implied_capability: since.clone(),
             read_policy: ReadPolicy::ValidFrom(since),
-            write_frontier: MutableAntichain::new_bottom(Timestamp::minimum()),
+            write_frontier: Antichain::from_elem(Timestamp::minimum()),
             collection_metadata: metadata,
         }
     }
@@ -1364,17 +1356,13 @@ pub struct ExportState<T> {
     pub description: ExportDescription<T>,
 
     /// Reported progress in the write capabilities.
-    ///
-    /// Importantly, this is not a write capability, but what we have heard about the
-    /// write capabilities of others. All future writes will have times greater than or
-    /// equal to `write_frontier.frontier()`.
-    pub write_frontier: MutableAntichain<T>,
+    pub write_frontier: Antichain<T>,
 }
 impl<T: Timestamp> ExportState<T> {
     fn new(description: ExportDescription<T>) -> Self {
         Self {
             description,
-            write_frontier: MutableAntichain::new_bottom(Timestamp::minimum()),
+            write_frontier: Antichain::from_elem(Timestamp::minimum()),
         }
     }
     fn from(&self) -> GlobalId {
@@ -1694,8 +1682,7 @@ mod persist_write_handles {
                     for (span, command) in commands {
                         match command {
                             PersistWorkerCmd::Register(id, write_handle) => {
-                                let previous = write_handles
-                                    .insert(id, (write_handle, Antichain::from_elem(T::minimum())));
+                                let previous = write_handles.insert(id, write_handle);
                                 if previous.is_some() {
                                     panic!(
                                         "already registered a ReadHandle for collection {:?}",
@@ -1741,7 +1728,7 @@ mod persist_write_handles {
                         >,
                         write_handles: &mut BTreeMap<
                             GlobalId,
-                            (WriteHandle<SourceData, (), T2, Diff>, Antichain<T2>),
+                            WriteHandle<SourceData, (), T2, Diff>,
                         >,
                         mut commands: BTreeMap<
                             GlobalId,
@@ -1757,7 +1744,7 @@ mod persist_write_handles {
                         // Instead, we first group the update by ID above and then iterate
                         // through all available write handles and see if there are any updates
                         // for it. If yes, we send them all in one go.
-                        for (id, (write, old_upper)) in write_handles.iter_mut() {
+                        for (id, write) in write_handles.iter_mut() {
                             if let Some((span, updates, new_upper)) = commands.remove(id) {
                                 let persist_upper = write.upper().clone();
                                 let updates = updates
@@ -1819,27 +1806,22 @@ mod persist_write_handles {
                                         .expect("cannot append updates")
                                         .or(Err(*id))?;
 
-                                    let mut change_batch = timely::progress::ChangeBatch::new();
-                                    change_batch.extend(new_upper.iter().cloned().map(|t| (t, 1)));
-                                    change_batch.extend(old_upper.iter().cloned().map(|t| (t, -1)));
-                                    old_upper.clone_from(&new_upper);
-
-                                    Ok::<_, GlobalId>((*id, change_batch))
+                                    Ok::<_, GlobalId>((*id, new_upper))
                                 })
                             }
                         }
 
                         use futures_util::StreamExt;
                         // Ensure all futures run to completion, and track status of each of them individually
-                        let (change_batches, failed_appends): (Vec<_>, Vec<_>) = futs
+                        let (new_uppers, failed_appends): (Vec<_>, Vec<_>) = futs
                             .collect::<Vec<_>>()
                             .await
                             .into_iter()
                             .partition_result();
 
                         // It is not strictly an error for the controller to hang up.
-                        let _ = frontier_responses
-                            .send(StorageResponse::FrontierUppers(change_batches));
+                        let _ =
+                            frontier_responses.send(StorageResponse::FrontierUppers(new_uppers));
 
                         if failed_appends.is_empty() {
                             Ok(())

--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -57,12 +57,7 @@ message ProtoFrontierUppersKind {
 
 message ProtoTrace {
     mz_repr.global_id.ProtoGlobalId id = 1;
-    repeated ProtoUpdate updates = 2;
-}
-
-message ProtoUpdate {
-    uint64 timestamp = 1;
-    int64 diff = 2;
+    mz_persist.gen.persist.ProtoU64Antichain upper = 2;
 }
 
 message ProtoStorageCommand {

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -16,15 +16,15 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::iter;
 
 use async_trait::async_trait;
+use differential_dataflow::lattice::Lattice;
 use proptest::prelude::{any, Arbitrary};
 use proptest::prop_oneof;
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
-use timely::progress::frontier::{Antichain, MutableAntichain};
-use timely::progress::ChangeBatch;
+use timely::progress::frontier::Antichain;
+use timely::PartialOrder;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
@@ -32,7 +32,7 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_service::grpc::{BidiProtoClient, ClientTransport, GrpcClient, GrpcServer, ResponseStream};
-use mz_timely_util::progress::any_change_batch;
+use mz_timely_util::progress::any_antichain;
 
 use crate::controller::CollectionMetadata;
 use crate::protocol::client::proto_storage_client::ProtoStorageClient;
@@ -276,8 +276,8 @@ impl Arbitrary for StorageCommand<mz_repr::Timestamp> {
 /// Responses that the storage nature of a worker/dataflow can provide back to the coordinator.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum StorageResponse<T = mz_repr::Timestamp> {
-    /// A list of identifiers of traces, with prior and new upper frontiers.
-    FrontierUppers(Vec<(GlobalId, ChangeBatch<T>)>),
+    /// A list of identifiers of traces, with new upper frontiers.
+    FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
 }
 
 impl RustType<ProtoStorageResponse> for StorageResponse<mz_repr::Timestamp> {
@@ -309,7 +309,7 @@ impl Arbitrary for StorageResponse<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         prop_oneof![
-            proptest::collection::vec((any::<GlobalId>(), any_change_batch()), 1..4)
+            proptest::collection::vec((any::<GlobalId>(), any_antichain()), 1..4)
                 .prop_map(StorageResponse::FrontierUppers),
         ]
         .boxed()
@@ -324,14 +324,15 @@ impl Arbitrary for StorageResponse<mz_repr::Timestamp> {
 pub struct PartitionedStorageState<T> {
     /// Number of partitions the state machine represents.
     parts: usize,
-    /// Upper frontiers for sources.
-    uppers: HashMap<GlobalId, MutableAntichain<T>>,
+    /// Upper frontiers for sources and sinks, both unioned across all partitions and from each
+    /// individual partition.
+    uppers: HashMap<GlobalId, (Antichain<T>, Vec<Antichain<T>>)>,
 }
 
 impl<T> Partitionable<StorageCommand<T>, StorageResponse<T>>
     for (StorageCommand<T>, StorageResponse<T>)
 where
-    T: timely::progress::Timestamp,
+    T: timely::progress::Timestamp + Lattice,
 {
     type PartitionedState = PartitionedStorageState<T>;
 
@@ -351,17 +352,17 @@ where
         match command {
             StorageCommand::IngestSources(ingestions) => {
                 for ingestion in ingestions {
-                    let mut frontier = MutableAntichain::new();
-                    frontier.update_iter(iter::once((T::minimum(), self.parts as i64)));
-                    let previous = self.uppers.insert(ingestion.id, frontier);
+                    let frontier = Antichain::from_elem(T::minimum());
+                    let part_frontiers = vec![frontier.clone(); self.parts];
+                    let previous = self.uppers.insert(ingestion.id, (frontier, part_frontiers));
                     assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", ingestion.id, command);
                 }
             }
             StorageCommand::ExportSinks(exports) => {
                 for export in exports {
-                    let mut frontier = MutableAntichain::new();
-                    frontier.update_iter(iter::once((T::minimum(), self.parts as i64)));
-                    let previous = self.uppers.insert(export.id, frontier);
+                    let frontier = Antichain::from_elem(T::minimum());
+                    let part_frontiers = vec![frontier.clone(); self.parts];
+                    let previous = self.uppers.insert(export.id, (frontier, part_frontiers));
                     assert!(previous.is_none(), "Protocol error: starting frontier tracking for already present identifier {:?} due to command {:?}", export.id, command);
                 }
             }
@@ -374,7 +375,7 @@ where
 
 impl<T> PartitionedState<StorageCommand<T>, StorageResponse<T>> for PartitionedStorageState<T>
 where
-    T: timely::progress::Timestamp,
+    T: timely::progress::Timestamp + Lattice,
 {
     fn split_command(&mut self, command: StorageCommand<T>) -> Vec<StorageCommand<T>> {
         self.observe_command(&command);
@@ -384,36 +385,34 @@ where
 
     fn absorb_response(
         &mut self,
-        _shard_id: usize,
+        shard_id: usize,
         response: StorageResponse<T>,
     ) -> Option<Result<StorageResponse<T>, anyhow::Error>> {
         match response {
             // Avoid multiple retractions of minimum time, to present as updates from one worker.
-            StorageResponse::FrontierUppers(mut list) => {
-                for (id, changes) in list.iter_mut() {
-                    if let Some(frontier) = self.uppers.get_mut(id) {
-                        let iter = frontier.update_iter(changes.drain());
-                        changes.extend(iter);
-                    } else {
-                        changes.clear();
-                    }
-                }
-                // The following block implements a `list.retain()` of non-empty change batches.
-                // This is more verbose than `list.retain()` because that method cannot mutate
-                // its argument, and `is_empty()` may need to do this (as it is lazily compacted).
-                let mut cursor = 0;
-                while let Some((_id, changes)) = list.get_mut(cursor) {
-                    if changes.is_empty() {
-                        list.swap_remove(cursor);
-                    } else {
-                        cursor += 1;
+            StorageResponse::FrontierUppers(list) => {
+                let mut new_uppers = Vec::new();
+
+                for (id, new_shard_upper) in list {
+                    if let Some((reported, tracked)) = self.uppers.get_mut(&id) {
+                        // Update the shard upper and compute a new global upper.
+                        tracked[shard_id].join_assign(&new_shard_upper);
+                        let mut new_upper = Antichain::new();
+                        for upper in tracked {
+                            new_upper.extend(upper.iter().cloned());
+                        }
+
+                        if PartialOrder::less_than(reported, &new_upper) {
+                            reported.clone_from(&new_upper);
+                            new_uppers.push((id, new_upper));
+                        }
                     }
                 }
 
-                if list.is_empty() {
+                if new_uppers.is_empty() {
                     None
                 } else {
-                    Some(Ok(StorageResponse::FrontierUppers(list)))
+                    Some(Ok(StorageResponse::FrontierUppers(new_uppers)))
                 }
             }
         }
@@ -428,37 +427,26 @@ pub struct Update<T = mz_repr::Timestamp> {
     pub diff: Diff,
 }
 
-impl RustType<ProtoTrace> for (GlobalId, ChangeBatch<mz_repr::Timestamp>) {
+impl RustType<ProtoTrace> for (GlobalId, Antichain<mz_repr::Timestamp>) {
     fn into_proto(&self) -> ProtoTrace {
         ProtoTrace {
             id: Some(self.0.into_proto()),
-            updates: self
-                .1
-                // Clone because the `iter()` expects
-                // `trace` to be mutable.
-                .clone()
-                .iter()
-                .map(|(t, d)| ProtoUpdate {
-                    timestamp: *t,
-                    diff: *d,
-                })
-                .collect(),
+            upper: Some((&self.1).into()),
         }
     }
 
     fn from_proto(proto: ProtoTrace) -> Result<Self, TryFromProtoError> {
-        let mut batch = ChangeBatch::new();
-        batch.extend(
+        Ok((
+            proto.id.into_rust_if_some("ProtoTrace::id")?,
             proto
-                .updates
-                .into_iter()
-                .map(|update| (update.timestamp, update.diff)),
-        );
-        Ok((proto.id.into_rust_if_some("ProtoTrace::id")?, batch))
+                .upper
+                .map(Into::into)
+                .ok_or_else(|| TryFromProtoError::missing_field("ProtoTrace::upper"))?,
+        ))
     }
 }
 
-impl RustType<ProtoFrontierUppersKind> for Vec<(GlobalId, ChangeBatch<mz_repr::Timestamp>)> {
+impl RustType<ProtoFrontierUppersKind> for Vec<(GlobalId, Antichain<mz_repr::Timestamp>)> {
     fn into_proto(&self) -> ProtoFrontierUppersKind {
         ProtoFrontierUppersKind {
             traces: self.into_proto(),
@@ -511,19 +499,7 @@ mod tests {
         fn storage_response_protobuf_roundtrip(expect in any::<StorageResponse<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoStorageResponse>(&expect);
             assert!(actual.is_ok());
-            let actual = actual.unwrap();
-            let StorageResponse::FrontierUppers(expected_traces) = expect;
-            let StorageResponse::FrontierUppers(actual_traces) = actual;
-            assert_eq!(actual_traces.len(), expected_traces.len());
-            for ((actual_id, mut actual_changes), (expected_id, mut expected_changes)) in actual_traces.into_iter().zip(expected_traces.into_iter()) {
-                assert_eq!(actual_id, expected_id);
-                // `ChangeBatch`es representing equivalent sets of
-                // changes could have different internal
-                // representations, so they need to be compacted before comparing.
-                actual_changes.compact();
-                expected_changes.compact();
-                assert_eq!(actual_changes, expected_changes);
-            }
+            assert_eq!(actual.unwrap(), expect);
         }
     }
 }

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -278,6 +278,9 @@ impl Arbitrary for StorageCommand<mz_repr::Timestamp> {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub enum StorageResponse<T = mz_repr::Timestamp> {
     /// A list of identifiers of traces, with new upper frontiers.
+    ///
+    /// TODO(teskje): Consider also reporting the previous upper frontier and using that
+    /// information to assert the correct implementation of our protocols at various places.
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
 }
 

--- a/src/timely-util/src/progress.rs
+++ b/src/timely-util/src/progress.rs
@@ -17,16 +17,13 @@
 
 use proptest::prelude::{any, Arbitrary};
 use proptest::strategy::Strategy;
-use timely::progress::ChangeBatch;
+use timely::progress::Antichain;
+use timely::PartialOrder;
 
-/// An out-of-crate [`Arbitrary`] implementation for [`ChangeBatch`].
-pub fn any_change_batch<T>() -> impl Strategy<Value = ChangeBatch<T>>
+/// An out-of-crate [`Arbitrary`] implementation for [`Antichain`].
+pub fn any_antichain<T: PartialOrder>() -> impl Strategy<Value = Antichain<T>>
 where
     T: Arbitrary + Ord,
 {
-    proptest::collection::vec((any::<T>(), any::<i64>()), 1..11).prop_map(|changes| {
-        let mut batch = ChangeBatch::new();
-        batch.extend(changes.into_iter());
-        batch
-    })
+    proptest::collection::vec(any::<T>(), 1..11).prop_map(Into::into)
 }


### PR DESCRIPTION
This PR changes the format of `FrontierUppers` storage and compute responses to communicate the new upper frontiers directly as `Antichain`s instead of `ChangeBatch`es. This means `FrontierUpper`s responses now don't contain information about the previous frontiers anymore.

The main benefit of this change is that we avoid all bugs that result from different components (e.g. the compute controller and computed) disagreeing over what the previous upper should have been. In the past we had several instances (e.g. https://github.com/MaterializeInc/materialize/issues/13454, https://github.com/MaterializeInc/materialize/issues/14261) where this happened after one of the components was restarted, which usually lead to the frontier in question no longer being advanced correctly.

The change also simplifies code, as non-differential updating of frontiers is usually more straightforward.

Finally, the new `FrontierUppers` format is consistent with the `AllowCompaction` storage/compute command, which also contains `Antichain`s instead of `ChangeBatch`es.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

* Part of this PR is reverting https://github.com/MaterializeInc/materialize/pull/14310, because that work-around is not needed anymore. Instead, uppers of introspection sinks are now tracked in `ActiveReplicationState::uppers` as well.
* I'm less familiar with the storage-part, so if you could pay extra attention there, that would be great!
* I suspect there might be easier or more efficient ways for doing some of the `Antichain` manipulation.
* The `FrontierUppers` format change breaks backwards-compatibility. I'm not sure how big of a deal this really is, depends on whether or not that data gets persisted somewhere. In any case, the release next week is going to break backwards-compatibility anyway, so if we can merge until then, there is no cause for concern.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
