### PR TITLE
Join-Dependent Predicate Duplication

### DIFF
--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -10,12 +10,13 @@
 use std::collections::HashSet;
 use std::ops::Range;
 
+use core::option::Option;
 use itertools::Itertools;
 
 use mz_repr::RelationType;
 
 use crate::visit::Visit;
-use crate::{MirRelationExpr, MirScalarExpr};
+use crate::{MirRelationExpr, MirScalarExpr, VariadicFunc};
 
 /// Any column in a join expression exists in two contexts:
 /// 1) It has a position relative to the result of the join (global)
@@ -250,6 +251,16 @@ impl JoinInputMapper {
         None
     }
 
+    /// Returns whether the given expr refers to columns of only the `index`th input.
+    pub fn is_localized(&self, expr: &MirScalarExpr, index: usize) -> bool {
+        if let Some(single_input) = self.single_input(expr) {
+            if single_input == index {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /// Takes an expression in the global context and looks in `equivalences`
     /// for an equivalent expression (also expressed in the global context) that
     /// belongs to one or more of the inputs in `bound_inputs`
@@ -305,16 +316,19 @@ impl JoinInputMapper {
         None
     }
 
-    /// Try to rewrite an expression from the global context so that all the
-    /// columns point to the `index` input by replacing subexpressions with their
+    /// Try to rewrite `expr` from the global context so that all the
+    /// columns point to the `index`th input by replacing subexpressions with their
     /// bound equivalents in the `index`th input if necessary.
-    /// The return value, if not None, is in the context of the `index`th input
-    pub fn try_map_to_input_with_bound_expr(
+    /// Returns whether the rewriting was successful.
+    /// If it returns true, then `expr` is in the context of the `index`th input.
+    /// If it returns false, then still some subexpressions might have been rewritten. However,
+    /// `expr` is still in the global context.
+    pub fn try_localize_to_input_with_bound_expr(
         &self,
-        mut expr: MirScalarExpr,
+        expr: &mut MirScalarExpr,
         index: usize,
         equivalences: &[Vec<MirScalarExpr>],
-    ) -> Option<MirScalarExpr> {
+    ) -> bool {
         // TODO (wangandi): Consider changing this code to be post-order
         // instead of pre-order? `lookup_inputs` traverses all the nodes in
         // `e` anyway, so we end up visiting nodes in `e` multiple times
@@ -344,15 +358,92 @@ impl JoinInputMapper {
             },
             &mut |_| {},
         );
-        // if the localization attempt is successful, all columns in `expr`
-        // should only come from input `index`
-        let mut inputs_after_localization = self.lookup_inputs(&expr);
-        if let Some(first_input) = inputs_after_localization.next() {
-            if inputs_after_localization.next().is_none() && first_input == index {
-                return Some(self.map_expr_to_local(expr));
+        if self.is_localized(&expr, index) {
+            // If the localization attempt is successful, all columns in `expr`
+            // should only come from input `index`. Switch to the local context.
+            *expr = self.map_expr_to_local(expr.clone());
+            return true;
+        }
+        false
+    }
+
+    /// Try to find a consequence `c` of the given expression `e` for the given input.
+    ///
+    /// If we return `Some(c)`, that means
+    ///   1. `c` uses only columns from the given input;
+    ///   2. if `c` doesn't hold on a row of the input, then `e` also wouldn't hold;
+    ///   3. if `c` holds on a row of the input, then `e` might or might not hold.
+    /// 1. and 2. means that if we have a join with predicate `e` then we can use `c` for
+    /// pre-filtering a join input before the join. However, 3. means that `e` shouldn't be deleted
+    /// from the join predicates, i.e., we can't do a "traditional" predicate pushdown.
+    ///
+    /// Note that "`c` is a consequence of `e`" is the same thing as 2., see
+    /// <https://en.wikipedia.org/wiki/Contraposition>
+    ///
+    /// Example: For
+    /// `(t1.f2 = 3 AND t2.f2 = 4) OR (t1.f2 = 5 AND t2.f2 = 6)`
+    /// we find
+    /// `t1.f2 = 3 OR t1.f2 = 5` for t1, and
+    /// `t2.f2 = 4 OR t2.f2 = 6` for t2.
+    ///
+    /// Further examples are in TPC-H Q07, Q19, and chbench Q07, Q19.
+    ///
+    /// Parameters:
+    ///  - `expr`: The expression `e` from above. `try_localize_to_input_with_bound_expr` should
+    ///    be called on `expr` before us!
+    ///  - `index`: The index of the join input whose columns we will use.
+    ///  - `equivalences`: Join equivalences that we can use for `try_map_to_input_with_bound_expr`.
+    /// If successful, the returned expression is in the local context of the specified input.
+    pub fn consequence_for_input(
+        &self,
+        expr: &MirScalarExpr,
+        index: usize,
+    ) -> Option<MirScalarExpr> {
+        if self.is_localized(&expr, index) {
+            Some(expr.clone())
+        } else {
+            match expr {
+                MirScalarExpr::CallVariadic {
+                    func: VariadicFunc::Or,
+                    exprs: or_args,
+                } => {
+                    // Each OR arg should provide a consequence. If they do, we OR them.
+                    let consequences_per_arg = or_args
+                        .into_iter()
+                        .map(|or_arg| {
+                            mz_ore::stack::maybe_grow(|| self.consequence_for_input(or_arg, index))
+                        })
+                        .collect::<Option<Vec<_>>>()?; // return None if any of them are None
+                    Some(self.map_expr_to_local(MirScalarExpr::CallVariadic {
+                        func: VariadicFunc::Or,
+                        exprs: consequences_per_arg,
+                    }))
+                }
+                MirScalarExpr::CallVariadic {
+                    func: VariadicFunc::And,
+                    exprs: and_args,
+                } => {
+                    // If any of the AND args provide a consequence, then we take those that do,
+                    // and AND them.
+                    let consequences_per_arg = and_args
+                        .into_iter()
+                        .map(|and_arg| {
+                            mz_ore::stack::maybe_grow(|| self.consequence_for_input(and_arg, index))
+                        })
+                        .flat_map(|c| c) // take only those that provide a consequence
+                        .collect_vec();
+                    if consequences_per_arg.is_empty() {
+                        None
+                    } else {
+                        Some(self.map_expr_to_local(MirScalarExpr::CallVariadic {
+                            func: VariadicFunc::And,
+                            exprs: consequences_per_arg,
+                        }))
+                    }
+                }
+                _ => None,
             }
         }
-        None
     }
 }
 
@@ -379,20 +470,19 @@ mod tests {
 
         // when the column is already part of the target input, all that happens
         // is that it gets localized
-        assert_eq!(
-            Some(MirScalarExpr::Column(1)),
-            input_mapper.try_map_to_input_with_bound_expr(key12.clone(), 2, &equivalences)
-        );
+        let mut cloned = key12.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 2, &equivalences);
+        assert_eq!(MirScalarExpr::Column(1), cloned,);
 
         // basic tests that we can find a column's corresponding column in a
         // different input
+        let mut cloned = key12.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 0, &equivalences);
+        assert_eq!(key10, cloned);
+        let mut cloned = key12.clone();
         assert_eq!(
-            Some(key10.clone()),
-            input_mapper.try_map_to_input_with_bound_expr(key12.clone(), 0, &equivalences)
-        );
-        assert_eq!(
-            None,
-            input_mapper.try_map_to_input_with_bound_expr(key12.clone(), 1, &equivalences)
+            false,
+            input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 1, &equivalences),
         );
 
         let key20 = MirScalarExpr::CallUnary {
@@ -413,14 +503,12 @@ mod tests {
 
         // basic tests that we can find an expression's corresponding expression in a
         // different input
-        assert_eq!(
-            Some(key20.clone()),
-            input_mapper.try_map_to_input_with_bound_expr(key21.clone(), 0, &equivalences)
-        );
-        assert_eq!(
-            Some(localized_key22.clone()),
-            input_mapper.try_map_to_input_with_bound_expr(key21.clone(), 2, &equivalences)
-        );
+        let mut cloned = key21.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 0, &equivalences);
+        assert_eq!(key20, cloned);
+        let mut cloned = key21.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 2, &equivalences);
+        assert_eq!(localized_key22, cloned);
 
         // test that `try_map_to_input_with_bound_expr` will map multiple
         // subexpressions to the corresponding expressions bound to a different input
@@ -429,20 +517,23 @@ mod tests {
             expr1: Box::new(key12.clone()),
             expr2: Box::new(key22),
         };
+        let mut cloned = key_comp.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 0, &equivalences);
         assert_eq!(
-            Some(MirScalarExpr::CallBinary {
+            MirScalarExpr::CallBinary {
                 func: BinaryFunc::MulInt32,
                 expr1: Box::new(key10.clone()),
                 expr2: Box::new(key20.clone()),
-            }),
-            input_mapper.try_map_to_input_with_bound_expr(key_comp.clone(), 0, &equivalences)
+            },
+            cloned,
         );
 
         // test that the function returns None when part
         // of the expression can be mapped to an input but the rest can't
+        let mut cloned = key_comp.clone();
         assert_eq!(
-            None,
-            input_mapper.try_map_to_input_with_bound_expr(key_comp.clone(), 1, &equivalences)
+            false,
+            input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 1, &equivalences),
         );
 
         let key_comp_plus_non_key = MirScalarExpr::CallBinary {
@@ -450,9 +541,10 @@ mod tests {
             expr1: Box::new(key_comp),
             expr2: Box::new(MirScalarExpr::Column(7)),
         };
+        let mut mutab = key_comp_plus_non_key;
         assert_eq!(
-            None,
-            input_mapper.try_map_to_input_with_bound_expr(key_comp_plus_non_key, 0, &equivalences)
+            false,
+            input_mapper.try_localize_to_input_with_bound_expr(&mut mutab, 0, &equivalences),
         );
 
         let key_comp_multi_input = MirScalarExpr::CallBinary {
@@ -462,35 +554,32 @@ mod tests {
         };
         // test that the function works when part of the expression is already
         // part of the target input
+        let mut cloned = key_comp_multi_input.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 2, &equivalences);
         assert_eq!(
-            Some(MirScalarExpr::CallBinary {
+            MirScalarExpr::CallBinary {
                 func: BinaryFunc::Eq,
                 expr1: Box::new(localized_key12),
                 expr2: Box::new(localized_key22),
-            }),
-            input_mapper.try_map_to_input_with_bound_expr(
-                key_comp_multi_input.clone(),
-                2,
-                &equivalences
-            )
+            },
+            cloned,
         );
         // test that the function works when parts of the expression come from
         // multiple inputs
+        let mut cloned = key_comp_multi_input.clone();
+        input_mapper.try_localize_to_input_with_bound_expr(&mut cloned, 0, &equivalences);
         assert_eq!(
-            Some(MirScalarExpr::CallBinary {
+            MirScalarExpr::CallBinary {
                 func: BinaryFunc::Eq,
                 expr1: Box::new(key10),
                 expr2: Box::new(key20),
-            }),
-            input_mapper.try_map_to_input_with_bound_expr(
-                key_comp_multi_input.clone(),
-                0,
-                &equivalences
-            )
+            },
+            cloned,
         );
+        let mut mutab = key_comp_multi_input;
         assert_eq!(
-            None,
-            input_mapper.try_map_to_input_with_bound_expr(key_comp_multi_input, 1, &equivalences)
+            false,
+            input_mapper.try_localize_to_input_with_bound_expr(&mut mutab, 1, &equivalences),
         )
     }
 }

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -489,6 +489,7 @@ WHERE l_quantity = 17
 ----
 %0 =
 | Get materialize.public.lineitem (u7)
