### PR TITLE
persist: special-case a shard with empty upper and empty since

### DIFF
--- a/src/persist-client/src/error.rs
+++ b/src/persist-client/src/error.rs
@@ -50,7 +50,7 @@ impl Determinacy for ExternalError {
 
 /// An error resulting from invalid usage of the API.
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub enum InvalidUsage<T> {
     /// Append bounds were invalid
     InvalidBounds {
@@ -163,7 +163,7 @@ impl<T> Determinacy for InvalidUsage<T> {
 
 /// The requested codecs don't match the actual ones in durable storage.
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub struct CodecMismatch {
     /// The requested (K, V, T, D) codecs.
     pub(crate) requested: (String, String, String, String),

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -21,6 +21,7 @@ use crate::internal::paths::PartialBatchKey;
 use crate::internal::state::{HollowBatch, HollowBatchPart};
 
 /// A [datadriven::TestCase] wrapper with helpers for parsing.
+#[derive(Debug)]
 pub struct DirectiveArgs<'a> {
     pub args: &'a HashMap<String, Vec<String>>,
     pub input: &'a str,

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -306,7 +306,6 @@ impl MetricsVecs {
             init_state: self.cmd_metrics("init_state"),
             add_and_remove_rollups: self.cmd_metrics("add_and_remove_rollups"),
             register: self.cmd_metrics("register"),
-            clone_reader: self.cmd_metrics("clone_reader"),
             compare_and_append: self.cmd_metrics("compare_and_append"),
             compare_and_append_noop:             registry.register(metric!(
                 name: "mz_persist_cmd_compare_and_append_noop",
@@ -319,6 +318,7 @@ impl MetricsVecs {
             expire_reader: self.cmd_metrics("expire_reader"),
             expire_writer: self.cmd_metrics("expire_writer"),
             merge_res: self.cmd_metrics("merge_res"),
+            become_tombstone: self.cmd_metrics("become_tombstone"),
         }
     }
 
@@ -483,7 +483,6 @@ pub struct CmdsMetrics {
     pub(crate) init_state: CmdMetrics,
     pub(crate) add_and_remove_rollups: CmdMetrics,
     pub(crate) register: CmdMetrics,
-    pub(crate) clone_reader: CmdMetrics,
     pub(crate) compare_and_append: CmdMetrics,
     pub(crate) compare_and_append_noop: IntCounter,
     pub(crate) compare_and_downgrade_since: CmdMetrics,
@@ -493,6 +492,7 @@ pub struct CmdsMetrics {
     pub(crate) expire_reader: CmdMetrics,
     pub(crate) expire_writer: CmdMetrics,
     pub(crate) merge_res: CmdMetrics,
+    pub(crate) become_tombstone: CmdMetrics,
 }
 
 #[derive(Debug)]

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -29,7 +29,7 @@ use crate::error::CodecMismatch;
 use crate::internal::machine::{retry_determinate, retry_external};
 use crate::internal::metrics::ShardMetrics;
 use crate::internal::paths::{BlobKey, PartialBlobKey, PartialRollupKey, RollupId};
-use crate::internal::state::State;
+use crate::internal::state::{NoOpStateTransition, State};
 use crate::internal::state_diff::{StateDiff, StateFieldValDiff};
 use crate::{Metrics, PersistConfig, ShardId};
 
@@ -560,7 +560,9 @@ impl StateVersions {
                 state.add_and_remove_rollups((rollup_seqno, &rollup_key), &[])
             }) {
             Continue(x) => x,
-            Break(x) => match x {},
+            Break(NoOpStateTransition(_)) => {
+                panic!("initial state transition should not be a no-op")
+            }
         };
         assert!(
             applied,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -496,7 +496,7 @@ impl PersistClient {
 
         let reader_id = LeasedReaderId::new();
         let heartbeat_ts = (self.cfg.now)();
-        let (_, read_cap) = machine
+        let reader_state = machine
             .register_leased_reader(
                 &reader_id,
                 purpose,
@@ -511,7 +511,7 @@ impl PersistClient {
             gc,
             Arc::clone(&self.blob),
             reader_id,
-            read_cap.since,
+            reader_state.since,
             heartbeat_ts,
         )
         .await;

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -1,0 +1,284 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for advancing the since to the empty antichain.  Also see empty_upper,
+# which ends up in the same place, but gets there in a different order.
+
+####### SETUP
+
+# Initialize a writer, a leased reader, a critical reader, some data, and an
+# initial since downgrade.
+register-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [0]
+
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+k2 1 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [1]
+
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [2]
+
+register-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
+----
+v5 [0]
+
+register-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
+----
+v6 [0]
+
+downgrade-since since=1 reader_id=r22222222-2222-2222-2222-222222222222
+----
+v7 [1]
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=1 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v8 0 [1]
+
+# Now advance the since to the empty antichain, closing this shard to reads.
+downgrade-since since=() reader_id=r22222222-2222-2222-2222-222222222222
+----
+v9 []
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=() reader_id=c22222222-2222-2222-2222-222222222222
+----
+v10 0 []
+
+####### SINCE IS EMPTY BUT UPPER IS NOT
+
+shard-desc
+----
+since=[] upper=[2]
+
+# Even though the shard is closed to reads, we can still write and compact. This
+# isn't particularly useful, but it keeps the separation of writers and readers
+# consistent.
+write-batch output=b2 lower=2 upper=3
+k1 2 -1
+----
+parts=1 len=1
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v11 [3]
+
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0  writer_id=w11111111-1111-1111-1111-111111111111
+----
+parts=1 len=2
+
+apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v12 true
+
+# We can still (no-op) downgrade since on both reader types.
+downgrade-since since=2 reader_id=r22222222-2222-2222-2222-222222222222
+----
+v13 []
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=2 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v14 0 []
+
+# We can still register a new leased reader and do all the normal things with
+# it.
+register-leased-reader reader_id=r33333333-3333-3333-3333-333333333333
+----
+v15 []
+
+downgrade-since since=() reader_id=r33333333-3333-3333-3333-333333333333
+----
+v16 []
+
+expire-leased-reader reader_id=r33333333-3333-3333-3333-333333333333
+----
+v17 ok
+
+# We can still register a new critical reader and do all the normal things with
+# it.
+register-critical-reader reader_id=c33333333-3333-3333-3333-333333333333
+----
+v18 []
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=() reader_id=c33333333-3333-3333-3333-333333333333
+----
+v19 0 []
+
+expire-critical-reader reader_id=c33333333-3333-3333-3333-333333333333
+----
+v20 ok
+
+# We can't read data
+snapshot as_of=2
+----
+error: Since(Antichain { elements: [] })
+
+# Flush out any maintenance so we ensure the tombstone process creates the
+# maintenance it needs.
+perform-maintenance
+----
+v21 ok
+v21 ok
+v21 ok
+v21 ok
+v21 ok
+v21 ok
+v22 ok
+v22 ok
+v22 ok
+v22 ok
+v22 ok
+
+# Now compare_and_append to the empty antichain, closing the shard to writes as
+# well. Everything still works (for idempotence), but this replaces the shard
+# with a "tombstone" which (after the final maintenance bits run) never gets
+# another SeqNo, keeps only that SeqNo in consensus (this one is still TODO, we
+# still keep the last few atm), and stores no batch data in blob.
+#
+# NB: We write data in this batch so we can test that we don't leak it.
+write-batch output=b3 lower=3 upper=() writer_id=w11111111-1111-1111-1111-111111111111
+k3 3 1
+----
+parts=1 len=1
+
+compare-and-append input=b3 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v24 []
+
+shard-desc
+----
+since=[] upper=[]
+
+# Run maintenance a few times to make sure it converges (because maintenance
+# like GC can result in followup maintenance)
+perform-maintenance
+----
+v25 ok
+
+perform-maintenance
+----
+<empty>
+
+perform-maintenance
+----
+<empty>
+
+consensus-scan from_seqno=v0
+----
+seqno=v24 batches=
+seqno=v25 batches=
+
+blob-scan-batches
+----
+<empty>
+
+####### TOMBSTONE (SINCE AND UPPER ARE BOTH EMPTY)
+
+# compare_and_append correctly returns an upper mismatch for an existing writer.
+# Description panics if you try to construct it with an empty lower, so the
+# closest we can get is u64::MAX.
+#
+# We can also do all the other writer operations.
+#
+# NB: Critically, none of these create a new seqno.
+write-batch output=b_inf lower=18446744073709551615 upper=()
+----
+parts=0 len=0
+
+compare-and-append input=b_inf writer_id=w11111111-1111-1111-1111-111111111111
+----
+error: Upper(Antichain { elements: [] })
+
+heartbeat-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v25 ok
+
+expire-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v25 ok
+
+# Perhaps counter-intuitively, we can "register" a new writer. This doesn't
+# actually register and produce a new SeqNo, but there's (intentionally) no
+# place to return an error to the persist user. Instead, we make sure we can
+# do all the above things the same with this writer.
+register-writer writer_id=w44444444-4444-4444-4444-444444444444
+----
+v25 []
+
+compare-and-append input=b_inf writer_id=w44444444-4444-4444-4444-444444444444
+----
+error: Upper(Antichain { elements: [] })
+
+heartbeat-writer writer_id=w44444444-4444-4444-4444-444444444444
+----
+v25 ok
+
+expire-writer writer_id=w44444444-4444-4444-4444-444444444444
+----
+v25 ok
+
+# Similarly, downgrade_since, as well as all the other reader operations, works
+# for an existing reader. As an odd side effect, CaDS works even when the token
+# doesn't match.
+#
+# NB: Critically, none of these create a new seqno.
+downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
+----
+v25 []
+
+expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
+----
+v25 ok
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v25 0 []
+
+compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v25 1 []
+
+expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
+----
+v25 ok
+
+# And ditto we can "register" both reader types and do the same ops.
+register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
+----
+v25 []
+
+downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
+----
+v25 []
+
+expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
+----
+v25 ok
+
+register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
+----
+v25 []
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
+----
+v25 0 []
+
+expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
+----
+v25 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -1,0 +1,255 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for advancing the upper to the empty antichain. Also see empty_since,
+# which ends up in the same place, but gets there in a different order.
+
+####### SETUP
+
+# Initialize a writer, a leased reader, a critical reader, some data, and an
+# initial since downgrade.
+register-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v2 [0]
+
+write-batch output=b0 lower=0 upper=1
+k1 0 1
+----
+parts=1 len=1
+
+write-batch output=b1 lower=1 upper=2
+k2 1 1
+----
+parts=1 len=1
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v3 [1]
+
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v4 [2]
+
+register-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
+----
+v5 [0]
+
+register-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
+----
+v6 [0]
+
+downgrade-since since=1 reader_id=r22222222-2222-2222-2222-222222222222
+----
+v7 [1]
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=1 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v8 0 [1]
+
+# Now advance the upper to the empty antichain, closing this shard to writes.
+#
+# NB: We write data in this batch so we can test that we don't leak it.
+write-batch output=b2 lower=2 upper=()
+k1 2 -1
+----
+parts=1 len=1
+
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v9 []
+
+####### UPPER IS EMPTY BUT SINCE IS NOT
+
+shard-desc
+----
+since=[1] upper=[]
+
+# Even though the shard is closed to writes, we can still compact.
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
+----
+parts=1 len=2
+
+apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
+----
+v10 true
+
+# We can still downgrade since on both reader types.
+downgrade-since since=2 reader_id=r22222222-2222-2222-2222-222222222222
+----
+v11 [2]
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=2 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v12 0 [2]
+
+# We can still register a new writer and do all the normal things with it.
+register-writer writer_id=w33333333-3333-3333-3333-333333333333
+----
+v13 []
+
+compare-and-append input=b2 writer_id=w33333333-3333-3333-3333-333333333333
+----
+error: Upper(Antichain { elements: [] })
+
+expire-writer writer_id=w33333333-3333-3333-3333-333333333333
+----
+v14 ok
+
+# We can still read data
+snapshot as_of=2
+----
+k2 2 1
+
+# Flush out any maintenance so we ensure the tombstone process creates the
+# maintenance it needs.
+perform-maintenance
+----
+v15 ok
+v15 ok
+v15 ok
+v15 ok
+v16 ok
+v16 ok
+v16 ok
+
+# Now downgrade_since to empty antichain, closing the shard to reads as well.
+# Everything still works (for idempotence), but this replaces the shard with a
+# "tombstone" which (after the final maintenance bits run) never gets another
+# SeqNo, keeps only that SeqNo in consensus (this one is still TODO, we still
+# keep the last few atm), and stores no batch data in blob.
+downgrade-since since=() reader_id=r22222222-2222-2222-2222-222222222222
+----
+v17 []
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=() reader_id=c22222222-2222-2222-2222-222222222222
+----
+v19 0 []
+
+shard-desc
+----
+since=[] upper=[]
+
+# Run maintenance a few times to make sure it converges (because maintenance
+# like GC can result in followup maintenance)
+perform-maintenance
+----
+v19 ok
+v20 ok
+
+perform-maintenance
+----
+<empty>
+
+perform-maintenance
+----
+<empty>
+
+consensus-scan from_seqno=v0
+----
+seqno=v19 batches=
+seqno=v20 batches=
+
+blob-scan-batches
+----
+<empty>
+
+####### TOMBSTONE (SINCE AND UPPER ARE BOTH EMPTY)
+
+# compare_and_append correctly returns an upper mismatch for an existing writer.
+# Description panics if you try to construct it with an empty lower, so the
+# closest we can get is u64::MAX.
+#
+# We can also do all the other writer operations.
+#
+# NB: Critically, none of these create a new seqno.
+write-batch output=b_inf lower=18446744073709551615 upper=()
+----
+parts=0 len=0
+
+compare-and-append input=b_inf writer_id=w11111111-1111-1111-1111-111111111111
+----
+error: Upper(Antichain { elements: [] })
+
+heartbeat-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v20 ok
+
+expire-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+v20 ok
+
+# Perhaps counter-intuitively, we can "register" a new writer. This doesn't
+# actually register and produce a new SeqNo, but there's (intentionally) no
+# place to return an error to the persist user. Instead, we make sure we can
+# do all the above things the same with this writer.
+register-writer writer_id=w44444444-4444-4444-4444-444444444444
+----
+v20 []
+
+compare-and-append input=b_inf writer_id=w44444444-4444-4444-4444-444444444444
+----
+error: Upper(Antichain { elements: [] })
+
+heartbeat-writer writer_id=w44444444-4444-4444-4444-444444444444
+----
+v20 ok
+
+expire-writer writer_id=w44444444-4444-4444-4444-444444444444
+----
+v20 ok
+
+# Similarly, downgrade_since, as well as all the other reader operations, works
+# for an existing reader. As an odd side effect, CaDS works even when the token
+# doesn't match.
+#
+# NB: Critically, none of these create a new seqno.
+downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
+----
+v20 []
+
+expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
+----
+v20 ok
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v20 0 []
+
+compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
+----
+v20 1 []
+
+expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
+----
+v20 ok
+
+# And ditto we can "register" both reader types and do the same ops.
+register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
+----
+v20 []
+
+downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
+----
+v20 []
+
+expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
+----
+v20 ok
+
+register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
+----
+v20 []
+
+compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
+----
+v20 0 []
+
+expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
+----
+v20 ok

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -86,11 +86,11 @@ seqno=v5 batches=b0,b1
 seqno=v6 batches=b0,b1,b2
 
 # compact and merge b0 and b1 into b0_1
-compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0
+compact output=b0_1 inputs=(b0,b1) lower=0 upper=2 since=0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 parts=1 len=3
 
-apply-merge-res input=b0_1
+apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v7 true
 

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -43,7 +43,7 @@ compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v6 [3]
 
-compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0
+compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 parts=1 len=2
 
@@ -62,7 +62,7 @@ compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 v7 [4]
 
 # Now apply the merged batch.
-apply-merge-res input=b0_1
+apply-merge-res input=b0_1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 v8 true
 


### PR DESCRIPTION
If the upper and shard-global since are both the empty antichain, then
no further writes can ever commit and no further reads can be served.
Optimize the shard into a final unchanging tombstone state by replacing
the spine with a single empty batch and clearing the reader and writer
registrations.

Also included are a couple tweaks that I felt helped make this easier to
reason about:
- We no longer allow compare_and_append with lower == upper (which we
  only allowed with empty updates). This was added originally to make
  heartbeats easier, but now that we have an explicit writer heartbeat
  cmd, it's now just adding complexity to the compare_and_append impl.
  (Hit this because I was thinking about CaA on a batch with empty lower
  and empty upper against a shard with upper empty.)
- Split the Break type for compare_and_append into an enum. It was
  previously abusing Result (me being lazy and it's been bugging me
  since), but now that we need 3 variants, it seems like a clear time to
  fix this. Edit: the 3rd variant actually got pulled out, but it still
  feels nice to not be abusing Result, so I left the new enum in.
- Reject any apply_merge_res from an expired writer. This is important
  to our leaked blob detection story, but was missing.
- Eliminate the clone_reader cmd. It was exactly the same impl as
  register_reader. Instead, we replace it with an assert in
  ReadHandle::clone that the since of the new registration is <= the
  since of the handle being cloned.
- Make apply_unbatched_idempotent_cmd return optional maintenance for
  no-op cmd application on tombstone shards.
- Allow specifying a writer_id in `compact` datadriven machine tests. If
  unspecified, it defaults to WriterId::new().

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

- I'm a little scared to merge this PR and run. It's pretty well tested, but there's been soooo much subtlety during development. The tests have caught a number of bugs, but also several times the tests passed unexpectedly, so I'm a little skeptical of them.
- There's an open question here around how much we care about leaking the data of the last compare_and_append batch _if the since was advanced to empty first_. The code is fine if the upper was advanced to empty before the since was (you'll see why when you review). The latter is the expected case in production, so I dunno how much we care. I tried another approach to the PR where `apply_unbatched_cmd` did the tombstone check and then `become_tombstone` became an explicit state transition. That seems much cleaner and easier to reason about, but apparently `async fn`s cannot be recursive unless you box them with some third party crate. I'm going to let this mull overnight, but I'm curious how y'all feel about it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [N/A]  This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
