### PR TITLE
Simplify compute controller drop api

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -406,26 +406,10 @@ impl<S: Append + 'static> Coordinator<S> {
         .await;
 
         // Migrate builtin objects.
-        for (compute_id, index_ids) in builtin_migration_metadata.previous_index_ids {
-            self.controller
-                .compute_mut(compute_id)
-                .unwrap()
-                .drop_indexes_unvalidated(index_ids)
-                .await?;
-        }
-        for (compute_id, recorded_view_ids) in
-            builtin_migration_metadata.previous_materialized_view_ids
-        {
-            self.controller
-                .compute_mut(compute_id)
-                .unwrap()
-                .drop_sinks_unvalidated(recorded_view_ids.clone())
-                .await?;
-            self.controller
-                .storage_mut()
-                .drop_sources_unvalidated(recorded_view_ids)
-                .await?;
-        }
+        self.controller
+            .storage_mut()
+            .drop_sources_unvalidated(builtin_migration_metadata.previous_materialized_view_ids)
+            .await?;
         self.controller
             .storage_mut()
             .drop_sources_unvalidated(builtin_migration_metadata.previous_source_ids)

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -270,7 +270,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
             if let Some(mut compute) = self.controller.compute_mut(compute_instance) {
-                compute.drop_sinks(ids).await.unwrap();
+                compute.drop_collections(ids).await.unwrap();
             }
         }
     }
@@ -302,7 +302,7 @@ impl<S: Append + 'static> Coordinator<S> {
             self.controller
                 .compute_mut(compute_instance)
                 .unwrap()
-                .drop_indexes(ids)
+                .drop_collections(ids)
                 .await
                 .unwrap();
         }
@@ -328,7 +328,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
             if let Some(mut compute) = self.controller.compute_mut(compute_instance) {
-                compute.drop_sinks(ids).await.unwrap();
+                compute.drop_collections(ids).await.unwrap();
             }
         }
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -479,28 +479,13 @@ where
 
         Ok(())
     }
-    /// Drops the read capability for the sinks and allows their resources to be reclaimed.
-    pub async fn drop_sinks(&mut self, identifiers: Vec<GlobalId>) -> Result<(), ComputeError> {
+    /// Drops the read capability for the given collections and allows their resources to be
+    /// reclaimed.
+    pub async fn drop_collections(&mut self, ids: Vec<GlobalId>) -> Result<(), ComputeError> {
         // Validate that the ids exist.
-        self.as_ref().validate_ids(identifiers.iter().cloned())?;
+        self.as_ref().validate_ids(ids.iter().cloned())?;
 
-        let compaction_commands = identifiers
-            .into_iter()
-            .map(|id| (id, Antichain::new()))
-            .collect();
-        self.allow_compaction(compaction_commands).await?;
-        Ok(())
-    }
-
-    /// Drops the read capability for the indexes and allows their resources to be reclaimed.
-    pub async fn drop_indexes(&mut self, identifiers: Vec<GlobalId>) -> Result<(), ComputeError> {
-        // Validate that the ids exist.
-        self.as_ref().validate_ids(identifiers.iter().cloned())?;
-
-        let compaction_commands = identifiers
-            .into_iter()
-            .map(|id| (id, Antichain::new()))
-            .collect();
+        let compaction_commands = ids.into_iter().map(|id| (id, Antichain::new())).collect();
         self.allow_compaction(compaction_commands).await?;
         Ok(())
     }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -492,28 +492,6 @@ where
         Ok(())
     }
 
-    /// Drops the read capability for the sinks and allows their resources to be reclaimed.
-    /// TODO(jkosh44): This method does not validate the provided identifiers. Currently when the
-    ///     controller starts/restarts it has no durable state. That means that it has no way of
-    ///     remembering any past commands sent. In the future we plan on persisting state for the
-    ///     controller so that it is aware of past commands.
-    ///     Therefore this method is for dropping sinks that we know to have been previously
-    ///     created, but have been forgotten by the controller due to a restart.
-    ///     Once command history becomes durable we can remove this method and use the normal
-    ///     `drop_sinks`.
-    pub async fn drop_sinks_unvalidated(
-        &mut self,
-        identifiers: Vec<GlobalId>,
-    ) -> Result<(), ComputeError> {
-        let compaction_commands = identifiers
-            .into_iter()
-            .map(|id| (id, Antichain::new()))
-            .collect();
-        self.allow_compaction_unvalidated(compaction_commands)
-            .await?;
-        Ok(())
-    }
-
     /// Drops the read capability for the indexes and allows their resources to be reclaimed.
     pub async fn drop_indexes(&mut self, identifiers: Vec<GlobalId>) -> Result<(), ComputeError> {
         // Validate that the ids exist.
@@ -524,28 +502,6 @@ where
             .map(|id| (id, Antichain::new()))
             .collect();
         self.allow_compaction(compaction_commands).await?;
-        Ok(())
-    }
-
-    /// Drops the read capability for the indexes and allows their resources to be reclaimed.
-    /// TODO(jkosh44): This method does not validate the provided identifiers. Currently when the
-    ///     controller starts/restarts it has no durable state. That means that it has no way of
-    ///     remembering any past commands sent. In the future we plan on persisting state for the
-    ///     controller so that it is aware of past commands.
-    ///     Therefore this method is for dropping indexes that we know to have been previously
-    ///     created, but have been forgotten by the controller due to a restart.
-    ///     Once command history becomes durable we can remove this method and use the normal
-    ///     `drop_indexes`.
-    pub async fn drop_indexes_unvalidated(
-        &mut self,
-        identifiers: Vec<GlobalId>,
-    ) -> Result<(), ComputeError> {
-        let compaction_commands = identifiers
-            .into_iter()
-            .map(|id| (id, Antichain::new()))
-            .collect();
-        self.allow_compaction_unvalidated(compaction_commands)
-            .await?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR makes two simplifications to the compute controller's API around dropping compute collections:

* It removes the `drop_*_unvalidated` methods, as that functionality is not needed (see first commit).
* It merges `drop_indexes` and `drop_sinks` into a single `drop_collections` method, to remove some duplicate code (see second commit).

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
