### PR TITLE
get rid of testdrive `publish` flag

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -421,7 +421,7 @@ $ set schema={
 A variable can be referenced in both the arguments and the body of a command.
 
 ```
-$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${schema} publish=true repeat=2
+$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${schema} repeat=2
 {"f1": "${schema}"}
 ```
 
@@ -686,10 +686,6 @@ The schema to use
 ##### `key-schema`
 
 For data that contains a key, the schema of the key
-
-##### `publish=true`
-
-Publish the schema and key schema provided to the schema registry.
 
 ##### `key-terminator=str`
 

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -47,7 +47,7 @@ class AlterIndex(Check):
 
                 $ kafka-create-topic topic=alter-index
 
-                $ kafka-ingest format=avro topic=alter-index schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "A${kafka-ingest.iteration}"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -71,26 +71,26 @@ class AlterIndex(Check):
             for s in [
                 """
                 > INSERT INTO alter_index_table SELECT 'B' || generate_series FROM generate_series(1,10000);
-                $ kafka-ingest format=avro topic=alter-index schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "B${kafka-ingest.iteration}"}
 
                 > ALTER INDEX alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms');
                 > ALTER INDEX alter_index_source_primary_idx SET (LOGICAL COMPACTION WINDOW = '1ms');
 
                 > INSERT INTO alter_index_table SELECT 'C' || generate_series FROM generate_series(1,10000);
-                $ kafka-ingest format=avro topic=alter-index schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "C${kafka-ingest.iteration}"}
                 """,
                 """
                 > INSERT INTO alter_index_table SELECT 'D' || generate_series FROM generate_series(1,10000);
-                $ kafka-ingest format=avro topic=alter-index schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "D${kafka-ingest.iteration}"}
 
                 > ALTER INDEX alter_index_table_primary_idx SET (LOGICAL COMPACTION WINDOW = '1h');
                 > ALTER INDEX alter_index_source_primary_idx SET (LOGICAL COMPACTION WINDOW = '1h');
 
                 > INSERT INTO alter_index_table SELECT 'E' || generate_series FROM generate_series(1,10000);
-                $ kafka-ingest format=avro topic=alter-index schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "E${kafka-ingest.iteration}"}
                 """,
             ]

--- a/misc/python/materialize/checks/error.py
+++ b/misc/python/materialize/checks/error.py
@@ -166,8 +166,9 @@ class DecodeError(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro topic=decode-error schema=${schema-f2} repeat=1
-                {"f2": 123456789}
+                # {"f2": 123456789}, no publish
+                $ kafka-ingest format=bytes topic=decode-error repeat=1
+                \\x00\x00\x00\x00\x01\xaa\xb4\xde\x75
                 """,
                 """
                 $ kafka-ingest format=bytes topic=decode-error repeat=1

--- a/misc/python/materialize/checks/error.py
+++ b/misc/python/materialize/checks/error.py
@@ -145,7 +145,7 @@ class DecodeError(Check):
                 """
                 $ kafka-create-topic topic=decode-error
 
-                $ kafka-ingest format=avro topic=decode-error schema=${schema-f1} publish=true repeat=1
+                $ kafka-ingest format=avro topic=decode-error schema=${schema-f1} repeat=1
                 {"f1": "A"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';

--- a/misc/python/materialize/checks/rename_source.py
+++ b/misc/python/materialize/checks/rename_source.py
@@ -34,7 +34,7 @@ class RenameSource(Check):
                 """
                 $ kafka-create-topic topic=rename-source
 
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "A"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -47,12 +47,12 @@ class RenameSource(Check):
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "B"}
 
                 > CREATE MATERIALIZED VIEW rename_source_view AS SELECT DISTINCT f1 FROM rename_source1;
 
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "C"}
                 """
             )
@@ -63,17 +63,17 @@ class RenameSource(Check):
             Testdrive(self._source_schema() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "D"}
                 > ALTER SOURCE rename_source1 RENAME to rename_source2;
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "E"}
                 """,
                 """
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "F"}
                 > ALTER SOURCE rename_source2 RENAME to rename_source3;
-                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema} publish=true
+                $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "G"}
                 """,
             ]

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -45,16 +45,16 @@ class SinkUpsert(Check):
                 """
                 $ kafka-create-topic topic=sink-source
 
-                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "U2${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "D2${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "U3${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "D3${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -82,7 +82,7 @@ class SinkUpsert(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "I2${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
                 {"key1": "U2${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
                 {"key1": "D2${kafka-ingest.iteration}"}
@@ -95,7 +95,7 @@ class SinkUpsert(Check):
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                 """,
                 """
-                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+                $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "I3${kafka-ingest.iteration}"} {"f1": "C${kafka-ingest.iteration}"}
                 {"key1": "U3${kafka-ingest.iteration}"} {"f1": "C${kafka-ingest.iteration}"}
                 {"key1": "D3${kafka-ingest.iteration}"}

--- a/misc/python/materialize/checks/top_k.py
+++ b/misc/python/materialize/checks/top_k.py
@@ -85,7 +85,7 @@ class MonotonicTopK(Check):
                 """
                 $ kafka-create-topic topic=monotonic-topk
 
-                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} publish=true repeat=1
+                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} repeat=1
                 {"f1": "A"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -108,17 +108,17 @@ class MonotonicTopK(Check):
             Testdrive(schema() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} publish=true repeat=2
+                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} repeat=2
                 {"f1": "B"}
                 > CREATE MATERIALIZED VIEW monotonic_topk_view1 AS SELECT f1, COUNT(f1) FROM monotonic_topk_source GROUP BY f1 ORDER BY f1 DESC NULLS LAST LIMIT 2;
-                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} publish=true repeat=3
+                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} repeat=3
                 {"f1": "C"}
                 """,
                 """
-                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} publish=true repeat=4
+                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} repeat=4
                 {"f1": "D"}
                 > CREATE MATERIALIZED VIEW monotonic_topk_view2 AS SELECT f1, COUNT(f1) FROM monotonic_topk_source GROUP BY f1 ORDER BY f1 ASC NULLS FIRST LIMIT 2;
-                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} publish=true repeat=5
+                $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} repeat=5
                 {"f1": "E"}
                 """,
             ]
@@ -154,7 +154,7 @@ class MonotonicTop1(Check):
                 """
                 $ kafka-create-topic topic=monotonic-top1
 
-                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} publish=true repeat=1
+                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} repeat=1
                 {"f1": "A"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -173,17 +173,17 @@ class MonotonicTop1(Check):
             Testdrive(schema() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} publish=true repeat=2
+                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} repeat=2
                 {"f1": "B"}
                 > CREATE MATERIALIZED VIEW monotonic_top1_view1 AS SELECT f1, COUNT(f1) FROM monotonic_top1_source GROUP BY f1 ORDER BY f1 DESC NULLS LAST LIMIT 1;
-                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} publish=true repeat=3
+                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} repeat=3
                 {"f1": "C"}
                 """,
                 """
-                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} publish=true repeat=4
+                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} repeat=4
                 {"f1": "C"}
                 > CREATE MATERIALIZED VIEW monotonic_top1_view2 AS SELECT f1, COUNT(f1) FROM monotonic_top1_source GROUP BY f1 ORDER BY f1 ASC NULLS FIRST LIMIT 1;
-                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} publish=true repeat=5
+                $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} repeat=5
                 {"f1": "D"}
                 """,
             ]

--- a/misc/python/materialize/checks/upsert.py
+++ b/misc/python/materialize/checks/upsert.py
@@ -45,7 +45,7 @@ class UpsertInsert(Check):
                 """
                 $ kafka-create-topic topic=upsert-insert
 
-                $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "A${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -68,11 +68,11 @@ class UpsertInsert(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "A${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
                 """,
                 """
-                $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "A${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
                 """,
             ]
@@ -100,7 +100,7 @@ class UpsertUpdate(Check):
                 """
                 $ kafka-create-topic topic=upsert-update
 
-                $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -121,11 +121,11 @@ class UpsertUpdate(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
                 """,
                 """
-                $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "${kafka-ingest.iteration}"} {"f1": "C${kafka-ingest.iteration}"}
                 """,
             ]
@@ -150,7 +150,7 @@ class UpsertDelete(Check):
                 """
                 $ kafka-create-topic topic=upsert-delete
 
-                $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} publish=true repeat=30000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} repeat=30000
                 {"key1": "${kafka-ingest.iteration}"} {"f1": "${kafka-ingest.iteration}"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -171,11 +171,11 @@ class UpsertDelete(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "${kafka-ingest.iteration}"}
                 """,
                 """
-                $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} publish=true start-iteration=20000 repeat=10000
+                $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} start-iteration=20000 repeat=10000
                 {"key1": "${kafka-ingest.iteration}"}
                 """,
             ]

--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -95,7 +95,7 @@ $ kafka-create-topic topic={self.topic.name} partitions={self.topic.partitions}
 
 {SCHEMA}
 
-$ kafka-ingest format=avro key-format=avro topic={self.topic.name} schema=${{schema}} key-schema=${{keyschema}} publish=true repeat=1
+$ kafka-ingest format=avro key-format=avro topic={self.topic.name} schema=${{schema}} key-schema=${{keyschema}} repeat=1
 {{"key": 0}} {{"f1": 0}}
 """
             )
@@ -125,7 +125,7 @@ class KafkaInsert(Ingest):
             f"""
 {SCHEMA}
 
-$ kafka-ingest format=avro key-format=avro topic={self.topic.name} schema=${{schema}} key-schema=${{keyschema}} start-iteration={prev_max + 1} publish=true repeat={self.delta}
+$ kafka-ingest format=avro key-format=avro topic={self.topic.name} schema=${{schema}} key-schema=${{keyschema}} start-iteration={prev_max + 1} repeat={self.delta}
 {{"key": ${{kafka-ingest.iteration}}}} {{"f1": ${{kafka-ingest.iteration}}}}
 """
         )
