### PR TITLE
storage: parse legacy with options with LEGACYWITH

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -502,7 +502,7 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
         f.write_str("FROM ");
         f.write_node(&self.connection);
         if !self.legacy_with_options.is_empty() {
-            f.write_str(" WITH (");
+            f.write_str(" LEGACYWITH (");
             f.write_node(&display::comma_separated(&self.legacy_with_options));
             f.write_str(")");
         }

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -182,6 +182,7 @@ Latest
 Leading
 Least
 Left
+Legacywith
 Level
 Like
 Limit

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2209,7 +2209,7 @@ impl<'a> Parser<'a> {
         let (col_names, key_constraint) = self.parse_source_columns()?;
         self.expect_keyword(FROM)?;
         let connection = self.parse_create_source_connection()?;
-        let legacy_with_options = self.parse_opt_with_options()?;
+        let legacy_with_options = self.parse_legacy_with_options()?;
         let format = match self.parse_one_of_keywords(&[KEY, FORMAT]) {
             Some(KEY) => {
                 self.expect_keyword(FORMAT)?;
@@ -3305,6 +3305,14 @@ impl<'a> Parser<'a> {
 
     fn parse_opt_with_options(&mut self) -> Result<Vec<WithOption<Raw>>, ParserError> {
         if self.parse_keyword(WITH) {
+            self.parse_with_options(true)
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    fn parse_legacy_with_options(&mut self) -> Result<Vec<WithOption<Raw>>, ParserError> {
+        if self.parse_keyword(LEGACYWITH) {
             self.parse_with_options(true)
         } else {
             Ok(vec![])

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -474,40 +474,40 @@ CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")
 
 
 parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SEKRET)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SEKRET)
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = sekret)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = sekret)
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("sekret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET)
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = secret)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = secret)
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("secret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a)
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a)
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement roundtrip
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET)
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = secret)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = secret)
 
 parse-statement roundtrip
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a)
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a)
 
 parse-statement
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a.b.c)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a.b.c)
 ----
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (a = SECRET a.b.c)
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a.b.c)
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
@@ -1357,9 +1357,9 @@ DROP CONNECTION conn1
 DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' LEGACYWITH (consistency = 'lug') FORMAT BYTES
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' WITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' LEGACYWITH (consistency = 'lug') FORMAT BYTES
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), with_options: [] }, topic: "baz", key: None }), legacy_with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
@@ -1499,6 +1499,22 @@ CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (REMOTE = 'johto:42', SIZE = large)
 =>
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }, CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
+
+# Ensure that we can parse REMOTE with pg
+parse-statement
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn PUBLICATION 'red' with (REMOTE 'johto:42');
+----
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn PUBLICATION 'red' WITH (REMOTE = 'johto:42')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), publication: "red", details: None }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
+
+# Ensure that we can parse legacy and non-legacy options
+parse-statement
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn PUBLICATION 'red' legacywith (a = 'hmm') with (REMOTE 'johto:42');
+----
+CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn PUBLICATION 'red' LEGACYWITH (a = 'hmm') WITH (REMOTE = 'johto:42')
+=>
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), publication: "red", details: None }, legacy_with_options: [WithOption { key: Ident("a"), value: Some(Value(String("hmm"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
 parse-statement
 ALTER SYSTEM SET wal_level TO logical

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -68,7 +68,7 @@ $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
 ! CREATE SOURCE connector_source
   FROM KAFKA CONNECTION kafka_sasl
   TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     security_protocol = 'sasl_ssl'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -43,7 +43,7 @@ contains:invalid CONNECTION: under-specified security configuration
 
 # ! CREATE SOURCE data
 #   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-#   WITH (
+#   LEGACYWITH (
 #       security_protocol = 'SASL_SSL',
 #       sasl_mechanisms = 'PLAIN',
 #       sasl_username = 'materialize',

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -127,7 +127,7 @@ a
 ! CREATE SOURCE IF NOT EXISTS duplicate_option_specified
   FROM KAFKA CONNECTION kafka_ssl
   TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     security_protocol = 'ssl'
   )
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl

--- a/test/s3-resumption/configure-materialize.td
+++ b/test/s3-resumption/configure-materialize.td
@@ -18,7 +18,7 @@
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 's3/*.text'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -29,7 +29,7 @@
   DISCOVER OBJECTS MATCHING 's3/*.gzip'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}',
   COMPRESSION GZIP
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )

--- a/test/sqllogictest/name_resolution.slt
+++ b/test/sqllogictest/name_resolution.slt
@@ -22,4 +22,4 @@ statement ok
 CREATE TABLE not_a_secret (a int);
 
 statement error materialize.public.not_a_secret is not a secret
-CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' WITH (secret = SECRET not_a_secret);
+CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (secret = SECRET not_a_secret);

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -207,7 +207,7 @@ a count
 
 > CREATE SOURCE data_v4
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (ignore_source_keys = true)
+  LEGACYWITH (ignore_source_keys = true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM
 

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -23,11 +23,11 @@ place""",CA,92679
   SECRET ACCESS KEY = SECRET s3_conn_secret_access_key,
   TOKEN = '${testdrive.aws-token}';
 
-# We should refuse to create a source with invalid WITH options
+# We should refuse to create a source with invalid LEGACYWITH options
 ! CREATE SOURCE invalid_with_option
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     badoption = true
@@ -38,7 +38,7 @@ contains:unexpected parameters for CREATE SOURCE: badoption
 > CREATE SOURCE mismatched_column_count
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -49,7 +49,7 @@ contains:CSV error at record number 1: expected 2 columns, got 3.
 > CREATE SOURCE matching_column_names
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -63,7 +63,7 @@ Rochester NY 14618
 > CREATE SOURCE matching_column_names_alias (a, b, c)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -77,7 +77,7 @@ Rochester NY 14618
 > CREATE SOURCE mismatched_column_names
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -88,7 +88,7 @@ contains:first mismatched column at index 1 expected=cities actual="city"
 > CREATE SOURCE mismatched_column_names_count
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -100,7 +100,7 @@ contains:CSV error at record number 1: expected 2 columns, got 3
 > CREATE SOURCE static_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -117,7 +117,7 @@ Rochester      NY        14618
 ! CREATE SOURCE static_csv_nothing_demanded_src
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -134,7 +134,7 @@ $ set-regex match=(\d{13}|u\d{1,3}) replacement=<>
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -188,7 +188,7 @@ badint,
 > CREATE SOURCE malformed_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'malformed.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -205,7 +205,7 @@ dollars,category
 > CREATE SOURCE bad_text_csv
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'bad-text.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -221,7 +221,7 @@ $ kafka-create-topic topic=static-csv-pkne-sink
 > CREATE SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )

--- a/test/testdrive/disabled/kinesis.td
+++ b/test/testdrive/disabled/kinesis.td
@@ -27,7 +27,7 @@ contains:If providing a custom region, an `endpoint` option must also be provide
 
 > CREATE SOURCE f
   FROM KINESIS ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
-  WITH (access_key_id = '${testdrive.aws-access-key-id}',
+  LEGACYWITH (access_key_id = '${testdrive.aws-access-key-id}',
         secret_access_key = '${testdrive.aws-secret-access-key}',
         token = '${testdrive.aws-token}',
         endpoint = '${testdrive.aws-endpoint}')

--- a/test/testdrive/disabled/s3-sqs-gh7146.td
+++ b/test/testdrive/disabled/s3-sqs-gh7146.td
@@ -19,7 +19,7 @@ $ s3-add-notifications bucket=philip-stoev-materialize queue=philip-stoev-materi
   DISCOVER OBJECTS MATCHING '**/*.csv'
   USING BUCKET SCAN 'testdrive-philip-stoev-materialize-${testdrive.seed}',
   SQS NOTIFICATIONS 'testdrive-philip-stoev-materialize-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',
@@ -116,7 +116,7 @@ $ s3-delete-objects bucket=philip-stoev-materialize
   DISCOVER OBJECTS MATCHING '**/*.csv'
   USING BUCKET SCAN 'testdrive-philip-stoev-materialize-${testdrive.seed}',
   SQS NOTIFICATIONS 'testdrive-philip-stoev-materialize-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',

--- a/test/testdrive/disabled/s3-sqs-gh7182.td
+++ b/test/testdrive/disabled/s3-sqs-gh7182.td
@@ -24,7 +24,7 @@ $ s3-add-notifications bucket=${buk} queue=${buk} sqs-validation-timeout=5m
   FROM S3
   DISCOVER OBJECTS MATCHING '**/*.csv' USING
   SQS NOTIFICATIONS 'testdrive-${buk}-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',
@@ -39,7 +39,7 @@ $ s3-add-notifications bucket=${buk} queue=${buk} sqs-validation-timeout=5m
   FROM S3
   DISCOVER OBJECTS MATCHING '**/*.csv' USING
   SQS NOTIFICATIONS 'testdrive-${buk}-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',

--- a/test/testdrive/disabled/s3-sqs-notifications.td
+++ b/test/testdrive/disabled/s3-sqs-notifications.td
@@ -32,7 +32,7 @@ $ s3-add-notifications bucket=other queue=other sqs-validation-timeout=5m
 > CREATE SOURCE s3_scan_notifications
   FROM S3 DISCOVER OBJECTS MATCHING 'short/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}', SQS NOTIFICATIONS 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',
@@ -74,7 +74,7 @@ e3
 
 > CREATE SOURCE s3_notifications
   FROM S3 DISCOVER OBJECTS MATCHING 'short/e' USING SQS NOTIFICATIONS 'testdrive-other-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',

--- a/test/testdrive/disabled/s3-sqs-repeated.td
+++ b/test/testdrive/disabled/s3-sqs-repeated.td
@@ -36,7 +36,7 @@ $ s3-delete-objects bucket=sqs-repeated
   FROM S3
   DISCOVER OBJECTS USING
   SQS NOTIFICATIONS 'testdrive-sqs-repeated-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}',
     access_key_id = '${testdrive.aws-access-key-id}',

--- a/test/testdrive/fetch-concurrent-same-source.td
+++ b/test/testdrive/fetch-concurrent-same-source.td
@@ -19,7 +19,7 @@ $ kafka-create-topic topic=fetch-concurrent-same-source
 
 > CREATE SOURCE fetch_concurrent_same_source
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-fetch-concurrent-same-source-${testdrive.seed}'
-  WITH( timestamp_frequency_ms = 10 )
+  LEGACYWITH( timestamp_frequency_ms = 10 )
   FORMAT AVRO USING SCHEMA '${int}'
   ENVELOPE NONE
 

--- a/test/testdrive/fetch-concurrent-two-sources.td
+++ b/test/testdrive/fetch-concurrent-two-sources.td
@@ -19,13 +19,13 @@ $ kafka-create-topic topic=fetch-concurrent-two-sources
 
 > CREATE SOURCE fetch_concurrent_two_sources1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-fetch-concurrent-two-sources-${testdrive.seed}'
-  WITH( timestamp_frequency_ms = 100 )
+  LEGACYWITH( timestamp_frequency_ms = 100 )
   FORMAT AVRO USING SCHEMA '${int}'
   ENVELOPE NONE
 
 > CREATE SOURCE fetch_concurrent_two_sources2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-fetch-concurrent-two-sources-${testdrive.seed}'
-  WITH( timestamp_frequency_ms = 100 )
+  LEGACYWITH( timestamp_frequency_ms = 100 )
   FORMAT AVRO USING SCHEMA '${int}'
   ENVELOPE NONE
 

--- a/test/testdrive/fetch-select-during-ingest.td
+++ b/test/testdrive/fetch-select-during-ingest.td
@@ -19,7 +19,7 @@ $ kafka-create-topic topic=tail-fetch-during-ingest
 
 > CREATE SOURCE fetch_during_ingest
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-fetch-during-ingest-${testdrive.seed}'
-  WITH( timestamp_frequency_ms = 100 )
+  LEGACYWITH( timestamp_frequency_ms = 100 )
   FORMAT AVRO USING SCHEMA '${int}'
   ENVELOPE NONE
 

--- a/test/testdrive/fetch-tail-during-ingest.td
+++ b/test/testdrive/fetch-tail-during-ingest.td
@@ -19,7 +19,7 @@ $ kafka-create-topic topic=tail-fetch-during-ingest
 
 > CREATE SOURCE fetch_during_ingest
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-tail-fetch-during-ingest-${testdrive.seed}'
-  WITH( timestamp_frequency_ms = 100 )
+  LEGACYWITH( timestamp_frequency_ms = 100 )
   FORMAT AVRO USING SCHEMA '${int}'
   ENVELOPE NONE
 

--- a/test/testdrive/github-7290.td
+++ b/test/testdrive/github-7290.td
@@ -23,7 +23,7 @@ bar
 > CREATE SOURCE posix
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -40,7 +40,7 @@ bar
 > CREATE SOURCE non_posix
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'non-posix' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -110,7 +110,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 # We should refuse to create a source with invalid WITH options
 ! CREATE SOURCE invalid_with_option
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (badoption = true)
+  LEGACYWITH (badoption = true)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
 contains:unexpected parameters for CREATE SOURCE: badoption

--- a/test/testdrive/kafka-headers-errors.td
+++ b/test/testdrive/kafka-headers-errors.td
@@ -63,7 +63,7 @@ $ s3-put-object bucket=test key=static.csv
 ! CREATE SOURCE headers_src
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'static.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -198,7 +198,7 @@ id creature
 # Test that it doesn't work with full deduplication
 ! CREATE SOURCE upsert_full_dedupe
   FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
-  WITH (deduplication = 'full')
+  LEGACYWITH (deduplication = 'full')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE DEBEZIUM UPSERT
 contains:unexpected parameters for CREATE SOURCE: deduplication

--- a/test/testdrive/kinesis.td
+++ b/test/testdrive/kinesis.td
@@ -44,7 +44,7 @@ contains:dns error: failed to lookup address information: Name or service not kn
 > CREATE SOURCE f
   FROM KINESIS CONNECTION kinesis_conn
   ARN 'arn:aws:kinesis:${testdrive.aws-region}:${testdrive.aws-account}:stream/testdrive-test-${testdrive.seed}'
-  WITH (endpoint = '${testdrive.aws-endpoint}')
+  LEGACYWITH (endpoint = '${testdrive.aws-endpoint}')
   FORMAT BYTES;
 
 > CREATE MATERIALIZED VIEW f_view

--- a/test/testdrive/s3-gzip.td
+++ b/test/testdrive/s3-gzip.td
@@ -32,7 +32,7 @@ b3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-no-compression-${testdrive.seed}'
   COMPRESSION NONE
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -67,7 +67,7 @@ b3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-gzip-compression-${testdrive.seed}'
   COMPRESSION GZIP
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -99,7 +99,7 @@ b3
 # > CREATE SOURCE s3_all_auto
 #   FROM S3 DISCOVER OBJECTS USING BUCKET SCAN '${bucket}'
 #   COMPRESSION AUTO
-#   WITH (
+#   LEGACYWITH (
 #     region = '${testdrive.aws-region}',
 #     endpoint = '${testdrive.aws-endpoint}',
 #     access_key_id = '${testdrive.aws-access-key-id}',

--- a/test/testdrive/s3.td
+++ b/test/testdrive/s3.td
@@ -29,7 +29,7 @@ b3
 > CREATE SOURCE s3_all
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -46,7 +46,7 @@ b3
 > CREATE SOURCE s3_glob_a
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING '**/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -60,7 +60,7 @@ a3
 > CREATE SOURCE s3_just_a
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'short/a' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -79,7 +79,7 @@ c,9
 > CREATE SOURCE csv_example (name, counts)
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING '*.csv' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -118,7 +118,7 @@ $ s3-put-object bucket=test key=logs/2021/01/01/frontend.log
 > CREATE SOURCE frontend_logs
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'logs/**/*.log' USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -144,7 +144,7 @@ c3
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'short/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}', BUCKET SCAN 'testdrive-other-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )
@@ -182,7 +182,7 @@ id,value
   FROM S3 CONNECTION s3_conn
   DISCOVER OBJECTS MATCHING 'csv/*'
   USING BUCKET SCAN 'testdrive-test-${testdrive.seed}'
-  WITH (
+  LEGACYWITH (
     region = '${testdrive.aws-region}',
     endpoint = '${testdrive.aws-endpoint}'
   )

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -50,12 +50,12 @@ $ kafka-ingest format=avro topic=data partition=3 schema=${schema}
 
 > CREATE SOURCE direct_source1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (timestamp_frequency_ms = 90)
+  LEGACYWITH (timestamp_frequency_ms = 90)
   FORMAT AVRO USING SCHEMA '${schema}';
 
 > CREATE SOURCE direct_source2
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
-  WITH (timestamp_frequency_ms = 100)
+  LEGACYWITH (timestamp_frequency_ms = 100)
   FORMAT AVRO USING SCHEMA '${schema}';
 
 $ kafka-ingest format=avro topic=data partition=4 schema=${schema}

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -116,7 +116,7 @@ $ kafka-ingest format=avro topic=input-cdcv2 schema=${schema}
 
 ! CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=false)
+    LEGACYWITH (epoch_ms_timeline=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
 contains:unsupported epoch_ms_timeline value
@@ -124,7 +124,7 @@ contains:unsupported epoch_ms_timeline value
 # Can't specify epoch_ms_timeline and timeline.
 ! CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=false)
+    LEGACYWITH (epoch_ms_timeline=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
   WITH (TIMELINE 'user')
@@ -132,7 +132,7 @@ contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
 
 > CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=true)
+    LEGACYWITH (epoch_ms_timeline=true)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
 

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=1
 
 > CREATE SOURCE t1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-top1-${testdrive.seed}'
-  WITH (timestamp_frequency_ms = 100)
+  LEGACYWITH (timestamp_frequency_ms = 100)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
   ENVELOPE NONE
 


### PR DESCRIPTION
See https://github.com/MaterializeInc/materialize/issues/14341#issuecomment-1226791078

This is blocking things like `REMOTE` working for pg sources; because with options are already only `unsafe`, we can change the name however we want, to make parsing less ambiguous! Note this ONLY affects sources, not sinks!


### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
