### PR TITLE
Decompose `record_create(...) = record_create(...)`

### DIFF
--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -344,10 +344,32 @@ WHERE a+a IN (2, 6)
 2
 6
 
-# In the following query, we would be able to detect literal constraints if we called `canonicalize_equivalences`
-
 statement ok
 CREATE INDEX idx_t2_a ON t2(a);
+
+# Only some of the fields are literals in an IN list. This exercises the
+# `record_create(a1, a2, ...) = record_create(b1, b2, ...)` case in `MirScalarExpr::reduce()`
+
+query T multiline
+EXPLAIN SELECT * FROM t2
+WHERE (a,b) IN ((1, 4*a), (2, 5*a), (3, a+20))
+----
+%0 =
+| ReadExistingIndex materialize.public.idx_t2_a
+| | Lookup values [(1); (2); (3)]
+| Filter (((#0 = 1) AND (#1 = (4 * #0))) OR ((#0 = 2) AND (#1 = (5 * #0))) OR ((#0 = 3) AND (#1 = (#0 + 20))))
+| Project (#0..=#2)
+
+EOF
+
+query III rowsort
+SELECT * FROM t2
+WHERE (a,b) IN ((1, 4*a), (2, 5*a), (3, a+20))
+----
+1  4  7
+3  23  33
+
+# In the following query, we would be able to detect literal constraints if we called `canonicalize_equivalences`
 
 query T multiline
 EXPLAIN SELECT a, b, c FROM t2 WHERE a IN (a + b, a + c, 1 + 5) AND a + b = 5 AND a + c = 4;


### PR DESCRIPTION
```
record_create(a1, a2, ...) = record_create(b1, b2, ...)
 -->
a1 = b1 AND a2 = b2 AND ...
```

This is similar to https://github.com/MaterializeInc/materialize/pull/14258, but we have `record_create` on both sides. This enables the extraction of literal constraints from such IN lists where only some of the fields are literals.

### Motivation

  * This PR adds a feature that has not yet been specified. This is a minor addition to https://github.com/MaterializeInc/materialize/issues/13151

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Minor change in handling IN lists: when we have `(a,b) IN ((1, 4*a), (2, 5*a))` (i.e., only `a`'s constraints are literals) we can do index lookups for `a`. We'll document this and other recent IN stuff in (or as a follow-up to) https://github.com/MaterializeInc/materialize/pull/13127 
