### PR TITLE
nix: add a flake.nix with a devshell that delegates to shell.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,9 @@ junit_*.xml
 perf.data*
 **/*.rej
 **/*.orig
+
+# This is un-orthodox, but adding it to the repo would "tie" it to each users
+# local version of nixpkgs. This way, we can all use the flake and have a
+# flake.lock that works well with the rest of the package versions on our
+# system.
+**/flake.lock

--- a/misc/nix/flake.nix
+++ b/misc/nix/flake.nix
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+{
+  description = "Devshell for materialize that delegates to the legacy shell.nix";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      rec {
+        # we pass `pkgs` directly to shell.nix
+        devShell = import ./shell.nix { inherit pkgs; };
+      }
+    );
+}

--- a/misc/nix/shell.nix
+++ b/misc/nix/shell.nix
@@ -7,7 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-with import <nixpkgs> {};
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 
 let
     target-analyzer = builtins.toString ./../../.rust-analyzer/target;
@@ -18,13 +19,13 @@ in
 stdenv.mkDerivation rec {
   name = "materialize";
   buildInputs = with pkgs; [
-      clang_13
+      clang_14
       cmake
       rustup
       openssl
       postgresql
       pkg-config
-      lld_13
+      lld_14
       python39
       scoped-rust-analyzer
   ];


### PR DESCRIPTION
### Motivation

Makes it more useful for Nix users with a flake-ified setup.

### Tips for reviewer

See comment in `.gitignore`. Also, for some reason I can't get git to actually ignore the file.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
