### PR TITLE
Avoid crash during the handling of a RecursionLimitError

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -9,7 +9,7 @@
 
 #![warn(missing_docs)]
 
-use std::cmp::Ordering;
+use std::cmp::{max, Ordering};
 use std::collections::{BTreeSet, HashSet};
 use std::fmt;
 use std::num::NonZeroUsize;
@@ -1383,6 +1383,34 @@ impl MirRelationExpr {
             Ok::<_, RecursionLimitError>(())
         })
         .expect("Unexpected error in `visit_scalars_mut` call");
+    }
+
+    /// Clears the contents of `self` even if it's so deep that simply dropping it would cause a
+    /// stack overflow in `drop_in_place`.
+    ///
+    /// Leaves `self` in an unusable state, so this should only be used if `self` is about to be
+    /// dropped or otherwise overwritten.
+    pub fn destroy_carefully(&mut self) {
+        #[allow(deprecated)] // Having `maybe_grow` and no limit is the point here
+        self.visit_mut_post_nolimit(&mut |e| {
+            e.take_dangerous();
+        });
+    }
+
+    /// Computes the size (total number of nodes) and maximum depth of a MirRelationExpr for
+    /// debug printing purposes. Might grow the stack to a size proportional to the maximum depth.
+    pub fn debug_size_and_depth(&self) -> (usize, usize) {
+        let mut size = 0;
+        let mut max_depth = 0;
+        fn dfs(expr: &MirRelationExpr, size: &mut usize, max_depth: &mut usize, cur_depth: usize) {
+            mz_ore::stack::maybe_grow(|| {
+                *size += 1;
+                *max_depth = max(*max_depth, cur_depth);
+                expr.visit_children(|child| dfs(child, size, max_depth, cur_depth + 1));
+            });
+        }
+        dfs(self, &mut size, &mut max_depth, 1);
+        (size, max_depth)
     }
 }
 

--- a/src/ore/src/stack.rs
+++ b/src/ore/src/stack.rs
@@ -246,6 +246,7 @@ impl RecursionGuard {
 #[derive(Clone, Debug)]
 pub struct RecursionLimitError {
     limit: usize,
+    // todo: add backtrace (say, bottom 20 frames) once `std::backtrace` stabilizes in Rust 1.65
 }
 
 impl fmt::Display for RecursionLimitError {


### PR DESCRIPTION
This PR mitigates https://github.com/MaterializeInc/materialize/issues/14141

There is no infinite recursion, the `MirRelationExpr` just gets too deep in `InlineLet`.

However, we still shouldn’t crash, but should print a `RecursionLimitError` to the user and move on. This PR takes care of this.

We were trying to throw a `RecursionLimitError`, but then crashed when dropping a deep `MirRelationExpr`. This PR does a “controlled demolition” of the `MirRelationExpr` instead of relying on the automatic dropping.

### Motivation

  * This PR mitigates https://github.com/MaterializeInc/materialize/issues/14141

### Tips for reviewer

We run into the 2048 recursion limit in `FuseAndCollapse` in `fusion::reduce::Reduce`.

Before `Reduce`, the previous transform is `InlineLet`. Before `InlineLet`, the tree depth is 290. After `InlineLet` it’s 206739, which is way too big for the 2048 recursion limit.

Note that the size of the MirRelationExpr (i.e., total number of nodes, not depth) doesn’t unreasonably increase during the pipeline:
- 9497337 before `TopKElision`, which is at the very beginning of the `logical_optimizer`,
- 6990740 before `InlineLet`,
- 5641908 before `Reduce`.

(I also committed my debug printing function for the size and depth, maybe it will be useful for similar investigations in the future.)

It also requires an explanation why the tree suddenly gets so deep during `InlineLet`. My guess is that initially it's a "bushy" Let tree, and after `InlineLet` it becomes a "right-deep" Let tree. That is, initially the Lets are distributed more or less evenly between the bodies and values of containing Lets, but after `InlineLet` it becomes a long chain of Lets nested always in the `body` of a containing Let. Looking at `lets.len()` in `InlineLet::transform` corroborates this: len is 206519.

In case somebody would like to investigate the tree after `InlineLet`, I attached a portion of that `MirRelationExpr`. (It’s only a portion because the printing code crashes with a stack overflow...) [deep_mir_after_inline_let.txt](https://github.com/MaterializeInc/materialize/files/9432024/deep_mir_after_inline_let.txt)

I think having a "variadic" `Let` (as already suggested earlier by @aalexandrov) would avoid even the recursion limit problem.

For now, this PR doesn't do anything about `InlineLet`, just avoids the crash to be able to gracefully print the error.

The crash was happening as follows:
- `Optimizer::optimize` calls `self.transform`.
- `self.transform` does lots of stuff and eventually returns a `RecursionLimitError`.
- The `?` after the call to `self.transform` tries to return from `Optimizer::optimize`.
- As part of returning from `Optimizer::optimize`, Rust tries to drop `relation`.
- At this point, `relation` is so deep (206739) that dropping it runs into the above stack overflow.

To avoid the crash (and be able to gracefully print the recursion limit error), we don’t call `self.transform` with a `?` in `Optimizer::optimize`. Instead, we manually inspect the `Result` of the call, and in case of `Err` we do a “controlled demolition” of the tree instead of relying on the automatic dropping.

Note that it would be tempting to define `Drop` for `MirRelationExpr` and call `destroy_carefully` there, but types implementing `Drop` have some unfortunate restrictions, so it’s probably not worth it (I tried it and had lots of compile errors in many places):
https://stackoverflow.com/questions/34278607/can-not-move-out-of-type-which-defines-the-drop-trait-e0509 

Btw. at first I thought it's an infinite recursion because at the point of the stack overflow the stack looked awfully repeating:
```
...
#111958 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111959 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111960 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111961 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111962 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111963 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111964 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111965 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111966 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111967 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111968 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111969 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111970 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111971 0x000056508d480dfb in core::ptr::drop_in_place<alloc::boxed::Box<mz_expr::relation::MirRelationExpr, alloc::alloc::Global>> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
#111972 core::ptr::drop_in_place<mz_expr::relation::MirRelationExpr> () at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ptr/mod.rs:487
...
```
However, then I realized that, even without an infinite recursion, `drop_in_place` can repeat like this in a stack trace if the stack overflow happens while dropping something. How dropping works is that `drop_in_place` calls itself for (some) fields of the struct, so any big tree of structs might produce `drop_in_place` calls nested deeply into each other, with nothing in-between them if dropping the struct doesn't involve other function calls.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
  - Well, I didn't add the query from the issue as a test, because it takes way too long for the optimizer pipeline to go through on it (especially in debug mode).
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No changes in query behavior, just better error reporting.
