### PR TITLE
storage: expose Kafka offsets as uint8 rather than int4

### DIFF
--- a/src/interchange/src/avro/encode.rs
+++ b/src/interchange/src/avro/encode.rs
@@ -271,14 +271,14 @@ impl<'a> mz_avro::types::ToAvro for TypedDatum<'a> {
                 ScalarType::Int16 => Value::Int(i32::from(datum.unwrap_int16())),
                 ScalarType::Int32 => Value::Int(datum.unwrap_int32()),
                 ScalarType::Int64 => Value::Long(datum.unwrap_int64()),
-                ScalarType::UInt16 => Value::Fixed(2, datum.unwrap_uint16().to_le_bytes().into()),
-                ScalarType::UInt32 => Value::Fixed(4, datum.unwrap_uint32().to_le_bytes().into()),
-                ScalarType::UInt64 => Value::Fixed(8, datum.unwrap_uint64().to_le_bytes().into()),
+                ScalarType::UInt16 => Value::Fixed(2, datum.unwrap_uint16().to_be_bytes().into()),
+                ScalarType::UInt32 => Value::Fixed(4, datum.unwrap_uint32().to_be_bytes().into()),
+                ScalarType::UInt64 => Value::Fixed(8, datum.unwrap_uint64().to_be_bytes().into()),
                 ScalarType::Oid
                 | ScalarType::RegClass
                 | ScalarType::RegProc
                 | ScalarType::RegType => {
-                    Value::Fixed(4, datum.unwrap_uint32().to_le_bytes().into())
+                    Value::Fixed(4, datum.unwrap_uint32().to_be_bytes().into())
                 }
                 ScalarType::Float32 => Value::Float(datum.unwrap_float32()),
                 ScalarType::Float64 => Value::Double(datum.unwrap_float64()),

--- a/src/interchange/src/json.rs
+++ b/src/interchange/src/json.rs
@@ -87,7 +87,7 @@ impl fmt::Debug for JsonEncoder {
 pub fn encode_datums_as_json<'a, I>(
     datums: I,
     names_types: &[(ColumnName, ColumnType)],
-) -> serde_json::value::Value
+) -> serde_json::Value
 where
     I: IntoIterator<Item = Datum<'a>>,
 {
@@ -96,19 +96,19 @@ where
         .zip(names_types)
         .map(|(datum, (name, typ))| (name.to_string(), TypedDatum::new(datum, typ.clone()).json()))
         .collect();
-    serde_json::value::Value::Object(value_fields)
+    serde_json::Value::Object(value_fields)
 }
 
 pub trait ToJson {
     /// Transforms this value to a JSON value.
-    fn json(self) -> serde_json::value::Value;
+    fn json(self) -> serde_json::Value;
 }
 
 impl ToJson for TypedDatum<'_> {
