### PR TITLE
adapter: allow upgrading started txns

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -104,7 +104,7 @@ impl<T: CoordTimestamp> Session<T> {
         isolation_level: Option<TransactionIsolationLevel>,
     ) -> Self {
         match self.transaction {
-            TransactionStatus::Default | TransactionStatus::Started(_) => {
+            TransactionStatus::Default => {
                 self.transaction = TransactionStatus::InTransaction(Transaction {
                     pcx: PlanContext::new(wall_time, self.vars.qgm_optimizations()),
                     ops: TransactionOps::None,
@@ -112,7 +112,7 @@ impl<T: CoordTimestamp> Session<T> {
                     access,
                 });
             }
-            TransactionStatus::InTransactionImplicit(txn) => {
+            TransactionStatus::Started(txn) | TransactionStatus::InTransactionImplicit(txn) => {
                 self.transaction = TransactionStatus::InTransaction(txn);
             }
             TransactionStatus::InTransaction(_) => {}

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -473,3 +473,93 @@ ReadyForQuery {"status":"I"}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
+
+# Verify implicit transactions are properly upgraded
+send
+Query {"query": "CREATE TABLE t (a INT)"}
+Parse {"query": "INSERT INTO t VALUES (1)"}
+Bind
+Execute
+Parse {"query": "BEGIN"}
+Bind
+Execute
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Verify implicit transactions are properly upgraded, and share fate
+# with upgraded txn; the insert of 2 should get discarded
+send
+Parse {"query": "INSERT INTO t VALUES (2)"}
+Bind
+Execute
+Parse {"query": "BEGIN"}
+Bind
+Execute
+Parse {"query": "SELECT 0/0"}
+Bind
+Execute
+Sync
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"E"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
Previously, upgrading a started txn to an explicit one caused MZ to drop the contents of the started txn. This commit changes that behavior to instead, as intended, upgrade the entire started txn to an explicit one.

### Motivation

This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Corrects the behavior of upgrading implicit transactions to explicit ones. Previously, the implicit transaction's contents would be discarded.
