### PR TITLE
sql: modularize KafkaConfigOptionExtracted access

### DIFF
--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -558,7 +558,7 @@ macro_rules! generate_extracted_config {
             pub struct [<$option_ty Extracted>] {
                 seen: HashSet::<[<$option_ty Name>]>,
                 $(
-                    [<$option_name:snake>]: $t,
+                    pub(crate) [<$option_name:snake>]: $t,
                 )*
             }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -367,56 +367,56 @@ pub fn plan_create_source(
 
     let (external_connection, encoding) = match connection {
         CreateSourceConnection::Kafka(kafka) => {
-            let (kafka_connection, options, optional_start_offset, group_id_prefix) =
-                match &kafka.connection {
-                    mz_sql_parser::ast::KafkaConnection::Inline { broker } => {
-                        scx.require_unsafe_mode("creating Kafka sources with inline connections")?;
-                        let mut options = BTreeMap::new();
-                        options.insert(
-                            "bootstrap.servers".into(),
-                            KafkaAddrs::from_str(broker)
-                                .map_err(|e| sql_err!("parsing kafka broker: {e}"))?
-                                .to_string()
-                                .into(),
-                        );
-                        let connection = KafkaConnection::try_from(&mut options)?;
-                        (connection, options, None, None)
+            let (kafka_connection, options, optional_start_offset, group_id_prefix) = match &kafka
+                .connection
+            {
+                mz_sql_parser::ast::KafkaConnection::Inline { broker } => {
+                    scx.require_unsafe_mode("creating Kafka sources with inline connections")?;
+                    let mut options = BTreeMap::new();
+                    options.insert(
+                        "bootstrap.servers".into(),
+                        KafkaAddrs::from_str(broker)
+                            .map_err(|e| sql_err!("parsing kafka broker: {e}"))?
+                            .to_string()
+                            .into(),
+                    );
+                    let connection = KafkaConnection::try_from(&mut options)?;
+                    (connection, options, None, None)
+                }
+                mz_sql_parser::ast::KafkaConnection::Reference {
+                    connection,
+                    with_options,
+                } => {
+                    let item = scx.get_item_by_resolved_name(&connection)?;
+                    let connection = match item.connection()? {
+                        Connection::Kafka(connection) => connection.clone(),
+                        _ => sql_bail!("{} is not a kafka connection", item.name()),
+                    };
+
+                    // Starting offsets are allowed out unsafe mode, as they are a simple,
+                    // useful way to specify where to start reading a topic.
+                    if with_options.iter().any(|opt| {
+                        opt.name != KafkaConfigOptionName::StartOffset
+                            && opt.name != KafkaConfigOptionName::StartTimestamp
+                    }) {
+                        scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
                     }
-                    mz_sql_parser::ast::KafkaConnection::Reference {
+
+                    let extracted_options: KafkaConfigOptionExtracted =
+                        with_options.clone().try_into()?;
+                    let optional_start_offset =
+                        Option::<kafka_util::KafkaStartOffsetType>::try_from(&extracted_options)?;
+                    let config_options =
+                        kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
+
+                    (
                         connection,
-                        with_options,
-                    } => {
-                        let item = scx.get_item_by_resolved_name(&connection)?;
-                        let connection = match item.connection()? {
-                            Connection::Kafka(connection) => connection.clone(),
-                            _ => sql_bail!("{} is not a kafka connection", item.name()),
-                        };
-
-                        // Starting offsets are allowed out unsafe mode, as they are a simple,
-                        // useful way to specify where to start reading a topic.
-                        if with_options.iter().any(|opt| {
-                            opt.name != KafkaConfigOptionName::StartOffset
-                                && opt.name != KafkaConfigOptionName::StartTimestamp
-                        }) {
-                            scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
-                        }
-
-                        let with_options: KafkaConfigOptionExtracted =
-                            with_options.clone().try_into()?;
-                        let (optional_start_offset, group_id_prefix, with_options): (
-                            _,
-                            _,
-                            BTreeMap<String, StringOrSecret>,
-                        ) = with_options.try_into()?;
-
-                        (
-                            connection,
-                            with_options,
-                            optional_start_offset,
-                            group_id_prefix,
-                        )
-                    }
-                };
+                        config_options,
+                        optional_start_offset,
+                        extracted_options.group_id_prefix,
+                    )
+                }
+            };
 
             let parse_offset = |s: i64| {
                 // we parse an i64 here, because we don't yet support u64's in
@@ -1889,10 +1889,9 @@ fn kafka_sink_builder(
                 scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
             }
 
-            let with_options: KafkaConfigOptionExtracted = with_options.try_into()?;
-            let (_, _, with_options): (_, _, BTreeMap<String, StringOrSecret>) =
-                with_options.try_into()?;
-            (connection, with_options)
+            let extracted_options: KafkaConfigOptionExtracted = with_options.try_into()?;
+            let config_options = kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
+            (connection, config_options)
         }
         mz_sql_parser::ast::KafkaConnection::Inline { .. } => unreachable!(),
     };


### PR DESCRIPTION
Rather than forcing everyone to create everything you might extract from `KafkaConfigOptionExtracted`, I'd prefer making this _a la carte_.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
