### PR TITLE
 storage: in persist_source, don't use async_op! macro for fetcher operator

### DIFF
--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -195,7 +195,7 @@ where
 
     let (inner, token) = crate::source::util::source(
         scope,
-        format!("persist_source {:?}: part distribution", source_id),
+        format!("persist_source {}: part distribution", source_id),
         move |info| {
             let waker_activator = Arc::new(scope.sync_activator_for(&info.address[..]));
             let waker = futures::task::waker(waker_activator);
@@ -245,10 +245,7 @@ where
     );
 
     let mut fetcher_builder = OperatorBuilder::new(
-        format!(
-            "persist_source {:?}: part fetcher {}",
-            worker_index, source_id
-        ),
+        format!("persist_source {}: part fetcher", source_id),
         scope.clone(),
     );
 
@@ -365,7 +362,7 @@ where
     // This operator is meant to only run on the chosen worker. All workers will
     // exchange their fetched ("consumed") parts back to the leasor.
     let mut consumed_part_builder = OperatorBuilder::new(
-        format!("persist_source {:?}: consumed part collector", source_id),
+        format!("persist_source {}: consumed part collector", source_id),
         scope.clone(),
     );
 


### PR DESCRIPTION
Before, the fetcher operator was scheduled a lot and was taking up 100%
of the CPU timer of its worker, even with no data coming in. After this
change, it mostly sits idle, as it should.

You can see the impact by looking at the introspection views, and by
observing that `computed` with a simple TAIL is not pegged at 100 %
usage anymore.

The below printouts are from running a TAIL on a table that doesn't see
new updates.

Without this fix:

```
materialize=> select mdo.id, mdo.name, mdo.worker, mse.elapsed_ns
from mz_scheduling_elapsed as mse,
     mz_dataflow_operators as mdo
where
    mse.id = mdo.id and
    mse.worker = mdo.worker
order by elapsed_ns desc;
 id  |                      name                       | worker | elapsed_ns
-----+-------------------------------------------------+--------+-------------
 328 | Dataflow: tail-t7                               |      0 | 29117620155
 341 | Dataflow: tail-t7                               |      0 | 28567992731
 330 | persist_source 0: part fetcher u1               |      0 | 27912365122
 329 | persist_source User(1): part distribution       |      0 |   298032358
 332 | persist_source User(1): consumed part collector |      0 |      817396
 338 | tail-t7                                         |      0 |      813745
 336 | InspectBatch                                    |      0 |      566229
 334 | OkErr                                           |      0 |      347089
(8 rows)

Time: 44.527 ms
```

With this fix:

```
materialize=> select mdo.id, mdo.name, mdo.worker, mse.elapsed_ns
from mz_scheduling_elapsed as mse,
     mz_dataflow_operators as mdo
where
    mse.id = mdo.id and
    mse.worker = mdo.worker
order by elapsed_ns desc;
  id  |                    name                    | worker | elapsed_ns
------+--------------------------------------------+--------+------------
 1078 | Dataflow: tail-t17                         |      0 |  111508724
 1091 | Dataflow: tail-t17                         |      0 |   96973716
 1079 | persist_source u1: part distribution       |      0 |   79733907
  266 | Dataflow: temp-view-t3                     |      0 |    6401428
  297 | Dataflow: temp-view-t5                     |      0 |    6299725
  295 | Dataflow: temp-view-t3                     |      0 |    5942598
  326 | Dataflow: temp-view-t5                     |      0 |    5841977
 1080 | persist_source u1: part fetcher 0/1        |      0 |    4820154
  268 | persist_source s263: part fetcher 0/1      |      0 |    2888588
  299 | persist_source s278: part fetcher 0/1      |      0 |    2782819
 1088 | tail-t17                                   |      0 |     671058
 1082 | persist_source u1: consumed part collector |      0 |     539166
 1086 | InspectBatch                               |      0 |     500139
 1084 | OkErr                                      |      0 |     308879
  285 | ArrangeBy[[Column(0), Column(1)]]          |      0 |      95100
  316 | ArrangeBy[[Column(0)]]                     |      0 |      80980
  290 | Map                                        |      0 |       2930
  321 | Map                                        |      0 |       2790
(18 rows)

Time: 39.292 ms
```

### Tips for reviewer

@petrosagg My only suspicion is that something doesn't work well with those `activate()` calls on the outputs. Maybe that they're not properly dropped when using `async_op!`. Do you have any idea what could be causing this?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
