### PR TITLE
test: properly name kafka topics in testdrive

### DIFF
--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -149,7 +149,7 @@ contains:depended upon by catalog item 'materialize.public.csr_source'
 > DROP CONNECTION csr_conn CASCADE
 
 ! CREATE SOURCE should_fail
-  FROM KAFKA CONNECTION does_not_exist (TOPIC 'error_topic')
+  FROM KAFKA CONNECTION does_not_exist (TOPIC 'testdrive-error_topic-${testdrive.seed}')
   FORMAT TEXT
 contains: unknown catalog item 'does_not_exist'
 

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -148,7 +148,7 @@ $ kafka-verify format=avro sink=materialize.public.nums_sink sort-messages=true
 # # Test that a Debezium sink created `AS OF 3` (the latest completed timestamp)
 # # is fully consolidated.
 # > CREATE SINK nums_sink FROM nums
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'nums-sink')
+#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-nums-sink-${testdrive.seed}')
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 #   AS OF 3
 #

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -232,7 +232,7 @@ $ kafka-create-topic topic=static-csv-pkne-sink
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK static_csv_pkne_sink FROM static_csv_pkne
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'static-csv-pkne-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-static-csv-pkne-sink-${testdrive.seed}')
   KEY (zip)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -110,20 +110,20 @@ contains:unknown catalog item 'test4'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE SINK s1 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 ! CREATE SINK s1 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:catalog item 's1' already exists
 
 > CREATE SINK IF NOT EXISTS s1 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v2')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v2-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK s2 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v3')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-v3-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # Test that sinks cannot be depended upon.

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -23,7 +23,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK data_sink FROM data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.data_sink sort-messages=true

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -25,7 +25,7 @@
 #> CREATE MATERIALIZED VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
 #
 #> CREATE SINK unnamed_cols_sink FROM unnamed_cols
-#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-cols-sink')
+#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-unnamed-cols-sink-${testdrive.seed}')
 #  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 #
 #$ kafka-verify format=avro sink=materialize.public.unnamed_cols_sink
@@ -37,7 +37,7 @@
 #> CREATE MATERIALIZED VIEW clashing_cols AS SELECT 1, 2 AS column1, 3 as b, 4 as b2, 5 as b3;
 #
 #> CREATE SINK clashing_cols_sink FROM clashing_cols
-#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'clashing-cols-sink')
+#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-clashing-cols-sink-${testdrive.seed}')
 #  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 #
 #$ kafka-verify format=avro sink=materialize.public.clashing_cols_sink
@@ -52,7 +52,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   (DATE '2000-02-01', TIMESTAMP '2000-02-01 10:10:10.111', TIMESTAMPTZ '2000-02-01 10:10:10.111+02')
 
 > CREATE SINK datetime_data_sink FROM datetime_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'datetime-data-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-datetime-data-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messages=true
@@ -62,7 +62,7 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messa
 > CREATE MATERIALIZED VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04')
 
 > CREATE SINK time_data_sink FROM time_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'time-data-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-time-data-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=true
@@ -75,7 +75,7 @@ $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=
 
 # Sinks with JSON columns should not crash - see https://github.com/MaterializeInc/materialize/issues/4722
 > CREATE SINK json_data_sink FROM json_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'json-data-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-json-data-sink-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
@@ -84,7 +84,7 @@ $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=
 > CREATE MATERIALIZED VIEW map_data (map) AS SELECT '{a => 1, b => 2}'::map[text=>int];
 
 > CREATE SINK map_sink FROM map_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'map-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-map-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.map_sink sort-messages=true
@@ -93,7 +93,7 @@ $ kafka-verify format=avro sink=materialize.public.map_sink sort-messages=true
 > CREATE MATERIALIZED VIEW list_data (list) AS SELECT LIST[1, 2];
 
 > CREATE SINK list_sink FROM list_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'list-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-list-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.list_sink sort-messages=true
