### PR TITLE
catalog: Add unsigned ints to builtin tables

### DIFF
--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -75,8 +75,8 @@ test_sink = """
 actual_indexes = """
 SELECT
     o.name,
-    ic.index_position,
-    ic.on_position,
+    ic.index_position::int8,
+    ic.on_position::int8,
     ic.on_expression
 FROM mz_indexes i
 JOIN mz_index_columns ic ON i.id = ic.index_id

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -228,7 +228,7 @@ impl CatalogState {
                     row: Row::pack_slice(&[
                         Datum::String(&id.to_string()),
                         Datum::String(column_name.as_str()),
-                        Datum::Int64(i as i64 + 1),
+                        Datum::UInt64(u64::try_from(i + 1).expect("invalid column number")),
                         Datum::from(column_type.nullable),
                         Datum::String(pgtype.name()),
                         default,
@@ -498,14 +498,14 @@ impl CatalogState {
                         .column_types,
                 )
                 .nullable;
-            let seq_in_index = i64::try_from(i + 1).expect("invalid index sequence number");
+            let seq_in_index = u64::try_from(i + 1).expect("invalid index sequence number");
             let key_sql = key_sqls
                 .get(i)
                 .expect("missing sql information for index key")
                 .to_string();
             let (field_number, expression) = match key {
                 MirScalarExpr::Column(col) => (
-                    Datum::Int64(i64::try_from(*col + 1).expect("invalid index column number")),
+                    Datum::UInt64(u64::try_from(*col + 1).expect("invalid index column number")),
                     Datum::Null,
                 ),
                 _ => (Datum::Null, Datum::String(&key_sql)),
@@ -514,7 +514,7 @@ impl CatalogState {
                 id: self.resolve_builtin_table(&MZ_INDEX_COLUMNS),
                 row: Row::pack_slice(&[
                     Datum::String(&id.to_string()),
-                    Datum::Int64(seq_in_index),
+                    Datum::UInt64(seq_in_index),
                     field_number,
                     expression,
                     Datum::from(nullable),
@@ -688,16 +688,11 @@ impl CatalogState {
             .into_row();
         let event_details = event_details.iter().next().unwrap();
         let dt = mz_ore::now::to_datetime(occurred_at).naive_utc();
-        let id = i64::try_from(event.sortable_id()).map_err(|e| {
-            Error::new(ErrorKind::Unstructured(format!(
-                "exceeded event id space: {}",
-                e
-            )))
-        })?;
+        let id = event.sortable_id();
         Ok(BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_AUDIT_EVENTS),
             row: Row::pack_slice(&[
-                Datum::Int64(id),
+                Datum::UInt64(id),
                 Datum::String(&format!("{}", event_type)),
                 Datum::String(&format!("{}", object_type)),
                 event_details,
@@ -735,12 +730,6 @@ impl CatalogState {
                 }
             };
 
-        let valid_id = i64::try_from(id).map_err(|e| {
-            Error::new(ErrorKind::Unstructured(format!(
-                "exceeded event id space: {}",
-                e
-            )))
-        })?;
         let table = self.resolve_builtin_table(&MZ_STORAGE_USAGE);
         let object_id_val = match object_id {
             Some(s) => Datum::String(s),
@@ -749,14 +738,9 @@ impl CatalogState {
         let dt = mz_ore::now::to_datetime(collection_timestamp).naive_utc();
 
         let row = Row::pack_slice(&[
-            Datum::Int64(valid_id),
+            Datum::UInt64(id),
             object_id_val,
-            Datum::Int64(
-                size_bytes
-                    .try_into()
-                    // Unless one object has over 9k petabytes of storage...
-                    .expect("Storage bytes size should not overflow i64"),
-            ),
+            Datum::UInt64(size_bytes),
             Datum::TimestampTz(DateTime::from_utc(dt, Utc)),
         ]);
         let diff = 1;

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -9,6 +9,7 @@
 
 //! Integration tests for Materialize server.
 
+use bytes::Buf;
 use std::error::Error;
 use std::thread;
 use std::time::Duration;
@@ -16,10 +17,28 @@ use std::time::Duration;
 use mz_ore::retry::Retry;
 use reqwest::{blocking::Client, StatusCode, Url};
 use serde_json::json;
+use tokio_postgres::types::{FromSql, Type};
 
 use crate::util::KAFKA_ADDRS;
 
 pub mod util;
+
+#[derive(Debug)]
+struct UInt8(u64);
+
+impl<'a> FromSql<'a> for UInt8 {
+    fn from_sql(_: &Type, mut raw: &'a [u8]) -> Result<Self, Box<dyn Error + Sync + Send>> {
+        let v = raw.get_u64();
+        if !raw.is_empty() {
+            return Err("invalid buffer size".into());
+        }
+        Ok(Self(v))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        ty.oid() == mz_pgrepr::oid::TYPE_UINT8_OID
+    }
+}
 
 #[test]
 fn test_persistence() -> Result<(), Box<dyn Error>> {
@@ -64,8 +83,11 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
         client
             .query("SHOW INDEXES FROM mat", &[])?
             .into_iter()
-            .map(|row| (row.get("Column_name"), row.get("Seq_in_index")))
-            .collect::<Vec<(String, i64)>>(),
+            .map(|row| (
+                row.get("Column_name"),
+                row.get::<_, UInt8>("Seq_in_index").0
+            ))
+            .collect::<Vec<(String, u64)>>(),
         &[
             ("a".into(), 1),
             ("a_data".into(), 2),

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -80,7 +80,7 @@ attrelid     false     oid
 attname      false     text
 atttypid     false     oid
 attlen       true      smallint
-attnum       false     bigint
+attnum       false     uint8
 atttypmod    false     integer
 attnotnull   false     boolean
 atthasdef    false     boolean


### PR DESCRIPTION
This commit is a follow up of b9adc8c7bb685797e47b011292994f5010066041
and changes more signed integers to unsigned integers.

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Changes columns of builtin tables to use unsigned integers.
