### PR TITLE
Initialize Timely lazily in computed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,7 @@ name = "mz-compute"
 version = "0.27.0-dev"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "bytesize",
  "clap",
@@ -3195,6 +3196,7 @@ dependencies = [
  "dec",
  "differential-dataflow",
  "dogsdogsdogs",
+ "futures",
  "mz-build-info",
  "mz-compute-client",
  "mz-expr",

--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -40,7 +40,10 @@ class UseComputed(Action):
         c.sql(
             """
             DROP CLUSTER REPLICA default.default_replica;
-            CREATE CLUSTER REPLICA default.default_replica REMOTE ['computed_1:2100'];
+            CREATE CLUSTER REPLICA default.default_replica
+                REMOTE ['computed_1:2100'],
+                COMPUTE ['computed_1:2102'],
+                WORKERS 1;
         """
         )
 
@@ -53,11 +56,7 @@ class KillComputed(Action):
 
 class StartComputed(Action):
     def execute(self, c: Composition) -> None:
-        with c.override(
-            Computed(
-                name="computed_1", options="--workers 1 --process 0 computed_1:2102"
-            )
-        ):
+        with c.override(Computed(name="computed_1")):
             c.up("computed_1")
 
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -139,7 +139,6 @@ class Computed(Service):
     def __init__(
         self,
         name: str = "computed",
-        peers: Optional[List[str]] = [],
         hostname: Optional[str] = None,
         image: Optional[str] = None,
         ports: List[int] = [2100, 2102],
@@ -147,7 +146,6 @@ class Computed(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        workers: Optional[int] = None,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:
@@ -178,13 +176,6 @@ class Computed(Service):
                 command_list.append(options)
             else:
                 command_list.extend(options)
-
-        if workers:
-            command_list.append(f"--workers {workers}")
-
-        if peers:
-            command_list.append(f"--process {peers.index(name)}")
-            command_list.append(" ".join(f"{peer}:2102" for peer in peers))
 
         command_list.append(f"--secrets-reader {secrets_reader}")
         command_list.append(

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -3087,9 +3088,15 @@ impl<S: Append> Catalog<S> {
     ) -> Result<ConcreteComputeInstanceReplicaLocation, AdapterError> {
         let cluster_replica_sizes = &self.state.cluster_replica_sizes;
         let location = match location {
-            SerializedComputeInstanceReplicaLocation::Remote { addrs } => {
-                ConcreteComputeInstanceReplicaLocation::Remote { addrs }
-            }
+            SerializedComputeInstanceReplicaLocation::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            } => ConcreteComputeInstanceReplicaLocation::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            },
             SerializedComputeInstanceReplicaLocation::Managed {
                 size,
                 availability_zone,
@@ -4595,6 +4602,8 @@ impl From<ConcreteComputeInstanceReplicaConfig> for SerializedComputeInstanceRep
 pub enum SerializedComputeInstanceReplicaLocation {
     Remote {
         addrs: BTreeSet<String>,
+        compute_addrs: BTreeSet<String>,
+        workers: NonZeroUsize,
     },
     Managed {
         size: String,
@@ -4608,7 +4617,15 @@ pub enum SerializedComputeInstanceReplicaLocation {
 impl From<ConcreteComputeInstanceReplicaLocation> for SerializedComputeInstanceReplicaLocation {
     fn from(loc: ConcreteComputeInstanceReplicaLocation) -> Self {
         match loc {
-            ConcreteComputeInstanceReplicaLocation::Remote { addrs } => Self::Remote { addrs },
+            ConcreteComputeInstanceReplicaLocation::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            } => Self::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            },
             ConcreteComputeInstanceReplicaLocation::Managed {
                 allocation: _,
                 size,

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -694,9 +694,15 @@ impl<S: Append + 'static> Coordinator<S> {
             // If the AZ was not specified, choose one, round-robin, from the ones with
             // the lowest number of configured replicas for this cluster.
             let location = match replica_config {
-                ComputeInstanceReplicaConfig::Remote { addrs } => {
-                    SerializedComputeInstanceReplicaLocation::Remote { addrs }
-                }
+                ComputeInstanceReplicaConfig::Remote {
+                    addrs,
+                    compute_addrs,
+                    workers,
+                } => SerializedComputeInstanceReplicaLocation::Remote {
+                    addrs,
+                    compute_addrs,
+                    workers,
+                },
                 ComputeInstanceReplicaConfig::Managed {
                     size,
                     availability_zone,
@@ -817,9 +823,15 @@ impl<S: Append + 'static> Coordinator<S> {
 
         // Choose default AZ if necessary
         let location = match config {
-            ComputeInstanceReplicaConfig::Remote { addrs } => {
-                SerializedComputeInstanceReplicaLocation::Remote { addrs }
-            }
+            ComputeInstanceReplicaConfig::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            } => SerializedComputeInstanceReplicaLocation::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            },
             ComputeInstanceReplicaConfig::Managed {
                 size,
                 availability_zone,

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -45,6 +45,7 @@ message ProtoComputeCommand {
         ProtoCancelPeeks cancel_peeks = 6;
         google.protobuf.Empty initialization_complete = 7;
         ProtoUpdateMaxResultSize update_max_result_size = 8;
+        ProtoCommunicationConfig create_timely = 9;
     }
 }
 
@@ -52,6 +53,12 @@ message ProtoInstanceConfig {
     mz_compute_client.logging.ProtoLoggingConfig logging = 1;
     uint64 replica_id = 2;
     uint32 max_result_size = 3;
+}
+
+message ProtoCommunicationConfig {
+    uint64 workers = 1;
+    uint64 process = 2;
+    repeated string addresses = 3;
 }
 
 message ProtoDataflowDescription {

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -779,7 +779,7 @@ where
             }
         }
         let mut replicas = ActiveReplication::new(build_info);
-        // These commands will be modified ActiveReplication
+        // These commands will be modified by ActiveReplication
         replicas.send(ComputeCommand::CreateTimely(Default::default()));
         replicas.send(ComputeCommand::CreateInstance(InstanceConfig {
             replica_id: Default::default(),

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -52,8 +52,8 @@ use mz_repr::{GlobalId, Row};
 use mz_storage::controller::{ReadPolicy, StorageController, StorageError};
 
 use crate::command::{
-    ComputeCommand, DataflowDescription, InstanceConfig, Peek, ProcessId, ReplicaId,
-    SourceInstanceDesc,
+    CommunicationConfig, ComputeCommand, DataflowDescription, InstanceConfig, Peek, ProcessId,
+    ReplicaId, SourceInstanceDesc,
 };
 use crate::logging::{LogVariant, LogView, LoggingConfig};
 use crate::response::{ComputeResponse, PeekResponse, TailBatch, TailResponse};
@@ -182,7 +182,12 @@ pub enum ConcreteComputeInstanceReplicaLocation {
     Remote {
         /// The network addresses of the processes in the replica.
         addrs: BTreeSet<String>,
+        /// The network addresses of the Timely endpoints of the processes in the replica.
+        compute_addrs: BTreeSet<String>,
+        /// The workers per process in the replica.
+        workers: NonZeroUsize,
     },
+    /// Out-of-process replica
     /// A remote but managed replica
     Managed {
         /// The resource allocation for the replica.
@@ -486,11 +491,20 @@ where
 
         // Add replicas backing that instance.
         match config.location {
-            ConcreteComputeInstanceReplicaLocation::Remote { addrs } => {
+            ConcreteComputeInstanceReplicaLocation::Remote {
+                addrs,
+                compute_addrs,
+                workers,
+            } => {
                 self.instance(instance_id)?.add_replica(
                     replica_id,
                     addrs.into_iter().collect(),
                     persisted_logs,
+                    CommunicationConfig {
+                        workers: workers.get(),
+                        process: 0,
+                        addresses: compute_addrs.into_iter().collect(),
+                    },
                 );
             }
             ConcreteComputeInstanceReplicaLocation::Managed {
@@ -498,14 +512,22 @@ where
                 availability_zone,
                 ..
             } => {
-                let replica_addrs = self
+                let service = self
                     .compute
                     .orchestrator
                     .ensure_replica(instance_id, replica_id, allocation, availability_zone)
                     .await?;
 
-                self.instance(instance_id)?
-                    .add_replica(replica_id, replica_addrs, persisted_logs);
+                self.instance(instance_id)?.add_replica(
+                    replica_id,
+                    service.addresses("controller"),
+                    persisted_logs,
+                    CommunicationConfig {
+                        workers: allocation.workers.get(),
+                        process: 0,
+                        addresses: service.addresses("compute"),
+                    },
+                );
             }
         }
 
@@ -757,6 +779,8 @@ where
             }
         }
         let mut replicas = ActiveReplication::new(build_info);
+        // These commands will be modified ActiveReplication
+        replicas.send(ComputeCommand::CreateTimely(Default::default()));
         replicas.send(ComputeCommand::CreateInstance(InstanceConfig {
             replica_id: Default::default(),
             logging,
@@ -808,6 +832,7 @@ where
         id: ReplicaId,
         addrs: Vec<String>,
         persisted_logs: HashMap<LogVariant, GlobalId>,
+        communication_config: CommunicationConfig,
     ) {
         // Create ComputeState entries in Instance
         for id in persisted_logs.values() {
@@ -832,7 +857,9 @@ where
             .collect();
 
         // Add the replica
-        self.compute.replicas.add_replica(id, addrs, persisted_logs);
+        self.compute
+            .replicas
+            .add_replica(id, addrs, persisted_logs, communication_config);
     }
 
     /// Remove an existing instance replica, by ID.

--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -44,7 +44,7 @@ use mz_repr::GlobalId;
 use mz_service::client::GenericClient;
 use mz_storage::controller::CollectionMetadata;
 
-use crate::command::{ComputeCommand, ComputeCommandHistory, Peek, ReplicaId};
+use crate::command::{CommunicationConfig, ComputeCommand, ComputeCommandHistory, Peek, ReplicaId};
 use crate::logging::LogVariant;
 use crate::response::{ComputeResponse, PeekResponse, TailBatch, TailResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
@@ -374,6 +374,8 @@ struct ReplicaState<T> {
     addrs: Vec<String>,
     /// Where to persist introspection sources
     persisted_logs: BTreeMap<LogVariant, (GlobalId, CollectionMetadata)>,
+    /// The communication config specific to this replica.
+    communication_config: CommunicationConfig,
 }
 
 impl<T> ReplicaState<T> {
@@ -397,6 +399,10 @@ impl<T> ReplicaState<T> {
             // Set replica id
             config.replica_id = replica_id;
         }
+
+        if let ComputeCommand::CreateTimely(comm_config) = command {
+            *comm_config = self.communication_config.clone();
+        }
     }
 }
 
@@ -413,6 +419,7 @@ where
         id: ReplicaId,
         addrs: Vec<String>,
         persisted_logs: BTreeMap<LogVariant, (GlobalId, CollectionMetadata)>,
+        communication_config: CommunicationConfig,
     ) {
         // Launch a task to handle communication with the replica
         // asynchronously. This isolates the main controller thread from
@@ -440,6 +447,7 @@ where
             _task: task.abort_on_drop(),
             addrs,
             persisted_logs,
+            communication_config,
         };
 
         // Replay the commands at the client, creating new dataflow identifiers.
@@ -482,8 +490,9 @@ where
     fn rehydrate_replica(&mut self, id: ReplicaId) {
         let addrs = self.replicas[&id].addrs.clone();
         let persisted_logs = self.replicas[&id].persisted_logs.clone();
+        let communication_config = self.replicas[&id].communication_config.clone();
         self.remove_replica(id);
-        self.add_replica(id, addrs, persisted_logs);
+        self.add_replica(id, addrs, persisted_logs, communication_config);
     }
 
     // We avoid implementing `GenericClient` here, because the protocol between

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.65"
+async-trait = "0.1.56"
 axum = "0.5.16"
 bytesize = "1.1.0"
 clap = { version = "3.2.20", features = ["derive", "env"] }
@@ -15,6 +16,7 @@ crossbeam-channel = "0.5.6"
 dec = { version = "0.4.8", features = ["serde"] }
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+futures = "0.3.21"
 mz-build-info = { path = "../build-info" }
 mz-compute-client = { path = "../compute-client" }
 mz-expr = { path = "../expr" }

--- a/src/compute/ci/entrypoint.sh
+++ b/src/compute/ci/entrypoint.sh
@@ -12,11 +12,5 @@
 set -euo pipefail
 
 args=(--controller-listen-addr=0.0.0.0:2100 --internal-http-listen-addr=0.0.0.0:6878)
-if [[ "${KUBERNETES_SERVICE_HOST:-}" ]]; then
-    # Hack: if running in Kubernetes, we parse the process index from the
-    # hostname, if possible. At present this is the only known way to get the
-    # ordinal index of a Kubernetes replica.
-    args+=(--process="${HOSTNAME##*-}")
-fi
 
 exec computed "${args[@]}" "$@"

--- a/src/compute/src/bin/computed.rs
+++ b/src/compute/src/bin/computed.rs
@@ -11,13 +11,11 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::process;
 
-use anyhow::bail;
 use axum::routing;
 use once_cell::sync::Lazy;
 use tracing::info;
 
 use mz_build_info::{build_info, BuildInfo};
-use mz_compute::server::CommunicationConfig;
 use mz_compute_client::service::proto_compute_server::ProtoComputeServer;
 use mz_orchestrator_tracing::TracingCliArgs;
 use mz_ore::cli::{self, CliConfig};
@@ -68,17 +66,6 @@ struct Args {
     )]
     internal_http_listen_addr: SocketAddr,
 
-    // === Dataflow options. ===
-    /// Number of dataflow worker threads.
-    #[clap(long, env = "WORKERS", value_name = "N", default_value = "1")]
-    workers: usize,
-    /// Number of this computed process.
-    #[clap(long, env = "PROCESS", value_name = "P")]
-    process: Option<usize>,
-    /// The addresses of all computed processes in the cluster.
-    #[clap(env = "ADDRESSES", use_value_delimiter = true)]
-    addresses: Vec<String>,
-
     // === Process orchestrator options. ===
     /// Where to write a PID lock file.
     ///
@@ -107,24 +94,6 @@ async fn main() {
     }
 }
 
-fn create_communication_config(args: &Args) -> Result<CommunicationConfig, anyhow::Error> {
-    let process = match args.process {
-        None => 0,
-        Some(process) if process >= args.addresses.len() => {
-            bail!(
-                "process index {process} out of range [0, {})",
-                args.addresses.len()
-            );
-        }
-        Some(process) => process,
-    };
-    Ok(CommunicationConfig {
-        threads: args.workers,
-        process,
-        addresses: args.addresses.clone(),
-    })
-}
-
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
     let otel_enable_callback = mz_ore::tracing::configure("computed", &args.tracing).await?;
@@ -133,11 +102,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
     if let Some(pid_file_location) = &args.pid_file_location {
         _pid_file = Some(PidFile::open(&pid_file_location).unwrap());
     }
-
-    if args.workers == 0 {
-        bail!("--workers must be greater than 0");
-    }
-    let comm_config = create_communication_config(&args)?;
 
     info!("about to bind to {:?}", args.controller_listen_addr);
 
@@ -175,8 +139,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
 
     let config = mz_compute::server::Config {
         build_info: &BUILD_INFO,
-        workers: args.workers,
-        comm_config,
         metrics_registry,
         now: SYSTEM_TIME.clone(),
     };

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -26,20 +26,20 @@ use timely::communication::allocator::zero_copy::initialize::initialize_networki
 use timely::communication::allocator::GenericBuilder;
 use tracing::{info, trace, warn};
 
-use crate::server::CommunicationConfig;
+use mz_compute_client::command::CommunicationConfig;
 
 /// Creates communication mesh from cluster config
 pub fn initialize_networking(
-    config: CommunicationConfig,
+    config: &CommunicationConfig,
 ) -> Result<(Vec<GenericBuilder>, Box<dyn Any + Send>), String> {
     let CommunicationConfig {
-        threads,
+        workers,
         process,
         addresses,
     } = config;
-    let sockets_result = create_sockets(addresses, process);
+    let sockets_result = create_sockets(addresses.clone(), *process);
     match sockets_result.and_then(|sockets| {
-        initialize_networking_from_sockets(sockets, process, threads, Box::new(|_| None))
+        initialize_networking_from_sockets(sockets, *process, *workers, Box::new(|_| None))
     }) {
         Ok((stuff, guard)) => Ok((
             stuff.into_iter().map(GenericBuilder::ZeroCopy).collect(),

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -106,6 +106,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         use ComputeCommand::*;
         self.compute_state.command_history.push(cmd.clone());
         match cmd {
+            CreateTimely(_) => panic!("CreateTimely must be captured before"),
             CreateInstance(config) => self.handle_create_instance(config),
             DropInstance => (),
             InitializationComplete => (),

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1071,6 +1071,10 @@ pub enum ReplicaOptionName {
     Size,
     /// The `AVAILABILITY ZONE [[=] <size>]` option.
     AvailabilityZone,
+    /// The `WORKERS [[=] <workers>]` option
+    Workers,
+    /// The `COMPUTE [<host> [, <host> ...]]` option.
+    Compute,
 }
 
 impl AstDisplay for ReplicaOptionName {
@@ -1079,6 +1083,8 @@ impl AstDisplay for ReplicaOptionName {
             ReplicaOptionName::Remote => f.write_str("REMOTE"),
             ReplicaOptionName::Size => f.write_str("SIZE"),
             ReplicaOptionName::AvailabilityZone => f.write_str("AVAILABILITY ZONE"),
+            ReplicaOptionName::Workers => f.write_str("WORKERS"),
+            ReplicaOptionName::Compute => f.write_str("COMPUTE"),
         }
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -73,6 +73,7 @@ Commit
 Committed
 Compaction
 Compression
+Compute
 Confluent
 Connection
 Connections
@@ -367,6 +368,7 @@ Wire
 With
 Without
 Work
+Workers
 Write
 Year
 Years

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2898,15 +2898,18 @@ impl<'a> Parser<'a> {
         }))
     }
     fn parse_replica_option(&mut self) -> Result<ReplicaOption<Raw>, ParserError> {
-        let name = match self.expect_one_of_keywords(&[AVAILABILITY, REMOTE, SIZE])? {
-            AVAILABILITY => {
-                self.expect_keyword(ZONE)?;
-                ReplicaOptionName::AvailabilityZone
-            }
-            REMOTE => ReplicaOptionName::Remote,
-            SIZE => ReplicaOptionName::Size,
-            _ => unreachable!(),
-        };
+        let name =
+            match self.expect_one_of_keywords(&[AVAILABILITY, COMPUTE, REMOTE, SIZE, WORKERS])? {
+                AVAILABILITY => {
+                    self.expect_keyword(ZONE)?;
+                    ReplicaOptionName::AvailabilityZone
+                }
+                COMPUTE => ReplicaOptionName::Compute,
+                REMOTE => ReplicaOptionName::Remote,
+                SIZE => ReplicaOptionName::Size,
+                WORKERS => ReplicaOptionName::Workers,
+                _ => unreachable!(),
+            };
         let value = self.parse_opt_with_option_value(false)?;
         Ok(ReplicaOption { name, value })
     }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1152,6 +1152,13 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1'], SIZE = '1'))
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }, ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }])] })
 
 parse-statement
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1:2400', 'host2:2400'], COMPUTE ['host1:2401', 'host2:2401'], WORKERS '1'))
+----
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1:2400', 'host2:2400'], COMPUTE = ['host1:2401', 'host2:2401'], WORKERS = '1'))
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1:2400"), String("host2:2400")]))) }, ReplicaOption { name: Compute, value: Some(Value(Array([String("host1:2401"), String("host2:2401")]))) }, ReplicaOption { name: Workers, value: Some(Value(String("1"))) }] }])] })
+
+parse-statement
 CREATE CLUSTER REPLICA replica REMOTE ['host1']
 ----
 error: Expected dot, found REMOTE

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -274,6 +274,8 @@ pub struct ComputeInstanceIntrospectionConfig {
 pub enum ComputeInstanceReplicaConfig {
     Remote {
         addrs: BTreeSet<String>,
+        compute_addrs: BTreeSet<String>,
+        workers: NonZeroUsize,
     },
     Managed {
         size: String,
@@ -284,7 +286,11 @@ pub enum ComputeInstanceReplicaConfig {
 impl ComputeInstanceReplicaConfig {
     pub fn get_az(&self) -> Option<&str> {
         match self {
-            ComputeInstanceReplicaConfig::Remote { addrs: _ } => None,
+            ComputeInstanceReplicaConfig::Remote {
+                addrs: _,
+                compute_addrs: _,
+                workers: _,
+            } => None,
             ComputeInstanceReplicaConfig::Managed {
                 size: _,
                 availability_zone,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2657,7 +2657,7 @@ fn plan_replica_config(
             }
             if compute_addrs.len() > remote_addrs.len() {
                 sql_bail!(
-                    "must specify as many COMPUTE addresses as REMOTE addresses for multi-process replicas"
+                    "must specify as many REMOTE addresses as COMPUTE addresses for multi-process replicas"
                 );
             }
 
@@ -2684,7 +2684,7 @@ fn plan_replica_config(
         }
         (_, _) => {
             // SIZE and REMOTE given, or none of them
-            sql_bail!("one of REMOTE or SIZE must be specified")
+            sql_bail!("only one of REMOTE or SIZE may be specified")
         }
     }
 }

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -216,22 +216,10 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
     c.wait_for_materialized()
 
     nodes = [
-        Computed(
-            name="computed_1_1",
-            peers=["computed_1_1", "computed_1_2"],
-        ),
-        Computed(
-            name="computed_1_2",
-            peers=["computed_1_1", "computed_1_2"],
-        ),
-        Computed(
-            name="computed_2_1",
-            peers=["computed_2_1", "computed_2_2"],
-        ),
-        Computed(
-            name="computed_2_2",
-            peers=["computed_2_1", "computed_2_2"],
-        ),
+        Computed(name="computed_1_1"),
+        Computed(name="computed_1_2"),
+        Computed(name="computed_2_1"),
+        Computed(name="computed_2_2"),
     ]
 
     with c.override(*nodes):
@@ -240,14 +228,22 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
         c.sql(
             """
             DROP CLUSTER IF EXISTS cluster1 CASCADE;
-            CREATE CLUSTER cluster1 REPLICAS (replica1 (REMOTE ['computed_1_1:2100', 'computed_1_2:2100']));
+            CREATE CLUSTER cluster1 REPLICAS (replica1 (
+                REMOTE ['computed_1_1:2100', 'computed_1_2:2100'],
+                COMPUTE ['computed_1_1:2102', 'computed_1_2:2102'],
+                WORKERS 1
+            ));
             """
         )
 
         c.sql(
             """
             DROP CLUSTER IF EXISTS cluster2 CASCADE;
-            CREATE CLUSTER cluster2 REPLICAS (replica1 (REMOTE ['computed_2_1:2100', 'computed_2_2:2100']));
+            CREATE CLUSTER cluster2 REPLICAS (replica1 (
+                REMOTE ['computed_2_1:2100', 'computed_2_2:2100'],
+                COMPUTE ['computed_2_1:2102', 'computed_2_2:2102'],
+                WORKERS 1
+            ));
             """
         )
 

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -230,8 +230,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             DROP CLUSTER IF EXISTS cluster1 CASCADE;
             CREATE CLUSTER cluster1 REPLICAS (replica1 (
                 REMOTE ['computed_1_1:2100', 'computed_1_2:2100'],
-                COMPUTE ['computed_1_1:2102', 'computed_1_2:2102'],
-                WORKERS 1
+                COMPUTE ['computed_1_1:2102', 'computed_1_2:2102']
             ));
             """
         )
@@ -241,8 +240,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             DROP CLUSTER IF EXISTS cluster2 CASCADE;
             CREATE CLUSTER cluster2 REPLICAS (replica1 (
                 REMOTE ['computed_2_1:2100', 'computed_2_2:2100'],
-                COMPUTE ['computed_2_1:2102', 'computed_2_2:2102'],
-                WORKERS 1
+                COMPUTE ['computed_2_1:2102', 'computed_2_2:2102']
             ));
             """
         )

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -120,9 +120,7 @@ def start_services(
             cluster_services.append(
                 Computed(
                     name=node_names[node_id],
-                    workers=workers,
                     options=options,
-                    peers=node_names,
                     image=f"materialize/computed:{tag}" if tag else None,
                 )
             )
@@ -151,7 +149,9 @@ def start_services(
             c.sql(
                 "CREATE CLUSTER REPLICA default.feature_benchmark REMOTE ["
                 + ",".join([f"'computed_{n}:2100'" for n in range(0, nodes)])
-                + "];"
+                + "], COMPUTE ["
+                + ",".join([f"'computed_{n}:2102'" for n in range(0, nodes)])
+                + f"], WORKERS {workers};"
             )
 
             c.sql("DROP CLUSTER REPLICA default.default_replica")

--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -74,8 +74,7 @@ def drop_create_replica(c: Composition) -> None:
             > DROP CLUSTER REPLICA cluster1.replica1
             > CREATE CLUSTER REPLICA cluster1.replica3
               REMOTE ['computed_1_1:2100', 'computed_1_2:2100'],
-              COMPUTE ['computed_1_1:2102', 'computed_1_2:2102'],
-              WORKERS 1
+              COMPUTE ['computed_1_1:2102', 'computed_1_2:2102']
             """
         )
     )
@@ -87,8 +86,7 @@ def create_invalid_replica(c: Composition) -> None:
             """
             > CREATE CLUSTER REPLICA cluster1.replica3
               REMOTE ['no_such_host:2100'],
-              COMPUTE ['no_such_host:2102'],
-              WORKERS 1
+              COMPUTE ['no_such_host:2102']
             """
         )
     )
@@ -204,13 +202,11 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             CREATE CLUSTER cluster1 REPLICAS (
                 replica1 (
                     REMOTE ['computed_1_1:2100', 'computed_1_2:2100'],
-                    COMPUTE ['computed_1_1:2102', 'computed_1_2:2102'],
-                    WORKERS 1
+                    COMPUTE ['computed_1_1:2102', 'computed_1_2:2102']
                     ),
                 replica2 (
                     REMOTE ['computed_2_1:2100', 'computed_2_2:2100'],
-                    COMPUTE ['computed_2_1:2102', 'computed_2_2:2102'],
-                    WORKERS 1
+                    COMPUTE ['computed_2_1:2102', 'computed_2_2:2102']
                     )
             )
             """

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -26,19 +26,19 @@ CREATE CLUSTER foo REPLICAS (), REPLICAS()
 # Creating cluster w/ remote replica works.
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
 
 statement error cluster 'foo' already exists
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
 
 statement error cannot create multiple replicas named 'r1' on cluster 'bar'
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234']), r1 (REMOTE ['localhost:1234']))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1), r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
 
 statement error REMOTE specified more than once
 CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234'], REMOTE ['localhost:1234']))
 
 statement ok
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235']), r2 (REMOTE ['localhost:1236']))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235'], COMPUTE [], WORKERS 1), r2 (REMOTE ['localhost:1236'], COMPUTE [], WORKERS 1))
 
 query TT rowsort
 SELECT * FROM mz_clusters
@@ -63,6 +63,12 @@ default
 
 statement error only one of REMOTE or SIZE may be specified
 CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], SIZE 'small'))
+
+statement error must specify as many REMOTE addresses as COMPUTE addresses for multi-process replicas
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234', 'localhost:4567'], COMPUTE [], WORKERS 1))
+
+statement error WORKERS must be greater 0
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 0))
 
 # Test `cluster` session variable.
 
@@ -268,7 +274,7 @@ statement ok
 DROP CLUSTER foo CASCADE
 
 statement ok
-CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234']))
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
 
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
@@ -285,13 +291,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1)), INTROSPECTION INTERVAL '1s'
 
 statement ok
 DROP CLUSTER foo CASCADE
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1)), INTROSPECTION INTERVAL '1s'
 
 statement ok
 DROP CLUSTER foo CASCADE
@@ -487,13 +493,13 @@ statement error AVAILABILITY ZONE specified more than once
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], WORKERS 1, AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], WORKERS 1, AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1']
+CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1'], WORKERS 1
 
 # Test that the contents of mz_cluster_replicas look sensible
 

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -26,19 +26,19 @@ CREATE CLUSTER foo REPLICAS (), REPLICAS()
 # Creating cluster w/ remote replica works.
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 statement error cluster 'foo' already exists
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 statement error cannot create multiple replicas named 'r1' on cluster 'bar'
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1), r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234']), r1 (REMOTE ['localhost:1234']))
 
 statement error REMOTE specified more than once
 CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1234'], REMOTE ['localhost:1234']))
 
 statement ok
-CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235'], COMPUTE [], WORKERS 1), r2 (REMOTE ['localhost:1236'], COMPUTE [], WORKERS 1))
+CREATE CLUSTER bar REPLICAS (r1 (REMOTE ['localhost:1235']), r2 (REMOTE ['localhost:1236']))
 
 query TT rowsort
 SELECT * FROM mz_clusters
@@ -67,8 +67,18 @@ CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], SIZE 'small'))
 statement error must specify as many REMOTE addresses as COMPUTE addresses for multi-process replicas
 CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234', 'localhost:4567'], COMPUTE [], WORKERS 1))
 
