### PR TITLE
deps: swap sha-1 for sha1 in transitive dependency graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,8 +2159,7 @@ dependencies = [
 [[package]]
 name = "headers"
 version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
+source = "git+https://github.com/hyperium/headers.git#31fe3e19e5763b95c9b5dfed1569bef555380dc4"
 dependencies = [
  "base64",
  "bitflags",
@@ -2169,14 +2168,13 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha-1",
+ "sha1",
 ]
 
 [[package]]
 name = "headers-core"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+source = "git+https://github.com/hyperium/headers.git#31fe3e19e5763b95c9b5dfed1569bef555380dc4"
 dependencies = [
  "http",
 ]
@@ -2926,9 +2924,8 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ce6fdcef94a8e87fea3f9402de4d7e403f10e8c20b6e2bd207e6b6f8a4eab0"
+version = "0.29.1"
+source = "git+https://github.com/blackbeam/rust_mysql_common.git#e9c8deef5bfd4a8b1ea049d92ce8ae8ca53c9ab8"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -2952,7 +2949,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha-1",
+ "sha1",
  "sha2",
  "smallvec",
  "subprocess",
@@ -5756,17 +5753,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6627,9 +6613,8 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tungstenite"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96a2dea40e7570482f28eb57afbe42d97551905da6a9400acc5c328d24004f5"
+version = "0.17.3"
+source = "git+https://github.com/snapview/tungstenite-rs.git#1978a1b5ffaa31251cbf7b2f7ecd8947a463bba1"
 dependencies = [
  "base64",
  "byteorder",
@@ -6638,7 +6623,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "sha-1",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,10 @@ debug = 1
 [patch.crates-io]
 csv = { git = "https://github.com/BurntSushi/rust-csv.git" }
 csv-core = { git = "https://github.com/BurntSushi/rust-csv.git" }
+headers = { git = "https://github.com/hyperium/headers.git" }
 postgres-protocol = { git = "https://github.com/MaterializeInc/rust-postgres" }
+mysql_common = { git = "https://github.com/blackbeam/rust_mysql_common.git" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tungstenite = { git = "https://github.com/snapview/tungstenite-rs.git" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/alacritty/vte" }

--- a/deny.toml
+++ b/deny.toml
@@ -19,14 +19,6 @@ name = "md5"
 # `sha-1` is the older and now deprecated name.
 [[bans.deny]]
 name = "sha-1"
-wrappers = [
-    # https://github.com/hyperium/headers/pull/117
-    "headers",
-    # https://github.com/blackbeam/rust_mysql_common/pull/71
-    "mysql_common",
-    # https://github.com/snapview/tungstenite-rs/pull/299
-    "tungstenite",
-]
 
 # Use `prost` or `protobuf-native` instead.
 [[bans.deny]]
@@ -172,6 +164,18 @@ allow-git = [
 
     # Waiting on https://github.com/MaterializeInc/serde-value/pull/35.
     "https://github.com/MaterializeInc/serde-value.git",
+
+    # Waiting on https://github.com/hyperium/headers/pull/117 to make it into
+    # a release.
+    "https://github.com/hyperium/headers.git",
+
+    # Waiting on https://github.com/blackbeam/rust_mysql_common/pull/71 to make
+    # it into a release.
+    "https://github.com/blackbeam/rust_mysql_common.git",
+
+    # Waiting on https://github.com/snapview/tungstenite-rs/pull/299 to make
+    # it into a release.
+    "https://github.com/snapview/tungstenite-rs.git",
 
     # Dependencies that we control upstream whose official releases we don't
     # care about.


### PR DESCRIPTION
This is a follow up to 11fb911 that makes the swap across the entire
transitive dependency graph. All of the necessary upstream PRs have been
merged; not all have been merged, but we can depend on upstream Git
repositories for now.

Fix #14480.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
