### PR TITLE
sql: fix SINK parsing

### DIFF
--- a/src/adapter/src/sink_connection.rs
+++ b/src/adapter/src/sink_connection.rs
@@ -127,11 +127,7 @@ async fn register_kafka_topic(
         TopicReplication::Fixed(replication_factor),
     );
 
-    let retention_ms_str = match retention.duration {
-        Some(Some(d)) => Some(d.as_millis().to_string()),
-        Some(None) => Some("-1".to_string()),
-        None => None,
-    };
+    let retention_ms_str = retention.duration.map(|d| d.to_string());
     let retention_bytes_str = retention.bytes.map(|s| s.to_string());
     if let Some(ref retention_ms) = retention_ms_str {
         kafka_topic = kafka_topic.set("retention.ms", retention_ms);

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -787,7 +787,6 @@ pub enum KafkaConfigOptionName {
     TransactionTimeoutMs,
     StartTimestamp,
     StartOffset,
-    ReuseTopic,
     AvroKeyFullName,
     AvroValueFullName,
     PartitionCount,
@@ -819,7 +818,6 @@ impl AstDisplay for KafkaConfigOptionName {
             KafkaConfigOptionName::ReplicationFactor => "REPLICATION FACTOR",
             KafkaConfigOptionName::RetentionBytes => "RETENTION BYTES",
             KafkaConfigOptionName::RetentionMs => "RETENTION MS",
-            KafkaConfigOptionName::ReuseTopic => "REUSE TOPIC",
         })
     }
 }

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -787,6 +787,13 @@ pub enum KafkaConfigOptionName {
     TransactionTimeoutMs,
     StartTimestamp,
     StartOffset,
+    ReuseTopic,
+    AvroKeyFullName,
+    AvroValueFullName,
+    PartitionCount,
+    ReplicationFactor,
+    RetentionMs,
+    RetentionBytes,
 }
 
 impl AstDisplay for KafkaConfigOptionName {
@@ -804,8 +811,15 @@ impl AstDisplay for KafkaConfigOptionName {
                 "TOPIC METADATA REFRESH INTERVAL MS"
             }
             KafkaConfigOptionName::TransactionTimeoutMs => "TRANSACTION TIMEOUT MS",
-            KafkaConfigOptionName::StartTimestamp => "START TIMESTAMP",
             KafkaConfigOptionName::StartOffset => "START OFFSET",
+            KafkaConfigOptionName::StartTimestamp => "START TIMESTAMP",
+            KafkaConfigOptionName::AvroKeyFullName => "AVRO KEY FULL NAME",
+            KafkaConfigOptionName::AvroValueFullName => "AVRO VALUE FULL NAME",
+            KafkaConfigOptionName::PartitionCount => "PARTITION COUNT",
+            KafkaConfigOptionName::ReplicationFactor => "REPLICATION FACTOR",
+            KafkaConfigOptionName::RetentionBytes => "RETENTION BYTES",
+            KafkaConfigOptionName::RetentionMs => "RETENTION MS",
+            KafkaConfigOptionName::ReuseTopic => "REUSE TOPIC",
         })
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -531,6 +531,38 @@ impl<T: AstInfo> AstDisplay for CreateSourceStatement<T> {
 }
 impl_display_t!(CreateSourceStatement);
 
+/// An option in a `CREATE SINK` statement.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CreateSinkOptionName {
+    Snapshot,
+}
+
+impl AstDisplay for CreateSinkOptionName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            CreateSinkOptionName::Snapshot => {
+                f.write_str("SNAPSHOT");
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateSinkOption<T: AstInfo> {
+    pub name: CreateSinkOptionName,
+    pub value: Option<WithOptionValue<T>>,
+}
+
+impl<T: AstInfo> AstDisplay for CreateSinkOption<T> {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.name);
+        if let Some(v) = &self.value {
+            f.write_str(" = ");
+            f.write_node(v);
+        }
+    }
+}
+
 /// `CREATE SINK`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateSinkStatement<T: AstInfo> {
