### PR TITLE
compute-client: remove DataflowDescription::global_id

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -626,18 +626,6 @@ where
             self.depends_on_into(id, out)
         }
     }
-
-    /// Determine a unique id for this dataflow based on the indexes it exports.
-    // TODO: The semantics of this function are only useful for command reconciliation at the moment.
-    pub fn global_id(&self) -> Option<GlobalId> {
-        let mut exports = self.export_ids();
-        let id = exports.next()?;
-        if exports.all(|other_id| other_id == id) {
-            Some(id)
-        } else {
-            None
-        }
-    }
 }
 
 impl<P: PartialEq, S: PartialEq, T: timely::PartialOrder> DataflowDescription<P, S, T> {


### PR DESCRIPTION
This method was used for compute reconciliation initially but is not used any longer (dataflows are now indexed by the union of their exports instead). Which makes this method dead code that also doesn't work with multi-export dataflows. Best to remove it.

### Motivation

   * This PR refactors existing code.

[Slack thread](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1661859840943019)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
