### PR TITLE
adapter,pgwire: fix command tags for `CREATE {CLUSTER|VIEWS}`

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -449,6 +449,7 @@ impl SessionClient {
                 | ExecuteResponse::CreatedSources
                 | ExecuteResponse::CreatedSink { existed: _ }
                 | ExecuteResponse::CreatedView { existed: _ }
+                | ExecuteResponse::CreatedViews { existed: _ }
                 | ExecuteResponse::CreatedMaterializedView { existed: _ }
                 | ExecuteResponse::CreatedType
                 | ExecuteResponse::Deleted(_)

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -353,7 +353,7 @@ impl ExecuteResponse {
             CreatedDatabase { .. } => created!("database"),
             CreatedSchema { .. } => created!("schema"),
             CreatedRole => created!("role"),
-            CreatedComputeInstance { .. } => created!("connection"),
+            CreatedComputeInstance { .. } => created!("cluster"),
             CreatedComputeInstanceReplica { .. } => created!("cluster replica"),
             CreatedIndex { .. } => created!("index"),
             CreatedSecret { .. } => created!("secret"),

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -230,6 +230,10 @@ pub enum ExecuteResponse {
     CreatedView {
         existed: bool,
     },
+    /// The requested views were created.
+    CreatedViews {
+        existed: bool,
+    },
     /// The requested materialized view was created.
     CreatedMaterializedView {
         existed: bool,
@@ -362,6 +366,7 @@ impl ExecuteResponse {
             CreatedSources => created!("sources"),
             CreatedTable { .. } => created!("table"),
             CreatedView { .. } => created!("view"),
+            CreatedViews { .. } => created!("views"),
             CreatedMaterializedView { .. } => created!("materialized view"),
             CreatedType => created!("type"),
             Deallocate { all } => Some(format!("DEALLOCATE{}", if *all { " ALL" } else { "" })),

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -1187,8 +1187,8 @@ impl<S: Append + 'static> Coordinator<S> {
             ops.append(&mut view_ops);
         }
         match self.catalog_transact(Some(session), ops, |_| Ok(())).await {
-            Ok(()) => Ok(ExecuteResponse::CreatedView { existed: false }),
-            Err(_) if plan.if_not_exists => Ok(ExecuteResponse::CreatedView { existed: true }),
+            Ok(()) => Ok(ExecuteResponse::CreatedViews { existed: false }),
+            Err(_) if plan.if_not_exists => Ok(ExecuteResponse::CreatedViews { existed: true }),
             Err(err) => Err(err),
         }
     }

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -493,6 +493,9 @@ impl ErrorResponse {
             CreatedView { existed } => {
                 existed!(*existed, SqlState::DUPLICATE_OBJECT, "view")
             }
+            CreatedViews { existed } => {
+                existed!(*existed, SqlState::DUPLICATE_OBJECT, "views")
+            }
             CreatedMaterializedView { existed } => {
                 existed!(*existed, SqlState::DUPLICATE_OBJECT, "materialized view")
             }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1231,6 +1231,7 @@ where
             | ExecuteResponse::CreatedTable { .. }
             | ExecuteResponse::CreatedType
             | ExecuteResponse::CreatedView { .. }
+            | ExecuteResponse::CreatedViews { .. }
             | ExecuteResponse::Deallocate { .. }
             | ExecuteResponse::Deleted(..)
             | ExecuteResponse::DiscardedAll


### PR DESCRIPTION
Details in commit messages.

Fixes a part of #14540.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
