### PR TITLE
storage: make ReclockFollower shareable

### DIFF
--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -37,7 +37,7 @@ mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-kinesis-util = { path = "../kinesis-util" }
-mz-ore = { path = "../ore", features = ["task", "tracing_"] }
+mz-ore = { path = "../ore", features = ["ssh", "task", "tracing_"] }
 mz-orchestrator = { path = "../orchestrator" }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -785,7 +785,7 @@ where
 
         let upper_ts = resume_upper.as_option().copied().unwrap();
         let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
-        let mut timestamper = ReclockFollower::new(as_of);
+        let timestamper = ReclockFollower::new(as_of);
 
         move |frontiers| {
             batch_input.for_each(|_cap, data| {
@@ -832,32 +832,34 @@ where
             );
 
             while let Some(untimestamped_batch) = untimestamped_batches.front_mut() {
-                let reclocked = match timestamper.reclock(&mut untimestamped_batch.messages) {
-                    Ok(reclocked) => reclocked,
-                    Err((pid, offset)) => panic!("failed to reclock {} @ {}", pid, offset),
-                };
+                // This scope is necessary to convince rustc that `untimestamped_batches` is unused
+                // when we pop from the front at the bottom of this loop.
+                {
+                    let reclocked = match timestamper.reclock(&mut untimestamped_batch.messages) {
+                        Ok(reclocked) => reclocked,
+                        Err((pid, offset)) => panic!("failed to reclock {} @ {}", pid, offset),
+                    };
 
-                let reclocked = match reclocked {
-                    Some(reclocked) => reclocked,
-                    None => {
-                        trace!(
-                            "reclock({id}) {worker_id}/{worker_count}: \
+                    let reclocked = match reclocked {
+                        Some(reclocked) => reclocked,
+                        None => {
+                            trace!(
+                                "reclock({id}) {worker_id}/{worker_count}: \
                                 cannot yet reclock batch with source frontier {:?} \
                                 reclock.source_frontier: {:?}",
-                            untimestamped_batch.source_upper,
-                            timestamper.source_upper
-                        );
-                        // We keep batches in the order they arrive from the
-                        // source. And we assume that the source frontier never
-                        // regressses. So we can break now.
-                        break;
-                    }
-                };
+                                untimestamped_batch.source_upper,
+                                timestamper.source_upper()
+                            );
+                            // We keep batches in the order they arrive from the
+                            // source. And we assume that the source frontier never
+                            // regressses. So we can break now.
+                            break;
+                        }
+                    };
 
-                let mut output = reclocked_output.activate();
+                    let mut output = reclocked_output.activate();
 
-                for (_, part_messages) in reclocked {
-                    for (message, ts) in part_messages {
+                    reclocked.for_each(|message, ts| {
                         trace!(
                             "reclock({id}) {worker_id}/{worker_count}: \
                                 handling reclocked message: {:?}:{:?} -> {}",
@@ -873,28 +875,28 @@ where
                             &mut metric_updates,
                             ts,
                         )
-                    }
-                }
+                    });
 
-                // TODO: We should not emit the non-definite errors as
-                // DataflowErrors, which will make them end up on the persist
-                // shard for this source. Instead they should be reported to the
-                // Healthchecker. But that's future work.
-                if !untimestamped_batch.non_definite_errors.is_empty() {
-                    // If there are errors, it means that someone must also have
-                    // given us a capability because a batch/batch-summary was
-                    // emitted to the remap operator.
-                    let err_cap = cap_set.delayed(
-                        cap_set
-                            .first()
-                            .expect("missing a capability for emitting errors"),
-                    );
-                    let mut session = output.session(&err_cap);
-                    let errors = untimestamped_batch
-                        .non_definite_errors
-                        .iter()
-                        .map(|e| Err(e.clone()));
-                    session.give_iterator(errors);
+                    // TODO: We should not emit the non-definite errors as
+                    // DataflowErrors, which will make them end up on the persist
+                    // shard for this source. Instead they should be reported to the
+                    // Healthchecker. But that's future work.
+                    if !untimestamped_batch.non_definite_errors.is_empty() {
+                        // If there are errors, it means that someone must also have
+                        // given us a capability because a batch/batch-summary was
+                        // emitted to the remap operator.
+                        let err_cap = cap_set.delayed(
+                            cap_set
+                                .first()
+                                .expect("missing a capability for emitting errors"),
+                        );
+                        let mut session = output.session(&err_cap);
+                        let errors = untimestamped_batch
+                            .non_definite_errors
+                            .iter()
+                            .map(|e| Err(e.clone()));
+                        session.give_iterator(errors);
+                    }
                 }
 
                 // Pop off the processed batch.


### PR DESCRIPTION
As part of BIR, the source reader operator will need access to the reclock trace to "invert" a _resumption_frontier_ into a _upstream commit frontier_. This pr makes the `ReclockFollower` share-able, within a single thread (worker), by using `Rc<RefCell>`. This should have a relatively low cost. This pr does NOT implement the inversion logic.

Notes:
- I chose the simplest route, which is to protect ALL data within the `RefCell`
- The reclock nested-iterator had to changed to a single `for_each`. @petrosagg came up with a way to avoid this with `Yoke`, but that seems needlessly complex for our usecae.
- Note that `borrow_mut()` users keep their `&mut` signatures. This can ensure that we reduce the chance of writing code that will hit a borrow error, while keep the api clean (`ReclockFollower: Clone`)

### Motivation
  * This PR adds a known-desirable feature.
**part of BIR**

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