+statement error must specify as many REMOTE addresses as COMPUTE addresses for multi-process replicas
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE [], COMPUTE ['localhost:1234', 'localhost:4567']))
+
 statement error WORKERS must be greater 0
 CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 0))
+
+# SIZE + Remote options produce error
+statement error cannot specify SIZE and WORKERS
+CREATE CLUSTER baz REPLICAS (r1 (SIZE '2', WORKERS 1))
+
+statement error cannot specify SIZE and COMPUTE
+CREATE CLUSTER baz REPLICAS (r1 (SIZE '2', COMPUTE ['localhost:1234']))
 
 # Test `cluster` session variable.
 
@@ -274,7 +284,7 @@ statement ok
 DROP CLUSTER foo CASCADE
 
 statement ok
-CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1))
+CREATE CLUSTER baz REPLICAS (r1 (REMOTE ['localhost:1234']))
 
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
@@ -291,13 +301,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1)), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
 
 statement ok
 DROP CLUSTER foo CASCADE
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'], COMPUTE [], WORKERS 1)), INTROSPECTION INTERVAL '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
 
 statement ok
 DROP CLUSTER foo CASCADE
@@ -493,13 +503,13 @@ statement error AVAILABILITY ZONE specified more than once
 CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', AVAILABILITY ZONE 'b'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], WORKERS 1, AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], WORKERS 1, AVAILABILITY ZONE 'a'
