### PR TITLE
Minor cleanup in the literal constraints detection

### DIFF
--- a/test/sqllogictest/literal_constraints.slt
+++ b/test/sqllogictest/literal_constraints.slt
@@ -393,10 +393,11 @@ statement ok
 CREATE INDEX idx_t1_b ON t1(b)
 
 query I
-SELECT a FROM t1 WHERE b IN ('l1', 'l2') AND (a > 0 OR a < 5)
+SELECT a FROM t1 WHERE (a < 3 OR a > 0) AND b IN ('l1', 'l2', 'l3', 'l9')
 ----
 1
 2
+3
 
 # Impossible predicates (exercise `remove_impossible_or_args`)
 

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -100,7 +100,7 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (2, 3);
 "%0 =| ReadExistingIndex t1_primary_idx| Filter ((#1 = 2) OR (#1 = 3))"
 
-# Partial matches are not optimized
+# Partial matches
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (3, 4);
 "%0 =| ReadExistingIndex t1_primary_idx| Filter (#1 = 3)"


### PR DESCRIPTION
This addresses the outstanding comments on https://github.com/MaterializeInc/materialize/pull/14549.

### Motivation

   * This PR refactors existing code. (minor cleanup)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - No
