### PR TITLE
deps: switch from `sha-1` to `sha1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,7 +3307,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "sha-1",
+ "sha1",
  "sha2",
  "uncased",
  "uuid",

--- a/deny.toml
+++ b/deny.toml
@@ -1,14 +1,32 @@
 [bans]
 multiple-versions = "deny"
 # Do not add exemptions for duplicate dependencies! Duplicate dependencies slow
-# down compilation and bloat the binary. Submit PRs upstream to remove
-# duplicated transitive dependencies. If necessary, use patch directives in the
-# root Cargo.toml to point at a Materialize-maintained fork that avoids the
+# down compilation, bloat the binary, and tickle race conditions in `cargo doc`
+# (see rust-lang/cargo#3613). Submit PRs upstream to remove duplicated
+# transitive dependencies. If necessary, use patch directives in the root
+# Cargo.toml to point at a Materialize-maintained fork that avoids the
 # duplicated transitive dependencies.
 
 # Use `tracing` instead.
 [[bans.deny]]
 name = "env_logger"
+
+# Use `md-5` instead, which is part of the RustCrypto ecosystem.
+[[bans.deny]]
+name = "md5"
+
+# Use `sha1` instead, which the RustCrypto ecosystem recently took control of.
+# `sha-1` is the older and now deprecated name.
+[[bans.deny]]
+name = "sha-1"
+wrappers = [
+    # https://github.com/hyperium/headers/pull/117
+    "headers",
+    # https://github.com/blackbeam/rust_mysql_common/pull/71
+    "mysql_common",
+    # https://github.com/snapview/tungstenite-rs/pull/299
+    "tungstenite",
+]
 
 # Use `prost` or `protobuf-native` instead.
 [[bans.deny]]

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -42,7 +42,7 @@ regex-syntax = "0.6.27"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.82"
 serde_regex = "1.1.0"
-sha-1 = "0.10.0"
+sha1 = "0.10.0"
 sha2 = "0.10.2"
 uncased = "0.9.7"
 uuid = "1.1.2"


### PR DESCRIPTION
The RustCrypto project recently got control of the crate name `sha1`.
This commit switches over to the new name; the old `sha-1` name is now
deprecated.

Details: https://github.com/RustCrypto/hashes/pull/350

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR works towards fixing a recognized bug: #14480.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
