### PR TITLE
explain: add unique keys attribute to new interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,9 +4365,12 @@ dependencies = [
  "mz-ore",
  "mz-repr",
  "mz-storage",
+ "num-derive",
+ "num-traits",
  "proc-macro2",
  "serde_json",
  "tracing",
+ "typemap_rev",
 ]
 
 [[package]]
@@ -4473,6 +4476,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/adapter/src/explain_new/mir/mod.rs
+++ b/src/adapter/src/explain_new/mir/mod.rs
@@ -19,7 +19,7 @@ use mz_expr::{visit::Visit, MirRelationExpr, OptimizedMirRelationExpr};
 use mz_ore::{stack::RecursionLimitError, str::bracketed, str::separated};
 use mz_repr::explain_new::{Explain, ExplainConfig, ExplainError, UnsupportedFormat};
 use mz_transform::attribute::{
-    Arity, AsKey, DerivedAttributes, NonNegative, RelationType, RequiredAttributes, SubtreeSize,
+    Arity, DerivedAttributes, NonNegative, RelationType, RequiredAttributes, SubtreeSize,
     UniqueKeys,
 };
 
@@ -119,19 +119,19 @@ impl From<&ExplainConfig> for ExplainAttributes {
     fn from(config: &ExplainConfig) -> ExplainAttributes {
         let mut builder = RequiredAttributes::default();
         if config.subtree_size {
-            builder.require::<AsKey<SubtreeSize>>();
+            builder.require::<SubtreeSize>();
         }
         if config.non_negative {
-            builder.require::<AsKey<NonNegative>>();
+            builder.require::<NonNegative>();
         }
         if config.types {
-            builder.require::<AsKey<RelationType>>();
+            builder.require::<RelationType>();
         }
         if config.arity {
-            builder.require::<AsKey<Arity>>();
+            builder.require::<Arity>();
         }
         if config.keys {
-            builder.require::<AsKey<UniqueKeys>>();
+            builder.require::<UniqueKeys>();
         }
         ExplainAttributes {
             deriver: builder.finish(),
@@ -159,7 +159,7 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
                 for (expr, attr) in std::iter::zip(
                     subtree_refs.iter(),
                     attribute_map
-                        .remove::<AsKey<SubtreeSize>>()
+                        .remove::<SubtreeSize>()
                         .unwrap()
                         .results
                         .into_iter(),
@@ -172,7 +172,7 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
                 for (expr, attr) in std::iter::zip(
                     subtree_refs.iter(),
                     attribute_map
-                        .remove::<AsKey<NonNegative>>()
+                        .remove::<NonNegative>()
                         .unwrap()
                         .results
                         .into_iter(),

--- a/src/adapter/src/explain_new/mir/mod.rs
+++ b/src/adapter/src/explain_new/mir/mod.rs
@@ -153,16 +153,12 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
             // get the annotation values
             let mut explain_attrs = ExplainAttributes::from(config);
             plan.visit(&mut explain_attrs.deriver)?;
-            let mut attribute_map = explain_attrs.deriver.take();
+            let mut attribute_map = explain_attrs.deriver;
 
             if config.subtree_size {
                 for (expr, attr) in std::iter::zip(
                     subtree_refs.iter(),
-                    attribute_map
-                        .remove::<SubtreeSize>()
-                        .unwrap()
-                        .results
-                        .into_iter(),
+                    attribute_map.remove_results::<SubtreeSize>().into_iter(),
                 ) {
                     let attrs = annotations.entry(expr).or_default();
                     attrs.subtree_size = Some(attr);
@@ -171,11 +167,7 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
             if config.non_negative {
                 for (expr, attr) in std::iter::zip(
                     subtree_refs.iter(),
-                    attribute_map
-                        .remove::<NonNegative>()
-                        .unwrap()
-                        .results
-                        .into_iter(),
+                    attribute_map.remove_results::<NonNegative>().into_iter(),
                 ) {
                     let attrs = annotations.entry(expr).or_default();
                     attrs.non_negative = Some(attr);
@@ -185,11 +177,7 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
             if config.arity {
                 for (expr, attr) in std::iter::zip(
                     subtree_refs.iter(),
-                    attribute_map
-                        .remove::<AsKey<Arity>>()
-                        .unwrap()
-                        .results
-                        .into_iter(),
+                    attribute_map.remove_results::<Arity>().into_iter(),
                 ) {
                     let attrs = annotations.entry(expr).or_default();
                     attrs.arity = Some(attr);
@@ -199,11 +187,7 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
             if config.types {
                 for (expr, types) in std::iter::zip(
                     subtree_refs.iter(),
-                    attribute_map
-                        .remove::<AsKey<RelationType>>()
-                        .unwrap()
-                        .results
-                        .into_iter(),
+                    attribute_map.remove_results::<RelationType>().into_iter(),
                 ) {
                     let humanized_columns = types
                         .into_iter()
@@ -218,11 +202,7 @@ impl<'a> AnnotatedPlan<'a, MirRelationExpr> {
             if config.keys {
                 for (expr, keys) in std::iter::zip(
                     subtree_refs.iter(),
-                    attribute_map
-                        .remove::<AsKey<UniqueKeys>>()
-                        .unwrap()
-                        .results
-                        .into_iter(),
+                    attribute_map.remove_results::<UniqueKeys>().into_iter(),
                 ) {
                     let formatted_keys = keys
                         .into_iter()

--- a/src/adapter/src/explain_new/mod.rs
+++ b/src/adapter/src/explain_new/mod.rs
@@ -88,6 +88,7 @@ pub struct Attributes {
     subtree_size: Option<usize>,
     arity: Option<usize>,
     types: Option<String>,
+    keys: Option<String>,
 }
 
 impl fmt::Display for Attributes {
@@ -104,6 +105,9 @@ impl fmt::Display for Attributes {
         }
         if let Some(types) = &self.types {
             builder.field("types", types);
+        }
+        if let Some(keys) = &self.keys {
+            builder.field("keys", keys);
         }
         builder.finish()
     }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6594,7 +6594,6 @@ mod test {
         let mut rti = mz_lowertest::ReflectedTypeInfo::default();
         UnaryFunc::add_to_reflected_type_info(&mut rti);
         for (variant, (_, f_types)) in rti.enum_dict["UnaryFunc"].iter() {
-            println!("f_types {:?}", f_types);
             if f_types.is_empty() {
                 let unary_unit_variant: UnaryFunc =
                     serde_json::from_str(&format!("\"{}\"", variant)).unwrap();

--- a/src/repr/src/explain_new.rs
+++ b/src/repr/src/explain_new.rs
@@ -363,6 +363,8 @@ pub struct ExplainConfig {
     pub arity: bool,
     /// Render implemented MIR `Join` nodes in a way which reflects the implementation.
     pub join_impls: bool,
+    /// Show the sets of unique keys.
+    pub keys: bool,
     /// Show the `non_negative` in the explanation if it is supported by the backing IR.
     pub non_negative: bool,
     /// Show the slow path plan even if a fast path plan was created. Useful for debugging.
@@ -381,7 +383,7 @@ pub struct ExplainConfig {
 
 impl ExplainConfig {
     pub fn requires_attributes(&self) -> bool {
-        self.subtree_size || self.non_negative || self.arity || self.types
+        self.subtree_size || self.non_negative || self.arity || self.types || self.keys
     }
 }
 
@@ -397,6 +399,7 @@ impl TryFrom<HashSet<String>> for ExplainConfig {
         let result = ExplainConfig {
             arity: config_flags.remove("arity"),
             join_impls: config_flags.remove("join_impls"),
+            keys: config_flags.remove("keys"),
             non_negative: config_flags.remove("non_negative"),
             no_fast_path: config_flags.remove("no_fast_path"),
             raw_plans: config_flags.remove("raw_plans"),
@@ -759,6 +762,7 @@ mod tests {
         let config = ExplainConfig {
             arity: false,
             join_impls: false,
+            keys: false,
             non_negative: false,
             no_fast_path: false,
             raw_plans: false,

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -14,7 +14,10 @@ mz-expr = { path = "../expr" }
 mz-ore = { path = "../ore" }
 mz-repr = { path = "../repr" }
 mz-storage = { path = "../storage" }
+num-traits = "0.2"
+num-derive = "0.3"
 tracing = "0.1.36"
+typemap_rev = "0.1.5"
 
 [dev-dependencies]
 anyhow = "1.0.62"

--- a/src/transform/src/attribute/arity.rs
+++ b/src/transform/src/attribute/arity.rs
@@ -11,7 +11,7 @@
 
 use mz_expr::MirRelationExpr;
 
-use super::{subtree_size::SubtreeSize, AsKey, Attribute, DerivedAttributes, RequiredAttributes};
+use super::{subtree_size::SubtreeSize, Attribute, DerivedAttributes, RequiredAttributes};
 
 /// Compute the column types of each subtree of a [MirRelationExpr] from the
 /// bottom-up.
@@ -32,7 +32,7 @@ impl Attribute for Arity {
         let mut offset = 1;
         for _ in 0..expr.num_inputs() {
             offsets.push(n - offset);
-            offset += &deps.get_results::<AsKey<SubtreeSize>>()[n - offset];
+            offset += &deps.get_results::<SubtreeSize>()[n - offset];
         }
         let subtree_arity =
             expr.arity_with_input_arities(offsets.into_iter().rev().map(|o| &self.results[o]));
@@ -43,7 +43,7 @@ impl Attribute for Arity {
     where
         Self: Sized,
     {
-        builder.require::<AsKey<SubtreeSize>>();
+        builder.require::<SubtreeSize>();
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/arity.rs
+++ b/src/transform/src/attribute/arity.rs
@@ -53,4 +53,8 @@ impl Attribute for Arity {
     fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
         &mut self.results
     }
+
+    fn take(self) -> Vec<Self::Value> {
+        self.results
+    }
 }

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -18,14 +18,14 @@ use mz_expr::{LocalId, MirRelationExpr};
 
 use self::{
     arity::Arity, non_negative::NonNegative, relation_type::RelationType,
-    subtree_size::SubtreeSize, /*unique_keys::UniqueKeys,*/
+    subtree_size::SubtreeSize, unique_keys::UniqueKeys,
 };
 
 pub mod arity;
 pub mod non_negative;
 pub mod relation_type;
 pub mod subtree_size;
-//pub mod unique_keys;
+pub mod unique_keys;
 
 /// A common interface to be implemented by all derived attributes.
 pub trait Attribute {
@@ -209,7 +209,7 @@ pub struct AttributeDeriver {
 }
 
 /// A topological sort of extant attributes.
-/// 
+///
 /// The attribute assigned value 0 depends on no other attributes.
 /// We expect the attributes to be assigned numbers in the range
 /// 0..TOTAL_ATTRIBUTES with no gaps in between.
@@ -219,11 +219,11 @@ enum AttributeId {
     NonNegative = 1,
     Arity = 2,
     RelationType = 3,
-    //UniqueKeys = 4,
+    UniqueKeys = 4,
 }
 
 /// Should always be equal to the number of attributes
-const TOTAL_ATTRIBUTES: usize = 4;
+const TOTAL_ATTRIBUTES: usize = 5;
 
 impl AttributeDeriver {
     /// Does derivation work required upon entering a subexpression
@@ -250,9 +250,9 @@ impl AttributeDeriver {
                 Some(AttributeId::Arity) => {
                     schedule_env_tasks::<Arity>(&mut self.attributes, expr);
                 }
-                /*Some(AttributeId::UniqueKeys) => {
+                Some(AttributeId::UniqueKeys) => {
                     schedule_env_tasks::<UniqueKeys>(&mut self.attributes, expr);
-                }*/
+                }
                 None => {}
             }
         }
@@ -285,9 +285,9 @@ impl AttributeDeriver {
                 Some(AttributeId::Arity) => {
                     post::<Arity>(&mut self.attributes, expr, &mut deps);
                 }
-                /*Some(AttributeId::UniqueKeys) => {
+                Some(AttributeId::UniqueKeys) => {
                     post::<UniqueKeys>(&mut self.attributes, expr, &mut deps);
-                }*/
+                }
                 None => {}
             }
         }
@@ -351,9 +351,14 @@ impl AttributeDeriver {
                         r.results.pop();
                     });
                 }
-                /*Some(AttributeId::UniqueKeys) => {
-                    post::<UniqueKeys>(&mut self.attributes, expr, &mut deps);
-                }*/
+                Some(AttributeId::UniqueKeys) => {
+                    self.attributes
+                        .get_mut::<UniqueKeys>()
+                        .iter_mut()
+                        .for_each(|r| {
+                            r.results.pop();
+                        });
+                }
                 None => {}
             }
         }

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -11,6 +11,7 @@
 
 use std::{collections::HashMap, marker::PhantomData};
 
+use mz_repr::explain_new::ExplainConfig;
 use num_traits::FromPrimitive;
 use typemap_rev::{TypeMap, TypeMapKey};
 
@@ -221,6 +222,28 @@ pub struct DerivedAttributes {
     to_be_derived: Box<TypeMap>,
 }
 
+impl From<&ExplainConfig> for DerivedAttributes {
+    fn from(config: &ExplainConfig) -> DerivedAttributes {
+        let mut builder = RequiredAttributes::default();
+        if config.subtree_size {
+            builder.require::<SubtreeSize>();
+        }
+        if config.non_negative {
+            builder.require::<NonNegative>();
+        }
+        if config.types {
+            builder.require::<RelationType>();
+        }
+        if config.arity {
+            builder.require::<Arity>();
+        }
+        if config.keys {
+            builder.require::<UniqueKeys>();
+        }
+        builder.finish()
+    }
+}
+
 /// A topological sort of extant attributes.
 ///
 /// The attribute assigned value 0 depends on no other attributes.
@@ -330,7 +353,7 @@ impl DerivedAttributes {
     /// After this call, no further attributes of this type will be derived.
     pub fn remove_results<A: Attribute>(&mut self) -> Vec<A::Value> {
         self.attributes.remove::<AsKey<A>>().unwrap().take()
-   }
+    }
 
     fn trim_attr<T: TypeMapKey>(&mut self)
     where

--- a/src/transform/src/attribute/non_negative.rs
+++ b/src/transform/src/attribute/non_negative.rs
@@ -13,7 +13,6 @@ use mz_expr::Id;
 use mz_expr::MirRelationExpr;
 
 use super::subtree_size::SubtreeSize;
-use super::AsKey;
 use super::DerivedAttributes;
 use super::RequiredAttributes;
 use super::{Attribute, Env};
@@ -92,7 +91,7 @@ impl Attribute for NonNegative {
                 let mut offset = 1;
                 for _ in 0..inputs.len() {
                     result &= &self.results[n - offset];
-                    offset += &deps.get_results::<AsKey<SubtreeSize>>()[n - offset];
+                    offset += &deps.get_results::<SubtreeSize>()[n - offset];
                 }
                 self.results.push(result); // can be refined
             }
@@ -115,7 +114,7 @@ impl Attribute for NonNegative {
                 let mut offset = 1;
                 for _ in 0..inputs.len() {
                     result &= &self.results[n - offset];
-                    offset += &deps.get_results::<AsKey<SubtreeSize>>()[n - offset];
+                    offset += &deps.get_results::<SubtreeSize>()[n - offset];
                 }
                 result &= &self.results[n - offset]; // include the base result
                 self.results.push(result); // can be refined
@@ -139,7 +138,7 @@ impl Attribute for NonNegative {
     where
         Self: Sized,
     {
-        builder.require::<AsKey<SubtreeSize>>();
+        builder.require::<SubtreeSize>();
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/non_negative.rs
+++ b/src/transform/src/attribute/non_negative.rs
@@ -148,4 +148,8 @@ impl Attribute for NonNegative {
     fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
         &mut self.results
     }
+
+    fn take(self) -> Vec<Self::Value> {
+        self.results
+    }
 }

--- a/src/transform/src/attribute/relation_type.rs
+++ b/src/transform/src/attribute/relation_type.rs
@@ -55,4 +55,8 @@ impl Attribute for RelationType {
     fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
         &mut self.results
     }
+
+    fn take(self) -> Vec<Self::Value> {
+        self.results
+    }
 }

--- a/src/transform/src/attribute/relation_type.rs
+++ b/src/transform/src/attribute/relation_type.rs
@@ -13,7 +13,7 @@ use mz_expr::MirRelationExpr;
 use mz_repr::ColumnType;
 
 use super::subtree_size::SubtreeSize;
-use super::{AsKey, Attribute, DerivedAttributes, RequiredAttributes};
+use super::{Attribute, DerivedAttributes, RequiredAttributes};
 
 /// Compute the column types of each subtree of a [MirRelationExpr] from the
 /// bottom-up.
@@ -34,7 +34,7 @@ impl Attribute for RelationType {
         let mut offset = 1;
         for _ in 0..expr.num_inputs() {
             offsets.push(n - offset);
-            offset += &deps.get_results::<AsKey<SubtreeSize>>()[n - offset];
+            offset += &deps.get_results::<SubtreeSize>()[n - offset];
         }
         let subtree_column_types =
             expr.col_with_input_cols(offsets.into_iter().rev().map(|o| &self.results[o]));
@@ -45,7 +45,7 @@ impl Attribute for RelationType {
     where
         Self: Sized,
     {
-        builder.require::<AsKey<SubtreeSize>>();
+        builder.require::<SubtreeSize>();
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/subtree_size.rs
+++ b/src/transform/src/attribute/subtree_size.rs
@@ -10,9 +10,8 @@
 //! Definition and helper structs for the [`SubtreeSize`] attribute.
 
 use mz_expr::MirRelationExpr;
-use typemap_rev::{TypeMap, TypeMapKey};
 
-use super::{Attribute, AttributeBuilder};
+use super::{Attribute, DerivedAttributes, RequiredAttributes};
 
 /// Compute the number of MirRelationExpr in each subtree in a bottom-up manner.
 #[derive(Default)]
@@ -23,14 +22,10 @@ pub struct SubtreeSize {
     pub results: Vec<usize>,
 }
 
-impl TypeMapKey for SubtreeSize {
-    type Value = SubtreeSize;
-}
-
 impl Attribute for SubtreeSize {
     type Value = usize;
 
-    fn derive(&mut self, expr: &MirRelationExpr, _deps: &TypeMap) {
+    fn derive(&mut self, expr: &MirRelationExpr, _deps: &DerivedAttributes) {
         use MirRelationExpr::*;
         let n = self.results.len();
         match expr {
@@ -101,7 +96,7 @@ impl Attribute for SubtreeSize {
         }
     }
 
-    fn add_dependencies(_builder: &mut AttributeBuilder)
+    fn add_dependencies(_builder: &mut RequiredAttributes)
     where
         Self: Sized,
     {

--- a/src/transform/src/attribute/subtree_size.rs
+++ b/src/transform/src/attribute/subtree_size.rs
@@ -109,4 +109,8 @@ impl Attribute for SubtreeSize {
     fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
         &mut self.results
     }
+
+    fn take(self) -> Vec<Self::Value> {
+        self.results
+    }
 }

--- a/src/transform/src/attribute/subtree_size.rs
+++ b/src/transform/src/attribute/subtree_size.rs
@@ -10,8 +10,9 @@
 //! Definition and helper structs for the [`SubtreeSize`] attribute.
 
 use mz_expr::MirRelationExpr;
+use typemap_rev::{TypeMap, TypeMapKey};
 
-use super::Attribute;
+use super::{Attribute, AttributeBuilder};
 
 /// Compute the number of MirRelationExpr in each subtree in a bottom-up manner.
 #[derive(Default)]
@@ -22,11 +23,14 @@ pub struct SubtreeSize {
     pub results: Vec<usize>,
 }
 
+impl TypeMapKey for SubtreeSize {
+    type Value = SubtreeSize;
+}
+
 impl Attribute for SubtreeSize {
     type Value = usize;
-    type Dependencies = ();
 
-    fn derive(&mut self, expr: &MirRelationExpr, _deps: &()) {
+    fn derive(&mut self, expr: &MirRelationExpr, _deps: &TypeMap) {
         use MirRelationExpr::*;
         let n = self.results.len();
         match expr {
@@ -95,5 +99,19 @@ impl Attribute for SubtreeSize {
                 self.results.push(input + 1);
             }
         }
+    }
+
+    fn add_dependencies(_builder: &mut AttributeBuilder)
+    where
+        Self: Sized,
+    {
+    }
+
+    fn get_results(&self) -> &Vec<Self::Value> {
+        &self.results
+    }
+
+    fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
+        &mut self.results
     }
 }

--- a/src/transform/src/attribute/unique_keys.rs
+++ b/src/transform/src/attribute/unique_keys.rs
@@ -12,8 +12,7 @@
 use mz_expr::MirRelationExpr;
 
 use super::{
-    arity::Arity, subtree_size::SubtreeSize, AsKey, Attribute, DerivedAttributes,
-    RequiredAttributes,
+    arity::Arity, subtree_size::SubtreeSize, Attribute, DerivedAttributes, RequiredAttributes,
 };
 
 /// Compute the unique keys of each subtree of a [MirRelationExpr] from the
@@ -36,14 +35,14 @@ impl Attribute for UniqueKeys {
         let mut offset = 1;
         for _ in 0..expr.num_inputs() {
             offsets.push(n - offset);
-            offset += &deps.get_results::<AsKey<SubtreeSize>>()[n - offset];
+            offset += &deps.get_results::<SubtreeSize>()[n - offset];
         }
 
         let subtree_keys = expr.keys_with_input_keys(
             offsets
                 .iter()
                 .rev()
-                .map(|o| deps.get_results::<AsKey<Arity>>()[*o]),
+                .map(|o| deps.get_results::<Arity>()[*o]),
             offsets.iter().rev().map(|o| &self.results[*o]),
         );
 
@@ -54,8 +53,8 @@ impl Attribute for UniqueKeys {
     where
         Self: Sized,
     {
-        builder.require::<AsKey<Arity>>();
-        builder.require::<AsKey<SubtreeSize>>();
+        builder.require::<Arity>();
+        builder.require::<SubtreeSize>();
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/unique_keys.rs
+++ b/src/transform/src/attribute/unique_keys.rs
@@ -1,0 +1,70 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Definition and helper structs for the [`UniqueKeys`] attribute.
+
+use mz_expr::MirRelationExpr;
+use typemap_rev::{TypeMap, TypeMapKey};
+
+use super::{arity::Arity, subtree_size::SubtreeSize, Attribute, AttributeBuilder};
+
+/// Compute the unique keys of each subtree of a [MirRelationExpr] from the
+/// bottom-up.
+#[derive(Default)]
+#[allow(missing_debug_implementations)]
+pub struct UniqueKeys {
+    /// A vector of results for all nodes in the visited tree in
+    /// post-visit order.
+    pub results: Vec<Vec<Vec<usize>>>,
+}
+
+impl TypeMapKey for UniqueKeys {
+    type Value = UniqueKeys;
+}
+
+impl Attribute for UniqueKeys {
+    type Value = Vec<Vec<usize>>;
+
+    fn derive(&mut self, expr: &MirRelationExpr, deps: &TypeMap) {
+        let n = self.results.len();
+
+        let mut offsets = Vec::new();
+        let mut offset = 1;
+        for _ in 0..expr.num_inputs() {
+            offsets.push(n - offset);
+            offset += &deps.get::<SubtreeSize>().unwrap().results[n - offset];
+        }
+
+        let subtree_keys = expr.keys_with_input_keys(
+            offsets
+                .iter()
+                .rev()
+                .map(|o| deps.get::<Arity>().unwrap().results[*o]),
+            offsets.iter().rev().map(|o| &self.results[*o]),
+        );
+
+        self.results.push(subtree_keys);
+    }
+
+    fn add_dependencies(builder: &mut AttributeBuilder)
+    where
+        Self: Sized,
+    {
+        builder.add_attribute::<Arity>();
+        builder.add_attribute::<SubtreeSize>();
+    }
+
+    fn get_results(&self) -> &Vec<Self::Value> {
+        &self.results
+    }
+
+    fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
+        &mut self.results
+    }
+}

--- a/src/transform/src/attribute/unique_keys.rs
+++ b/src/transform/src/attribute/unique_keys.rs
@@ -64,4 +64,8 @@ impl Attribute for UniqueKeys {
     fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
         &mut self.results
     }
+
+    fn take(self) -> Vec<Self::Value> {
+        self.results
+    }
 }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -60,6 +60,9 @@ pub mod dataflow;
 pub use dataflow::optimize_dataflow;
 use mz_ore::stack::RecursionLimitError;
 
+#[macro_use]
+extern crate num_derive;
+
 /// Arguments that get threaded through all transforms.
 #[derive(Debug)]
 pub struct TransformArgs<'a> {

--- a/src/transform/src/threshold_elision.rs
+++ b/src/transform/src/threshold_elision.rs
@@ -15,7 +15,7 @@
 //! The Subset(X) notation means that the collection is a multiset subset of X:
 //! multiplicities of each record in Subset(X) are at most that of X.
 
-use crate::attribute::{AsKey, DerivedAttributes, RequiredAttributes};
+use crate::attribute::{DerivedAttributes, RequiredAttributes};
 use crate::attribute::{NonNegative, SubtreeSize};
 use crate::TransformArgs;
 
@@ -44,8 +44,8 @@ struct ThresholdElisionAction {
 impl Default for ThresholdElisionAction {
     fn default() -> Self {
         let mut builder = RequiredAttributes::default();
-        builder.require::<AsKey<NonNegative>>();
-        builder.require::<AsKey<SubtreeSize>>();
+        builder.require::<NonNegative>();
+        builder.require::<SubtreeSize>();
         Self {
             deriver: builder.finish(),
         }
@@ -68,8 +68,8 @@ impl ThresholdElisionAction {
     pub fn action(&mut self, expr: &mut MirRelationExpr) {
         // The results vectors or all attributes should be equal after each step.
         debug_assert_eq!(
-            self.deriver.get_results::<AsKey<NonNegative>>().len(),
-            self.deriver.get_results::<AsKey<SubtreeSize>>().len()
+            self.deriver.get_results::<NonNegative>().len(),
+            self.deriver.get_results::<SubtreeSize>().len()
         );
 
         if let MirRelationExpr::Threshold { input } = expr {
@@ -83,9 +83,9 @@ impl ThresholdElisionAction {
                         // - the Union (i.e., the Threshold input) is n - 2,
                         // - the Union input[0] is at position n - 3 and its subtree size is m,
                         // - the Union base therefore is at position n - m - 3
-                        let n = self.deriver.get_results::<AsKey<NonNegative>>().len();
-                        let m = self.deriver.get_results::<AsKey<SubtreeSize>>()[n - 3];
-                        if self.deriver.get_results::<AsKey<NonNegative>>()[n - m - 3]
+                        let n = self.deriver.get_results::<NonNegative>().len();
+                        let m = self.deriver.get_results::<SubtreeSize>()[n - 3];
+                        if self.deriver.get_results::<NonNegative>()[n - m - 3]
                             && is_superset_of(base, &*input)
                         {
                             should_replace = true;
@@ -101,11 +101,7 @@ impl ThresholdElisionAction {
                 // We can be a bit smarter when adjusting the NonNegative result. Since the Threshold
                 // at the root can only be safely elided iff its input is non-negative, we can overwrite
                 // the new last value to be `true`.
-                if let Some(result) = self
-                    .deriver
-                    .get_results_mut::<AsKey<NonNegative>>()
-                    .last_mut()
-                {
+                if let Some(result) = self.deriver.get_results_mut::<NonNegative>().last_mut() {
                     *result = true;
                 }
             }

--- a/src/transform/src/threshold_elision.rs
+++ b/src/transform/src/threshold_elision.rs
@@ -19,7 +19,7 @@ use crate::attribute::{DerivedAttributes, RequiredAttributes};
 use crate::attribute::{NonNegative, SubtreeSize};
 use crate::TransformArgs;
 
-use mz_expr::visit::{Visit, VisitorMut};
+use mz_expr::visit::{Visit, Visitor, VisitorMut};
 use mz_expr::MirRelationExpr;
 
 /// Remove Threshold operators that have no effect.

--- a/src/transform/src/threshold_elision.rs
+++ b/src/transform/src/threshold_elision.rs
@@ -15,9 +15,8 @@
 //! The Subset(X) notation means that the collection is a multiset subset of X:
 //! multiplicities of each record in Subset(X) are at most that of X.
 
-use crate::attribute::non_negative::NonNegative;
-use crate::attribute::subtree_size::SubtreeSize;
-use crate::attribute::{AttributeBuilder, AttributeDeriver};
+use crate::attribute::{AsKey, DerivedAttributes, RequiredAttributes};
+use crate::attribute::{NonNegative, SubtreeSize};
 use crate::TransformArgs;
 
 use mz_expr::visit::{Visit, VisitorMut};
@@ -39,14 +38,14 @@ impl crate::Transform for ThresholdElision {
 }
 
 struct ThresholdElisionAction {
-    deriver: AttributeDeriver,
+    deriver: DerivedAttributes,
 }
 
 impl Default for ThresholdElisionAction {
     fn default() -> Self {
-        let mut builder = AttributeBuilder::default();
-        builder.add_attribute::<NonNegative>();
-        builder.add_attribute::<SubtreeSize>();
+        let mut builder = RequiredAttributes::default();
+        builder.require::<AsKey<NonNegative>>();
+        builder.require::<AsKey<SubtreeSize>>();
         Self {
             deriver: builder.finish(),
         }
@@ -69,8 +68,8 @@ impl ThresholdElisionAction {
     pub fn action(&mut self, expr: &mut MirRelationExpr) {
         // The results vectors or all attributes should be equal after each step.
         debug_assert_eq!(
-            self.deriver.get_results::<NonNegative>().len(),
-            self.deriver.get_results::<SubtreeSize>().len()
+            self.deriver.get_results::<AsKey<NonNegative>>().len(),
+            self.deriver.get_results::<AsKey<SubtreeSize>>().len()
         );
 
         if let MirRelationExpr::Threshold { input } = expr {
@@ -84,9 +83,9 @@ impl ThresholdElisionAction {
                         // - the Union (i.e., the Threshold input) is n - 2,
                         // - the Union input[0] is at position n - 3 and its subtree size is m,
                         // - the Union base therefore is at position n - m - 3
-                        let n = self.deriver.get_results::<NonNegative>().len();
-                        let m = self.deriver.get_results::<SubtreeSize>()[n - 3];
-                        if self.deriver.get_results::<NonNegative>()[n - m - 3]
+                        let n = self.deriver.get_results::<AsKey<NonNegative>>().len();
+                        let m = self.deriver.get_results::<AsKey<SubtreeSize>>()[n - 3];
+                        if self.deriver.get_results::<AsKey<NonNegative>>()[n - m - 3]
                             && is_superset_of(base, &*input)
                         {
                             should_replace = true;
@@ -102,7 +101,11 @@ impl ThresholdElisionAction {
                 // We can be a bit smarter when adjusting the NonNegative result. Since the Threshold
                 // at the root can only be safely elided iff its input is non-negative, we can overwrite
                 // the new last value to be `true`.
-                if let Some(result) = self.deriver.get_results_mut::<NonNegative>().last_mut() {
+                if let Some(result) = self
+                    .deriver
+                    .get_results_mut::<AsKey<NonNegative>>()
+                    .last_mut()
+                {
                     *result = true;
                 }
             }

--- a/test/sqllogictest/explain/attributes/mir_arity.slt
+++ b/test/sqllogictest/explain/attributes/mir_arity.slt
@@ -130,6 +130,40 @@ EOF
 
 query T multiline
 EXPLAIN OPTIMIZED PLAN WITH(arity) AS TEXT FOR
-SELECT * FROM u WHERE (SELECT f FROM v WHERE v.e = u.d)
+SELECT * FROM u WHERE (SELECT f FROM v WHERE v.e = u.d) = 1
 ----
+Explained Query
+  Let // { arity: 2 }
+    Project (#0, #1) // { arity: 2 }
+      Join on=(#1 = #2) type=differential // { arity: 3 }
+        ArrangeBy keys=[[#1]] // { arity: 2 }
+          Get materialize.public.u // { arity: 2 }
+        Union // { arity: 1 }
+          Project (#0) // { arity: 1 }
+            Filter (#1 = 1) // { arity: 2 }
+              Get l0 // { arity: 2 }
+          Project (#0) // { arity: 1 }
+            Filter error("more than one record produced in subquery") AND (#1 > 1) // { arity: 2 }
+              Reduce group_by=[#0] aggregates=[count(true)] // { arity: 2 }
+                Project (#0) // { arity: 1 }
+                  Get l0 // { arity: 2 }
+    Where
+      l0 =
+        Project (#0, #2) // { arity: 2 }
+          Join on=(#0 = #1) type=differential // { arity: 3 }
+            ArrangeBy keys=[[#0]] // { arity: 1 }
+              Distinct group_by=[#0] // { arity: 1 }
+                Project (#1) // { arity: 1 }
+                  Filter (#1) IS NOT NULL // { arity: 2 }
+                    Get materialize.public.u // { arity: 2 }
+            Filter (#0) IS NOT NULL // { arity: 2 }
+              Get materialize.public.v // { arity: 2 }
+
+Source materialize.public.v
+  Demand (#0, #1)
+  Filter (#0) IS NOT NULL
+
+Used Indexes:
+  - materialize.public.u_d_idx
+
 EOF

--- a/test/sqllogictest/explain/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/explain/attributes/mir_unique_keys.slt
@@ -1,0 +1,177 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE t (
+  a int,
+  b int
+)
+
+statement ok
+CREATE TABLE u (
+  c int,
+  d int
+)
+
+# A global aggregation has a key []
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR SELECT sum(a) FROM t
+----
+Explained Query
+  Let // { keys: "([])" }
+    Union // { keys: "([])" }
+      Get l0 // { keys: "([])" }
+      Map (null) // { keys: "()" }
+        Union // { keys: "()" }
+          Negate // { keys: "()" }
+            Project () // { keys: "([])" }
+              Get l0 // { keys: "([])" }
+          Constant // { keys: "([])" }
+            - ()
+    Where
+      l0 =
+        Reduce aggregates=[sum(#0)] // { keys: "([])" }
+          Project (#0) // { keys: "()" }
+            Get materialize.public.t // { keys: "()" }
+
+Source materialize.public.t
+  Demand (#0)
+
+EOF
+
+# all columns that have unique values are unique keys of an ok constant
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys, no_fast_path) AS TEXT FOR SELECT * FROM (VALUES (1, 2, 3), (4, 2, 4));
+----
+Explained Query
+  Constant // { keys: "([0], [2])" }
+    - (1, 2, 3)
+    - (4, 2, 4)
+
+EOF
+
+statement ok
+CREATE VIEW v as SELECT c, d FROM u GROUP BY c, d;
+
+statement ok
+CREATE DEFAULT INDEX on v;
+
+# join + unique key sets being split by a predicate `<column1> = <column2>`
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR
+SELECT * FROM
+(SELECT sum(a) as a, b FROM t GROUP BY b) t
+INNER JOIN
+(SELECT * FROM v WHERE c = d) u
+ON t.b = u.d;
+----
+Explained Query
+  Project (#1, #0, #2, #0) // { keys: "([1])" }
+    Join on=(#0 = #3) type=differential // { keys: "([0])" }
+      ArrangeBy keys=[[#0]] // { keys: "([0])" }
+        Reduce group_by=[#1] aggregates=[sum(#0)] // { keys: "([0])" }
+          Filter (#1) IS NOT NULL // { keys: "()" }
+            Get materialize.public.t // { keys: "()" }
+      Filter (#0 = #1) // { keys: "([0], [1])" }
+        Get materialize.public.v // { keys: "([0, 1])" }
+
+Source materialize.public.t
+  Demand (#0, #1)
+  Filter (#1) IS NOT NULL
+
+Used Indexes:
+  - materialize.public.v_primary_idx
+
+EOF
+
+# topk limit = 1 + filter column = constant
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR
+(SELECT a, c::double FROM
+    (SELECT DISTINCT c FROM u) grp,
+    LATERAL (
+        SELECT a FROM t
+        WHERE b = grp.c
+        LIMIT 1
+    ))
+EXCEPT ALL
+(SELECT c, d::double FROM v WHERE c = 1)
+----
+Explained Query
+  Threshold // { keys: "()" }
+    Union // { keys: "()" }
+      Project (#1, #2) // { keys: "([1])" }
+        Map (integer_to_double(#0)) // { keys: "([0], [2])" }
+          TopK group_by=[#0] limit=1 monotonic=false // { keys: "([0])" }
+            Project (#0, #1) // { keys: "()" }
+              Join on=(#0 = #2) type=differential // { keys: "()" }
+                ArrangeBy keys=[[#0]] // { keys: "([0])" }
+                  Distinct group_by=[#0] // { keys: "([0])" }
+                    Project (#0) // { keys: "()" }
+                      Filter (#0) IS NOT NULL // { keys: "()" }
+                        Get materialize.public.u // { keys: "()" }
+                Filter (#1) IS NOT NULL // { keys: "()" }
+                  Get materialize.public.t // { keys: "()" }
+      Negate // { keys: "()" }
+        Project (#0, #2) // { keys: "([1])" }
+          Filter (#0 = 1) // { keys: "([1], [2])" }
+            Map (integer_to_double(#1)) // { keys: "([0, 1], [0, 2])" }
+              Get materialize.public.v // { keys: "([0, 1])" }
+
+Source materialize.public.t
+  Demand (#0, #1)
+  Filter (#1) IS NOT NULL
+Source materialize.public.u
+  Demand (#0)
+  Filter (#0) IS NOT NULL
+
+Used Indexes:
+  - materialize.public.v_primary_idx
+
+EOF
+
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(keys) AS TEXT FOR
+SELECT 1 = (Select * FROM generate_series(1, 100000) limit 3)
+----
+Explained Query
+  Let // { keys: "()" }
+    Project (#1) // { keys: "()" }
+      Map ((#0 = 1)) // { keys: "()" }
+        Union // { keys: "()" }
+          Get l1 // { keys: "()" }
+          Map (null) // { keys: "()" }
+            Union // { keys: "()" }
+              Negate // { keys: "()" }
+                Distinct // { keys: "([])" }
+                  Project () // { keys: "()" }
+                    Get l1 // { keys: "()" }
+              Constant // { keys: "([])" }
+                - ()
+    Where
+      l1 =
+        Union // { keys: "()" }
+          Get l0 // { keys: "()" }
+          Map (error("more than one record produced in subquery")) // { keys: "([])" }
+            Project () // { keys: "([])" }
+              Filter (#0 > 1) // { keys: "([])" }
+                Reduce aggregates=[count(true)] // { keys: "([])" }
+                  Project () // { keys: "()" }
+                    Get l0 // { keys: "()" }
+      l0 =
+        TopK limit=3 monotonic=true // { keys: "()" }
+          FlatMap generate_series(1, 100000, 1) // { keys: "()" }
+            Constant // { keys: "([])" }
+              - ()
+
+EOF

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -290,8 +290,7 @@ Explained Query
   Let // { non_negative: false }
     Project (#2, #4) // { non_negative: false }
       Join on=(eq(#0, #1, #3)) type=differential // { non_negative: false }
-        ArrangeBy keys=[[#0]] // { non_negative: true }
-          Get l0 // { non_negative: true }
+        Get l0 // { non_negative: true }
         ArrangeBy keys=[[#0]] // { non_negative: false }
           Union // { non_negative: false }
             Get l3 // { non_negative: true }
@@ -301,14 +300,15 @@ Explained Query
                   Project (#0) // { non_negative: true }
                     Get l3 // { non_negative: true }
                 Get l1 // { non_negative: true }
-        Union // { non_negative: false }
-          Get l4 // { non_negative: true }
-          Map (null) // { non_negative: false }
-            Union // { non_negative: false }
-              Negate // { non_negative: false }
-                Project (#0) // { non_negative: true }
-                  Get l4 // { non_negative: true }
-              Get l1 // { non_negative: true }
+        ArrangeBy keys=[[#0]] // { non_negative: false }
+          Union // { non_negative: false }
+            Get l4 // { non_negative: true }
+            Map (null) // { non_negative: false }
+              Union // { non_negative: false }
+                Negate // { non_negative: false }
+                  Project (#0) // { non_negative: true }
+                    Get l4 // { non_negative: true }
+                Get l1 // { non_negative: true }
     Where
       l4 =
         TopK group_by=[#0] limit=1 monotonic=false // { non_negative: true }

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -438,13 +438,13 @@ Query:
 %4 =
 | Union %0 %3
 | | types = (integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?)
-| | keys = ()
+| | keys = (())
 | Map (bigint_to_double(#2) / bigint_to_double(if (#3 = 0) then {null} else {#3})), sqrtnumeric(((#4 - ((#5 * #5) / bigint_to_numeric(if (#6 = 0) then {null} else {#6}))) / bigint_to_numeric(if (0 = (#6 - 1)) then {null} else {(#6 - 1)})))
 | | types = (integer?, integer?, bigint?, bigint, numeric?, numeric?, bigint, integer list?, double precision?, numeric?)
-| | keys = ()
+| | keys = (())
 | Project (#0, #1, #8, #9, #7)
 | | types = (integer?, integer?, double precision?, numeric?, integer list?)
-| | keys = ()
+| | keys = (())
 
 EOF
 
@@ -499,7 +499,7 @@ Query:
 %4 =
 | Union %0 %3
 | | types = (bigint, bigint)
-| | keys = ()
+| | keys = (())
 
 EOF
 
@@ -711,7 +711,7 @@ Query:
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
 | | keys = ()
-| ArrangeBy (#0)
+| ArrangeBy (#0, #1)
 | | types = (integer?, integer)
 | | keys = ()
 
@@ -737,7 +737,10 @@ Query:
 %13 =
 | Union %4 %12
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
+| ArrangeBy (#0)
+| | types = (integer?, boolean?)
+| | keys = ((#0))
 
 %14 =
 | Get %5 (l2)
@@ -782,9 +785,6 @@ Query:
 | Union %14 %16
 | | types = (integer?, integer, boolean)
 | | keys = ()
-| ArrangeBy (#0, #1)
-| | types = (integer?, integer, boolean)
-| | keys = ()
 
 %18 =
 | Get %9 (l3)
@@ -808,14 +808,14 @@ Query:
 %20 =
 | Union %9 %19
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 | ArrangeBy (#0, #1)
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 
 %21 =
 | Join %10 %13 %17 %20 (= #0 #2 #4 #7) (= #1 #5 #8)
-| | implementation = Differential %13 %10.(#0) %17.(#0, #1) %20.(#0, #1)
+| | implementation = Differential %17 %20.(#0, #1) %13.(#0) %10.(#0, #1)
 | | types = (integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?)
 | | keys = ()
 | Map null, null
@@ -929,7 +929,7 @@ Query:
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
 | | keys = ()
-| ArrangeBy (#0)
+| ArrangeBy (#0, #1)
 | | types = (integer?, integer)
 | | keys = ()
 
@@ -955,7 +955,10 @@ Query:
 %15 =
 | Union %4 %14
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
+| ArrangeBy (#0)
+| | types = (integer?, boolean?)
+| | keys = ((#0))
 
 %16 =
 | Get %5 (l2)
@@ -991,9 +994,6 @@ Query:
 | Union %16 %18
 | | types = (integer?, integer, boolean)
 | | keys = ()
-| ArrangeBy (#0, #1)
-| | types = (integer?, integer, boolean)
-| | keys = ()
 
 %20 =
 | Get %9 (l4)
@@ -1017,10 +1017,10 @@ Query:
 %22 =
 | Union %9 %21
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 | ArrangeBy (#0, #1)
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 
 %23 =
 | Get %11 (l5)
@@ -1044,14 +1044,14 @@ Query:
 %25 =
 | Union %11 %24
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 | ArrangeBy (#0, #1)
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 
 %26 =
 | Join %12 %15 %19 %22 %25 (= #0 #2 #4 #7 #10) (= #1 #5 #8 #11)
-| | implementation = Differential %15 %12.(#0) %19.(#0, #1) %22.(#0, #1) %25.(#0, #1)
+| | implementation = Differential %19 %22.(#0, #1) %25.(#0, #1) %15.(#0) %12.(#0, #1)
 | | types = (integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?)
 | | keys = ()
 | Map null, null
@@ -1164,7 +1164,7 @@ Query:
 | Get materialize.public.int_table (u1)
 | | types = (integer?, integer)
 | | keys = ()
-| ArrangeBy (#0)
+| ArrangeBy (#0, #1)
 | | types = (integer?, integer)
 | | keys = ()
 
@@ -1190,7 +1190,10 @@ Query:
 %15 =
 | Union %4 %14
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
+| ArrangeBy (#0)
+| | types = (integer?, boolean?)
+| | keys = ((#0))
 
 %16 =
 | Get %5 (l2)
@@ -1226,9 +1229,6 @@ Query:
 | Union %16 %18
 | | types = (integer?, integer, boolean)
 | | keys = ()
-| ArrangeBy (#0, #1)
-| | types = (integer?, integer, boolean)
-| | keys = ()
 
 %20 =
 | Get %9 (l4)
@@ -1252,10 +1252,10 @@ Query:
 %22 =
 | Union %9 %21
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 | ArrangeBy (#0, #1)
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 
 %23 =
 | Get %11 (l5)
@@ -1279,14 +1279,14 @@ Query:
 %25 =
 | Union %11 %24
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 | ArrangeBy (#0, #1)
 | | types = (integer?, integer, boolean?)
-| | keys = ()
+| | keys = ((#0, #1))
 
 %26 =
 | Join %12 %15 %19 %22 %25 (= #0 #2 #4 #7 #10) (= #1 #5 #8 #11)
-| | implementation = Differential %15 %12.(#0) %19.(#0, #1) %22.(#0, #1) %25.(#0, #1)
+| | implementation = Differential %19 %22.(#0, #1) %25.(#0, #1) %15.(#0) %12.(#0, #1)
 | | types = (integer?, integer, integer?, boolean?, integer?, integer, boolean, integer?, integer, boolean?, integer?, integer, boolean?)
 | | keys = ()
 | Map NOT(#6), null, null
@@ -1380,7 +1380,7 @@ Query:
 %6 = Let l4 =
 | Union %3 %5
 | | types = (integer, boolean?)
-| | keys = ()
+| | keys = ((#0))
 
 %7 = Let l5 =
 | Get %2 (l2)
@@ -1413,70 +1413,65 @@ Query:
 %10 = Let l6 =
 | Union %7 %9
 | | types = (integer, boolean?)
-| | keys = ()
+| | keys = ((#0))
 
 %11 =
-| Get %0 (l0)
+| Get %6 (l4)
+| | types = (integer, boolean?)
+| | keys = ((#0))
+| Project (#0)
 | | types = (integer)
-| | keys = ()
-| ArrangeBy (#0)
+| | keys = ((#0))
+| Negate
 | | types = (integer)
 | | keys = ()
 
 %12 =
-| Get %6 (l4)
+| Union %11 %1
+| | types = (integer)
+| | keys = ()
+| Map null
 | | types = (integer, boolean?)
-| | keys = ()
-| Project (#0)
-| | types = (integer)
-| | keys = ()
-| Negate
-| | types = (integer)
 | | keys = ()
 
 %13 =
-| Union %12 %1
-| | types = (integer)
-| | keys = ()
-| Map null
+| Union %6 %12
 | | types = (integer, boolean?)
-| | keys = ()
-
-%14 =
-| Union %6 %13
-| | types = (integer, boolean?)
-| | keys = ()
+| | keys = ((#0))
 | ArrangeBy (#0)
 | | types = (integer, boolean?)
-| | keys = ()
+| | keys = ((#0))
 
-%15 =
+%14 =
 | Get %10 (l6)
 | | types = (integer, boolean?)
-| | keys = ()
+| | keys = ((#0))
 | Project (#0)
 | | types = (integer)
-| | keys = ()
+| | keys = ((#0))
 | Negate
 | | types = (integer)
 | | keys = ()
 
-%16 =
-| Union %15 %1
+%15 =
+| Union %14 %1
 | | types = (integer)
 | | keys = ()
 | Map null
 | | types = (integer, boolean?)
 | | keys = ()
 
-%17 =
-| Union %10 %16
+%16 =
+| Union %10 %15
 | | types = (integer, boolean?)
-| | keys = ()
+| | keys = ((#0))
+| ArrangeBy (#0)
+| | types = (integer, boolean?)
+| | keys = ((#0))
 
-%18 =
-| Join %11 %14 %17 (= #0 #1 #3)
-| | implementation = Differential %17 %11.(#0) %14.(#0)
+%17 =
+| Join %0 %13 %16 (= #0 #1 #3)
+| | implementation = Differential %0 %13.(#0) %16.(#0)
 | | types = (integer, integer, boolean?, integer, boolean?)
 | | keys = ()
 | Project (#2, #4, #2)
@@ -1828,7 +1823,7 @@ Query:
 %8 = Let l4 =
 | Union %5 %7
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
 
 %9 =
 | Get materialize.public.int_table (u1)
@@ -1922,10 +1917,10 @@ Query:
 %19 =
 | Get %8 (l4)
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
 | Project (#0)
 | | types = (integer?)
-| | keys = ()
+| | keys = ((#0))
 | Negate
 | | types = (integer?)
 | | keys = ()
@@ -1941,14 +1936,14 @@ Query:
 %21 =
 | Union %8 %20
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
 | ArrangeBy (#0)
 | | types = (integer?, boolean?)
-| | keys = ()
+| | keys = ((#0))
 
 %22 =
 | Join %9 %14 %18 %21 (= #0 #3 #6) (= #1 #4)
-| | implementation = Differential %14 %9.() %18.(#0, #1) %21.(#0)
+| | implementation = Differential %14 %9.() %21.(#0) %18.(#0, #1)
 | | types = (integer?, integer, boolean, integer?, integer, boolean, integer?, boolean?)
 | | keys = ()
 | Project (#2, #5, #7)

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -534,7 +534,6 @@ Query:
 
 %12 =
 | Get materialize.public.t2 (u2)
-| ArrangeBy (#0)
 
 %13 =
 | Get %7 (l3)
@@ -560,10 +559,11 @@ Query:
 
 %18 =
 | Union %11 %17
+| ArrangeBy (#0)
 
 %19 =
 | Join %12 %15 %18 (= #0 #1 #3)
-| | implementation = Differential %18 %12.(#0) %15.(#0)
+| | implementation = Differential %12 %15.(#0) %18.(#0)
 | Project (#2, #4)
 
 EOF


### PR DESCRIPTION
### Motivation

Closes #14347 

To avoid repeating the attribute dependency map when you want to generate attributes, generate attributes inside a `DerivedAttributes` struct, which essentially has a hard-coding of the topological sort of attribute dependencies.

The addition of the `DerivedAttributes` enables unique key attributes, which have two dependencies, to be supported.

Contains a couple of bonuses:
* An extra test for printing out arities that appeared to have just sat in my sandbox and never got checked in
* Fixes unique key detection for aggregating over the whole source/view. The comment for the unique key detection code reads:
```
// If there are A, B, each with a unique `key` such that
// we are looking at
//
//     A.proj(set_containing_key) + (B - A.proj(key)).map(stuff)
//
// Then we can report `key` as a unique key.
```
It turns out that the code only detected `A.proj(set_containing_key) + (B + (- A).proj(key)).map(stuff)` and not also `A.proj(set_containing_key) + (B - A.proj(key)).map(stuff)`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

No user facing behavior changes.
