### PR TITLE
persist: track blob size in HollowBatch

### DIFF
--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -208,20 +208,20 @@ where
         while let Some(state) = states.next() {
             if state.seqno < req.new_seqno_since {
                 state.collections.trace.map_batches(|b| {
-                    for key in b.keys.iter() {
+                    for part in b.parts.iter() {
                         // It's okay (expected) if the key already exists in
                         // deleteable_batch_blobs, it may have been present in
                         // previous versions of state.
-                        deleteable_batch_blobs.insert(key.to_owned());
+                        deleteable_batch_blobs.insert(part.key.to_owned());
                     }
                 });
             } else if state.seqno == req.new_seqno_since {
                 state.collections.trace.map_batches(|b| {
-                    for key in b.keys.iter() {
+                    for part in b.parts.iter() {
                         // It's okay (expected) if the key doesn't exist in
                         // deleteable_batch_blobs, it may have been added in
                         // this version of state.
-                        let _ = deleteable_batch_blobs.remove(key);
+                        let _ = deleteable_batch_blobs.remove(&part.key);
                     }
                 });
                 // We only need to detect deletable rollups in the last iter

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -714,6 +714,7 @@ pub struct ShardsMetrics {
     // later in favor of only having the latter.
     batch_count: mz_ore::metrics::UIntGaugeVec,
     update_count: mz_ore::metrics::UIntGaugeVec,
+    encoded_batch_size: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
     // We hand out `Arc<ShardMetrics>` to read and write handles, but store it
     // here as `Weak`. This allows us to discover if it's no longer in use and
@@ -779,6 +780,13 @@ impl ShardsMetrics {
                     var_labels: ["shard"],
                 ),
             ),
+            encoded_batch_size: registry.register(
+                metric!(
+                    name: "mz_persist_shard_encoded_batch_size",
+                    help: "total encoded batch size of all active shards on this process",
+                    var_labels: ["shard"],
+                ),
+            ),
             seqnos_held: registry.register(
                 metric!(
                     name: "mz_persist_shard_seqnos_held",
@@ -834,6 +842,7 @@ pub struct ShardMetrics {
     encoded_diff_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     batch_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     update_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    encoded_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
 }
 
@@ -859,6 +868,9 @@ impl ShardMetrics {
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             update_count: shards_metrics
                 .update_count
+                .get_delete_on_drop_gauge(vec![shard.clone()]),
+            encoded_batch_size: shards_metrics
+                .encoded_batch_size
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             seqnos_held: shards_metrics
                 .seqnos_held
@@ -906,6 +918,11 @@ impl ShardMetrics {
 
     pub fn set_update_count(&self, update_count: usize) {
         self.update_count.set(u64::cast_from(update_count))
+    }
+
+    pub fn set_encoded_batch_size(&self, encoded_batch_size: usize) {
+        self.encoded_batch_size
+            .set(u64::cast_from(encoded_batch_size))
     }
 
     pub fn set_seqnos_held(&self, seqnos_held: usize) {

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -22,14 +22,16 @@ message ProtoU64Description {
 }
 
 message ProtoHollowBatchPart {
-    ProtoU64Description desc = 1;
-    string key = 2;
+    string key = 1;
+    uint64 encoded_size_bytes = 2;
 }
 
 message ProtoHollowBatch {
     ProtoU64Description desc = 1;
-    repeated string keys = 2;
+    repeated ProtoHollowBatchPart parts = 4;
     uint64 len = 3;
+
+    repeated string deprecated_keys = 2;
 }
 
 message ProtoTrace {

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -486,8 +486,8 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
             key: ins,
             val: StateFieldValDiff::Insert(()),
         }] => {
-            if del.keys.len() == 0
-                && ins.keys.len() == 0
+            if del.parts.len() == 0
+                && ins.parts.len() == 0
                 && del.desc.lower() == ins.desc.lower()
                 && PartialOrder::less_than(del.desc.upper(), ins.desc.upper())
             {
@@ -502,7 +502,7 @@ fn apply_diffs_spine<T: Timestamp + Lattice>(
                         // frontier is for these batches (nothing in them, so nothing could have been compacted.
                         Antichain::from_elem(T::minimum()),
                     ),
-                    keys: vec![],
+                    parts: vec![],
                     len: 0,
                 });
                 metrics.state.apply_spine_fast_path.inc();

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -218,6 +218,7 @@ impl StateVersions {
                 shard_metrics.set_upper(&new_state.upper());
                 shard_metrics.set_batch_count(new_state.batch_count());
                 shard_metrics.set_update_count(new_state.num_updates());
+                shard_metrics.set_encoded_batch_size(new_state.encoded_batch_size());
                 shard_metrics.set_seqnos_held(new_state.seqnos_held());
                 shard_metrics.inc_encoded_diff_size(payload_len);
                 Ok(Ok(()))

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -534,12 +534,12 @@ where
         batch: HollowBatch<T>,
         metadata: SerdeLeasedBatchPartMetadata,
     ) -> impl Iterator<Item = LeasedBatchPart<T>> + '_ {
-        batch.keys.into_iter().map(move |key| LeasedBatchPart {
+        batch.parts.into_iter().map(move |part| LeasedBatchPart {
             shard_id: self.machine.shard_id(),
             reader_id: self.reader_id.clone(),
             metadata: metadata.clone(),
             desc: batch.desc.clone(),
-            key,
+            key: part.key,
             leased_seqno: Some(self.lease_seqno()),
         })
     }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -432,13 +432,13 @@ where
         let since = Antichain::from_elem(T::minimum());
         let desc = Description::new(lower, upper, since);
 
-        let (mut keys, mut num_updates) = (Vec::new(), 0);
+        let (mut parts, mut num_updates) = (Vec::new(), 0);
         for batch in batches.iter() {
-            if let Err(err) = validate_truncate_batch(&batch.desc, &desc) {
+            if let Err(err) = validate_truncate_batch(&batch.batch.desc, &desc) {
                 return Ok(Err(err));
             }
-            keys.extend_from_slice(&batch.blob_keys);
-            num_updates += batch.num_updates;
+            parts.extend_from_slice(&batch.batch.parts);
+            num_updates += batch.batch.len;
         }
 
         let heartbeat_timestamp = (self.cfg.now)();
@@ -447,7 +447,7 @@ where
             .compare_and_append(
                 &HollowBatch {
                     desc: desc.clone(),
-                    keys,
+                    parts,
                     len: num_updates,
                 },
                 &self.writer_id,


### PR DESCRIPTION
This will be necessary for bounded memory compaction, but doing it early
because I want the shard-level metric it enables.

### Motivation

  * This PR adds a feature that has not yet been specified.


### Tips for reviewer

Proto change is backward compatible. ProtoHollowBatches written before this will just get a zero size.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