@@ -152,7 +152,7 @@ class KafkaDeleteFromHead(Ingest):
                 f"""
 {SCHEMA}
 
-$ kafka-ingest format=avro topic={self.topic.name} key-format=avro key-schema=${{keyschema}} schema=${{schema}} start-iteration={self.topic.watermarks.max + 1} publish=true repeat={actual_delta}
+$ kafka-ingest format=avro topic={self.topic.name} key-format=avro key-schema=${{keyschema}} schema=${{schema}} start-iteration={self.topic.watermarks.max + 1} repeat={actual_delta}
 {{"key": ${{kafka-ingest.iteration}}}}
 """
             )
@@ -178,7 +178,7 @@ class KafkaDeleteFromTail(Ingest):
                 f"""
 {SCHEMA}
 
-$ kafka-ingest format=avro topic={self.topic.name} key-format=avro key-schema=${{keyschema}} schema=${{schema}} start-iteration={prev_min} publish=true repeat={actual_delta}
+$ kafka-ingest format=avro topic={self.topic.name} key-format=avro key-schema=${{keyschema}} schema=${{schema}} start-iteration={prev_min} repeat={actual_delta}
 {{"key": ${{kafka-ingest.iteration}}}}
 """
             )

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -346,9 +346,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let mut retain_ids = BTreeSet::default();
 
         // We only have a compute history if we are in an initialized state
