### PR TITLE
adapter: rename SSH tunnel connections to `ssh-tunnel` in `mz_connections`

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -308,7 +308,7 @@ impl CatalogState {
                     }
                     mz_storage::types::connections::Connection::Postgres { .. } => "postgres",
                     mz_storage::types::connections::Connection::Aws(..) => "aws",
-                    mz_storage::types::connections::Connection::Ssh { .. } => "ssh",
+                    mz_storage::types::connections::Connection::Ssh { .. } => "ssh-tunnel",
                 }),
             ]),
             diff,

--- a/test/ssh-connection/ssh-connections.td
+++ b/test/ssh-connection/ssh-connections.td
@@ -92,7 +92,7 @@ contains: yshtola is not an SSH connection
 > SELECT name, type FROM mz_connections;
 name    type
 ----------------
-phoenix ssh
+phoenix ssh-tunnel
 yshtola postgres
 
 # SSH tunnel dependencies are properly tracked


### PR DESCRIPTION
For consistency with other connections. It shouldn't require a migration, since the Adapter bootstrap logic should fix any inconsistencies automatically after this is deployed.

### Motivation

  * This PR fixes a recognized bug: #14666

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - SSH tunnel connections in `mz_connections` now show up as `ssh-tunnel`, instead of just `ssh`.
