### PR TITLE
Run nightly SQL logic test with a parallelism of 4

### DIFF
--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -14,6 +14,7 @@ steps:
     artifact_paths: target/slt-summary.json
     agents:
       queue: linux-x86_64
+    parallelism: 4
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest


### PR DESCRIPTION
This should avoid the 10h timeouts we've been seeing in CI.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
