### PR TITLE
api/sql: simple protocol-style txns

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -385,6 +385,133 @@ impl SessionClient {
         .await
     }
 
+    async fn simple_execute_inner(
+        &mut self,
+        stmt: Statement<Raw>,
+    ) -> Result<SimpleResult, SimpleResult> {
+        const EMPTY_PORTAL: &str = "";
+
+        if let Err(e) = self.declare(EMPTY_PORTAL.into(), stmt, vec![]).await {
+            return Err(SimpleResult::err(e));
+        }
+
+        let desc = self
+            .session()
+            // We do not need to verify here because `self.execute` verifies below.
+            .get_portal_unverified(EMPTY_PORTAL)
+            .map(|portal| portal.desc.clone())
+            .expect("unnamed portal should be present");
+        if !desc.param_types.is_empty() {
+            return Err(SimpleResult::err("query parameters are not supported"));
+        }
+
+        let res = match self.execute(EMPTY_PORTAL.into()).await {
+            Ok(res) => res,
+            Err(e) => {
+                return Err(SimpleResult::err(e));
+            }
+        };
+
+        match res {
+            ExecuteResponse::Canceled => {
+                Err(SimpleResult::err("statement canceled due to user request"))
+            }
+            res @ (ExecuteResponse::CreatedConnection { existed: _ }
+            | ExecuteResponse::CreatedDatabase { existed: _ }
+            | ExecuteResponse::CreatedSchema { existed: _ }
+            | ExecuteResponse::CreatedRole
+            | ExecuteResponse::CreatedComputeInstance { existed: _ }
+            | ExecuteResponse::CreatedComputeInstanceReplica { existed: _ }
+            | ExecuteResponse::CreatedTable { existed: _ }
+            | ExecuteResponse::CreatedIndex { existed: _ }
+            | ExecuteResponse::CreatedSecret { existed: _ }
+            | ExecuteResponse::CreatedSource { existed: _ }
+            | ExecuteResponse::CreatedSources
+            | ExecuteResponse::CreatedSink { existed: _ }
+            | ExecuteResponse::CreatedView { existed: _ }
+            | ExecuteResponse::CreatedViews { existed: _ }
+            | ExecuteResponse::CreatedMaterializedView { existed: _ }
+            | ExecuteResponse::CreatedType
+            | ExecuteResponse::Deleted(_)
+            | ExecuteResponse::DiscardedTemp
+            | ExecuteResponse::DiscardedAll
+            | ExecuteResponse::DroppedDatabase
+            | ExecuteResponse::DroppedSchema
+            | ExecuteResponse::DroppedRole
+            | ExecuteResponse::DroppedComputeInstance
+            | ExecuteResponse::DroppedComputeInstanceReplicas
+            | ExecuteResponse::DroppedSource
+            | ExecuteResponse::DroppedIndex
+            | ExecuteResponse::DroppedSink
+            | ExecuteResponse::DroppedTable
+            | ExecuteResponse::DroppedView
+            | ExecuteResponse::DroppedMaterializedView
+            | ExecuteResponse::DroppedType
+            | ExecuteResponse::DroppedSecret
+            | ExecuteResponse::DroppedConnection
+            | ExecuteResponse::EmptyQuery
+            | ExecuteResponse::Inserted(_)
+            | ExecuteResponse::StartedTransaction { duplicated: _ }
+            | ExecuteResponse::TransactionExited {
+                tag: _,
+                was_implicit: _,
+            }
+            | ExecuteResponse::Updated(_)
+            | ExecuteResponse::AlteredObject(_)
+            | ExecuteResponse::AlteredIndexLogicalCompaction
+            | ExecuteResponse::AlteredSystemConfiguraion
+            | ExecuteResponse::Deallocate { all: _ }
+            | ExecuteResponse::Prepare) => Ok(SimpleResult::ok(res)),
+            ExecuteResponse::SendingRows {
+                future: rows,
+                span: _,
+            } => {
+                let rows = match rows.await {
+                    PeekResponseUnary::Rows(rows) => rows,
+                    PeekResponseUnary::Error(e) => {
+                        return Err(SimpleResult::err(e));
+                    }
+                    PeekResponseUnary::Canceled => {
+                        return Err(SimpleResult::err("statement canceled due to user request"));
+                    }
+                };
+                let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
+                let col_names = match desc.relation_desc {
+                    Some(desc) => desc.iter_names().map(|name| name.to_string()).collect(),
+                    None => vec![],
+                };
+                let mut datum_vec = mz_repr::DatumVec::new();
+                for row in rows {
+                    let datums = datum_vec.borrow_with(&row);
+                    sql_rows.push(datums.iter().map(From::from).collect());
+                }
+
+                Ok(SimpleResult::Rows {
+                    rows: sql_rows,
+                    col_names,
+                })
+            }
+            ExecuteResponse::Fetch { .. }
+            | ExecuteResponse::SetVariable { .. }
+            | ExecuteResponse::Tailing { .. }
+            | ExecuteResponse::CopyTo { .. }
+            | ExecuteResponse::CopyFrom { .. }
+            | ExecuteResponse::Raise { .. }
+            | ExecuteResponse::DeclaredCursor
+            | ExecuteResponse::ClosedCursor => {
+                // NOTE(benesch): it is a bit scary to ignore the response
+                // to these types of planning *after* they have been
+                // planned, as they may have mutated state. On a quick
+                // glance, though, ignoring the execute response in all of
+                // the above situations seems safe enough, and it's a more
+                // target allowlist than the code that was here before.
+                Err(SimpleResult::err(
+                    "executing statements of this type is unsupported via this API",
+                ))
+            }
+        }
+    }
+
     /// Executes SQL statements using a simple protocol that does not involve
     /// portals.
     ///
