### PR TITLE
Simplify PartialOrder::less_than invocations

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -162,7 +162,7 @@ impl<S: Append + 'static> Coordinator<S> {
             // It should not be possible to request an invalid time. SINK doesn't support
             // AS OF. TAIL and Peek check that their AS OF is >= since.
             assert!(
-                <_ as PartialOrder>::less_equal(&since, as_of),
+                PartialOrder::less_equal(&since, as_of),
                 "Dataflow {} requested as_of ({:?}) not >= since ({:?})",
                 dataflow.debug_name,
                 as_of,

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -339,7 +339,7 @@ where
                     .or(Err(ComputeError::IdentifierMissing(*source_id)))?
                     .read_capabilities
                     .frontier();
-                if !(<_ as timely::order::PartialOrder>::less_equal(since, &as_of.borrow())) {
+                if !(timely::order::PartialOrder::less_equal(since, &as_of.borrow())) {
                     Err(ComputeError::DataflowSinceViolation(*source_id))?;
                 }
 
@@ -351,7 +351,7 @@ where
             for index_id in dataflow.index_imports.keys() {
                 let collection = self.as_ref().collection(*index_id)?;
                 let since = collection.read_capabilities.frontier();
-                if !(<_ as timely::order::PartialOrder>::less_equal(&since, &as_of.borrow())) {
+                if !(timely::order::PartialOrder::less_equal(&since, &as_of.borrow())) {
                     Err(ComputeError::DataflowSinceViolation(*index_id))?;
                 } else {
                     compute_dependencies.push(*index_id);
@@ -655,7 +655,7 @@ where
             if let Ok(collection) = self.collection_mut(id) {
                 let mut new_read_capability = policy.frontier(collection.write_frontier.frontier());
 
-                if <_ as timely::order::PartialOrder>::less_equal(
+                if timely::order::PartialOrder::less_equal(
                     &collection.implied_capability,
                     &new_read_capability,
                 ) {
@@ -787,7 +787,7 @@ where
             let mut new_read_capability = collection
                 .read_policy
                 .frontier(collection.write_frontier.frontier());
-            if <_ as timely::order::PartialOrder>::less_equal(
+            if timely::order::PartialOrder::less_equal(
                 &collection.implied_capability,
                 &new_read_capability,
             ) {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -570,10 +570,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         for (id, frontier) in self.compute_state.sink_write_frontiers.iter() {
             new_frontier.clone_from(&frontier.borrow());
             if let Some(prev_frontier) = self.compute_state.reported_frontiers.get_mut(&id) {
-                assert!(<_ as PartialOrder>::less_equal(
-                    prev_frontier,
-                    &new_frontier
-                ));
+                assert!(PartialOrder::less_equal(prev_frontier, &new_frontier));
                 if prev_frontier != &new_frontier {
                     add_progress(*id, &new_frontier, &prev_frontier, &mut progress);
                     prev_frontier.clone_from(&new_frontier);

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -263,7 +263,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
             // Only do a thing if it *advances* the frontier, not just *changes* the frontier.
             // This is protection against `frontier` lagging behind what we have conditionally reported.
-            if <_ as PartialOrder>::less_than(reported_frontier, &observed_frontier) {
+            if PartialOrder::less_than(reported_frontier, &observed_frontier) {
                 let mut change_batch = ChangeBatch::new();
                 for time in reported_frontier.elements().iter() {
                     change_batch.update(time.clone(), -1);


### PR DESCRIPTION
This PR replaces multiple occurrences of `<_ as PartialOrder>::less_than(...)` with just `PartialOrder::less_than(...)`, to improve readability.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I don't actually know why the code was written like this in the first place. My assumption is that once upon a time Rust didn't allow the second form. But maybe that's wrong and there is a good reason to keep the first form even now!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
