### PR TITLE
Flag inputs to `SELECT` queries as monotonic if `until` is set.

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -268,16 +268,8 @@ impl crate::coord::Coordinator {
         let peek_plan = fast_path_plan.map_or_else(
             // finalize the dataflow and produce a PeekPlan::SlowPath as a default
             || {
-                let mut desc = self.finalize_dataflow(dataflow, compute_instance)?;
-                // We have the opportunity to name an `until` frontier that will prevent work we needn't perform.
-                // By default, `until` will be `Antichain::new()`, which prevents no updates and is safe.
-                if let Some(as_of) = desc.as_of.as_ref() {
-                    if !as_of.is_empty() {
-                        if let Some(next) = as_of.elements()[0].checked_add(1) {
-                            desc.until = timely::progress::Antichain::from_elem(next);
-                        }
-                    }
-                }
+                let desc = self.finalize_dataflow(dataflow, compute_instance)?;
+
                 Ok::<_, AdapterError>(PeekPlan::SlowPath(PeekDataflowPlan {
                     desc,
                     id: index_id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2195,7 +2195,7 @@ impl Coordinator {
         // We do this here so that `optimize_dataflow` can pick up the monotonicity information.
         if let Some(as_of) = dataflow.as_of.as_ref() {
             if !as_of.is_empty() {
-                if let Some(next) = as_of.elements()[0].checked_add(1) {
+                if let Some(next) = as_of.as_option().and_then(|as_of| as_of.checked_add(1)) {
                     dataflow.until = timely::progress::Antichain::from_elem(next);
                     // Indicate imported sources and indexes as monotonic; as we will produce
                     // only the snapshot (without retractions).

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -844,8 +844,11 @@ where
         (key, values)
     });
 
-    // We arrange the inputs ourself to force it into a leaner structure because we know we
-    // won't care about values.
+    // We ensure physical monotonicity of the input collection by:
+    // (a) Consolidating the input so as to transform any logical monotonicity
+    // into physical monotonicity;
+    // (b) Ensuring that physical monotonicity has been attained and producing
+    // errors otherwise.
     let consolidated =
         collection.consolidate_named::<RowKeySpine<_, _, _>>("Consolidated ReduceMonotonic input");
     let debug_name = debug_name.to_string();

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -576,6 +576,16 @@ static ENABLE_WITH_MUTUALLY_RECURSIVE: ServerVar<bool> = ServerVar {
     safe: true,
 };
 
+/// Feature flag indicating whether monotonic evaluation of one-shot SELECT queries is enabled.
+static ENABLE_MONOTONIC_ONESHOT_SELECTS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_monotonic_oneshot_selects"),
+    value: &false,
+    description: "Feature flag indicating whether monotonic evaluation of one-shot SELECT queries \
+                  is enabled (Materialize).",
+    internal: true,
+    safe: true,
+};
+
 /// Feature flag indicating whether real time recency is enabled.
 static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("real_time_recency"),
@@ -1291,6 +1301,7 @@ pub struct SystemVars {
 
     // features
     enable_with_mutually_recursive: SystemVar<bool>,
+    enable_monotonic_oneshot_selects: SystemVar<bool>,
     enable_rbac_checks: SystemVar<bool>,
 
     // storage configuration
@@ -1360,6 +1371,7 @@ impl Default for SystemVars {
             metrics_retention: SystemVar::new(&METRICS_RETENTION),
             mock_audit_event_timestamp: SystemVar::new(&MOCK_AUDIT_EVENT_TIMESTAMP),
             enable_with_mutually_recursive: SystemVar::new(&ENABLE_WITH_MUTUALLY_RECURSIVE),
+            enable_monotonic_oneshot_selects: SystemVar::new(&ENABLE_MONOTONIC_ONESHOT_SELECTS),
             enable_rbac_checks: SystemVar::new(&ENABLE_RBAC_CHECKS),
         }
     }
@@ -1401,6 +1413,7 @@ impl SystemVars {
             &self.metrics_retention,
             &self.mock_audit_event_timestamp,
             &self.enable_with_mutually_recursive,
+            &self.enable_monotonic_oneshot_selects,
             &self.enable_rbac_checks,
         ];
         vars.into_iter()
@@ -1488,6 +1501,8 @@ impl SystemVars {
             Ok(&self.mock_audit_event_timestamp)
         } else if name == ENABLE_WITH_MUTUALLY_RECURSIVE.name {
             Ok(&self.enable_with_mutually_recursive)
+        } else if name == ENABLE_MONOTONIC_ONESHOT_SELECTS.name {
+            Ok(&self.enable_monotonic_oneshot_selects)
         } else if name == ENABLE_RBAC_CHECKS.name {
             Ok(&self.enable_rbac_checks)
         } else {
@@ -1567,6 +1582,8 @@ impl SystemVars {
             self.mock_audit_event_timestamp.is_default(input)
         } else if name == ENABLE_WITH_MUTUALLY_RECURSIVE.name {
             self.enable_with_mutually_recursive.is_default(input)
+        } else if name == ENABLE_MONOTONIC_ONESHOT_SELECTS.name {
+            self.enable_monotonic_oneshot_selects.is_default(input)
         } else if name == ENABLE_RBAC_CHECKS.name {
             self.enable_rbac_checks.is_default(input)
         } else {
@@ -1652,6 +1669,8 @@ impl SystemVars {
             self.mock_audit_event_timestamp.set(input)
         } else if name == ENABLE_WITH_MUTUALLY_RECURSIVE.name {
             self.enable_with_mutually_recursive.set(input)
+        } else if name == ENABLE_MONOTONIC_ONESHOT_SELECTS.name {
+            self.enable_monotonic_oneshot_selects.set(input)
         } else if name == ENABLE_RBAC_CHECKS.name {
             self.enable_rbac_checks.set(input)
         } else {
@@ -1733,6 +1752,8 @@ impl SystemVars {
             Ok(self.mock_audit_event_timestamp.reset())
         } else if name == ENABLE_WITH_MUTUALLY_RECURSIVE.name {
             Ok(self.enable_with_mutually_recursive.reset())
+        } else if name == ENABLE_MONOTONIC_ONESHOT_SELECTS.name {
+            Ok(self.enable_monotonic_oneshot_selects.reset())
         } else if name == ENABLE_RBAC_CHECKS.name {
             Ok(self.enable_rbac_checks.reset())
         } else {
@@ -1896,6 +1917,11 @@ impl SystemVars {
         self.enable_with_mutually_recursive
             .set(VarInput::Flat(value.format().as_str()))
             .expect("valid parameter value")
+    }
+
+    /// Returns the `enable_monotonic_oneshot_selects` configuration parameter.
+    pub fn enable_monotonic_oneshot_selects(&self) -> bool {
+        *self.enable_monotonic_oneshot_selects.value()
     }
 
     /// Returns the `enable_rbac_checks` configuration parameter.


### PR DESCRIPTION
This PR flags sources and indexes as `monotonic` if we are in a `Peek` setting and have successfully set `until` to be one greater than the query timestamp. In such a setting, we will ingest only the snapshot and no further modifications, which means no retractions. We can use simpler dataflow fragments in cases such as `min`, `max`, and `top_k`.

### Motivation

  * This PR adds a feature that has not yet been specified.

One-off `SELECT` queries use dataflows that are more general than strictly required, and this is one example of how that can be relaxed.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
