### PR TITLE
adapter: Require unsafe mode for all index opts

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3543,6 +3543,11 @@ fn plan_index_options(
     scx: &StatementContext,
     with_opts: Vec<IndexOption<Aug>>,
 ) -> Result<Vec<crate::plan::IndexOption>, PlanError> {
+    if !with_opts.is_empty() {
+        // Index options are not durable.
+        scx.require_unsafe_mode("INDEX OPTIONS")?;
+    }
+
     let IndexOptionExtracted {
         logical_compaction_window,
         ..


### PR DESCRIPTION
Index options are not made durable anywhere, which means they are
potentially lost or reset whenever Materialize restarts. Currently
Materialize only has a single index option, which is gated by unsafe
mode and likely to be removed in the future. This commit gates all
index options by unsafe mode, to protect against adding new options in
the future without making them durable.

Works towards resolving #13305

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