+CREATE CLUSTER REPLICA default.replica REMOTE ['host1'], AVAILABILITY ZONE 'a'
 
 statement error cannot specify AVAILABILITY ZONE and REMOTE
-CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1'], WORKERS 1
+CREATE CLUSTER REPLICA default.replica AVAILABILITY ZONE 'a', REMOTE ['host1']
 
 # Test that the contents of mz_cluster_replicas look sensible
 

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -12,7 +12,7 @@
 mode cockroach
 
 statement ok
-create cluster c replicas (r1 (remote ['1.0:1234'], workers 1))
+create cluster c replicas (r1 (remote ['1.0:1234']))
 
 statement ok
 set cluster = c

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -12,7 +12,7 @@
 mode cockroach
 
 statement ok
-create cluster c replicas (r1 (remote ['1.0:1234']))
+create cluster c replicas (r1 (remote ['1.0:1234'], workers 1))
 
 statement ok
 set cluster = c

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -182,7 +182,7 @@ contains:unknown catalog item 'nonexistent'
 ! SHOW INDEXES FROM foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
 
-> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234']))
+> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234'], WORKERS 1))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
 > SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
 foo_primary_idx1    foo clstr   {a,b,z}

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -182,7 +182,7 @@ contains:unknown catalog item 'nonexistent'
 ! SHOW INDEXES FROM foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
 
-> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234'], WORKERS 1))
+> CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234']))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
 > SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
 foo_primary_idx1    foo clstr   {a,b,z}


### PR DESCRIPTION
Initialize the Timely networking fabric using a dedicated `CreateTimely` command.

The command line arguments `--workers` and `--process` are removed from computed. 

### Motivation

This switches the initialization order of clusters around. Before, we would first initialize the Timely communication layer, and then start the GRPC server. With this change, the client provided to the GRPC server gains the knowledge on how to start and stop Timely clusters. This would be a prerequisite to the controller providing incarnation-specific UUIDs, which would allow the Timely fabric to detect split-brain situations.

The PR also removes access to secrets as a byproduct, they are not used anymore since removing general sinks from compute.

The PR removes the [hack](https://github.com/MaterializeInc/materialize/pull/14379/files#diff-8c02cfe28d853e3eeab6fea9b878eb410b865c017d1e013e0a218bb6f200102cL15) that used the hostname to determine the timely process id from the hostname.

Fixes #14531

## Tips to the reviewer

We can probably remove the `ClusterClientConfig` type, depending on how odd it feels.

The commands are documented [here](https://github.com/MaterializeInc/materialize/pull/14379/files#diff-8a737964bbd9cfe7847c5b19a1323b35ac048183d529f75d5e6cffc636acd200R44)


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None.  Developers that use `--unsafe-mode` must use the new remote replica syntax.
