### PR TITLE
docs: Fix a typo in ssh connection docs

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -145,7 +145,7 @@ Field                       | Value            | Required | Description
 ##### Example
 
 ```sql
-CREAT CONNECTION ssh_connection
+CREATE CONNECTION ssh_connection
   FOR SSH TUNNEL
     HOST '<SSH_BASTION_HOST>',
     USER '<SSH_BASTION_USER>',


### PR DESCRIPTION
### Motivation

Fix a minor typo in the create SSH connection documentation.