### PR TITLE
cloudtest: Disable the 'shared fate' scenarios altogether

### DIFF
--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -10,6 +10,8 @@
 import subprocess
 from textwrap import dedent
 
+import pytest
+
 from materialize.cloudtest.application import MaterializeApplication
 
 # We would like to use large clusters here, e.g. SIZE=16, in order to get a pronounced
@@ -103,7 +105,13 @@ def kill_computed(mz: MaterializeApplication, compute_id: int) -> None:
         pass
 
 
-def test_kill_all_computeds(mz: MaterializeApplication) -> None:
+pytest.skip(
+    "Start of multi-process clusters is unreliable, see gh#14689",
+    allow_module_level=True,
+)
+
+
+def test_kill_all_computeds(mz: MaterializeApplication) -> None:  # type: ignore
     """Kill all computeds"""
     populate(mz, 1)
 


### PR DESCRIPTION
Starting even a 4-node compute cluster is not reliable enough for CI

References #14689

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
