### PR TITLE
limits test: Fix syntax errors

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -223,7 +223,6 @@ class KafkaPartitions(Generator):
         print(
             """> CREATE SOURCE s1
             FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-kafka-partitions-${testdrive.seed}'
-            WITH (topic_metadata_refresh_interval_ms = 1000)
             FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.schema-registry-url}'
             ENVELOPE NONE;
             """
@@ -376,11 +375,14 @@ class KafkaSinks(Generator):
             print(f"> CREATE MATERIALIZED VIEW v{i} (f1) AS VALUES ({i})")
         for i in cls.all():
             print(
-                f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
-              > CREATE SINK s{i} FROM v{i}
-              INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-sink-same-source-{i}'
-              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}';
-        """
+                dedent(
+                    f"""
+                     > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
+                     > CREATE SINK s{i} FROM v{i}
+                       INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-sink-same-source-{i}'
+                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}';
+                     """
+                )
             )
 
         for i in cls.all():
@@ -403,11 +405,14 @@ class KafkaSinksSameSource(Generator):
         print("> CREATE MATERIALIZED VIEW v1 (f1) AS VALUES (123)")
         for i in cls.all():
             print(
-                f"""> CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
-              > CREATE SINK s{i} FROM v1
-              INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-sink-same-source-{i}'
-              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}';
-        """
+                dedent(
+                    f"""
+                     > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
+                     > CREATE SINK s{i} FROM v1
+                       INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-sink-same-source-{i}'
+                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${{testdrive.schema-registry-url}}';
+                     """
+                )
             )
 
         for i in cls.all():


### PR DESCRIPTION

    limits test: Fix failures due to changed syntax
    
    - Remove the use of topic_metadata_refresh_interval_ms. The syntax
      used to set the option is no longer valid and the option was ignored anyway.
    
    - Properly generate a testdrive-compatible CREATE CONNECTION statements.


### Motivation

  * This PR fixes a previously unreported bug.
Nightly CI Limits was failing