### PR TITLE
storage: don't use async_op! macro in persist_source

### DIFF
--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -31,7 +31,6 @@ use mz_persist::location::ExternalError;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::fetch::SerdeLeasedBatchPart;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
-use mz_timely_util::async_op;
 use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 
 use crate::controller::CollectionMetadata;
@@ -268,7 +267,7 @@ where
 
     fetcher_builder.build_async(
         scope.clone(),
-        async_op!(|initial_capabilities, _frontiers| {
+        move |mut initial_capabilities, frontiers, scheduler| async move {
             let fetcher = persist_clients
                 .lock()
                 .await
@@ -290,76 +289,91 @@ where
 
             let mut buffer = Vec::new();
 
-            while let Some((cap, data)) = fetcher_input.next() {
-                // `LeasedBatchPart`es cannot be dropped at this point w/o
-                // panicking, so swap them to an owned version.
-                data.swap(&mut buffer);
+            loop {
+                scheduler.notified().await;
+                while let Some((cap, data)) = fetcher_input.next() {
+                    // `LeasedBatchPart`es cannot be dropped at this point w/o
+                    // panicking, so swap them to an owned version.
+                    data.swap(&mut buffer);
 
-                let update_cap = cap.delayed_for_output(cap.time(), update_output_port);
-                let mut update_session = output_handle.session(&update_cap);
+                    let update_cap = cap.delayed_for_output(cap.time(), update_output_port);
+                    let mut update_session = output_handle.session(&update_cap);
 
-                let consumed_part_cap = cap.delayed_for_output(cap.time(), consumed_part_port);
-                let mut consumed_part_session =
-                    consumed_part_output_handle.session(&consumed_part_cap);
+                    let consumed_part_cap = cap.delayed_for_output(cap.time(), consumed_part_port);
+                    let mut consumed_part_session =
+                        consumed_part_output_handle.session(&consumed_part_cap);
 
-                for (_idx, part) in buffer.drain(..) {
-                    let (consumed_part, updates) = fetcher.fetch_leased_part(part.into()).await;
+                    for (_idx, part) in buffer.drain(..) {
+                        let (consumed_part, updates) = fetcher.fetch_leased_part(part.into()).await;
 
-                    let updates = updates
-                        .expect("shard_id generated for sources must match across all workers");
+                        let updates = updates
+                            .expect("shard_id generated for sources must match across all workers");
 
-                    // Apply as much logic to `updates` as we can, before we emit anything.
-                    let mut update_outputs = Vec::with_capacity(updates.len());
-                    for ((key, val), time, diff) in updates {
-                        if !until.less_equal(&time) {
-                            match (key, val) {
-                                (Ok(SourceData(Ok(row))), Ok(())) => {
-                                    if let Some(mfp) = &mut map_filter_project {
-                                        let arena = mz_repr::RowArena::new();
-                                        let mut datums_local = datum_vec.borrow_with(&row);
-                                        for result in mfp.evaluate(
-                                            &mut datums_local,
-                                            &arena,
-                                            time,
-                                            diff,
-                                            |time| !until.less_equal(time),
-                                            &mut row_builder,
-                                        ) {
-                                            match result {
-                                                Ok((row, time, diff)) => {
-                                                    // Additional `until` filtering due to temporal filters.
-                                                    if !until.less_equal(&time) {
-                                                        update_outputs.push((Ok(row), time, diff));
+                        // Apply as much logic to `updates` as we can, before we emit anything.
+                        let mut update_outputs = Vec::with_capacity(updates.len());
+                        for ((key, val), time, diff) in updates {
+                            if !until.less_equal(&time) {
+                                match (key, val) {
+                                    (Ok(SourceData(Ok(row))), Ok(())) => {
+                                        if let Some(mfp) = &mut map_filter_project {
+                                            let arena = mz_repr::RowArena::new();
+                                            let mut datums_local = datum_vec.borrow_with(&row);
+                                            for result in mfp.evaluate(
+                                                &mut datums_local,
+                                                &arena,
+                                                time,
+                                                diff,
+                                                |time| !until.less_equal(time),
+                                                &mut row_builder,
+                                            ) {
+                                                match result {
+                                                    Ok((row, time, diff)) => {
+                                                        // Additional `until` filtering due to temporal filters.
+                                                        if !until.less_equal(&time) {
+                                                            update_outputs.push((
+                                                                Ok(row),
+                                                                time,
+                                                                diff,
+                                                            ));
+                                                        }
                                                     }
-                                                }
-                                                Err((err, time, diff)) => {
-                                                    // Additional `until` filtering due to temporal filters.
-                                                    if !until.less_equal(&time) {
-                                                        update_outputs.push((Err(err), time, diff));
+                                                    Err((err, time, diff)) => {
+                                                        // Additional `until` filtering due to temporal filters.
+                                                        if !until.less_equal(&time) {
+                                                            update_outputs.push((
+                                                                Err(err),
+                                                                time,
+                                                                diff,
+                                                            ));
+                                                        }
                                                     }
                                                 }
                                             }
+                                        } else {
+                                            update_outputs.push((Ok(row), time, diff));
                                         }
-                                    } else {
-                                        update_outputs.push((Ok(row), time, diff));
                                     }
+                                    (Ok(SourceData(Err(err))), Ok(())) => {
+                                        update_outputs.push((Err(err), time, diff));
+                                    }
+                                    // TODO(petrosagg): error handling
+                                    _ => panic!("decoding failed"),
                                 }
-                                (Ok(SourceData(Err(err))), Ok(())) => {
-                                    update_outputs.push((Err(err), time, diff));
-                                }
-                                // TODO(petrosagg): error handling
-                                _ => panic!("decoding failed"),
                             }
                         }
-                    }
-                    differential_dataflow::consolidation::consolidate_updates(&mut update_outputs);
+                        differential_dataflow::consolidation::consolidate_updates(
+                            &mut update_outputs,
+                        );
 
-                    update_session.give_vec(&mut update_outputs);
-                    consumed_part_session.give(consumed_part.into_exchangeable_part());
+                        update_session.give_vec(&mut update_outputs);
+                        consumed_part_session.give(consumed_part.into_exchangeable_part());
+                    }
+                }
+                if frontiers.borrow().iter().all(|f| f.is_empty()) {
+                    break;
                 }
             }
-            false
-        }),
+        },
     );
 
     // This operator is meant to only run on the chosen worker. All workers will
@@ -380,7 +394,7 @@ where
 
     consumed_part_builder.build_async(
         scope.clone(),
-        async_op!(|initial_capabilities, _frontiers| {
+        move |mut initial_capabilities, frontiers, scheduler| async move {
             initial_capabilities.clear();
 
             // The chosen worker is the leasor because it issues batches.
@@ -389,28 +403,32 @@ where
                     "We are not the batch leasor for {:?}, exiting...",
                     source_id
                 );
-                return false;
+                return;
             }
 
             let mut buffer = Vec::new();
 
-            while let Some((_cap, data)) = consumed_part_input.next() {
-                data.swap(&mut buffer);
+            loop {
+                scheduler.notified().await;
+                while let Some((_cap, data)) = consumed_part_input.next() {
+                    data.swap(&mut buffer);
 
-                for part in buffer.drain(..) {
-                    if let Err(mpsc::error::SendError(_part)) = consumed_part_tx.send(part) {
-                        // Subscribe loop dropped, which drops its ReadHandle,
-                        // which in turn drops all leases, so doing anything
-                        // else here is both moot and impossible.
-                        //
-                        // The parts we tried to send will just continue being
-                        // `SerdeLeasedBatchPart`'es.
+                    for part in buffer.drain(..) {
+                        if let Err(mpsc::error::SendError(_part)) = consumed_part_tx.send(part) {
+                            // Subscribe loop dropped, which drops its ReadHandle,
+                            // which in turn drops all leases, so doing anything
+                            // else here is both moot and impossible.
+                            //
+                            // The parts we tried to send will just continue being
+                            // `SerdeLeasedBatchPart`'es.
+                        }
                     }
                 }
+                if frontiers.borrow().iter().all(|f| f.is_empty()) {
+                    break;
+                }
             }
-
-            false
-        }),
+        },
     );
 
     let token = Rc::new(token);


### PR DESCRIPTION
Alternative to #14572 for discussion. All glory and honor to Aljoscha,
who wrote the original fix and also figured out the root cause. This PR
differs from that one in that it's a slightly more straightforward
(brainless) copy of the async_op logic into where it was called
(adjusting things as minimally as possible to still fix the bug).

When using async_op! the entire body is run anytime the operator is
invoked (because of new input, frontier changes, or because someone
feels like it). The body is costly because it does things like
registering a new read handle (!!), allocating buffers etc. With this
change, we only do that once, and then keep that one future around until
the operator is finished.

Before, the fetcher operator was scheduled a lot and was taking up 100%
of the CPU timer of its worker, even with no data coming in. After this
change, it mostly sits idle, as it should.

You can see the impact by looking at the introspection views, and by
observing that `computed` with a simple TAIL is not pegged at 100 %
usage anymore.

The below printouts are from running a TAIL on a table that doesn't see
new updates.

Without this fix:

```
materialize=> select mdo.id, mdo.name, mdo.worker, mse.elapsed_ns
from mz_scheduling_elapsed as mse,
     mz_dataflow_operators as mdo
where
    mse.id = mdo.id and
    mse.worker = mdo.worker
order by elapsed_ns desc;
 id  |                      name                       | worker | elapsed_ns
-----+-------------------------------------------------+--------+-------------
 328 | Dataflow: tail-t7                               |      0 | 29117620155
 341 | Dataflow: tail-t7                               |      0 | 28567992731
 330 | persist_source 0: part fetcher u1               |      0 | 27912365122
 329 | persist_source User(1): part distribution       |      0 |   298032358
 332 | persist_source User(1): consumed part collector |      0 |      817396
 338 | tail-t7                                         |      0 |      813745
 336 | InspectBatch                                    |      0 |      566229
 334 | OkErr                                           |      0 |      347089
(8 rows)

Time: 44.527 ms
```

With this fix:

```
materialize=> select mdo.id, mdo.name, mdo.worker, mse.elapsed_ns
from mz_scheduling_elapsed as mse,
     mz_dataflow_operators as mdo
where
    mse.id = mdo.id and
    mse.worker = mdo.worker
order by elapsed_ns desc;
  id  |                    name                    | worker | elapsed_ns
------+--------------------------------------------+--------+------------
 1078 | Dataflow: tail-t17                         |      0 |  111508724
 1091 | Dataflow: tail-t17                         |      0 |   96973716
 1079 | persist_source u1: part distribution       |      0 |   79733907
  266 | Dataflow: temp-view-t3                     |      0 |    6401428
  297 | Dataflow: temp-view-t5                     |      0 |    6299725
  295 | Dataflow: temp-view-t3                     |      0 |    5942598
  326 | Dataflow: temp-view-t5                     |      0 |    5841977
 1080 | persist_source u1: part fetcher 0/1        |      0 |    4820154
  268 | persist_source s263: part fetcher 0/1      |      0 |    2888588
  299 | persist_source s278: part fetcher 0/1      |      0 |    2782819
 1088 | tail-t17                                   |      0 |     671058
 1082 | persist_source u1: consumed part collector |      0 |     539166
 1086 | InspectBatch                               |      0 |     500139
 1084 | OkErr                                      |      0 |     308879
  285 | ArrangeBy[[Column(0), Column(1)]]          |      0 |      95100
  316 | ArrangeBy[[Column(0)]]                     |      0 |      80980
  290 | Map                                        |      0 |       2930
  321 | Map                                        |      0 |       2790
(18 rows)

Time: 39.292 ms
```


### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

The `produce_to_kafka` operator also uses this macro, but I wasn't able to quickly ramp up on that code enough to feel confident giving it the same fix.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
