### PR TITLE
cloudtest: Make sure kubeconfig is always available

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -48,6 +48,11 @@ echo "--- KinD: Make sure KinD is running ..."
 
 bin/ci-builder run stable kind create cluster --config misc/kind/cluster.yaml --wait 30s || true
 
+# Make sure a kubeconfig file is generated and placed in $KUBECONFIG
+# of the ci-builder container, as defined in its Dockerfile
+
+bin/ci-builder run stable kind export kubeconfig
+
 # Sometimes build cancellations prevent us from properly cleaning up the last
 # cloudtest run, so force a cleanup just in case
 


### PR DESCRIPTION
Call 'kind export kubeconfig' explicitly in order to make sure that a kubeconfig file is always generated and available regardless of the state of the kind cluster

### Motivation

  * This PR fixes a previously unreported bug.

The cloudtest CI job was failing when kubeconfig was not available for some reason. Force the file to be created and made available at the start of the CI job.