@@ -403,149 +530,35 @@ impl SessionClient {
     ) -> Result<SimpleExecuteResponse, AdapterError> {
         let stmts =
             mz_sql::parse::parse(&stmts).map_err(|e| AdapterError::Unstructured(e.into()))?;
+
         let num_stmts = stmts.len();
-        const EMPTY_PORTAL: &str = "";
         let mut results = vec![];
+
         for stmt in stmts {
-            // Mirror the behavior of the PostgreSQL simple query protocol.
-            // See the pgwire::protocol::StateMachine::query method for details.
+            if matches!(self.session().transaction(), TransactionStatus::Failed(_)) {
+                break;
+            }
+
             self.start_transaction(Some(num_stmts)).await?;
 
-            if let Err(e) = self.declare(EMPTY_PORTAL.into(), stmt, vec![]).await {
-                results.push(SimpleResult::err(e));
-                break;
-            }
-
-            let desc = self
-                .session()
-                // We do not need to verify here because `self.execute` verifies below.
-                .get_portal_unverified(EMPTY_PORTAL)
-                .map(|portal| portal.desc.clone())
-                .expect("unnamed portal should be present");
-            if !desc.param_types.is_empty() {
-                results.push(SimpleResult::err("query parameters are not supported"));
-                break;
-            }
-
-            let res = match self.execute(EMPTY_PORTAL.into()).await {
-                Ok(res) => res,
-                Err(e) => {
-                    results.push(SimpleResult::err(e));
-                    break;
+            let res = match self.simple_execute_inner(stmt).await {
+                Ok(res) => {
+                    assert!(!matches!(res, SimpleResult::Err { .. }));
+                    res
+                }
+                Err(res) => {
+                    assert!(matches!(res, SimpleResult::Err { .. }));
+                    self.fail_transaction();
+                    res
                 }
             };
-
-            match res {
-                ExecuteResponse::Canceled => {
-                    results.push(SimpleResult::err("statement canceled due to user request"));
-                    break;
-                }
-                res @ (ExecuteResponse::CreatedConnection { existed: _ }
-                | ExecuteResponse::CreatedDatabase { existed: _ }
-                | ExecuteResponse::CreatedSchema { existed: _ }
-                | ExecuteResponse::CreatedRole
-                | ExecuteResponse::CreatedComputeInstance { existed: _ }
-                | ExecuteResponse::CreatedComputeInstanceReplica { existed: _ }
-                | ExecuteResponse::CreatedTable { existed: _ }
-                | ExecuteResponse::CreatedIndex { existed: _ }
-                | ExecuteResponse::CreatedSecret { existed: _ }
-                | ExecuteResponse::CreatedSource { existed: _ }
-                | ExecuteResponse::CreatedSources
-                | ExecuteResponse::CreatedSink { existed: _ }
-                | ExecuteResponse::CreatedView { existed: _ }
-                | ExecuteResponse::CreatedViews { existed: _ }
-                | ExecuteResponse::CreatedMaterializedView { existed: _ }
-                | ExecuteResponse::CreatedType
-                | ExecuteResponse::Deleted(_)
-                | ExecuteResponse::DiscardedTemp
-                | ExecuteResponse::DiscardedAll
-                | ExecuteResponse::DroppedDatabase
-                | ExecuteResponse::DroppedSchema
-                | ExecuteResponse::DroppedRole
-                | ExecuteResponse::DroppedComputeInstance
-                | ExecuteResponse::DroppedComputeInstanceReplicas
-                | ExecuteResponse::DroppedSource
-                | ExecuteResponse::DroppedIndex
-                | ExecuteResponse::DroppedSink
-                | ExecuteResponse::DroppedTable
-                | ExecuteResponse::DroppedView
-                | ExecuteResponse::DroppedMaterializedView
-                | ExecuteResponse::DroppedType
-                | ExecuteResponse::DroppedSecret
-                | ExecuteResponse::DroppedConnection
-                | ExecuteResponse::EmptyQuery
-                | ExecuteResponse::Inserted(_)
-                | ExecuteResponse::StartedTransaction { duplicated: _ }
-                | ExecuteResponse::TransactionExited {
-                    tag: _,
-                    was_implicit: _,
-                }
-                | ExecuteResponse::Updated(_)
-                | ExecuteResponse::AlteredObject(_)
-                | ExecuteResponse::AlteredIndexLogicalCompaction
-                | ExecuteResponse::AlteredSystemConfiguraion
-                | ExecuteResponse::Deallocate { all: _ }
-                | ExecuteResponse::Prepare) => {
-                    results.push(SimpleResult::ok(res));
-                }
-                ExecuteResponse::SendingRows {
-                    future: rows,
-                    span: _,
-                } => {
-                    let rows = match rows.await {
-                        PeekResponseUnary::Rows(rows) => rows,
-                        PeekResponseUnary::Error(e) => {
-                            results.push(SimpleResult::err(e.to_string()));
-                            continue;
-                        }
-                        PeekResponseUnary::Canceled => {
-                            results
-                                .push(SimpleResult::err("statement canceled due to user request"));
-                            continue;
-                        }
-                    };
-                    let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
-                    let col_names = match desc.relation_desc {
-                        Some(desc) => desc.iter_names().map(|name| name.to_string()).collect(),
-                        None => vec![],
-                    };
-                    let mut datum_vec = mz_repr::DatumVec::new();
-                    for row in rows {
-                        let datums = datum_vec.borrow_with(&row);
-                        sql_rows.push(datums.iter().map(From::from).collect());
-                    }
-                    results.push(SimpleResult::Rows {
-                        rows: sql_rows,
-                        col_names,
-                    });
-                }
-                ExecuteResponse::Fetch { .. }
-                | ExecuteResponse::SetVariable { .. }
-                | ExecuteResponse::Tailing { .. }
-                | ExecuteResponse::CopyTo { .. }
-                | ExecuteResponse::CopyFrom { .. }
-                | ExecuteResponse::Raise { .. }
-                | ExecuteResponse::DeclaredCursor
-                | ExecuteResponse::ClosedCursor => {
-                    // NOTE(benesch): it is a bit scary to ignore the response
-                    // to these types of planning *after* they have been
-                    // planned, as they may have mutated state. On a quick
-                    // glance, though, ignoring the execute response in all of
-                    // the above situations seems safe enough, and it's a more
-                    // target allowlist than the code that was here before.
-                    results.push(SimpleResult::err(
-                        "executing statements of this type is unsupported via this API",
-                    ));
-                }
-            };
+            results.push(res);
         }
 
-        let action = if matches!(results.last(), Some(SimpleResult::Err { .. })) {
-            EndTransactionAction::Rollback
-        } else {
-            EndTransactionAction::Commit
-        };
-        let _ = self.end_transaction(action).await?;
+        // If not in an uncommited explicit transaction, commit.
+        if self.session().transaction().is_implicit() {
+            self.end_transaction(EndTransactionAction::Commit).await?;
+        }
 
         Ok(SimpleExecuteResponse { results })
     }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -551,9 +551,7 @@ pub enum TransactionStatus<T> {
     /// Currently in an implicit transaction started from a multi-statement query
     /// with more than 1 statements. Matches `TBLOCK_IMPLICIT_INPROGRESS`.
     InTransactionImplicit(Transaction<T>),
-    /// In a failed transaction that was started explicitly (i.e., previously
-    /// InTransaction). We do not use Failed for implicit transactions because
-    /// those cleanup after themselves. Matches `TBLOCK_ABORT`.
+    /// In a failed transaction. Matches `TBLOCK_ABORT`.
     Failed(Transaction<T>),
 }
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -177,13 +177,31 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCase {
             query: "create view v1 as select 1; create view v2 as select 1",
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block"},{"error":"CREATE VIEW v2 AS SELECT 1 cannot be run inside a transaction block"}]}"#,
+            body: r#"{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block"}]}"#,
         },
         // Syntax errors fail the request.
         TestCase {
             query: "'",
             status: StatusCode::BAD_REQUEST,
             body: r#"unterminated quoted string"#,
+        },
+        // Tables
+        TestCase {
+            query: "create table t (a int);",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"CREATE TABLE"}]}"#,
+        },
+        TestCase {
+            query: "insert into t values (1)",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"INSERT 0 1"}]}"#,
+        },
+        // n.b. this used to fail because the insert was treated as an
+        // uncommitted explicit transaction
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
         },
     ];
 

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -203,6 +203,103 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
         },
