### PR TITLE
adapter: firm up prohibited statements in /api/sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "dec",
  "derivative",
  "differential-dataflow",
+ "enum-kinds",
  "fail",
  "futures",
  "itertools",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -14,6 +14,7 @@ const_format = "0.2.26"
 dec = "0.4.8"
 derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+enum-kinds = "0.5.1"
 fail = { version = "0.5.0", features = ["failpoints"] }
 futures = "0.3.21"
 itertools = "0.10.3"

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -151,6 +151,12 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block"},{"error":"CREATE VIEW v2 AS SELECT 1 cannot be run inside a transaction block"}]}"#,
         },
+        // Unsupported statement types
+        TestCase {
+            query: "tail (select * from v1)",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"executing statements of this type is unsupported via this API"}]}"#,
+        },
         // Syntax errors fail the request.
         TestCase {
             query: "'",


### PR DESCRIPTION
/api/sql cannot handle many types of ExecuteResponses; however,
it only receives statements as input. To make sure we don't
accept statements whose responses we can't handle, this commit
introduces a method to try to formalize the types of responses
each statement can generate.

### Motivation

This PR adds a known-desirable feature. #14070

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
