### PR TITLE
adapter: enrich SimpleResult::Ok

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -436,7 +436,7 @@ impl SessionClient {
                 ExecuteResponse::Canceled => {
                     results.push(SimpleResult::err("statement canceled due to user request"));
                 }
-                ExecuteResponse::CreatedConnection { existed: _ }
+                res @ (ExecuteResponse::CreatedConnection { existed: _ }
                 | ExecuteResponse::CreatedDatabase { existed: _ }
                 | ExecuteResponse::CreatedSchema { existed: _ }
                 | ExecuteResponse::CreatedRole
@@ -481,8 +481,8 @@ impl SessionClient {
                 | ExecuteResponse::AlteredIndexLogicalCompaction
                 | ExecuteResponse::AlteredSystemConfiguraion
                 | ExecuteResponse::Deallocate { all: _ }
-                | ExecuteResponse::Prepare => {
-                    results.push(SimpleResult::Ok);
+                | ExecuteResponse::Prepare) => {
+                    results.push(SimpleResult::ok(res));
                 }
                 ExecuteResponse::SendingRows {
                     future: rows,

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -45,7 +45,10 @@ pub mod client;
 pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
-pub use crate::command::{Canceled, ExecuteResponse, RowsFuture, StartupMessage, StartupResponse};
+pub use crate::command::{
+    Canceled, ExecuteResponse, ExecuteResponsePartialError, RowsFuture, StartupMessage,
+    StartupResponse,
+};
 pub use crate::coord::peek::PeekResponseUnary;
 pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};
 pub use crate::error::AdapterError;

--- a/src/adapter/src/session/vars.rs
+++ b/src/adapter/src/session/vars.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use const_format::concatcp;
 use once_cell::sync::Lazy;
+use serde::Serialize;
 use uncased::UncasedStr;
 
 use mz_ore::cast;
@@ -1465,6 +1466,15 @@ pub enum ClientSeverity {
     /// Sends only NOTICE, WARNING, INFO, ERROR, FATAL and PANIC level messages.
     /// Not listed as a valid value, but accepted by Postgres
     Info,
+}
+
+impl Serialize for ClientSeverity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
 }
 
 impl ClientSeverity {

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -165,7 +165,13 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCase {
             query: "create view v as select 1",
             status: StatusCode::OK,
-            body: r#"{"results":[null]}"#,
+            body: r#"{"results":[{"ok":"CREATE VIEW"}]}"#,
+        },
+        // Partial errors make it to the client.
+        TestCase {
+            query: "create view if not exists v as select 1",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"CREATE VIEW","partial_err":{"severity":"notice","message":"view already exists, skipping"}}]}"#,
         },
         // Multiple CREATEs do not work.
         TestCase {

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -10,8 +10,8 @@
 use std::collections::HashMap;
 
 use itertools::Itertools;
-use mz_adapter::ExecuteResponse;
-use mz_sql::ast::NoticeSeverity;
+use mz_adapter::session::ClientSeverity;
+use mz_adapter::ExecuteResponsePartialError;
 use postgres::error::SqlState;
 
 use mz_adapter::session::ClientSeverity as AdapterClientSeverity;
@@ -437,150 +437,6 @@ impl ErrorResponse {
         }
     }
 
