### PR TITLE
docs: Correct possible typo in hopping window example

### DIFF
--- a/doc/user/content/sql/patterns/temporal-filters.md
+++ b/doc/user/content/sql/patterns/temporal-filters.md
@@ -94,7 +94,7 @@ FROM events
 -- The interval begins here ...
 WHERE mz_logical_timestamp() >= PERIOD_MS * (insert_ms / PERIOD_MS)
 -- ... and ends here.
-  AND mz_logical_timestamp() < INTERVALS * (PERIOD_MS + insert_ms / PERIOD_MS)
+  AND mz_logical_timestamp() < PERIOD_MS * (INTERVALS + insert_ms / PERIOD_MS)
 ```
 
 Note that when `INTERVALS` is one, this query is identical to the query above it.


### PR DESCRIPTION
I think the expression for the hopping window end time in the docs has `INTERVALS` and `PERIOD_MS` interchanged; please disregard if I'm wrong though.