### PR TITLE
cloudtest: Drastically tone down the 'shared fate' tests

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -548,7 +548,6 @@ steps:
     timeout_in_minutes: 30
     artifact_paths: junit_cloudtest_*.xml
     inputs: [test/cloudtest]
-    soft_fail: true
     plugins:
       - ./ci/plugins/cloudtest:
           args: [test/cloudtest/]

--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -12,7 +12,10 @@ from textwrap import dedent
 
 from materialize.cloudtest.application import MaterializeApplication
 
-CLUSTER_SIZE = 16
+# We would like to use large clusters here, e.g. SIZE=16, in order to get a pronounced
+# "thundering herd" effect when restarting, but due to https://github.com/MaterializeInc/materialize/issues/14689
+# clusters of sizes 8 and 16 can not be reliably started, let alone restarted.
+CLUSTER_SIZE = 4
 
 
 def populate(mz: MaterializeApplication, seed: int) -> None:
@@ -127,7 +130,7 @@ def test_kill_first_computed(mz: MaterializeApplication) -> None:
 def test_kill_all_but_one_computed(mz: MaterializeApplication) -> None:
     """Kill all computeds except one"""
     populate(mz, 4)
-    for compute_id in list(range(0, 4)) + list(range(5, CLUSTER_SIZE)):
+    for compute_id in list(range(0, 2)) + list(range(3, CLUSTER_SIZE)):
         kill_computed(mz, compute_id)
 
     validate(mz, 4)


### PR DESCRIPTION
Due to #14689 it is not possible to reliably use large cluster sizes to test shared-fate operation and restarts.

Use a 4-node cluster instead.

Fixes #14569

Relates to #14689

### Motivation

  * This PR fixes a recognized bug.
- #14569