### PR TITLE
[sinks] Rename the `consistency_topic` field in the catalog

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1044,7 +1044,7 @@ pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("sink_id", ScalarType::String.nullable(false))
         .with_column("topic", ScalarType::String.nullable(false))
-        .with_column("consistency_topic", ScalarType::String.nullable(true))
+        .with_column("progress_topic", ScalarType::String.nullable(true))
         .with_key(vec![0]),
 });
 pub static MZ_DATABASES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -437,13 +437,13 @@ impl CatalogState {
                 StorageSinkConnection::Kafka(KafkaSinkConnection {
                     topic, consistency, ..
                 }) => {
-                    let consistency_topic = Datum::String(consistency.topic.as_str());
+                    let progress_topic = Datum::String(consistency.topic.as_str());
                     updates.push(BuiltinTableUpdate {
                         id: self.resolve_builtin_table(&MZ_KAFKA_SINKS),
                         row: Row::pack_slice(&[
                             Datum::String(&id.to_string()),
                             Datum::String(topic.as_str()),
-                            consistency_topic,
+                            progress_topic,
                         ]),
                         diff,
                     });


### PR DESCRIPTION
The current naming is pretty misleading!

### Motivation

Followup to #14526.

### Tips for reviewer

NB: I believe this is a breaking change; I'm only opening the PR now so we don't lose track. We should merge only at the next breaking release.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Rename the `consistency_topic` column in the catalog to `progress_topic`
