### PR TITLE
persist: flatten snapshot LeasedBatches into parts

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -27,10 +27,10 @@ use uuid::Uuid;
 use mz_persist::location::{Blob, SeqNo};
 use mz_persist_types::{Codec, Codec64};
 
-use crate::fetch::{fetch_batch, BatchFetcher, LeasedBatch};
+use crate::fetch::{fetch_batch, BatchFetcher, LeasedBatch, LeasedBatchMetadata};
 use crate::internal::machine::Machine;
 use crate::internal::metrics::Metrics;
-use crate::internal::state::Since;
+use crate::internal::state::{HollowBatch, Since};
 use crate::{GarbageCollector, PersistConfig};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
@@ -467,21 +467,34 @@ where
     pub async fn snapshot(&mut self, as_of: Antichain<T>) -> Result<Vec<LeasedBatch<T>>, Since<T>> {
         let batches = self.machine.snapshot(&as_of).await?;
 
-        let r = batches
-            .into_iter()
-            .filter(|batch| batch.len > 0)
-            .map(|batch| LeasedBatch {
-                shard_id: self.machine.shard_id(),
-                reader_id: self.reader_id.clone(),
-                metadata: crate::fetch::LeasedBatchMetadata::Snapshot {
-                    as_of: as_of.clone(),
-                },
-                batch,
-                leased_seqno: Some(self.lease_seqno()),
-            })
-            .collect::<Vec<_>>();
-
-        Ok(r)
+        let mut leased_batches = Vec::new();
+        for batch in batches {
+            // Flatten the HollowBatch into one LeasedBatch per key. Each key
+            // corresponds to a "part" or s3 object. This allows persist_source
+            // to distribute work by parts (smallish, more even size) instead of
+            // batches (arbitrarily large).
+            //
+            // TODO: Do the same for Listen batches. It's tricker because of the
+            // progress.
+            for key in batch.keys {
+                leased_batches.push(LeasedBatch {
+                    shard_id: self.machine.shard_id(),
+                    reader_id: self.reader_id.clone(),
+                    metadata: LeasedBatchMetadata::Snapshot {
+                        as_of: as_of.clone(),
+                    },
+                    batch: HollowBatch {
+                        desc: batch.desc.clone(),
+                        keys: vec![key.clone()],
+                        // This isn't quite right, but it's not used by anything
+                        // take operates on the leased_batch.
+                        len: batch.len,
+                    },
+                    leased_seqno: Some(self.lease_seqno()),
+                });
+            }
+        }
+        Ok(leased_batches)
     }
 
     /// Generates a [shapshot](Self::snapshot), and fetches all of the batches


### PR DESCRIPTION
LeasedBatch exists so that persist_source can try to evenly distribute
the work of fetching and decoding shard data. However, Batches are
unevenly sized and can be arbitrarily large. Instead, distribute _batch
parts_, which are smallish (currently <128MiB, hopefully more like 8-32
MiB after inc state lands) and more evenly sized.

This commit only switches Snapshot to distribute based on parts because
it was simple and will give an immediate win. We should follow up to
give the same treatment to Listen (and also rename LeasedBatch to
something like LeasedPart) in a followup, but it's tricker because of
the attached progress.

Also included is a fix to persist_source to distributed randomly instead of round robin. This was previously a round robin seeded with the source_id, so if we scheduled multiple copies of the same source_id (which is currently the common case for postgres sources), we'd end up distributing batches in lock step.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

Opinions on merging the snapshot fix now vs waiting until we also get listens?

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [N/A] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