-    fn json(self) -> serde_json::value::Value {
+    fn json(self) -> serde_json::Value {
         let TypedDatum { datum, typ } = self;
         if typ.nullable && datum.is_null() {
-            serde_json::value::Value::Null
+            serde_json::Value::Null
         } else {
             match &typ.scalar_type {
                 ScalarType::Bool => json!(datum.unwrap_bool()),
@@ -131,28 +131,24 @@ impl ToJson for TypedDatum<'_> {
                     json!(datum.unwrap_numeric().0.to_standard_notation_string())
                 }
                 // https://stackoverflow.com/questions/10286204/what-is-the-right-json-date-format
-                ScalarType::Date => {
-                    serde_json::value::Value::String(format!("{}", datum.unwrap_date()))
-                }
-                ScalarType::Time => {
-                    serde_json::value::Value::String(format!("{:?}", datum.unwrap_time()))
-                }
-                ScalarType::Timestamp => serde_json::value::Value::String(format!(
+                ScalarType::Date => serde_json::Value::String(format!("{}", datum.unwrap_date())),
+                ScalarType::Time => serde_json::Value::String(format!("{:?}", datum.unwrap_time())),
+                ScalarType::Timestamp => serde_json::Value::String(format!(
                     "{:?}",
                     datum.unwrap_timestamp().timestamp_millis()
                 )),
-                ScalarType::TimestampTz => serde_json::value::Value::String(format!(
+                ScalarType::TimestampTz => serde_json::Value::String(format!(
                     "{:?}",
                     datum.unwrap_timestamptz().timestamp_millis()
                 )),
                 ScalarType::Interval => {
-                    serde_json::value::Value::String(format!("{}", datum.unwrap_interval()))
+                    serde_json::Value::String(format!("{}", datum.unwrap_interval()))
                 }
                 ScalarType::Bytes => json!(datum.unwrap_bytes()),
                 ScalarType::String | ScalarType::VarChar { .. } => json!(datum.unwrap_str()),
                 ScalarType::Char { length } => {
                     let s = char::format_str_pad(datum.unwrap_str(), *length);
-                    serde_json::value::Value::String(s)
+                    serde_json::Value::String(s)
                 }
                 ScalarType::Jsonb => JsonbRef::from_datum(datum).to_serde_json(),
                 ScalarType::Uuid => json!(datum.unwrap_uuid()),
@@ -177,11 +173,11 @@ impl ToJson for TypedDatum<'_> {
                             datum.json()
                         })
                         .collect();
-                    serde_json::value::Value::Array(values)
+                    serde_json::Value::Array(values)
                 }
                 ScalarType::Record { fields, .. } => {
                     let list = datum.unwrap_list();
-                    let fields: Map<String, serde_json::value::Value> = fields
+                    let fields: Map<String, serde_json::Value> = fields
                         .iter()
                         .zip(list.into_iter())
                         .map(|((name, typ), datum)| {
@@ -209,7 +205,7 @@ impl ToJson for TypedDatum<'_> {
                             (key.to_string(), value)
                         })
                         .collect();
-                    serde_json::value::Value::Object(elements)
+                    serde_json::Value::Object(elements)
                 }
                 ScalarType::MzTimestamp => json!(datum.unwrap_mztimestamp().to_string()),
             }
@@ -222,7 +218,7 @@ fn build_row_schema_field<F: FnMut() -> String>(
     names_seen: &mut HashSet<String>,
     custom_names: &HashMap<GlobalId, String>,
     typ: &ColumnType,
-) -> serde_json::value::Value {
+) -> serde_json::Value {
     let mut field_type = match &typ.scalar_type {
         ScalarType::Bool => json!("boolean"),
         ScalarType::PgLegacyChar => json!({
@@ -233,24 +229,13 @@ fn build_row_schema_field<F: FnMut() -> String>(
             json!("int")
         }
         ScalarType::Int64 => json!("long"),
-        ScalarType::UInt16 => json!({
-            "type": "fixed",
-            "size": 2,
-        }),
+        ScalarType::UInt16 => build_unsigned_type(names_seen, 2),
         ScalarType::UInt32
         | ScalarType::Oid
         | ScalarType::RegClass
         | ScalarType::RegProc
-        | ScalarType::RegType => {
-            json!({
-                "type": "fixed",
-                "size": 4,
-            })
-        }
-        ScalarType::UInt64 => json!({
-            "type": "fixed",
-            "size": 8,
-        }),
+        | ScalarType::RegType => build_unsigned_type(names_seen, 4),
+        ScalarType::UInt64 => build_unsigned_type(names_seen, 8),
         ScalarType::Float32 => json!("float"),
         ScalarType::Float64 => json!("double"),
         ScalarType::Date => json!({
@@ -356,7 +341,7 @@ pub(super) fn build_row_schema_fields<F: FnMut() -> String>(
     names_seen: &mut HashSet<String>,
     namer: &mut F,
     custom_names: &HashMap<GlobalId, String>,
-) -> Vec<serde_json::value::Value> {
+) -> Vec<serde_json::Value> {
     let mut fields = Vec::new();
     for (name, typ) in columns.iter() {
         let field_type = build_row_schema_field(namer, names_seen, custom_names, typ);
@@ -368,18 +353,34 @@ pub(super) fn build_row_schema_fields<F: FnMut() -> String>(
     fields
 }
 
+const AVRO_NAMESPACE: &str = "com.materialize.sink";
+
+fn build_unsigned_type(names_seen: &mut HashSet<String>, width: usize) -> serde_json::Value {
+    let name = format!("{AVRO_NAMESPACE}.uint{width}");
+    if names_seen.contains(&name) {
+        json!(name)
+    } else {
+        names_seen.insert(name.clone());
+        json!({
+            "type": "fixed",
+            "size": width,
+            "name": name,
+        })
+    }
+}
+
 /// Builds the JSON for the row schema, which can be independently useful.
 pub fn build_row_schema_json(
     columns: &[(ColumnName, ColumnType)],
     name: &str,
     custom_names: &HashMap<GlobalId, String>,
-) -> serde_json::value::Value {
+) -> serde_json::Value {
     let mut name_idx = 0;
     let fields = build_row_schema_fields(
         columns,
         &mut Default::default(),
         &mut move || {
-            let ret = format!("com.materialize.sink.record{}", name_idx);
+            let ret = format!("{AVRO_NAMESPACE}.record{name_idx}");
             name_idx += 1;
             ret
         },

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -689,13 +689,7 @@ fn to_metadata_row(
             for item in metadata_items.iter() {
                 match item {
                     IncludedColumnSource::Partition => packer.push(Datum::from(partition)),
-                    IncludedColumnSource::Offset => {
-                        // note this is bitwise cast, so offsets > i64::MAX will be
-                        // rendered as negative
-                        // TODO: make this an native u64 when https://github.com/MaterializeInc/materialize/issues/7629
-                        // is resolved.
-                        packer.push(Datum::from(position as i64))
-                    }
+                    IncludedColumnSource::Offset => packer.push(Datum::UInt64(position)),
                     IncludedColumnSource::Timestamp => {
                         let ts =
                             upstream_time_millis.expect("kafka sources always have upstream_time");

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -1288,7 +1288,7 @@ impl SourceConnection {
             }) => {
                 let mut items = BTreeMap::new();
                 for (include, ty) in [
-                    (offset, ScalarType::Int64),
+                    (offset, ScalarType::UInt64),
                     (part, ScalarType::Int32),
                     (time, ScalarType::Timestamp),
                     (topic, ScalarType::String),

--- a/test/kafka-resumption/verify-success.td
+++ b/test/kafka-resumption/verify-success.td
@@ -13,8 +13,8 @@ Hanover,PA,17331
 
 
 $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
-{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "offset":3}}}
-{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "offset":4}}}
-{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "offset":1}}}
-{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "offset":0}}}
-{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "offset":2}}}
+{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "offset":[0,0,0,0,0,0,0,3]}}}
+{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "offset":[0,0,0,0,0,0,0,4]}}}
+{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "offset":[0,0,0,0,0,0,0,1]}}}
+{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "offset":[0,0,0,0,0,0,0,0]}}}
+{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "offset":[0,0,0,0,0,0,0,2]}}}

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -27,7 +27,7 @@ $ kafka-ingest format=bytes topic=bytes timestamp=1
 name       nullable  type
 --------------------------
 data       false     bytea
