### PR TITLE
Determine infallibility of some expressions, optimize joins

### DIFF
--- a/src/compute-client/src/plan/join/mod.rs
+++ b/src/compute-client/src/plan/join/mod.rs
@@ -278,6 +278,15 @@ impl JoinClosure {
     pub fn is_identity(&self) -> bool {
         self.ready_equivalences.is_empty() && self.before.is_identity()
     }
+
+    /// Returns true if evaluation could introduce an error on non-error inputs.
+    pub fn could_error(&self) -> bool {
+        self.before.could_error()
+            || self
+                .ready_equivalences
+                .iter()
+                .any(|es| es.iter().any(|e| e.could_error()))
+    }
 }
 
 /// Maintained state as we construct join dataflows.

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -141,7 +141,7 @@ where
                                 source_relation,
                                 initial_closure,
                             );
-                            region_errs.extend(err_stream);
+                            region_errs.push(err_stream);
                             update_stream
                         }
                         Err(trace) => {
@@ -152,7 +152,7 @@ where
                                 source_relation,
                                 initial_closure,
                             );
-                            region_errs.extend(err_stream);
+                            region_errs.push(err_stream);
                             update_stream
                         }
                     };
@@ -230,7 +230,7 @@ where
                                 }
                             };
                         update_stream = oks;
-                        region_errs.extend(errs);
+                        region_errs.push(errs);
                     }
 
                     // Delay updates as appropriate.
@@ -248,7 +248,6 @@ where
                     // For example, we may have expressions not pushed down (e.g. literals)
                     // and projections that could not be applied (e.g. column repetition).
                     if let Some(final_closure) = final_closure {
-                        let could_error = final_closure.could_error();
                         let (updates, errors) =
                             update_stream.flat_map_fallible("DeltaJoinFinalization", {
                                 // Reuseable allocation for unpacking.
@@ -266,28 +265,20 @@ where
                             });
 
                         update_stream = updates;
-                        if could_error {
-                            region_errs.push(errors);
-                        }
+                        region_errs.push(errors);
                     }
 
-                    if !region_errs.is_empty() {
-                        inner_errs.push(
-                            differential_dataflow::collection::concatenate(region, region_errs)
-                                .leave(),
-                        );
-                    }
+                    inner_errs.push(
+                        differential_dataflow::collection::concatenate(region, region_errs).leave(),
+                    );
                     update_stream.leave()
                 });
 
                 join_results.push(path_results);
             }
 
-            if !inner_errs.is_empty() {
-                scope_errs.push(
-                    differential_dataflow::collection::concatenate(inner, inner_errs).leave(),
-                );
-            }
+            scope_errs
+                .push(differential_dataflow::collection::concatenate(inner, inner_errs).leave());
 
             // Concatenate the results of each delta query as the accumulated results.
             (
@@ -324,7 +315,7 @@ fn build_halfjoin<G, Tr, CF>(
     closure: JoinClosure,
 ) -> (
     Collection<G, (Row, G::Timestamp), Diff>,
-    Vec<Collection<G, DataflowError, Diff>>,
+    Collection<G, DataflowError, Diff>,
 )
 where
     G: Scope,
@@ -332,8 +323,6 @@ where
     Tr: TraceReader<Time = G::Timestamp, Key = Row, Val = Row, R = Diff> + Clone + 'static,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
 {
-    let mut errors = Vec::new();
-    let prev_key_could_error = prev_key.iter().any(|e| e.could_error());
     let (updates, errs) = updates.map_fallible("DeltaJoinKeyPreparation", {
         // Reuseable allocation for unpacking.
         let mut datums = DatumVec::new();
@@ -356,10 +345,6 @@ where
         }
     });
 
-    if prev_key_could_error {
-        errors.push(errs);
-    }
-
     use crate::render::RenderTimestamp;
     use differential_dataflow::AsCollection;
     use timely::dataflow::operators::OkErr;
@@ -367,7 +352,7 @@ where
     let mut datums = DatumVec::new();
     let mut row_builder = Row::default();
 
-    let oks = if closure.could_error() {
+    if closure.could_error() {
         let (oks, errs2) = dogsdogsdogs::operators::half_join::half_join_internal_unsafe(
             &updates,
             trace,
@@ -395,10 +380,12 @@ where
             }
         });
 
-        errors.push(errs2.as_collection());
-        oks.as_collection().flat_map(|x| x)
+        (
+            oks.as_collection().flat_map(|x| x),
+            errs.concat(&errs2.as_collection()),
+        )
     } else {
-        dogsdogsdogs::operators::half_join::half_join_internal_unsafe(
+        let oks = dogsdogsdogs::operators::half_join::half_join_internal_unsafe(
             &updates,
             trace,
             |time| time.step_back(),
@@ -416,10 +403,10 @@ where
                 let diff = diff1.clone() * diff2.clone();
                 row.map(|r| ((r, time.clone()), initial.clone(), diff))
             },
-        )
-    };
+        );
 
