### PR TITLE
compute,storage: disable spurious tonic recompiles

### DIFF
--- a/src/compute-client/build.rs
+++ b/src/compute-client/build.rs
@@ -13,6 +13,12 @@ fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
     tonic_build::configure()
+        // Enabling `emit_rerun_if_changed` will rerun the build script when
+        // anything in the include directory (..) changes. This causes quite a
+        // bit of spurious recompilation, so we disable it. The default behavior
+        // is to re-run if any file in the crate changes; that's still a bit too
+        // broad, but it's better.
+        .emit_rerun_if_changed(false)
         .extern_path(".mz_ccsr.config", "::mz_ccsr")
         .extern_path(".mz_expr.id", "::mz_expr")
         .extern_path(".mz_expr.linear", "::mz_expr")

--- a/src/postgres-util/build.rs
+++ b/src/postgres-util/build.rs
@@ -13,6 +13,12 @@ fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
     tonic_build::configure()
+        // Enabling `emit_rerun_if_changed` will rerun the build script when
+        // anything in the include directory (..) changes. This causes quite a
+        // bit of spurious recompilation, so we disable it. The default behavior
+        // is to re-run if any file in the crate changes; that's still a bit too
+        // broad, but it's better.
+        .emit_rerun_if_changed(false)
         .compile(&["postgres-util/src/desc.proto"], &[".."])
         .unwrap();
 }

--- a/src/storage/build.rs
+++ b/src/storage/build.rs
@@ -13,6 +13,12 @@ fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
     tonic_build::configure()
+        // Enabling `emit_rerun_if_changed` will rerun the build script when
+        // anything in the include directory (..) changes. This causes quite a
+        // bit of spurious recompilation, so we disable it. The default behavior
+        // is to re-run if any file in the crate changes; that's still a bit too
+        // broad, but it's better.
+        .emit_rerun_if_changed(false)
         .extern_path(".mz_ccsr.config", "::mz_ccsr")
         .extern_path(".mz_expr.id", "::mz_expr")
         .extern_path(".mz_expr.linear", "::mz_expr")


### PR DESCRIPTION
tonic-build v0.8 will emit Cargo rerun-if-changed directives that are
actively unhelpful: because we use `..` as the Protobuf include path, we
end up recompiling if any file in `src` changes.

This commit restores the behavior of tonic-build v0.7, where the build
script for a crate is rerun only if the files inside of that crate
change.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Tips for reviewer

I didn't test this myself. @lluki, @antiguru—can you verify that this fixes the issue you were seeing?

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
