### PR TITLE
adapter: accept parameters in /api/sql endpoint

### DIFF
--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1057,7 +1057,7 @@ impl From<&Datum<'_>> for serde_json::Value {
             Datum::Float64(n) => float_to_json(n.into_inner()),
             Datum::Numeric(d) => {
                 // serde_json requires floats to be finite
-                if d.0.is_infinite() {
+                if !d.0.is_finite() {
                     serde_json::Value::String(d.0.to_string())
                 } else {
                     serde_json::Value::Number(


### PR DESCRIPTION
Accept user parameters in a PG Simple Query-friendly way.

This approach is inspired by PG, namely this sentence
from the description of the Extended Query protocol:

> Furthermore, additional features are available [in Extended Query],
> such as the possibility of supplying data values as separate
> parameters instead of having to insert them directly into a query
> string.

This design does a slightly more safe version of what PG suggests,
by using a visitor over the AST and inserting the cast expressions
wherever there are parameters. Surely this is what PG themselves
must do.

For details on this design, see:
https://github.com/MaterializeInc/materialize/pull/14073

### Motivation

This PR adds a known-desirable feature.  Closes #14067

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Support parameters over the `api/sql` endpoint using a structure like:
     ```json
    {
      "sql": "INSERT INTO foo VALUES ($1);",
      "parameters": [{"type": "int", "value": "1"}]
    }
    ```
