### PR TITLE
persist: fix over-aggressive assertion in GC

### DIFF
--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -203,6 +203,17 @@ where
             states.len()
         );
 
+        // Fast-path: Someone already GC'd past `req.new_seqno_since`, don't
+        // bother running any of the below logic.
+        //
+        // Also a fix for #14580.
+        if states
+            .peek_seqno()
+            .map_or(true, |x| x > req.new_seqno_since)
+        {
+            return;
+        }
+
         let mut deleteable_batch_blobs = HashSet::new();
         let mut deleteable_rollup_blobs = Vec::new();
         while let Some(state) = states.next() {

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -561,6 +561,11 @@ impl<K, V, T: Timestamp + Lattice + Codec64, D> StateVersionsIter<K, V, T, D> {
         self.diffs.len()
     }
 
+    /// Returns the SeqNo of the next state returned by `next`.
+    pub fn peek_seqno(&self) -> Option<SeqNo> {
+        self.diffs.last().map(|x| x.seqno)
+    }
+
     pub fn next(&mut self) -> Option<&State<K, V, T, D>> {
         let diff = match self.diffs.pop() {
             Some(x) => x,

--- a/src/persist-client/tests/machine/regression_gc_behind
+++ b/src/persist-client/tests/machine/regression_gc_behind
@@ -1,0 +1,39 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #14580, a bug where an over-aggressive internal
+# validation would fire if a GC request was behind the actual set of live
+# states.
+
+# Generate some new state versions
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+compare-and-append input=b0
+----
+ok
+
+consensus-scan from_seqno=0
+----
+seqno=v1 batches=
+seqno=v2 batches=
+seqno=v3 batches=b0
+
+# Run gc up to our latest seqno
+gc from_seqno=0 to_seqno=3
+----
+ok
+
+# Now some slow gc req comes in that's behind. In the regression case, this
+# panics.
+gc from_seqno=0 to_seqno=1
+----
+ok


### PR DESCRIPTION
The `assert_eq!(state.seqno, req.new_seqno_since)` could fire if _all_
states returned by the earlier `fetch_live_states` call are already past
`req.new_seqno_since`. We can just sniff this out and return early,
which is a nice fast path anyway.

Fixes #14580

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
