### PR TITLE
Literal constraints -- support multiple lookups on fast path

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -71,7 +71,7 @@ pub enum FastPathPlan<T = mz_repr::Timestamp> {
     /// may be helpful when printing out an explanation.
     Constant(Result<Vec<(Row, T, Diff)>, EvalError>, RelationType),
     /// The view can be read out of an existing arrangement.
-    PeekExisting(GlobalId, Option<Row>, mz_expr::SafeMfpPlan),
+    PeekExisting(GlobalId, Option<Vec<Row>>, mz_expr::SafeMfpPlan),
 }
 
 impl FastPathPlan {
@@ -79,7 +79,7 @@ impl FastPathPlan {
         let mut explanation = String::new();
         use std::fmt::Write;
         match self {
-            FastPathPlan::PeekExisting(index, value, mfp) => {
+            FastPathPlan::PeekExisting(index, literal_constraints, mfp) => {
                 writeln!(
                     &mut explanation,
                     "%0 =\n| ReadExistingIndex {}",
@@ -88,8 +88,23 @@ impl FastPathPlan {
                         .unwrap_or_else(|| index.to_string())
                 )
                 .unwrap();
-                if let Some(value) = value {
-                    writeln!(&mut explanation, "| | Lookup value {}", value).unwrap();
+                if let Some(literal_constraints) = literal_constraints {
+                    write!(&mut explanation, "| | Lookup ").unwrap();
+                    if literal_constraints.len() == 1 {
+                        writeln!(
+                            &mut explanation,
+                            "value {}",
+                            literal_constraints.get(0).unwrap()
+                        )
+                        .unwrap();
+                    } else {
+                        writeln!(
+                            &mut explanation,
+                            "values [{}]",
+                            separated("; ", literal_constraints)
+                        )
+                        .unwrap();
+                    }
                 }
                 if !mfp.is_identity() {
                     let (map, filter, project) = mfp.as_map_filter_project();
@@ -186,7 +201,7 @@ where
             FastPathPlan::Constant(Err(err), _) => {
                 writeln!(f, "{}Error {}", ctx.as_mut(), err.to_string().quoted())
             }
-            FastPathPlan::PeekExisting(id, lookup, mfp) => {
+            FastPathPlan::PeekExisting(id, literal_constraints, mfp) => {
                 ctx.as_mut().set();
                 let (map, filter, project) = mfp.as_map_filter_project();
                 if project.len() != mfp.input_arity + map.len()
@@ -210,14 +225,18 @@ where
                     .as_ref()
                     .humanize_id(*id)
                     .unwrap_or_else(|| id.to_string());
-                if let Some(lookup) = lookup {
-                    writeln!(
+                if let Some(literal_constraints) = literal_constraints {
+                    write!(
                         f,
-                        "{}ReadExistingIndex {} lookup_value={}",
+                        "{}ReadExistingIndex {} lookup ",
                         ctx.as_mut(),
-                        humanized_index,
-                        lookup
+                        humanized_index
                     )?;
+                    if literal_constraints.len() == 1 {
+                        writeln!(f, "value {}", literal_constraints.get(0).unwrap())?;
+                    } else {
+                        writeln!(f, "values [{}]", separated("; ", literal_constraints))?;
+                    }
                 } else {
                     writeln!(f, "{}ReadExistingIndex {}", ctx.as_mut(), humanized_index)?;
                 }
@@ -308,22 +327,18 @@ pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
                     if let mz_expr::JoinImplementation::IndexedFilter(id, key, vals) =
                         implementation
                     {
-                        // For now, PeekExisting handles only 1 lookup.
-                        if vals.len() == 1 {
-                            let val = vals.get(0).unwrap();
-                            // We should only get excited if we can track down an index for `id`.
-                            // If `keys` is non-empty, that means we think one exists.
-                            for (index_id, (desc, _typ, _monotonic)) in
-                                dataflow_plan.index_imports.iter()
-                            {
-                                if desc.on_id == *id && &desc.key == key {
-                                    // Indicate an early exit with a specific index and key value.
-                                    return Ok(Some(FastPathPlan::PeekExisting(
-                                        *index_id,
-                                        Some(val.clone()),
-                                        permute_oneshot_mfp_around_index(mfp, key)?,
-                                    )));
-                                }
+                        // We should only get excited if we can track down an index for `id`.
+                        // If `keys` is non-empty, that means we think one exists.
+                        for (index_id, (desc, _typ, _monotonic)) in
+                            dataflow_plan.index_imports.iter()
+                        {
+                            if desc.on_id == *id && &desc.key == key {
+                                // Indicate an early exit with a specific index and key value.
+                                return Ok(Some(FastPathPlan::PeekExisting(
+                                    *index_id,
+                                    Some(vals.clone()),
+                                    permute_oneshot_mfp_around_index(mfp, key)?,
+                                )));
                             }
                         }
                     }
@@ -437,8 +452,18 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
 
         // If we must build the view, ship the dataflow.
         let (peek_command, drop_dataflow) = match fast_path {
-            PeekPlan::FastPath(FastPathPlan::PeekExisting(id, key, map_filter_project)) => (
-                (id, key, timestamp, finishing.clone(), map_filter_project),
+            PeekPlan::FastPath(FastPathPlan::PeekExisting(
+                id,
+                literal_constraints,
+                map_filter_project,
+            )) => (
+                (
+                    id,
+                    literal_constraints,
+                    timestamp,
+                    finishing.clone(),
+                    map_filter_project,
+                ),
                 None,
             ),
             PeekPlan::SlowPath(PeekDataflowPlan {
@@ -521,14 +546,14 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             .entry(conn_id)
             .or_default()
             .insert(uuid, compute_instance);
-        let (id, key, timestamp, _finishing, map_filter_project) = peek_command;
+        let (id, literal_constraints, timestamp, _finishing, map_filter_project) = peek_command;
 
         self.controller
             .compute_mut(compute_instance)
             .unwrap()
             .peek(
                 id,
-                key,
+                literal_constraints,
                 uuid,
                 timestamp,
                 finishing.clone(),
@@ -667,7 +692,7 @@ mod tests {
         );
         let lookup = FastPathPlan::<mz_repr::Timestamp>::PeekExisting(
             GlobalId::User(11),
-            Some(Row::pack(Some(Datum::Int32(5)))),
+            Some(vec![Row::pack(Some(Datum::Int32(5)))]),
             MapFilterProject::new(3)
                 .filter(Some(
                     MirScalarExpr::column(0).call_unary(UnaryFunc::IsNull(IsNull)),
@@ -683,7 +708,7 @@ mod tests {
 
         let constant_err_exp = "Error \"division by zero\"\n";
         let no_lookup_exp = "Project (#1, #4)\n  Map ((#0 OR #2))\n    ReadExistingIndex u10\n";
-        let lookup_exp = "Filter (#0) IS NULL\n  ReadExistingIndex u11 lookup_value=(5)\n";
+        let lookup_exp = "Filter (#0) IS NULL\n  ReadExistingIndex u11 lookup value (5)\n";
 
         assert_eq!(text_string_at(&constant_err, ctx_gen), constant_err_exp);
         assert_eq!(text_string_at(&no_lookup, ctx_gen), no_lookup_exp);

--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -111,7 +111,7 @@ message ProtoSourceInstanceArguments {
 
 message ProtoPeek {
     mz_repr.global_id.ProtoGlobalId id = 1;
-    mz_repr.row.ProtoRow key = 2;
+    repeated mz_repr.row.ProtoRow key = 2;
     mz_proto.ProtoU128 uuid = 3;
     uint64 timestamp = 4;
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -542,7 +542,7 @@ where
     pub async fn peek(
         &mut self,
         id: GlobalId,
-        key: Option<Row>,
+        literal_constraints: Option<Vec<Row>>,
         uuid: Uuid,
         timestamp: T,
         finishing: RowSetFinishing,
@@ -563,7 +563,7 @@ where
 
         self.compute.replicas.send(ComputeCommand::Peek(Peek {
             id,
-            key,
+            literal_constraints,
             uuid,
             timestamp,
             finishing,

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -715,3 +715,19 @@ Used Indexes:
   - materialize.public.t_a_b_idx
 
 EOF
+
+# Test an IndexedFilter join on fast path WITH(join_impls).
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(join_impls, non_negative) AS TEXT FOR
+SELECT *
+FROM t
+WHERE (a = 0 AND b = 1) OR (a = 3 AND b = 4) OR (a = 7 AND b = 8)
+----
+Explained Query (fast path)
+  Project (#0, #1)
+    ReadExistingIndex materialize.public.t_a_b_idx lookup values [(0, 1); (3, 4); (7, 8)]
+
+Used Indexes:
+  - materialize.public.t_a_b_idx
+
+EOF

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -54,22 +54,15 @@ WHERE a IN (1, 1+1)
 statement ok
 CREATE INDEX idx_t1_a ON t1(a)
 
-# Same query as above, but we do a semi-join with the index. (Fast path doesn't yet handle multiple lookups.)
+# Same query as above, but use the index.
 
 query T multiline
 EXPLAIN SELECT * FROM t1
 WHERE a IN (1, 1+1)
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
-
-%1 =
-| Constant (1) (2)
-
-%2 =
-| Join %0 %1 (= #0 #2)
-| | implementation = IndexedFilter (#0 = 1) OR (#0 = 2)
+| ReadExistingIndex materialize.public.idx_t1_a
+| | Lookup values [(1); (2)]
 | Project (#0, #1)
 
 EOF
@@ -171,15 +164,8 @@ EXPLAIN SELECT * FROM t1
 WHERE (a,b) IN ((1,'l1'), (2,'l2'))
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
-
-%1 =
-| Constant (1, "l1") (2, "l2")
-
-%2 =
-| Join %0 %1 (= #0 #2) (= #1 #3)
-| | implementation = IndexedFilter (#0 = 1 AND #1 = "l1") OR (#0 = 2 AND #1 = "l2")
+| ReadExistingIndex materialize.public.idx_t1_a_b
+| | Lookup values [(1, "l1"); (2, "l2")]
 | Project (#0, #1)
 
 EOF
@@ -198,15 +184,8 @@ EXPLAIN SELECT * FROM t1
 WHERE (a,b) IN ((1, 'l1'), (1, 'a'))
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0, #1)
-
-%1 =
-| Constant (1, "a") (1, "l1")
-
-%2 =
-| Join %0 %1 (= #0 #2) (= #1 #3)
-| | implementation = IndexedFilter (#0 = 1 AND #1 = "a") OR (#0 = 1 AND #1 = "l1")
+| ReadExistingIndex materialize.public.idx_t1_a_b
+| | Lookup values [(1, "a"); (1, "l1")]
 | Project (#0, #1)
 
 EOF
@@ -234,15 +213,8 @@ EXPLAIN SELECT * FROM t2
 WHERE (a,b,c) IN ((1,2,3), (1,4,5), (1,4,7))
 ----
 %0 =
-| Get materialize.public.t2 (u4)
-| ArrangeBy (#0, #1, #2)
-
-%1 =
-| Constant (1, 2, 3) (1, 4, 5) (1, 4, 7)
-
-%2 =
-| Join %0 %1 (= #0 #3) (= #1 #4) (= #2 #5)
-| | implementation = IndexedFilter (#0 = 1 AND #1 = 2 AND #2 = 3) OR (#0 = 1 AND #1 = 4 AND #2 = 5) OR (#0 = 1 AND #1 = 4 AND #2 = 7)
+| ReadExistingIndex materialize.public.idx_t2_a_b_c
+| | Lookup values [(1, 2, 3); (1, 4, 5); (1, 4, 7)]
 | Project (#0..=#2)
 
 EOF
@@ -270,15 +242,8 @@ EXPLAIN SELECT * FROM t1
 WHERE (a = 1) OR (a = 3 AND b = 'l3')
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy (#0)
-
-%1 =
-| Constant (1) (3)
-
-%2 =
-| Join %0 %1 (= #0 #2)
-| | implementation = IndexedFilter (#0 = 1) OR (#0 = 3)
+| ReadExistingIndex materialize.public.idx_t1_a
+| | Lookup values [(1); (3)]
 | Filter ((#0 = 1) OR ((#0 = 3) AND (#1 = "l3")))
 | Project (#0, #1)
 
@@ -338,25 +303,18 @@ WHERE a+a = 2
 
 query T multiline
 EXPLAIN SELECT a FROM t1
-WHERE a+a IN (2, 6)
+WHERE a+a IN (-1, 1, 2, 3, 6, 7, 9)
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy ((#0 + #0))
-
-%1 =
-| Constant (2) (6)
-
-%2 =
-| Join %0 %1 (= (#0 + #0) #2)
-| | implementation = IndexedFilter ((#0 + #0) = 2) OR ((#0 + #0) = 6)
-| Project (#0)
+| ReadExistingIndex materialize.public.idx_t1_aa
+| | Lookup values [(1); (2); (3); (6); (7); (9); (-1)]
+| Project (#1)
 
 EOF
 
 query I
 SELECT a FROM t1
-WHERE a+a IN (2, 6)
+WHERE a+a IN (-1, 1, 2, 3, 6, 7, 9)
 ----
 1
 1
@@ -371,17 +329,10 @@ EXPLAIN SELECT a+a FROM t1
 WHERE a+a IN (2, 6);
 ----
 %0 =
-| Get materialize.public.t1 (u1)
-| ArrangeBy ((#0 + #0))
-
-%1 =
-| Constant (2) (6)
-
-%2 =
-| Join %0 %1 (= (#0 + #0) #2)
-| | implementation = IndexedFilter ((#0 + #0) = 2) OR ((#0 + #0) = 6)
-| Map (#0 + #0)
-| Project (#3)
+| ReadExistingIndex materialize.public.idx_t1_aa
+| | Lookup values [(2); (6)]
+| Map (#1 + #1)
+| Project (#4)
 
 EOF
 


### PR DESCRIPTION
Add support for multiple literal lookups on fast path.

### Motivation

  * This PR adds a known-desirable feature. Part of https://github.com/MaterializeInc/materialize/issues/13151


### Tips for reviewer

**The first 3 commits are the same as in https://github.com/MaterializeInc/materialize/pull/14353**. Only the last commit is new.

Note that this changes the protobuf format of `Peek`: `key` goes from `optional` to `repeated`. However, this is a backwards-compatible change, see https://stackoverflow.com/questions/45849903/can-a-proto3-optional-field-be-changed-to-repeated-without-breaking-wire-compati
(But anyway, I heard somewhere (maybe at the Compute sync) that the release next week will be backwards-incompatible already, so no problem for more incompatible changes.)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Queries with multiple literal constraints ORed (e.g., `c=3 OR c=7 OR c=9`) can be executed on fast path
