### PR TITLE
Deduplicate in detect_literal_constraints

### DIFF
--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -77,6 +77,21 @@ where
     }
 }
 
+/// Remove the elements from `v` at the positions indicated by `indexes`, and return the removed
+/// elements in a new vector.
+///
+/// `indexes` shouldn't have duplicates. (Might panic or behave incorrectly in case of
+/// duplicates.)
+pub fn swap_remove_multiple<T>(v: &mut Vec<T>, mut indexes: Vec<usize>) -> Vec<T> {
+    indexes.sort();
+    indexes.reverse();
+    let mut result = Vec::new();
+    for r in indexes {
+        result.push(v.swap_remove(r));
+    }
+    result
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -207,6 +207,14 @@ impl CanonicalizeMfp {
                 }
                 literal_values.push(row);
             }
+            // We should deduplicate, because a constraint can be duplicated by
+            // `distribute_and_over_or`. For example: `IN ('l1', 'l2') AND (a > 0 OR a < 5)`. Here,
+            // the 2 args of the OR will cause the IN constraints to be duplicated. This doesn't
+            // alter the meaning of the expression when evaluated as a filter, but if we extract
+            // those literals 2 times into `literal_values` then the Peek code will look up those
+            // keys from the index 2 times, leading to duplicate results.
+            literal_values.sort();
+            literal_values.dedup();
             Some(literal_values)
         }
 

--- a/test/sqllogictest/column_knowledge.slt
+++ b/test/sqllogictest/column_knowledge.slt
@@ -604,37 +604,14 @@ EXPLAIN SELECT * FROM t1 LEFT JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 2
 EOF
 
 #
-# Not all impossible conditions after propagation are currently not detected as such
+# The following impossible condition is removed by `CanonicalizeMfp::remove_impossible_or_args`
 #
 
 query T multiline
 EXPLAIN SELECT * FROM t1 FULL OUTER JOIN t2 USING (f1) WHERE t1.f1 = 123 AND t2.f1 = 234;
 ----
-Source materialize.public.t1 (u1):
-| Filter (#0 = 123), (#0 = 234)
-| Project (#0, #1)
-
-Source materialize.public.t2 (u2):
-| Filter (#0 = 123), (#0 = 234)
-| Project (#0, #1)
-
-Query:
 %0 =
-| Get materialize.public.t1 (u1)
-| Filter (#0 = 123), (#0 = 234)
-| Project (#1)
-| ArrangeBy ()
-
-%1 =
-| Get materialize.public.t2 (u2)
-| Filter (#0 = 123), (#0 = 234)
-| Project (#1)
-
-%2 =
-| Join %0 %1
-| | implementation = Differential %1 %0.()
-| Map 123
-| Project (#2, #0, #1)
+| Constant
 
 EOF
 

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -398,6 +398,50 @@ SELECT a FROM t1 WHERE b IN ('l1', 'l2') AND (a > 0 OR a < 5)
 1
 2
 
+# Impossible predicates (exercise `remove_impossible_or_args`)
+
+query T multiline
+EXPLAIN SELECT a FROM t1
+WHERE a = 3 AND a = 5
+----
+%0 =
+| Constant
+
+EOF
+
+query T multiline
+EXPLAIN SELECT a FROM t1
+WHERE a IN (1,2) AND a IN (3,4,5)
+----
+%0 =
+| Constant
+
+EOF
+
+# Only some subexpressions of the predicates can be removed due to being impossible
+
+query T multiline
+EXPLAIN SELECT a FROM t1
+WHERE (a = 4 AND a = 7) OR (a = 9)
+----
+%0 =
+| ReadExistingIndex materialize.public.idx_t1_a
+| | Lookup value (9)
+| Project (#0)
+
+EOF
+
+query T multiline
+EXPLAIN SELECT a FROM t1
+WHERE a IN (1,2) AND a IN (2,3,4)
+----
+%0 =
+| ReadExistingIndex materialize.public.idx_t1_a
+| | Lookup value (2)
+| Project (#0)
+
+EOF
+
 # In the following query, we would be able to detect literal constraints if we called `canonicalize_equivalences`
 
 query T multiline

--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -387,6 +387,17 @@ SELECT pk FROM tab0 WHERE (((col4 >= 660.98) AND ((col4 IN (724.71,445.29,441.2,
 0
 1
 
+# Regression test for https://github.com/MaterializeInc/materialize/issues/14548
+
+statement ok
+CREATE INDEX idx_t1_b ON t1(b)
+
+query I
+SELECT a FROM t1 WHERE b IN ('l1', 'l2') AND (a > 0 OR a < 5)
+----
+1
+2
+
 # In the following query, we would be able to detect literal constraints if we called `canonicalize_equivalences`
 
 query T multiline

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -103,10 +103,10 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # Partial matches are not optimized
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (3, 4);
-"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 = 3) OR ((#1 = 2) AND (#1 = 4)))"
+"%0 =| ReadExistingIndex t1_primary_idx| Filter (#1 = 3)"
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (4, 5);
-"%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 = 2) OR (#1 = 3)), ((#1 = 4) OR (#1 = 5))"
+"%0 =| Constant"
 
 # Expression inside an IN list
 


### PR DESCRIPTION
The first commit fixes #14548.

The second commit fixes a more tricky bug, which happens in `remove_literal_constraints` when there are contradicting literal constraints.


### Motivation

  * This PR fixes a recognized bug: #14548

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No
