### PR TITLE
cloudtest: wire the internal port through

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -36,12 +36,15 @@ from materialize.cloudtest.k8s import K8sService, K8sStatefulSet
 class EnvironmentdService(K8sService):
     def __init__(self) -> None:
         service_port = V1ServicePort(name="sql", port=6875)
+        internal_port = V1ServicePort(name="internal", port=6877)
         self.service = V1Service(
             api_version="v1",
             kind="Service",
             metadata=V1ObjectMeta(name="environmentd", labels={"app": "environmentd"}),
             spec=V1ServiceSpec(
-                type="NodePort", ports=[service_port], selector={"app": "environmentd"}
+                type="NodePort",
+                ports=[service_port, internal_port],
+                selector={"app": "environmentd"},
             ),
         )
 
@@ -85,6 +88,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 "--persist-consensus-url=postgres://postgres@postgres.default?options=--search_path=consensus",
                 "--adapter-stash-url=postgres://postgres@postgres.default?options=--search_path=catalog",
                 "--storage-stash-url=postgres://postgres@postgres.default?options=--search_path=storage",
+                "--internal-sql-listen-addr=0.0.0.0:6877",
                 "--unsafe-mode",
             ],
             env=env,

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -44,6 +44,7 @@ class Testdrive(K8sPod):
                 "--",
                 "testdrive",
                 "--materialize-url=postgres://materialize:materialize@environmentd:6875/materialize",
+                "--materialize-url-internal=postgres://materialize:materialize@environmentd:6877/materialize",
                 "--kafka-addr=redpanda:9092",
                 "--schema-registry-url=http://redpanda:8081",
                 "--default-timeout=300s",


### PR DESCRIPTION
Now that testdrive requires the internal SQL port to be accessible, wire it all the way through K8s.

### Motivation

  * This PR fixes a previously unreported bug.

The cloudtest CI job started failing.

@jkosh44 FYI