### PR TITLE
[draft] Repurpose `flatten_and_or` as `flatten_associative`

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6255,32 +6255,33 @@ impl VariadicFunc {
 
     pub fn is_associative(&self) -> bool {
         match self {
-            VariadicFunc::Coalesce => true,
-            VariadicFunc::Greatest => true,
-            VariadicFunc::Least => true,
-            VariadicFunc::Concat => true,
-            VariadicFunc::MakeTimestamp => false,
-            VariadicFunc::PadLeading => false,
-            VariadicFunc::Substr => false,
-            VariadicFunc::Replace => false,
-            VariadicFunc::JsonbBuildArray => false,
-            VariadicFunc::JsonbBuildObject => false,
-            VariadicFunc::ArrayCreate { elem_type: _ } => false,
-            VariadicFunc::ArrayToString { elem_type: _ } => false,
-            VariadicFunc::ArrayIndex { offset: _ } => false,
-            VariadicFunc::ListCreate { elem_type: _ } => false,
-            VariadicFunc::RecordCreate { field_names: _ } => false,
-            VariadicFunc::ListIndex => false,
-            VariadicFunc::ListSliceLinear => false,
-            VariadicFunc::SplitPart => false,
-            VariadicFunc::RegexpMatch => false,
-            VariadicFunc::HmacString => false,
-            VariadicFunc::HmacBytes => false,
-            VariadicFunc::ErrorIfNull => false,
-            VariadicFunc::DateBinTimestamp => false,
-            VariadicFunc::DateBinTimestampTz => false,
-            VariadicFunc::And => true,
-            VariadicFunc::Or => true,
+            VariadicFunc::Coalesce
+            | VariadicFunc::Greatest
+            | VariadicFunc::Least
+            | VariadicFunc::Concat
+            | VariadicFunc::And
+            | VariadicFunc::Or => true,
+
+            VariadicFunc::MakeTimestamp
+            | VariadicFunc::PadLeading
+            | VariadicFunc::Substr
+            | VariadicFunc::Replace
+            | VariadicFunc::JsonbBuildArray
+            | VariadicFunc::JsonbBuildObject
+            | VariadicFunc::ArrayCreate { elem_type: _ }
+            | VariadicFunc::ArrayToString { elem_type: _ }
+            | VariadicFunc::ArrayIndex { offset: _ }
+            | VariadicFunc::ListCreate { elem_type: _ }
+            | VariadicFunc::RecordCreate { field_names: _ }
+            | VariadicFunc::ListIndex
+            | VariadicFunc::ListSliceLinear
+            | VariadicFunc::SplitPart
+            | VariadicFunc::RegexpMatch
+            | VariadicFunc::HmacString
+            | VariadicFunc::HmacBytes
+            | VariadicFunc::ErrorIfNull
+            | VariadicFunc::DateBinTimestamp
+            | VariadicFunc::DateBinTimestampTz => false,
         }
     }
 

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6253,6 +6253,37 @@ impl VariadicFunc {
         }
     }
 
+    pub fn is_associative(&self) -> bool {
+        match self {
+            VariadicFunc::Coalesce => true,
+            VariadicFunc::Greatest => true,
+            VariadicFunc::Least => true,
+            VariadicFunc::Concat => true,
+            VariadicFunc::MakeTimestamp => false,
+            VariadicFunc::PadLeading => false,
+            VariadicFunc::Substr => false,
+            VariadicFunc::Replace => false,
+            VariadicFunc::JsonbBuildArray => false,
+            VariadicFunc::JsonbBuildObject => false,
+            VariadicFunc::ArrayCreate { elem_type: _ } => false,
+            VariadicFunc::ArrayToString { elem_type: _ } => false,
+            VariadicFunc::ArrayIndex { offset: _ } => false,
+            VariadicFunc::ListCreate { elem_type: _ } => false,
+            VariadicFunc::RecordCreate { field_names: _ } => false,
+            VariadicFunc::ListIndex => false,
+            VariadicFunc::ListSliceLinear => false,
+            VariadicFunc::SplitPart => false,
+            VariadicFunc::RegexpMatch => false,
+            VariadicFunc::HmacString => false,
+            VariadicFunc::HmacBytes => false,
+            VariadicFunc::ErrorIfNull => false,
+            VariadicFunc::DateBinTimestamp => false,
+            VariadicFunc::DateBinTimestampTz => false,
+            VariadicFunc::And => true,
+            VariadicFunc::Or => true,
+        }
+    }
+
     pub fn output_type(&self, input_types: Vec<ColumnType>) -> ColumnType {
         use VariadicFunc::*;
         let in_nullable = input_types.iter().any(|t| t.nullable);

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -884,7 +884,12 @@ impl MirScalarExpr {
                             }
                         }
                     }
