### PR TITLE
 adapter: accept parameters in /api/sql endpoint using portals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3341,6 +3341,7 @@ dependencies = [
  "mz-prof",
  "mz-repr",
  "mz-secrets",
+ "mz-sql",
  "mz-stash",
  "mz-storage",
  "nix",

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -233,7 +233,8 @@ pub struct ExtendedRequest {
     /// 0 or 1 queries
     pub query: String,
     /// Optional parameters for the query
-    pub params: Option<Vec<Option<String>>>,
+    #[serde(default)]
+    pub params: Vec<Option<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -103,32 +103,6 @@ impl Client {
             inner: self.clone(),
         })
     }
-
-    /// Executes SQL statements, as if by
-    /// [`SessionClient::execute_sql_http_request`], as a system user.
-    pub async fn system_execute(
-        &self,
-        stmts: &str,
-    ) -> Result<SqlHttpExecuteResponse, AdapterError> {
-        let conn_client = self.new_conn()?;
-        let session = Session::new(conn_client.conn_id(), SYSTEM_USER.into());
-        let (mut session_client, _) = conn_client.startup(session, false).await?;
-        let req = HttpSqlRequest::Simple {
-            query: stmts.to_string(),
-        };
-        session_client.execute_sql_http_request(req).await
-    }
-
-    /// Like [`Client::system_execute`], but for cases when `stmt` is known to
-    /// contain just one statement.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `stmt` parses to more than one SQL statement.
-    pub async fn system_execute_one(&self, stmt: &str) -> Result<SimpleResult, AdapterError> {
-        let response = self.system_execute(stmt).await?;
-        Ok(response.results.into_element())
-    }
 }
 
 /// A coordinator client that is bound to a connection.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -594,9 +594,9 @@ impl ExecuteResponse {
     }
 }
 
-/// The response to [`SessionClient::simple_execute`](crate::SessionClient::simple_execute).
+/// The response to [`crate::SessionClient::execute_sql_http_request`].
 #[derive(Debug, Serialize)]
-pub struct SimpleExecuteResponse {
+pub struct SqlHttpExecuteResponse {
     pub results: Vec<SimpleResult>,
 }
 

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -594,52 +594,6 @@ impl ExecuteResponse {
     }
 }
 
