### PR TITLE
doc/user: bump LTS support date through at least October 31, 2022

### DIFF
--- a/doc/user/content/release-notes.md
+++ b/doc/user/content/release-notes.md
@@ -23,7 +23,7 @@ process by the release notes team.
 
 {{< note >}}
 v0.26 is a **long-term support (LTS)** release of Materialize. We will support
-the v0.26.x series through at least August 31 2022, issuing **patch releases** as
+the v0.26.x series through at least October 31, 2022, issuing **patch releases** as
 necessary to address severe bugs and security vulnerabilities.
 {{</ note >}}
 


### PR DESCRIPTION
We're committed to supporting v0.26 LTS for at least two more months,
since our new cloud product is not yet GA.

### Motivation

  * This PR updates docs.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
