### PR TITLE
adapter: add join support to `EXPLAIN AS TEXT` for LIR plans

### DIFF
--- a/src/adapter/src/explain_new/hir/mod.rs
+++ b/src/adapter/src/explain_new/hir/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for `Hir` structures.
+//! `EXPLAIN` support for HIR structures.
 
 pub(crate) mod text;
 

--- a/src/adapter/src/explain_new/hir/text.rs
+++ b/src/adapter/src/explain_new/hir/text.rs
@@ -7,7 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for `Hir` structures.
+//! `EXPLAIN ... AS TEXT` support for HIR structures.
+//!
+//! The format adheres to the following conventions:
+//! 1. In general, every line corresponds to an [`HirRelationExpr`] node in the
+//!    plan.
+//! 2. Non-recursive parameters of each sub-plan are written as `$key=$val`
+//!    pairs on the same line.
+//! 3. A single non-recursive parameter can be written just as `$val`.
+//! 4. Exceptions in (1) can be made when virtual syntax is requested (done by
+//!    default, can be turned off with `WITH(raw_syntax)`).
 
 use std::fmt;
 

--- a/src/adapter/src/explain_new/lir/mod.rs
+++ b/src/adapter/src/explain_new/lir/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for `Mir` structures.
+//! `EXPLAIN` support for LIR structures.
 
 pub(crate) mod json;
 pub(crate) mod text;

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -8,6 +8,17 @@
 // by the Apache License, Version 2.0.
 
 //! `EXPLAIN ... AS TEXT` support for LIR structures.
+//!
+//! The format adheres to the following conventions:
+//! 1. In general, every line that starts with an uppercase character
+//!    corresponds to a [`Plan`] variant.
+//! 2. Whenever the variant has an attached `~Plan`, the printed name is
+//!    `$V::$P` where `$V` identifies the variant and `$P` the plan.
+//! 3. The fields of a `~Plan` struct attached to a [`Plan`] are rendered as if
+//!    they were part of the variant themself.
+//! 4. Non-recursive parameters of each sub-plan are written as `$key=$val`
+//!    pairs on the same line or as lowercase `$key` fields on indented lines.
+//! 5. A single non-recursive parameter can be written just as `$val`.
 
 use std::{collections::HashMap, fmt, ops::Deref};
 

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -20,7 +20,11 @@
 //!    pairs on the same line or as lowercase `$key` fields on indented lines.
 //! 5. A single non-recursive parameter can be written just as `$val`.
 
-use std::{collections::HashMap, fmt, ops::Deref};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    ops::Deref,
+};
 
 use mz_compute_client::plan::{
     join::{
@@ -733,16 +737,16 @@ struct Permutation<'a>(&'a HashMap<usize, usize>);
 impl<'a> fmt::Display for Permutation<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut pairs = vec![];
-        for (x, y) in self.0.iter() {
-            if x != y {
-                pairs.push(format!("#{}: #{}", x, y))
-            }
+        // convert the wrapped `HashMap` to a `BTreeMap` first and then iterate
+        // over the individual pairs for deterministic output
+        for (x, y) in BTreeMap::from_iter(self.0.iter().filter(|(x, y)| x != y)) {
+            pairs.push(format!("#{}: #{}", x, y));
         }
 
         if pairs.len() > 0 {
-            bracketed("{", "}", separated(", ", pairs)).fmt(f)
+            write!(f, "{{{}}}", separated(", ", pairs))
         } else {
-            separated("", vec!["id".to_string()]).fmt(f)
+            write!(f, "id")
         }
     }
 }

--- a/src/adapter/src/explain_new/lir/text.rs
+++ b/src/adapter/src/explain_new/lir/text.rs
@@ -12,6 +12,11 @@
 use std::{collections::HashMap, fmt, ops::Deref};
 
 use mz_compute_client::plan::{
+    join::{
+        delta_join::{DeltaPathPlan, DeltaStagePlan},
+        linear_join::LinearStagePlan,
+        DeltaJoinPlan, JoinClosure, LinearJoinPlan,
+    },
     reduce::{AccumulablePlan, BasicPlan, CollationPlan, HierarchicalPlan},
     AvailableCollections, Plan,
 };
@@ -149,8 +154,24 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, Plan> {
                     Displayable::from(input.as_ref()).fmt_text(f, ctx)
                 })?;
             }
