### PR TITLE
Parse EPOCH MS TIMESTAMP in the new block

### DIFF
--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1272,6 +1272,7 @@ impl_display!(KeyConstraint);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CreateSourceOptionName {
+    EpochMsTimeline,
     Remote,
     Size,
     Timeline,
@@ -1280,6 +1281,7 @@ pub enum CreateSourceOptionName {
 impl AstDisplay for CreateSourceOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
+            CreateSourceOptionName::EpochMsTimeline => "EPOCH MS TIMELINE",
             CreateSourceOptionName::Remote => "REMOTE",
             CreateSourceOptionName::Size => "SIZE",
             CreateSourceOptionName::Timeline => "TIMELINE",

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -114,6 +114,7 @@ Enable
 End
 Enforced
 Envelope
+Epoch
 Escape
 Except
 Execute

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2291,7 +2291,11 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_source_option_name(&mut self) -> Result<CreateSourceOptionName, ParserError> {
-        let name = match self.expect_one_of_keywords(&[REMOTE, SIZE, TIMELINE])? {
+        let name = match self.expect_one_of_keywords(&[EPOCH, REMOTE, SIZE, TIMELINE])? {
+            EPOCH => {
+                self.expect_keywords(&[MS, TIMELINE])?;
+                CreateSourceOptionName::EpochMsTimeline
+            }
             REMOTE => CreateSourceOptionName::Remote,
             SIZE => CreateSourceOptionName::Size,
             TIMELINE => CreateSourceOptionName::Timeline,

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -116,25 +116,24 @@ $ kafka-ingest format=avro topic=input-cdcv2 schema=${schema}
 
 ! CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
-contains:unsupported epoch_ms_timeline value
+  WITH (EPOCH MS TIMELINE false)
+contains:unsupported EPOCH MS TIMELINE value
 
 # Can't specify epoch_ms_timeline and timeline.
 ! CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=false)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
-  WITH (TIMELINE 'user')
-contains:unexpected parameters for CREATE SOURCE: epoch_ms_timeline
+  WITH (TIMELINE 'user', EPOCH MS TIMELINE)
+contains:only one of TIMELINE and EPOCH MS TIMELINE can be set
 
 > CREATE SOURCE source_cdcv2_system
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'
-    WITH (epoch_ms_timeline=true)
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
+  WITH (EPOCH MS TIMELINE)
 
 > CREATE SOURCE source_cdcv2_user
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-input-cdcv2-${testdrive.seed}'


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
