### PR TITLE
Retry broken connections when establishing...

### DIFF
--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -15,7 +15,7 @@
 //! of spuriously accepted connections that has been observed in Kubernetes with linkerd.
 
 use std::any::Any;
-use std::io::{self, Read};
+use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream, ToSocketAddrs};
 use std::sync::Arc;
 use std::thread;
@@ -142,7 +142,7 @@ fn start_connections(
     while results.iter().any(|r| r.is_none()) {
         if results[i].is_none() {
             match TcpStream::connect_timeout(&addresses[i], Duration::from_secs(1)) {
-                Ok(s) => {
+                Ok(mut s) => {
                     s.set_nodelay(true).expect("set_nodelay call failed");
 
                     s.write_all(&my_index.to_ne_bytes());

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -93,14 +93,13 @@ fn gc_broken_connections<'a, I>(conns: I, first_idx: usize)
 where
     I: IntoIterator<Item = &'a mut Option<TcpStream>>,
 {
-    let mut buf = [0];
+    let mut buf = [0; 1024];
     for (i, maybe_conn) in conns.into_iter().enumerate() {
         info!("peeking... {}", first_idx + i);
         if let Some(conn) = maybe_conn {
             let closed = match conn.peek(&mut buf) {
                 Ok(0) => true, // EOF
-                Ok(1) => false,
-                Ok(_) => unreachable!("We only attempted to read one byte"),
+                Ok(_) => false,
                 Err(err) => err.kind() != std::io::ErrorKind::WouldBlock,
             };
             if closed {

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use mz_ore::collections::CollectionExt;
 use timely::communication::allocator::zero_copy::initialize::initialize_networking_from_sockets;
 use timely::communication::allocator::GenericBuilder;
-use tracing::{info, warn, trace};
+use tracing::{info, trace, warn};
 
 use crate::server::CommunicationConfig;
 

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -119,7 +119,7 @@ fn start_connections(
     addresses: Arc<Vec<String>>,
     my_index: usize,
 ) -> Result<Vec<Option<TcpStream>>, io::Error> {
-    let addresses: Vec<_> = addresses.iter().cloned().take(my_index).collect();
+    let addresses: Vec<_> = addresses.iter().take(my_index).cloned().collect();
     let mut results: Vec<_> = (0..my_index).map(|_| None).collect();
 
     // We do not want to provide opportunities for the startup

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -93,7 +93,7 @@ fn gc_broken_connections<'a, I>(conns: I, first_idx: usize)
 where
     I: IntoIterator<Item = &'a mut Option<TcpStream>>,
 {
-    let mut buf = [0; 1024];
+    let mut buf = [0];
     for (i, maybe_conn) in conns.into_iter().enumerate() {
         info!("peeking... {}", first_idx + i);
         if let Some(conn) = maybe_conn {

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -125,7 +125,7 @@ fn start_connections(
                 .as_str()
                 .to_socket_addrs()
                 .expect("Failed to parse address")
-                .into_first()
+                .into_element()
         })
         .collect();
     let mut results: Vec<_> = (0..(addresses.len() - my_index - 1))
@@ -143,6 +143,10 @@ fn start_connections(
         if results[i].is_none() {
             match TcpStream::connect_timeout(&addresses[i], Duration::from_secs(1)) {
                 Ok(s) => {
+                    s.set_nodelay(true).expect("set_nodelay call failed");
+
+                    s.write_all(&my_index.to_ne_bytes());
+
                     s.set_nonblocking(true)
                         .expect("set_nonblocking(true) call failed");
                     info!(worker = my_index, "Connected to process {i}");

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -129,9 +129,7 @@ fn start_connections(
                 .into_element()
         })
         .collect();
-    let mut results: Vec<_> = (0..my_index)
-        .map(|_| None)
-        .collect();
+    let mut results: Vec<_> = (0..my_index).map(|_| None).collect();
 
     // We do not want to provide opportunities for the startup
     // sequence to hang waiting for one of its peers, not noticing that another has gone down;

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -120,6 +120,7 @@ fn start_connections(
 ) -> Result<Vec<Option<TcpStream>>, io::Error> {
     let addresses: Vec<_> = addresses
         .iter()
+        .take(my_index)
         .map(|address| {
             address
                 .as_str()
@@ -128,7 +129,7 @@ fn start_connections(
                 .into_element()
         })
         .collect();
-    let mut results: Vec<_> = (0..(addresses.len() - my_index - 1))
+    let mut results: Vec<_> = (0..my_index)
         .map(|_| None)
         .collect();
 

--- a/src/compute/src/communication.rs
+++ b/src/compute/src/communication.rs
@@ -145,7 +145,8 @@ fn start_connections(
                 Ok(mut s) => {
                     s.set_nodelay(true).expect("set_nodelay call failed");
 
-                    s.write_all(&my_index.to_ne_bytes());
+                    s.write_all(&my_index.to_ne_bytes())
+                        .expect("failed to send worker index");
 
                     s.set_nonblocking(true)
                         .expect("set_nonblocking(true) call failed");

--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -103,12 +103,7 @@ def kill_computed(mz: MaterializeApplication, compute_id: int) -> None:
         pass
 
 
-pytest.skip(
-    "Restart of multi-replica clusters is broken - gh#14301", allow_module_level=True
-)
-
-# mypy ignore required because of the 'pytest.skip' above
-def test_kill_all_computeds(mz: MaterializeApplication) -> None:  # type: ignore
+def test_kill_all_computeds(mz: MaterializeApplication) -> None:
     """Kill all computeds"""
     populate(mz, 1)
 

--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -10,8 +10,6 @@
 import subprocess
 from textwrap import dedent
 
-import pytest
-
 from materialize.cloudtest.application import MaterializeApplication
 
 CLUSTER_SIZE = 16


### PR DESCRIPTION
...the initial networking infrastructure.

It still needs testing, but I believe this should fix #12800 -style issues.

We make the following changes:

* Allow a new peer connection to replace an old one (e.g., if peer `n` connects to us, and we already have a connection for peer `n`, just drop the old one)
* Periodically check that all connections are alive, and drop/retry the ones that aren't (in both the await and connect paths)

This approach has a few advantages:
* If a peer we connected to goes down, we will just drop it and wait for Kubernetes to replace it, rather than considering startup to be complete and then immediately crashing when we spin up Timely on the (dead) sockets.
* We will not hang forever trying to connect to a peer.

These properties should combine to prevent deadlocks, crash loops, etc.