### PR TITLE
adapter,compute,storage: rename GRANULARITY to INTERVAL

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -649,7 +649,7 @@ impl CatalogState {
                     active_logs.insert(log.variant.clone(), index_id);
                 }
                 Some(DataflowLoggingConfig {
-                    granularity_ns: introspection.granularity.as_nanos(),
+                    interval_ns: introspection.interval.as_nanos(),
                     log_logging: introspection.debugging,
                     active_logs,
                     sink_logs: BTreeMap::new(),

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -224,7 +224,7 @@ async fn migrate<S: Append>(
                     name: "default".into(),
                     config: Some(ComputeInstanceIntrospectionConfig {
                         debugging: false,
-                        granularity: Duration::from_secs(1),
+                        interval: Duration::from_secs(1),
                     }),
                 },
             )?;

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -157,9 +157,9 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
             }
             ControllerResponse::ComputeReplicaHeartbeat(replica_id, when) => {
-                let replica_status_granularity = chrono::Duration::seconds(60);
+                let replica_status_interval = chrono::Duration::seconds(60);
                 let when_coarsened = when
-                    .duration_trunc(replica_status_granularity)
+                    .duration_trunc(replica_status_interval)
                     .expect("Time coarsening should not fail");
                 let new = ReplicaMetadata {
                     last_heartbeat: when_coarsened,

--- a/src/compute-client/src/logging.proto
+++ b/src/compute-client/src/logging.proto
@@ -69,7 +69,7 @@ message ProtoLogVariant {
 }
 
 message ProtoLoggingConfig {
-    mz_proto.ProtoU128 granularity_ns = 1;
+    mz_proto.ProtoU128 interval_ns = 1;
     repeated ProtoActiveLog active_logs = 2;
     bool log_logging = 3;
     repeated ProtoSinkLog sink_logs = 4;

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -24,7 +24,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_client.logging.rs"));
 /// Logging configuration.
 #[derive(Arbitrary, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LoggingConfig {
-    pub granularity_ns: u128,
+    pub interval_ns: u128,
     /// Logs to keep in an arrangement
     pub active_logs: BTreeMap<LogVariant, GlobalId>,
     /// Whether we should report logs for the log-processing dataflows
@@ -45,7 +45,7 @@ impl LoggingConfig {
 impl RustType<ProtoLoggingConfig> for LoggingConfig {
     fn into_proto(&self) -> ProtoLoggingConfig {
         ProtoLoggingConfig {
-            granularity_ns: Some(self.granularity_ns.into_proto()),
+            interval_ns: Some(self.interval_ns.into_proto()),
             active_logs: self.active_logs.into_proto(),
             log_logging: self.log_logging,
             sink_logs: self.sink_logs.into_proto(),
@@ -54,9 +54,9 @@ impl RustType<ProtoLoggingConfig> for LoggingConfig {
 
     fn from_proto(proto: ProtoLoggingConfig) -> Result<Self, TryFromProtoError> {
         Ok(LoggingConfig {
-            granularity_ns: proto
-                .granularity_ns
-                .into_rust_if_some("ProtoLoggingConfig::granularity_ns")?,
+            interval_ns: proto
+                .interval_ns
+                .into_rust_if_some("ProtoLoggingConfig::interval_ns")?,
             active_logs: proto.active_logs.into_rust()?,
             log_logging: proto.log_logging,
             sink_logs: proto.sink_logs.into_rust()?,

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -265,7 +265,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
         use crate::logging::BatchLogger;
         use timely::dataflow::operators::capture::event::link::EventLink;
 
-        let granularity_ms = std::cmp::max(1, logging.granularity_ns / 1_000_000) as Timestamp;
+        let interval = std::cmp::max(1, logging.interval_ns / 1_000_000) as Timestamp;
 
         // Track time relative to the Unix epoch, rather than when the server
         // started, so that the logging sources can be joined with tables and
@@ -277,13 +277,13 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
 
         // Establish loggers first, so we can either log the logging or not, as we like.
         let t_linked = std::rc::Rc::new(EventLink::new());
-        let mut t_logger = BatchLogger::new(Rc::clone(&t_linked), granularity_ms);
+        let mut t_logger = BatchLogger::new(Rc::clone(&t_linked), interval);
         let r_linked = std::rc::Rc::new(EventLink::new());
-        let mut r_logger = BatchLogger::new(Rc::clone(&r_linked), granularity_ms);
+        let mut r_logger = BatchLogger::new(Rc::clone(&r_linked), interval);
         let d_linked = std::rc::Rc::new(EventLink::new());
-        let mut d_logger = BatchLogger::new(Rc::clone(&d_linked), granularity_ms);
+        let mut d_logger = BatchLogger::new(Rc::clone(&d_linked), interval);
         let c_linked = std::rc::Rc::new(EventLink::new());
-        let mut c_logger = BatchLogger::new(Rc::clone(&c_linked), granularity_ms);
+        let mut c_logger = BatchLogger::new(Rc::clone(&c_linked), interval);
 
         let mut t_traces = HashMap::new();
         let mut r_traces = HashMap::new();
@@ -747,7 +747,7 @@ impl PendingPeek {
         while cursor.key_valid(&storage) {
             while cursor.val_valid(&storage) {
                 // TODO: This arena could be maintained and reuse for longer
-                // but it wasn't clear at what granularity we should flush
+                // but it wasn't clear at what interval we should flush
                 // it to ensure we don't accidentally spike our memory use.
                 // This choice is conservative, and not the end of the world
                 // from a performance perspective.

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -94,13 +94,13 @@ pub fn construct<A: Allocate>(
     compute: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, ComputeEvent)>>,
     activator: RcActivator,
 ) -> HashMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
+    let interval_ms = std::cmp::max(1, config.interval_ns / 1_000_000) as Timestamp;
 
     let traces = worker.dataflow_named("Dataflow: compute logging", move |scope| {
         let (compute_logs, token) = Some(compute).mz_replay(
             scope,
             "compute logs",
-            Duration::from_nanos(config.granularity_ns as u64),
+            Duration::from_nanos(config.interval_ns as u64),
             activator.clone(),
         );
 
@@ -144,8 +144,8 @@ pub fn construct<A: Allocate>(
                     let mut peek_duration_session = peek_duration.session(&time);
 
                     for (time, worker, datum) in demux_buffer.drain(..) {
-                        let time_ms = (((time.as_millis() as Timestamp / granularity_ms) + 1)
-                            * granularity_ms) as Timestamp;
+                        let time_ms = (((time.as_millis() as Timestamp / interval_ms) + 1)
+                            * interval_ms) as Timestamp;
 
                         match datum {
                             ComputeEvent::Dataflow(id, is_create) => {

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -50,13 +50,13 @@ pub fn construct<A: Allocate>(
     linked: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, DifferentialEvent)>>,
     activator: RcActivator,
 ) -> HashMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
+    let interval_ms = std::cmp::max(1, config.interval_ns / 1_000_000) as Timestamp;
 
     let traces = worker.dataflow_named("Dataflow: differential logging", move |scope| {
         let (logs, token) = Some(linked).mz_replay(
             scope,
             "differential logs",
-            Duration::from_nanos(config.granularity_ns as u64),
+            Duration::from_nanos(config.interval_ns as u64),
             activator,
         );
 
@@ -84,8 +84,8 @@ pub fn construct<A: Allocate>(
                     data.swap(&mut demux_buffer);
 
                     for (time, worker, datum) in demux_buffer.drain(..) {
-                        let time_ms = (((time.as_millis() as Timestamp / granularity_ms) + 1)
-                            * granularity_ms) as Timestamp;
+                        let time_ms = (((time.as_millis() as Timestamp / interval_ms) + 1)
+                            * interval_ms) as Timestamp;
 
                         match datum {
                             DifferentialEvent::Batch(event) => {

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -61,14 +61,14 @@ pub fn construct<A: Allocate>(
     >,
     activator: RcActivator,
 ) -> HashMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
+    let interval_ms = std::cmp::max(1, config.interval_ns / 1_000_000) as Timestamp;
 
     // A dataflow for multiple log-derived arrangements.
     let traces = worker.dataflow_named("Dataflow: timely reachability logging", move |scope| {
         let (logs, token) = Some(linked).mz_replay(
             scope,
             "reachability logs",
-            Duration::from_nanos(config.granularity_ns as u64),
+            Duration::from_nanos(config.interval_ns as u64),
             activator,
         );
 
@@ -111,8 +111,8 @@ pub fn construct<A: Allocate>(
                         data.swap(&mut buffer);
 
                         for (time, worker, (addr, massaged)) in buffer.drain(..) {
-                            let time_ms = (((time.as_millis() as Timestamp / granularity_ms) + 1)
-                                * granularity_ms)
+                            let time_ms = (((time.as_millis() as Timestamp / interval_ms) + 1)
+                                * interval_ms)
                                 as Timestamp;
                             for (source, port, update_type, ts, diff) in massaged {
                                 updates_session.give(

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -49,7 +49,7 @@ pub fn construct<A: Allocate>(
     linked: std::rc::Rc<EventLink<Timestamp, (Duration, WorkerIdentifier, TimelyEvent)>>,
     activator: RcActivator,
 ) -> HashMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
-    let granularity_ms = std::cmp::max(1, config.granularity_ns / 1_000_000) as Timestamp;
+    let interval_ms = std::cmp::max(1, config.interval_ns / 1_000_000) as Timestamp;
     let peers = worker.peers();
 
     // A dataflow for multiple log-derived arrangements.
@@ -57,7 +57,7 @@ pub fn construct<A: Allocate>(
         let (logs, token) = Some(linked).mz_replay(
             scope,
             "timely logs",
-            Duration::from_nanos(config.granularity_ns as u64),
+            Duration::from_nanos(config.interval_ns as u64),
             activator,
         );
 
@@ -114,8 +114,8 @@ pub fn construct<A: Allocate>(
 
                     for (time, worker, datum) in demux_buffer.drain(..) {
                         let time_ns = time.as_nanos();
-                        let time_ms = (((time.as_millis() as Timestamp / granularity_ms) + 1)
-                            * granularity_ms) as Timestamp;
+                        let time_ms = (((time.as_millis() as Timestamp / interval_ms) + 1)
+                            * interval_ms) as Timestamp;
 
                         match datum {
                             TimelyEvent::Operates(event) => {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -988,8 +988,8 @@ impl_display_t!(CreateClusterStatement);
 /// An option in a `CREATE CLUSTER` statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ClusterOption<T: AstInfo> {
-    /// The `INTROSPECTION GRANULARITY [[=] <interval>] option.
-    IntrospectionGranularity(WithOptionValue<T>),
+    /// The `INTROSPECTION INTERVAL [[=] <interval>] option.
+    IntrospectionInterval(WithOptionValue<T>),
     /// The `INTROSPECTION DEBUGGING [[=] <enabled>] option.
     IntrospectionDebugging(WithOptionValue<T>),
     /// The `REPLICAS` option.
@@ -999,9 +999,9 @@ pub enum ClusterOption<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for ClusterOption<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            ClusterOption::IntrospectionGranularity(granularity) => {
-                f.write_str("INTROSPECTION GRANULARITY ");
-                f.write_node(granularity);
+            ClusterOption::IntrospectionInterval(interval) => {
+                f.write_str("INTROSPECTION INTERVAL ");
+                f.write_node(interval);
             }
             ClusterOption::IntrospectionDebugging(debugging) => {
                 f.write_str("INTROSPECTION DEBUGGING ");

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -136,7 +136,6 @@ Forward
 From
 Full
 Generator
-Granularity
 Graph
 Greatest
 Group

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2896,16 +2896,16 @@ impl<'a> Parser<'a> {
                 self.expect_token(&Token::RParen)?;
                 Ok(ClusterOption::Replicas(replicas))
             }
-            INTROSPECTION => match self.expect_one_of_keywords(&[DEBUGGING, GRANULARITY])? {
+            INTROSPECTION => match self.expect_one_of_keywords(&[DEBUGGING, INTERVAL])? {
                 DEBUGGING => {
                     let _ = self.consume_token(&Token::Eq);
                     Ok(ClusterOption::IntrospectionDebugging(
                         self.parse_with_option_value()?,
                     ))
                 }
-                GRANULARITY => {
+                INTERVAL => {
                     let _ = self.consume_token(&Token::Eq);
-                    Ok(ClusterOption::IntrospectionGranularity(
+                    Ok(ClusterOption::IntrospectionInterval(
                         self.parse_with_option_value()?,
                     ))
                 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1110,46 +1110,46 @@ CREATE CLUSTER cluster REPLICAS ()
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([])] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL '1s'
 ----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL '1s'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s', REPLICAS ()
+CREATE CLUSTER cluster INTROSPECTION INTERVAL '1s', REPLICAS ()
 ----
-CREATE CLUSTER cluster INTROSPECTION GRANULARITY '1s', REPLICAS ()
+CREATE CLUSTER cluster INTROSPECTION INTERVAL '1s', REPLICAS ()
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionGranularity(Value(String("1s"))), Replicas([])] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [IntrospectionInterval(Value(String("1s"))), Replicas([])] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = '1s'
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL = '1s'
 ----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL '1s'
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(String("1s")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(String("1s")))] })
 
 parse-statement
-CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION GRANULARITY = '1s'
+CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION INTERVAL = '1s'
 ----
 error: Expected one of REPLICAS or INTROSPECTION, found WITH
-CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION GRANULARITY = '1s'
+CREATE CLUSTER cluster WITH REPLICAS (), INTROSPECTION INTERVAL = '1s'
                        ^
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = 0
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL = 0
 ----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY 0
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL 0
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(Number("0")))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(Number("0")))] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY = NULL
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL = NULL
 ----
-CREATE CLUSTER cluster REPLICAS (), INTROSPECTION GRANULARITY NULL
+CREATE CLUSTER cluster REPLICAS (), INTROSPECTION INTERVAL NULL
 =>
-CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionGranularity(Value(Null))] })
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([]), IntrospectionInterval(Value(Null))] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (), BADOPT
@@ -1166,11 +1166,11 @@ CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']))
 CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }])] })
 
 parse-statement
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')), INTROSPECTION INTERVAL '1s'
 ----
-error: Expected end of statement, found INTROSPECTION
-CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1']), b (SIZE '1')) INTROSPECTION GRANULARITY '1s'
-                                                                     ^
+CREATE CLUSTER cluster REPLICAS (a (REMOTE = ['host1']), b (SIZE = '1')), INTROSPECTION INTERVAL '1s'
+=>
+CreateCluster(CreateClusterStatement { name: Ident("cluster"), options: [Replicas([ReplicaDefinition { name: Ident("a"), options: [ReplicaOption { name: Remote, value: Some(Value(Array([String("host1")]))) }] }, ReplicaDefinition { name: Ident("b"), options: [ReplicaOption { name: Size, value: Some(Value(String("1"))) }] }]), IntrospectionInterval(Value(String("1s")))] })
 
 parse-statement
 CREATE CLUSTER cluster REPLICAS (a (REMOTE ['host1'], SIZE '1'))

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -179,7 +179,7 @@ pub struct ComputeInstanceIntrospectionConfig {
     /// Whether to introspect the introspection.
     pub debugging: bool,
     /// The interval at which to introspect.
-    pub granularity: Duration,
+    pub interval: Duration,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2702,7 +2702,7 @@ pub fn plan_create_cluster(
 ) -> Result<Plan, PlanError> {
     let mut replicas_definitions = None;
     let mut introspection_debugging = None;
-    let mut introspection_granularity: Option<Option<Interval>> = None;
+    let mut introspection_interval: Option<Option<Interval>> = None;
 
     for option in options {
         match option {
@@ -2715,13 +2715,13 @@ pub fn plan_create_cluster(
                         .map_err(|e| sql_err!("invalid INTROSPECTION DEBUGGING: {}", e))?,
                 );
             }
-            ClusterOption::IntrospectionGranularity(interval) => {
-                if introspection_granularity.is_some() {
-                    sql_bail!("INTROSPECTION GRANULARITY specified more than once");
+            ClusterOption::IntrospectionInterval(interval) => {
+                if introspection_interval.is_some() {
+                    sql_bail!("INTROSPECTION INTERVAL specified more than once");
                 }
-                introspection_granularity = Some(
+                introspection_interval = Some(
                     OptionalInterval::try_from_value(interval)
-                        .map_err(|e| sql_err!("invalid INTROSPECTION GRANULARITY: {}", e))?
+                        .map_err(|e| sql_err!("invalid INTROSPECTION INTERVAL: {}", e))?
                         .0,
                 );
             }
@@ -2744,19 +2744,17 @@ pub fn plan_create_cluster(
         None => bail_unsupported!("CLUSTER without REPLICAS option"),
     };
 
-    let introspection_granularity =
-        introspection_granularity.unwrap_or(Some(DEFAULT_INTROSPECTION_GRANULARITY));
+    let introspection_interval =
+        introspection_interval.unwrap_or(Some(DEFAULT_INTROSPECTION_INTERVAL));
 
-    let config = match (introspection_debugging, introspection_granularity) {
+    let config = match (introspection_debugging, introspection_interval) {
         (None | Some(false), None) => None,
-        (debugging, Some(granularity)) => Some(ComputeInstanceIntrospectionConfig {
+        (debugging, Some(interval)) => Some(ComputeInstanceIntrospectionConfig {
             debugging: debugging.unwrap_or(false),
-            granularity: granularity.duration()?,
+            interval: interval.duration()?,
         }),
         (Some(true), None) => {
-            sql_bail!(
-                "INTROSPECTION DEBUGGING cannot be specified without INTROSPECTION GRANULARITY"
-            )
+            sql_bail!("INTROSPECTION DEBUGGING cannot be specified without INTROSPECTION INTERVAL")
         }
     };
     Ok(Plan::CreateComputeInstance(CreateComputeInstancePlan {
@@ -2766,7 +2764,7 @@ pub fn plan_create_cluster(
     }))
 }
 
-const DEFAULT_INTROSPECTION_GRANULARITY: Interval = Interval {
+const DEFAULT_INTROSPECTION_INTERVAL: Interval = Interval {
     micros: 1_000_000,
     months: 0,
     days: 0,

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -275,13 +275,13 @@ SELECT name FROM mz_indexes WHERE name NOT LIKE 'mz_%';
 
 # Test that dropping a cluster and re-creating it with the same name is valid if introspection sources are enabled
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
 
 statement ok
 DROP CLUSTER foo CASCADE
 
 statement ok
-CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION GRANULARITY '1s'
+CREATE CLUSTER foo REPLICAS (r1 (REMOTE ['localhost:1234'])), INTROSPECTION INTERVAL '1s'
 
 statement ok
 DROP CLUSTER foo CASCADE

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -21,7 +21,7 @@ CREATE CLUSTER test
     replica_a (SIZE '1'),
     replica_b (SIZE '2')
   ),
-  INTROSPECTION GRANULARITY '50 milliseconds'
+  INTROSPECTION INTERVAL '50 milliseconds'
 
 statement ok
 SET cluster = test
@@ -127,7 +127,7 @@ DROP CLUSTER test CASCADE
 statement ok
 CREATE CLUSTER test
   REPLICAS (replica_a (SIZE '1')),
-  INTROSPECTION GRANULARITY 0
+  INTROSPECTION INTERVAL 0
 
 query error cannot read log sources on cluster with disabled introspection
 SELECT * FROM mz_materializations


### PR DESCRIPTION
Rename `INTROSPECTION GRANULARITY` and `TIMESTAMP GRANULARITY` to
`INTROSPECTION INTERVAL` and `TIMESTAMP INTERVAL`, respectively.

Suggested by @frankmcsherry [0].

[0]: https://github.com/MaterializeInc/materialize/pull/14422#issuecomment-1227878260

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR renames an option by request.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
