### PR TITLE
persist: add `<T>` timestamp parameter to BlobTraceBatchPart

### DIFF
--- a/src/persist-client/benches/plumbing.rs
+++ b/src/persist-client/benches/plumbing.rs
@@ -197,9 +197,9 @@ pub fn bench_encode_batch(name: &str, throughput: bool, c: &mut Criterion, data:
 
     let trace = BlobTraceBatchPart {
         desc: Description::new(
-            Antichain::from_elem(0),
+            Antichain::from_elem(0u64),
             Antichain::new(),
-            Antichain::from_elem(0),
+            Antichain::from_elem(0u64),
         ),
         index: 0,
         updates: data.batches().collect::<Vec<_>>(),

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -413,34 +413,9 @@ impl<T: Timestamp + Codec64> BatchParts<T> {
         let handle = mz_ore::task::spawn(
             || "batch::write_part",
             async move {
-                // TODO: Get rid of the from_le_bytes.
-                let encoded_desc = Description::new(
-                    Antichain::from(
-                        desc.lower()
-                            .elements()
-                            .iter()
-                            .map(|x| u64::from_le_bytes(T::encode(x)))
-                            .collect::<Vec<_>>(),
-                    ),
-                    Antichain::from(
-                        desc.upper()
-                            .elements()
-                            .iter()
-                            .map(|x| u64::from_le_bytes(T::encode(x)))
-                            .collect::<Vec<_>>(),
-                    ),
-                    Antichain::from(
-                        desc.since()
-                            .elements()
-                            .iter()
-                            .map(|x| u64::from_le_bytes(T::encode(x)))
-                            .collect::<Vec<_>>(),
-                    ),
-                );
-
                 let goodbytes = updates.goodbytes();
                 let batch = BlobTraceBatchPart {
-                    desc: encoded_desc.clone(),
+                    desc,
                     updates: vec![updates],
                     index,
                 };

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -268,7 +268,7 @@ where
         // - Batches written by compaction. These always have an inline desc
         //   that exactly matches the one they are registered with. The since
         //   can be anything.
-        let inline_desc = decode_inline_desc(&batch.desc);
+        let inline_desc = &batch.desc;
         let needs_truncation = inline_desc.lower() != registered_desc.lower()
             || inline_desc.upper() != registered_desc.upper();
         if needs_truncation {
@@ -300,7 +300,7 @@ where
             );
         } else {
             assert_eq!(
-                &inline_desc, registered_desc,
+                inline_desc, registered_desc,
                 "key={} inline={:?} registered={:?}",
                 key, inline_desc, registered_desc
             );
@@ -327,24 +327,6 @@ where
     });
 
     Ok(())
-}
-
-// TODO: This goes away the desc on BlobTraceBatchPart becomes a Description<T>,
-// which should be a straightforward refactor but it touches a decent bit.
-fn decode_inline_desc<T: Timestamp + Codec64>(desc: &Description<u64>) -> Description<T> {
-    fn decode_antichain<T: Timestamp + Codec64>(x: &Antichain<u64>) -> Antichain<T> {
-        Antichain::from(
-            x.elements()
-                .iter()
-                .map(|x| T::decode(x.to_le_bytes()))
-                .collect::<Vec<_>>(),
-        )
-    }
-    Description::new(
-        decode_antichain(desc.lower()),
-        decode_antichain(desc.upper()),
-        decode_antichain(desc.since()),
-    )
 }
 
 /// Propagates metadata from readers alongside a `HollowBatch` to apply the

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -555,13 +555,13 @@ mod tests {
         blob: &(dyn Blob + Send + Sync),
         key: &BlobKey,
     ) -> (
-        BlobTraceBatchPart,
+        BlobTraceBatchPart<T>,
         Vec<((Result<K, String>, Result<V, String>), T, D)>,
     )
     where
         K: Codec,
         V: Codec,
-        T: Codec64,
+        T: Timestamp + Codec64,
         D: Codec64,
     {
         let value = blob

--- a/src/persist/src/indexed/columnar/parquet.rs
+++ b/src/persist/src/indexed/columnar/parquet.rs
@@ -16,6 +16,7 @@ use arrow2::io::parquet::write::{
     CompressionOptions, Encoding, FileWriter, KeyValue, RowGroupIterator, Version, WriteOptions,
 };
 use differential_dataflow::trace::Description;
+use mz_persist_types::Codec64;
 use timely::progress::{Antichain, Timestamp};
 
 use crate::error::Error;
@@ -31,7 +32,10 @@ use crate::indexed::encoding::{
 const INLINE_METADATA_KEY: &'static str = "MZ:inline";
 
 /// Encodes an BlobTraceBatchPart into the Parquet format.
-pub fn encode_trace_parquet<W: Write>(w: &mut W, batch: &BlobTraceBatchPart) -> Result<(), Error> {
+pub fn encode_trace_parquet<W: Write, T: Timestamp + Codec64>(
+    w: &mut W,
+    batch: &BlobTraceBatchPart<T>,
+) -> Result<(), Error> {
     // Better to error now than write out an invalid batch.
     batch.validate()?;
     encode_parquet_kvtd(
@@ -42,7 +46,9 @@ pub fn encode_trace_parquet<W: Write>(w: &mut W, batch: &BlobTraceBatchPart) -> 
 }
 
 /// Decodes a BlobTraceBatchPart from the Parquet format.
-pub fn decode_trace_parquet<R: Read + Seek>(r: &mut R) -> Result<BlobTraceBatchPart, Error> {
+pub fn decode_trace_parquet<R: Read + Seek, T: Timestamp + Codec64>(
+    r: &mut R,
+) -> Result<BlobTraceBatchPart<T>, Error> {
     let metadata = read_metadata(r).map_err(|err| err.to_string())?;
     let metadata = metadata
         .key_value_metadata()
@@ -62,9 +68,9 @@ pub fn decode_trace_parquet<R: Read + Seek>(r: &mut R) -> Result<BlobTraceBatchP
         desc: meta.desc.map_or_else(
             || {
                 Description::new(
-                    Antichain::from_elem(u64::minimum()),
-                    Antichain::from_elem(u64::minimum()),
-                    Antichain::from_elem(u64::minimum()),
+                    Antichain::from_elem(T::minimum()),
+                    Antichain::from_elem(T::minimum()),
+                    Antichain::from_elem(T::minimum()),
                 )
             },
             |x| x.into(),


### PR DESCRIPTION
This resolves a TODO that has become substantially easier since we
deleted the old persist code. The Antichain<u64> was stressing Matt (and
rightfully so!), so seemed like a good time to pick this one off.

After this, there are no more `Antichain<u64>` in persist code.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
