### PR TITLE
docs: Add consistency docs

### DIFF
--- a/doc/user/content/sql/_index.md
+++ b/doc/user/content/sql/_index.md
@@ -17,6 +17,7 @@ This section is a reference that details the SQL commands and features we suppor
 - [Identifiers](./identifiers)
 - [Namespaces](./namespaces)
 - [System catalog](./system-catalog)
+- [Isolation level](./isolation-level)
 
 ## Statements
 

--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -49,22 +49,25 @@ SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE';
 The SQL standard defines the Serializable isolation level as preventing the following three phenomenons:
 
 - **P1 (”Dirty Read”):**
-  > SQL-transaction T1 modifies a row. SQL-transaction T2 then reads that row before T1 performs a
+  > "SQL-transaction T1 modifies a row. SQL-transaction T2 then reads that row before T1 performs a
   COMMIT. If T1 then performs a ROLLBACK, T2 will have read a row that was never committed and that may thus be
-  considered to have never existed.
+  considered to have never existed."
+  (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
 
 - **P2 (”Non-repeatable read”):**
 
-  > SQL-transaction T1 reads a row. SQL-transaction T2 then modifies or deletes that row and performs
+  > "SQL-transaction T1 reads a row. SQL-transaction T2 then modifies or deletes that row and performs
   a COMMIT. If T1 then attempts to reread the row, it may receive the modified value or discover that the row has been
-  deleted.
+  deleted."
+  (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
 
 - **P3 (”Phantom”):**
 
-  > SQL-transaction T1 reads the set of rows N that satisfy some <search condition>. SQL-transaction
+  > "SQL-transaction T1 reads the set of rows N that satisfy some <search condition>. SQL-transaction
   T2 then executes SQL-statements that generate one or more rows that satisfy the <search condition> used by
   SQL-transaction T1. If SQL-transaction T1 then repeats the initial read with the same <search condition>, it obtains a
-  different collection of rows.
+  different collection of rows."
+  (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
 
 Furthermore, Serializable also guarantees that the result of executing a group of concurrent SQL-transactions produces
 the same effect as some serial execution of those same transactions. A serial execution is one where each

--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -74,8 +74,7 @@ consistent with the real time ordering of the transactions, in other words trans
 if SQL-transaction T1 happens before SQL-transaction T2 in real time, then the result may be equivalent to a serial
 order where T2 was executed first.
 
-In practice non-linearizable orderings are unlikely to happen, but still possible, when querying directly from tables
-and sources. Non-linearizable orderings are likely to surface when querying from indexes and materialized views with
+Non-linearizable orderings are more likely to surface when querying from indexes and materialized views with
 large propagation delays. For example, if SQL-transaction T1 happens before SQL-transaction T2 in real time, T1 queries
 table t, and T2 queries materialized view mv where mv is an expensive materialized view including t, then T2 may not see
 all the rows that were seen by T1 if they are executed close enough together in real time.

--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -1,0 +1,87 @@
+---
+title: "Isolation Level"
+description: "The isolation level defines how Materialize isolates the execution of transactions."
+aliases:
+ - /sql/consistency
+menu:
+  main:
+    parent: 'reference'
+    weight: 160
+---
+
+The SQL standard defines four levels of transaction isolation. In order of least strict to most strict they are Read
+Uncommitted, Read Committed, Repeatable Read, and Serializable. In Materialize, you can request any of these isolation
+levels, but they all behave the same as the Serializable isolation level. In addition to the four levels defined in the
+SQL Standard, Materialize also defines a Strict Serializable isolation level.
+
+Isolation level is a per session configurable variable. To set the current session’s isolation level you can
+execute `SET TRANSACTION_ISOLATION TO '<isolation-level>';`. The default isolation level is Strict Serializable.
+
+## Serializable
+
+The SQL standard defines the Serializable isolation level as preventing the following three phenomenons:
+
+- **P1 (”Dirty Read”):**
+  > SQL-transaction T1 modifies a row. SQL-transaction T2 then reads that row before T1 performs a
+  COMMIT. If T1 then performs a ROLLBACK, T2 will have read a row that was never committed and that may thus be
+  considered to have never existed.
+
+- **P2 (”Non-repeatable read”):**
+
+  > SQL-transaction T1 reads a row. SQL-transaction T2 then modifies or deletes that row and performs
+  a COMMIT. If T1 then attempts to reread the row, it may receive the modified value or discover that the row has been
+  deleted.
+
+- **P3 (”Phantom”):**
+
+  > SQL-transaction T1 reads the set of rows N that satisfy some <search condition>. SQL-transaction
+  T2 then executes SQL-statements that generate one or more rows that satisfy the <search condition> used by
+  SQL-transaction T1. If SQL-transaction T1 then repeats the initial read with the same <search condition>, it obtains a
+  different collection of rows.
+
+Furthermore, Serializable also guarantees that the result of executing a group of concurrent SQL-transactions produces
+the same effect as some serial execution of those same transactions. A serial execution is one where each
+SQL-transaction executes to completion before the next one begins. There is no guarantee that this serial ordering is
+consistent with the real time ordering of the transactions, in other words transactions are not linearizable under the
+Serializable isolation level. For example if SQL-transaction T1 happens before SQL-transaction T2 in real time, then the
+result may be equivalent to a serial order where T2 was executed first.
+
+In practice non-linearizable orderings are unlikely to happen, but still possible, when querying directly from tables
+and sources. Non-linearizable orderings are likely to surface when querying from indexes and materialized views with
+large propagation delays. For example, if SQL-transaction T1 happens before SQL-transaction T2 in real time, T1 queries
+table t, and T2 queries materialized view mv where mv is an expensive materialized view including t, then T2 may not see
+all the rows that were seen by T1 if they are executed close enough together in real time.
+
+## Strict Serializable
+
+The Strict Serializable isolation level provides all the same guarantees as Serializable, with the addition that
+transactions are linearizable. That means that if SQL-transaction T1 happens before SQL-transaction T2 in real time,
+then the execution is equivalent to a serial execution where T1 comes before T2.
+
+For example, if SQL-transaction T1 happens before SQL-transaction T2 in real time, T1 queries table t, and
+T2 queries materialized view mv where mv is an expensive materialized view including t, then T2 is guaranteed to see all
+of the rows that were seen by T1.
+
+It’s important to note that the linearizable guarantee only applies to transactions (including single statement SQL
+queries which are implicitly single statement transactions), not to data written while ingesting from upstream sources.
+So if some piece of data has been fully ingested from an upstream source, then it is not guaranteed to appear in the
+next read transaction. See https://github.com/MaterializeInc/materialize/issues/11531
+and https://github.com/MaterializeInc/materialize/issues/13107 for more details. If some piece of data has been
+fully ingested from an upstream source AND is included in the results of some read transaction THEN all subsequent read
+transactions are guaranteed to see that piece of data.
+
+## Choosing the Right Isolation Level
+
+It may not be immediately clear which isolation level is right for you. Materialize recommends to start with the default
+Strict Serializable isolation level. If you are noticing performance issues on reads, and your application does not need
+linearizable transactions, then you should downgrade to the Serializable isolation level.
+
+Strict Serializable provides stronger consistency guarantees but may have slower reads than Serializable. This is
+because Strict Serializable may need to wait for writes to propagate through materialized views and indexes, while
+Serializable does not.
+
+See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html) for more information on
+isolation levels.
+
+See the [Jepsen Consistency Models documentation](https://jepsen.io/consistency) for more information on consistency
+models.

--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -9,10 +9,16 @@ menu:
     weight: 160
 ---
 
-The SQL standard defines four levels of transaction isolation. In order of least strict to most strict they are Read
-Uncommitted, Read Committed, Repeatable Read, and Serializable. In Materialize, you can request any of these isolation
+The SQL standard defines four levels of transaction isolation. In order of least strict to most strict they are:
+
+  * Read Uncommitted
+  * Read Committed
+  * Repeatable Read
+  * Serializable. 
+
+In Materialize, you can request any of these isolation
 levels, but they all behave the same as the Serializable isolation level. In addition to the four levels defined in the
-SQL Standard, Materialize also defines a Strict Serializable isolation level.
+SQL Standard, Materialize also defines a [Strict Serializable](#strict-serializable) isolation level.
 
 Isolation level is a per session configurable variable. To set the current session’s isolation level you can
 execute `SET TRANSACTION_ISOLATION TO '<isolation-level>';`. The default isolation level is Strict Serializable.
@@ -65,10 +71,10 @@ of the rows that were seen by T1.
 It’s important to note that the linearizable guarantee only applies to transactions (including single statement SQL
 queries which are implicitly single statement transactions), not to data written while ingesting from upstream sources.
 So if some piece of data has been fully ingested from an upstream source, then it is not guaranteed to appear in the
-next read transaction. See https://github.com/MaterializeInc/materialize/issues/11531
-and https://github.com/MaterializeInc/materialize/issues/13107 for more details. If some piece of data has been
-fully ingested from an upstream source AND is included in the results of some read transaction THEN all subsequent read
-transactions are guaranteed to see that piece of data.
+next read transaction. See [real-time recency](https://github.com/MaterializeInc/materialize/issues/11531)
+and [strengthening correctness](https://github.com/MaterializeInc/materialize/issues/13107) for more details. If some
+piece of data has been fully ingested from an upstream source AND is included in the results of some read transaction
+THEN all subsequent read transactions are guaranteed to see that piece of data.
 
 ## Choosing the Right Isolation Level
 
@@ -80,8 +86,11 @@ Strict Serializable provides stronger consistency guarantees but may have slower
 because Strict Serializable may need to wait for writes to propagate through materialized views and indexes, while
 Serializable does not.
 
-See the [PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html) for more information on
-isolation levels.
 
-See the [Jepsen Consistency Models documentation](https://jepsen.io/consistency) for more information on consistency
-models.
+## Learn more
+
+Check out:
+
+- [PostgreSQL documentation](https://www.postgresql.org/docs/current/transaction-iso.html) for more information on
+  isolation levels.
+- [Jepsen Consistency Models documentation](https://jepsen.io/consistency) for more information on consistency models.

--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -20,8 +20,29 @@ In Materialize, you can request any of these isolation
 levels, but they all behave the same as the Serializable isolation level. In addition to the four levels defined in the
 SQL Standard, Materialize also defines a [Strict Serializable](#strict-serializable) isolation level.
 
-Isolation level is a per session configurable variable. To set the current session’s isolation level you can
-execute `SET TRANSACTION_ISOLATION TO '<isolation-level>';`. The default isolation level is Strict Serializable.
+Isolation level is a per session configurable variable that can be set by the user. The default isolation level is
+[Strict Serializable](#strict-serializable).
+
+## Syntax
+
+{{< diagram "set-transaction-isolation.svg" >}}
+
+| Valid Isolation Levels                      |
+|---------------------------------------------|
+| [Read Uncommitted](#serializable)           |
+| [Read Committed](#serializable)             |
+| [Repeatable Read](#serializable)            |
+| [Serializable](#serializable)               |
+| [Strict Serializable](#strict-serializable) |
+
+## Examples
+
+```sql
+SET TRANSACTION_ISOLATION TO 'SERIALIZABLE';
+```
+```sql
+SET TRANSACTION_ISOLATION TO 'STRICT SERIALIZABLE';
+```
 
 ## Serializable
 
@@ -48,9 +69,10 @@ The SQL standard defines the Serializable isolation level as preventing the foll
 Furthermore, Serializable also guarantees that the result of executing a group of concurrent SQL-transactions produces
 the same effect as some serial execution of those same transactions. A serial execution is one where each
 SQL-transaction executes to completion before the next one begins. There is no guarantee that this serial ordering is
-consistent with the real time ordering of the transactions, in other words transactions are not linearizable under the
-Serializable isolation level. For example if SQL-transaction T1 happens before SQL-transaction T2 in real time, then the
-result may be equivalent to a serial order where T2 was executed first.
+consistent with the real time ordering of the transactions, in other words transactions are not
+[linearizable](https://jepsen.io/consistency/models/linearizable) under the Serializable isolation level. For example
+if SQL-transaction T1 happens before SQL-transaction T2 in real time, then the result may be equivalent to a serial
+order where T2 was executed first.
 
 In practice non-linearizable orderings are unlikely to happen, but still possible, when querying directly from tables
 and sources. Non-linearizable orderings are likely to surface when querying from indexes and materialized views with

--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -14,7 +14,7 @@ The SQL standard defines four levels of transaction isolation. In order of least
   * Read Uncommitted
   * Read Committed
   * Repeatable Read
-  * Serializable. 
+  * Serializable
 
 In Materialize, you can request any of these isolation
 levels, but they all behave the same as the Serializable isolation level. In addition to the four levels defined in the

--- a/doc/user/layouts/partials/sql-grammar/set-transaction-isolation.svg
+++ b/doc/user/layouts/partials/sql-grammar/set-transaction-isolation.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="565" height="81">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="46" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SET</text>
+   <rect x="97" y="3" width="208" height="32" rx="10"/>
+   <rect x="95"
+         y="1"
+         width="208"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="105" y="21">TRANSACTION_ISOLATION</text>
+   <rect x="345" y="3" width="40" height="32" rx="10"/>
+   <rect x="343"
+         y="1"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="21">TO</text>
+   <rect x="345" y="47" width="28" height="32" rx="10"/>
+   <rect x="343"
+         y="45"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="65">=</text>
+   <rect x="425" y="3" width="112" height="32"/>
+   <rect x="423" y="1" width="112" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="433" y="21">isolation_level</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m46 0 h10 m0 0 h10 m208 0 h10 m20 0 h10 m40 0 h10 m-80 0 h20 m60 0 h20 m-100 0 q10 0 10 10 m80 0 q0 -10 10 -10 m-90 10 v24 m80 0 v-24 m-80 24 q0 10 10 10 m60 0 q10 0 10 -10 m-70 10 h10 m28 0 h10 m0 0 h12 m20 -44 h10 m112 0 h10 m3 0 h-3"/>
+   <polygon points="555 17 563 13 563 21"/>
+   <polygon points="555 17 547 13 547 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -283,6 +283,8 @@ select_stmt ::=
   ( 'LIMIT' integer )?
   ( 'OFFSET' integer )?
   ( ( 'UNION' | 'INTERSECT' | 'EXCEPT' ) ( 'ALL' | 'DISTINCT' )? another_select_stmt )?
+set_transaction_isolation ::=
+  'SET' 'TRANSACTION_ISOLATION' ( 'TO' | '=' ) isolation_level
 show_columns ::=
   'SHOW' 'COLUMNS' 'FROM' item_ref ('LIKE' 'pattern' | 'WHERE' expr)
 show_connections ::=


### PR DESCRIPTION
This commit adds user documentation describing the consistency guarantees of Materialize.

Fixes #14330

### Motivation
Adds documenation.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