@@ -103,7 +103,7 @@ $ kafka-verify format=avro sink=materialize.public.list_sink sort-messages=true
 > CREATE MATERIALIZED VIEW namespace_value_data (namespace) AS SELECT 1;
 
 > CREATE SINK namespace_value_sink FROM namespace_value_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'namespace-value-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-namespace-value-sink-${testdrive.seed}')
   FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'abc.def.ghi')
 
@@ -117,7 +117,7 @@ $ kafka-verify format=avro sink=materialize.public.namespace_value_sink sort-mes
 > CREATE MATERIALIZED VIEW namespace_key_value_data (a, b) AS SELECT * FROM (VALUES (1, 2));
 
 > CREATE SINK namespace_key_value_sink FROM namespace_key_value_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'namespace-key-value-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-namespace-key-value-sink-${testdrive.seed}')
   KEY (b)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.foo', AVRO VALUE FULLNAME = 'some.neat.class.bar')
 
@@ -133,27 +133,27 @@ $ kafka-verify format=avro sink=materialize.public.namespace_key_value_sink sort
 > CREATE MATERIALIZED VIEW input (a, b) AS SELECT * FROM (VALUES (1, 2))
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a, a)
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}') KEY (a, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Repeated column name in sink key: a
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'some.neat.class.foo', AVRO KEY FULLNAME = 'some.neat.class.bar')
 contains:Cannot specify AVRO KEY FULLNAME without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.bar')
 contains:Cannot specify AVRO KEY FULLNAME without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.bar')
 contains:Must specify both AVRO KEY FULLNAME and AVRO VALUE FULLNAME when specifying generated schema names
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-sink-${testdrive.seed}') KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'some.neat.class.bar')
 contains:Must specify both AVRO KEY FULLNAME and AVRO VALUE FULLNAME when specifying generated schema names

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -446,7 +446,7 @@ a b
 -1 7
 
 ! CREATE SOURCE recursive
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'ignored')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-ignored-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
 contains:validating avro schema: Recursive types are not supported: .a
 

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -50,7 +50,7 @@ $ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert
   ENVELOPE UPSERT
 
 > CREATE SINK upsert_input_sink FROM upsert_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'upsert-input-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-input-sink-${testdrive.seed}')
   KEY (key1, key2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -26,7 +26,7 @@ $ kafka-verify format=json sink=materialize.public.simple_view_sink key=false
 {"before": null, "after": {"a": 1, "b": 2, "c": 3}, "transaction": {"id": "<TIMESTAMP>"}}
 
 > CREATE SINK simple_view_upsert FROM simple_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-upsert')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-unnamed-upsert-${testdrive.seed}')
   KEY (b)
   FORMAT JSON
   ENVELOPE UPSERT
@@ -53,7 +53,7 @@ $ kafka-verify format=json sink=materialize.public.simple_view_upsert key=true
   '{"a": 2}'::jsonb c14
 
 > CREATE SINK types_sink FROM types_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'types-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-types-sink-${testdrive.seed}')
   FORMAT JSON
 
 # Due to limitations in $ kafka-verify, the entire expected JSON output needs to be provided on a single line