-                    MirScalarExpr::CallVariadic { func, exprs } => {
+                    MirScalarExpr::CallVariadic { .. } => {
+                        e.flatten_associative();
+                        let (func, exprs) = match e {
+                            MirScalarExpr::CallVariadic { func, exprs } => (func, exprs),
+                            _ => unreachable!("`flatten_associative` shouldn't change node type"),
+                        };
                         if *func == VariadicFunc::Coalesce {
                             // If all inputs are null, output is null. This check must
                             // be done before `exprs.retain...` because `e.typ` requires
@@ -957,7 +962,6 @@ impl MirScalarExpr {
                             let top_list_create = exprs.swap_remove(0);
                             *e = reduce_list_create_list_index_literal(top_list_create, ind_exprs);
                         } else if *func == VariadicFunc::Or || *func == VariadicFunc::And {
-                            e.flatten_associative();
                             e.undistribute_and_or();
                             e.reduce_and_canonicalize_and_or();
                         }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1226,7 +1226,7 @@ impl MirScalarExpr {
                     })
                     .collect();
             }
-            _ => {},
+            _ => {}
         }
     }
 

--- a/src/expr/tests/testdata/reduce
+++ b/src/expr/tests/testdata/reduce
@@ -281,7 +281,7 @@ reduce
 ----
 ((#0) IS NULL OR ((#1) IS NULL AND (#2) IS NULL))
 
-# flatten_and_or + undistribute_and_or
+# flatten_associative + undistribute_and_or
 # ((#0 OR #1) OR (#2 > 2)) AND (#0 OR ((#2 < 3) OR #1))
 reduce
 (call_variadic and [
@@ -291,6 +291,36 @@ reduce
 [bool bool int32]
 ----
 (#0 OR #1 OR ((#2 < 3) AND (#2 > 2)))
+
+# Test that flatten_associative works on
+# functions other than `and` and `or`.
+reduce
+(call_variadic greatest [
+    (call_variadic greatest [#0 #1 #2])
+    (call_variadic least [#3 #4 #5])
+    (call_variadic greatest [#6 #7 #8])
+])
+[int32 int32 int32 int32 int32 int32 int32 int32 int32]
+----
+greatest(#0, #1, #2, least(#3, #4, #5), #6, #7, #8)
+
+# Right-deep tree
+reduce
+(call_variadic coalesce [
+    #0 (call_variadic coalesce [#1 (call_variadic coalesce [#2 (call_variadic coalesce [#3 #4])])])
+])
+[int32 int32 int32 int32 int32]
+----
+coalesce(#0, #1, #2, #3, #4)
+
+# Left-deep tree
+reduce
+(call_variadic coalesce [
+    (call_variadic coalesce [(call_variadic coalesce [(call_variadic coalesce [#0 #1]) #2]) #3]) #4
+])
+[int32 int32 int32 int32 int32]
+----
+coalesce(#0, #1, #2, #3, #4)
 
 # undistribute_and_or -- more than 2 args at the top level.
 # (#0 OR #1 OR (#2 > 2)) AND (#0 OR (#2 < 3) OR #1) AND (#1 OR (#5 < 7) OR #0)

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -562,7 +562,7 @@ impl CanonicalizeMfp {
                     }
                 })?;
                 p.visit_mut_post(&mut |e: &mut MirScalarExpr| {
-                    e.flatten_and_or();
+                    e.flatten_associative();
                 })?;
             }
             Ok(())

--- a/src/transform/src/canonicalize_mfp.rs
+++ b/src/transform/src/canonicalize_mfp.rs
@@ -493,7 +493,7 @@ impl CanonicalizeMfp {
     /// This effectively converts to disjunctive normal form (DNF) (i.e., an OR of ANDs), because
     /// [MirScalarExpr::reduce] did Demorgans and double-negation-elimination. So after
     /// [MirScalarExpr::reduce], we get here a tree of AND/OR nodes. A distribution step lifts an OR
-    /// up the tree by 1 level, and a [MirScalarExpr::flatten_and_or] merges two ORs that are at
+    /// up the tree by 1 level, and a [MirScalarExpr::flatten_associative] merges two ORs that are at
     /// adjacent levels, so eventually we'll end up with just one OR that is at the top of the tree,
     /// with ANDs below it.
     /// For example:
@@ -510,7 +510,7 @@ impl CanonicalizeMfp {
     /// (#0 = 1 AND (#1 = 2 OR #1 = 4)) OR (#0 = 8 AND #1 = 5)
     /// And now we distribute the first AND over the first OR in 2 steps: First to
     /// ((#0 = 1 AND #1 = 2) OR (#0 = 1 AND #1 = 4)) OR (#0 = 8 AND #1 = 5)
-    /// then [MirScalarExpr::flatten_and_or]:
+    /// then [MirScalarExpr::flatten_associative]:
     /// (#0 = 1 AND #1 = 2) OR (#0 = 1 AND #1 = 4) OR (#0 = 8 AND #1 = 5)
     ///
     /// Note that [MirScalarExpr::undistribute_and_or] is not exactly an inverse to this because


### PR DESCRIPTION
Fixes #13928

@ggevay (or someone else), could you please suggest where would be a good place to add tests for this?

After I add tests, I will mark this as non-draft.