### PR TITLE
storage: implement the resumption frontier operator

### DIFF
--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -45,6 +45,7 @@ use tokio_stream::StreamMap;
 use tracing::debug;
 
 use mz_build_info::BuildInfo;
+use mz_expr::PartitionId;
 use mz_orchestrator::NamespacedOrchestrator;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::{PersistLocation, ShardId};
@@ -61,7 +62,7 @@ use crate::protocol::client::{
 use crate::types::errors::DataflowError;
 use crate::types::hosts::{StorageHostConfig, StorageHostResourceAllocation};
 use crate::types::sinks::{ProtoDurableExportMetadata, SinkAsOf, StorageSinkDesc};
-use crate::types::sources::IngestionDescription;
+use crate::types::sources::{IngestionDescription, MzOffset, SourceData, SourceEnvelope};
 
 mod hosts;
 mod rehydration;
@@ -409,6 +410,55 @@ impl Codec for CollectionMetadata {
     fn decode(buf: &[u8]) -> Result<Self, String> {
         let proto = ProtoCollectionMetadata::decode(buf).map_err(|err| err.to_string())?;
         proto.into_rust().map_err(|err| err.to_string())
+    }
+}
+
+impl CollectionMetadata {
+    pub async fn get_resume_upper<T>(
+        &self,
+        persist: &Mutex<PersistClientCache>,
+        envelope: &SourceEnvelope,
+    ) -> Antichain<T>
+    where
+        T: timely::progress::Timestamp + Lattice + Codec64,
+    {
+        let persist = persist
+            .lock()
+            .await
+            .open(self.persist_location.clone())
+            .await
+            .unwrap();
+        // Calculate the point at which we can resume ingestion computing the greatest
+        // antichain that is less or equal to all state and output shard uppers.
+        let mut resume_upper: Antichain<T> = Antichain::new();
+        let remap_write = persist
+            .open_writer::<(), PartitionId, T, MzOffset>(self.remap_shard)
+            .await
+            .unwrap();
+        for t in remap_write.upper().elements() {
+            resume_upper.insert(t.clone());
+        }
+        let data_write = persist
+            .open_writer::<SourceData, (), T, Diff>(self.data_shard)
+            .await
+            .unwrap();
+        for t in data_write.upper().elements() {
+            resume_upper.insert(t.clone());
+        }
+
+        // Check if this ingestion is using any operators that are stateful AND are not
+        // storing their state in persist shards. This whole section should be eventually
+        // removed as we make each operator durably record its state in persist shards.
+        let resume_upper = match envelope {
+            // We can only resume with the None envelope, which is stateless,
+            // or with the [Debezium] Upsert envelope, which is easy
+            //   (re-ingest the last emitted state)
+            SourceEnvelope::None(_) => resume_upper,
+            SourceEnvelope::Upsert(_) => resume_upper,
+            // Otherwise re-ingest everything
+            _ => Antichain::from_elem(T::minimum()),
+        };
+        resume_upper
     }
 }
 
@@ -812,7 +862,10 @@ where
                     desc: ingestion.desc,
                     typ: description.desc.typ().clone(),
                 };
