### PR TITLE
revert erroneous changes to test_remote_storaged

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -240,7 +240,9 @@ def workflow_test_remote_storaged(c: Composition) -> None:
             "materialized",
             "postgres",
             "storaged",
-            "redpanda",
+            "zookeeper",
+            "kafka",
+            "schema-registry",
         ]
         c.start_and_wait_for_tcp(
             services=dependencies,


### PR DESCRIPTION
Accidentally committed my testing changes in https://github.com/MaterializeInc/materialize/pull/14421, this pr goes to the original code
