### PR TITLE
expr,storage: various u64 -> mz_repr::Timestamp

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1703,7 +1703,7 @@ pub mod plan {
                                 // An `Ok` conversion is a valid upper bound, and an `Err` error
                                 // indicates a value above `u64::MAX`. The `ok()` method does the
                                 // conversion we want to an `Option<u64>`.
-                                let v = u64::try_from(d.0).ok();
+                                let v = u64::try_from(d.0).ok().map(mz_repr::Timestamp::from);
                                 // Update `lower_bound` to be the maximum with `v`, where a `None`
                                 // value is treated as larger than `Some(_)` values.
                                 lower_bound = match (lower_bound, v) {
@@ -1755,7 +1755,7 @@ pub mod plan {
                                 // An `Ok` conversion is a valid upper bound, and an `Err` error
                                 // indicates a value above `u64::MAX`. The `ok()` method does the
                                 // conversion we want to an `Option<u64>`.
-                                let v = u64::try_from(d.0).ok();
+                                let v = u64::try_from(d.0).ok().map(mz_repr::Timestamp::from);
                                 // Update `upper_bound` to be the minimum with `v`, where a `None`
                                 // value is treated as larger than `Some(_)` values.
                                 upper_bound = match (upper_bound, v) {

--- a/src/storage/src/controller.rs
+++ b/src/storage/src/controller.rs
@@ -321,7 +321,7 @@ impl ReadPolicy<mz_repr::Timestamp> {
             } else {
                 // Subtract the lag from the time, and then round down to a multiple thereof to cut chatter.
                 let mut time = upper[0];
-                if lag != 0 {
+                if lag != mz_repr::Timestamp::default() {
                     time = time.saturating_sub(lag);
                     time = time.saturating_sub(time % lag);
                 }

--- a/src/storage/src/protocol/client.rs
+++ b/src/storage/src/protocol/client.rs
@@ -259,7 +259,7 @@ impl Arbitrary for StorageCommand<mz_repr::Timestamp> {
             proptest::collection::vec(
                 (
                     any::<GlobalId>(),
-                    proptest::collection::vec(any::<u64>(), 1..4)
+                    proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..4)
                 ),
                 1..4
             )

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -318,7 +318,7 @@ where
                             // We are at the end of time, so our `as_of` is everything.
                             Some(Timestamp::MAX)
                         }
-                        Some(&0) => {
+                        Some(&Timestamp::MIN) => {
                             // We are the beginning of time (no data persisted yet), so we can
                             // skip reading out of persist.
                             None
@@ -366,8 +366,11 @@ where
                     // place and re-use. There seem to be enough instances of this
                     // by now.
                     fn split_ok_err(
-                        x: (Result<Row, DataflowError>, u64, Diff),
-                    ) -> Result<(Row, u64, Diff), (DataflowError, u64, Diff)> {
+                        x: (Result<Row, DataflowError>, mz_repr::Timestamp, Diff),
+                    ) -> Result<
+                        (Row, mz_repr::Timestamp, Diff),
+                        (DataflowError, mz_repr::Timestamp, Diff),
+                    > {
                         match x {
                             (Ok(row), ts, diff) => Ok((row, ts, diff)),
                             (Err(err), ts, diff) => Err((err, ts, diff)),

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -72,7 +72,7 @@ pub(crate) fn upsert<G>(
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    if as_of_frontier != Antichain::from_elem(0) {
+    if as_of_frontier != Antichain::from_elem(timely::progress::Timestamp::minimum()) {
         info!("upsert resuming from time {as_of_frontier:?}");
     }
     // Currently, the upsert-specific transformations run in the
@@ -552,7 +552,7 @@ fn process_new_data(
 fn process_pending_values_batch(
     // The time, capability, and map of data at that time we
     // are processing in this call.
-    time: &u64,
+    time: &Timestamp,
     cap: &mut Capability<Timestamp>,
     map: &mut HashMap<Option<Result<Row, DecodeError>>, UpsertSourceData>,
     // The current map of values we use to perform the upsert comparision
@@ -581,10 +581,10 @@ fn process_pending_values_batch(
     output: &mut timely::dataflow::operators::generic::OutputHandle<
         '_,
         Timestamp,
-        (Result<Row, DataflowError>, u64, Diff),
+        (Result<Row, DataflowError>, Timestamp, Diff),
         timely::dataflow::channels::pushers::tee::Tee<
             Timestamp,
-            (Result<Row, DataflowError>, u64, Diff),
+            (Result<Row, DataflowError>, Timestamp, Diff),
         >,
     >,
 ) {

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -809,7 +809,7 @@ impl KafkaSinkState {
 
                 if let Some(ts) = maybe_decode_consistency_end_record(&message, consistency_topic)?
                 {
-                    if ts >= latest_ts.unwrap_or(0) {
+                    if ts >= latest_ts.unwrap_or_else(timely::progress::Timestamp::minimum) {
                         latest_ts = Some(ts);
                     }
                 }
@@ -1251,7 +1251,7 @@ where
             });
 
             // Move any newly closed timestamps from pending to ready
-            let mut closed_ts: Vec<u64> = s
+            let mut closed_ts: Vec<Timestamp> = s
                 .pending_rows
                 .iter()
                 .filter(|(ts, _)| !frontier.less_equal(*ts))

--- a/src/storage/src/source/healthcheck.rs
+++ b/src/storage/src/source/healthcheck.rs
@@ -219,7 +219,11 @@ impl Healthchecker {
     /// Currently assumes that the collection only contains assertions (rows with diff = 1)
     fn process_collection_updates(
         &mut self,
-        mut updates: Vec<((Result<SourceData, String>, Result<(), String>), u64, i64)>,
+        mut updates: Vec<(
+            (Result<SourceData, String>, Result<(), String>),
+            Timestamp,
+            i64,
+        )>,
     ) {
         // Sort by timestamp and diff
         updates.sort_by(|(_, t1, d1), (_, t2, d2)| (t1, d1).cmp(&(t2, d2)));
@@ -246,7 +250,7 @@ impl Healthchecker {
         &self,
         status_update: &SourceStatusUpdate,
         ts: u64,
-    ) -> Vec<((SourceData, ()), u64, i64)> {
+    ) -> Vec<((SourceData, ()), Timestamp, i64)> {
         let timestamp = NaiveDateTime::from_timestamp(
             (ts / 1000)
                 .try_into()

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -164,7 +164,7 @@ where
             let waker_activator = Arc::new(scope.sync_activator_for(&info.address[..]));
             let waker = futures::task::waker(waker_activator);
 
-            let mut current_ts = 0;
+            let mut current_ts = timely::progress::Timestamp::minimum();
 
             move |cap_set, output| {
                 let mut context = Context::from_waker(&waker);

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -261,7 +261,7 @@ pub struct ReclockOperator {
     /// The function that should be used to get the current time when minting new bindings
     now: NowFn,
     /// Values of current time will be rounded to be multiples of this duration in milliseconds
-    update_interval_ms: Timestamp,
+    update_interval_ms: u64,
 }
 
 impl ReclockOperator {
@@ -718,7 +718,7 @@ mod tests {
         as_of: Antichain<Timestamp>,
     ) -> (ReclockOperator, ReclockFollower) {
         let start = tokio::time::Instant::now();
-        let now_fn = NowFn::from(move || start.elapsed().as_millis() as Timestamp);
+        let now_fn = NowFn::from(move || start.elapsed().as_millis().try_into().unwrap());
 
         let metadata = CollectionMetadata {
             persist_location: PersistLocation {

--- a/src/storage/src/types/sinks.rs
+++ b/src/storage/src/types/sinks.rs
@@ -195,7 +195,10 @@ impl Arbitrary for SinkAsOf<mz_repr::Timestamp> {
     type Parameters = ();
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (proptest::collection::vec(any::<u64>(), 1..4), any::<bool>())
+        (
+            proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..4),
+            any::<bool>(),
+        )
             .prop_map(|(frontier, strict)| SinkAsOf {
                 frontier: Antichain::from(frontier),
                 strict,


### PR DESCRIPTION
In preparation for a larger change.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a