### PR TITLE
Unique key computation: Do not call typ() in keys_with_input_keys.

### DIFF
--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -757,13 +757,18 @@ impl MirRelationExpr {
                                         {
                                             if first_id == second_id {
                                                 result.extend(
-                                                    inputs[0].typ().keys.drain(..).filter(|key| {
-                                                        key.iter().all(|c| {
-                                                            outputs.get(*c) == Some(c)
-                                                                && base_projection.get(*c)
-                                                                    == Some(c)
+                                                    input_keys
+                                                        .next()
+                                                        .unwrap()
+                                                        .iter()
+                                                        .filter(|key| {
+                                                            key.iter().all(|c| {
+                                                                outputs.get(*c) == Some(c)
+                                                                    && base_projection.get(*c)
+                                                                        == Some(c)
+                                                            })
                                                         })
-                                                    }),
+                                                        .cloned(),
                                                 );
                                             }
                                         }


### PR DESCRIPTION
### Motivation

  * This PR fixes a previously unreported bug.

`keys_with_input_keys` is supposed to compute keys using the pre-computed keys of the expression's children. It is not supposed to call `typ()` to recompute keys of an expression's child.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.

No user-facing behavior changes
