### PR TITLE
Allow SSH connections outside of unsafe mode

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3115,7 +3115,6 @@ pub fn plan_create_connection(
             Connection::Aws(connection)
         }
         CreateConnection::Ssh { with_options } => {
-            scx.require_unsafe_mode("CREATE CONNECTION ... SSH")?;
             let c = SshConnectionOptionExtracted::try_from(with_options)?;
             let connection = mz_storage::types::connections::SshConnection::try_from(c)?;
             Connection::Ssh(connection)


### PR DESCRIPTION
Allow users to create SSH connections outside of unsafe mode.

### Motivation
  * This PR adds a feature that has not yet been specified: allow users to create SSH connections.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