+| Filter ((#4 = 7) OR (#4 = 17) OR (#4 = 33))
 | Project (#0, #4)
 | ArrangeBy ()
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -627,6 +627,7 @@ ORDER BY su_nationkey, cust_nation, l_year
 ----
 %0 = Let l0 =
 | Get materialize.public.nation (u22)
+| Filter ((#1 = "GERMANY") OR (#1 = "CAMBODIA"))
 | Project (#0, #1)
 | ArrangeBy (#0)
 
@@ -1410,9 +1411,9 @@ WHERE (
 )
 ----
 Source materialize.public.item (u17):
-| Map dummy, dummy
-| Filter (#3 <= 400000), (#3 >= 1)
-| Project (#0, #5, #6, #3, #4)
+| Map padchar(#4), dummy, dummy
+| Filter (#3 <= 400000), (#3 >= 1), ("%a" ~~(#5) OR "%b" ~~(#5) OR "%c" ~~(#5))
+| Project (#0, #6, #7, #3, #4)
 
 Query:
 %0 =
@@ -1421,7 +1422,8 @@ Query:
 
 %1 =
 | Get materialize.public.item (u17)
-| Filter (#3 <= 400000), (#3 >= 1)
+| Map padchar(#4)
+| Filter (#3 <= 400000), (#3 >= 1), ("%a" ~~(#5) OR "%b" ~~(#5) OR "%c" ~~(#5))
 | Project (#0, #4)
 | ArrangeBy (#0)
 
@@ -1430,8 +1432,8 @@ Query:
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#4)
-| Map padchar(#11), (#2 = 1), (#2 = 2), (#2 = 3)
-| Filter (#7 <= 10), (#7 >= 1), (("%a" ~~(#12) AND (#13 OR #14 OR #15)) OR ("%b" ~~(#12) AND (#13 OR #14 OR (#2 = 4))) OR ("%c" ~~(#12) AND (#13 OR #15 OR (#2 = 5))))
+| Map (#2 = 1), (#2 = 2), (#2 = 3), (#2 = 4), (#2 = 5), padchar(#11)
+| Filter (#7 <= 10), (#7 >= 1), (#12 OR #13 OR #14 OR #15 OR #16), (("%a" ~~(#17) AND (#12 OR #13 OR #14)) OR ("%b" ~~(#17) AND (#12 OR #13 OR #15)) OR ("%c" ~~(#17) AND (#12 OR #14 OR #16)))
 | Project (#8)
 | Reduce group=()
 | | agg sum(#0)

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -549,6 +549,7 @@ ORDER BY
 ----
 %0 = Let l0 =
 | Get materialize.public.nation (u1)
+| Filter ((#1 = "FRANCE") OR (#1 = "GERMANY"))
 | Project (#0, #1)
 | ArrangeBy (#0)
 
@@ -1481,7 +1482,7 @@ WHERE
 ----
 Source materialize.public.part (u4):
 | Map dummy, dummy, dummy, dummy, dummy
-| Filter (#5 >= 1)
+| Filter (#5 >= 1), (((#3 = "Brand#12") AND (#5 <= 5) AND ((#6 = "SM BOX") OR (#6 = "SM PKG") OR (#6 = "SM CASE") OR (#6 = "SM PACK"))) OR ((#3 = "Brand#23") AND (#5 <= 10) AND ((#6 = "MED BAG") OR (#6 = "MED BOX") OR (#6 = "MED PKG") OR (#6 = "MED PACK"))) OR ((#3 = "Brand#34") AND (#5 <= 15) AND ((#6 = "LG BOX") OR (#6 = "LG PKG") OR (#6 = "LG CASE") OR (#6 = "LG PACK"))))
 | Project (#0, #9, #10, #3, #11, #5, #6, #12, #13)
 
 Query:
@@ -1491,7 +1492,7 @@ Query:
 
 %1 =
 | Get materialize.public.part (u4)
-| Filter (#5 >= 1)
+| Filter (#5 >= 1), (((#3 = "Brand#12") AND (#5 <= 5) AND ((#6 = "SM BOX") OR (#6 = "SM PKG") OR (#6 = "SM CASE") OR (#6 = "SM PACK"))) OR ((#3 = "Brand#23") AND (#5 <= 10) AND ((#6 = "MED BAG") OR (#6 = "MED BOX") OR (#6 = "MED PKG") OR (#6 = "MED PACK"))) OR ((#3 = "Brand#34") AND (#5 <= 15) AND ((#6 = "LG BOX") OR (#6 = "LG PKG") OR (#6 = "LG CASE") OR (#6 = "LG PACK"))))
 | Project (#0, #3, #5, #6)
 | ArrangeBy (#0)
 
@@ -1500,7 +1501,8 @@ Query:
 | | implementation = DeltaQuery
 | |   delta %0 %1.(#0)
 | |   delta %1 %0.(#1)
-| Filter (#13 = "DELIVER IN PERSON"), ((#14 = "AIR") OR (#14 = "AIR REG")), (((#17 = "Brand#12") AND (#4 <= 11) AND (#18 <= 5) AND (#4 >= 1) AND ((#19 = "SM BOX") OR (#19 = "SM PKG") OR (#19 = "SM CASE") OR (#19 = "SM PACK"))) OR ((#17 = "Brand#23") AND (#4 <= 20) AND (#18 <= 10) AND (#4 >= 10) AND ((#19 = "MED BAG") OR (#19 = "MED BOX") OR (#19 = "MED PKG") OR (#19 = "MED PACK"))) OR ((#17 = "Brand#34") AND (#4 <= 30) AND (#18 <= 15) AND (#4 >= 20) AND ((#19 = "LG BOX") OR (#19 = "LG PKG") OR (#19 = "LG CASE") OR (#19 = "LG PACK"))))
+| Map (#4 <= 20), (#4 >= 10), (#4 <= 30), (#4 >= 20), (#4 <= 11), (#4 >= 1)
+| Filter (#13 = "DELIVER IN PERSON"), ((#14 = "AIR") OR (#14 = "AIR REG")), ((#20 AND #21) OR (#22 AND #23) OR (#24 AND #25)), ((#20 AND #21 AND (#17 = "Brand#23") AND (#18 <= 10) AND ((#19 = "MED BAG") OR (#19 = "MED BOX") OR (#19 = "MED PKG") OR (#19 = "MED PACK"))) OR (#22 AND #23 AND (#17 = "Brand#34") AND (#18 <= 15) AND ((#19 = "LG BOX") OR (#19 = "LG PKG") OR (#19 = "LG CASE") OR (#19 = "LG PACK"))) OR (#24 AND #25 AND (#17 = "Brand#12") AND (#18 <= 5) AND ((#19 = "SM BOX") OR (#19 = "SM PKG") OR (#19 = "SM CASE") OR (#19 = "SM PACK"))))
 | Project (#5, #6)
 | Reduce group=()
 | | agg sum((#0 * (1 - #1)))

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -311,3 +311,160 @@ Query:
 | | implementation = Differential %1 %0.((#0 + 1))
 
 EOF
+
+# Join-Dependent Predicate Duplication (JoinInputMapper::consequence_for_input)
+
+query T multiline
+EXPLAIN
+SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND ((t1.f2 = 3 AND t2.f2 = 4) OR (t1.f2 = 5 AND t2.f2 = 6));
+----
+Source materialize.public.t1 (u3):
+| Filter (#0) IS NOT NULL, ((#1 = 3) OR (#1 = 5))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Filter (#0) IS NOT NULL, ((#1 = 4) OR (#1 = 6))
+| Project (#0, #1)
+
+Query:
+%0 =
+| Get materialize.public.t1 (u3)
+| Filter (#0) IS NOT NULL, ((#1 = 3) OR (#1 = 5))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u4)
+| Filter (#0) IS NOT NULL, ((#1 = 4) OR (#1 = 6))
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| Filter (((#1 = 3) AND (#3 = 4)) OR ((#1 = 5) AND (#3 = 6)))
+| Project (#0, #1, #0, #3)
+
+EOF
+
+query T multiline
+EXPLAIN
+SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND ((t1.f2 = 3 AND t2.f2 = 4) OR t1.f2 = 5);
+----
+Source materialize.public.t1 (u3):
+| Filter (#0) IS NOT NULL, ((#1 = 3) OR (#1 = 5))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Filter (#0) IS NOT NULL
+| Project (#0, #1)
+
+Query:
+%0 =
+| Get materialize.public.t1 (u3)
+| Filter (#0) IS NOT NULL, ((#1 = 3) OR (#1 = 5))
+| ArrangeBy (#0)
+
+%1 =
+| Get materialize.public.t2 (u4)
+| Filter (#0) IS NOT NULL
+
+%2 =
+| Join %0 %1 (= #0 #2)
+| | implementation = Differential %1 %0.(#0)
+| Filter ((#1 = 5) OR ((#1 = 3) AND (#3 = 4)))
+| Project (#0, #1, #0, #3)
+
+EOF
+
+query T multiline
+EXPLAIN
+SELECT * FROM t1, t2
+WHERE t1.f2 = 27 OR (t1.f2 <= 1995 AND t1.f1 = t2.f1);
+----
+Source materialize.public.t1 (u3):
+| Filter ((#1 = 27) OR (#1 <= 1995))
+| Project (#0, #1)
+
+Source materialize.public.t2 (u4):
+| Project (#0, #1)
+
+Query:
+%0 =
+| Get materialize.public.t1 (u3)
+| Filter ((#1 = 27) OR (#1 <= 1995))
+| ArrangeBy ()
+
+%1 =
+| Get materialize.public.t2 (u4)
+
+%2 =
+| Join %0 %1
+| | implementation = Differential %1 %0.()
+| Filter ((#1 = 27) OR ((#0 = #2) AND (#1 <= 1995)))
+
+EOF
+
+# Delta join -- In this case, `JoinImplementation` lifts the newly created predicates to after the join at the end of
+# MIR. However, MIR -> LIR lowering will push these predicates to their correct place. We can check this in the physical
+# plan, i.e., that they are in the `initial_closure`.
+
+statement ok
+CREATE INDEX t1_f1_ind on t1(f1)
+
+statement ok
+CREATE INDEX t2_f1_ind on t2(f1)
+
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND ((t1.f2 = 3 AND t2.f2 = 4) OR (t1.f2 = 5 AND t2.f2 = 6));
+----
+Explained Query
+  Join::Delta
+    plan_path[0]
+      final_closure
+        project=(#0, #1, #0, #2)
+      delta_stage[0]
+        closure
+          project=(#0, #1, #4)
+          filter=((#5 OR #6) AND ((#2 AND #5) OR (#3 AND #6)))
+          map=((#4 = 4), (#4 = 6))
+        lookup={ relation=1, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#3) }
+      initial_closure
+        project=(#0..=#3)
+        filter=((#0) IS NOT NULL AND (#2 OR #3))
+        map=((#1 = 3), (#1 = 5))
+      source={ relation=0, key=[#0] }
+    plan_path[1]
+      final_closure
+        project=(#0, #1, #0, #2)
+      delta_stage[0]
+        closure
+          project=(#0, #4, #1)
+          filter=((#0) IS NOT NULL AND (#5 OR #6) AND ((#5 AND #2) OR (#6 AND #3)))
+          map=((#4 = 3), (#4 = 5))
+        lookup={ relation=0, key=[#0] }
+        stream={ key=[#0], thinning=(#1..=#3) }
+      initial_closure
+        project=(#0..=#3)
+        filter=((#2 OR #3))
+        map=((#1 = 4), (#1 = 6))
+      source={ relation=1, key=[#0] }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.t1
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    ArrangeBy
+      input_key=[#0]
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+      Get::PassArrangements materialize.public.t2
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t1_f1_ind
+  - materialize.public.t2_f1_ind
+
+EOF


### PR DESCRIPTION
There are cases where a traditional predicate pushdown is not possible, but it's still possible to create an extra filter on some join inputs, and thereby reduce the data volume that goes into the join.

For example:
```
SELECT * FROM t1, t2 WHERE t1.f1 = t2.f1 AND ((t1.f2 = 3 AND t2.f2 = 4) OR (t1.f2 = 5 AND t2.f2 = 6));
```
Here, we can pre-filter `t1` with `t1.f2 = 3 OR t1.f2 = 5`, and `t2` with `t2.f2 = 4 OR t2.f2 = 6`.

Similar situations occur in TPC-H Q07, Q19, and chbench Q07, Q19.

### Motivation

  * This PR adds a known-desirable feature: #14501, and #7409 (partially).

### Tips for reviewer

In TPC-H Q19 and chbench Q19 some of the newly created filters get lifted to after the join by `join_implementation.rs`, which doesn't looks so good at first glance. However:
- I presume that the rendering might still be able to push those to the join closure that is just after that input, which means that we'll filter with them before joining in other inputs.
- Even if they end up in the final closure, evaluating the expression might still be slightly faster, because the lifted filters (fortunately) come before the original predicate, and they are simpler than the original predicate.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Performance improvement, see above.
