### PR TITLE
Compute controller structs refactor

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -520,7 +520,7 @@ impl<S: Append + 'static> Coordinator<S> {
                         let dataflow_plan =
                             vec![self.finalize_dataflow(dataflow, idx.compute_instance)];
                         self.controller
-                            .compute_mut(idx.compute_instance)
+                            .active_compute(idx.compute_instance)
                             .unwrap()
                             .create_dataflows(dataflow_plan)
                             .await

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -50,7 +50,7 @@ pub struct DataflowBuilder<'a, T> {
     ///
     /// This can also be used to grab a handle to the storage abstraction, through
     /// its `storage_mut()` method.
-    pub compute: ComputeController<'a, T>,
+    pub compute: &'a ComputeController<T>,
     recursion_guard: RecursionGuard,
 }
 
@@ -102,7 +102,7 @@ impl<S: Append + 'static> Coordinator<S> {
             dataflow_plans.push(self.finalize_dataflow(dataflow, instance));
         }
         self.controller
-            .compute_mut(instance)
+            .active_compute(instance)
             .unwrap()
             .create_dataflows(dataflow_plans)
             .await

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -269,7 +269,7 @@ impl<S: Append + 'static> Coordinator<S> {
             .into_group_map();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Some(mut compute) = self.controller.compute_mut(compute_instance) {
+            if let Some(mut compute) = self.controller.active_compute(compute_instance) {
                 compute.drop_collections(ids).await.unwrap();
             }
         }
@@ -300,7 +300,7 @@ impl<S: Append + 'static> Coordinator<S> {
         }
         for (compute_instance, ids) in by_compute_instance {
             self.controller
-                .compute_mut(compute_instance)
+                .active_compute(compute_instance)
                 .unwrap()
                 .drop_collections(ids)
                 .await
@@ -327,7 +327,7 @@ impl<S: Append + 'static> Coordinator<S> {
         // TODO(chae): Drop storage sinks when they're moved over
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Some(mut compute) = self.controller.compute_mut(compute_instance) {
+            if let Some(mut compute) = self.controller.active_compute(compute_instance) {
                 compute.drop_collections(ids).await.unwrap();
             }
         }

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -25,7 +25,7 @@ use crate::coord::{CollectionIdBundle, Coordinator};
 #[derive(Debug)]
 pub struct ComputeInstanceIndexOracle<'a, T> {
     catalog: &'a CatalogState,
-    compute: ComputeController<'a, T>,
+    compute: &'a ComputeController<T>,
 }
 
 impl<S: Append> Coordinator<S> {

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -483,7 +483,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
 
                 // Very important: actually create the dataflow (here, so we can destructure).
                 self.controller
-                    .compute_mut(compute_instance)
+                    .active_compute(compute_instance)
                     .unwrap()
                     .create_dataflows(vec![dataflow])
                     .await
@@ -552,7 +552,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         let (id, literal_constraints, timestamp, _finishing, map_filter_project) = peek_command;
 
         self.controller
-            .compute_mut(compute_instance)
+            .active_compute(compute_instance)
             .unwrap()
             .peek(
                 id,
@@ -604,7 +604,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             }
             for (compute_instance, uuids) in inverse {
                 self.controller
-                    .compute_mut(compute_instance)
+                    .active_compute(compute_instance)
                     .unwrap()
                     .cancel_peeks(&uuids)
                     .await

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -179,7 +179,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 compute_policy_updates.push((*id, self.read_capability[&id].policy()));
             }
             self.controller
-                .compute_mut(*compute_instance)
+                .active_compute(*compute_instance)
                 .unwrap()
                 .set_read_policy(compute_policy_updates)
                 .await
@@ -241,7 +241,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             .expect("coord out of sync");
         capability.base_policy = base_policy;
         self.controller
-            .compute_mut(compute_instance)
+            .active_compute(compute_instance)
             .unwrap()
             .set_read_policy(vec![(id, capability.policy())])
             .await
@@ -283,9 +283,9 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         // Update COMPUTE read policies
         for (compute_instance, compute_ids) in read_holds.id_bundle.compute_ids.iter() {
             let mut policy_changes = Vec::new();
-            let mut compute = self.controller.compute_mut(*compute_instance).unwrap();
+            let mut compute = self.controller.active_compute(*compute_instance).unwrap();
             for id in compute_ids.iter() {
-                let collection = compute.as_ref().collection(*id).unwrap();
+                let collection = compute.collection(*id).unwrap();
                 assert!(collection
                     .read_frontier()
                     .less_equal(&read_holds.time),
@@ -346,9 +346,9 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         // Update COMPUTE read policies
         for (compute_instance, compute_ids) in compute_ids.iter() {
             let mut policy_changes = Vec::new();
-            let mut compute = self.controller.compute_mut(*compute_instance).unwrap();
+            let mut compute = self.controller.active_compute(*compute_instance).unwrap();
             for id in compute_ids.iter() {
-                let collection = compute.as_ref().collection(*id).unwrap();
+                let collection = compute.collection(*id).unwrap();
                 assert!(collection
                     .read_frontier()
                     .less_equal(&new_time),
@@ -409,7 +409,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     policy_changes.push((*id, read_needs.policy()));
                 }
             }
-            if let Some(mut compute) = self.controller.compute_mut(*compute_instance) {
+            if let Some(mut compute) = self.controller.active_compute(*compute_instance) {
                 compute.set_read_policy(policy_changes).await.unwrap();
             }
         }


### PR DESCRIPTION
Previously, the state of a (per-instance) compute controller was kept in a `ComputeControllerState` struct. Two wrapper structs, `ComputeController` and `ComputeControllerMut` existed to bundle this state with a `&mut StorageController`, and provide immutable and mutable access to the controller state, respectively. The environment-global `Controller` kept a collection of `ComputeControllerState`s, and converted those into `ComputeController`s/`ComputeControllerMut`s as necessary.

This commit changes this approach by replacing the above structs with two new ones: `ComputeController` and `ActiveComputeController`. `ComputeController` is what was previously the `ComputeControllerState` (plus the instance ID), whereas `ActiveComputeController` is what was previously `ComputeControllerMut`. The old `ComputeController` has been replaced by `&ComputeController`, no separate struct is required.


### Motivation

   * This PR refactors existing code.

The main motivation for this change is that it simplifies the implementation of durable [compute controller commands](https://github.com/MaterializeInc/materialize/pull/14640) (#13222). Some parts of the controller state (e.g. `stashed_response`) should not be made durable, and the new design makes factoring out the durable part of the state more straightforward. Aside from that, the new approach is also subjectively more intuitive, and it is consistent with the approach we already use in `computed` (see `ComputeState` and `ActiveComputeState`).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
