### PR TITLE
doc/user: Update DocSearch to V3

### DIFF
--- a/doc/user/assets/sass/_layout.scss
+++ b/doc/user/assets/sass/_layout.scss
@@ -32,64 +32,12 @@ body {
 .relative {
     position: relative;
 }
-.algolia-autocomplete {
-    width: 100%;
 
-    .ds-cursor .algolia-docsearch-suggestion--content {
-        background: rgba($purple, 0.03) !important;
-    }
-
-    .algolia-docsearch-suggestion--highlight {
-        background: rgba($purple, 0.03) !important;
-        color: $purple !important;
-        box-shadow: inset 0 -2px 0 0 $purple-40 !important;
-    }
-}
-
-.search-wrap {
-    padding: 2rem 4rem 1rem;
-}
-
-.search-icon {
-    position: absolute;
-    z-index: 2;
-    top: 2.9rem;
-    left: 5rem;
-}
-
-.search_shortcut {
-    background: linear-gradient(-225deg, #d5dbe4, #f8f8f8);
-    border-radius: 3px;
-    box-shadow: inset 0 -2px 0 0 #cdcde6, inset 0 0 1px 1px #fff,
-        0 1px 2px 1px rgba(30, 35, 90, 0.4);
-    color: #969faf;
-    display: block;
-    font-size: 16px;
-    line-height: 16px;
-    height: 18px;
-    pointer-events: none;
-    position: absolute;
-    right: 5.5rem;
-    text-align: center;
-    top: 2.625rem;
-    width: 20px;
-}
-
-#search-input {
-    background-color: $white-v2;
-    border-radius: 999px;
-    border: 1px solid $dark-grey-v2;
-    box-sizing: border-box;
-    font-size: 16px;
-    margin-bottom: 12px;
-    padding: 0.75rem 1rem 0.5rem 2.5rem;
-    width: 100%;
-    min-width: 200px;
-
-    &:focus {
-        outline-width: 0;
-        border: 1px solid $purple-v2;
-        box-shadow: 0 0 3px $purple-v2;
+#docsearch {
+    margin-bottom: 16px;
+    .DocSearch-Button {
+        margin: 0 0 16px 0;
+        width: 100%;
     }
 }
 

--- a/doc/user/content/integrations/_index.md
+++ b/doc/user/content/integrations/_index.md
@@ -2,6 +2,7 @@
 title: Tools and integrations
 description: "Get details about third-party tools and integrations supported by Materialize"
 disable_list: true
+make_table_row_headers_searchable: true
 aliases:
   - /third-party/supported-tools/
   - /third-party/

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE CLUSTER REPLICA"
 description: "`CREATE CLUSTER REPLICA` provisions physical resources to perform computations."
+pagerank: 20
 menu:
   main:
     parent: commands

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE CLUSTER"
 description: "`CREATE CLUSTER` creates a logical cluster, which contains indexes."
+pagerank: 10
 menu:
   main:
     parent: commands

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE CONNECTION"
 description: "`CREATE CONNECTION` describes how to connect and authenticate to an external system in Materialize"
+pagerank: 10
 menu:
   main:
     parent: 'commands'

--- a/doc/user/content/sql/create-materialized-view.md
+++ b/doc/user/content/sql/create-materialized-view.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE MATERIALIZED VIEW"
 description: "`CREATE MATERIALIZED VIEW` defines a view that is persisted in durable storage and incrementally updated as new data arrives."
+pagerank: 10
 menu:
   main:
     parent: 'commands'

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE SINK"
 description: "`CREATE SINK` sends data from Materialize to an external sink."
+pagerank: 10
 draft: true
 #menu:
   # This should also have a "non-content entry" under Connect, which is

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -2,6 +2,7 @@
 title: "CREATE SOURCE"
 description: "`CREATE SOURCE` connects Materialize to an external data source."
 disable_list: true
+pagerank: 10
 menu:
   main:
     parent: reference

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE SOURCE: Kafka"
 description: "Connecting Materialize to a Kafka or Redpanda broker"
+pagerank: 10
 menu:
   main:
     parent: 'create-source'

--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -1,6 +1,7 @@
 ---
 title: "CREATE SOURCE: PostgreSQL"
 description: "Connecting Materialize to a PostgreSQL database"
+pagerank: 10
 menu:
   main:
     parent: 'create-source'

--- a/doc/user/layouts/_default/baseof.html
+++ b/doc/user/layouts/_default/baseof.html
@@ -24,7 +24,7 @@ by the Apache License, Version 2.0.  */}}
         <div class="content-wrapper">
             {{ partial "sidebar.html" . }}
 
-            <main class="content">
+            <main class="content {{ if .Params.make_table_row_headers_searchable }} docsearch_index_table_headers {{ end }}">
                 {{ partial "breadcrumbs.html" . }}
                 {{ block "main" . }}{{ end }}
                 <!-- Footer goes in main so the border-right of
