### PR TITLE
Use timely fabric to forward ComputeCommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,7 @@ dependencies = [
  "mz-secrets",
  "once_cell",
  "semver",
+ "timely",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -30,7 +30,7 @@ use mz_repr::{Diff, GlobalId, Row};
 use mz_service::client::{GenericClient, Partitionable, PartitionedState};
 use mz_service::grpc::{BidiProtoClient, ClientTransport, GrpcClient, GrpcServer, ResponseStream};
 
-use crate::command::{BuildDesc, ComputeCommand, DataflowDescription, ProtoComputeCommand};
+use crate::command::{ComputeCommand, ProtoComputeCommand};
 use crate::response::{
     ComputeResponse, PeekResponse, ProtoComputeResponse, TailBatch, TailResponse,
 };
@@ -179,51 +179,11 @@ impl<T> PartitionedState<ComputeCommand<T>, ComputeResponse<T>> for PartitionedC
 where
     T: timely::progress::Timestamp + Lattice,
 {
-    fn split_command(&mut self, command: ComputeCommand<T>) -> Vec<ComputeCommand<T>> {
+    fn split_command(&mut self, command: ComputeCommand<T>) -> Vec<Option<ComputeCommand<T>>> {
         self.observe_command(&command);
-
-        match command {
-            ComputeCommand::CreateDataflows(dataflows) => {
-                let mut dataflows_parts = vec![Vec::new(); self.parts];
-
-                for dataflow in dataflows {
-                    // A list of descriptions of objects for each part to build.
-                    let mut builds_parts = vec![Vec::new(); self.parts];
-                    // Partition each build description among `parts`.
-                    for build_desc in dataflow.objects_to_build {
-                        let build_part = build_desc.plan.partition_among(self.parts);
-                        for (plan, objects_to_build) in
-                            build_part.into_iter().zip(builds_parts.iter_mut())
-                        {
-                            objects_to_build.push(BuildDesc {
-                                id: build_desc.id,
-                                plan,
-                            });
-                        }
-                    }
-                    // Each list of build descriptions results in a dataflow description.
-                    for (dataflows_part, objects_to_build) in
-                        dataflows_parts.iter_mut().zip(builds_parts)
-                    {
-                        dataflows_part.push(DataflowDescription {
-                            source_imports: dataflow.source_imports.clone(),
-                            index_imports: dataflow.index_imports.clone(),
-                            objects_to_build,
-                            index_exports: dataflow.index_exports.clone(),
-                            sink_exports: dataflow.sink_exports.clone(),
-                            as_of: dataflow.as_of.clone(),
-                            until: dataflow.until.clone(),
-                            debug_name: dataflow.debug_name.clone(),
-                        });
-                    }
-                }
-                dataflows_parts
-                    .into_iter()
-                    .map(ComputeCommand::CreateDataflows)
-                    .collect()
-            }
-            command => vec![command; self.parts],
-        }
+        let mut r = vec![None; self.parts];
+        r[0] = Some(command);
+        r
     }
 
     fn absorb_response(

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -82,7 +82,6 @@ pub fn serve(
     let client_rxs: Mutex<Vec<_>> = Mutex::new(client_rxs.into_iter().map(Some).collect());
 
     let tokio_executor = tokio::runtime::Handle::current();
-    let has_networked_workers = config.comm_config.addresses.len() > 1;
 
     let (builders, other) =
         initialize_networking(config.comm_config).map_err(|e| anyhow!("{e}"))?;
@@ -111,7 +110,6 @@ pub fn serve(
                 compute_state: None,
                 trace_metrics: trace_metrics.clone(),
                 persist_clients,
-                has_networked_workers,
             }
             .run()
         },
@@ -166,8 +164,6 @@ struct Worker<'w, A: Allocate> {
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
     persist_clients: Arc<tokio::sync::Mutex<PersistClientCache>>,
-    /// Indicates if the timely instance has workers connected via network
-    has_networked_workers: bool,
 }
 
 impl<'w, A: Allocate> Worker<'w, A> {
@@ -332,10 +328,6 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 command => new_commands.push(command),
             }
         }
-
-        if self.compute_state.is_some() && self.has_networked_workers {
-            panic!("Reconciliation is supported only in process local timely instances");
-        };
 
         // Commands we will need to apply before entering normal service.
         // These commands may include dropping existing dataflows, compacting existing dataflows,

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -382,23 +382,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 compute_state.traces.maintenance();
             }
 
-            // Ask Timely to execute a unit of work.
-            //
-            // If there are no pending commands, we ask Timely to park the
-            // thread if there's nothing to do. We rely on another thread
-            // unparking us when there's new work to be done, e.g., when sending
-            // a command or when new Kafka messages have arrived.
-            //
-            // It is critical that we allow Timely to park iff there are no
-            // pending commands. The unpark token associated with any pending
-            // commands may have already been consumed by the call to
-            // `client_rx.recv`. For details, see:
-            // https://github.com/MaterializeInc/materialize/pull/13973#issuecomment-1200312212
-            if command_rx.is_empty() {
-                self.timely_worker.step_or_park(None);
-            } else {
-                self.timely_worker.step();
-            }
+            self.timely_worker.step_or_park(None);
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -21,6 +21,7 @@ mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-orchestrator-kubernetes = { path = "../orchestrator-kubernetes" }
 once_cell = "1.13.1"
 semver = "1.0.13"
+timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = "1.19.2"
 tokio-stream = "0.1.9"
 tonic = "0.8.0"

--- a/src/service/src/client.rs
+++ b/src/service/src/client.rs
@@ -125,7 +125,9 @@ where
     async fn send(&mut self, cmd: C) -> Result<(), anyhow::Error> {
         let cmd_parts = self.state.split_command(cmd);
         for (shard, cmd_part) in self.parts.iter_mut().zip(cmd_parts) {
-            shard.send(cmd_part).await?;
+            if let Some(cmd) = cmd_part {
+                shard.send(cmd).await?;
+            }
         }
         Ok(())
     }
@@ -168,7 +170,7 @@ pub trait Partitionable<C, R> {
 /// amalgamates responses from multiple partitions.
 pub trait PartitionedState<C, R>: fmt::Debug + Send {
     /// Splits a command into multiple partitions.
-    fn split_command(&mut self, command: C) -> Vec<C>;
+    fn split_command(&mut self, command: C) -> Vec<Option<C>>;
 
     /// Absorbs a response from a single partition.
     ///

--- a/src/service/src/local.rs
+++ b/src/service/src/local.rs
@@ -15,32 +15,52 @@ use std::thread::Thread;
 use async_trait::async_trait;
 use crossbeam_channel::Sender;
 use itertools::Itertools;
+use timely::scheduling::SyncActivator;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::client::{GenericClient, Partitionable, Partitioned};
+
+pub trait Activatable {
+    fn activate(&self);
+}
+
+impl Activatable for SyncActivator {
+    fn activate(&self) {
+        self.activate().unwrap()
+    }
+}
+
+impl Activatable for Thread {
+    fn activate(&self) {
+        self.unpark()
+    }
+}
 
 /// A client to a thread in the same process.
 ///
 /// The thread is unparked on every call to [`send`](LocalClient::send) and on
 /// `Drop`.
 #[derive(Debug)]
-pub struct LocalClient<C, R> {
+pub struct LocalClient<C, R, A: Activatable> {
     rx: UnboundedReceiver<R>,
     tx: Sender<C>,
-    thread: Thread,
+    tx_activator: A,
 }
 
 #[async_trait]
-impl<C, R> GenericClient<C, R> for LocalClient<C, R>
+impl<C, R, A> GenericClient<C, R> for LocalClient<C, R, A>
 where
     C: fmt::Debug + Send,
     R: fmt::Debug + Send,
+    A: fmt::Debug + Activatable + Send,
 {
     async fn send(&mut self, cmd: C) -> Result<(), anyhow::Error> {
         self.tx
             .send(cmd)
             .expect("worker command receiver should not drop first");
-        self.thread.unpark();
+
+        self.tx_activator.activate();
+
         Ok(())
     }
 
@@ -49,17 +69,21 @@ where
     }
 }
 
-impl<C, R> LocalClient<C, R> {
+impl<C, R, A: Activatable> LocalClient<C, R, A> {
     /// Create a new instance of [`LocalClient`] from its parts.
-    pub fn new(rx: UnboundedReceiver<R>, tx: Sender<C>, thread: Thread) -> Self {
-        Self { rx, tx, thread }
+    pub fn new(rx: UnboundedReceiver<R>, tx: Sender<C>, tx_activator: A) -> Self {
+        Self {
+            rx,
+            tx,
+            tx_activator,
+        }
     }
 
     /// Create a new partitioned local client from parts for each client.
     pub fn new_partitioned(
         rxs: Vec<UnboundedReceiver<R>>,
         txs: Vec<Sender<C>>,
-        threads: Vec<Thread>,
+        tx_activators: Vec<A>,
     ) -> Partitioned<Self, C, R>
     where
         (C, R): Partitionable<C, R>,
@@ -67,8 +91,8 @@ impl<C, R> LocalClient<C, R> {
         let clients = rxs
             .into_iter()
             .zip_eq(txs)
-            .zip_eq(threads)
-            .map(|((rx, tx), thread)| LocalClient::new(rx, tx, thread))
+            .zip_eq(tx_activators)
+            .map(|((rx, tx), tx_activator)| LocalClient::new(rx, tx, tx_activator))
             .collect();
         Partitioned::new(clients)
     }
@@ -76,13 +100,13 @@ impl<C, R> LocalClient<C, R> {
 
 // We implement `Drop` so that we can wake each of the threads and have them
 // notice the drop.
-impl<C, R> Drop for LocalClient<C, R> {
+impl<C, R, A: Activatable> Drop for LocalClient<C, R, A> {
     fn drop(&mut self) {
         // Drop the thread handle.
         let (tx, _rx) = crossbeam_channel::unbounded();
         self.tx = tx;
         // Unpark the thread once the handle is dropped, so that it can observe
         // the emptiness.
-        self.thread.unpark();
+        self.tx_activator.activate();
     }
 }

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -383,10 +383,10 @@ impl<T> PartitionedState<StorageCommand<T>, StorageResponse<T>> for PartitionedS
 where
     T: timely::progress::Timestamp + Lattice,
 {
-    fn split_command(&mut self, command: StorageCommand<T>) -> Vec<StorageCommand<T>> {
+    fn split_command(&mut self, command: StorageCommand<T>) -> Vec<Option<StorageCommand<T>>> {
         self.observe_command(&command);
 
-        vec![command; self.parts]
+        vec![Some(command); self.parts]
     }
 
     fn absorb_response(


### PR DESCRIPTION
This PR implements option 2) of #13603 : Environmentd sends command only to the first process, which then uses timely internally to disseminate the command. Responses are still sent over the network from each process.

Fixes #13603

### Motivation


  * This PR fixes a recognized bug.


### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None
