### PR TITLE
Set a standard indent for .td files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,9 @@ indent_size = 2
 [*.jsx]
 indent_size = 2
 
+[*.td]
+indent_size = 2
+
 [*.ts]
 indent_size = 2
 


### PR DESCRIPTION
### Motivation

Just a minor QOL improvement for folks working in testdrive.