-    /// When an appropriate error response can be totally determined by the
-    /// `ExecuteResponse`, generate it if it is non-terminal, i.e. should not be
-    /// returned as an error instead of the value.
-    pub fn non_terminating_from_execute_response(
-        response: &ExecuteResponse,
-    ) -> Option<ErrorResponse> {
-        macro_rules! existed {
-            ($existed:expr, $code:expr, $type:expr) => {{
-                if $existed {
-                    Some(ErrorResponse::notice(
-                        $code,
-                        concat!($type, " already exists, skipping"),
-                    ))
-                } else {
-                    None
-                }
-            }};
-        }
-
-        use ExecuteResponse::*;
-        match response {
-            CreatedConnection { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "connection")
-            }
-            CreatedDatabase { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_DATABASE, "database")
-            }
-            CreatedSchema { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_SCHEMA, "schema")
-            }
-            CreatedRole => {
-                existed!(false, SqlState::DUPLICATE_OBJECT, "role")
-            }
-            CreatedComputeInstance { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "cluster")
-            }
-            CreatedComputeInstanceReplica { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "cluster replica")
-            }
-            CreatedTable { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_TABLE, "table")
-            }
-            CreatedIndex { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "index")
-            }
-            CreatedSecret { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "secret")
-            }
-            CreatedSource { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "source")
-            }
-            CreatedSink { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "sink")
-            }
-            CreatedView { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "view")
-            }
-            CreatedViews { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "views")
-            }
-            CreatedMaterializedView { existed } => {
-                existed!(*existed, SqlState::DUPLICATE_OBJECT, "materialized view")
-            }
-
-            Raise { severity } => Some(match severity {
-                NoticeSeverity::Debug => {
-                    ErrorResponse::debug(SqlState::WARNING, "raised a test debug")
-                }
-                NoticeSeverity::Info => {
-                    ErrorResponse::info(SqlState::WARNING, "raised a test info")
-                }
-                NoticeSeverity::Log => ErrorResponse::log(SqlState::WARNING, "raised a test log"),
-                NoticeSeverity::Notice => {
-                    ErrorResponse::notice(SqlState::WARNING, "raised a test notice")
-                }
-                NoticeSeverity::Warning => {
-                    ErrorResponse::warning(SqlState::WARNING, "raised a test warning")
-                }
-            }),
-
-            StartedTransaction { duplicated } => {
-                if *duplicated {
-                    Some(ErrorResponse::warning(
-                        SqlState::ACTIVE_SQL_TRANSACTION,
-                        "there is already a transaction in progress",
-                    ))
-                } else {
-                    None
-                }
-            }
-
-            TransactionExited { was_implicit, .. } => {
-                // In Postgres, if a user sends a COMMIT or ROLLBACK in an implicit
-                // transaction, a warning is sent warning them. (The transaction is still closed
-                // and a new implicit transaction started, though.)
-                if *was_implicit {
-                    Some(ErrorResponse::warning(
-                        SqlState::NO_ACTIVE_SQL_TRANSACTION,
-                        "there is no transaction in progress",
-                    ))
-                } else {
-                    None
-                }
-            }
-
-            CreatedSources
-            | CreatedType
-            | AlteredObject(..)
-            | AlteredIndexLogicalCompaction
-            | AlteredSystemConfiguraion
-            | Canceled
-            | ClosedCursor
-            | CopyTo { .. }
-            | CopyFrom { .. }
-            | Deallocate { .. }
-            | DeclaredCursor
-            | Deleted(..)
-            | DiscardedTemp
-            | DiscardedAll
-            | DroppedConnection
-            | DroppedComputeInstance
-            | DroppedComputeInstanceReplicas
-            | DroppedDatabase
-            | DroppedRole
-            | DroppedSchema
-            | DroppedSource
-            | DroppedTable
-            | DroppedView
-            | DroppedMaterializedView
-            | DroppedIndex
-            | DroppedSink
-            | DroppedType
-            | DroppedSecret
-            | EmptyQuery
-            | Fetch { .. }
-            | Inserted(..)
-            | Prepare
-            | SendingRows { .. }
-            | SetVariable { .. }
-            | Tailing { .. }
-            | Updated(..) => None,
-        }
-    }
-
     pub fn from_startup_message(message: StartupMessage) -> ErrorResponse {
         ErrorResponse {
             severity: Severity::Notice,
@@ -595,6 +451,30 @@ impl ErrorResponse {
     pub fn with_position(mut self, position: usize) -> ErrorResponse {
         self.position = Some(position);
         self
+    }
+}
+
+impl From<ExecuteResponsePartialError> for ErrorResponse {
+    fn from(
+        ExecuteResponsePartialError {
+            severity,
+            code,
+            message,
+        }: ExecuteResponsePartialError,
+    ) -> Self {
+        let gen = match severity {
+            ClientSeverity::Debug1
+            | ClientSeverity::Debug2
+            | ClientSeverity::Debug3
+            | ClientSeverity::Debug4
+            | ClientSeverity::Debug5 => Self::debug,
+            ClientSeverity::Error => Self::error,
+            ClientSeverity::Info => Self::info,
+            ClientSeverity::Log => Self::log,
+            ClientSeverity::Notice => Self::notice,
+            ClientSeverity::Warning => Self::warning,
+        };
+        gen(code, &message)
     }
 }
 

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1067,7 +1067,7 @@ where
         timeout: ExecuteTimeout,
     ) -> Result<State, io::Error> {
         let mut tag = response.tag();
-        let mut non_term_err = ErrorResponse::non_terminating_from_execute_response(&response);
+        let mut non_term_err = response.partial_err().map(ErrorResponse::from);
 
         macro_rules! command_complete {
             () => {{


### PR DESCRIPTION
`SimpleResult::Ok` didn't carry any information when getting returned to the client, so enrich it with the tag and any non-error bits.

### Motivation

This PR adds a known-desirable feature. Closes https://github.com/MaterializeInc/materialize/issues/14069

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Produce more meaningful responses through `/api/sql` when statements succeed.
