### PR TITLE
zippy: Increase the timeout for the UserTables scenario

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -251,7 +251,7 @@ steps:
 
   - id: zippy-user-tables
     label: "Zippy User Tables"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     agents:
       queue: linux-x86_64
     plugins:


### PR DESCRIPTION
A recent performance regression has caused the test to time out
after 120 minutes. Adjust the timeout to 180 minutes.

### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI was failing