### PR TITLE
adapter: Convert system config to unsigned ints

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -19,6 +19,7 @@ use tracing::Level;
 use tracing::{event, warn};
 
 use mz_compute_client::controller::{ComputeInstanceId, ComputeSinkId};
+use mz_ore::cast::CastFrom;
 use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_repr::{GlobalId, Timestamp};
@@ -578,51 +579,31 @@ impl<S: Append + 'static> Coordinator<S> {
         }
 
         self.validate_resource_limit(
-            self.catalog
-                .user_tables()
-                .count()
-                .try_into()
-                .expect("number of tables should fit into i32"),
+            self.catalog.user_tables().count(),
             new_tables,
             SystemVars::max_tables,
             "Table",
         )?;
         self.validate_resource_limit(
-            self.catalog
-                .user_sources()
-                .count()
-                .try_into()
-                .expect("number of sources should fit into i32"),
+            self.catalog.user_sources().count(),
             new_sources,
             SystemVars::max_sources,
             "Source",
         )?;
         self.validate_resource_limit(
-            self.catalog
-                .user_sinks()
-                .count()
-                .try_into()
-                .expect("number of sinks should fit into i32"),
+            self.catalog.user_sinks().count(),
             new_sinks,
             SystemVars::max_sinks,
             "Sink",
         )?;
         self.validate_resource_limit(
-            self.catalog
-                .user_materialized_views()
-                .count()
-                .try_into()
-                .expect("number of materialized views should fit into i32"),
+            self.catalog.user_materialized_views().count(),
             new_materialized_views,
             SystemVars::max_materialized_views,
             "Materialized view",
         )?;
         self.validate_resource_limit(
-            self.catalog
-                .compute_instances()
-                .count()
-                .try_into()
-                .expect("number of compute instances should fit into i32"),
+            self.catalog.compute_instances().count(),
             new_clusters,
             SystemVars::max_clusters,
             "Cluster",
@@ -632,13 +613,7 @@ impl<S: Append + 'static> Coordinator<S> {
             let current_amount = self
                 .catalog
                 .resolve_compute_instance(cluster_name)
-                .map(|instance| {
-                    instance
-                        .replicas_by_id
-                        .len()
-                        .try_into()
-                        .expect("number of replicas should fit into i32")
-                })
+                .map(|instance| instance.replicas_by_id.len())
                 .unwrap_or(0);
             self.validate_resource_limit(
                 current_amount,
@@ -648,23 +623,14 @@ impl<S: Append + 'static> Coordinator<S> {
             )?;
         }
         self.validate_resource_limit(
-            self.catalog
-                .databases()
-                .count()
-                .try_into()
-                .expect("number of databases should fit into i32"),
+            self.catalog.databases().count(),
             new_databases,
             SystemVars::max_databases,
             "Database",
         )?;
         for (database_id, new_schemas) in new_schemas_per_database {
             self.validate_resource_limit(
-                self.catalog
-                    .get_database(database_id)
-                    .schemas_by_id
-                    .len()
-                    .try_into()
-                    .expect("number of schemas should fit into i32"),
+                self.catalog.get_database(database_id).schemas_by_id.len(),
                 new_schemas,
                 SystemVars::max_schemas_per_database,
                 "Schemas per database",
@@ -675,30 +641,20 @@ impl<S: Append + 'static> Coordinator<S> {
                 self.catalog
                     .get_schema(&database_spec, &schema_spec, conn_id)
                     .items
-                    .len()
-                    .try_into()
-                    .expect("number of items should fit into i32"),
+                    .len(),
                 new_objects,
                 SystemVars::max_objects_per_schema,
                 "Objects per schema",
             )?;
         }
         self.validate_resource_limit(
-            self.catalog
-                .user_secrets()
-                .count()
-                .try_into()
-                .expect("number of secrets should fit into i32"),
+            self.catalog.user_secrets().count(),
             new_secrets,
             SystemVars::max_secrets,
             "Secret",
         )?;
         self.validate_resource_limit(
-            self.catalog
-                .user_roles()
-                .count()
-                .try_into()
-                .expect("number of secrets should fit into i32"),
+            self.catalog.user_roles().count(),
             new_roles,
             SystemVars::max_roles,
             "Role",
@@ -709,16 +665,20 @@ impl<S: Append + 'static> Coordinator<S> {
     /// Validate a specific type of resource limit and return an error if that limit is exceeded.
     fn validate_resource_limit<F>(
         &self,
-        current_amount: i32,
-        new_instances: i32,
+        current_amount: usize,
+        new_instances: u32,
         resource_limit: F,
         resource_type: &str,
     ) -> Result<(), AdapterError>
     where
-        F: Fn(&SystemVars) -> i32,
+        F: Fn(&SystemVars) -> u32,
     {
         let limit = resource_limit(self.catalog.state().system_config());
-        if new_instances > 0 && current_amount + new_instances > limit {
+        if current_amount > usize::cast_from(u32::MAX)
+            || (new_instances > 0
+                && u32::try_from(current_amount).expect("guaranteed to fit") + new_instances
+                    > limit)
+        {
             Err(AdapterError::ResourceExhaustion {
                 resource_type: resource_type.to_string(),
                 limit,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -117,8 +117,8 @@ pub enum AdapterError {
     /// A query tried to create more resources than is allowed in the system configuration.
     ResourceExhaustion {
         resource_type: String,
-        limit: i32,
-        current_amount: i32,
+        limit: u32,
+        current_amount: usize,
     },
     /// The specified feature is not permitted in safe mode.
     SafeModeViolation(String),

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -173,68 +173,68 @@ const TRANSACTION_ISOLATION: ServerVar<IsolationLevel> = ServerVar {
     description: "Sets the current transaction's isolation level (PostgreSQL).",
 };
 
-const MAX_TABLES: ServerVar<i32> = ServerVar {
+const MAX_TABLES: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_tables"),
     value: &25,
     description: "The maximum number of tables in the region, across all schemas (Materialize).",
 };
 
-const MAX_SOURCES: ServerVar<i32> = ServerVar {
+const MAX_SOURCES: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_sources"),
     value: &25,
     description: "The maximum number of sources in the region, across all schemas (Materialize).",
 };
 
-const MAX_SINKS: ServerVar<i32> = ServerVar {
+const MAX_SINKS: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_sinks"),
     value: &25,
     description: "The maximum number of sinks in the region, across all schemas (Materialize).",
 };
 
-const MAX_MATERIALIZED_VIEWS: ServerVar<i32> = ServerVar {
+const MAX_MATERIALIZED_VIEWS: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_materialized_views"),
     value: &100,
     description:
         "The maximum number of materialized views in the region, across all schemas (Materialize).",
 };
 
-const MAX_CLUSTERS: ServerVar<i32> = ServerVar {
+const MAX_CLUSTERS: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_clusters"),
     value: &10,
     description: "The maximum number of clusters in the region (Materialize).",
 };
 
-const MAX_REPLICAS_PER_CLUSTER: ServerVar<i32> = ServerVar {
+const MAX_REPLICAS_PER_CLUSTER: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_replicas_per_cluster"),
     value: &5,
     description: "The maximum number of replicas of a single cluster (Materialize).",
 };
 
-const MAX_DATABASES: ServerVar<i32> = ServerVar {
+const MAX_DATABASES: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_databases"),
     value: &1000,
     description: "The maximum number of databases in the region (Materialize).",
 };
 
-const MAX_SCHEMAS_PER_DATABASE: ServerVar<i32> = ServerVar {
+const MAX_SCHEMAS_PER_DATABASE: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_schemas_per_database"),
     value: &1000,
     description: "The maximum number of schemas in a database (Materialize).",
 };
 
-const MAX_OBJECTS_PER_SCHEMA: ServerVar<i32> = ServerVar {
+const MAX_OBJECTS_PER_SCHEMA: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_objects_per_schema"),
     value: &1000,
     description: "The maximum number of objects in a schema (Materialize).",
 };
 
-const MAX_SECRETS: ServerVar<i32> = ServerVar {
+const MAX_SECRETS: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_secrets"),
     value: &100,
     description: "The maximum number of secrets in the region, across all schemas (Materialize).",
 };
 
-const MAX_ROLES: ServerVar<i32> = ServerVar {
+const MAX_ROLES: ServerVar<u32> = ServerVar {
     name: UncasedStr::new("max_roles"),
     value: &1000,
     description: "The maximum number of roles in the region (Materialize).",
@@ -747,17 +747,17 @@ impl SessionVars {
 /// See [`SessionVars`] for more details on the Materialize configuration model.
 #[derive(Debug, Clone)]
 pub struct SystemVars {
-    max_tables: SystemVar<i32>,
-    max_sources: SystemVar<i32>,
-    max_sinks: SystemVar<i32>,
-    max_materialized_views: SystemVar<i32>,
-    max_clusters: SystemVar<i32>,
-    max_replicas_per_cluster: SystemVar<i32>,
-    max_databases: SystemVar<i32>,
-    max_schemas_per_database: SystemVar<i32>,
-    max_objects_per_schema: SystemVar<i32>,
-    max_secrets: SystemVar<i32>,
-    max_roles: SystemVar<i32>,
+    max_tables: SystemVar<u32>,
+    max_sources: SystemVar<u32>,
+    max_sinks: SystemVar<u32>,
+    max_materialized_views: SystemVar<u32>,
+    max_clusters: SystemVar<u32>,
+    max_replicas_per_cluster: SystemVar<u32>,
+    max_databases: SystemVar<u32>,
+    max_schemas_per_database: SystemVar<u32>,
+    max_objects_per_schema: SystemVar<u32>,
+    max_secrets: SystemVar<u32>,
+    max_roles: SystemVar<u32>,
 }
 
 impl Default for SystemVars {
@@ -906,57 +906,57 @@ impl SystemVars {
     }
 
     /// Returns the value of the `max_tables` configuration parameter.
-    pub fn max_tables(&self) -> i32 {
+    pub fn max_tables(&self) -> u32 {
         *self.max_tables.value()
     }
 
     /// Returns the value of the `max_sources` configuration parameter.
-    pub fn max_sources(&self) -> i32 {
+    pub fn max_sources(&self) -> u32 {
         *self.max_sources.value()
     }
 
     /// Returns the value of the `max_sinks` configuration parameter.
-    pub fn max_sinks(&self) -> i32 {
+    pub fn max_sinks(&self) -> u32 {
         *self.max_sinks.value()
     }
 
     /// Returns the value of the `max_materialized_views` configuration parameter.
-    pub fn max_materialized_views(&self) -> i32 {
+    pub fn max_materialized_views(&self) -> u32 {
         *self.max_materialized_views.value()
     }
 
     /// Returns the value of the `max_clusters` configuration parameter.
-    pub fn max_clusters(&self) -> i32 {
+    pub fn max_clusters(&self) -> u32 {
         *self.max_clusters.value()
     }
 
     /// Returns the value of the `max_replicas_per_cluster` configuration parameter.
-    pub fn max_replicas_per_cluster(&self) -> i32 {
+    pub fn max_replicas_per_cluster(&self) -> u32 {
         *self.max_replicas_per_cluster.value()
     }
 
     /// Returns the value of the `max_databases` configuration parameter.
-    pub fn max_databases(&self) -> i32 {
+    pub fn max_databases(&self) -> u32 {
         *self.max_databases.value()
     }
 
     /// Returns the value of the `max_schemas_per_database` configuration parameter.
-    pub fn max_schemas_per_database(&self) -> i32 {
+    pub fn max_schemas_per_database(&self) -> u32 {
         *self.max_schemas_per_database.value()
     }
 
     /// Returns the value of the `max_objects_per_schema` configuration parameter.
-    pub fn max_objects_per_schema(&self) -> i32 {
+    pub fn max_objects_per_schema(&self) -> u32 {
         *self.max_objects_per_schema.value()
     }
 
     /// Returns the value of the `max_secrets` configuration parameter.
-    pub fn max_secrets(&self) -> i32 {
+    pub fn max_secrets(&self) -> u32 {
         *self.max_secrets.value()
     }
 
     /// Returns the value of the `max_roles` configuration parameter.
-    pub fn max_roles(&self) -> i32 {
+    pub fn max_roles(&self) -> u32 {
         *self.max_roles.value()
     }
 }
@@ -1214,6 +1214,18 @@ impl Value for i32 {
     const TYPE_NAME: &'static str = "integer";
 
     fn parse(s: &str) -> Result<i32, ()> {
+        s.parse().map_err(|_| ())
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Value for u32 {
+    const TYPE_NAME: &'static str = "unsigned integer";
+
+    fn parse(s: &str) -> Result<u32, ()> {
         s.parse().map_err(|_| ())
     }
 


### PR DESCRIPTION
The system configuration variables were always strictly positive
numbers, but we were using signed integers to represent them. This
commit converts them to use unsigned integers.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