-            Join { inputs: _, plan: _ } => {
-                // todo
+            Join { inputs, plan } => {
+                use mz_compute_client::plan::join::JoinPlan;
+                match plan {
+                    JoinPlan::Linear(plan) => {
+                        writeln!(f, "{}Join::Linear", ctx.indent)?;
+                        ctx.indented(|ctx| Displayable::from(plan).fmt_text(f, ctx))?;
+                    }
+                    JoinPlan::Delta(plan) => {
+                        writeln!(f, "{}Join::Delta", ctx.indent)?;
+                        ctx.indented(|ctx| Displayable::from(plan).fmt_text(f, ctx))?;
+                    }
+                }
+                ctx.indented(|ctx| {
+                    for input in inputs {
+                        Displayable::from(input).fmt_text(f, ctx)?;
+                    }
+                    Ok(())
+                })?;
             }
             Reduce {
                 input,
@@ -362,6 +383,181 @@ impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, MapFilt
             writeln!(f, "{}map=({})", ctx.indent, scalars)?;
         }
 
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, LinearJoinPlan> {
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, Plan>,
+    ) -> fmt::Result {
+        let plan = self.0;
+        if let Some(closure) = plan.final_closure.as_ref() {
+            if !closure.is_identity() {
+                writeln!(f, "{}final_closure", ctx.indent)?;
+                ctx.indented(|ctx| Displayable::from(closure).fmt_text(f, ctx))?;
+            }
+        }
+        for (i, plan) in plan.stage_plans.iter().enumerate().rev() {
+            writeln!(f, "{}linear_stage[{}]", ctx.indent, i)?;
+            ctx.indented(|ctx| Displayable::from(plan).fmt_text(f, ctx))?;
+        }
+        if let Some(closure) = plan.initial_closure.as_ref() {
+            if !closure.is_identity() {
+                writeln!(f, "{}initial_closure", ctx.indent)?;
+                ctx.indented(|ctx| Displayable::from(closure).fmt_text(f, ctx))?;
+            }
+        }
+        {
+            let source_relation = &plan.source_relation;
+            let source_key = plan.source_key.iter().flatten().map(Displayable::from);
+            let source_key = separated_text(", ", source_key);
+            writeln!(
+                f,
+                "{}source={{ relation={}, key=[{}] }}",
+                ctx.indent, source_relation, source_key
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, LinearStagePlan> {
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, Plan>,
+    ) -> fmt::Result {
+        let plan = self.0;
+        if !plan.closure.is_identity() {
+            writeln!(f, "{}closure", ctx.indent)?;
+            ctx.indented(|ctx| Displayable::from(&plan.closure).fmt_text(f, ctx))?;
+        }
+        {
+            let lookup_relation = &plan.lookup_relation;
+            let lookup_key = separated_text(", ", plan.lookup_key.iter().map(Displayable::from));
+            writeln!(
+                f,
+                "{}lookup={{ relation={}, key=[{}] }}",
+                ctx.indent, lookup_relation, lookup_key
+            )?;
+        }
+        {
+            let stream_key = separated_text(", ", plan.stream_key.iter().map(Displayable::from));
+            let stream_thinning = Indices(&plan.stream_thinning);
+            writeln!(
+                f,
+                "{}stream={{ key=[{}], thinning=({}) }}",
+                ctx.indent, stream_key, stream_thinning
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, DeltaJoinPlan> {
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, Plan>,
+    ) -> fmt::Result {
+        for (i, plan) in self.0.path_plans.iter().enumerate() {
+            writeln!(f, "{}plan_path[{}]", ctx.indent, i)?;
+            ctx.indented(|ctx| Displayable::from(plan).fmt_text(f, ctx))?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, DeltaPathPlan> {
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, Plan>,
+    ) -> fmt::Result {
+        let plan = self.0;
+        if let Some(closure) = plan.final_closure.as_ref() {
+            if !closure.is_identity() {
+                writeln!(f, "{}final_closure", ctx.indent)?;
+                ctx.indented(|ctx| Displayable::from(closure).fmt_text(f, ctx))?;
+            }
+        }
+        for (i, plan) in plan.stage_plans.iter().enumerate().rev() {
+            writeln!(f, "{}delta_stage[{}]", ctx.indent, i)?;
+            ctx.indented(|ctx| Displayable::from(plan).fmt_text(f, ctx))?;
+        }
+        if !plan.initial_closure.is_identity() {
+            writeln!(f, "{}initial_closure", ctx.indent)?;
+            ctx.indented(|ctx| Displayable::from(&plan.initial_closure).fmt_text(f, ctx))?;
+        }
+        {
+            let source_relation = &plan.source_relation;
+            let source_key = separated_text(", ", plan.source_key.iter().map(Displayable::from));
+            writeln!(
+                f,
+                "{}source={{ relation={}, key=[{}] }}",
+                ctx.indent, source_relation, source_key
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, DeltaStagePlan> {
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, Plan>,
+    ) -> fmt::Result {
+        let plan = self.0;
+        if !plan.closure.is_identity() {
+            writeln!(f, "{}closure", ctx.indent)?;
+            ctx.indented(|ctx| Displayable::from(&plan.closure).fmt_text(f, ctx))?;
+        }
+        {
+            let lookup_relation = &plan.lookup_relation;
+            let lookup_key = separated_text(", ", plan.lookup_key.iter().map(Displayable::from));
+            writeln!(
+                f,
+                "{}lookup={{ relation={}, key=[{}] }}",
+                ctx.indent, lookup_relation, lookup_key
+            )?;
+        }
+        {
+            let stream_key = separated_text(", ", plan.stream_key.iter().map(Displayable::from));
+            let stream_thinning = Indices(&plan.stream_thinning);
+            writeln!(
+                f,
+                "{}stream={{ key=[{}], thinning=({}) }}",
+                ctx.indent, stream_key, stream_thinning
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> DisplayText<PlanRenderingContext<'_, Plan>> for Displayable<'a, JoinClosure> {
+    fn fmt_text(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        ctx: &mut PlanRenderingContext<'_, Plan>,
+    ) -> fmt::Result {
+        Displayable::from(self.0.before.deref()).fmt_text(f, ctx)?;
+        if !self.0.ready_equivalences.is_empty() {
+            let equivalences = separated(
+                " AND ",
+                self.0.ready_equivalences.iter().map(|equivalence| {
+                    if equivalence.len() == 2 {
+                        bracketed("", "", separated(" = ", equivalence))
+                    } else {
+                        bracketed("eq(", ")", separated(", ", equivalence))
+                    }
+                }),
+            );
+            writeln!(f, "{}ready_equivalences={}", ctx.indent, equivalences)?;
+        }
         Ok(())
     }
 }

--- a/src/adapter/src/explain_new/mir/mod.rs
+++ b/src/adapter/src/explain_new/mir/mod.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for `Mir` structures.
+//! `EXPLAIN` support for MIR structures.
 
 pub(crate) mod text;
 

--- a/src/adapter/src/explain_new/mir/text.rs
+++ b/src/adapter/src/explain_new/mir/text.rs
@@ -7,7 +7,18 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-//! `EXPLAIN` support for `Mir` structures.
+//! `EXPLAIN ... AS TEXT` support for MIR structures.
+//!
+//! The format adheres to the following conventions:
+//! 1. In general, every line corresponds to an [`MirRelationExpr`] node in the
+//!    plan.
+//! 2. Non-recursive parameters of each sub-plan are written as `$key=$val`
+//!    pairs on the same line.
+//! 3. A single non-recursive parameter can be written just as `$val`.
+//! 4. Exceptions in (1) can be made when virtual syntax is requested (done by
+//!    default, can be turned off with `WITH(raw_syntax)`).
+//! 5. Exceptions in (2) can be made when join implementations are rendered
+//!    explicitly `WITH(join_impls)`.
 
 use std::fmt;
 

--- a/src/compute-client/src/plan/join/mod.rs
+++ b/src/compute-client/src/plan/join/mod.rs
@@ -88,8 +88,8 @@ impl RustType<ProtoJoinPlan> for JoinPlan {
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct JoinClosure {
-    ready_equivalences: Vec<Vec<MirScalarExpr>>,
-    before: mz_expr::SafeMfpPlan,
+    pub ready_equivalences: Vec<Vec<MirScalarExpr>>,
+    pub before: mz_expr::SafeMfpPlan,
 }
 
 impl Arbitrary for JoinClosure {

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -21,6 +21,12 @@ CREATE TABLE u (
 )
 
 statement ok
+CREATE TABLE v (
+  e int,
+  f int
+)
+
+statement ok
 CREATE INDEX t_a_idx ON T(a);
 
 statement ok
@@ -628,5 +634,200 @@ Explained Query
 
 Used Indexes:
   - materialize.public.t_a_idx
+
+EOF
+
+# Test Join::Differential (acyclic).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non_negative) AS TEXT FOR
+SELECT b + d, c + e, a + e
+FROM t, u, v
+WHERE a = c AND d = e AND b + d > 42
+----
+Explained Query
+  Join::Linear
+    final_closure
+      project=(#0, #1, #1)
+    linear_stage[1]
+      closure
+        project=(#3, #4)
+        filter=((#3 > 42))
+        map=((#2 + #1), (#0 + #1))
+      lookup={ relation=0, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    linear_stage[0]
+      closure
+        project=(#1, #0)
+      lookup={ relation=1, key=[#1] }
+      stream={ key=[#0], thinning=() }
+    source={ relation=2, key=[] }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+      Get::Collection materialize.public.u
+        filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+        raw=true
+    Get::Collection materialize.public.v
+      project=(#0)
+      filter=((#0) IS NOT NULL)
+      raw=true
+
+Source materialize.public.u
+  Demand (#0, #1)
+  Filter (#0) IS NOT NULL AND (#1) IS NOT NULL
+Source materialize.public.v
+  Demand (#0)
+  Filter (#0) IS NOT NULL
+
+Used Indexes:
+  - materialize.public.t_a_idx
+
+EOF
+
+# Create indexes required for differential join tests
+
+statement ok
+CREATE INDEX u_c_idx ON U(c);
+
+statement ok
+CREATE INDEX u_d_idx ON U(d);
+
+statement ok
+CREATE INDEX v_e_idx ON V(e);
+
+# Test Join::Differential (cyclic).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c AND d = e AND f = a
+----
+Explained Query
+  Join::Linear
+    final_closure
+      project=(#0, #1, #0, #2, #2, #0)
+    linear_stage[1]
+      closure
+        project=(#0, #2, #1)
+      lookup={ relation=0, key=[#0] }
+      stream={ key=[#0], thinning=(#1) }
+    linear_stage[0]
+      closure
+        project=(#1, #0)
+      lookup={ relation=2, key=[#0, #1] }
+      stream={ key=[#1, #0], thinning=() }
+    source={ relation=1, key=[] }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    Get::Arrangement materialize.public.u
+      filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+      key=#0
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+      Get::Arrangement materialize.public.v
+        filter=((#0) IS NOT NULL AND (#1) IS NOT NULL)
+        key=#0
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+  - materialize.public.u_c_idx
+  - materialize.public.v_e_idx
+
+EOF
+
+# Test Join::Delta (star).
+query T multiline
+EXPLAIN PHYSICAL PLAN WITH(non_negative) AS TEXT FOR
+SELECT a, b, c, d, e, f
+FROM t, u, v
+WHERE a = c and a = e
+----
+Explained Query
+  Join::Delta
+    plan_path[0]
+      final_closure
+        project=(#0, #1, #0, #2, #0, #3)
+      delta_stage[1]
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#0], thinning=(#1, #2) }
+      delta_stage[0]
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      initial_closure
+        filter=((#0) IS NOT NULL)
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      final_closure
+        project=(#0, #1, #0, #2, #0, #3)
+      delta_stage[1]
+        closure
+          project=(#1..=#4)
+        lookup={ relation=2, key=[#0] }
+        stream={ key=[#2], thinning=(#0, #1, #3) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #0, #1)
+          filter=((#0) IS NOT NULL)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=1, key=[#0] }
+    plan_path[2]
+      final_closure
+        project=(#0, #1, #0, #2, #0, #3)
+      delta_stage[1]
+        closure
+          project=(#1, #2, #4, #3)
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#2], thinning=(#0, #1, #3) }
+      delta_stage[0]
+        closure
+          project=(#0, #2, #0, #1)
+          filter=((#0) IS NOT NULL)
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1) }
+      source={ relation=2, key=[#0] }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.u
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.v
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx
+  - materialize.public.u_c_idx
+  - materialize.public.v_e_idx
 
 EOF


### PR DESCRIPTION
Add support and tests for the `Join` variant.

### Motivation

  * This PR adds a known-desirable feature.

Closes #13472.

### Tips for reviewer

* First commit adds join support for LIR plans and adds tests. This gets quite verbose and I think there are some obvious ways to compact it, but I don't have the cycles to make it better right now. I suggest to merge it as it is and revisit if we have problems investigating plans based no this sytnax.
* Second commit fixes module-level comments, outlining the basic principles for coming up with the `EXPLAIN AS TEXT` syntax for the individual IRs for posterity.
 
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user-facing behavior changes. The format will be made public in #13302.
