### PR TITLE
test: Reset all system config before testdrive

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -260,6 +260,16 @@ impl State {
     }
 
     pub async fn reset_materialize(&mut self) -> Result<(), anyhow::Error> {
+        let (inner_client, _) = postgres_client(&format!(
+            "postgres://mz_system:materialize@{}",
+            self.materialize_sql_addr_internal
+        ))
+        .await?;
+        inner_client
+            .batch_execute("ALTER SYSTEM RESET ALL")
+            .await
+            .context("resetting materialize state: ALTER SYSTEM RESET ALL")?;
+
         for row in self
             .pgclient
             .query("SHOW DATABASES", &[])

--- a/test/kafka-sasl-plain/mzcompose.py
+++ b/test/kafka-sasl-plain/mzcompose.py
@@ -102,6 +102,7 @@ SERVICES = [
             "--kafka-option=sasl.password=sekurity "
             "--schema-registry-url=https://materialize:sekurity@schema-registry:8081 "
             "--materialize-url=postgres://materialize@materialized:6875 "
+            "--materialize-url-internal=postgres://materialize@materialized:6877 "
             "--cert=/share/secrets/producer.p12 "
             "--cert-password=mzmzmz "
             '--var=ca="$$(</share/secrets/ca.crt)" '

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -88,6 +88,7 @@ SERVICES = [
             "--kafka-addr=kafka:9092 "
             "--schema-registry-url=https://schema-registry:8081 "
             "--materialize-url=postgres://materialize@materialized:6875 "
+            "--materialize-url-internal=postgres://materialize@materialized:6877 "
             "--cert=/share/secrets/producer.p12 "
             "--cert-password=mzmzmz "
             "--ccsr-password=sekurity "


### PR DESCRIPTION
This commit adds a feature to testdrive that will reset all system
configurations at the start of each testdrive test. This is consistent
with our current approach of trying to reset Materialize's state at the
start of each test. This also helps protect against people forgetting
to reset configurations at the end of test, and configurations not
resetting due to failed tests.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