@@ -66,7 +66,7 @@ $ kafka-verify format=json sink=materialize.public.types_sink key=false
   SELECT 'текст' c1, '"' c2, '''' c3, '\' c4, E'a\n\tb' c5
 
 > CREATE SINK special_characters_sink FROM special_characters_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'special-characters-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-special-characters-sink-${testdrive.seed}')
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.special_characters_sink key=false
@@ -77,7 +77,7 @@ $ kafka-verify format=json sink=materialize.public.special_characters_sink key=f
 > CREATE MATERIALIZED VIEW record_view AS SELECT simple_view FROM simple_view;
 
 > CREATE SINK record_sink FROM record_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'record-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-record-sink-${testdrive.seed}')
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.record_sink key=false
@@ -103,7 +103,7 @@ contains:column "a" specified more than once
 > CREATE MATERIALIZED VIEW complex_type_view AS SELECT '{{1,2},{3,4}}'::int4_list_list c1, '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map c2;
 
 > CREATE SINK complex_type_sink FROM complex_type_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'complex-type-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-complex-type-sink-${testdrive.seed}')
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.complex_type_sink key=false

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -145,7 +145,7 @@ a  b
 
 # Cannot create sink from unmaterialized view.
 ! CREATE SINK not_mat_sink2 FROM data_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-view2-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-view2-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:data_view is a view, which cannot be exported as a sink
 
@@ -156,7 +156,7 @@ contains:data_view is a view, which cannot be exported as a sink
 
 # or from an indexed unmaterialized view
 ! CREATE SINK not_mat_sink2 FROM test5
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-view2-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-view2-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:test5 is a view, which cannot be exported as a sink
 

--- a/test/testdrive/protobuf-recursive.td
+++ b/test/testdrive/protobuf-recursive.td
@@ -30,10 +30,10 @@ message Mutual3 {
 
 $ protobuf-compile-descriptors inputs=recursive.proto output=recursive.pb
 
-! CREATE SOURCE recursive FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'recursive'
+! CREATE SOURCE recursive FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-recursive-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Self' USING SCHEMA FILE '${testdrive.temp-dir}/recursive.pb'
 contains:Recursive types are not supported: Self
 
-! CREATE SOURCE recursive FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'recursive'
+! CREATE SOURCE recursive FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-recursive-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Mutual1' USING SCHEMA FILE '${testdrive.temp-dir}/recursive.pb'
 contains:Recursive types are not supported: Mutual1

--- a/test/testdrive/protobuf-unsigned.td
+++ b/test/testdrive/protobuf-unsigned.td
@@ -31,18 +31,18 @@ message Fixed64 {
 
 $ protobuf-compile-descriptors inputs=unsigned.proto output=unsigned.pb
 
-! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
+! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-unsigned-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.UInt32' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
 contains:Protobuf unsigned integer types are not supported
 
-! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
+! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-unsigned-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.UInt64' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
 contains:Protobuf unsigned integer types are not supported
 
-! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
+! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-unsigned-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Fixed32' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
 contains:Protobuf unsigned integer types are not supported
 
-! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'unsigned'
+! CREATE SOURCE unsigned FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-unsigned-${testdrive.seed}'
   FORMAT PROTOBUF MESSAGE '.Fixed64' USING SCHEMA FILE '${testdrive.temp-dir}/unsigned.pb'
 contains:Protobuf unsigned integer types are not supported

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -209,7 +209,7 @@ contains:Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE
 
 ##### Temporary sinks.
 ! CREATE TEMPORARY SINK data_sink FROM data
-  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'data-sink'
+  INTO KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Expected DATABASE, SCHEMA, ROLE, USER, TYPE, INDEX, SINK, SOURCE, TABLE, SECRET or [OR REPLACE] [TEMPORARY] VIEW or VIEWS after CREATE, found SINK
 

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -179,7 +179,7 @@ $ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-s
 > CREATE MATERIALIZED VIEW kafka_verify_regexp (a) AS VALUES ('u123'), ('u234');
 
 > CREATE SINK kafka_verify_regexp_sink FROM kafka_verify_regexp
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-verify-regexp-sink')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-verify-regexp-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.kafka_verify_regexp_sink sort-messages=true

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -60,7 +60,7 @@ u      false     uuid
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK uuid_sink_${testdrive.seed} FROM data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data')
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sort-messages=true sink=materialize.public.uuid_sink_${testdrive.seed}


### PR DESCRIPTION
@philip-stoev noted in #14712 that some tests did not properly name kafka topics; this PR aims to follow his suggestion to fix the naming convention unilaterally, but does not go as far as erroring on topics that do not contain the seed.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