-/// The response to [`crate::SessionClient::execute_sql_http_request`].
-#[derive(Debug, Serialize)]
-pub struct SqlHttpExecuteResponse {
-    pub results: Vec<SimpleResult>,
-}
-
-/// The result of a single query executed with `simple_execute`.
-#[derive(Debug, Serialize)]
-#[serde(untagged)]
-pub enum SimpleResult {
-    /// The query returned rows.
-    Rows {
-        /// The result rows.
-        rows: Vec<Vec<serde_json::Value>>,
-        /// The name of the columns in the row.
-        col_names: Vec<String>,
-    },
-    /// The query executed successfully but did not return rows.
-    Ok {
-        ok: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        partial_err: Option<ExecuteResponsePartialError>,
-    },
-    /// The query returned an error.
-    Err { error: String },
-}
-
-impl SimpleResult {
-    pub(crate) fn err(msg: impl fmt::Display) -> SimpleResult {
-        SimpleResult::Err {
-            error: msg.to_string(),
-        }
-    }
-
-    /// Generates a `SimpleResult::Ok` based on an `ExecuteResponse`.
-    ///
-    /// # Panics
-    /// - If [`ExecuteResponse::partial_err`] returns an error with
-    ///   [`ClientSeverity::Error`].
-    pub(crate) fn ok(res: ExecuteResponse) -> SimpleResult {
-        let ok = res.tag();
-        let partial_err = res.partial_err();
-        SimpleResult::Ok { ok, partial_err }
-    }
-}
-
 /// The state of a cancellation request.
 #[derive(Debug, Clone, Copy)]
 pub enum Canceled {

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -40,11 +40,13 @@ mz-orchestrator-process = { path = "../orchestrator-process" }
 mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 mz-ore = { path = "../ore", features = ["task", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
+mz-pgrepr = { path = "../pgrepr" }
 mz-pgwire = { path = "../pgwire" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-prof = { path = "../prof" }
 mz-repr = { path = "../repr" }
 mz-secrets = { path = "../secrets" }
+mz-sql = { path = "../sql" }
 mz-stash = { path = "../stash" }
 mz-storage = { path = "../storage" }
 nix = "0.25.0"

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -220,8 +220,7 @@ impl SimpleResult {
     /// Generates a `SimpleResult::Ok` based on an `ExecuteResponse`.
     ///
     /// # Panics
-    /// - If [`ExecuteResponse::partial_err`] returns an error with
-    ///   [`ClientSeverity::Error`].
+    /// - If `ExecuteResponse::partial_err(&res)` panics.
     pub(crate) fn ok(res: ExecuteResponse) -> SimpleResult {
         let ok = res.tag();
         let partial_err = res.partial_err();

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -16,11 +16,13 @@
 // Axum handlers must use async, but often don't actually use `await`.
 #![allow(clippy::unused_async)]
 
+use std::convert::From;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use anyhow::anyhow;
 use async_trait::async_trait;
 use axum::extract::{FromRequest, RequestParts};
 use axum::middleware::{self, Next};
@@ -34,9 +36,11 @@ use http::header::{AUTHORIZATION, CONTENT_TYPE};
 use http::{Request, StatusCode};
 use hyper::server::conn::AddrIncoming;
 use hyper_openssl::MaybeHttpsStream;
+use itertools::izip;
 use openssl::nid::Nid;
 use openssl::ssl::{Ssl, SslContext};
 use openssl::x509::X509;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
@@ -45,11 +49,14 @@ use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 use tracing::{error, warn};
 
 use mz_adapter::catalog::HTTP_DEFAULT_USER;
-use mz_adapter::session::Session;
-use mz_adapter::SessionClient;
+use mz_adapter::session::{EndTransactionAction, Session, TransactionStatus};
+use mz_adapter::{ExecuteResponse, ExecuteResponsePartialError, PeekResponseUnary, SessionClient};
 use mz_frontegg_auth::{FronteggAuthentication, FronteggError};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::tracing::OpenTelemetryEnableCallback;
+use mz_repr::{Datum, RowArena};
+use mz_sql::ast::display::AstDisplay;
+use mz_sql::ast::{Raw, Statement};
 
 use crate::BUILD_INFO;
 
@@ -182,7 +189,358 @@ struct AuthedUser {
     create_if_not_exists: bool,
 }
 
+/// The result of a single query executed with `simple_execute`.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum SimpleResult {
+    /// The query returned rows.
+    Rows {
+        /// The result rows.
+        rows: Vec<Vec<serde_json::Value>>,
+        /// The name of the columns in the row.
+        col_names: Vec<String>,
+    },
+    /// The query executed successfully but did not return rows.
+    Ok {
+        ok: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        partial_err: Option<ExecuteResponsePartialError>,
+    },
+    /// The query returned an error.
+    Err { error: String },
+}
+
+impl SimpleResult {
+    pub(crate) fn err(msg: impl std::fmt::Display) -> SimpleResult {
+        SimpleResult::Err {
+            error: msg.to_string(),
+        }
+    }
+
+    /// Generates a `SimpleResult::Ok` based on an `ExecuteResponse`.
+    ///
+    /// # Panics
+    /// - If [`ExecuteResponse::partial_err`] returns an error with
+    ///   [`ClientSeverity::Error`].
+    pub(crate) fn ok(res: ExecuteResponse) -> SimpleResult {
+        let ok = res.tag();
+        let partial_err = res.partial_err();
+        SimpleResult::Ok { ok, partial_err }
+    }
+}
+
+/// The response to [`AuthedClient::execute_sql_http_request`].
+#[derive(Debug, Serialize)]
+pub struct SqlHttpExecuteResponse {
+    pub results: Vec<SimpleResult>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ExtendedRequest {
+    // TODO: we can remove this alias once platforms issues these requests
+    // using `query`.
+    #[serde(alias = "sql")]
+    /// 0 or 1 queries
+    pub query: String,
+    /// Optional parameters for the query
+    #[serde(default)]
+    pub params: Vec<Option<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum HttpSqlRequest {
+    /// 0 or more queries delimited by semicolons in the same strings. Do not
+    /// support parameters.
+    Simple {
+        #[serde(alias = "sql")]
+        query: String,
+    },
+    /// 0 or more [`ExtendedRequest`]s.
+    Extended { queries: Vec<ExtendedRequest> },
+}
+
 pub struct AuthedClient(pub SessionClient);
+
+impl AuthedClient {
+    /// Executes an [`HttpSqlRequest`].
+    ///
+    /// The provided `stmts` are executed directly, and their results
+    /// are returned as a vector of rows, where each row is a vector of JSON
+    /// objects.
+    pub async fn execute_sql_http_request(
+        &mut self,
+        request: HttpSqlRequest,
+    ) -> Result<SqlHttpExecuteResponse, anyhow::Error> {
+        let mut results = vec![];
+
+        match request {
+            HttpSqlRequest::Simple { query } => {
+                let stmts = mz_sql::parse::parse(&query).map_err(|e| anyhow!(e))?;
+                let num_stmts = stmts.len();
+
+                for stmt in stmts {
+                    if matches!(self.0.session().transaction(), TransactionStatus::Failed(_)) {
+                        break;
+                    }
+                    // Mirror the behavior of the PostgreSQL simple query protocol.
+                    // See the pgwire::protocol::StateMachine::query method for details.
+                    if let Err(e) = self.0.start_transaction(Some(num_stmts)).await {
+                        results.push(SimpleResult::err(e));
+                        break;
+                    }
+                    let res = self.execute_stmt(stmt, vec![]).await;
+                    if matches!(res, SimpleResult::Err { .. }) {
+                        self.0.fail_transaction();
+                    }
+                    results.push(res);
+                }
+            }
+            HttpSqlRequest::Extended { queries } => {
+                for ExtendedRequest { query, params } in queries {
+                    if matches!(self.0.session().transaction(), TransactionStatus::Failed(_)) {
+                        break;
+                    }
+
+                    let mut stmts = match mz_sql::parse::parse(&query) {
+                        Ok(stmts) => stmts,
+                        Err(e) => {
+                            results.push(SimpleResult::err(e));
+                            break;
+                        }
+                    };
+
+                    if stmts.len() > 1 {
+                        results.push(SimpleResult::err(
+                            "each query can contain at most 1 statement",
+                        ));
+                        break;
+                    }
+
+                    match stmts.pop() {
+                        Some(stmt) => {
+                            // Mirror the behavior of the PostgreSQL simple query protocol.
+                            // See the pgwire::protocol::StateMachine::query method for details.
+                            if let Err(e) = self.0.start_transaction(Some(1)).await {
+                                results.push(SimpleResult::err(e));
+                                break;
+                            }
+                            let res = self.execute_stmt(stmt, params).await;
+                            if matches!(res, SimpleResult::Err { .. }) {
+                                self.0.fail_transaction();
+                            }
+                            results.push(res);
+                        }
+                        None => {
+                            if !params.is_empty() {
+                                results.push(SimpleResult::err(
+                                    "cannot provide parameters to an empty query",
+                                ));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if self.0.session().transaction().is_implicit() {
+            self.0.end_transaction(EndTransactionAction::Commit).await?;
+        }
+        Ok(SqlHttpExecuteResponse { results })
+    }
+
+    async fn execute_stmt(
+        &mut self,
+        stmt: Statement<Raw>,
+        raw_params: Vec<Option<String>>,
+    ) -> SimpleResult {
+        let client = &mut self.0;
+
+        const EMPTY_PORTAL: &str = "";
+        if let Err(e) = client
+            .describe(EMPTY_PORTAL.into(), Some(stmt.clone()), vec![])
+            .await
+        {
+            return SimpleResult::err(e);
+        }
+
+        let prep_stmt = match client.get_prepared_statement(&EMPTY_PORTAL).await {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                return SimpleResult::err(err);
+            }
+        };
+
+        let param_types = &prep_stmt.desc().param_types;
+        if param_types.len() != raw_params.len() {
+            let message = format!(
+                "request supplied {actual} parameters, \
+                         but {statement} requires {expected}",
+                statement = (&stmt).to_ast_string(),
+                actual = raw_params.len(),
+                expected = param_types.len()
+            );
+            return SimpleResult::err(message);
+        }
+
+        let buf = RowArena::new();
+        let mut params = vec![];
+        for (raw_param, mz_typ) in izip!(raw_params, param_types) {
+            let pg_typ = mz_pgrepr::Type::from(mz_typ);
+            let datum = match raw_param {
+                None => Datum::Null,
+                Some(raw_param) => {
+                    match mz_pgrepr::Value::decode(
+                        mz_pgrepr::Format::Text,
+                        &pg_typ,
+                        &raw_param.as_bytes(),
+                    ) {
+                        Ok(param) => param.into_datum(&buf, &pg_typ),
+                        Err(err) => {
+                            let msg = format!("unable to decode parameter: {}", err);
+                            return SimpleResult::err(msg);
+                        }
+                    }
+                }
+            };
+            params.push((datum, mz_typ.clone()))
+        }
+
+        let result_formats = vec![
+            mz_pgrepr::Format::Text;
+            prep_stmt
+                .desc()
+                .relation_desc
+                .clone()
+                .map(|desc| desc.typ().column_types.len())
+                .unwrap_or(0)
+        ];
+
+        let desc = prep_stmt.desc().clone();
+        let revision = prep_stmt.catalog_revision;
+        let stmt = prep_stmt.sql().cloned();
+        if let Err(err) = client.session().set_portal(
+            EMPTY_PORTAL.into(),
+            desc,
+            stmt,
+            params,
+            result_formats,
+            revision,
+        ) {
+            return SimpleResult::err(err.to_string());
+        }
+
+        let desc = client
+            .session()
+            // We do not need to verify here because `self.execute` verifies below.
+            .get_portal_unverified(EMPTY_PORTAL)
+            .map(|portal| portal.desc.clone())
+            .expect("unnamed portal should be present");
+
+        let res = match client.execute(EMPTY_PORTAL.into()).await {
+            Ok(res) => res,
+            Err(e) => {
+                return SimpleResult::err(e);
+            }
+        };
+
+        match res {
+            ExecuteResponse::Canceled => {
+                SimpleResult::err("statement canceled due to user request")
+            }
+            res @ (ExecuteResponse::CreatedConnection { existed: _ }
+            | ExecuteResponse::CreatedDatabase { existed: _ }
+            | ExecuteResponse::CreatedSchema { existed: _ }
+            | ExecuteResponse::CreatedRole
+            | ExecuteResponse::CreatedComputeInstance { existed: _ }
+            | ExecuteResponse::CreatedComputeInstanceReplica { existed: _ }
+            | ExecuteResponse::CreatedTable { existed: _ }
+            | ExecuteResponse::CreatedIndex { existed: _ }
+            | ExecuteResponse::CreatedSecret { existed: _ }
+            | ExecuteResponse::CreatedSource { existed: _ }
+            | ExecuteResponse::CreatedSources
+            | ExecuteResponse::CreatedSink { existed: _ }
+            | ExecuteResponse::CreatedView { existed: _ }
+            | ExecuteResponse::CreatedViews { existed: _ }
+            | ExecuteResponse::CreatedMaterializedView { existed: _ }
+            | ExecuteResponse::CreatedType
+            | ExecuteResponse::Deleted(_)
+            | ExecuteResponse::DiscardedTemp
+            | ExecuteResponse::DiscardedAll
+            | ExecuteResponse::DroppedDatabase
+            | ExecuteResponse::DroppedSchema
+            | ExecuteResponse::DroppedRole
+            | ExecuteResponse::DroppedComputeInstance
+            | ExecuteResponse::DroppedComputeInstanceReplicas
+            | ExecuteResponse::DroppedSource
+            | ExecuteResponse::DroppedIndex
+            | ExecuteResponse::DroppedSink
+            | ExecuteResponse::DroppedTable
+            | ExecuteResponse::DroppedView
+            | ExecuteResponse::DroppedMaterializedView
+            | ExecuteResponse::DroppedType
+            | ExecuteResponse::DroppedSecret
+            | ExecuteResponse::DroppedConnection
+            | ExecuteResponse::EmptyQuery
+            | ExecuteResponse::Inserted(_)
+            | ExecuteResponse::StartedTransaction { duplicated: _ }
+            | ExecuteResponse::TransactionExited {
+                tag: _,
+                was_implicit: _,
+            }
+            | ExecuteResponse::Updated(_)
+            | ExecuteResponse::AlteredObject(_)
+            | ExecuteResponse::AlteredIndexLogicalCompaction
+            | ExecuteResponse::AlteredSystemConfiguraion
+            | ExecuteResponse::Deallocate { all: _ }
+            | ExecuteResponse::Prepare) => SimpleResult::ok(res),
+            ExecuteResponse::SendingRows {
+                future: rows,
+                span: _,
+            } => {
+                let rows = match rows.await {
+                    PeekResponseUnary::Rows(rows) => rows,
+                    PeekResponseUnary::Error(e) => {
+                        return SimpleResult::err(e);
+                    }
+                    PeekResponseUnary::Canceled => {
+                        return SimpleResult::err("statement canceled due to user request");
+                    }
+                };
+                let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
+                let col_names = match desc.relation_desc {
+                    Some(desc) => desc.iter_names().map(|name| name.to_string()).collect(),
+                    None => vec![],
+                };
+                let mut datum_vec = mz_repr::DatumVec::new();
+                for row in rows {
+                    let datums = datum_vec.borrow_with(&row);
+                    sql_rows.push(datums.iter().map(From::from).collect());
+                }
+                SimpleResult::Rows {
+                    rows: sql_rows,
+                    col_names,
+                }
+            }
+            ExecuteResponse::Fetch { .. }
+            | ExecuteResponse::SetVariable { .. }
+            | ExecuteResponse::Tailing { .. }
+            | ExecuteResponse::CopyTo { .. }
+            | ExecuteResponse::CopyFrom { .. }
+            | ExecuteResponse::Raise { .. }
+            | ExecuteResponse::DeclaredCursor
+            | ExecuteResponse::ClosedCursor => {
+                // NOTE(benesch): it is a bit scary to ignore the response
+                // to these types of planning *after* they have been
+                // planned, as they may have mutated state. On a quick
+                // glance, though, ignoring the execute response in all of
+                // the above situations seems safe enough, and it's a more
+                // target allowlist than the code that was here before.
+                SimpleResult::err("executing statements of this type is unsupported via this API")
+            }
+        }
+    }
+}
 
 #[async_trait]
 impl<B> FromRequest<B> for AuthedClient

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -56,7 +56,7 @@ use crate::BUILD_INFO;
 mod catalog;
 mod memory;
 mod root;
-mod sql;
+pub(crate) mod sql;
 
 #[derive(Debug, Clone)]
 pub struct Config {

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -11,12 +11,10 @@ use axum::response::IntoResponse;
 use axum::Json;
 use http::StatusCode;
 
-use mz_adapter::client::HttpSqlRequest;
-
-use crate::http::AuthedClient;
+use crate::http::{AuthedClient, HttpSqlRequest};
 
 pub async fn handle_sql(
-    AuthedClient(mut client): AuthedClient,
+    mut client: AuthedClient,
     Json(request): Json<HttpSqlRequest>,
 ) -> impl IntoResponse {
     match client.execute_sql_http_request(request).await {

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -310,13 +310,13 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
         },
-        // Syntax errors fail the request.
+        // Emtpy query OK.
         TestCase {
             query: "",
             status: StatusCode::OK,
             body: r#"{"results":[]}"#,
         },
-        // Syntax errors fail the request.
+        // Does not support parameters
         TestCase {
             query: "select $1",
             status: StatusCode::OK,
@@ -425,23 +425,18 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         TestCaseParams {
             requests: vec![("", vec![])],
             status: StatusCode::OK,
-            body: r#"{"results":[]}"#,
-        },
-        TestCaseParams {
-            requests: vec![("", vec![])],
-            status: StatusCode::OK,
-            body: r#"{"results":[]}"#,
+            body: r#"{"results":[{"error":"each query must contain exactly 1 statement"}]}"#,
         },
         // Empty query w/ param
         TestCaseParams {
             requests: vec![("", vec![Some("1")])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"error":"cannot provide parameters to an empty query"}]}"#,
+            body: r#"{"results":[{"error":"each query must contain exactly 1 statement"}]}"#,
         },
         TestCaseParams {
             requests: vec![("select 1 as col", vec![]), ("", vec![None])],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"error":"cannot provide parameters to an empty query"}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"error":"each query must contain exactly 1 statement"}]}"#,
         },
         // Multiple statements
         TestCaseParams {
@@ -450,7 +445,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
                 ("select 1; select 2;", vec![None]),
             ],
             status: StatusCode::OK,
-            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"error":"each query can contain at most 1 statement"}]}"#,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"error":"each query must contain exactly 1 statement"}]}"#,
         },
         // Txns
         // - Rolledback

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -213,105 +213,115 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
         },
-        // // # Txns
-        // // ## Txns, read only
-        // TestCase {
-        //     query: "begin; select 1; commit",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
-        // },
-        // TestCase {
-        //     query: "begin; select 1; commit; select 2;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"rows":[[2]],"col_names":["?column?"]}]}"#,
-        // },
-        // TestCase {
-        //     query: "select 1; begin; select 2; commit;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"rows":[[2]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
-        // },
-        // TestCase {
-        //     query: "begin; select 1/0; commit; select 2;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
-        // },
-        // TestCase {
-        //     query: "begin; select 1; commit; select 1/0;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
-        // },
-        // TestCase {
-        //     query: "select 1/0; begin; select 2; commit;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"error":"division by zero"}]}"#,
-        // },
-        // TestCase {
-        //     query: "select 1; begin; select 1/0; commit;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
-        // },
-        // // ## Txns w/ writes
-        // // Implicit txn aborted on first error
-        // TestCase {
-        //     query: "insert into t values (1); select 1/0; insert into t values (2)",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
-        // },
-        // // Values not successfully written due to aborted txn
-        // TestCase {
-        //     query: "select * from t;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
-        // },
-        // // Explicit txn invocation commits values w/in txn, irrespective of results outside txn
-        // TestCase {
-        //     query: "begin; insert into t values (1); commit; insert into t values (2); select 1/0;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
-        // },
-        // TestCase {
-        //     query: "select * from t;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
-        // },
-        // TestCase {
-        //     query: "delete from t;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
-        // },
-        // TestCase {
-        //     query: "delete from t;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
-        // },
-        // TestCase {
-        //     query: "select * from t;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
-        // },
-        // // Explicit txn must be terminated to commit
-        // TestCase {
-        //     query: "begin; insert into t values (1)",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
-        // },
-        // TestCase {
-        //     query: "select * from t;",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
-        // },
-        // // Syntax errors fail the request.
-        // TestCase {
-        //     query: "",
-        //     status: StatusCode::OK,
-        //     body: r#"{"results":[]}"#,
-        // },
-        // // Syntax errors fail the request.
-        // TestCase {
-        //     query: "select $1",
-        //     status: StatusCode::BAD_REQUEST,
-        //     body: r#"request supplied 0 parameters, but SELECT $1 requires 1"#,
-        // },
+        // # Txns
+        // ## Txns, read only
+        TestCase {
+            query: "begin; select 1; commit",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
+        },
+        TestCase {
+            query: "begin; select 1; commit; select 2;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"rows":[[2]],"col_names":["?column?"]}]}"#,
+        },
+        TestCase {
+            query: "select 1; begin; select 2; commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"rows":[[2]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
+        },
+        TestCase {
+            query: "begin; select 1/0; commit; select 2;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "begin; select 1; commit; select 1/0;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "select 1/0; begin; select 2; commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "select 1; begin; select 1/0; commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
+        },
+        // ## Txns w/ writes
+        // Implicit txn aborted on first error
+        TestCase {
+            query: "insert into t values (1); select 1/0; insert into t values (2)",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+        },
+        // Values not successfully written due to aborted txn
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+        },
+        // Explicit txn invocation commits values w/in txn, irrespective of results outside txn
+        TestCase {
+            query: "begin; insert into t values (1); commit; insert into t values (2); select 1/0;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+        },
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
+        },
+        TestCase {
+            query: "delete from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
+        },
+        TestCase {
+            query: "delete from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
+        },
+        TestCase {
+            query: "insert into t values (1); begin; insert into t values (2); insert into t values (3); commit;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"}]}"#,
+        },
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
+        },
+        TestCase {
+            query: "delete from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"DELETE 3"}]}"#,
+        },
+        // Explicit txn must be terminated to commit
+        TestCase {
+            query: "begin; insert into t values (1)",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
+        },
+        TestCase {
+            query: "select * from t;",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+        },
+        // Syntax errors fail the request.
+        TestCase {
+            query: "",
+            status: StatusCode::OK,
+            body: r#"{"results":[]}"#,
+        },
+        // Syntax errors fail the request.
+        TestCase {
+            query: "select $1",
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"request supplied 0 parameters, but SELECT $1 requires 1"}]}"#,
+        },
     ];
 
     for tc in tests {
@@ -390,14 +400,14 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         // Too many parameters
         TestCaseParams {
             requests: vec![("select $1 as col", Some(vec![Some("1"), Some("2")]))],
-            status: StatusCode::BAD_REQUEST,
-            body: r#"request supplied 2 parameters, but SELECT $1 AS col requires 1"#,
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"request supplied 2 parameters, but SELECT $1 AS col requires 1"}]}"#,
         },
         // Too few parameters
         TestCaseParams {
             requests: vec![("select $1+$2::int as col", Some(vec![Some("1")]))],
-            status: StatusCode::BAD_REQUEST,
-            body: r#"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2"#,
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2"}]}"#,
         },
         // NaN
         TestCaseParams {
@@ -425,19 +435,81 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         // Empty query w/ param
         TestCaseParams {
             requests: vec![("", Some(vec![Some("1")]))],
-            status: StatusCode::BAD_REQUEST,
-            body: r#"cannot provide parameters to an empty query"#,
+            status: StatusCode::OK,
+            body: r#"{"results":[{"error":"cannot provide parameters to an empty query"}]}"#,
         },
         TestCaseParams {
-            requests: vec![("", Some(vec![None]))],
-            status: StatusCode::BAD_REQUEST,
-            body: r#"cannot provide parameters to an empty query"#,
+            requests: vec![("select 1 as col", None), ("", Some(vec![None]))],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"error":"cannot provide parameters to an empty query"}]}"#,
         },
         // Multiple statements
         TestCaseParams {
-            requests: vec![("select 1; select 2;", Some(vec![None]))],
-            status: StatusCode::BAD_REQUEST,
-            body: r#"each query can contain at most 1 statement"#,
+            requests: vec![
+                ("select 1 as col", None),
+                ("select 1; select 2;", Some(vec![None])),
+            ],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"error":"each query can contain at most 1 statement"}]}"#,
+        },
+        // Txns
+        // - Rolledback
+        TestCaseParams {
+            requests: vec![
+                ("begin;", None),
+                ("insert into t values (1);", None),
+                ("rollback", None),
+            ],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"ROLLBACK"}]}"#,
+        },
+        // - Implicit txn
+        TestCaseParams {
+            requests: vec![("insert into t values (1);", None), ("select 1/0;", None)],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+        },
+        // - Errors prevent commit + further execution
+        TestCaseParams {
+            requests: vec![
+                ("begin;", None),
+                ("insert into t values (1);", None),
+                ("select 1/0;", None),
+                ("select * from t", None),
+                ("commit", None),
+            ],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
+        },
+        // - Requires explicit commit in explicit txn
+        TestCaseParams {
+            requests: vec![("begin;", None), ("insert into t values (1);", None)],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
+        },
+        TestCaseParams {
+            requests: vec![("select * from t", None)],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
+        },
+        // Writes
+        // TODO: add this to pg test
+        TestCaseParams {
+            requests: vec![
+                ("insert into t values ($1);", Some(vec![Some("1")])),
+                ("begin;", None),
+                ("insert into t values ($1);", Some(vec![Some("2")])),
+                ("insert into t values ($1);", Some(vec![Some("3")])),
+                ("commit;", None),
+                ("select 1/0", None),
+            ],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
+        },
+        TestCaseParams {
+            requests: vec![("select * from t", None)],
+            status: StatusCode::OK,
+            body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
         },
     ];
 
