### PR TITLE
test: triage nightly test failures 22-09-01

### DIFF
--- a/misc/python/materialize/checks/top_k.py
+++ b/misc/python/materialize/checks/top_k.py
@@ -92,8 +92,6 @@ class MonotonicTopK(Check):
 
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE monotonic_topk_source
                   FROM KAFKA CONNECTION kafka_conn
                   TOPIC 'testdrive-monotonic-topk-${testdrive.seed}'
@@ -158,6 +156,8 @@ class MonotonicTop1(Check):
                 {"f1": "A"}
 
                 > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE monotonic_top1_source
                   FROM KAFKA CONNECTION kafka_conn


### PR DESCRIPTION
See:
https://buildkite.com/materialize/nightlies/builds/1124#0182f8d2-2aae-432d-b962-2f2269a9f750

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
