### PR TITLE
Don't generate empty literal_constraints in Arbitrary Peek

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -839,7 +839,9 @@ impl RustType<ProtoIndexDesc> for IndexDesc {
 pub struct Peek<T = mz_repr::Timestamp> {
     /// The identifier of the arrangement.
     pub id: GlobalId,
-    /// An optional key that should be used for the arrangement.
+    /// If `Some`, then look up only the given keys from the arrangement (instead of a full scan).
+    /// The vector is never empty.
+    #[proptest(strategy = "proptest::option::of(proptest::collection::vec(any::<Row>(), 1..5))")]
     pub literal_constraints: Option<Vec<Row>>,
     /// The identifier of this peek request.
     ///


### PR DESCRIPTION
I accidentally made the `peek_protobuf_roundtrip` test flaky with https://github.com/MaterializeInc/materialize/pull/14403, because of empty `literal_constraints` vectors, which blow up the test because of an assert in `into_proto`. This PR corrects this by avoiding the generation of empty vectors in `Arbitrary`. (And also updates the comment on the field.)

### Motivation

  * This PR fixes a previously unreported bug: flaky `protobuf_roundtrip` test for `Peek`, see above.

### Tips for reviewer

Note: Since the vector is always non-empty, the `Option<Vec<Row>>` could just be a `Vec<Row>`. However, I think having the `Option` is semantically more clear: `None` means that we do a full scan, while `Some(keys)` means that we look up only the given keys in the arrangement. Without the `Option`, we would have to interpret an empty vector as a full scan. The `Option` makes the full scan vs. lookups choice more cleanly separated.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - Ran `peek_protobuf_roundtrip` 10 times, and it didn't fail, so the flake has disappeared.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
