### PR TITLE
storage: calculate resume_upper in storaged

### DIFF
--- a/src/storage/src/protocol/client.proto
+++ b/src/storage/src/protocol/client.proto
@@ -35,7 +35,8 @@ message ProtoAllowCompaction {
 message ProtoIngestSourceCommand {
     mz_repr.global_id.ProtoGlobalId id = 1;
     mz_storage.types.sources.ProtoIngestionDescription description = 2;
-    mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
+    // deprecated
+    // mz_persist.gen.persist.ProtoU64Antichain resume_upper = 3;
 }
 
 message ProtoIngestSources {

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -103,7 +103,7 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
     /// initial state.
     InitializationComplete,
     /// Create the enumerated sources, each associated with its identifier.
-    IngestSources(Vec<IngestSourceCommand<T>>),
+    IngestSources(Vec<IngestSourceCommand>),
     /// Enable compaction in storage-managed collections.
     ///
     /// Each entry in the vector names a collection and provides a frontier after which
@@ -114,17 +114,15 @@ pub enum StorageCommand<T = mz_repr::Timestamp> {
 
 /// A command that starts ingesting the given ingestion description
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct IngestSourceCommand<T> {
+pub struct IngestSourceCommand {
     /// The id of the storage collection being ingested.
     pub id: GlobalId,
     /// The description of what source type should be ingested and what post-processing steps must
     /// be applied to the data before writing them down into the storage collection
     pub description: IngestionDescription<CollectionMetadata>,
-    /// The upper frontier that this ingestion should resume at
-    pub resume_upper: Antichain<T>,
 }
 
-impl Arbitrary for IngestSourceCommand<mz_repr::Timestamp> {
+impl Arbitrary for IngestSourceCommand {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
 
@@ -132,23 +130,17 @@ impl Arbitrary for IngestSourceCommand<mz_repr::Timestamp> {
         (
             any::<GlobalId>(),
             any::<IngestionDescription<CollectionMetadata>>(),
-            proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..4).prop_map(Antichain::from),
         )
-            .prop_map(|(id, description, resume_upper)| Self {
-                id,
-                description,
-                resume_upper,
-            })
+            .prop_map(|(id, description)| Self { id, description })
             .boxed()
     }
 }
 
-impl RustType<ProtoIngestSourceCommand> for IngestSourceCommand<mz_repr::Timestamp> {
+impl RustType<ProtoIngestSourceCommand> for IngestSourceCommand {
     fn into_proto(&self) -> ProtoIngestSourceCommand {
         ProtoIngestSourceCommand {
             id: Some(self.id.into_proto()),
             description: Some(self.description.into_proto()),
-            resume_upper: Some((&self.resume_upper).into()),
         }
     }
 
@@ -158,9 +150,6 @@ impl RustType<ProtoIngestSourceCommand> for IngestSourceCommand<mz_repr::Timesta
             description: proto
                 .description
                 .into_rust_if_some("ProtoIngestSourceCommand::description")?,
-            resume_upper: proto.resume_upper.map(Into::into).ok_or_else(|| {
-                TryFromProtoError::missing_field("ProtoIngestSourceCommand::resume_upper")
-            })?,
         })
     }
 }
@@ -251,7 +240,7 @@ impl Arbitrary for StorageCommand<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         prop_oneof![
-            proptest::collection::vec(any::<IngestSourceCommand<mz_repr::Timestamp>>(), 1..4)
+            proptest::collection::vec(any::<IngestSourceCommand>(), 1..4)
                 .prop_map(StorageCommand::IngestSources),
             proptest::collection::vec(any::<ExportSinkCommand<mz_repr::Timestamp>>(), 1..4)
                 .prop_map(StorageCommand::ExportSinks),

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -181,12 +181,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
                     // TODO(guswynn&&petrosagg): remove all uses of `block_on` in
                     // timely workers
-                    let resume_upper = TokioHandle::current().block_on(
+                    println!("HERE");
+                    let resume_upper = dbg!(TokioHandle::current().block_on(
                         ingestion.description.storage_metadata.get_resume_upper(
                             &self.storage_state.persist_clients,
                             &ingestion.description.desc.envelope,
                         ),
-                    );
+                    ));
+                    println!("AFTER");
 
                     crate::render::build_ingestion_dataflow(
                         &mut self.timely_worker,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -189,6 +189,10 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         ),
                     ));
                     println!("AFTER");
+                    self.timely_worker.step();
+                    self.timely_worker.step();
+                    self.timely_worker.step();
+                    println!("STEPPED");
 
                     crate::render::build_ingestion_dataflow(
                         &mut self.timely_worker,

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -13,28 +13,22 @@ use std::collections::{BTreeMap, HashMap};
 use std::num::TryFromIntError;
 use std::ops::{Add, AddAssign, Deref, DerefMut};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
 use bytes::BufMut;
-use differential_dataflow::lattice::Lattice;
 use globset::{Glob, GlobBuilder};
-use mz_expr::PartitionId;
 use mz_ore::now::NowFn;
-use mz_persist_client::cache::PersistClientCache;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use timely::progress::Antichain;
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use mz_persist_types::{Codec, Codec64};
+use mz_persist_types::Codec;
 use mz_proto::{any_uuid, TryFromProtoError};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType};
-use mz_repr::{ColumnType, Diff, GlobalId, RelationDesc, RelationType, Row, ScalarType};
+use mz_repr::{ColumnType, GlobalId, RelationDesc, RelationType, Row, ScalarType};
 
 use crate::controller::CollectionMetadata;
 use crate::types::connections::aws::AwsConfig;
@@ -82,51 +76,6 @@ where
                 typ,
             })
             .boxed()