@@ -540,7 +572,7 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub connection: CreateSinkConnection<T>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope<T>>,
-    pub with_snapshot: bool,
+    pub with_options: Vec<CreateSinkOption<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateSinkStatement<T> {
@@ -562,10 +594,11 @@ impl<T: AstInfo> AstDisplay for CreateSinkStatement<T> {
             f.write_str(" ENVELOPE ");
             f.write_node(envelope);
         }
-        if self.with_snapshot {
-            f.write_str(" WITH SNAPSHOT");
-        } else {
-            f.write_str(" WITHOUT SNAPSHOT");
+
+        if !self.with_options.is_empty() {
+            f.write_str(" WITH (");
+            f.write_node(&display::comma_separated(&self.with_options));
+            f.write_str(")");
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -538,7 +538,6 @@ pub struct CreateSinkStatement<T: AstInfo> {
     pub if_not_exists: bool,
     pub from: T::ObjectName,
     pub connection: CreateSinkConnection<T>,
-    pub with_options: Vec<WithOption<T>>,
     pub format: Option<Format<T>>,
     pub envelope: Option<Envelope<T>>,
     pub with_snapshot: bool,
@@ -555,11 +554,6 @@ impl<T: AstInfo> AstDisplay for CreateSinkStatement<T> {
         f.write_node(&self.from);
         f.write_str(" INTO ");
         f.write_node(&self.connection);
-        if !self.with_options.is_empty() {
-            f.write_str(" WITH (");
-            f.write_node(&display::comma_separated(&self.with_options));
-            f.write_str(")");
-        }
         if let Some(format) = &self.format {
             f.write_str(" FORMAT ");
             f.write_node(format);

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -275,7 +275,6 @@ Reset
 Restrict
 Retention
 Returning
-Reuse
 Right
 Role
 Roles

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -79,6 +79,7 @@ Connections
 Consistency
 Constraint
 Copy
+Count
 Counter
 Create
 Cross
@@ -109,6 +110,7 @@ Distinct
 Dot
 Double
 Drop
+Duration
 Else
 Enable
 End
@@ -121,6 +123,7 @@ Exists
 Explain
 Extended
 Extract
+Factor
 False
 Fetch
 Fields
@@ -206,6 +209,7 @@ Mode
 Month
 Months
 Ms
+Name
 Names
 Natural
 Next
@@ -266,9 +270,12 @@ Repeatable
 Replace
 Replica
 Replicas
+Replication
 Reset
 Restrict
+Retention
 Returning
+Reuse
 Right
 Role
 Roles

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2338,14 +2338,6 @@ impl<'a> Parser<'a> {
         let from = self.parse_raw_name()?;
         self.expect_keyword(INTO)?;
         let connection = self.parse_create_sink_connection()?;
-        let mut with_options = vec![];
-        if self.parse_keyword(WITH) {
-            if let Some(Token::LParen) = self.next_token() {
-                self.prev_token();
-                self.prev_token();
-                with_options = self.parse_opt_with_options()?;
-            }
-        }
         let format = if self.parse_keyword(FORMAT) {
             Some(self.parse_format()?)
         } else {
@@ -2372,7 +2364,6 @@ impl<'a> Parser<'a> {
             name,
             from,
             connection,
-            with_options,
             format,
             envelope,
             with_snapshot,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -2026,7 +2026,6 @@ impl<'a> Parser<'a> {
             PARTITION,
             REPLICATION,
             RETENTION,
-            REUSE,
             SNAPSHOT,
             START,
             STATISTICS,

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -64,7 +64,6 @@ pub fn validate_options_for_context<T: AstInfo>(
             ReplicationFactor => Some(Sink),
             RetentionBytes => Some(Sink),
             RetentionMs => Some(Sink),
-            ReuseTopic => Some(Sink),
         };
         if limited_to_context.is_some() && limited_to_context != Some(context) {
             bail!(
@@ -104,8 +103,7 @@ generate_extracted_config!(
     (PartitionCount, i32, Default(-1)),
     (ReplicationFactor, i32, Default(-1)),
     (RetentionBytes, i64),
-    (RetentionMs, i64),
-    (ReuseTopic, bool, Default(false))
+    (RetentionMs, i64)
 );
 
 /// The config options we expect to pass along when connecting to librdkafka

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -46,7 +46,14 @@ generate_extracted_config!(
     (TopicMetadataRefreshIntervalMs, i32),
     (TransactionTimeoutMs, i32),
     (StartTimestamp, i64),
-    (StartOffset, Vec<i64>)
+    (StartOffset, Vec<i64>),
+    (AvroKeyFullName, String),
+    (AvroValueFullName, String),
+    (PartitionCount, i32, Default(-1)),
+    (ReplicationFactor, i32, Default(-1)),
+    (RetentionBytes, i64),
+    (RetentionMs, i64),
+    (ReuseTopic, bool, Default(false))
 );
 
 /// The config options we expect to pass along when connecting to librdkafka

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -540,13 +540,13 @@ pub fn create_statement(
 macro_rules! generate_extracted_config {
     // No default specified, have remaining options.
     ($option_ty:ty, [$($processed:tt)*], ($option_name:path, $t:ty), $($tail:tt),*) => {
-        generate_extracted_config!($option_ty, [$($processed)* ($option_name, Option<$t>, None)], $(
+        generate_extracted_config!($option_ty, [$($processed)* ($option_name, Option::<$t>, None)], $(
             $tail
         ),*);
     };
     // No default specified, no remaining options.
     ($option_ty:ty, [$($processed:tt)*], ($option_name:path, $t:ty)) => {
-        generate_extracted_config!($option_ty, [$($processed)* ($option_name, Option<$t>, None)]);
+        generate_extracted_config!($option_ty, [$($processed)* ($option_name, Option::<$t>, None)]);
     };
     // Default specified, have remaining options.
     ($option_ty:ty, [$($processed:tt)*], ($option_name:path, $t:ty, Default($v:expr)), $($tail:tt),*) => {
@@ -573,7 +573,7 @@ macro_rules! generate_extracted_config {
                     [<$option_ty Extracted>] {
                         seen: HashSet::<[<$option_ty Name>]>::new(),
                         $(
-                            [<$option_name:snake>]: $v.into(),
+                            [<$option_name:snake>]: $t::from($v),
                         )*
                     }
                 }

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -397,7 +397,6 @@ pub fn create_statement(
             connection: _,
             format: _,
             envelope: _,
-            with_snapshot: _,
             if_not_exists,
             ..
         }) => {

--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -395,7 +395,6 @@ pub fn create_statement(
         Statement::CreateSink(CreateSinkStatement {
             name,
             connection: _,
-            with_options: _,
             format: _,
             envelope: _,
             with_snapshot: _,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1923,7 +1923,6 @@ pub fn plan_create_sink(
         name,
         from,
         connection,
-        with_options,
         format,
         envelope,
         with_snapshot,
@@ -1948,8 +1947,6 @@ pub fn plan_create_sink(
     };
     let name = scx.allocate_qualified_name(normalize::unresolved_object_name(name)?)?;
     let from = scx.get_item_by_resolved_name(&from)?;
-
-    let mut with_options = normalize::options(&with_options)?;
 
     let desc = from.desc(&scx.catalog.resolve_full_name(from.name()))?;
     let key_indices = match &connection {
@@ -2036,8 +2033,6 @@ pub fn plan_create_sink(
             envelope,
         )?,
     };
-
-    normalize::ensure_empty_options(&with_options, "CREATE SINK")?;
 
     Ok(Plan::CreateSink(CreateSinkPlan {
         name,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2120,7 +2120,6 @@ fn kafka_sink_builder(
         connection,
         config_options,
         KafkaConfigOptionExtracted {
-            reuse_topic,
             avro_key_full_name,
             avro_value_full_name,
             partition_count,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -401,6 +401,11 @@ pub fn plan_create_source(
                         scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
                     }
 
+                    kafka_util::validate_options_for_context(
+                        &with_options,
+                        kafka_util::KafkaOptionCheckContext::Source,
+                    )?;
+
                     let extracted_options: KafkaConfigOptionExtracted =
                         with_options.clone().try_into()?;
                     let optional_start_offset =
@@ -2131,18 +2136,14 @@ fn kafka_sink_builder(
                 _ => sql_bail!("{} is not a kafka connection", item.name()),
             };
 
-            for option in with_options.iter() {
-                if matches!(
-                    option.name,
-                    KafkaConfigOptionName::StartOffset | KafkaConfigOptionName::StartTimestamp
-                ) {
-                    sql_bail!("Sinks do not support {}", option.name.to_ast_string());
-                }
-            }
-
             if !with_options.is_empty() {
                 scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
             }
+
+            kafka_util::validate_options_for_context(
+                &with_options,
+                kafka_util::KafkaOptionCheckContext::Sink,
+            )?;
 
             let extracted_options: KafkaConfigOptionExtracted = with_options.try_into()?;
             let config_options = kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;

--- a/src/storage/src/types/sinks.rs
+++ b/src/storage/src/types/sinks.rs
@@ -554,7 +554,7 @@ impl PopulateClientConfig for KafkaSinkConnectionBuilder {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSinkConnectionRetention {
-    pub duration: Option<Option<Duration>>,
+    pub duration: Option<i64>,
     pub bytes: Option<i64>,
 }
 

--- a/src/storage/src/types/sinks.rs
+++ b/src/storage/src/types/sinks.rs
@@ -10,7 +10,6 @@
 //! Types and traits related to reporting changing collections out of `dataflow`.
 
 use std::collections::{BTreeMap, HashSet};
-use std::time::Duration;
 
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -145,22 +145,22 @@ $ kafka-verify format=avro sink=materialize.public.snk4
 {"before": null, "after": {"row":{"c": true}}, "transaction": {"id": "<TIMESTAMP>"}}
 {"before": null, "after": {"row":{"c": true}}, "transaction": {"id": "<TIMESTAMP>"}}
 
-# Test AS OF and WITH/WITHOUT SNAPSHOT.
+# Test WITH (SNAPSHOT).
 #
 # N.B. It's important that we've verified above that a sink exporting
 # src_materialized has processed the row. This means the data has a definite
-# timestamp.  Without that, WITHOUT SNAPSHOT could correct either include or
+# timestamp.  Without that, WITH (SNAPSHOT = false) could correct either include or
 # exclude the old rows.
 
 > CREATE SINK snk5 FROM src_materialized
   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk5'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  WITHOUT SNAPSHOT
+  WITH (SNAPSHOT = false)
 
 > CREATE SINK snk6 FROM src_materialized
   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk6'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  WITH SNAPSHOT
+  WITH (SNAPSHOT = true)
 
 $ kafka-ingest topic=test format=bytes
 extra,row
@@ -173,19 +173,19 @@ $ kafka-verify format=avro sink=materialize.public.snk6 sort-messages=true
 {"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}, "transaction": {"id": "<TIMESTAMP>"}}
 {"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}, "transaction": {"id": "<TIMESTAMP>"}}
 
-# Test that we are correctly handling WITH/WITHOUT SNAPSHOT on views with
-# empty upper frontier
+# Test that we are correctly handling SNAPSHOT on views with empty upper
+# frontier
 > CREATE MATERIALIZED VIEW foo AS VALUES (1), (2), (3);
 
 > CREATE SINK snk7 FROM foo
   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk7'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  WITHOUT SNAPSHOT
+  WITH (SNAPSHOT = false)
 
 > CREATE SINK snk8 FROM foo
   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk8'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  WITH SNAPSHOT
+  WITH (SNAPSHOT)
 
 $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"column1": 1}}, "transaction": {"id": "<TIMESTAMP>"}}

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -10,4 +10,4 @@
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" WITH SNAPSHOT"
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" WITH (SNAPTSHOT = true)"


### PR DESCRIPTION
yolo CI run
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