-                let resume_upper = desc.get_resume_upper(Arc::clone(&self.persist)).await;
+                let resume_upper = desc
+                    .storage_metadata
+                    .get_resume_upper(&self.persist, &desc.desc.envelope)
+                    .await;
                 let augmented_ingestion = IngestSourceCommand {
                     id,
                     description: desc,

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -473,6 +473,10 @@ impl<T: timely::progress::Timestamp + Lattice + Codec64> ResumptionFrontierCalcu
     async fn calculate_resumption_frontier(&self, state: &mut Self::State) -> Antichain<T> {
         let (remap_write, data_write) = state;
 
+        // Update to latest upper.
+        remap_write.fetch_recent_upper().await;
+        data_write.fetch_recent_upper().await;
+
         self.collection_metadata
             .get_resume_upper_from_handles(remap_write, data_write, &self.source_envelope)
             .await
@@ -492,10 +496,6 @@ impl CollectionMetadata {
     where
         T: timely::progress::Timestamp + Lattice + Codec64,
     {
-        // Update to latest upper.
-        remap_write.fetch_recent_upper().await;
-        data_write.fetch_recent_upper().await;
-
         // Calculate the point at which we can resume ingestion computing the greatest
         // antichain that is less or equal to all state and output shard uppers.
         let mut resume_upper: Antichain<T> = Antichain::new();

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -170,10 +170,16 @@ where
             .expect("retry retries forever");
 
         for ingest in self.ingestions.values_mut() {
+            let mut persist_clients = self.persist.lock().await;
+            let persist_client = persist_clients
+                .open(ingest.description.storage_metadata.persist_location.clone())
+                .await
+                .expect("error creating persist client");
+
             ingest.resume_upper = ingest
                 .description
                 .storage_metadata
-                .get_resume_upper::<T, _>(&self.persist, &ingest.description.desc.envelope)
+                .get_resume_upper::<T>(&persist_client, &ingest.description.desc.envelope)
                 .await;
         }
 

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -173,7 +173,7 @@ where
             ingest.resume_upper = ingest
                 .description
                 .storage_metadata
-                .get_resume_upper::<T>(&self.persist, &ingest.description.desc.envelope)
+                .get_resume_upper::<T, _>(&self.persist, &ingest.description.desc.envelope)
                 .await;
         }
 

--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -172,7 +172,8 @@ where
         for ingest in self.ingestions.values_mut() {
             ingest.resume_upper = ingest
                 .description
-                .get_resume_upper::<T>(Arc::clone(&self.persist))
+                .storage_metadata
+                .get_resume_upper::<T>(&self.persist, &ingest.description.desc.envelope)
                 .await;
         }
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -121,6 +121,7 @@ where
         resume_upper: resume_upper.clone(),
         storage_metadata: description.storage_metadata.clone(),
         persist_clients: Arc::clone(&storage_state.persist_clients),
+        envelope: envelope.clone(),
     };
 
     // Build the _raw_ ok and error sources using `create_raw_source` and the

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -121,50 +121,54 @@ where
         resume_upper: resume_upper.clone(),
         storage_metadata: description.storage_metadata.clone(),
         persist_clients: Arc::clone(&storage_state.persist_clients),
-        envelope: envelope.clone(),
     };
 
     // Build the _raw_ ok and error sources using `create_raw_source` and the
     // correct `SourceReader` implementations
     let ((ok_source, err_source), capability) = match connection {
         SourceConnection::Kafka(_) => {
-            let ((ok, err), cap) = source::create_raw_source::<_, KafkaSourceReader>(
+            let ((ok, err), cap) = source::create_raw_source::<_, KafkaSourceReader, _>(
                 base_source_config,
                 &connection,
                 storage_state.connection_context.clone(),
+                envelope.clone(),
             );
             ((SourceType::Delimited(ok), err), cap)
         }
         SourceConnection::Kinesis(_) => {
             let ((ok, err), cap) =
-                source::create_raw_source::<_, DelimitedValueSource<KinesisSourceReader>>(
+                source::create_raw_source::<_, DelimitedValueSource<KinesisSourceReader>, _>(
                     base_source_config,
                     &connection,
                     storage_state.connection_context.clone(),
+                    envelope.clone(),
                 );
             ((SourceType::Delimited(ok), err), cap)
         }
         SourceConnection::S3(_) => {
-            let ((ok, err), cap) = source::create_raw_source::<_, S3SourceReader>(
+            let ((ok, err), cap) = source::create_raw_source::<_, S3SourceReader, _>(
                 base_source_config,
                 &connection,
                 storage_state.connection_context.clone(),
+                envelope.clone(),
             );
             ((SourceType::ByteStream(ok), err), cap)
         }
         SourceConnection::Postgres(_) => {
-            let ((ok, err), cap) = source::create_raw_source::<_, PostgresSourceReader>(
+            let ((ok, err), cap) = source::create_raw_source::<_, PostgresSourceReader, _>(
                 base_source_config,
                 &connection,
                 storage_state.connection_context.clone(),
+                envelope.clone(),
             );
             ((SourceType::Row(ok), err), cap)
         }
         SourceConnection::LoadGenerator(_) => {
-            let ((ok, err), cap) = source::create_raw_source::<_, LoadGeneratorSourceReader>(
+            let ((ok, err), cap) = source::create_raw_source::<_, LoadGeneratorSourceReader, _>(
                 base_source_config,
                 &connection,
                 storage_state.connection_context.clone(),
+                envelope.clone(),
             );
             ((SourceType::Row(ok), err), cap)
         }

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -46,6 +46,7 @@ pub mod metrics;
 pub mod persist_source;
 mod postgres;
 mod reclock;
+mod resumption;
 mod s3;
 mod source_reader_pipeline;
 pub mod types;

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -200,13 +200,14 @@ where
     let (inner, token) = crate::source::util::source(
         scope,
         format!("persist_source {}: part distribution", source_id),
+        None,
         move |info| {
             let waker_activator = Arc::new(scope.sync_activator_for(&info.address[..]));
             let waker = futures::task::waker(waker_activator);
 
             let mut current_ts = timely::progress::Timestamp::minimum();
 
-            move |cap_set, output| {
+            move |cap_set, output, _| {
                 let mut context = Context::from_waker(&waker);
 
                 while let Poll::Ready(item) = pinned_stream.as_mut().poll_next(&mut context) {

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -207,7 +207,7 @@ where
 
             let mut current_ts = timely::progress::Timestamp::minimum();
 
-            move |cap_set, output, _| {
+            move |cap_set, output, _optional_input| {
                 let mut context = Context::from_waker(&waker);
 
                 while let Poll::Ready(item) = pinned_stream.as_mut().poll_next(&mut context) {

--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -78,8 +78,10 @@ where
             // TODO: determine what interval we want here.
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
 
-            let mut persist_clients = persist_clients.lock().await;
+            // The lock MUST be dropped before we enter the main loop.
             let persist_client = persist_clients
+                .lock()
+                .await
                 .open(storage_metadata.persist_location)
                 .await
                 .expect("error creating persist client");

--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -1,0 +1,107 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! This module implements the "Resumption Frontier Operator".
+//! See [`resumption_operator`] for more info.
+//!
+//! TODO(guswynn): link to design doc when its merged
+
+use std::any::Any;
+use std::rc::Rc;
+
+use differential_dataflow::Hashable;
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::operators::CapabilitySet;
+use timely::dataflow::Scope;
+use timely::order::PartialOrder;
+use timely::progress::frontier::Antichain;
+use timely::progress::timestamp::Timestamp as _;
+
+use crate::source::source_reader_pipeline::RawSourceCreationConfig;
+use mz_repr::Timestamp;
+use mz_timely_util::operators_async_ext::OperatorBuilderExt;
+
+/// Generates a timely `Stream` with no inputs that periodically
+/// downgrades its output `Capability` _to the "resumption frontier"
+/// of the source_. It does not produce meaningful data.
+pub fn resumption_operator<G>(
+    config: RawSourceCreationConfig<G>,
+) -> (timely::dataflow::Stream<G, ()>, Rc<dyn Any>)
+where
+    G: Scope<Timestamp = Timestamp>,
+{
+    let RawSourceCreationConfig {
+        id,
+        scope,
+        worker_count,
+        worker_id,
+        storage_metadata,
+        persist_clients,
+        envelope,
+        ..
+    } = config;
+
+    let chosen_worker = (id.hashed() % worker_count as u64) as usize;
+    let active_worker = chosen_worker == worker_id;
+
+    let operator_name = format!("resumption({})", id);
+    let mut resume_op = OperatorBuilder::new(operator_name, scope.clone());
+    // we just downgrade the capability
+    let (_resume_output, resume_stream) = resume_op.new_output();
+
+    let token = Rc::new(());
+    let token_weak = Rc::downgrade(&token);
+
+    let mut upper = Antichain::from_elem(Timestamp::minimum());
+
+    resume_op.build_async(
+        scope.clone(),
+        move |mut capabilities, _frontiers, scheduler| async move {
+            let mut cap_set = if active_worker {
+                CapabilitySet::from_elem(capabilities.pop().expect("missing capability"))
+            } else {
+                CapabilitySet::new()
+            };
+            // Explicitly release the unneeded capabilities!
+            capabilities.clear();
+
+            // TODO: determine what interval we want here.
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(10));
+
+            while scheduler.notified().await {
+                if token_weak.upgrade().is_none() {
+                    return;
+                }
+                if !active_worker {
+                    continue;
+                }
+
+                interval.tick().await;
+                let new_upper = storage_metadata
+                    .get_resume_upper(&persist_clients, &envelope)
+                    .await;
+
+                if PartialOrder::less_equal(&new_upper, &upper) {
+                    continue;
+                }
+
+                tracing::trace!(
+                    %id,
+                    ?new_upper,
+                    "read new resumption frontier from persist",
+                );
+
+                cap_set.downgrade(new_upper.elements());
+                upper = new_upper;
+            }
+        },
+    );
+
+    (resume_stream, token)
+}

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -158,9 +158,8 @@ where
     G: Scope<Timestamp = Timestamp>,
     S: SourceReader,
 {
-    let (resume_stream, downgrade_resume_token, shutdown_resume_token) =
+    let (resume_stream, downgrade_resume_token) =
         super::resumption::resumption_operator(config.clone());
-    let resume_stream = resume_stream.broadcast();
 
     let ((batches, source_upper_summaries), source_reader_token) = source_reader_operator::<G, S>(
         config.clone(),
@@ -176,7 +175,7 @@ where
     let ((reclocked_stream, reclocked_err_stream), _reclock_token) =
         reclock_operator::<G, S>(config, batches, remap_stream);
 
-    let token = Rc::new((source_reader_token, remap_token, shutdown_resume_token));
+    let token = Rc::new((source_reader_token, remap_token));
 
     ((reclocked_stream, reclocked_err_stream), Some(token))
 }
@@ -437,6 +436,7 @@ where
                 &resumption_frontier.borrow(),
             ) {
                 tracing::trace!(
+                    %id,
                     resumption_frontier = ?input_resumption_frontier.unwrap().frontier(),
                     "received new resumption frontier"
                 );

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -158,7 +158,7 @@ where
     S: SourceReader,
     R: ResumptionFrontierCalculator<Timestamp> + 'static,
 {
-    let (resume_stream, source_reader_feedback_handle, _resume_token) =
+    let (resume_stream, source_reader_feedback_handle) =
         super::resumption::resumption_operator(config.clone(), calc);
 
     let ((batches, source_upper_summaries, resumption_feedback_stream), source_reader_token) =

--- a/src/storage/src/source/util.rs
+++ b/src/storage/src/source/util.rs
@@ -58,6 +58,8 @@ use crate::source::types::SourceToken;
 /// argument. Otherwise, the operator just gets `None`. Inspection of the
 /// data of this input remains unimplemented. Note that this input also
 /// does not effect the progress tracking of the `source` operator.
+//
+// TODO(guswynn): refactor this to clean up its various callsites
 pub fn source<G, D, B, L>(
     scope: &G,
     name: String,
@@ -88,7 +90,7 @@ where
             &input,
             Pipeline,
             // As documented, the optional input does not
-            // participate in feedback tracking.
+            // participate in progress tracking.
             vec![Antichain::new()],
         )
     });

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -13,28 +13,22 @@ use std::collections::{BTreeMap, HashMap};
 use std::num::TryFromIntError;
 use std::ops::{Add, AddAssign, Deref, DerefMut};
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
 use bytes::BufMut;
-use differential_dataflow::lattice::Lattice;
 use globset::{Glob, GlobBuilder};
-use mz_expr::PartitionId;
 use mz_ore::now::NowFn;
-use mz_persist_client::cache::PersistClientCache;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use timely::progress::Antichain;
-use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use mz_persist_types::{Codec, Codec64};
+use mz_persist_types::Codec;
 use mz_proto::{any_uuid, TryFromProtoError};
 use mz_proto::{IntoRustIfSome, ProtoType, RustType};
-use mz_repr::{ColumnType, Diff, GlobalId, RelationDesc, RelationType, Row, ScalarType};
+use mz_repr::{ColumnType, GlobalId, RelationDesc, RelationType, Row, ScalarType};
 
 use crate::controller::CollectionMetadata;
 use crate::types::connections::aws::AwsConfig;
@@ -82,51 +76,6 @@ where
                 typ,
             })
             .boxed()
-    }
-}
-
-impl IngestionDescription<CollectionMetadata> {
-    pub async fn get_resume_upper<T>(&self, persist: Arc<Mutex<PersistClientCache>>) -> Antichain<T>
-    where
-        T: timely::progress::Timestamp + Lattice + Codec64,
-    {
-        let persist = persist
-            .lock()
-            .await
-            .open(self.storage_metadata.persist_location.clone())
-            .await
-            .unwrap();
-        // Calculate the point at which we can resume ingestion computing the greatest
-        // antichain that is less or equal to all state and output shard uppers.
-        let mut resume_upper: Antichain<T> = Antichain::new();
-        let remap_write = persist
-            .open_writer::<(), PartitionId, T, MzOffset>(self.storage_metadata.remap_shard)
-            .await
-            .unwrap();
-        for t in remap_write.upper().elements() {
-            resume_upper.insert(t.clone());
-        }
-        let data_write = persist
-            .open_writer::<SourceData, (), T, Diff>(self.storage_metadata.data_shard)
-            .await
-            .unwrap();
-        for t in data_write.upper().elements() {
-            resume_upper.insert(t.clone());
-        }
-
-        // Check if this ingestion is using any operators that are stateful AND are not
-        // storing their state in persist shards. This whole section should be eventually
-        // removed as we make each operator durably record its state in persist shards.
-        let resume_upper = match self.desc.envelope {
-            // We can only resume with the None envelope, which is stateless,
-            // or with the [Debezium] Upsert envelope, which is easy
-            //   (re-ingest the last emitted state)
-            SourceEnvelope::None(_) => resume_upper,
-            SourceEnvelope::Upsert(_) => resume_upper,
-            // Otherwise re-ingest everything
-            _ => Antichain::from_elem(T::minimum()),
-        };
-        resume_upper
     }
 }
 


### PR DESCRIPTION
This pr implements the first step of the design laid out in https://github.com/MaterializeInc/materialize/pull/14314, namely implementing the `ResumptionOperator`.

This operator periodically calculates the _resumption frontier_ and communicates it to the source reader pipeline. See "Tips for reviewer" for more info on each commit

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

- The bottom commit on this pure code movement, to make this pr easier to write
- The second is the main logic.
  - A subtle change is to the `util::source` operator, to optionally allow an input. This was done with `Option` and unwrapping, but we could copy this function and have an input and non-input one, if we want
  - Additionally, we now need the `SourceEnvelope` in the raw source creation config. Its possible this is an api break and we should adjust where we do the resumption frontier envelope check
- The third commit fixes a subtle bug: it allows a `Finished` source to downgrade its upper to `[]`. This requires downgrading the capability of the new operator (by returning) when the downstream source operator is done, communicating through a token.
  - Its possible we don't need the two token thing I do, to distinguish shutdown from downgrade. @aljoscha, I noticed that we don't use the `_reclock_token`, so its possible we don't need to explicitly shutdown this operator on full shutdown
  - I currently do something that I consider very hacky: I ensure that single-instance source reader's are on the same worker as the `ResumptionOperator`, so that downgrading works in a multi-worker setup. This scenario remains untested, and reviewers may come up with a better solution
- The 4th commit adjusts the resumption frontier operator to avoid extra locking and persist client creation.
  - @danhhz may be interested in my usage of `fetch_new_upper` here. Perhaps a read listener is a better choice in the future.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
