### PR TITLE
Correct the testdrive regex docs

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -493,15 +493,11 @@ The environment variables are available uppercase, with an the `env.` prefix:
 
 # Dealing with variable output
 
-Certain tests produce variable output and testdrive provides a way to mask that via regular expression substitution
+Certain tests produce variable output and testdrive provides a way to mask that via regular expression substitution.
 
 #### `$ set-regex match=regular_expression replacement=replacement_str`
 
-All matches of the regular expression in the entire test will be converted to ```replacement_str```.
-
-> :warning: **only one regular expression and replacement string can be used for the entire test**
->
-> The place where the regular expression is declared within the script does not matter, it will be applied to all lines of the test.
+All matches of the regular expression in the rest of the test will be converted to ```replacement_str```.
 
 For example, this will convert all UNIX-like timestamps to the fixed string `<TIMESTAMP>`and this test will pass:
 
@@ -510,6 +506,8 @@ $ set-regex match=\d{10} replacement=<TIMESTAMP>
 > SELECT round(extract(epoch FROM now()));
 <TIMESTAMP>
 ```
+
+Note that only one regex can be active at a time: additional calls to `set-regex` will unset the previous regex. If you want to unset the regex without setting a new one, `unset-regex` will do that for you.
 
 ## Useful regular expressions
 


### PR DESCRIPTION
It turns out that testdrive's regex functionality doesn't work as specified, but instead in a much nicer and more useful way. Let's document it!

### Motivation

Previously-unreported documentation issue, I guess?

#14372 takes advantage of this undocumented functionality, if you care to see it in action.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
