### PR TITLE
Allow using sinks outside of unsafe mode

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1946,10 +1946,9 @@ fn get_kafka_sink_consistency_config(
 }
 
 pub fn describe_create_sink(
-    scx: &StatementContext,
+    _: &StatementContext,
     _: CreateSinkStatement<Aug>,
 ) -> Result<StatementDesc, PlanError> {
-    scx.require_unsafe_mode("CREATE SINK")?;
     Ok(StatementDesc::new(None))
 }
 
@@ -1959,8 +1958,6 @@ pub fn plan_create_sink(
     scx: &StatementContext,
     stmt: CreateSinkStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    scx.require_unsafe_mode("CREATE SINK")?;
-
     let create_sql = normalize::create_statement(scx, Statement::CreateSink(stmt.clone()))?;
     let CreateSinkStatement {
         name,


### PR DESCRIPTION
Marking sinks as out of unsafe mode: we've landed the most significant changes, and this needs to hit the next release window if we don't want to slow down onboarding.

### Motivation

On the checklist for #11503!

### Checklist
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support the CREATE SINK command outside unsafe mode.
