### PR TITLE
Update Timely dependency to 330f15f8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6212,7 +6212,7 @@ checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 [[package]]
 name = "timely"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#1f3a315354ce6d41185a8f26c8a71e883adc1ef9"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#330f15f84e4420c90468ff141ceb9edd5f58d1b8"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -6230,12 +6230,12 @@ dependencies = [
 [[package]]
 name = "timely_bytes"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#1f3a315354ce6d41185a8f26c8a71e883adc1ef9"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#330f15f84e4420c90468ff141ceb9edd5f58d1b8"
 
 [[package]]
 name = "timely_communication"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#1f3a315354ce6d41185a8f26c8a71e883adc1ef9"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#330f15f84e4420c90468ff141ceb9edd5f58d1b8"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -6251,7 +6251,7 @@ dependencies = [
 [[package]]
 name = "timely_container"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#1f3a315354ce6d41185a8f26c8a71e883adc1ef9"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#330f15f84e4420c90468ff141ceb9edd5f58d1b8"
 dependencies = [
  "columnation",
  "serde",
@@ -6260,7 +6260,7 @@ dependencies = [
 [[package]]
 name = "timely_logging"
 version = "0.12.0"
-source = "git+https://github.com/TimelyDataflow/timely-dataflow#1f3a315354ce6d41185a8f26c8a71e883adc1ef9"
+source = "git+https://github.com/TimelyDataflow/timely-dataflow#330f15f84e4420c90468ff141ceb9edd5f58d1b8"
 
 [[package]]
 name = "tinytemplate"


### PR DESCRIPTION
### Motivation

Update the dependency on Timely to https://github.com/TimelyDataflow/timely-dataflow/commit/330f15f84e4420c90468ff141ceb9edd5f58d1b8

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
