### PR TITLE
MirRelationExpr iterative drop

### DIFF
--- a/src/adapter/src/explain_new/mir/mod.rs
+++ b/src/adapter/src/explain_new/mir/mod.rs
@@ -406,9 +406,14 @@ fn normalize_lets_at_root(expr: &mut MirRelationExpr) {
                 .drain(..)
                 .map(|input| {
                     let mut residual = input;
-                    while let Let { id, value, body } = residual {
-                        bindings.push((id, value));
-                        residual = *body;
+                    while let Let {
+                        id,
+                        ref mut value,
+                        ref mut body,
+                    } = residual
+                    {
+                        bindings.push((id, (value.take_dangerous().into())));
+                        residual = body.take_dangerous();
                     }
                     residual
                 })
@@ -507,9 +512,14 @@ fn normalize_lets_at_root(expr: &mut MirRelationExpr) {
                 .into_iter()
                 .map(|input| {
                     let mut residual = input;
-                    while let Let { id, value, body } = residual {
-                        bindings.push((id, value));
-                        residual = *body;
+                    while let Let {
+                        id,
+                        ref mut value,
+                        ref mut body,
+                    } = residual
+                    {
+                        bindings.push((id, value.take_dangerous().into()));
+                        residual = body.take_dangerous();
                     }
                     residual
                 })

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -261,14 +261,14 @@ impl HirRelationExpr {
                     body,
                 } => {
                     let value = value.applied_to(id_gen, get_outer.clone(), col_map, cte_map);
-                    value.let_in(id_gen, |id_gen, get_value| {
+                    value.let_in(id_gen, |id_gen, mut get_value| {
                         let (new_id, typ) = if let mz_expr::MirRelationExpr::Get {
-                            id: mz_expr::Id::Local(id),
-                            typ,
+                            id: mz_expr::Id::Local(ref mut id),
+                            ref mut typ,
                             ..
                         } = get_value
                         {
-                            (id, typ)
+                            (id, std::mem::replace(typ, RelationType::empty()))
                         } else {
                             panic!(
                                 "get_value: expected a MirRelationExpr::Get with local Id, found {:?}",
@@ -280,7 +280,7 @@ impl HirRelationExpr {
                         let old_value = cte_map.insert(
                             id.clone(),
                             CteDesc {
-                                new_id,
+                                new_id: *new_id,
                                 relation_type: typ,
                                 outer_relation: get_outer.clone(),
                             },

--- a/src/transform/src/fusion/flatmap_to_map.rs
+++ b/src/transform/src/fusion/flatmap_to_map.rs
@@ -33,9 +33,13 @@ impl FlatMapToMap {
         if let MirRelationExpr::FlatMap { func, exprs, .. } = relation {
             if let TableFunc::Wrap { width, .. } = func {
                 if *width >= exprs.len() {
-                    if let MirRelationExpr::FlatMap { exprs, input, .. } = relation.take_dangerous()
+                    if let MirRelationExpr::FlatMap {
+                        ref mut exprs,
+                        ref mut input,
+                        ..
+                    } = relation.take_dangerous()
                     {
-                        *relation = input.map(exprs);
+                        *relation = input.take_dangerous().map(std::mem::take(exprs));
                     }
                 }
             }

--- a/src/transform/src/reduction.rs
+++ b/src/transform/src/reduction.rs
@@ -13,6 +13,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::iter;
+use std::mem::take;
 
 use mz_expr::visit::Visit;
 use mz_expr::{AggregateExpr, ColumnOrder, EvalError, MirRelationExpr, MirScalarExpr, TableFunc};
@@ -373,9 +374,9 @@ impl FoldConstants {
                     for input in iter::once(&mut **base).chain(&mut *inputs) {
                         match input.take_dangerous() {
                             MirRelationExpr::Constant {
-                                rows: Ok(rs),
+                                rows: Ok(ref mut rs),
                                 typ: _,
-                            } => rows.extend(rs),
+                            } => rows.extend(take(rs)),
                             input => new_inputs.push(input),
                         }
                     }


### PR DESCRIPTION
Signed-off-by: Moritz Hoffmann <mh@materialize.com>

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
