### PR TITLE
mzcompose: upgrade to ARM-supporting Confluent Platform

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -15,7 +15,7 @@ from packaging import version
 
 from materialize.mzcompose import Service, ServiceConfig
 
-DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.3"
+DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.5"
 
 # Be sure to use a `X.Y.Z.Final` tag here; `X.Y` tags refer to the latest
 # minor version in the release series, and minor versions have been known to

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -9,7 +9,7 @@
 
 from pathlib import Path
 
-from materialize import ci_util, ui
+from materialize import ci_util
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
     Kafka,
@@ -20,7 +20,6 @@ from materialize.mzcompose.services import (
     Testdrive,
     Zookeeper,
 )
-from materialize.xcompile import Arch
 
 SERVICES = [
     Zookeeper(),
@@ -57,13 +56,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="run against the specified files",
     )
     args = parser.parse_args()
-
-    if not args.redpanda and Arch.host() == Arch.AARCH64:
-        ui.warn(
-            "Running the Confluent Platform in Docker on ARM-based machines is "
-            "nearly unusably slow. Consider using Redpanda instead (--redpanda) "
-            "or running tests without mzcompose."
-        )
 
     dependencies = ["materialized"]
     if args.redpanda:


### PR DESCRIPTION
This commit upgrades our mzcompose-based tests to Confluent Platform
v7.0.5, which has ARM images available on Docker Hub.

This makes all of our mzcompose compositions runnable on M1 Macs,
without requiring plumbing a `--redpanda` option through every
composition.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