@@ -43,14 +43,6 @@ by the Apache License, Version 2.0.  */}}
 
         /* Make external links open in new tabs */
         $('a[href*="//"]:not([href*="materialize.com"])').attr({target:"_blank", title:"External Link"});
-
-        /* s to search */
-        document.addEventListener("keyup", e => {
-          if (e.key !== "s" || e.ctrlKey || e.metaKey) return;
-          if (/^(?:input|textarea|select|button)$/i.test(e.target.tagName)) return;
-          e.preventDefault();
-          document.getElementById("search-input").focus();
-        });
 
         /* Add "Click to Copy" button to code blocks */
         $(document).ready(function() {

--- a/doc/user/layouts/partials/head.html
+++ b/doc/user/layouts/partials/head.html
@@ -40,16 +40,18 @@
 <link rel="stylesheet" href="{{ $style.RelPermalink }}">
 
 {{/* Algolia DocSearch */}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
-<script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+{{if (isset .Params "pagerank")}}
+<meta name="docsearch_pagerank" content='{{ .Params.pagerank }}' />
+{{end}}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
+<script src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script defer>
 addEventListener("DOMContentLoaded", () => {
   docsearch({
     apiKey: "5fb0a95d60e603d3c83c2506e1de4a64",
     appId: "9LF5B9GMOF",
     indexName: "materialize_unstable",
-    inputSelector: '#search-input',
-    debug: true,
+    container: '#docsearch',
   });
 });
 </script>

--- a/doc/user/layouts/partials/header.html
+++ b/doc/user/layouts/partials/header.html
@@ -22,23 +22,8 @@
   <a href="{{.Site.BaseURL}}" class="primary gradient_text">
     Materialize Documentation
   </a>
-  <div class="flex_grow relative search-wrap">
-    <svg class="search-icon" width="13" height="13" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M5.529 10.058C8.0303 10.058 10.058 8.0303 10.058 5.529C10.058 3.0277 8.0303 1 5.529 1C3.0277 1 1 3.0277 1 5.529C1 8.0303 3.0277 10.058 5.529 10.058Z" stroke="url(#paint0_linear)" stroke-linecap="round" stroke-linejoin="round"/>
-      <path d="M12 12L8.75201 8.75195" stroke="url(#paint1_linear)" stroke-linecap="round" stroke-linejoin="round"/>
-      <defs>
-      <linearGradient id="paint0_linear" x1="7.91395" y1="10.0815" x2="1.95483" y2="3.19243" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#5A34CB"/>
-      <stop offset="1" stop-color="#B634CB"/>
-      </linearGradient>
-      <linearGradient id="paint1_linear" x1="11.2312" y1="12.0084" x2="9.0944" y2="9.53811" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#5A34CB"/>
-      <stop offset="1" stop-color="#B634CB"/>
-      </linearGradient>
-      </defs>
-    </svg>
-    <input id="search-input" placeholder="Search">
-    <span class="search_shortcut">s</span>
+  <div class="flex_grow" >
+
   </div>
   <a class="btn" href="https://materialize.com/s/chat">
     <svg width="21" height="21" viewBox="0 0 21 21" fill="currentColor" xmlns="http://www.w3.org/2000/svg">

--- a/doc/user/layouts/partials/sidebar.html
+++ b/doc/user/layouts/partials/sidebar.html
@@ -2,6 +2,7 @@
   {{ $currentPage := . }}
   <nav role="navigation" class="sidebar">
     <ul>
+      <div id="docsearch"></div>
       {{ range .Site.Menus.main.ByWeight }}
       <li class="level-1">
         <a class="{{if $currentPage.IsMenuCurrent "main" .}}active{{end}}">


### PR DESCRIPTION
### Motivation

This is an attempt to solve several search issues:

1. Cannot navigate to top-level of pages - this was a subtle bug that I think I already fixed in the index for unstable, where you previously were only able to navigate to the subsections of any particular page. I bumped everything down one level (so `lvl0` in Algolia crawler settings is just "Docs" and `lvl1` is the H1 of a page.) I think this is the way it is supposed to function.

See:
![image](https://user-images.githubusercontent.com/11527560/186725948-77cd216b-faa6-4657-851c-5e7b9659d3b1.png)
and then:
![image](https://user-images.githubusercontent.com/11527560/186726027-cd975032-d3fa-4eba-8421-4985f7697464.png)

2. Command-K shortcut for Search - This comes for free by upgrading to docsearch v3 in the UI. https://github.com/MaterializeInc/www/issues/50

3. "Create [Object]" pages don't rank above "SHOW CREATE [OBJECT]" pages - This needs to be completed in the algolia settings, but for a preparatory task, I added a `pagerank` frontmatter attribute to certain pages that renders out as a tag in the header of pages when present. The plan is to scan this in to the pagerank field in Algolia and use it as a tiebreaker to rank pages with lowest pagerank first. 