+        TestCase {
+            query: "delete from t",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
+        },
+        TestCase {
+            query: "delete from t",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
+        },
+        // # Txns
+        // ## Txns, read only
+        TestCase {
+            query: "begin; select 1; commit",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
+        },
+        TestCase {
+            query: "begin; select 1; commit; select 2;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"rows":[[2]],"col_names":["?column?"]}]}"#,
+        },
+        TestCase {
+            query: "select 1; begin; select 2; commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"rows":[[2]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
+        },
+        TestCase {
+            query: "begin; select 1/0; commit; select 2;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "begin; select 1; commit; select 1/0;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "select 1/0; begin; select 2; commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "select 1; begin; select 1/0; commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+        },
+        // ## Txns w/ writes
+        // Implicit txn aborted on first error
+        TestCase {
+            query: "insert into t values (1); select 1/0; insert into t values (2)",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+        },
+        // Values not successfully written due to aborted txn
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+        },
+        // Explicit txn invocation commits values w/in txn, irrespective of results outside txn
+        TestCase {
+            query: "begin; insert into t values (1); commit; insert into t values (2); select 1/0;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
+        },
+        TestCase {
+            query: "delete from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
+        },
+        TestCase {
+            query: "delete from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
+        },
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+        },
+        // Explicit txn must be terminated to commit
+        TestCase {
+            query: "begin; insert into t values (1)",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
+        },
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+        },
     ];
 
     for tc in tests {


### PR DESCRIPTION
@mjibson -- can you take a look at this? I'm very willing to believe the session transactions should work a little differently than this, but this was what I managed to figure out. Notably, the previous method of only starting but never committing single statement transactions caused them to not commit, so afaict there needs to be an explicit bit to end the transaction somewhere.

### Motivation

This PR adds a known-desirable feature. Closes #14066

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Transactional semantics more akin to the [PostgreSQL Simple Query Protocol](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.4) when using  the `api/sql` endpoint. 