-offset     false     bigint
+offset     false     uint8
 
 > SELECT * FROM data
 data           offset

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -111,16 +111,25 @@ snk2
 snk3
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 1}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 0}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk2 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 1}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 0}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
 {"before": null, "after": {"row":{"c": "jackjill"}}}
+
+# Test Avro serialization of unsigned values.
+> CREATE MATERIALIZED VIEW unsigned (a, b, c, d, e, f) AS
+  VALUES ('1'::uint2, '2'::uint2, '3'::uint4, '4'::uint4, '5'::uint8, '6'::uint8)
+> CREATE SINK snk_unsigned FROM unsigned
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk2')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+$ kafka-verify format=avro sink=materialize.public.snk_unsigned sort-messages=true
+{"before": null, "after": {"row":{"a": [0, 1], "b": [0, 2], "c": [0, 0, 0, 3], "d": [0, 0, 0, 4], "e": [0, 0, 0, 0, 0, 0, 0, 5], "f": [0, 0, 0, 0, 0, 0, 0, 6]}}}
 
 # Test the case where we have non +/- 1 multiplicities
 
@@ -156,12 +165,12 @@ $ kafka-ingest topic=test format=bytes
 extra,row
 
 $ kafka-verify format=avro sink=materialize.public.snk5
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 2}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": [0, 0, 0, 0, 0, 0, 0, 2]}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk6 sort-messages=true
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 2}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 1}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 0}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": [0, 0, 0, 0, 0, 0, 0, 2]}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": [0, 0, 0, 0, 0, 0, 0, 1]}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": [0, 0, 0, 0, 0, 0, 0, 0]}}}
 
 # Test that we are correctly handling SNAPSHOT on views with empty upper
 # frontier
@@ -193,6 +202,7 @@ snk5
 snk6
 snk7
 snk8
+snk_unsigned
 
 # test explicit partition count
 > CREATE SINK snk9 FROM foo


### PR DESCRIPTION
Now that we have support for unsigned integers, use uint8 for the Kafka
offset column rather than int4. This avoids a potentially lossy (i.e.,
incorrect) cast.

Fix https://github.com/MaterializeInc/materialize/issues/12977.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
