### PR TITLE
[sinks] Recover some exactly-once tests

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -705,9 +705,11 @@ Set the starting value of the `${kafka-ingest.iteration}` variable.
 
 Send the data to the specified partition.
 
-#### `kafka-verify format=avro sink=... [sort-messages=true] [consistency=debezium] [partial-search=usize]`
+#### `kafka-verify format=avro [sink=... | topic=...] [sort-messages=true] [partial-search=usize]`
 
-Obtains the data from the specified `sink` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test. If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The recordsdo not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
+Obtains the data from the specified `sink` or `topic` and compares it to the expected data recorded in the test. The comparison algorithm is sensitive to the order in which data arrives, so `sort-messages=true` can be used along with manually pre-sorting the expected data in the test.
+
+If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The records do not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
 
 #### `headers=<list or object>`
 

--- a/src/testdrive/src/action/kafka/verify.rs
+++ b/src/testdrive/src/action/kafka/verify.rs
@@ -259,10 +259,14 @@ impl Action for VerifyAction {
                 let mut actual_messages = vec![];
                 for (key, value) in actual_bytes {
                     let key_datum = match key {
-                        Some(bytes) if *has_key => {
-                            Some(serde_json::from_slice(&bytes).context("decoding json")?)
+                        Some(bytes) => {
+                            if *has_key {
+                                Some(serde_json::from_slice(&bytes).context("decoding json")?)
+                            } else {
+                                None
+                            }
                         }
-                        _ => None,
+                        None => None,
                     };
                     let value_datum = match value {
                         None => None,

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -144,7 +144,8 @@ $ kafka-create-topic topic=input_dbz
 $ kafka-create-topic topic=input_cdcv2
 
 > CREATE CONNECTION kafka_conn
-  FOR KAFKA BROKER '${testdrive.kafka-addr}';
+  FOR KAFKA BROKER '${testdrive.kafka-addr}',
+  PROGRESS TOPIC 'testdrive-progress-${testdrive.seed}';
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
   FOR CONFLUENT SCHEMA REGISTRY
@@ -237,10 +238,6 @@ contains:input_values_view is a view, which cannot be exported as a sink
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'output13-view-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
-> CREATE SINK output14_custom_consistency_topic FROM input_kafka_cdcv2
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output14-view-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-
 # We need some data -- any data -- to start creating timestamp bindings
 $ kafka-ingest format=avro topic=input_cdcv2 schema=${cdcv2-schema}
 {"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
@@ -249,33 +246,52 @@ $ kafka-ingest format=avro topic=input_cdcv2 schema=${cdcv2-schema}
 $ kafka-ingest format=avro topic=input_dbz schema=${dbz-schema} timestamp=1
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "source": {"lsn": {"long": 3}, "sequence": {"string": "[\"1\", \"3\"]"}, "snapshot": {"string": "false"}}, "op": "c"}
 
-# ensure that the sink works with log compaction enabled on the consistency topic
+# verify output of progress topic with fixed timestamps
 
-$ kafka-create-topic topic=compaction-test-input
-
-# create topic with known compaction settings, instead of letting
-# Materialize create it when creating the sink
-$ kafka-create-topic topic=compaction-test-output-consistency compaction=true
+> CREATE CONNECTION kafka_fixed
+  FOR KAFKA BROKER '${testdrive.kafka-addr}',
+  PROGRESS TOPIC 'testdrive-progress-fixed-${testdrive.seed}';
 
 > CREATE SOURCE compaction_test_input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-compaction-test-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-compaction-test-input-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${cdcv2-schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK compaction_test_sink FROM compaction_test_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'compaction-test-output-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_fixed (TOPIC 'compaction-test-output-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE DEBEZIUM
 
+# NB: the final timestamp is incomplete and should be present in neither output nor progress topic
 $ kafka-ingest format=avro topic=compaction-test-input schema=${cdcv2-schema}
 {"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
 {"array":[{"data":{"a":2,"b":2},"time":1,"diff":1}]}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}
-
-# We cannot observe the consistency topic, because compaction is not deterministic.
-# We indirectly test this by verifying that the data output is correct. If this
-# output were not here, something must have gone wrong with comitting to the
-# consistency topic.
+{"array":[{"data":{"a":2,"b":2},"time":3,"diff":1}]}
 
 $ kafka-verify format=avro sink=materialize.public.compaction_test_sink sort-messages=true
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "1"}}
 {"before": null, "after": {"row": {"a": 2, "b": 2}}, "transaction": {"id": "1"}}
+
+$ kafka-verify format=json key=false topic=testdrive-progress-fixed-${testdrive.seed}
+{"timestamp": 1}
+
+# verify output of progress topic with real-time timestamps
+
+$ set-regex match=\d{13} replacement=<TIMESTAMP>
+
+$ kafka-create-topic topic=rt-binding-progress-test-input
+
+> CREATE SOURCE rt_binding_progress_test_source
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rt-binding-progress-test-input-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${dbz-schema}' ENVELOPE DEBEZIUM
+
+> CREATE SINK rt_binding_progress_test_sink FROM rt_binding_progress_test_source
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'rt-binding-progress-test-output-${testdrive.seed}')
+  FORMAT AVRO
+  USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE DEBEZIUM
+
+$ kafka-ingest format=avro topic=rt-binding-progress-test-input schema=${dbz-schema} timestamp=1
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "source": {"lsn": {"long": 3}, "sequence": {"string": "[\"1\", \"3\"]"}, "snapshot": {"string": "false"}}, "op": "c"}
+
+$ kafka-verify format=avro sink=materialize.public.rt_binding_progress_test_sink
+{"before": null, "after": {"row": {"a": 1, "b": 1}}, "transaction": {"id": "<TIMESTAMP>"}}

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -247,13 +247,14 @@ $ kafka-ingest format=avro topic=input_dbz schema=${dbz-schema} timestamp=1
 {"before": null, "after": {"row": {"a": 1, "b": 1}}, "source": {"lsn": {"long": 3}, "sequence": {"string": "[\"1\", \"3\"]"}, "snapshot": {"string": "false"}}, "op": "c"}
 
 # verify output of progress topic with fixed timestamps
+$ kafka-create-topic topic=progress-test-input
 
 > CREATE CONNECTION kafka_fixed
   FOR KAFKA BROKER '${testdrive.kafka-addr}',
   PROGRESS TOPIC 'testdrive-progress-fixed-${testdrive.seed}';
 
 > CREATE SOURCE compaction_test_input
-  FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-compaction-test-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_fixed (TOPIC 'testdrive-progress-test-input-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${cdcv2-schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK compaction_test_sink FROM compaction_test_input
@@ -262,7 +263,7 @@ $ kafka-ingest format=avro topic=input_dbz schema=${dbz-schema} timestamp=1
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE DEBEZIUM
 
 # NB: the final timestamp is incomplete and should be present in neither output nor progress topic
-$ kafka-ingest format=avro topic=compaction-test-input schema=${cdcv2-schema}
+$ kafka-ingest format=avro topic=progress-test-input schema=${cdcv2-schema}
 {"array":[{"data":{"a":1,"b":1},"time":1,"diff":1}]}
 {"array":[{"data":{"a":2,"b":2},"time":1,"diff":1}]}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -144,8 +144,7 @@ $ kafka-create-topic topic=input_dbz
 $ kafka-create-topic topic=input_cdcv2
 
 > CREATE CONNECTION kafka_conn
-  FOR KAFKA BROKER '${testdrive.kafka-addr}',
-  PROGRESS TOPIC 'testdrive-progress-${testdrive.seed}';
+  FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn
   FOR CONFLUENT SCHEMA REGISTRY
@@ -276,7 +275,7 @@ $ kafka-verify format=avro sink=materialize.public.compaction_test_sink sort-mes
 $ kafka-verify format=json key=false topic=testdrive-progress-fixed-${testdrive.seed}
 {"timestamp": 1}
 
-# verify output of progress topic with real-time timestamps
+# verify output with real-time timestamps
 
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 


### PR DESCRIPTION
Re-adds some testing removed in #14526.

This also tweaks `kafka-verify` a bit; instead of direct support for consistency topics, it allows specifying a topic name explicitly instead of going via the sink. This is straightforward now that most topic names are deterministic for a particular test and seed.

### Motivation

  * This PR adds a known-desirable feature: identified followup to #14526;

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
