### PR TITLE
ci/plugins/scratch: assume AWS role for 12 hours

### DIFF
--- a/ci/plugins/scratch-aws-access/hooks/pre-command
+++ b/ci/plugins/scratch-aws-access/hooks/pre-command
@@ -13,7 +13,7 @@ set -euo pipefail
 
 echo "~~~ Assuming scratch AWS role"
 
-creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --role-session-name ci)
+creds=$(aws sts assume-role --role-arn "$AWS_SCRATCH_ROLE_ARN" --duration-seconds 43200 --role-session-name ci)
 
 AWS_ACCESS_KEY_ID=$(jq -r '.Credentials.AccessKeyId' <<< "$creds")
 AWS_SECRET_ACCESS_KEY=$(jq -r '.Credentials.SecretAccessKey' <<< "$creds")


### PR DESCRIPTION
The default session length is one hour. Many of our nightlies take much longer than that to run.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
