### PR TITLE
compute-client: remove a misleading error log

### DIFF
--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -263,8 +263,6 @@ where
                             reported.clone_from(&new_upper);
                             new_uppers.push((id, new_upper));
                         }
-                    } else {
-                        tracing::error!("received `FrontierUppers` for untracked ID: {id}");
                     }
                 }
                 if !new_uppers.is_empty() {


### PR DESCRIPTION
It is entirely possible for the compute controller to receive `FrontierUppers` responses for collections it already has stopped tracking.

For example, the following sequence is valid:
  1. `computed` sends `FrontierUppers([(id, frontier)])`.
  2. Adapter calls `controller.drop_indexes([id])`.
  3. Controller stops tracking `id`.
  4. Controller sends `AllowCompaction([(id, [])])`.
  5. Controller receives the `FrontierUppers` from (1).

This is fine, so logging an error in that case is wrong.

### Motivation

  * This PR fixes a recognized bug.

Fixes #14586.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