-    }
-}
-
-impl IngestionDescription<CollectionMetadata> {
-    pub async fn get_resume_upper<T>(&self, persist: Arc<Mutex<PersistClientCache>>) -> Antichain<T>
-    where
-        T: timely::progress::Timestamp + Lattice + Codec64,
-    {
-        let persist = persist
-            .lock()
-            .await
-            .open(self.storage_metadata.persist_location.clone())
-            .await
-            .unwrap();
-        // Calculate the point at which we can resume ingestion computing the greatest
-        // antichain that is less or equal to all state and output shard uppers.
-        let mut resume_upper: Antichain<T> = Antichain::new();
-        let remap_write = persist
-            .open_writer::<(), PartitionId, T, MzOffset>(self.storage_metadata.remap_shard)
-            .await
-            .unwrap();
-        for t in remap_write.upper().elements() {
-            resume_upper.insert(t.clone());
-        }
-        let data_write = persist
-            .open_writer::<SourceData, (), T, Diff>(self.storage_metadata.data_shard)
-            .await
-            .unwrap();
-        for t in data_write.upper().elements() {
-            resume_upper.insert(t.clone());
-        }
-
-        // Check if this ingestion is using any operators that are stateful AND are not
-        // storing their state in persist shards. This whole section should be eventually
-        // removed as we make each operator durably record its state in persist shards.
-        let resume_upper = match self.desc.envelope {
-            // We can only resume with the None envelope, which is stateless,
-            // or with the [Debezium] Upsert envelope, which is easy
-            //   (re-ingest the last emitted state)
-            SourceEnvelope::None(_) => resume_upper,
-            SourceEnvelope::Upsert(_) => resume_upper,
-            // Otherwise re-ingest everything
-            _ => Antichain::from_elem(T::minimum()),
-        };
-        resume_upper
     }
 }
 

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -264,11 +264,13 @@ def workflow_test_remote_storaged(c: Composition) -> None:
         c.kill("storaged")
         c.run("testdrive", "storaged/03-while-storaged-down.td")
 
-        print("Sleeping for 20 seconds")
-        time.sleep(20)
-
-        c.up("storaged")
-        c.run("testdrive", "storaged/04-after-storaged-restart.td")
+        with c.override(
+            Storaged(
+                environment=["GUS=1"]
+            )
+        ):
+            c.up("storaged")
+            c.run("testdrive", "storaged/04-after-storaged-restart.td")
 
 
 def workflow_test_drop_default_cluster(c: Composition) -> None:

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -191,18 +191,28 @@ def workflow_test_github_12251(c: Composition) -> None:
     c.sql("SELECT * FROM log_table;")
 
 
-def workflow_test_upsert(c: Composition) -> None:
+def workflow_test_upsert(c: Composition, parser: WorkflowArgumentParser) -> None:
     """Test creating upsert sources and continuing to ingest them after a restart."""
+
+    parser.add_argument(
+        "--redpanda",
+        action="store_true",
+        help="run against Redpanda instead of the Confluent Platform",
+    )
+    args = parser.parse_args()
     with c.override(
         Testdrive(default_timeout="30s", no_reset=True, consistent_seed=True),
     ):
         c.down(destroy_volumes=True)
-        dependencies = [
-            "materialized",
-            "zookeeper",
-            "kafka",
-            "schema-registry",
-        ]
+        if args.redpanda:
+            dependencies = ["materialized", "redpanda"]
+        else:
+            dependencies = [
+                "materialized",
+                "zookeeper",
+                "kafka",
+                "schema-registry",
+            ]
         c.start_and_wait_for_tcp(
             services=dependencies,
         )

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -249,9 +249,7 @@ def workflow_test_remote_storaged(c: Composition) -> None:
             "materialized",
             "postgres",
             "storaged",
-            "zookeeper",
-            "kafka",
-            "schema-registry",
+            "redpanda",
         ]
         c.start_and_wait_for_tcp(
             services=dependencies,
@@ -265,6 +263,9 @@ def workflow_test_remote_storaged(c: Composition) -> None:
 
         c.kill("storaged")
         c.run("testdrive", "storaged/03-while-storaged-down.td")
+
+        print("Sleeping for 20 seconds")
+        time.sleep(20)
 
         c.up("storaged")
         c.run("testdrive", "storaged/04-after-storaged-restart.td")


### PR DESCRIPTION
This is the first part of "Bounded Input Reliance": https://github.com/MaterializeInc/materialize/pull/14314

We are no longer going to be worrying about the `resume_upper` in the controller; instead, we calculate it once to start sources, and in the future, will regularly calculate changes to _resumption_frontier_'s (and converted to _commit upstream frontier_'s. This pr is the first step of that entire process

Some consequences of this are:
- there is only one last usage of persist in the storage controller; this pr removes one that can take time from the coordinator
- we have to use `block_on` in the common-path (we use it in some CSR cases now) for source rendering. I don't really know a good way around this

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
  - [ ] it deprecates a field 
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
