### PR TITLE
testdrive: Fix bit rot in Kafka-topic related tests

### DIFF
--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -37,7 +37,7 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
 > CREATE DEFAULT INDEX ON mz_data
 
 > CREATE SINK sink1 FROM mz_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE VIEW mz_view AS
@@ -202,7 +202,7 @@ materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"de
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'snk1') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-snk1-${testdrive.seed}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -9,7 +9,7 @@
 
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
-$ kafka-create-topic topic=test
+$ kafka-create-topic topic=test partitions=1
 $ kafka-ingest topic=test format=bytes
 jack,jill
 goofus,gallant
@@ -43,7 +43,7 @@ goofus,gallant
 # We should refuse to create a sink with invalid WITH options
 
 ! CREATE SINK invalid_with_option FROM src
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Expected one of SNAPSHOT
@@ -56,30 +56,30 @@ name
 #
 # # Invalid in that the address is not well formed
 # ! CREATE SINK bad_schema_registry FROM v3
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.kafka-addr}'
 # contains:cannot construct a CCSR client with a cannot-be-a-base URL
 #
 # # Invalid in that the address points to an invalid host
 # ! CREATE SINK bad_schema_registry FROM v3
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://no-such-host'
 # contains:unable to publish value schema to registry in kafka sink
 #
 # # Invalid in that the address is not for a schema registry
 # ! CREATE SINK bad_schema_registry FROM v3
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialized:6875'
 # contains:unable to publish value schema to registry in kafka sink
 #
 # ! CREATE SINK bad_view FROM v1
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 # contains:v1 is a view, which cannot be exported as a sink
 #
 # # ...Even if that view is based on a materialized source
 # ! CREATE SINK bad_view2 FROM v2
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
 #   WITH (retention_ms=1000000)
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 # contains:v2 is a view, which cannot be exported as a sink
@@ -92,15 +92,15 @@ name
 # that depend on views, as the code paths are different.
 
 > CREATE SINK snk1 FROM src
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk1-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK snk2 FROM src_materialized
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk2')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk2-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK snk3 FROM v3
-  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = 1000000000000, TOPIC 'snk3')
+  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = 1000000000000, TOPIC 'testdrive-snk3-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > SHOW SINKS
@@ -135,7 +135,7 @@ $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
   SELECT true AS c FROM src
 
 > CREATE SINK snk4 FROM v4
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk4')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk4-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.snk4
@@ -150,12 +150,12 @@ $ kafka-verify format=avro sink=materialize.public.snk4
 # exclude the old rows.
 
 > CREATE SINK snk5 FROM src_materialized
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk5')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk5-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT = false)
 
 > CREATE SINK snk6 FROM src_materialized
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk6')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk6-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT = true)
 
@@ -175,12 +175,12 @@ $ kafka-verify format=avro sink=materialize.public.snk6 sort-messages=true
 > CREATE MATERIALIZED VIEW foo AS VALUES (1), (2), (3);
 
 > CREATE SINK snk7 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk7')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk7-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT = false)
 
 > CREATE SINK snk8 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk8')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk8-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT)
 
@@ -203,25 +203,25 @@ snk8        user
 
 # test explicit partition count
 > CREATE SINK snk9 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, TOPIC 'snk9')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, TOPIC 'testdrive-snk9-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test explicit replication factor
 > CREATE SINK snk10 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR=1, TOPIC 'snk10')
+  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR=1, TOPIC 'testdrive-snk10-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test explicit partition count and replication factor
 > CREATE SINK snk11 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, REPLICATION FACTOR=1, TOPIC 'snk11')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, REPLICATION FACTOR=1, TOPIC 'testdrive-snk11-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test broker defaulted partition count and replication factor
 > CREATE SINK snk12 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk12')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-snk12-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test explicit request for broker defaulted partition count and replication factor
 > CREATE SINK snk13 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=-1, REPLICATION FACTOR=-1, TOPIC 'snk13')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=-1, REPLICATION FACTOR=-1, TOPIC 'testdrive-snk13-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn


### PR DESCRIPTION
- tests that examine offsets need to have partitions=1 hard-coded so that they can also run with testdrive --kafka-default-partitions=>1 @bkirwi FYI

- to avoid conflicts across tests, TOPIC names must be made unique by including ${testdrive.seed}, which is unique for every individual test that testdrive runs. @sploiselle

### Motivation

  * This PR fixes a previously unreported bug.
Nightly testdrive builds were failing because they were running conflicting tests in a single CI job. The per-push CI is apparently running those same tests in paralle, so the conflicts do not show up there.

### Tips for reviewer

@sploiselle I only fixed the tests that were causing conflicts. However, there are many more instances of TOPIC names that do not include `${testdrive.seed}`. I tried to come up with a smart `sed -i` one-liner that would cover them but could not.

```
pstoev@Ubuntu-2004-focal-64-minimal:~/philip-stoev-testdrive-fix-sink-tests/test/testdrive$ grep -F 'TOPIC ' *.td | grep -v seed | grep -v -F '!' | grep -v INCLUDE | grep -v REFRESH
connection-create-drop.td:  FROM KAFKA CONNECTION does_not_exist (TOPIC 'error_topic')
consolidation.td:#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'nums-sink')
csv-sources.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'static-csv-pkne-sink')
dependencies.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v')
dependencies.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v')
dependencies.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v2')
dependencies.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v3')
kafka-avro-debezium-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink')
kafka-avro-sinks.td:#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-cols-sink')
kafka-avro-sinks.td:#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'clashing-cols-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'datetime-data-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'time-data-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'json-data-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'map-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'list-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'namespace-value-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'namespace-key-value-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a, a)
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink')
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a)
kafka-avro-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a)
kafka-avro-sources.td:  FROM KAFKA CONNECTION kafka_conn (TOPIC 'ignored')
kafka-avro-upsert-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'upsert-input-sink')
kafka-json-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-upsert')
kafka-json-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'types-sink')
kafka-json-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'special-characters-sink')
kafka-json-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'record-sink')
kafka-json-sinks.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'complex-type-sink')
kafka-time-offset.td:  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, TOPIC 'missing_topic')
materializations.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-view2-sink')
materializations.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-view2-sink')
temporary.td:  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
testdrive.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-verify-regexp-sink')
uuid.td:  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data')
```

Ideally, we should have `testdrive` fail at startup if the .td file (whose contents we already parse at test startup) contains a `CREATE` statement with a `TOPIC` that does not include a seed.