### PR TITLE
persist: use columnar format for ProtoStateFieldDiffs

### DIFF
--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -65,17 +65,39 @@ message ProtoStateRollup {
     map<string, ProtoWriterState> writers = 9;
 }
 
+enum ProtoStateField {
+    ROLLUPS = 0;
+    LAST_GC_REQ = 1;
+    READERS = 2;
+    WRITERS = 3;
+    SINCE = 4;
+    SPINE = 5;
+}
+
 enum ProtoStateFieldDiffType {
     INSERT = 0;
     UPDATE = 1;
     DELETE = 2;
 }
 
-message ProtoStateFieldDiff {
-    bytes key = 1;
-    ProtoStateFieldDiffType diff_type = 2;
-    bytes from = 3;
-    bytes to = 4;
+// A columnar encoding of Vec<StateFieldDiff<K, V>> with heterogeneous K and V.
+//
+// - The number of diffs (len) == fields.len() == diff_types.len()
+// - Each diff is encoded into 1 data slice for the key and 1 (Insert, Delete)
+//   or 2 (Update) data slices for the val
+// - These data slices are concatenated together in data_bytes and the
+//   corresponding lengths of each slice in data_lens. (So number of data slices
+//   == data_lens.len().)
+// - We store the length of each data_slice, not e.g. an offset into data_bytes.
+//   This makes random access slower, but we only ever iterate (random access by
+//   diff idx would be tricky anyway because each diff gets a variable number of
+//   data slices based on it's type.) Storing the lengths, OTOH, compresses much
+//   better with protobuf varints.
+message ProtoStateFieldDiffs {
+    repeated ProtoStateField fields = 1;
+    repeated ProtoStateFieldDiffType diff_types = 2;
+    repeated uint64 data_lens = 3;
+    bytes data_bytes = 4;
 }
 
 message ProtoStateDiff {
@@ -85,13 +107,7 @@ message ProtoStateDiff {
     uint64 seqno_to = 3;
     string latest_rollup_key = 4;
 
-    // TODO: columnar encoding of these just in case?
-    repeated ProtoStateFieldDiff rollups = 5;
-    repeated ProtoStateFieldDiff last_gc_req = 6;
-    repeated ProtoStateFieldDiff readers = 7;
-    repeated ProtoStateFieldDiff writers = 8;
-    repeated ProtoStateFieldDiff since = 9;
-    repeated ProtoStateFieldDiff spine = 10;
+    ProtoStateFieldDiffs field_diffs = 5;
 }
 
 message ProtoLeasedBatchMetadata {


### PR DESCRIPTION
We don't have a concrete reason to expect a large number of diffs to be
stored, but columnar-izing this is self-contained, relatively
straightforward, and insulates us against lots of short lived allocs in
proto decoding if it does happen.

- The number of diffs (len) == fields.len() == diff_types.len()
- Each diff is encoded into 1 data slice for the key and 1 (Insert,
  Delete) or 2 (Update) data slices for the val
- These data slices are concatenated together in data_bytes and the
  corresponding lengths of each slice in data_lens. (So number of data
  slices == data_lens.len().)
- We store the length of each data_slice, not e.g. an offset into
  data_bytes. This makes random access slower, but we only ever iterate
  (random access by diff idx would be tricky anyway because each diff
  gets a variable number of data slices based on it's type.) Storing the
  lengths, OTOH, compresses much better with protobuf varints.

### Motivation

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

### Tips for reviewer

Proto encoding could be made backward compatible, but we don't because this is getting merged in a backward incompatible release week.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