-        //
-        // If this is not the case (e.g. before a `CreateInstance` or after a `DropInstance`),
-        // just copy `new_commands` into `todo_commands`.
+        // e.g. before a `CreateInstance` or after a `DropInstance`).
+        // If this is not the case, just copy `new_commands` into `todo_commands`.
         if let Some(compute_state) = &mut self.compute_state {
             // Reduce the installed commands.
             // Importantly, act as if all peeks may have been retired (as we cannot know otherwise).
@@ -363,7 +362,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // reasoning, as we cannot be certain that peeks still exist at any other worker.
 
             // Having reduced our installed command history retaining no peeks (above), we should be able
-            // to track down installed dataflows we can use as surrogates for requested dataflows (which
+            // to use track down installed dataflows we can use as surrogates for requested dataflows (which
             // have retained all of their peeks, creating a more demainding `as_of` requirement).
             // NB: installed dataflows may still be allowed to further compact, and we should double check
             // this before being too confident. It should be rare without peeks, but could happen with e.g.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -346,8 +346,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
         let mut retain_ids = BTreeSet::default();
 
         // We only have a compute history if we are in an initialized state
-        // e.g. before a `CreateInstance` or after a `DropInstance`).
-        // If this is not the case, just copy `new_commands` into `todo_commands`.
+        //
+        // If this is not the case (e.g. before a `CreateInstance` or after a `DropInstance`),
+        // just copy `new_commands` into `todo_commands`.
         if let Some(compute_state) = &mut self.compute_state {
             // Reduce the installed commands.
             // Importantly, act as if all peeks may have been retired (as we cannot know otherwise).
@@ -362,7 +363,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // reasoning, as we cannot be certain that peeks still exist at any other worker.
 
             // Having reduced our installed command history retaining no peeks (above), we should be able
-            // to use track down installed dataflows we can use as surrogates for requested dataflows (which
+            // to track down installed dataflows we can use as surrogates for requested dataflows (which
             // have retained all of their peeks, creating a more demainding `as_of` requirement).
             // NB: installed dataflows may still be allowed to further compact, and we should double check
             // this before being too confident. It should be rare without peeks, but could happen with e.g.

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -36,13 +36,27 @@ pub struct IngestAction {
     format: Format,
     key_format: Option<Format>,
     timestamp: Option<i64>,
-    publish: bool,
     rows: Vec<String>,
     start_iteration: isize,
     repeat: isize,
     headers: Option<Vec<(String, Option<String>)>>,
     omit_key: bool,
     omit_value: bool,
+}
+
+impl IngestAction {
+    /// Whether the action causes a schema to be published
+    /// to CSR
+    pub fn publish(&self) -> bool {
+        match &self.format {
+            Format::Avro {
+                confluent_wire_format,
+                ..
+            } => *confluent_wire_format,
+            Format::Protobuf { .. } => false,
+            Format::Bytes { .. } => false,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -64,10 +78,12 @@ enum Format {
 }
 
 enum Transcoder {
-    Avro {
+    PlainAvro {
+        schema: Schema,
+    },
+    ConfluentAvro {
         schema: Schema,
         schema_id: i32,
-        confluent_wire_format: bool,
     },
     Protobuf {
         message: MessageDescriptor,
@@ -99,23 +115,32 @@ impl Transcoder {
         R: BufRead,
     {
         match self {
-            Transcoder::Avro {
+            Transcoder::ConfluentAvro {
                 schema,
                 schema_id,
-                confluent_wire_format,
             } => {
                 if let Some(val) = Self::decode_json(row)? {
                     let val = avro::from_json(&val, schema.top_node())?;
                     let mut out = vec![];
-                    if *confluent_wire_format {
-                        // The first byte is a magic byte (0) that indicates the Confluent
-                        // serialization format version, and the next four bytes are a
-                        // 32-bit schema ID.
-                        //
-                        // https://docs.confluent.io/3.3.0/schema-registry/docs/serializer-formatter.html#wire-format
-                        out.write_u8(0).unwrap();
-                        out.write_i32::<NetworkEndian>(*schema_id).unwrap();
-                    }
+                    // The first byte is a magic byte (0) that indicates the Confluent
+                    // serialization format version, and the next four bytes are a
+                    // 32-bit schema ID.
+                    //
+                    // https://docs.confluent.io/3.3.0/schema-registry/docs/serializer-formatter.html#wire-format
+                    out.write_u8(0).unwrap();
+                    out.write_i32::<NetworkEndian>(*schema_id).unwrap();
+                    out.extend(avro::to_avro_datum(&schema, val)?);
+                    Ok(Some(out))
+                } else {
+                    Ok(None)
+                }
+            }
+            Transcoder::PlainAvro {
+                schema,
+            } => {
+                if let Some(val) = Self::decode_json(row)? {
+                    let val = avro::from_json(&val, schema.top_node())?;
+                    let mut out = vec![];
                     out.extend(avro::to_avro_datum(&schema, val)?);
                     Ok(Some(out))
                 } else {
@@ -177,7 +202,6 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
     let partition = cmd.args.opt_parse::<i32>("partition")?;
     let start_iteration = cmd.args.opt_parse::<isize>("start-iteration")?.unwrap_or(0);
     let repeat = cmd.args.opt_parse::<isize>("repeat")?.unwrap_or(1);
-    let publish = cmd.args.opt_bool("publish")?.unwrap_or(false);
     let omit_key = cmd.args.opt_bool("omit-key")?.unwrap_or(false);
     let omit_value = cmd.args.opt_bool("omit-value")?.unwrap_or(false);
     let format = match cmd.args.string("format")?.as_str() {
@@ -270,11 +294,26 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
 
     cmd.args.done()?;
 
-    if publish
-        && !matches!(format, Format::Avro { .. })
-        && !matches!(key_format, Some(Format::Avro { .. }))
-    {
-        bail!("publish=true is invalid unless format=avro or key-format=avro");
+    if let Some(kf) = &key_format {
+        fn is_confluent_format(fmt: &Format) -> Option<bool> {
+            match fmt {
+                Format::Avro {
+                    confluent_wire_format,
+                    ..
+                } => Some(*confluent_wire_format),
+                Format::Protobuf {
+                    confluent_wire_format,
+                    ..
+                } => Some(*confluent_wire_format),
+                Format::Bytes { .. } => None,
+            }
+        }
+        match (is_confluent_format(kf), is_confluent_format(&format)) {
+            (Some(false), Some(true)) | (Some(true), Some(false)) => {
+                bail!("It does not make sense to have the key be in confluent format and not the value, or vice versa.");
+            }
+            _ => {}
+        }
     }
 
     Ok(IngestAction {
@@ -283,7 +322,6 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
         format,
         key_format,
         timestamp,
-        publish,
         rows: cmd.input,
         start_iteration,
         repeat,
@@ -296,7 +334,7 @@ pub fn build_ingest(mut cmd: BuiltinCommand) -> Result<IngestAction, anyhow::Err
 #[async_trait]
 impl Action for IngestAction {
     async fn undo(&self, state: &mut State) -> Result<(), anyhow::Error> {
-        if self.publish {
+        if self.publish() {
             let subjects = state
                 .ccsr_client
                 .list_subjects()
@@ -336,22 +374,19 @@ impl Action for IngestAction {
                     schema,
                     confluent_wire_format,
                 } => {
-                    let schema_id = if self.publish {
+                    if confluent_wire_format {
                         let schema_id = ccsr_client
                             .publish_schema(&ccsr_subject, &schema, mz_ccsr::SchemaType::Avro, &[])
                             .await
                             .context("publishing to schema registry")?;
-                        schema_id
+                        let schema = avro::parse_schema(&schema)
+                            .with_context(|| format!("parsing avro schema: {}", schema))?;
+                        Ok::<_, anyhow::Error>(Transcoder::ConfluentAvro { schema, schema_id })
                     } else {
-                        1
-                    };
-                    let schema = avro::parse_schema(&schema)
-                        .with_context(|| format!("parsing avro schema: {}", schema))?;
-                    Ok::<_, anyhow::Error>(Transcoder::Avro {
-                        schema,
-                        schema_id,
-                        confluent_wire_format,
-                    })
+                        let schema = avro::parse_schema(&schema)
+                            .with_context(|| format!("parsing avro schema: {}", schema))?;
+                        Ok(Transcoder::PlainAvro { schema })
+                    }
                 }
                 Format::Protobuf {
                     descriptor_file,

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -115,10 +115,7 @@ impl Transcoder {
         R: BufRead,
     {
         match self {
-            Transcoder::ConfluentAvro {
-                schema,
-                schema_id,
-            } => {
+            Transcoder::ConfluentAvro { schema, schema_id } => {
                 if let Some(val) = Self::decode_json(row)? {
                     let val = avro::from_json(&val, schema.top_node())?;
                     let mut out = vec![];
@@ -135,9 +132,7 @@ impl Transcoder {
                     Ok(None)
                 }
             }
-            Transcoder::PlainAvro {
-                schema,
-            } => {
+            Transcoder::PlainAvro { schema } => {
                 if let Some(val) = Self::decode_json(row)? {
                     let val = avro::from_json(&val, schema.top_node())?;
                     let mut out = vec![];

--- a/test/cluster/upsert/01-create-sources.td
+++ b/test/cluster/upsert/01-create-sources.td
@@ -48,7 +48,7 @@ $ set schema={
 
 $ kafka-create-topic topic=dbzupsert partitions=1
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "salamander"}}}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "lizard"}}}
@@ -75,5 +75,5 @@ $ kafka-ingest format=bytes topic=dbzupsert key-format=bytes
 broken-key:bar
 
 # Ingest a broken value with a good key
-$ kafka-ingest format=bytes topic=dbzupsert key-format=avro key-schema=${keyschema} publish=true
+$ kafka-ingest format=bytes topic=dbzupsert key-format=avro key-schema=${keyschema}
 {"id": 2}bar2

--- a/test/cluster/upsert/02-after-storaged-restart.td
+++ b/test/cluster/upsert/02-after-storaged-restart.td
@@ -48,7 +48,7 @@ $ set schema={
 # TODO - we should verify here that the topic is not being re-read from the beginning,
 # but I don't know of any way to do that in Testdrive today.
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "Tyrannosaurus rex"}}}
 {"id": 1} {"before": null, "after": {"row": {"id": 1, "creature": "dragon"}}}
 
@@ -65,7 +65,7 @@ broken-key:
 contains: Value error
 
 # Update the bad value
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "cow"}}}
 
 > SELECT * FROM upsert

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -657,7 +657,7 @@ class KafkaRaw(ScenarioDisabled):
             + f"""
 $ kafka-create-topic topic=kafka-raw
 
-$ kafka-ingest format=avro topic=kafka-raw schema=${{schema}} publish=true repeat={self.n()}
+$ kafka-ingest format=avro topic=kafka-raw schema=${{schema}} repeat={self.n()}
 {{"f2": 1}}
 """
         )
@@ -739,10 +739,10 @@ class KafkaUpsert(Kafka):
             + f"""
 $ kafka-create-topic topic=kafka-upsert
 
-$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()}
 {{"f1": 1}} {{"f2": ${{kafka-ingest.iteration}} }}
 
-$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true
+$ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keyschema}} schema=${{schema}}
 {{"f1": 2}} {{"f2": 2}}
 """
         )
@@ -782,7 +782,7 @@ class KafkaUpsertUnique(Kafka):
             + f"""
 $ kafka-create-topic topic=upsert-unique partitions=16
 
-$ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+$ kafka-ingest format=avro topic=upsert-unique key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()}
 {{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
         )
@@ -824,7 +824,7 @@ class KafkaRestart(ScenarioDisabled):
             + f"""
 $ kafka-create-topic topic=kafka-recovery partitions=8
 
-$ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+$ kafka-ingest format=avro topic=kafka-recovery key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()}
 {{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
         )
@@ -1013,7 +1013,7 @@ class ExactlyOnce(Sink):
             + f"""
 $ kafka-create-topic topic=sink-input partitions=16
 
-$ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keyschema}} schema=${{schema}} publish=true repeat={self.n()}
+$ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()}
 {{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
         )
@@ -1273,7 +1273,7 @@ class StartupLoaded(ScenarioDisabled):
             + f"""
 $ kafka-create-topic topic=startup-time
 
-$ kafka-ingest format=avro topic=startup-time schema=${{schema}} publish=true repeat=1
+$ kafka-ingest format=avro topic=startup-time schema=${{schema}} repeat=1
 {{"f2": 1}}
 """
         )

--- a/test/feature-benchmark/scenarios_concurrency.py
+++ b/test/feature-benchmark/scenarios_concurrency.py
@@ -28,7 +28,7 @@ class ParallelIngestion(Concurrency):
             + f"""
 $ kafka-create-topic topic=kafka-parallel-ingestion partitions=4
 
-$ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()} publish=true
+$ kafka-ingest format=avro topic=kafka-parallel-ingestion key-format=avro key-schema=${{keyschema}} schema=${{schema}} repeat={self.n()}
 {{"f1": ${{kafka-ingest.iteration}} }} {{"f2": ${{kafka-ingest.iteration}} }}
 """
         )

--- a/test/kafka-avro-ccsr/test.td
+++ b/test/kafka-avro-ccsr/test.td
@@ -15,10 +15,10 @@ $ set first-writer-schema={"type": "record", "name": "row", "fields": [{"name": 
 $ set second-writer-schema={"type": "record", "name": "row", "fields": [{"name": "a", "type": "long"}, {"name": "b", "type": "long"}, {"name": "c", "type": ["null", "long"], "default": null}]}
 $ set reader-schema={"type": "record", "name": "row", "fields": [{"name": "a", "type": "long"}]}
 
-$ kafka-ingest format=avro topic=schema-strategy-test schema=${first-writer-schema} timestamp=1 publish=true
+$ kafka-ingest format=avro topic=schema-strategy-test schema=${first-writer-schema} timestamp=1
 {"a": 0, "b": 1}
 
-$ kafka-ingest format=avro topic=schema-strategy-test schema=${second-writer-schema} timestamp=1 publish=true
+$ kafka-ingest format=avro topic=schema-strategy-test schema=${second-writer-schema} timestamp=1
 {"a": 2, "b": 3, "c": {"long": 4}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/kafka-matrix/kafka-matrix.td
+++ b/test/kafka-matrix/kafka-matrix.td
@@ -89,7 +89,7 @@ $ set schema={
 
 $ kafka-create-topic topic=input_avro
 
-$ kafka-ingest format=avro topic=input_avro schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=input_avro schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 123}}, "op": "c", "source": {"snapshot": false, "lsn": null, "sequence": null}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -19,7 +19,7 @@ $ set schema={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"a": 1}
 
 > CREATE SECRET sasl_password AS 'sekurity'

--- a/test/kafka-sasl-plain/with-options-errors.td
+++ b/test/kafka-sasl-plain/with-options-errors.td
@@ -30,7 +30,7 @@ $ set schema={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"before": null, "after": {"row": {"a": 1}}}
 
 ! CREATE CONNECTION kafka_sasl

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -19,7 +19,7 @@ $ set schema={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"a": 1}
 
 > CREATE SECRET ssl_key_kafka AS '${arg.materialized-kafka-key}'

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -19,7 +19,7 @@ $ set schema={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"a": 1}
 
 > CREATE SECRET ssl_key_kafka AS '${arg.materialized-kafka-key}'

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -151,7 +151,7 @@ class KafkaTopics(Generator):
             topic = f"kafka-sources-{i}"
             print(f"$ kafka-create-topic topic={topic}")
             print(
-                f"$ kafka-ingest format=avro topic={topic} key-format=avro key-schema=${{key-schema}} schema=${{value-schema}} publish=true"
+                f"$ kafka-ingest format=avro topic={topic} key-format=avro key-schema=${{key-schema}} schema=${{value-schema}}"
             )
             print(f'"{i}" {{"f1": "{i}"}}')
 
@@ -184,7 +184,7 @@ class KafkaSourcesSameTopic(Generator):
         )
         print("$ kafka-create-topic topic=topic")
         print(
-            "$ kafka-ingest format=avro topic=topic key-format=avro key-schema=${key-schema} schema=${value-schema} publish=true"
+            "$ kafka-ingest format=avro topic=topic key-format=avro key-schema=${key-schema} schema=${value-schema}"
         )
         print('"123" {"f1": "123"}')
 
@@ -229,7 +229,7 @@ class KafkaPartitions(Generator):
             f"$ kafka-create-topic topic=kafka-partitions partitions={round(cls.COUNT/2)}"
         )
         print(
-            "$ kafka-ingest format=avro topic=kafka-partitions key-format=avro key-schema=${key-schema} schema=${value-schema} publish=true partition=-1"
+            "$ kafka-ingest format=avro topic=kafka-partitions key-format=avro key-schema=${key-schema} schema=${value-schema} partition=-1"
         )
         for i in cls.all():
             print(f'"{i}" {{"f1": "{i}"}}')
@@ -256,7 +256,7 @@ class KafkaPartitions(Generator):
         )
 
         print(
-            "$ kafka-ingest format=avro topic=kafka-partitions key-format=avro key-schema=${key-schema} schema=${value-schema} publish=true partition=-1"
+            "$ kafka-ingest format=avro topic=kafka-partitions key-format=avro key-schema=${key-schema} schema=${value-schema} partition=-1"
         )
         for i in cls.all():
             print(f'"{i}" {{"f1": "{i}"}}')
@@ -280,7 +280,7 @@ class KafkaRecordsEnvelopeNone(Generator):
         )
         print("$ kafka-create-topic topic=kafka-records-envelope-none")
         print(
-            f"$ kafka-ingest format=avro topic=kafka-records-envelope-none schema=${{kafka-records-envelope-none}} publish=true repeat={cls.COUNT}"
+            f"$ kafka-ingest format=avro topic=kafka-records-envelope-none schema=${{kafka-records-envelope-none}} repeat={cls.COUNT}"
         )
         print('{"f1": "123"}')
 
@@ -323,7 +323,7 @@ class KafkaRecordsEnvelopeUpsertSameValue(Generator):
         )
         print("$ kafka-create-topic topic=kafka-records-envelope-upsert-same")
         print(
-            f"$ kafka-ingest format=avro topic=kafka-records-envelope-upsert-same key-format=avro key-schema=${{kafka-records-envelope-upsert-same-key}} schema=${{kafka-records-envelope-upsert-same-value}} publish=true repeat={cls.COUNT}"
+            f"$ kafka-ingest format=avro topic=kafka-records-envelope-upsert-same key-format=avro key-schema=${{kafka-records-envelope-upsert-same-key}} schema=${{kafka-records-envelope-upsert-same-value}} repeat={cls.COUNT}"
         )
         print('{"key": "fish"} {"f1": "fish"}')
 
@@ -367,7 +367,7 @@ class KafkaRecordsEnvelopeUpsertDistinctValues(Generator):
         )
         print("$ kafka-create-topic topic=kafka-records-envelope-upsert-distinct")
         print(
-            f"$ kafka-ingest format=avro topic=kafka-records-envelope-upsert-distinct key-format=avro key-schema=${{kafka-records-envelope-upsert-distinct-key}} schema=${{kafka-records-envelope-upsert-distinct-value}} publish=true repeat={cls.COUNT}"
+            f"$ kafka-ingest format=avro topic=kafka-records-envelope-upsert-distinct key-format=avro key-schema=${{kafka-records-envelope-upsert-distinct-key}} schema=${{kafka-records-envelope-upsert-distinct-value}} repeat={cls.COUNT}"
         )
         print(
             '{"key": "${kafka-ingest.iteration}"} {"f1": "${kafka-ingest.iteration}"}'
@@ -393,7 +393,7 @@ class KafkaRecordsEnvelopeUpsertDistinctValues(Generator):
         )
 
         print(
-            f"$ kafka-ingest format=avro topic=kafka-records-envelope-upsert-distinct key-format=avro key-schema=${{kafka-records-envelope-upsert-distinct-key}} schema=${{kafka-records-envelope-upsert-distinct-value}} publish=true repeat={cls.COUNT}"
+            f"$ kafka-ingest format=avro topic=kafka-records-envelope-upsert-distinct key-format=avro key-schema=${{kafka-records-envelope-upsert-distinct-key}} schema=${{kafka-records-envelope-upsert-distinct-value}} repeat={cls.COUNT}"
         )
         print('{"key": "${kafka-ingest.iteration}"}')
 
@@ -1358,7 +1358,7 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
 
                     $ kafka-create-topic topic=instance-size
 
-                    $ kafka-ingest format=avro topic=instance-size schema=${schema} publish=true repeat=10000
+                    $ kafka-ingest format=avro topic=instance-size schema=${schema} repeat=10000
                     {"f1": "fish"}
                     """
                 )

--- a/test/persistence/failpoints/after.td
+++ b/test/persistence/failpoints/after.td
@@ -35,10 +35,10 @@ true
 
 # Make sure that ingestion can continue
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "k${kafka-ingest.iteration}"} {"f2": "k${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "l${kafka-ingest.iteration}"} {"f2": "l${kafka-ingest.iteration}"}
 
 > SELECT COUNT(*), COUNT(DISTINCT f1), COUNT(DISTINCT f2) FROM failpoint;
@@ -62,10 +62,10 @@ $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschem
 120000 120000 120000
 
 # Delete some values inserted pre-restart
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "a${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "b${kafka-ingest.iteration}"}
 
 # And validate again

--- a/test/persistence/failpoints/before.td
+++ b/test/persistence/failpoints/before.td
@@ -30,10 +30,10 @@ $ set schema={
 
 $ kafka-create-topic topic=failpoint partitions=5
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "b${kafka-ingest.iteration}"} {"f2": "b${kafka-ingest.iteration}"}
 
 > CREATE CONNECTION kafka_conn
@@ -55,10 +55,10 @@ $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschem
   KEY (f1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "c${kafka-ingest.iteration}"} {"f2": "c${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "d${kafka-ingest.iteration}"} {"f2": "d${kafka-ingest.iteration}"}
 
 # Make sure that we read (and persisted) at least one message before activating the failpoint.
@@ -67,20 +67,20 @@ true
 
 > SET failpoints = '${arg.failpoint}=${arg.action}';
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "e${kafka-ingest.iteration}"} {"f2": "e${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "f${kafka-ingest.iteration}"} {"f2": "f${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "g${kafka-ingest.iteration}"} {"f2": "g${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "h${kafka-ingest.iteration}"} {"f2": "h${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "i${kafka-ingest.iteration}"} {"f2": "i${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "j${kafka-ingest.iteration}"} {"f2": "j${kafka-ingest.iteration}"}

--- a/test/persistence/kafka-sources/delayed-materialization-after.td
+++ b/test/persistence/kafka-sources/delayed-materialization-after.td
@@ -30,7 +30,7 @@ $ set schema={
         ]
     }
 
-$ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count}
 {"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
 
 > CREATE DEFAULT INDEX ON materialized_via_create_index_after_restart;

--- a/test/persistence/kafka-sources/delayed-materialization-before.td
+++ b/test/persistence/kafka-sources/delayed-materialization-before.td
@@ -32,7 +32,7 @@ $ set schema={
 
 $ kafka-create-topic topic=delayed-materialization
 
-$ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1
+$ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-schema=${keyschema} schema=${schema} repeat=1
 {"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -59,7 +59,7 @@ $ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-sch
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
-$ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=delayed-materialization key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count}
 {"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
 
 > CREATE DEFAULT INDEX ON materialized_via_create_index_before_restart;

--- a/test/persistence/kafka-sources/envelope-none-after.td
+++ b/test/persistence/kafka-sources/envelope-none-after.td
@@ -18,10 +18,10 @@ $ set schema={
 > SELECT COUNT(*) FROM envelope_none;
 10000
 
-$ kafka-ingest format=avro topic=envelope-none schema=${schema} publish=true repeat=5000
+$ kafka-ingest format=avro topic=envelope-none schema=${schema} repeat=5000
 {"f1": ${kafka-ingest.iteration}}
 
-$ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${schema} schema=${schema} publish=true repeat=5000
+$ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${schema} schema=${schema} repeat=5000
 {"f1": ${kafka-ingest.iteration}} {"f1": ${kafka-ingest.iteration}}
 
 > SELECT COUNT(*), COUNT(DISTINCT f1), MIN(f1), MAX(f1) FROM envelope_none;

--- a/test/persistence/kafka-sources/envelope-none-before.td
+++ b/test/persistence/kafka-sources/envelope-none-before.td
@@ -19,10 +19,10 @@ $ kafka-create-topic topic=envelope-none partitions=2
 
 # Make sure that no upsert semantics kicks in -- all the 15K records we insert must be processed independently
 
-$ kafka-ingest format=avro topic=envelope-none schema=${schema} publish=true repeat=5000
+$ kafka-ingest format=avro topic=envelope-none schema=${schema} repeat=5000
 {"f1": ${kafka-ingest.iteration}}
 
-$ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${schema} schema=${schema} publish=true repeat=5000
+$ kafka-ingest format=avro topic=envelope-none key-format=avro key-schema=${schema} schema=${schema} repeat=5000
 {"f1": ${kafka-ingest.iteration}} {"f1": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/exactly-once-sink-after.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-after.td
@@ -23,7 +23,7 @@ $ set schema={
         ]
     }
 
-$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=40
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2 start-iteration=40
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 

--- a/test/persistence/kafka-sources/exactly-once-sink-before.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-before.td
@@ -29,7 +29,7 @@ $ set schema={
 
 $ kafka-create-topic topic=exactly-once
 
-$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
@@ -47,16 +47,16 @@ $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keysc
   INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
-$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=10
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2 start-iteration=10
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > SELECT COUNT(*) FROM exactly_once;
 4
 
-$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=20
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2 start-iteration=20
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
-$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=2 start-iteration=30
+$ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2 start-iteration=30
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 # Make sure that we have produced stuff to the sink before we restart

--- a/test/persistence/kafka-sources/multipart-key-after.td
+++ b/test/persistence/kafka-sources/multipart-key-after.td
@@ -32,7 +32,7 @@ $ set schema={
 10000 10000 10000
 
 # Delete all rows
-$ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "KEY1", "f2": "${kafka-ingest.iteration}"}
 {"f1": "${kafka-ingest.iteration}", "f2": "KEY2"}
 

--- a/test/persistence/kafka-sources/multipart-key-before.td
+++ b/test/persistence/kafka-sources/multipart-key-before.td
@@ -32,7 +32,7 @@ $ set schema={
 $ kafka-create-topic topic=multipart-key
 
 # Ingest data where the first or the second part of the key has high cardinality
-$ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=multipart-key key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": "KEY1", "f2": "${kafka-ingest.iteration}"} {"f3": "KEY1", "f4": "${kafka-ingest.iteration}"}
 {"f1": "${kafka-ingest.iteration}", "f2": "KEY2"} {"f3": "${kafka-ingest.iteration}", "f4": "KEY2"}
 

--- a/test/persistence/kafka-sources/partition-change-after.td
+++ b/test/persistence/kafka-sources/partition-change-after.td
@@ -23,7 +23,7 @@ $ set schema={
         ]
     }
 
-$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} publish=true start-iteration=10000 repeat=10000
+$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} start-iteration=10000 repeat=10000
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > SELECT COUNT(*), MIN(f1), MAX(f1), MIN(f2), MAX(f2) FROM partition_change;

--- a/test/persistence/kafka-sources/partition-change-before.td
+++ b/test/persistence/kafka-sources/partition-change-before.td
@@ -29,7 +29,7 @@ $ set schema={
 
 $ kafka-create-topic topic=partition-change partitions=5
 
-$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn
@@ -51,5 +51,5 @@ true
 
 $ kafka-add-partitions topic=partition-change total-partitions=10
 
-$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+$ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${keyschema} schema=${schema} repeat=1000
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}

--- a/test/persistence/kafka-sources/repeated-source-rendering-before.td
+++ b/test/persistence/kafka-sources/repeated-source-rendering-before.td
@@ -20,7 +20,7 @@ $ kafka-create-topic topic=re-created partitions=1
 # Make sure that we can render a source (by creating an indexed view), drop
 # it, and render it again.
 
-$ kafka-ingest format=avro topic=re-created schema=${schema} publish=true repeat=10
+$ kafka-ingest format=avro topic=re-created schema=${schema} repeat=10
 {"f1": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/start-offset-after.td
+++ b/test/persistence/kafka-sources/start-offset-after.td
@@ -30,7 +30,7 @@ $ set schema={
         ]
     }
 
-$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count} timestamp=4
+$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count} timestamp=4
 {"f1": "d${kafka-ingest.iteration}"} {"f2": "d${kafka-ingest.iteration}"}
 
 > SELECT COUNT(*) FROM start_offset;

--- a/test/persistence/kafka-sources/start-offset-before.td
+++ b/test/persistence/kafka-sources/start-offset-before.td
@@ -35,13 +35,13 @@ $ set schema={
 
 $ kafka-create-topic topic=offset
 
-$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count} timestamp=1
+$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count} timestamp=1
 {"f1": "a${kafka-ingest.iteration}"} {"f2": "a${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count} timestamp=2
+$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count} timestamp=2
 {"f1": "b${kafka-ingest.iteration}"} {"f2": "b${kafka-ingest.iteration}"}
 
-$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=${count} timestamp=3
+$ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count} timestamp=3
 {"f1": "c${kafka-ingest.iteration}"} {"f2": "c${kafka-ingest.iteration}"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/topic-compaction-after.td
+++ b/test/persistence/kafka-sources/topic-compaction-after.td
@@ -26,7 +26,7 @@ $ set schema={
 > SELECT COUNT(*) FROM topic_compaction WHERE f2 LIKE 'C%';
 1000
 
-$ kafka-ingest format=avro topic=topic-compaction key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+$ kafka-ingest format=avro topic=topic-compaction key-format=avro key-schema=${keyschema} schema=${schema} repeat=1000
 {"f1": ${kafka-ingest.iteration}} {"f2": "D${kafka-ingest.iteration}"}
 
 > SELECT COUNT(*) FROM topic_compaction WHERE f2 LIKE 'D%';

--- a/test/persistence/kafka-sources/topic-compaction-before.td
+++ b/test/persistence/kafka-sources/topic-compaction-before.td
@@ -25,7 +25,7 @@ $ set schema={
 
 $ kafka-create-topic topic=topic-compaction compaction=true
 
-$ kafka-ingest format=avro topic=topic-compaction key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+$ kafka-ingest format=avro topic=topic-compaction key-format=avro key-schema=${keyschema} schema=${schema} repeat=1000
 {"f1": ${kafka-ingest.iteration}} {"f2": "A${kafka-ingest.iteration}"}
 {"f1": ${kafka-ingest.iteration}} {"f2": "B${kafka-ingest.iteration}"}
 {"f1": ${kafka-ingest.iteration}} {"f2": "C${kafka-ingest.iteration}"}

--- a/test/persistence/kafka-sources/topic-compression-after.td
+++ b/test/persistence/kafka-sources/topic-compression-after.td
@@ -23,7 +23,7 @@ $ set schema={
         ]
     }
 
-$ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+$ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} repeat=1000
 {"f1": ${kafka-ingest.iteration}} {"f2": "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"}
 
 > SELECT COUNT(*), COUNT(DISTINCT f2), MIN(LENGTH(f2)), MAX(LENGTH(f2)) FROM topic_compression;

--- a/test/persistence/kafka-sources/topic-compression-before.td
+++ b/test/persistence/kafka-sources/topic-compression-before.td
@@ -25,7 +25,7 @@ $ set schema={
 
 $ kafka-create-topic topic=topic-compression compression=gzip
 
-$ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=1000
+$ kafka-ingest format=avro topic=topic-compression key-format=avro key-schema=${keyschema} schema=${schema} repeat=1000
 {"f1": ${kafka-ingest.iteration}} {"f2": "abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/upsert-deletion-after.td
+++ b/test/persistence/kafka-sources/upsert-deletion-after.td
@@ -25,7 +25,7 @@ $ set schema={
 
 # Delete 5K records post-restart
 
-$ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=5000
+$ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${keyschema} schema=${schema} repeat=5000
 {"f1": ${kafka-ingest.iteration}}
 
 > SELECT COUNT(*), MIN(f1), MAX(f1), MIN(f2) , MAX(f2) FROM upsert_deletion;

--- a/test/persistence/kafka-sources/upsert-deletion-before.td
+++ b/test/persistence/kafka-sources/upsert-deletion-before.td
@@ -29,7 +29,7 @@ $ set schema={
 
 $ kafka-create-topic topic=upsert-deletion
 
-$ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=upsert-deletion key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/upsert-include-key-after.td
+++ b/test/persistence/kafka-sources/upsert-include-key-after.td
@@ -26,7 +26,7 @@ $ set schema={
 
 # Delete 5K records post-restart
 
-$ kafka-ingest format=avro topic=include-key key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=5000
+$ kafka-ingest format=avro topic=include-key key-format=avro key-schema=${keyschema} schema=${schema} repeat=5000
 {"f1": ${kafka-ingest.iteration}, "key2": 1}
 
 > SELECT COUNT(*), MIN((named).f1), MAX((named).f1), MIN(f2) , MAX(f2) FROM include_key;

--- a/test/persistence/kafka-sources/upsert-include-key-before.td
+++ b/test/persistence/kafka-sources/upsert-include-key-before.td
@@ -30,7 +30,7 @@ $ set schema={
 
 $ kafka-create-topic topic=include-key
 
-$ kafka-ingest format=avro topic=include-key key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=include-key key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": ${kafka-ingest.iteration}, "key2": 1} {"f2": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/upsert-modification-after.td
+++ b/test/persistence/kafka-sources/upsert-modification-after.td
@@ -25,7 +25,7 @@ $ set schema={
 
 # Update 5K records
 
-$ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} publish=true start-iteration=2500 repeat=5000
+$ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} start-iteration=2500 repeat=5000
 {"f1": ${kafka-ingest.iteration}} {"f2": "a${kafka-ingest.iteration}"}
 
 > SELECT COUNT(*), MIN(f1), MAX(f1) FROM upsert_modification;

--- a/test/persistence/kafka-sources/upsert-modification-before.td
+++ b/test/persistence/kafka-sources/upsert-modification-before.td
@@ -29,7 +29,7 @@ $ set schema={
 
 $ kafka-create-topic topic=upsert-modification
 
-$ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10000
+$ kafka-ingest format=avro topic=upsert-modification key-format=avro key-schema=${keyschema} schema=${schema} repeat=10000
 {"f1": ${kafka-ingest.iteration}} {"f2": "${kafka-ingest.iteration}"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/persistence/kafka-sources/wide-data-after.td
+++ b/test/persistence/kafka-sources/wide-data-after.td
@@ -26,7 +26,7 @@ $ set schema={
 
 # Cause some more rows to be produced in the Kafka topic
 
-$ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10 start-iteration=10
+$ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} repeat=10 start-iteration=10
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > SELECT COUNT(*), MIN(LENGTH(value)), MAX(LENGTH(value)) FROM wide_data_source;

--- a/test/persistence/kafka-sources/wide-data-before.td
+++ b/test/persistence/kafka-sources/wide-data-before.td
@@ -37,7 +37,7 @@ $ set schema={
 
 $ kafka-create-topic topic=wide-data-ten
 
-$ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} publish=true repeat=10
+$ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keyschema} schema=${schema} repeat=10
 {"f1": ${kafka-ingest.iteration}} {"f2": ${kafka-ingest.iteration}}
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn

--- a/test/testdrive/avro-decode.td
+++ b/test/testdrive/avro-decode.td
@@ -154,10 +154,10 @@ $ set reader-schema={
 
 $ kafka-create-topic topic=avro-data
 
-$ kafka-ingest format=avro topic=avro-data schema=${writer-schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=avro-data schema=${writer-schema} timestamp=1
 { "f5": 1234, "f4": {"variant1": [0]}, "f3": 2345, "f2": "Diamonds", "f1": {"variant4": [0, 1, 2, 3]}, "f6": {"hello": 123, "another": 2144} }
 
-$ kafka-ingest format=avro topic=avro-data schema=${reader-schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=avro-data schema=${reader-schema} timestamp=1
 { "f0": {"f0_0": 9999, "f0_1": null}, "f1": {"long": 3456}, "f2": "Jokers", "f5": {"extra_variant": [0,1,2,3,4,5,6,7,8,9]}, "f6": {"key": 8372} }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -184,7 +184,7 @@ f0 f11 f12 f13 f2 f51 f52
 
 $ kafka-create-topic topic=avro-data-no-registry
 
-$ kafka-ingest format=avro topic=avro-data-no-registry schema=${reader-schema} publish=true confluent-wire-format=false timestamp=1
+$ kafka-ingest format=avro topic=avro-data-no-registry schema=${reader-schema} confluent-wire-format=false timestamp=1
 { "f0": {"f0_0": 9999, "f0_1": null}, "f1": {"long": 3456}, "f2": "Jokers", "f5": {"extra_variant": [0,1,2,3,4,5,6,7,8,9]}, "f6": {"key": 8372} }
 
 > CREATE SOURCE avro_data_no_registry

--- a/test/testdrive/avro-registry.td
+++ b/test/testdrive/avro-registry.td
@@ -137,7 +137,7 @@ $ set schema-v2={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema-v1} publish=true timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema-v1} timestamp=1
 {"before": null, "after": {"row": {"a": 1}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c"}
 
 > CREATE SOURCE data_v1
@@ -150,7 +150,7 @@ a
 ---
 1
 
-$ kafka-ingest format=avro topic=data schema=${schema-v2} publish=true timestamp=3
+$ kafka-ingest format=avro topic=data schema=${schema-v2} timestamp=3
 {"before": null, "after": {"row": {"a": 2, "b": -1}}, "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c"}
 
 > CREATE SOURCE data_v2
@@ -178,7 +178,7 @@ $ set valid-key-schema={
     ]
   }
 
-$ kafka-ingest topic=data publish=true timestamp=5
+$ kafka-ingest topic=data timestamp=5
   format=avro schema=${schema-v1} key-format=avro key-schema=${valid-key-schema}
 {"a": 1} {"before": null, "after": {"row": {"a": 1}}, "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}, "op": "c"}
 

--- a/test/testdrive/avro-resolution-enums.td
+++ b/test/testdrive/avro-resolution-enums.td
@@ -16,7 +16,7 @@ $ set enum-writer={"type": "record", "name": "schema_enum", "fields": [ {"name":
 
 $ kafka-create-topic topic=resolution-enums
 
-$ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} timestamp=1
 {"f1": "E1" }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,10 +29,10 @@ $ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} publish=
   ENVELOPE NONE
 
 # E5 will be recorded as E_DEFAULT
-$ kafka-ingest format=avro topic=resolution-enums schema=${enum-writer} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-enums schema=${enum-writer} timestamp=2
 {"f1": "E5" }
 
-$ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-enums schema=${enum-reader} timestamp=1
 {"f1": "E1" }
 
 > SHOW COLUMNS FROM resolution_enums

--- a/test/testdrive/avro-resolution-less-columns.td
+++ b/test/testdrive/avro-resolution-less-columns.td
@@ -16,7 +16,7 @@ $ set 1column={"type": "record", "name": "schema_less_columns", "fields": [ {"na
 
 $ kafka-create-topic topic=resolution-2to1
 
-$ kafka-ingest format=avro topic=resolution-2to1 schema=${2columns} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-2to1 schema=${2columns} timestamp=1
 {"f1": "val_f1a", "f2": "val_f2a"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=resolution-2to1 schema=${2columns} publish=true
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-2to1 schema=${1column} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-2to1 schema=${1column} timestamp=2
 {"f1": "val_f1b"}
 
 > SELECT * FROM resolution_2to1

--- a/test/testdrive/avro-resolution-more-columns.td
+++ b/test/testdrive/avro-resolution-more-columns.td
@@ -16,7 +16,7 @@ $ set 2columns={"type": "record", "name": "schema_more_columns", "fields": [ {"n
 
 $ kafka-create-topic topic=resolution-1to2
 
-$ kafka-ingest format=avro topic=resolution-1to2 schema=${1column} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-1to2 schema=${1column} timestamp=1
 {"f1": "val_f1b"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=resolution-1to2 schema=${1column} publish=true 
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-1to2 schema=${2columns} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-1to2 schema=${2columns} timestamp=2
 {"f1": "val_f1a", "f2": "val_f2a"}
 
 > SELECT * FROM resolution_1to2

--- a/test/testdrive/avro-resolution-no-publish-reader.td
+++ b/test/testdrive/avro-resolution-no-publish-reader.td
@@ -11,12 +11,14 @@
 # Test the case where we fail to publish the schema of the reader
 #
 
-$ set int-schema={"type": "record", "name": "schema_int", "fields": [ {"name": "f1", "type": "int"} ] }
 
 $ kafka-create-topic topic=resolution-no-publish-writer
 
-$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
-{"f1": 123}
+# The schema is {"type": "record", "name": "schema_int", "fields": [ {"name": "f1", "type": "int"} ] }.
+# and the value is {"f1": 123}
+# We encode it manually to avoid publishing it.
+$ kafka-ingest format=bytes topic=resolution-no-publish-writer timestamp=1
+\\x00\x00\x00\x00\x01\xf6\x01
 
 > DROP SCHEMA IF EXISTS public CASCADE
 > CREATE SCHEMA public

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -15,7 +15,7 @@ $ set int-schema={"type": "record", "name": "schema_int", "fields": [ {"name": "
 
 $ kafka-create-topic topic=resolution-no-publish-writer
 
-$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
 {"f1": 123}
 
 > DROP SCHEMA IF EXISTS public CASCADE

--- a/test/testdrive/avro-resolution-no-publish-writer.td
+++ b/test/testdrive/avro-resolution-no-publish-writer.td
@@ -30,8 +30,10 @@ $ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schem
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-no-publish-writer schema=${int-schema} timestamp=1
-{"f1": 123}
+# The value is {"f1": 123}.
+# We encode it manually to avoid publishing it.
+$ kafka-ingest format=bytes topic=resolution-no-publish-writer timestamp=1
+\\x00\x00\x00\x00\x01\xf6\x01
 
 ! SELECT * FROM resolution_no_publish_writer;
 contains:to resolve

--- a/test/testdrive/avro-resolution-notnull2null.td
+++ b/test/testdrive/avro-resolution-notnull2null.td
@@ -16,7 +16,7 @@ $ set null={"type": "record", "name": "schema_union", "fields": [ {"name": "f1",
 
 $ kafka-create-topic topic=resolution-unions
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${not-null} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-unions schema=${not-null} timestamp=1
 {"f1": {"int": 123 } }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${not-null} publish=tr
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${null} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-unions schema=${null} timestamp=2
 {"f1": null }
 {"f1": {"int": 123 } }
 

--- a/test/testdrive/avro-resolution-types-array.td
+++ b/test/testdrive/avro-resolution-types-array.td
@@ -16,7 +16,7 @@ $ set array-int={"type": "record", "name": "schema_array", "fields": [ {"name": 
 
 $ kafka-create-topic topic=resolution-arrays
 
-$ kafka-ingest format=avro topic=resolution-arrays schema=${array-int} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-arrays schema=${array-int} timestamp=1
 {"f1": [ 123 ] }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=resolution-arrays schema=${array-int} publish=t
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-arrays schema=${array-double} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-arrays schema=${array-double} timestamp=2
 {"f1": [ 234.345 ] }
 
 ! SELECT f1[0] FROM resolution_arrays

--- a/test/testdrive/avro-resolution-types-map.td
+++ b/test/testdrive/avro-resolution-types-map.td
@@ -16,7 +16,7 @@ $ set map-int={"type": "record", "name": "schema_map", "fields": [ {"name": "f1"
 
 $ kafka-create-topic topic=resolution-maps
 
-$ kafka-ingest format=avro topic=resolution-maps schema=${map-int} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-maps schema=${map-int} timestamp=1
 {"f1": { "key1": 123 } }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=resolution-maps schema=${map-int} publish=true 
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-maps schema=${map-double} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-maps schema=${map-double} timestamp=2
 {"f1": { "key1": 234.345 } }
 
 ! SELECT f1 -> 'key1' FROM resolution_maps

--- a/test/testdrive/avro-resolution-types-records.td
+++ b/test/testdrive/avro-resolution-types-records.td
@@ -17,7 +17,7 @@ $ set double-col={"type": "record", "name": "outer", "fields": [ {"name": "f1", 
 
 $ kafka-create-topic topic=resolution-records-int2double
 
-$ kafka-ingest format=avro topic=resolution-records-int2double schema=${int-col} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-records-int2double schema=${int-col} timestamp=1
 {"f1": { "f1": 123 }}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=resolution-records-int2double schema=${int-col}
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-records-int2double schema=${double-col} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-records-int2double schema=${double-col} timestamp=2
 {"f1": { "f1": 123.234 }}
 
 ! SELECT * FROM resolution_records_int2double

--- a/test/testdrive/avro-resolution-types.td
+++ b/test/testdrive/avro-resolution-types.td
@@ -17,7 +17,7 @@ $ set double-col={"type": "record", "name": "schema_int_double", "fields": [ {"n
 
 $ kafka-create-topic topic=resolution-int2double
 
-$ kafka-ingest format=avro topic=resolution-int2double schema=${int-col} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-int2double schema=${int-col} timestamp=1
 {"f1": 123}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=resolution-int2double schema=${int-col} publish
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-int2double schema=${double-col} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-int2double schema=${double-col} timestamp=2
 {"f1": 234.456}
 
 ! SELECT * FROM resolution_int2double

--- a/test/testdrive/avro-resolution-union-concrete.td
+++ b/test/testdrive/avro-resolution-union-concrete.td
@@ -17,7 +17,7 @@ $ set concrete-double={"type": "record", "name": "schema_union", "fields": [ {"n
 
 $ kafka-create-topic topic=resolution-union-concrete
 
-$ kafka-ingest format=avro topic=resolution-union-concrete schema=${union-int} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-union-concrete schema=${union-int} timestamp=1
 {"f1": {"int": 123 } }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=resolution-union-concrete schema=${union-int} p
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-union-concrete schema=${concrete-double} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-union-concrete schema=${concrete-double} timestamp=2
 {"f1": 123.456 }
 
 ! SELECT f1 FROM resolution_union_concrete

--- a/test/testdrive/avro-resolution-union-reader.td
+++ b/test/testdrive/avro-resolution-union-reader.td
@@ -17,7 +17,7 @@ $ set int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", 
 
 $ kafka-create-topic topic=resolution-unions
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} timestamp=1
 {"f1": {"int": 123 } }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=t
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${int} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-unions schema=${int} timestamp=2
 {"f1": 234 }
 
 > SELECT f1 FROM resolution_unions

--- a/test/testdrive/avro-resolution-union-writer.td
+++ b/test/testdrive/avro-resolution-union-writer.td
@@ -17,7 +17,7 @@ $ set int={"type": "record", "name": "schema_union", "fields": [ {"name": "f1", 
 
 $ kafka-create-topic topic=resolution-unions
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${int} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-unions schema=${int} timestamp=1
 {"f1": 234 }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${int} publish=true ti
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} timestamp=2
 {"f1": {"int": 123 } }
 
 > SELECT f1 FROM resolution_unions

--- a/test/testdrive/avro-resolution-unions.td
+++ b/test/testdrive/avro-resolution-unions.td
@@ -17,7 +17,7 @@ $ set union-int={"type": "record", "name": "schema_union", "fields": [ {"name": 
 
 $ kafka-create-topic topic=resolution-unions
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=true timestamp=1
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int} timestamp=1
 {"f1": {"int": 123 } }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -29,7 +29,7 @@ $ kafka-ingest format=avro topic=resolution-unions schema=${union-int} publish=t
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=resolution-unions schema=${union-int-string} publish=true timestamp=2
+$ kafka-ingest format=avro topic=resolution-unions schema=${union-int-string} timestamp=2
 {"f1": {"int": 123 } }
 {"f1": {"string": "abc" } }
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -254,7 +254,7 @@ $ set schema={
     ]
   }
 $ kafka-create-topic topic=data
-$ kafka-ingest format=avro topic=data schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"a": 1}
 
 > CREATE TABLE tbl (a int, b text);

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -113,7 +113,7 @@ $ set schema={
 
 $ kafka-create-topic topic=csr_test partitions=1
 
-$ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=csr_test key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}}

--- a/test/testdrive/github-10587.td
+++ b/test/testdrive/github-10587.td
@@ -24,52 +24,52 @@ $ set count=100000
 
 $ kafka-create-topic topic=multi-topic-0
 
-$ kafka-ingest format=avro topic=multi-topic-0 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-0 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-1
 
-$ kafka-ingest format=avro topic=multi-topic-1 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-1 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-2
 
-$ kafka-ingest format=avro topic=multi-topic-2 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-2 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-3
 
-$ kafka-ingest format=avro topic=multi-topic-3 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-3 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-4
 
-$ kafka-ingest format=avro topic=multi-topic-4 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-4 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-5
 
-$ kafka-ingest format=avro topic=multi-topic-5 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-5 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-6
 
-$ kafka-ingest format=avro topic=multi-topic-6 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-6 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-7
 
-$ kafka-ingest format=avro topic=multi-topic-7 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-7 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-8
 
-$ kafka-ingest format=avro topic=multi-topic-8 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-8 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 $ kafka-create-topic topic=multi-topic-9
 
-$ kafka-ingest format=avro topic=multi-topic-9 schema=${schema} publish=true repeat=${count}
+$ kafka-ingest format=avro topic=multi-topic-9 schema=${schema} repeat=${count}
 {"f2": ${kafka-ingest.iteration} }
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -468,7 +468,7 @@ $ set value-schema={"type": "record", "name": "r", "fields": [{"name": "a", "typ
 
 $ kafka-create-topic topic=non-subset-key
 
-$ kafka-ingest format=avro topic=non-subset-key key-format=avro key-schema=${key-schema} schema=${value-schema} publish=true
+$ kafka-ingest format=avro topic=non-subset-key key-format=avro key-schema=${key-schema} schema=${value-schema}
 "asdf" {"a": "asdf"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -33,7 +33,7 @@ $ set upsert-schema={
 
 $ kafka-create-topic topic=upsert-avro
 
-$ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert-keyschema} schema=${upsert-schema} publish=true
+$ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert-keyschema} schema=${upsert-schema}
 {"key1": "fish", "key2": 2} {"f1": "fish", "f2": 1000}
 {"key1": "fisch", "key2": 42} {"f1": "fish", "f2": 1000}
 
@@ -59,7 +59,7 @@ $ kafka-verify format=avro sink=materialize.public.upsert_input_sink sort-messag
 {"key1": "fisch", "key2": 42} {"key1": "fisch", "key2": 42, "f1": "fish", "f2": 1000, "transaction": {"id": "<TIMESTAMP>"}}
 {"key1": "fish", "key2": 2} {"key1": "fish", "key2": 2, "f1": "fish", "f2": 1000, "transaction": {"id": "<TIMESTAMP>"}}
 
-$ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert-keyschema} schema=${upsert-schema} publish=true
+$ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert-keyschema} schema=${upsert-schema}
 {"key1": "fisch", "key2": 42} {"f1": "richtig, fisch", "f2": 2000}
 
 $ kafka-verify format=avro sink=materialize.public.upsert_input_sink

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -13,10 +13,10 @@ $ kafka-create-topic topic=topic0
 
 $ kafka-create-topic topic=topic1
 
-$ kafka-ingest format=avro topic=topic0 schema=${schema} publish=true repeat=1
+$ kafka-ingest format=avro topic=topic0 schema=${schema} repeat=1
 {"f2": 1}
 
-$ kafka-ingest format=avro topic=topic1 schema=${schema} publish=true repeat=1
+$ kafka-ingest format=avro topic=topic1 schema=${schema} repeat=1
 {"f2": 7}
 
 > CREATE CONNECTION kafka_conn

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -25,7 +25,7 @@ $ set schema={
   }
 
 $ kafka-create-topic topic=avro-data partitions=1
-$ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflictkeyschema} schema=${schema} timestamp=1 publish=true
+$ kafka-ingest format=avro key-format=avro topic=avro-data key-schema=${conflictkeyschema} schema=${schema} timestamp=1
 {"id": 1} {"id": 2, "b": 3}
 
 ! CREATE SOURCE missing_key_format

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -418,31 +418,31 @@ $ set schema={
 
 $ kafka-create-topic topic=dbzupsert
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}}
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=2
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=2
 {"id": 1} {"before": {"row": {"id": 1, "creature": "lizard"}}, "after": {"row": {"id": 1, "creature": "dino"}}}
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=3
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=3
 {"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "archeopteryx"}}}
 {"id": 2} {"before": {"row": {"id": 2, "creature": "archeopteryx"}}, "after": {"row": {"id": 2, "creature": "velociraptor"}}}
 
 # test duplicates
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=4
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=4
 {"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}}
 {"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}}
 
 # test removal and reinsertion
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=5
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=5
 {"id": 4} {"before": null, "after": {"row": {"id": 4, "creature": "moros"}}}
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=6
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=6
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": null}
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=7
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=7
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": {"row": {"id": 4, "creature": "chicken"}}}
 
 > CREATE SOURCE upsert_time_skip

--- a/test/testdrive/kafka-upsert-debezium-sources-unordered.td
+++ b/test/testdrive/kafka-upsert-debezium-sources-unordered.td
@@ -48,7 +48,7 @@ $ set schema={
 
 $ kafka-create-topic topic=dbzupsert
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"before": {"row": {"creature": "fish", "id": 1}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}}
 {"id": 1} {"before": {"row": {"creature": "mudskipper", "id": 1}}, "after": {"row": {"id": 1, "creature": "salamander"}}}
 {"id": 1} {"before": {"row": {"creature": "salamander", "id": 1}}, "after": {"row": {"id": 1, "creature": "lizard"}}}

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -90,7 +90,7 @@ $ set schema={
 
 $ kafka-create-topic topic=dbzupsert partitions=1
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=1
 {"id": 1} {"before": {"row": {"id": 1, "creature": "fish"}}, "after": {"row": {"id": 1, "creature": "mudskipper"}}, "op": "u", "source": {"file": "binlog1", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "mudskipper"}}, "after": {"row": {"id": 1, "creature": "salamander"}}, "op": "u", "source": {"file": "binlog2", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
@@ -111,7 +111,7 @@ id creature
 -----------
 1  lizard
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=2
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=2
 {"id": 1} {"before": {"row": {"id": 1, "creature": "lizard"}}, "after": {"row": {"id": 1, "creature": "dino"}}, "op": "u", "source": {"file": "binlog4", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 > SELECT * FROM doin_upsert
@@ -119,7 +119,7 @@ id creature
 -----------
 1  dino
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=3
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=3
 {"id": 2} {"before": null, "after": {"row": {"id": 2, "creature": "archeopteryx"}}, "op": "c", "source": {"file": "binlog5", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 {"id": 2} {"before": {"row": {"id": 2, "creature": "archeopteryx"}}, "after": {"row": {"id": 2, "creature": "velociraptor"}}, "op": "u", "source": {"file": "binlog6", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
@@ -130,7 +130,7 @@ id creature
 2  velociraptor
 
 # test duplicates
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=4
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=4
 {"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}, "op": "u", "source": {"file": "binlog7", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 {"id": 3} {"before": {"row": {"id": 3, "creature": "protoceratops"}}, "after": {"row": {"id": 3, "creature": "triceratops"}}, "op": "u", "source": {"file": "binlog8", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
@@ -140,7 +140,7 @@ id creature
 3  triceratops
 
 # test removal and reinsertion
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=5
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=5
 {"id": 4} {"before": null, "after": {"row": {"id": 4, "creature": "moros"}}, "op": "c", "source": {"file": "binlog9", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 > SELECT creature FROM doin_upsert WHERE id = 4
@@ -166,14 +166,14 @@ id creature partition test_kafka_offset
 ---------------------------------------
 4  moros    0         9
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=6
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=6
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": null, "op": "d", "source": {"file": "binlog10", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 > SELECT creature FROM doin_upsert WHERE id = 4
 creature
 --------
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true timestamp=7
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=7
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": {"row": {"id": 4, "creature": "chicken"}}, "op": "u", "source": {"file": "binlog11", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 > SELECT creature FROM doin_upsert WHERE id = 4

--- a/test/testdrive/kafka-upsert-sources-key-decode-error.td
+++ b/test/testdrive/kafka-upsert-sources-key-decode-error.td
@@ -33,7 +33,7 @@ $ set schema={
 
 $ kafka-create-topic topic=int2long
 
-$ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema-1-int-key} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema-1-int-key} schema=${schema}
 {"key": 1234} {"nokey": "nokey1"}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -46,7 +46,7 @@ $ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
-$ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema-1-long-key} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=int2long key-format=avro key-schema=${keyschema-1-long-key} schema=${schema}
 {"key": 999999999999} {"nokey": "nokey1"}
 
 ! SELECT * FROM int2long

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -35,7 +35,7 @@ $ kafka-create-topic topic=avroavro
   FOR CONFLUENT SCHEMA REGISTRY
   URL '${testdrive.schema-registry-url}';
 
-$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema} schema=${schema}
 {"key": "fish"} {"f1": "fish", "f2": 1000}
 {"key": "bird1"} {"f1":"goose", "f2": 1}
 {"key": "birdmore"} {"f1":"geese", "f2": 2}
@@ -61,7 +61,7 @@ mammalmore    moose    2
 
 $ kafka-create-topic topic=textavro
 
-$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true
+$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema}
 fish: {"f1": "fish", "f2": 1000}
 bìrd1: {"f1":"goose", "f2": 1}
 birdmore: {"f1":"geese", "f2": 2}
@@ -89,7 +89,7 @@ b\xc3\xacrd1  goose    1
 birdmore      geese    2
 mammal1       moose    1
 
-$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema} publish=true
+$ kafka-ingest format=avro topic=textavro key-format=bytes key-terminator=: schema=${schema}
 bìrd1:
 birdmore: {"f1":"geese", "f2": 56}
 mämmalmore: {"f1": "moose", "f2": 42}
@@ -285,7 +285,7 @@ $ set keyschema2={
     ]
   }
 
-$ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema}
 {"f3": {"string": "fire"}, "f4": {"string": "yang"}} {"f1": "dog", "f2": 42}
 {"f3": null, "f4": {"string": "yin"}} {"f1": "sheep", "f2": 53}
 {"f3": {"string": "water"}, "f4": null} {"f1":"plesiosaur", "f2": 224}
@@ -327,7 +327,7 @@ f3        f4        f1           f2
 water     <null>    crocodile    7
 
 # ensure that having deletion on a key that never existed does not break anything
-$ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${keyschema2} schema=${schema}
 {"f3": {"string": "fire"}, "f4": {"string": "yin"}}
 {"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "pigeon", "f2": 10}
 {"f3": {"string": "air"}, "f4":{"string": "qi"}} {"f1": "owl", "f2": 15}
@@ -365,7 +365,7 @@ $ set schema2={
     ]
   }
 
-$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2}
 {"k1": null, "k2": {"long": 2}} {"f1": {"string": "date"}, "f2": {"long": 5}}
 {"k1": {"string": "épicerie"}, "k2": {"long": 10}} {"f1": {"string": "melon"}, "f2": {"long": 2}}
 {"k1": {"string": "boucherie"}, "k2": {"long": 5}} {"f1": {"string": "apple"}, "f2": {"long": 7}}
@@ -420,7 +420,7 @@ k1       k2
 
 # add records that match the filter
 # make sure that rows that differ on unneeded key columns are treated as separate
-$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2}
 {"k1": {"string": "librairie"}, "k2": {"long": 10}} {"f1":null, "f2": {"long": 2}}
 {"k1": null, "k2": null} {"f1": {"string": "date"}, "f2": {"long": 5}}
 {"k1": {"string": "épicerie"}, "k2": {"long": 6}} {"f1": {"string": "pear"}, "f2": null}
@@ -451,7 +451,7 @@ k1        k2
 librairie 10
 
 # update records so that they don't match the filter
-$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2}
 {"k1": {"string": "librairie"}, "k2": {"long": 10}} {"f1":null, "f2": {"long": 6}}
 {"k1": null, "k2": null} {"f1": {"string": "grape"}, "f2": {"long": 5}}
 
@@ -471,7 +471,7 @@ k1        k2
 épicerie  10
 
 # update records so that they do match the filter
-$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2}
 {"k1": {"string": "librairie"}, "k2": {"long": 10}} {"f1":{"string": "melon"}, "f2": {"long": 2}}
 {"k1": null, "k2": null} {"f1": {"string": "date"}, "f2": {"long": 12}}
 
@@ -494,7 +494,7 @@ k1        k2
 librairie 10
 
 # delete records
-$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2} publish=true
+$ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=${keyschema3} schema=${schema2}
 {"k1": {"string": "boucherie"}, "k2": {"long": 5}}
 {"k1": {"string": "épicerie"}, "k2": {"long": 10}}
 {"k1": {"string": "boulangerie"}, "k2": null}

--- a/test/testdrive/materialized-views.td
+++ b/test/testdrive/materialized-views.td
@@ -25,7 +25,7 @@ $ set materialized-views={
 
 $ kafka-create-topic topic=materialized-views
 
-$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views} publish=true
+$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 {"f1": "123"}
 
 > CREATE CONNECTION kafka_conn
@@ -45,7 +45,7 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views} publish=true
+$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 {"f1": "234"}
 
 > SELECT COUNT(*) FROM s1;
@@ -53,7 +53,7 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 
 > CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(f1::integer) AS c1 FROM s1;
 
-$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views} publish=true
+$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 {"f1": "345"}
 
 > SELECT * FROM v1;
@@ -70,7 +70,7 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views} publish=true
+$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 {"f1": "456"}
 
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
@@ -83,7 +83,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 # Inject failure in the source
 
-$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views} publish=true
+$ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 {"f1": "ABC"}
 
 ! SELECT * FROM v1;

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -34,7 +34,7 @@ $ set schema={
 
 $ kafka-create-topic topic=t1
 
-$ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys} schema=${schema}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
   FOR CONFLUENT SCHEMA REGISTRY
@@ -148,7 +148,7 @@ $ set schema={
 
 $ kafka-create-topic topic=t1-pkne
 
-$ kafka-ingest format=avro topic=t1-pkne schema=${schema} publish=true
+$ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 
 > CREATE SOURCE t1_pkne (PRIMARY KEY (key1, key2) NOT ENFORCED)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -126,7 +126,7 @@ $ set kafka-ingest-repeat={
 
 $ kafka-create-topic topic=kafka-ingest-repeat
 
-$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repeat} publish=true repeat=2
+$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repeat} repeat=2
 {"f1": "fish"}
 
 > CREATE SOURCE kafka_ingest_repeat_input
@@ -141,7 +141,7 @@ fish
 
 # kafka-ingest repeat with ${kafka-ingest.iteration}
 
-$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repeat} publish=true repeat=2
+$ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repeat} repeat=2
 {"f1": "${kafka-ingest.iteration}"}
 
 > SELECT * FROM kafka_ingest_repeat_input;
@@ -157,7 +157,7 @@ $ set kafka-ingest-no-partition-value={"type": "record", "name": "r", "fields": 
 
 $ kafka-create-topic topic=kafka-ingest-no-partition partitions=2
 
-$ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-schema=${kafka-ingest-no-partition-key} schema=${kafka-ingest-no-partition-value} publish=true
+$ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-schema=${kafka-ingest-no-partition-key} schema=${kafka-ingest-no-partition-value}
 "a" {"a": "a"}
 "b" {"a": "b"}
 "c" {"a": "c"}

--- a/test/testdrive/top-1-monotonic.td
+++ b/test/testdrive/top-1-monotonic.td
@@ -25,7 +25,7 @@ $ set schema={"type": "record", "name": "schema", "fields": [ {"name": "f1", "ty
 
 $ kafka-create-topic topic=top1
 
-$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=1
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
   FOR CONFLUENT SCHEMA REGISTRY
@@ -96,7 +96,7 @@ a
 # Over a source with a single record
 #
 
-$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=1
+$ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=1
 {"f1": {"int": 123}, "f2": {"int": -123} }
 
 > SELECT * from limit_only;
@@ -121,7 +121,7 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=1
 # A second record arrives, causes the ORDER BY DESC view to change output
 #
 
-$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=2
+$ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=2
 {"f1": {"int": 234}, "f2": {"int" : -234} }
 
 > SELECT * from limit_only;
@@ -148,7 +148,7 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=2
 # The third record causes all other views to change outputs
 #
 
-$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=3
+$ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=3
 {"f1": {"int": 0}, "f2": {"int": 0} }
 
 > SELECT * from limit_only;
@@ -177,7 +177,7 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=3
 # Insert some more rows, mostly for the benefit of the "in_top_1" views
 #
 
-$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=4
+$ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=4
 {"f1": {"int": 0}, "f2": {"int": 0}}
 {"f1": {"int": 234}, "f2": {"int": 0}}
 {"f1": {"int": 123}, "f2": {"int": -234} }
@@ -214,7 +214,7 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=4
 # And finally, insert some NULL values
 #
 
-$ kafka-ingest format=avro topic=top1 schema=${schema} publish=true timestamp=5
+$ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=5
 {"f1": null, "f2": null}
 {"f1": {"int":0}, "f2": null}
 {"f1": null, "f2": {"int": 0}}

--- a/test/testdrive/upsert-unordered-key.td
+++ b/test/testdrive/upsert-unordered-key.td
@@ -54,7 +54,7 @@ $ set schema={
 
 $ kafka-create-topic topic=dbzupsert partitions=1
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish2", "b": "bdata"}}}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
@@ -71,7 +71,7 @@ a data b
 -----------
 1 fish2 bdata
 
-$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} publish=true
+$ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema}
 {"b": "bdata", "a": 1} {"before": {"row": {"a": 1, "data": "fish2", "b": "bdata"}}, "after": {"row": {"a": 1, "data": "fish3", "b": "bdata"}}}
 
 > SELECT * FROM doin_upsert

--- a/test/upgrade/create-in-current_source-schema-registry.td
+++ b/test/upgrade/create-in-current_source-schema-registry.td
@@ -17,7 +17,7 @@ $ set schema={
 
 $ kafka-create-topic topic=data
 
-$ kafka-ingest format=avro topic=data schema=${schema} publish=true
+$ kafka-ingest format=avro topic=data schema=${schema}
 {"a": 1}
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn


### PR DESCRIPTION
it does not make sense to create Confluent Avro sources without using a schema registry.

Make it so we never try to publish schemas for the non-Confluent Avro case, and we always do for the Confluent case.