### PR TITLE
[draft] Remove inline Kafka config support from sources

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -370,18 +370,8 @@ pub fn plan_create_source(
             let (kafka_connection, options, optional_start_offset, group_id_prefix) = match &kafka
                 .connection
             {
-                mz_sql_parser::ast::KafkaConnection::Inline { broker } => {
-                    scx.require_unsafe_mode("creating Kafka sources with inline connections")?;
-                    let mut options = BTreeMap::new();
-                    options.insert(
-                        "bootstrap.servers".into(),
-                        KafkaAddrs::from_str(broker)
-                            .map_err(|e| sql_err!("parsing kafka broker: {e}"))?
-                            .to_string()
-                            .into(),
-                    );
-                    let connection = KafkaConnection::try_from(&mut options)?;
-                    (connection, options, None, None)
+                mz_sql_parser::ast::KafkaConnection::Inline { broker: _ } => {
+                    sql_bail!("inline kafka connection specification is no longer supported")
                 }
                 mz_sql_parser::ast::KafkaConnection::Reference {
                     connection,

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -10,10 +10,10 @@
 //! Connection types.
 
 use std::collections::{BTreeMap, HashSet};
-use std::str::FromStr;
+
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail};
+
 use async_trait::async_trait;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
@@ -22,7 +22,7 @@ use tokio_postgres::config::SslMode;
 use url::Url;
 
 use mz_ccsr::tls::{Certificate, Identity};
-use mz_kafka_util::KafkaAddrs;
+
 use mz_proto::tokio_postgres::any_ssl_mode;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::any_url;
@@ -276,68 +276,6 @@ impl From<KafkaConnection> for BTreeMap<String, StringOrSecret> {
         }
 
         r
-    }
-}
-
-impl TryFrom<&mut BTreeMap<String, StringOrSecret>> for KafkaConnection {
-    type Error = anyhow::Error;
-    /// Extracts only the options necessary to create a `KafkaConnection` from
-    /// a `BTreeMap<String, StringOrSecret>`, and returns the remaining
-    /// options.
-    ///
-    /// # Panics
-    /// - If `value` was not sufficiently or incorrectly type checked and
-    ///   parameters expected to reference objects (i.e. secrets) are instead
-    ///   `String`s, or vice versa.
-    fn try_from(map: &mut BTreeMap<String, StringOrSecret>) -> Result<Self, Self::Error> {
-        use KafkaConnectionOptionName::*;
-
-        let key_or_err = |config: &str,
-                          map: &mut BTreeMap<String, StringOrSecret>,
-                          key: KafkaConnectionOptionName| {
-            map.remove(&key.config_key()).ok_or_else(|| {
-                anyhow!(
-                    "invalid {} config: missing {} ({})",
-                    config.to_uppercase(),
-                    key,
-                    key.config_key(),
-                )
-            })
-        };
-
-        let security = if let Some(v) = map.remove("security.protocol") {
-            match v.unwrap_string().to_lowercase().as_str() {
-                config @ "ssl" => Some(KafkaSecurity::Tls(KafkaTlsConfig {
-                    identity: Some(TlsIdentity {
-                        key: key_or_err(config, map, SslKey)?.unwrap_secret(),
-                        cert: key_or_err(config, map, SslCertificate)?,
-                    }),
-                    root_cert: map.remove(&SslCertificateAuthority.config_key()),
-                })),
-                config @ "sasl_ssl" => Some(KafkaSecurity::Sasl(SaslConfig {
-                    mechanisms: key_or_err(config, map, SaslMechanisms)?
-                        .unwrap_string()
-                        .to_string(),
-                    username: key_or_err(config, map, SaslUsername)?,
-                    password: key_or_err(config, map, SaslPassword)?.unwrap_secret(),
-                    tls_root_cert: map.remove(&SslCertificateAuthority.config_key()),
-                })),
-                o => bail!("unsupported security.protocol: {}", o),
-            }
-        } else {
-            None
-        };
-
-        let brokers = match map.remove(&Broker.config_key()) {
-            Some(v) => KafkaAddrs::from_str(&v.unwrap_string())?
-                .to_string()
-                .split(',')
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>(),
-            None => bail!("must specify {}", Broker.config_key()),
-        };
-
-        Ok(KafkaConnection { brokers, security })
     }
 }
 


### PR DESCRIPTION
### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
