### PR TITLE
persist: flatten listen LeasedBatches into parts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3735,6 +3735,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rand",
+ "serde",
  "serde_json",
  "tempfile",
  "timely",

--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -93,7 +93,7 @@ pub enum InvalidUsage<T> {
         /// The expected upper of the batch
         expected_upper: Antichain<T>,
     },
-    /// A [crate::batch::Batch] or [crate::fetch::LeasedBatch] was
+    /// A [crate::batch::Batch] or [crate::fetch::LeasedBatchPart] was
     /// given to a [crate::write::WriteHandle] from a different shard
     BatchNotFromThisShard {
         /// The shard of the batch

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -398,15 +398,6 @@ where
         SerdeLeasedBatch::from(self)
     }
 
-    /// Signals whether or not `self` should downgrade the `Capability` its
-    /// presented alongside.
-    pub fn generate_progress(&self) -> Option<Antichain<T>> {
-        match self.metadata {
-            LeasedBatchMetadata::Listen { .. } => Some(self.batch.desc.upper().clone()),
-            LeasedBatchMetadata::Snapshot { .. } => None,
-        }
-    }
-
     /// Because sources get dropped without notice, we need to permit another
     /// operator to safely expire leases.
     ///

--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_persist::location::SeqNo;
+use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -53,7 +54,7 @@ impl PartId {
 /// Used to reduce the bytes needed to refer to a blob key in memory and in
 /// persistent state, all access to blobs are always within the context of an
 /// individual shard.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PartialBatchKey(pub(crate) String);
 
 impl PartialBatchKey {

--- a/src/persist-client/src/internal/state.proto
+++ b/src/persist-client/src/internal/state.proto
@@ -109,27 +109,3 @@ message ProtoStateDiff {
 
     ProtoStateFieldDiffs field_diffs = 5;
 }
-
-message ProtoLeasedBatchMetadata {
-    message ProtoLeasedBatchMetadataSnapshot {
-        ProtoU64Antichain as_of = 1;
-    }
-
-    message ProtoLeasedBatchMetadataListen {
-        ProtoU64Antichain as_of = 1;
-        ProtoU64Antichain until = 2;
-    }
-
-    oneof kind {
-        ProtoLeasedBatchMetadataSnapshot snapshot = 1;
-        ProtoLeasedBatchMetadataListen listen = 2;
-    }
-}
-
-message ProtoLeasedBatch {
-    string shard_id = 1;
-    ProtoLeasedBatchMetadata reader_metadata = 2;
-    ProtoHollowBatch batch = 3;
-    optional uint64 leased_seqno = 4;
-    string reader_id = 5;
-}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -774,8 +774,8 @@ mod tests {
                 .await;
             let fetcher1 = read1.clone().await.batch_fetcher().await;
             for batch in snap {
-                let (batch, res) = fetcher1.fetch_batch(batch).await;
-                read0.process_returned_leased_batch(batch);
+                let (batch, res) = fetcher1.fetch_leased_part(batch).await;
+                read0.process_returned_leased_part(batch);
                 assert_eq!(
                     res.unwrap_err(),
                     InvalidUsage::BatchNotFromThisShard {

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -42,6 +42,7 @@ openssl-sys = { version = "0.9.75", features = ["vendored"] }
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 prost = { version = "0.11.0", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
+serde = { version = "1.0.144", features = ["derive"] }
 timely = { git = "https://github.com/TimelyDataflow/timely-dataflow", default-features = false, features = ["bincode"] }
 tokio = { version = "1.19.2", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -17,6 +17,7 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use mz_persist_types::Codec;
 use mz_proto::RustType;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Error;
 
@@ -33,7 +34,7 @@ use crate::error::Error;
 /// Read-only requests are assigned the SeqNo of a write, indicating that all
 /// mutating requests up to and including that one are reflected in the read
 /// state.
-#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SeqNo(pub u64);
 
 impl std::fmt::Display for SeqNo {

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -150,7 +150,8 @@ id price
 
 > DECLARE c CURSOR FOR TAIL data_schema_inline WITH (SNAPSHOT = FALSE, PROGRESS = TRUE);
 
-> FETCH 1 FROM c WITH (timeout = '60s')
+> FETCH 2 FROM c WITH (timeout = '60s')
+14 true <null> <null> <null>
 15 true <null> <null> <null>
 
 $ kafka-ingest format=avro topic=data schema=${schema} timestamp=6


### PR DESCRIPTION
LeasedBatch exists so that persist_source can try to evenly distribute
the work of fetching and decoding shard data. However, Batches are
unevenly sized and can be arbitrarily large. Instead, distribute _batch
parts_, which are smallish (currently <128MiB, hopefully more like 8-32
MiB after inc state lands) and more evenly sized.

This commit switches Listen. Snapshot was already done in https://github.com/MaterializeInc/materialize/pull/14452

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Feel free to skim the third commit. I tried to push the interesting things into the first two for easier review and leave the third as mechanical as possible.

Timely clusters are, and
always will be, shared fate and thus run the same version of code.
Persist then doesn't need to worry about backward/forward compatibility
in its ExchangeData impl and so this protobuf dance is wasted work and
cycles. Instead, derive Serialize and Deserialize as normal.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
