### PR TITLE
feature-benchmark: Disable the Nightly CI jobs

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -30,8 +30,8 @@ steps:
           - { value: testdrive-workers-1 }
           - { value: testdrive-workers-32 }
           - { value: testdrive-partitions-5 }
-          - { value: feature-benchmark-single-node }
-          - { value: feature-benchmark-cluster }
+#          - { value: feature-benchmark-single-node }
+#          - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
           - { value: zippy-user-tables }
           - { value: secrets }
@@ -62,39 +62,40 @@ steps:
 
   - wait: ~
 
-  - id: feature-benchmark-single-node
-    label: "Feature benchmark (single node)"
-    timeout_in_minutes: 360
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args:
-            - --this-nodes
-            - 1
-            - --this-workers
-            - 4
-            - --other-tag
-            - latest
-            - --other-options
-            - --workers 4
+# Disabled until we formulate a general performance strategy
+#  - id: feature-benchmark-single-node
+#    label: "Feature benchmark (single node)"
+#    timeout_in_minutes: 360
+#    agents:
+#      queue: linux-x86_64
+#    plugins:
+#      - ./ci/plugins/mzcompose:
+#          composition: feature-benchmark
+#          args:
+#            - --this-nodes
+#            - 1
+#            - --this-workers
+#            - 4
+#            - --other-tag
+#            - latest
+#            - --other-options
+#            - --workers 4
 
-  - id: feature-benchmark-cluster
-    label: "Feature benchmark (cluster)"
-    timeout_in_minutes: 360
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args:
-            - --this-nodes
-            - 4
-            - --other-tag
-            - latest
-            - --other-options
-            - --workers 4
+#  - id: feature-benchmark-cluster
+#    label: "Feature benchmark (cluster)"
+#    timeout_in_minutes: 360
+#    agents:
+#      queue: linux-x86_64
+#    plugins:
+#      - ./ci/plugins/mzcompose:
+#          composition: feature-benchmark
+#          args:
+#            - --this-nodes
+#            - 4
+#            - --other-tag
+#            - latest
+#            - --other-options
+#            - --workers 4
 
   - id: coverage
     label: Code coverage


### PR DESCRIPTION
The jobs have started failing due to shifting SQL syntax. Disable until a performance strategy is formulated.


### Motivation

  * This PR fixes a previously unreported bug.
The Feature benchmarks Nightly CI jobs were failing.


### Tips for reviewer

@uce , @benesch , I am abandoning this hill altogether.

Repeated changes to the SQL syntax make it impossible to run the feature benchmarks in comparison mode unless for many scenarios we maintain multiple versions of each scenario . I expect further breaking changes to the syntaxes going forward and accounting for them is not a maintenance battle that I want to wage right now.

I am disabling the feature benchmark CI jobs until: 
- the syntax stabilizes
- we release a syntax-compatible version on Docker Hub that can be used as a baseline version for performance comparisons.