### PR TITLE
test: Fix flaky storage test

### DIFF
--- a/test/cluster/pg-snapshot-resumption/03-while-storaged-down.td
+++ b/test/cluster/pg-snapshot-resumption/03-while-storaged-down.td
@@ -7,5 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+> SET transaction_isolation = serializable
+
 > SELECT COUNT(*) FROM t1;
 0
+
+> SET transaction_isolation = 'strict serializable'


### PR DESCRIPTION
The pg-snapshot-resumption test was flakey and sometimes failing. The reason was that in step 03, Materialize was sometimes unable to select a valid timestamp for the query and would hang forever.

The test purposely crashes STORAGED, which prevents the upper of t1 from advancing. However, the global timestamp does keep advancing. If the global timestamp advances past the upper of t1, then we are unable to select a valid timestamp under strict serializability, and the query hangs forever.

Switching the isolation level to serializable for this test increases the likelihood that we are able to select a valid timestamp for t1. Due to #14696, there is still some possibility that the test will flake. Once #14696 is fixed then this test should completely stop being flakey.

Fixes #14533

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