@@ -455,8 +527,8 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         }
         let req = mz_adapter::client::HttpSqlRequest::Extended { queries };
         let res = Client::new().post(url.clone()).json(&req).send()?;
-        assert_eq!(res.status(), tc.status);
-        assert_eq!(res.text()?, tc.body);
+        assert_eq!(res.status(), tc.status, "{:?}: {:?}", req, res.text());
+        assert_eq!(res.text()?, tc.body, "{:?}", req);
     }
 
     Ok(())

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -305,7 +305,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
     for tc in tests {
         let res = Client::new()
             .post(url.clone())
-            .json(&json!({"sql": tc.query}))
+            .json(&json!([{"query": tc.query}]))
             .send()?;
         assert_eq!(res.status(), tc.status);
         assert_eq!(res.text()?, tc.body);

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1063,7 +1063,7 @@ impl From<&Datum<'_>> for serde_json::Value {
             Datum::Float64(n) => float_to_json(n.into_inner()),
             Datum::Numeric(d) => {
                 // serde_json requires floats to be finite
-                if d.0.is_infinite() {
+                if !d.0.is_finite() {
                     serde_json::Value::String(d.0.to_string())
                 } else {
                     serde_json::Value::Number(


### PR DESCRIPTION
rewrite of #14499 using portals to support parameters

### Motivation

This PR adds a known-desirable feature. Closes https://github.com/MaterializeInc/materialize/issues/14067

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - will add a release note once approved
