### PR TITLE
environmentd: bump pgtest timeout more

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -466,7 +466,7 @@ fn pg_test_inner(dir: PathBuf) -> Result<(), Box<dyn Error>> {
             _ => panic!("only tcp connections supported"),
         };
         let user = config.get_user().unwrap();
-        let timeout = Duration::from_secs(30);
+        let timeout = Duration::from_secs(60);
 
         mz_pgtest::run_test(tf, addr, user.to_string(), timeout);
     });


### PR DESCRIPTION
This is to test the hypothesis that 14384 just needs a larger timeout?
Seems excessive but maybe.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug. Maybe #14384
 
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a