-    (oks, errors)
+        (oks, errs)
+    }
 }
 
 /// Builds the beginning of the update stream of a delta path.
@@ -432,10 +419,7 @@ fn build_update_stream<G, Tr>(
     as_of: Antichain<mz_repr::Timestamp>,
     source_relation: usize,
     initial_closure: JoinClosure,
-) -> (
-    Collection<G, Row, Diff>,
-    Option<Collection<G, DataflowError, Diff>>,
-)
+) -> (Collection<G, Row, Diff>, Collection<G, DataflowError, Diff>)
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
@@ -450,8 +434,6 @@ where
     for event_time in as_of.elements().iter() {
         inner_as_of.insert(<G::Timestamp>::to_inner(event_time.clone()));
     }
-
-    let could_error = initial_closure.could_error();
 
     let mut row_buf = Row::default();
     let (ok_stream, err_stream) =
@@ -518,10 +500,6 @@ where
 
     (
         ok_stream.as_collection(),
-        if could_error {
-            Some(err_stream.as_collection().map(DataflowError::from))
-        } else {
-            None
-        },
+        err_stream.as_collection().map(DataflowError::from),
     )
 }

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1447,6 +1447,12 @@ pub mod plan {
             }
             Ok(true)
         }
+
+        /// Returns true if evaluation could introduce an error on non-error inputs.
+        pub fn could_error(&self) -> bool {
+            self.mfp.predicates.iter().any(|(_pos, e)| e.could_error())
+                || self.mfp.expressions.iter().any(|e| e.could_error())
+        }
     }
 
     impl std::ops::Deref for SafeMfpPlan {
@@ -1824,6 +1830,13 @@ pub mod plan {
             } else {
                 None.into_iter().chain(None.into_iter())
             }
+        }
+
+        /// Returns true if evaluation could introduce an error on non-error inputs.
+        pub fn could_error(&self) -> bool {
+            self.mfp.could_error()
+                || self.lower_bounds.iter().any(|e| e.could_error())
+                || self.upper_bounds.iter().any(|e| e.could_error())
         }
     }
 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -2865,6 +2865,19 @@ impl BinaryFunc {
             _ => None,
         }
     }
+
+    /// Returns true if the function could introduce an error on non-error inputs.
+    pub fn could_error(&self) -> bool {
+        match self {
+            BinaryFunc::Eq
+            | BinaryFunc::NotEq
+            | BinaryFunc::Lt
+            | BinaryFunc::Gte
+            | BinaryFunc::Gt
+            | BinaryFunc::Lte => false,
+            _ => true,
+        }
+    }
 }
 
 impl fmt::Display for BinaryFunc {
@@ -3961,6 +3974,14 @@ impl UnaryFunc {
             UnaryFunc::IsTrue(_) => Some("TRUE"),
             UnaryFunc::IsFalse(_) => Some("FALSE"),
             _ => None,
+        }
+    }
+
+    /// Returns true if the function could introduce an error on non-error input.
+    pub fn could_error(&self) -> bool {
+        match self {
+            UnaryFunc::IsNull(_) | UnaryFunc::CastVarCharToString(_) | UnaryFunc::Not(_) => false,
+            _ => true,
         }
     }
 }
@@ -6365,6 +6386,15 @@ impl VariadicFunc {
             VariadicFunc::And => MirScalarExpr::literal_false(),
             VariadicFunc::Or => MirScalarExpr::literal_true(),
             _ => unreachable!(),
+        }
+    }
+
+    /// Returns true if the function could introduce an error on non-error inputs.
+    pub fn could_error(&self) -> bool {
+        match self {
+            VariadicFunc::And | VariadicFunc::Or => false,
+            // All other cases are unknown
+            _ => true,
         }
     }
 }


### PR DESCRIPTION
This PR introduces a `could_error()` to several expression-like things (functions, scalar expressions, MFPs, join closures). This method conservatively establishes whether an expression could error when presented with non-error inputs.

Based on this, and as a first cut, we optimize the implementation of join stages to not include `OkErr` operators when a join closure claims that it cannot introduce errors.

### Motivation

  * This PR adds a feature that has not yet been specified.

Expressions aren't currently able to certainly state that they will not error. Adding this unlocks a variety of optimizations where we do work to accommodate the `Result` types that might be produced from expression evaluation.

### Tips for reviewer

  * The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
