### PR TITLE
compute-client: remove DataflowDescription::id

### DIFF
--- a/src/compute-client/src/command.proto
+++ b/src/compute-client/src/command.proto
@@ -85,7 +85,7 @@ message ProtoDataflowDescription {
     repeated ProtoSinkExport sink_exports = 5;
     optional mz_persist.gen.persist.ProtoU64Antichain as_of = 6;
     string debug_name = 7;
-    mz_proto.ProtoU128 id = 8;
+    reserved 8;
 }
 
 message ProtoIndexDesc {

--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -349,8 +349,6 @@ pub struct DataflowDescription<P, S = (), T = mz_repr::Timestamp> {
     pub as_of: Option<Antichain<T>>,
     /// Human readable name
     pub debug_name: String,
-    /// Unique ID of the dataflow
-    pub id: uuid::Uuid,
 }
 
 fn any_source_import(
@@ -395,7 +393,6 @@ proptest::prop_compose! {
         as_of_some in any::<bool>(),
         as_of in proptest::collection::vec(any::<u64>(), 1..5),
         debug_name in ".*",
-        id in any_uuid(),
     ) -> DataflowDescription<Plan, CollectionMetadata, mz_repr::Timestamp> {
         DataflowDescription {
             source_imports: BTreeMap::from_iter(source_imports.into_iter()),
@@ -411,7 +408,6 @@ proptest::prop_compose! {
                 None
             },
             debug_name,
-            id,
         }
     }
 }
@@ -436,7 +432,6 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
             sink_exports: Default::default(),
             as_of: Default::default(),
             debug_name: name,
-            id: uuid::Uuid::new_v4(),
         }
     }
 
@@ -673,7 +668,6 @@ impl RustType<ProtoDataflowDescription>
             sink_exports: self.sink_exports.into_proto(),
             as_of: self.as_of.as_ref().map(Into::into),
             debug_name: self.debug_name.clone(),
-            id: Some(self.id.into_proto()),
         }
     }
 
@@ -686,7 +680,6 @@ impl RustType<ProtoDataflowDescription>
             sink_exports: proto.sink_exports.into_rust()?,
             as_of: proto.as_of.map(Into::into),
             debug_name: proto.debug_name,
-            id: proto.id.into_rust_if_some("ProtoDataflowDescription::id")?,
         })
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -461,7 +461,6 @@ where
                 index_exports: d.index_exports,
                 as_of: d.as_of,
                 debug_name: d.debug_name,
-                id: d.id,
             });
         }
 

--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -434,13 +434,6 @@ impl<T> ReplicaState<T> {
             // Set replica id
             config.replica_id = replica_id;
         }
-
-        // Replace dataflow identifiers with new unique ids.
-        if let ComputeCommand::CreateDataflows(dataflows) = command {
-            for dataflow in dataflows.iter_mut() {
-                dataflow.id = uuid::Uuid::new_v4();
-            }
-        }
     }
 }
 

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -803,16 +803,11 @@ impl RustType<ProtoGetPlan> for GetPlan {
 pub struct LirDebugInfo<'a> {
     debug_name: &'a str,
     id: GlobalId,
-    dataflow_uuid: uuid::Uuid,
 }
 
 impl<'a> std::fmt::Display for LirDebugInfo<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Debug name: {}; id: {}; dataflow UUID: {}",
-            self.debug_name, self.id, self.dataflow_uuid
-        )
+        write!(f, "Debug name: {}; id: {}", self.debug_name, self.id)
     }
 }
 
@@ -886,7 +881,6 @@ impl<T: timely::progress::Timestamp> Plan<T> {
         fields(
             dataflow.name = debug_info.debug_name,
             dataflow.id = %debug_info.id,
-            dataflow.uuid = %debug_info.dataflow_uuid
         )
     )]
     pub fn from_mir(
@@ -1491,7 +1485,6 @@ This is not expected to cause incorrect results, but could indicate a performanc
                 LirDebugInfo {
                     debug_name: &desc.debug_name,
                     id: build.id,
-                    dataflow_uuid: desc.id,
                 },
             )?;
             arrangements.insert(Id::Global(build.id), keys);
@@ -1506,7 +1499,6 @@ This is not expected to cause incorrect results, but could indicate a performanc
             sink_exports: desc.sink_exports,
             as_of: desc.as_of,
             debug_name: desc.debug_name,
-            id: desc.id,
         })
     }
 

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -208,7 +208,6 @@ where
                             sink_exports: dataflow.sink_exports.clone(),
                             as_of: dataflow.as_of.clone(),
                             debug_name: dataflow.debug_name.clone(),
-                            id: dataflow.id,
                         });
                     }
                 }


### PR DESCRIPTION
This field only seems to be used for some debug logging and it seems like it doesn't provide much value there either.

I propose we remove it, so there is one less thing to be confused about.

### Motivation

   * This PR refactors existing code.

[Slack thread for context.](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1661431570743219)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
