### PR TITLE
[sources] WITH TIMELINE

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,9 @@ indent_size = 2
 [*.jsx]
 indent_size = 2
 
+[*.td]
+indent_size = 2
+
 [*.ts]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -19,9 +19,6 @@ indent_size = 2
 [*.jsx]
 indent_size = 2
 
-[*.td]
-indent_size = 2
-
 [*.ts]
 indent_size = 2
 

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1272,15 +1272,17 @@ impl_display!(KeyConstraint);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSourceOptionName {
-    Size,
     Remote,
+    Size,
+    Timeline,
 }
 
 impl AstDisplay for CreateSourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
-            CreateSourceOptionName::Size => "SIZE",
             CreateSourceOptionName::Remote => "REMOTE",
+            CreateSourceOptionName::Size => "SIZE",
+            CreateSourceOptionName::Timeline => "TIMELINE",
         })
     }
 }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -319,6 +319,7 @@ Then
 Tick
 Ties
 Time
+Timeline
 Timeout
 Timestamp
 Timing

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2291,9 +2291,10 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_source_option_name(&mut self) -> Result<CreateSourceOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[SIZE, REMOTE])? {
-            SIZE => CreateSourceOptionName::Size,
+        let name = match self.expect_one_of_keywords(&[REMOTE, SIZE, TIMELINE])? {
             REMOTE => CreateSourceOptionName::Remote,
+            SIZE => CreateSourceOptionName::Size,
+            TIMELINE => CreateSourceOptionName::Timeline,
             _ => unreachable!(),
         };
         Ok(name)

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1027,7 +1027,7 @@ ALTER INDEX name RESET (property = true)
 parse-statement
 ALTER SOURCE name SET (property = true)
 ----
-error: Expected one of SIZE or REMOTE, found identifier "property"
+error: Expected one of REMOTE or SIZE or TIMELINE, found identifier "property"
 ALTER SOURCE name SET (property = true)
                        ^
 
@@ -1423,14 +1423,14 @@ CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("lg")]), 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH ()
 ----
-error: Expected one of SIZE or REMOTE, found right parenthesis
+error: Expected one of REMOTE or SIZE or TIMELINE, found right parenthesis
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH ()
                                                                                                                                   ^
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (A = 2)
 ----
-error: Expected one of SIZE or REMOTE, found identifier "a"
+error: Expected one of REMOTE or SIZE or TIMELINE, found identifier "a"
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (A = 2)
                                                                                                                                   ^
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -866,10 +866,6 @@ pub fn plan_create_source(
     let create_sql = normalize::create_statement(&scx, Statement::CreateSource(stmt))?;
 
     // Allow users to specify a timeline. If they do not, determine a default timeline for the source.
-    if legacy_with_options.remove("timeline").is_some() {
-        warn!("unexpected 'timeline' option in the legacy options block");
-    }
-
     let timeline = if let Some(timeline) = timeline {
         Timeline::User(timeline)
     } else {

--- a/test/restart/timelines.td
+++ b/test/restart/timelines.td
@@ -91,8 +91,8 @@ $ kafka-ingest format=avro topic=foo schema=${schema}
 
 > CREATE SOURCE data_foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
-    WITH (timeline='user')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
+  WITH (TIMELINE 'user')
 
 > CREATE MATERIALIZED VIEW foo AS SELECT a, b FROM data_foo
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -17,8 +17,8 @@ $ kafka-create-topic topic=input-system
 
 > CREATE SOURCE source_system_user
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-system-${testdrive.seed}'
-    WITH (timeline = 'user')
   FORMAT BYTES
+  WITH (TIMELINE 'user')
 
 $ set schema=[
   {
@@ -124,9 +124,10 @@ contains:unsupported epoch_ms_timeline value
 # Can't specify epoch_ms_timeline and timeline.
 ! CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=false, timeline='user')
+    WITH (epoch_ms_timeline=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
+  WITH (TIMELINE 'user')
 contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 
 > CREATE SOURCE source_cdcv2_system
@@ -137,9 +138,9 @@ contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 
 > CREATE SOURCE source_cdcv2_user
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (timeline='user')
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
+  WITH (TIMELINE 'user')
 
 > CREATE TABLE input_table (a bigint);
 

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -93,14 +93,13 @@ $ kafka-ingest format=avro topic=bar schema=${schema}
 
 > CREATE SOURCE data_foo
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-foo-${testdrive.seed}'
-    WITH (timeline='user')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
+  WITH (TIMELINE 'user')
 
 > CREATE SOURCE data_bar
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-bar-${testdrive.seed}'
-    WITH (timeline='user')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
-
+  WITH (TIMELINE 'user')
 
 > CREATE MATERIALIZED VIEW foo AS SELECT b, sum(a) FROM data_foo GROUP BY b
 


### PR DESCRIPTION
Moves the `TIMELINE` param option to the new WITH block, adding a keyword etc.

### Motivation

Known valuable: https://github.com/MaterializeInc/materialize/issues/14341 and https://github.com/MaterializeInc/materialize/issues/13919

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Changes parsing behaviour behind the unsafe flag, IIUC.
