### PR TITLE
test: better mzcompose tests for SSH connections

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -773,3 +773,18 @@ class Metabase(Service):
                 "ports": ["3000"],
             },
         )
+
+
+class SshBastionHost(Service):
+    def __init__(self, name: str = "ssh-bastion-host") -> None:
+        super().__init__(
+            name=name,
+            config={
+                "image": "panubo/sshd:1.5.0",
+                "ports": ["22"],
+                "environment": [
+                    "SSH_USERS=mz:1000:1000",
+                    "TCP_FORWARDING=true",
+                ],
+            },
+        )

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -8,16 +8,132 @@
 # by the Apache License, Version 2.0.
 
 from materialize.mzcompose import Composition
-from materialize.mzcompose.services import Materialized, Testdrive
+from materialize.mzcompose.services import (
+    Materialized,
+    Postgres,
+    SshBastionHost,
+    TestCerts,
+    Testdrive,
+)
 
 SERVICES = [
     Materialized(),
     Testdrive(),
+    SshBastionHost(),
+    Postgres(),
+    TestCerts(),
 ]
 
 
-def workflow_default(c: Composition) -> None:
-    c.start_and_wait_for_tcp(services=["materialized"])
+def restart_mz(c: Composition) -> None:
+    c.kill("materialized")
+    c.up("materialized")
+    c.wait_for_materialized()
+
+
+def workflow_basic_ssh_features(c: Composition) -> None:
+    c.start_and_wait_for_tcp(services=["materialized", "ssh-bastion-host", "postgres"])
     c.wait_for_materialized("materialized")
 
     c.run("testdrive", "ssh-connections.td")
+
+
+# This test should also be executed with SSL enabled when it stops being flaky
+def workflow_pg_via_ssh_tunnel(c: Composition) -> None:
+    c.start_and_wait_for_tcp(services=["materialized", "ssh-bastion-host", "postgres"])
+    c.wait_for_materialized("materialized")
+
+    c.run("testdrive", "setup.td")
+
+    public_key = c.sql_query("SELECT public_key_1 FROM mz_ssh_tunnel_connections;")[0][
+        0
+    ]
+
+    c.exec(
+        "ssh-bastion-host",
+        "bash",
+        "-c",
+        f"echo '{public_key}' > /etc/authorized_keys/mz",
+    )
+
+    c.wait_for_postgres()
+
+    c.run("testdrive", "--no-reset", "pg-source.td")
+
+
+def workflow_ssh_key_after_restart(c: Composition) -> None:
+    c.start_and_wait_for_tcp(services=["materialized"])
+    c.wait_for_materialized("materialized")
+
+    c.run("testdrive", "setup.td")
+
+    (primary, secondary) = c.sql_query(
+        "SELECT public_key_1, public_key_2 FROM mz_ssh_tunnel_connections;"
+    )[0]
+
+    restart_mz(c)
+
+    (restart_primary, restart_secondary) = c.sql_query(
+        "SELECT public_key_1, public_key_2 FROM mz_ssh_tunnel_connections;"
+    )[0]
+
+    if (primary, secondary) != (restart_primary, restart_secondary):
+        print("initial public keys: ", (primary, secondary))
+        print("public keys after restart:", (restart_primary, restart_secondary))
+        raise Exception("public key not equal after restart")
+
+    c.sql("DROP CONNECTION thancred;")
+    num_connections = c.sql_query("SELECT count(*) FROM mz_ssh_tunnel_connections;")[0][
+        0
+    ]
+    if num_connections != 0:
+        connections = c.sql_query("SELECT * FROM mz_ssh_tunnel_connections;")
+        print("Found connections in mz_ssh_tunnel_connections: ", connections)
+        raise Exception(
+            "ssh tunnel connection not properly removed from mz_ssh_tunnel_connections"
+        )
+
+
+def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
+    c.start_and_wait_for_tcp(services=["materialized"])
+    c.wait_for_materialized("materialized")
+
+    c.run("testdrive", "setup.td")
+
+    secondary_public_key = c.sql_query(
+        "SELECT public_key_2 FROM mz_ssh_tunnel_connections;"
+    )[0][0]
+
+    c.sql("ALTER CONNECTION thancred ROTATE KEYS;")
+
+    restart_mz(c)
+
+    primary_public_key_after_restart = c.sql_query(
+        "SELECT public_key_1 FROM mz_ssh_tunnel_connections;"
+    )[0][0]
+
+    if secondary_public_key != primary_public_key_after_restart:
+        print("initial secondary key:", secondary_public_key)
+        print(
+            "primary public key after rotation + restart:",
+            primary_public_key_after_restart,
+        )
+        raise Exception("public keys don't match")
+
+    c.sql("DROP CONNECTION thancred;")
+    num_connections = c.sql_query("SELECT count(*) FROM mz_ssh_tunnel_connections;")[0][
+        0
+    ]
+    if num_connections != 0:
+        connections = c.sql_query("SELECT * FROM mz_ssh_tunnel_connections;")
+        print("Found connections in mz_ssh_tunnel_connections: ", connections)
+        raise Exception(
+            "ssh tunnel connection not properly removed from mz_ssh_tunnel_connections after key rotation"
+        )
+
+
+def workflow_default(c: Composition) -> None:
+    workflow_basic_ssh_features(c)
+    workflow_pg_via_ssh_tunnel(c)
+    workflow_ssh_key_after_restart(c)
+    workflow_rotated_ssh_key_after_restart(c)

--- a/test/ssh-connection/pg-source.td
+++ b/test/ssh-connection/pg-source.td
@@ -1,0 +1,50 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test creating a Postgres source using SSH
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg FOR POSTGRES
+  HOST postgres,
+  DATABASE postgres,
+  USER postgres,
+  PASSWORD SECRET pgpass,
+  SSH TUNNEL thancred
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 INTEGER);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg
+  PUBLICATION 'mz_source';
+
+> SELECT COUNT(*) = 1 FROM mz_source;
+true
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> SELECT f1 FROM t1;
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 VALUES (1), (2);
+
+> SELECT f1 FROM t1 ORDER BY f1 ASC;
+1
+1
+2

--- a/test/ssh-connection/setup.td
+++ b/test/ssh-connection/setup.td
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# Basic connection setup for most workflows.
+# Done here instead of in the workflow to ensure the state is reset.
+
+> CREATE CONNECTION IF NOT EXISTS thancred
+    FOR SSH TUNNEL
+        HOST 'ssh-bastion-host',
+        USER 'mz',
+        PORT 22;


### PR DESCRIPTION
Including a full end-to-end test workflow, as well as tests validating that the state stays correct after restarts, since this requires some unique interactions with the secrets store that no other catalog object does.

### Motivation

   * This PR refactors existing code: it adds better tests for SSH tunnel connections.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
