### PR TITLE
sql: Remove full and extended from SHOW commands

### DIFF
--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -17,23 +17,11 @@ aliases:
 Field                | Use
 ---------------------|-----
 _schema&lowbar;name_ | The schema to show connections from. If omitted, connections from all schemas are shown. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**FULL**             | Returns all connections, including information about the connection type.
 
 ## Examples
 
 ```sql
 SHOW CONNECTIONS;
-```
-
-```nofmt
-       name
-------------------
- kafka_connection
- postgres_connection
-```
-
-```sql
-SHOW FULL CONNECTIONS;
 ```
 
 ```nofmt
@@ -48,9 +36,9 @@ SHOW CONNECTIONS LIKE 'kafka%';
 ```
 
 ```nofmt
-       name
-------------------
- kafka_connection
+       name      | type
+-----------------+------
+ kafka_connection| user
 ```
 
 

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -23,13 +23,13 @@ SHOW INDEXES FROM my_view;
 ```
 
 ```nofmt
-     name
--------------
- my_view_idx
+ cluster | on_name |  key_name   | seq_in_index | column_name | expression | nullable
+---------+---------+-------------+--------------+-------------+------------+----------
+ default | t       | my_view_idx | 1            | a           |            | t
 ```
 
 ```sql
-SHOW CREATE INDEX my_view_index;
+SHOW CREATE INDEX my_view_idx;
 ```
 
 ```nofmt

--- a/doc/user/content/sql/show-index.md
+++ b/doc/user/content/sql/show-index.md
@@ -19,8 +19,6 @@ Field | Use
 ------|-----
 _on&lowbar;name_ | The name of the object whose indexes you want to show. If omitted, all indexes in the cluster are shown.
 _cluster&lowbar;name_ | The cluster to show indexes from. If omitted, indexes from all clusters are shown.
-**EXTENDED** | Returns system indexes as well as user-created indexes. By default, only user-created indexes are returned.
-**FULL** | Returns all materialized views, including their associated cluster and type.
 
 ## Details
 
@@ -47,13 +45,13 @@ Field | Meaning
 ## Examples
 
 ```sql
-SHOW FULL VIEWS;
+SHOW VIEWS;
 ```
 ```nofmt
-          name           | type | materialized
--------------------------+------+ -------------
- my_nonmaterialized_view | user | f
- my_materialized_view    | user | t
+          name           | type
+-------------------------+------
+ my_nonmaterialized_view | user
+ my_materialized_view    | user
 ```
 
 ```sql

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -17,22 +17,11 @@ Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show materialized views from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
 _cluster&lowbar;name_ | The cluster to show materialized views from. If omitted, materialized views from all clusters are shown.
-**FULL** | Returns all materialized views, including their associated cluster and type.
 
 ## Examples
 
 ```sql
 SHOW MATERIALIZED VIEWS;
-```
-
-```nofmt
-     name
---------------
- winning_bids
-```
-
-```sql
-SHOW FULL MATERIALIZED VIEWS;
 ```
 
 ```nofmt
@@ -46,9 +35,9 @@ SHOW MATERIALIZED VIEWS LIKE '%bid%';
 ```
 
 ```nofmt
-     name
---------------
- winning_bids
+ cluster |     name     | type
+---------+--------------+------
+ default | winning_bids | user
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -23,8 +23,8 @@ _schema&lowbar;name_ | The schema to show objects from. Defaults to `public` in 
 
 ### Output format
 
-`SHOW OBJECTS`'s output is a table with one column, `name`. `SHOW FULL OBJECTS` will output a table with
-two columns, `name` and `type`. `type` indicates whether the object was created by the `system` or a `user`.
+`SHOW OBJECTS` will output a table with two columns, `name` and `type`. `type` indicates whether the object was created
+by the `system` or a `user`.
 
 ## Examples
 
@@ -32,45 +32,30 @@ two columns, `name` and `type`. `type` indicates whether the object was created 
 SHOW SCHEMAS;
 ```
 ```nofmt
-public
+  name  | type
+--------+------
+ public | user
 ```
 ```sql
 SHOW OBJECTS FROM public;
 ```
 ```nofmt
-my_table
-my_source
-my_view
-my_other_source
+  name          | type
+----------------+------
+my_table        | user
+my_source       | user
+my_view         | user
+my_other_source | user
 ```
 ```sql
 SHOW OBJECTS;
 ```
 ```nofmt
-my_table
-my_source
-my_view
-```
-
-```sql
-SHOW FULL OBJECTS;
-```
-```nofmt
-my_table
-my_source
-my_view
-my_other_source
-```
-
-```sql
-SHOW EXTENDED FULL OBJECTS;
-```
-```nofmt
-my_table        user
-my_source       user
-my_view         user
-my_other_source user
-builtin_view    system
+  name          | type
+----------------+------
+my_table        | user
+my_source       | user
+my_view         | user
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-schemas.md
+++ b/doc/user/content/sql/show-schemas.md
@@ -38,9 +38,9 @@ my_db
 SHOW SCHEMAS FROM my_db
 ```
 ```nofmt
- name
-------
-public
+  name  | type
+--------+------
+ public | user
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-sinks.md
+++ b/doc/user/content/sql/show-sinks.md
@@ -20,21 +20,19 @@ aliases:
 Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show sinks from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**FULL** | Return details about your sinks.
 
 ### Output format
 
-`SHOW FULL SINKS`'s output is a table, with this structure:
+`SHOW SINKS`'s output is a table, with this structure:
 
 ```nofmt
-cluster | name  | type
---------+-------+-------
-...     | ...   | ...
+name  | type
+------+-------
+...   | ...
 ```
 
 Field | Meaning
 ------|--------
-**cluster** | The name of the [cluster](/overview/key-concepts/#clusters) containing the sink.
 **name** | The name of the sink.
 **type** | Whether the sink was created by the `user` or the `system`.
 
@@ -44,6 +42,9 @@ Field | Meaning
 SHOW SINKS;
 ```
 ```nofmt
+name    | type
+--------+-------
+my_sink | user
 my_sink
 ```
 

--- a/doc/user/content/sql/show-sources.md
+++ b/doc/user/content/sql/show-sources.md
@@ -16,13 +16,12 @@ instances.
 Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show sources from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**FULL** | Return details about your sources.
 
 ## Details
 
-### Output format for `SHOW FULL SOURCES`
+### Output format for `SHOW SOURCES`
 
-`SHOW FULL SOURCES`'s output is a table, with this structure:
+`SHOW SOURCES`'s output is a table, with this structure:
 
 ```nofmt
  name  | type | type
@@ -59,32 +58,27 @@ source in the `mz_catalog` schema.
 SHOW SCHEMAS;
 ```
 ```nofmt
-public
+  name  | type
+--------+------
+ public | user
 ```
 ```sql
 SHOW SOURCES FROM public;
 ```
 ```nofmt
-my_kafka_source
-my_postgres_source
+            name           | type | type
+---------------------------+------+---------
+ my_kafka_source           | user | kafka
+ my_postgres_source        | user | postgres
 ```
 ```sql
 SHOW SOURCES;
 ```
 ```nofmt
-my_kafka_source
-my_postgres_source
-```
-
-### Show details about sources
-
-```sql
-SHOW FULL SOURCES;
-```
-```nofmt
             name           | type | type
----------------------------+------+------
+---------------------------+------+---------
  my_kafka_source           | user | kafka
+ my_postgres_source        | user | postgres
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-tables.md
+++ b/doc/user/content/sql/show-tables.md
@@ -15,8 +15,6 @@ menu:
 Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show tables from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**EXTENDED** | Returns system tables as well as user-created tables. By default, only user-created tables are returned.
-**FULL**  | Returns a column that lists table type (`system`, `user`, or `temp`).
 
 ## Details
 
@@ -31,8 +29,10 @@ _schema&lowbar;name_ | The schema to show tables from. Defaults to `public` in t
 SHOW TABLES;
 ```
 ```nofmt
-my_table
-my_other_table
+ name           | type
+----------------+-----
+ my_table       | user
+ my_other_table | user
 ```
 
 ### Show tables from specified schema
@@ -40,32 +40,18 @@ my_other_table
 SHOW SCHEMAS;
 ```
 ```nofmt
-public
+  name  | type
+--------+------
+ public | user
 ```
 ```sql
 SHOW TABLES FROM public;
 ```
 ```nofmt
-my_table
-my_other_table
-```
-
-### Show all tables and include table type
-
-`EXTENDED` lists system tables as well as user-created tables; `FULL` adds the `type` column that specifies whether the table was created by a user or a temp process or is a system table.
-
-```sql
-SHOW EXTENDED FULL TABLES;
-```
-```nofmt
-name                  |  type
-----------------------+--------
- mz_array_types       | system
- mz_base_types        | system
- ...
- my_table             | user
- my_other_table       | user
-(23 rows)
+ name           | type
+----------------+-----
+ my_table       | user
+ my_other_table | user
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-types.md
+++ b/doc/user/content/sql/show-types.md
@@ -14,8 +14,8 @@ menu:
 
 Field | Use
 ------|-----
-`EXTENDED` |  Returns system types as well as user-created types. By default, only user-created types are returned.
-`FULL`| Returns the creator of the data type (user or system).
+_schema&lowbar;name_ | The schema to show types from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
+
 
 ## Examples
 
@@ -25,26 +25,9 @@ Field | Use
 SHOW TYPES;
 ```
 ```
-      name
-----------------
-  int4_list
-```
-
-### Show all data types
-
-```sql
-SHOW EXTENDED FULL TYPES;
-```
-```
      name       |  type
 ----------------+--------
- _bool          | system
- _bytea         | system
- _date          | system
- _float4        | system
- _float8        | system
  int4_list      | user
-...
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-views.md
+++ b/doc/user/content/sql/show-views.md
@@ -15,13 +15,12 @@ menu:
 Field | Use
 ------|-----
 _schema&lowbar;name_ | The schema to show views from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
-**FULL** | Return details about your views.
 
 ## Details
 
-### Output format for `SHOW FULL VIEWS`
+### Output format for `SHOW VIEWS`
 
-`SHOW FULL VIEWS`'s output is a table, with this structure:
+`SHOW VIEWS`'s output is a table, with this structure:
 
 ```nofmt
  name  | type
@@ -40,17 +39,6 @@ Field | Meaning
 
 ```sql
 SHOW VIEWS;
-```
-```nofmt
-  name
----------
- my_view
-```
-
-### Show details about views
-
-```sql
-SHOW FULL VIEWS;
 ```
 ```nofmt
   name   | type

--- a/doc/user/layouts/partials/sql-grammar/show-connections.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-connections.svg
@@ -1,70 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="487" height="199">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="64" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="515" height="199">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">SHOW</text>
-   <rect x="137" y="35" width="54" height="32" rx="10"/>
-   <rect x="135"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="145" y="53">FULL</text>
-   <rect x="231" y="3" width="124" height="32" rx="10"/>
-   <rect x="229"
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="124" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="124"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="239" y="21">CONNECTIONS</text>
-   <rect x="45" y="121" width="60" height="32" rx="10"/>
-   <rect x="43"
-         y="119"
+   <text class="terminal" x="123" y="21">CONNECTIONS</text>
+   <rect x="279" y="35" width="60" height="32" rx="10"/>
+   <rect x="277"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="139">FROM</text>
-   <rect x="125" y="121" width="114" height="32"/>
-   <rect x="123" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="133" y="139">schema_name</text>
-   <rect x="299" y="121" width="50" height="32" rx="10"/>
-   <rect x="297"
+   <text class="terminal" x="287" y="53">FROM</text>
+   <rect x="359" y="35" width="114" height="32"/>
+   <rect x="357" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="367" y="53">schema_name</text>
+   <rect x="327" y="121" width="50" height="32" rx="10"/>
+   <rect x="325"
          y="119"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="307" y="139">LIKE</text>
-   <rect x="369" y="121" width="70" height="32" rx="10"/>
-   <rect x="367"
+   <text class="terminal" x="335" y="139">LIKE</text>
+   <rect x="397" y="121" width="70" height="32" rx="10"/>
+   <rect x="395"
          y="119"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="377" y="139">pattern</text>
-   <rect x="299" y="165" width="70" height="32" rx="10"/>
-   <rect x="297"
+   <text class="terminal" x="405" y="139">pattern</text>
+   <rect x="327" y="165" width="70" height="32" rx="10"/>
+   <rect x="325"
          y="163"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="307" y="183">WHERE</text>
-   <rect x="389" y="165" width="48" height="32"/>
-   <rect x="387" y="163" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="397" y="183">expr</text>
+   <text class="terminal" x="335" y="183">WHERE</text>
+   <rect x="417" y="165" width="48" height="32"/>
+   <rect x="415" y="163" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="425" y="183">expr</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m124 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-374 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m40 -32 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
-   <polygon points="477 103 485 99 485 107"/>
-   <polygon points="477 103 469 99 469 107"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m124 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-230 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
+   <polygon points="505 103 513 99 513 107"/>
+   <polygon points="505 103 497 99 497 107"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-index.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-index.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="559" height="361">
+<svg xmlns="http://www.w3.org/2000/svg" width="559" height="235">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="64" height="32" rx="10"/>
@@ -9,105 +9,97 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="41" y="21">SHOW</text>
-   <rect x="137" y="35" width="96" height="32" rx="10"/>
+   <rect x="137" y="3" width="62" height="32" rx="10"/>
    <rect x="135"
-         y="33"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="145" y="53">EXTENDED</text>
-   <rect x="293" y="3" width="62" height="32" rx="10"/>
-   <rect x="291"
          y="1"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="21">INDEX</text>
-   <rect x="293" y="47" width="80" height="32" rx="10"/>
-   <rect x="291"
+   <text class="terminal" x="145" y="21">INDEX</text>
+   <rect x="137" y="47" width="80" height="32" rx="10"/>
+   <rect x="135"
          y="45"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="65">INDEXES</text>
-   <rect x="293" y="91" width="58" height="32" rx="10"/>
-   <rect x="291"
+   <text class="terminal" x="145" y="65">INDEXES</text>
+   <rect x="137" y="91" width="58" height="32" rx="10"/>
+   <rect x="135"
          y="89"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="301" y="109">KEYS</text>
-   <rect x="203" y="173" width="60" height="32" rx="10"/>
-   <rect x="201"
-         y="171"
+   <text class="terminal" x="145" y="109">KEYS</text>
+   <rect x="297" y="35" width="60" height="32" rx="10"/>
+   <rect x="295"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="211" y="191">FROM</text>
-   <rect x="203" y="217" width="34" height="32" rx="10"/>
-   <rect x="201"
-         y="215"
+   <text class="terminal" x="305" y="53">FROM</text>
+   <rect x="297" y="79" width="34" height="32" rx="10"/>
+   <rect x="295"
+         y="77"
          width="34"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="211" y="235">IN</text>
-   <rect x="303" y="173" width="78" height="32"/>
-   <rect x="301" y="171" width="78" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="311" y="191">on_name</text>
-   <rect x="45" y="315" width="34" height="32" rx="10"/>
+   <text class="terminal" x="305" y="97">IN</text>
+   <rect x="397" y="35" width="78" height="32"/>
+   <rect x="395" y="33" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="405" y="53">on_name</text>
+   <rect x="45" y="189" width="34" height="32" rx="10"/>
    <rect x="43"
-         y="313"
+         y="187"
          width="34"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="333">IN</text>
-   <rect x="99" y="315" width="84" height="32" rx="10"/>
+   <text class="terminal" x="53" y="207">IN</text>
+   <rect x="99" y="189" width="84" height="32" rx="10"/>
    <rect x="97"
-         y="313"
+         y="187"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="107" y="333">CLUSTER</text>
-   <rect x="203" y="315" width="108" height="32"/>
-   <rect x="201" y="313" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="211" y="333">cluster_name</text>
-   <rect x="371" y="283" width="50" height="32" rx="10"/>
+   <text class="terminal" x="107" y="207">CLUSTER</text>
+   <rect x="203" y="189" width="108" height="32"/>
+   <rect x="201" y="187" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="211" y="207">cluster_name</text>
+   <rect x="371" y="157" width="50" height="32" rx="10"/>
    <rect x="369"
-         y="281"
+         y="155"
          width="50"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="379" y="301">LIKE</text>
-   <rect x="441" y="283" width="70" height="32" rx="10"/>
+   <text class="terminal" x="379" y="175">LIKE</text>
+   <rect x="441" y="157" width="70" height="32" rx="10"/>
    <rect x="439"
-         y="281"
+         y="155"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="449" y="301">pattern</text>
-   <rect x="371" y="327" width="70" height="32" rx="10"/>
+   <text class="terminal" x="449" y="175">pattern</text>
+   <rect x="371" y="201" width="70" height="32" rx="10"/>
    <rect x="369"
-         y="325"
+         y="199"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="379" y="345">WHERE</text>
-   <rect x="461" y="327" width="48" height="32"/>
-   <rect x="459" y="325" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="469" y="345">expr</text>
+   <text class="terminal" x="379" y="219">WHERE</text>
+   <rect x="461" y="201" width="48" height="32"/>
+   <rect x="459" y="199" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="469" y="219">expr</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m62 0 h10 m0 0 h18 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m58 0 h10 m0 0 h22 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-274 138 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h208 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v12 m238 0 v-12 m-238 12 q0 10 10 10 m218 0 q10 0 10 -10 m-208 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m34 0 h10 m0 0 h26 m20 -44 h10 m78 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-420 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
-   <polygon points="549 297 557 293 557 301"/>
-   <polygon points="549 297 541 293 541 301"/>
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m62 0 h10 m0 0 h18 m-120 0 h20 m100 0 h20 m-140 0 q10 0 10 10 m120 0 q0 -10 10 -10 m-130 10 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m80 0 h10 m-110 -10 v20 m120 0 v-20 m-120 20 v24 m120 0 v-24 m-120 24 q0 10 10 10 m100 0 q10 0 10 -10 m-110 10 h10 m58 0 h10 m0 0 h22 m40 -88 h10 m0 0 h208 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v12 m238 0 v-12 m-238 12 q0 10 10 10 m218 0 q10 0 10 -10 m-208 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m34 0 h10 m0 0 h26 m20 -44 h10 m78 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-514 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
+   <polygon points="549 171 557 167 557 175"/>
+   <polygon points="549 171 541 167 541 175"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-materialized-views.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-materialized-views.svg
@@ -1,54 +1,46 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="579" height="155">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="64" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="567" height="155">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">SHOW</text>
-   <rect x="137" y="35" width="54" height="32" rx="10"/>
-   <rect x="135"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="145" y="53">FULL</text>
-   <rect x="231" y="3" width="176" height="32" rx="10"/>
-   <rect x="229"
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="176" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="176"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="239" y="21">MATERIALIZED VIEWS</text>
-   <rect x="45" y="121" width="60" height="32" rx="10"/>
-   <rect x="43"
-         y="119"
+   <text class="terminal" x="123" y="21">MATERIALIZED VIEWS</text>
+   <rect x="331" y="35" width="60" height="32" rx="10"/>
+   <rect x="329"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="139">FROM</text>
-   <rect x="125" y="121" width="114" height="32"/>
-   <rect x="123" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="133" y="139">schema_name</text>
-   <rect x="299" y="121" width="104" height="32" rx="10"/>
-   <rect x="297"
+   <text class="terminal" x="339" y="53">FROM</text>
+   <rect x="411" y="35" width="114" height="32"/>
+   <rect x="409" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="419" y="53">schema_name</text>
+   <rect x="287" y="121" width="104" height="32" rx="10"/>
+   <rect x="285"
          y="119"
          width="104"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="307" y="139">IN CLUSTER</text>
-   <rect x="423" y="121" width="108" height="32"/>
-   <rect x="421" y="119" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="431" y="139">cluster_name</text>
+   <text class="terminal" x="295" y="139">IN CLUSTER</text>
+   <rect x="411" y="121" width="108" height="32"/>
+   <rect x="409" y="119" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="419" y="139">cluster_name</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m176 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-426 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m40 -32 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"/>
-   <polygon points="569 103 577 99 577 107"/>
-   <polygon points="569 103 561 99 561 107"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m176 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-322 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m23 -32 h-3"/>
+   <polygon points="557 103 565 99 565 107"/>
+   <polygon points="557 103 549 99 549 107"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-objects.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-objects.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="493" height="155">
+<svg xmlns="http://www.w3.org/2000/svg" width="483" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -9,43 +9,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="96" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="143" y="53">EXTENDED</text>
-   <rect x="291" y="35" width="54" height="32" rx="10"/>
-   <rect x="289"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="299" y="53">FULL</text>
-   <rect x="385" y="3" width="86" height="32" rx="10"/>
-   <rect x="383"
+   <rect x="115" y="3" width="86" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="393" y="21">OBJECTS</text>
-   <rect x="251" y="121" width="60" height="32" rx="10"/>
-   <rect x="249"
-         y="119"
+   <text class="terminal" x="123" y="21">OBJECTS</text>
+   <rect x="241" y="35" width="60" height="32" rx="10"/>
+   <rect x="239"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="259" y="139">FROM</text>
-   <rect x="331" y="121" width="114" height="32"/>
-   <rect x="329" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="339" y="139">schema_name</text>
+   <text class="terminal" x="249" y="53">FROM</text>
+   <rect x="321" y="35" width="114" height="32"/>
+   <rect x="319" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="329" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m86 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-284 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
-   <polygon points="483 103 491 99 491 107"/>
-   <polygon points="483 103 475 99 475 107"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m86 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="473 17 481 13 481 21"/>
+   <polygon points="473 17 465 13 465 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-sinks.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-sinks.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="573" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="459" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -9,35 +9,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="54" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="143" y="53">FULL</text>
-   <rect x="229" y="3" width="62" height="32" rx="10"/>
-   <rect x="227"
+   <rect x="115" y="3" width="62" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="21">SINKS</text>
-   <rect x="331" y="35" width="60" height="32" rx="10"/>
-   <rect x="329"
+   <text class="terminal" x="123" y="21">SINKS</text>
+   <rect x="217" y="35" width="60" height="32" rx="10"/>
+   <rect x="215"
          y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="339" y="53">FROM</text>
-   <rect x="411" y="35" width="114" height="32"/>
-   <rect x="409" y="33" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="419" y="53">schema_name</text>
+   <text class="terminal" x="225" y="53">FROM</text>
+   <rect x="297" y="35" width="114" height="32"/>
+   <rect x="295" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="305" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m62 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
-   <polygon points="563 17 571 13 571 21"/>
-   <polygon points="563 17 555 13 555 21"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m62 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="449 17 457 13 457 21"/>
+   <polygon points="449 17 441 13 441 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-sources.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-sources.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="339" height="155">
+<svg xmlns="http://www.w3.org/2000/svg" width="485" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -9,35 +9,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="54" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="143" y="53">FULL</text>
-   <rect x="229" y="3" width="88" height="32" rx="10"/>
-   <rect x="227"
+   <rect x="115" y="3" width="88" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="88"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="21">SOURCES</text>
-   <rect x="97" y="121" width="60" height="32" rx="10"/>
-   <rect x="95"
-         y="119"
+   <text class="terminal" x="123" y="21">SOURCES</text>
+   <rect x="243" y="35" width="60" height="32" rx="10"/>
+   <rect x="241"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="105" y="139">FROM</text>
-   <rect x="177" y="121" width="114" height="32"/>
-   <rect x="175" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="185" y="139">schema_name</text>
+   <text class="terminal" x="251" y="53">FROM</text>
+   <rect x="323" y="35" width="114" height="32"/>
+   <rect x="321" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="331" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m88 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-284 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
-   <polygon points="329 103 337 99 337 107"/>
-   <polygon points="329 103 321 99 321 107"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="475 17 483 13 483 21"/>
+   <polygon points="475 17 467 13 467 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-tables.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-tables.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="481" height="155">
+<svg xmlns="http://www.w3.org/2000/svg" width="471" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -9,43 +9,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="96" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="143" y="53">EXTENDED</text>
-   <rect x="291" y="35" width="54" height="32" rx="10"/>
-   <rect x="289"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="299" y="53">FULL</text>
-   <rect x="385" y="3" width="74" height="32" rx="10"/>
-   <rect x="383"
+   <rect x="115" y="3" width="74" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="393" y="21">TABLES</text>
-   <rect x="239" y="121" width="60" height="32" rx="10"/>
-   <rect x="237"
-         y="119"
+   <text class="terminal" x="123" y="21">TABLES</text>
+   <rect x="229" y="35" width="60" height="32" rx="10"/>
+   <rect x="227"
+         y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="247" y="139">FROM</text>
-   <rect x="319" y="121" width="114" height="32"/>
-   <rect x="317" y="119" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="139">schema_name</text>
+   <text class="terminal" x="237" y="53">FROM</text>
+   <rect x="309" y="35" width="114" height="32"/>
+   <rect x="307" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="317" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m74 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-284 86 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
-   <polygon points="471 103 479 99 479 107"/>
-   <polygon points="471 103 463 99 463 107"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m74 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="461 17 469 13 469 21"/>
+   <polygon points="461 17 453 13 453 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-types.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-types.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="393" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="463" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -9,24 +9,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="96" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="96"
+   <rect x="115" y="3" width="66" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="143" y="53">EXTENDED</text>
-   <rect x="291" y="35" width="54" height="32" rx="10"/>
-   <rect x="289"
+   <text class="terminal" x="123" y="21">TYPES</text>
+   <rect x="221" y="35" width="60" height="32" rx="10"/>
+   <rect x="219"
          y="33"
-         width="54"
+         width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="299" y="53">FULL</text>
+   <text class="terminal" x="229" y="53">FROM</text>
+   <rect x="301" y="35" width="114" height="32"/>
+   <rect x="299" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="309" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h106 m-136 0 h20 m116 0 h20 m-156 0 q10 0 10 10 m136 0 q0 -10 10 -10 m-146 10 v12 m136 0 v-12 m-136 12 q0 10 10 10 m116 0 q10 0 10 -10 m-126 10 h10 m96 0 h10 m40 -32 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m23 -32 h-3"/>
-   <polygon points="383 17 391 13 391 21"/>
-   <polygon points="383 17 375 13 375 21"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="453 17 461 13 461 21"/>
+   <polygon points="453 17 445 13 445 21"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/show-views.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-views.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="577" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="463" height="69">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="64" height="32" rx="10"/>
@@ -9,35 +9,27 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="135" y="35" width="54" height="32" rx="10"/>
-   <rect x="133"
-         y="33"
-         width="54"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="143" y="53">FULL</text>
-   <rect x="229" y="3" width="66" height="32" rx="10"/>
-   <rect x="227"
+   <rect x="115" y="3" width="66" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="237" y="21">VIEWS</text>
-   <rect x="335" y="35" width="60" height="32" rx="10"/>
-   <rect x="333"
+   <text class="terminal" x="123" y="21">VIEWS</text>
+   <rect x="221" y="35" width="60" height="32" rx="10"/>
+   <rect x="219"
          y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="343" y="53">FROM</text>
-   <rect x="415" y="35" width="114" height="32"/>
-   <rect x="413" y="33" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="423" y="53">schema_name</text>
+   <text class="terminal" x="229" y="53">FROM</text>
+   <rect x="301" y="35" width="114" height="32"/>
+   <rect x="299" y="33" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="309" y="53">schema_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m20 0 h10 m0 0 h64 m-94 0 h20 m74 0 h20 m-114 0 q10 0 10 10 m94 0 q0 -10 10 -10 m-104 10 v12 m94 0 v-12 m-94 12 q0 10 10 10 m74 0 q10 0 10 -10 m-84 10 h10 m54 0 h10 m20 -32 h10 m66 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
-   <polygon points="567 17 575 13 575 21"/>
-   <polygon points="567 17 559 13 559 21"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-224 10 h10 m60 0 h10 m0 0 h10 m114 0 h10 m23 -32 h-3"/>
+   <polygon points="453 17 461 13 461 21"/>
+   <polygon points="453 17 445 13 445 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -286,7 +286,7 @@ select_stmt ::=
 show_columns ::=
   'SHOW' 'COLUMNS' 'FROM' item_ref ('LIKE' 'pattern' | 'WHERE' expr)
 show_connections ::=
-  'SHOW' 'FULL'? 'CONNECTIONS'
+  'SHOW' 'CONNECTIONS'
   ('FROM' schema_name)?
   ('LIKE' 'pattern' | 'WHERE' expr)?
 show_create_connection ::=
@@ -306,28 +306,28 @@ show_create_view ::=
 show_databases ::=
     'SHOW' 'DATABASES' ('LIKE' 'pattern' | 'WHERE' expr)?
 show_index ::=
-    'SHOW' 'EXTENDED'? ('INDEX' | 'INDEXES' | 'KEYS')
+    'SHOW' ('INDEX' | 'INDEXES' | 'KEYS')
     (('FROM' | 'IN') on_name)?
     ('IN' 'CLUSTER' cluster_name)?
     ('LIKE' 'pattern' | 'WHERE' expr)
 show_materialized_views ::=
-    'SHOW' 'FULL'? 'MATERIALIZED VIEWS' ('FROM' schema_name)? ('IN CLUSTER' cluster_name)?
+    'SHOW' 'MATERIALIZED VIEWS' ('FROM' schema_name)? ('IN CLUSTER' cluster_name)?
 show_secrets ::=
     'SHOW' 'SECRETS' ('FROM' schema_name)? ('LIKE' 'pattern' | 'WHERE' expr)?
 show_schemas ::=
     'SHOW' 'SCHEMAS' ('FROM' database_name)?
 show_sinks ::=
-   'SHOW' 'FULL'? 'SINKS' ('FROM' schema_name)?
+   'SHOW' 'SINKS' ('FROM' schema_name)?
 show_sources ::=
-  'SHOW' 'FULL'? 'SOURCES' ('FROM' schema_name)?
+  'SHOW' 'SOURCES' ('FROM' schema_name)?
 show_tables ::=
-  'SHOW' 'EXTENDED'? 'FULL'? 'TABLES' ('FROM' schema_name)?
+  'SHOW' 'TABLES' ('FROM' schema_name)?
 show_types ::=
-  'SHOW' 'EXTENDED'? 'FULL'?
+  'SHOW' 'TYPES' ('FROM' schema_name)?
 show_views ::=
-  'SHOW' 'FULL'? 'VIEWS' ('FROM' schema_name)?
+  'SHOW' 'VIEWS' ('FROM' schema_name)?
 show_objects ::=
-  'SHOW' 'EXTENDED'? 'FULL'?  'OBJECTS' ('FROM' schema_name)?
+  'SHOW' 'OBJECTS' ('FROM' schema_name)?
 string_agg ::=
   'string_agg' '(' value ',' delimiter    ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 table_ref ::=

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1523,20 +1523,12 @@ impl_display_t!(ShowDatabasesStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowSchemasStatement<T: AstInfo> {
     pub from: Option<T::DatabaseName>,
-    pub extended: bool,
-    pub full: bool,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for ShowSchemasStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW");
-        if self.extended {
-            f.write_str(" EXTENDED");
-        }
-        if self.full {
-            f.write_str(" FULL");
-        }
         f.write_str(" SCHEMAS");
         if let Some(from) = &self.from {
             f.write_str(" FROM ");
@@ -1563,20 +1555,12 @@ pub struct ShowObjectsStatement<T: AstInfo> {
     pub object_type: ObjectType,
     pub from: Option<T::SchemaName>,
     pub in_cluster: Option<T::ClusterName>,
-    pub extended: bool,
-    pub full: bool,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW");
-        if self.extended {
-            f.write_str(" EXTENDED");
-        }
-        if self.full {
-            f.write_str(" FULL");
-        }
         f.write_str(" ");
         f.write_str(match &self.object_type {
             ObjectType::Table => "TABLES",
@@ -1614,16 +1598,12 @@ impl_display_t!(ShowObjectsStatement);
 pub struct ShowIndexesStatement<T: AstInfo> {
     pub table_name: Option<T::ObjectName>,
     pub in_cluster: Option<T::ClusterName>,
-    pub extended: bool,
     pub filter: Option<ShowStatementFilter<T>>,
 }
 
 impl<T: AstInfo> AstDisplay for ShowIndexesStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW ");
-        if self.extended {
-            f.write_str("EXTENDED ");
-        }
         f.write_str("INDEXES");
         if let Some(table_name) = &self.table_name {
             f.write_str(" FROM ");
@@ -1646,8 +1626,6 @@ impl_display_t!(ShowIndexesStatement);
 /// Note: this is a MySQL-specific statement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowColumnsStatement<T: AstInfo> {
-    pub extended: bool,
-    pub full: bool,
     pub table_name: T::ObjectName,
     pub filter: Option<ShowStatementFilter<T>>,
 }
@@ -1655,12 +1633,6 @@ pub struct ShowColumnsStatement<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for ShowColumnsStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW ");
-        if self.extended {
-            f.write_str("EXTENDED ");
-        }
-        if self.full {
-            f.write_str("FULL ");
-        }
         f.write_str("COLUMNS FROM ");
         f.write_node(&self.table_name);
         if let Some(filter) = &self.filter {

--- a/src/sql-parser/src/keywords.txt
+++ b/src/sql-parser/src/keywords.txt
@@ -119,7 +119,6 @@ Except
 Execute
 Exists
 Explain
-Extended
 Extract
 Factor
 False

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1298,7 +1298,7 @@ SHOW SECRETS
 ----
 SHOW SECRETS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Secret, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Secret, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 ALTER SECRET secret RENAME TO secret2

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1284,4 +1284,4 @@ SELECT * FROM (SHOW TABLES)
 ----
 SELECT * FROM (SHOW TABLES)
 =>
-Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, extended: false, full: false, filter: None })), order_by: [], limit: None, offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+Select(SelectStatement { query: Query { ctes: [], body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Derived { lateral: false, subquery: Query { ctes: [], body: Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: None })), order_by: [], limit: None, offset: None }, alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -37,28 +37,28 @@ SHOW ROLES
 ----
 SHOW ROLES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW CLUSTERS
 ----
 SHOW CLUSTERS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW USERS
 ----
 SHOW ROLES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Role, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW SCHEMAS
 ----
 SHOW SCHEMAS
 =>
-Show(ShowSchemas(ShowSchemasStatement { from: None, extended: false, full: false, filter: None }))
+Show(ShowSchemas(ShowSchemasStatement { from: None, filter: None }))
 
 parse-statement
 SHOW SCHEMAS FROM foo.bar
@@ -72,168 +72,147 @@ SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW SOURCES FROM foo.bar
 ----
 SHOW SOURCES FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW VIEWS
 ----
 SHOW VIEWS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: View, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW VIEWS FROM foo.bar
 ----
 SHOW VIEWS FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS
 ----
 SHOW MATERIALIZED VIEWS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS FROM foo.bar
 ----
 SHOW MATERIALIZED VIEWS FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS FROM foo.bar IN CLUSTER baz
 ----
 SHOW MATERIALIZED VIEWS FROM foo.bar IN CLUSTER baz
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), filter: None }))
 
 parse-statement
 SHOW MATERIALIZED VIEWS IN CLUSTER baz
 ----
 SHOW MATERIALIZED VIEWS IN CLUSTER baz
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: None, in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: MaterializedView, from: None, in_cluster: Some(Unresolved(Ident("baz"))), filter: None }))
 
 parse-statement
 SHOW TABLES
 ----
 SHOW TABLES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW TABLES FROM foo.bar
 ----
 SHOW TABLES FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW SINKS
 ----
 SHOW SINKS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW SINKS FROM foo.bar
 ----
 SHOW SINKS FROM foo.bar
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW SINKS FROM foo.bar IN CLUSTER baz
 ----
 SHOW SINKS FROM foo.bar IN CLUSTER baz
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Sink, from: Some(UnresolvedSchemaName([Ident("foo"), Ident("bar")])), in_cluster: Some(Unresolved(Ident("baz"))), filter: None }))
 
 parse-statement
 SHOW TABLES LIKE '%foo%'
 ----
 SHOW TABLES LIKE '%foo%'
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, extended: false, full: false, filter: Some(Like("%foo%")) }))
-
-parse-statement
-SHOW FULL VIEWS
-----
-SHOW FULL VIEWS
-=>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: None, in_cluster: None, extended: false, full: true, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Table, from: None, in_cluster: None, filter: Some(Like("%foo%")) }))
 
 parse-statement
 SHOW SOURCES
 ----
 SHOW SOURCES
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Source, from: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW VIEWS FROM foo LIKE '%foo%'
 ----
 SHOW VIEWS FROM foo LIKE '%foo%'
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo")])), in_cluster: None, extended: false, full: false, filter: Some(Like("%foo%")) }))
+Show(ShowObjects(ShowObjectsStatement { object_type: View, from: Some(UnresolvedSchemaName([Ident("foo")])), in_cluster: None, filter: Some(Like("%foo%")) }))
 
 parse-statement
 SHOW INDEXES FROM foo
 ----
 SHOW INDEXES FROM foo
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: false, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW INDEXES IN foo
 ----
 SHOW INDEXES FROM foo
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: false, filter: None }))
-
-parse-statement
-SHOW EXTENDED INDEXES FROM foo
-----
-SHOW EXTENDED INDEXES FROM foo
-=>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: true, filter: None }))
-
-parse-statement
-SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
-----
-SHOW EXTENDED INDEXES FROM foo WHERE index_name = 'bar'
-=>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, extended: true, filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Identifier([Ident("index_name")]), expr2: Some(Value(String("bar"))) })) }))
+Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, filter: None }))
 
 parse-statement
 SHOW INDEXES
 ----
 SHOW INDEXES
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: None, extended: false, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW INDEXES IN CLUSTER c
 ----
 SHOW INDEXES IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: Some(Unresolved(Ident("c"))), extended: false, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
 
 parse-statement
 SHOW INDEXES FROM c IN CLUSTER c
 ----
 SHOW INDEXES FROM c IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("c")]))), in_cluster: Some(Unresolved(Ident("c"))), extended: false, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("c")]))), in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
 
 parse-statement
 SHOW CREATE VIEW foo
@@ -268,70 +247,49 @@ SHOW COLUMNS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW COLUMNS FROM mydb.mytable
 ----
 SHOW COLUMNS FROM mydb.mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mydb"), Ident("mytable")])), filter: None }))
-
-parse-statement
-SHOW EXTENDED COLUMNS FROM mytable
-----
-SHOW EXTENDED COLUMNS FROM mytable
-=>
-Show(ShowColumns(ShowColumnsStatement { extended: true, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
-
-parse-statement
-SHOW FULL COLUMNS FROM mytable
-----
-SHOW FULL COLUMNS FROM mytable
-=>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: true, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
-
-parse-statement
-SHOW EXTENDED FULL COLUMNS FROM mytable
-----
-SHOW EXTENDED FULL COLUMNS FROM mytable
-=>
-Show(ShowColumns(ShowColumnsStatement { extended: true, full: true, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mydb"), Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 ----
 SHOW COLUMNS FROM mytable LIKE 'pattern'
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Like("pattern")) }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Like("pattern")) }))
 
 parse-statement
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 ----
 SHOW COLUMNS FROM mytable WHERE 1 = 2
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) })) }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: Some(Where(Op { op: Op { namespace: [], op: "=" }, expr1: Value(Number("1")), expr2: Some(Value(Number("2"))) })) }))
 
 parse-statement
 SHOW FIELDS FROM mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW COLUMNS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW FIELDS IN mytable
 ----
 SHOW COLUMNS FROM mytable
 =>
-Show(ShowColumns(ShowColumnsStatement { extended: false, full: false, table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
+Show(ShowColumns(ShowColumnsStatement { table_name: Name(UnresolvedObjectName([Ident("mytable")])), filter: None }))
 
 parse-statement
 SHOW a
@@ -345,7 +303,7 @@ SHOW CLUSTERS
 ----
 SHOW CLUSTERS
 =>
-Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, extended: false, full: false, filter: None }))
+Show(ShowObjects(ShowObjectsStatement { object_type: Cluster, from: None, in_cluster: None, filter: None }))
 
 # TODO(justin): "all" here should be its own token so that it doesn't get
 # downcased.

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -267,13 +267,20 @@ pub fn show_schemas<'a>(
     scx: &'a StatementContext<'a>,
     ShowSchemasStatement { from, filter }: ShowSchemasStatement<Aug>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let mut query = format!(
+    let database_id = match from {
+        Some(ResolvedDatabaseName::Database { id, .. }) => id.0,
+        None => match scx.active_database() {
+            Some(id) => id.0,
+            None => sql_bail!("no database specified and no active database"),
+        },
+        Some(ResolvedDatabaseName::Error) => {
+            unreachable!("should have been handled in name resolution")
+        }
+    };
+    let query = format!(
         "SELECT name, CASE WHEN database_id IS NULL THEN 'system' ELSE 'user' END AS type
-            FROM mz_catalog.mz_schemas",
+            FROM mz_catalog.mz_schemas WHERE database_id IS NULL OR database_id = {database_id}",
     );
-    if let Some(ResolvedDatabaseName::Database { id, .. }) = from {
-        query = format!("{query} WHERE database_id = {}", id.0);
-    }
     ShowSelect::new(scx, query, filter, None, None)
 }
 

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -107,7 +107,23 @@ SHOW INDEXES IN CLUSTER bar;
 bar  v  v_primary_idx  1  ?column?  NULL  false
 
 query TTTTTTT
-SHOW EXTENDED INDEXES IN CLUSTER bar;
+SELECT
+    clusters.name AS cluster,
+    objs.name AS on_name,
+    idxs.name AS key_name,
+    idx_cols.index_position AS seq_in_index,
+    obj_cols.name AS column_name,
+    idx_cols.on_expression AS expression,
+    idx_cols.nullable AS nullable
+FROM
+    mz_catalog.mz_indexes AS idxs
+    JOIN mz_catalog.mz_index_columns AS idx_cols ON idxs.id = idx_cols.index_id
+    JOIN mz_catalog.mz_objects AS objs ON idxs.on_id = objs.id
+    JOIN mz_catalog.mz_clusters AS clusters ON clusters.id = idxs.cluster_id
+    LEFT JOIN mz_catalog.mz_columns AS obj_cols
+        ON idxs.on_id = obj_cols.id AND idx_cols.on_position = obj_cols.position
+WHERE clusters.name = 'bar'
+ORDER BY on_name, seq_in_index ASC;
 ----
 bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_4_primary_idx  1  operator  NULL  false
 bar  mz_arrangement_batches_internal  mz_arrangement_batches_internal_4_primary_idx  2  worker  NULL  false

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -76,7 +76,7 @@ statement ok
 CREATE MATERIALIZED VIEW other_mv IN CLUSTER other AS SELECT 1
 
 query TTT colnames,rowsort
-SHOW FULL MATERIALIZED VIEWS
+SHOW MATERIALIZED VIEWS
 ----
 cluster name     type
 default mv       user
@@ -262,22 +262,15 @@ materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"
 statement ok
 CREATE MATERIALIZED VIEW other_mv IN CLUSTER other AS SELECT 1
 
-query T colnames,rowsort
-SHOW MATERIALIZED VIEWS
-----
-name
-mv
-other_mv
-
 query TTT colnames,rowsort
-SHOW FULL MATERIALIZED VIEWS
+SHOW MATERIALIZED VIEWS
 ----
 cluster name     type
 default mv       user
 other   other_mv user
 
 query TTT colnames,rowsort
-SHOW FULL MATERIALIZED VIEWS IN CLUSTER other
+SHOW MATERIALIZED VIEWS IN CLUSTER other
 ----
 cluster name     type
 other   other_mv user
@@ -325,12 +318,12 @@ SELECT count(*) FROM mz_materialized_views
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT 1
 
-query T colnames,rowsort
+query TT colnames,rowsort
 SHOW OBJECTS
 ----
-name
-mv
-t
+name type
+mv   user
+t    user
 
 
 # Test: Indexes on materialized views show in `SHOW INDEXES`.

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -157,10 +157,10 @@ BEGIN
 ----
 COMPLETE 0
 
-query T rowsort
+query TT rowsort
 SHOW TABLES
 ----
-t
+t   user
 
 simple
 COMMIT

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -30,15 +30,15 @@ Indexes:
 
 # What schemas do we have by default?
 > SHOW SCHEMAS
-public
-> SHOW EXTENDED SCHEMAS
-name
--------
-information_schema
-public
-mz_catalog
-mz_internal
-pg_catalog
+public  user
+> SELECT name, 'system' FROM mz_catalog.mz_schemas WHERE database_id IS NULL
+name                type
+--------------------------
+information_schema  system
+public              system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
 $ psql-execute command=\dn
 \   List of schemas
     Name     | Owner
@@ -63,20 +63,16 @@ $ psql-execute command="\dn mz_*"
 
 # What objects do we have by default?
 > SHOW OBJECTS
-name
-----
-
-> SHOW FULL OBJECTS
 name   type
 -----------
 
 # Creating a schema should be reflected in the output of SHOW SCHEMAS.
 > CREATE SCHEMA s
 > SHOW SCHEMAS
-name
-----
-public
-s
+name    type
+------------
+public  user
+s       user
 
 # Creating a schema with a name that already exists should fail.
 ! CREATE SCHEMA s
@@ -96,9 +92,9 @@ contains:schema 'materialize.s' cannot be dropped without CASCADE while it conta
 
 # What databases do we have by default?
 > SHOW DATABASES
-name
-----
-materialize
+name        type
+----------------
+materialize user
 
 > SELECT name FROM mz_databases
 name
@@ -108,10 +104,10 @@ materialize
 # Creating a database should be reflected in the output of SHOW DATABASES.
 > CREATE DATABASE d
 > SHOW DATABASES
-name
-----
-d
-materialize
+name        type
+----------------
+d           user
+materialize user
 
 # ...and also in `\l`
 $ psql-execute command="\l"
@@ -139,14 +135,14 @@ d
 # WHERE clause.
 > SHOW DATABASES LIKE 'foo'
 > SHOW DATABASES LIKE 'd'
-d
+d   user
 > SHOW DATABASES LIKE 'mat%'
-materialize
+materialize user
 > SHOW DATABASES WHERE (SELECT name = name)
 materialize
-d
+d   user
 > SHOW DATABASES WHERE (name = (SELECT min(name) FROM mz_databases))
-d
+d   user
 ! SHOW DATABASES WHERE 7
 contains:WHERE clause must have type boolean, not type integer
 
@@ -156,53 +152,53 @@ contains:database 'd' already exists
 
 # The new database should have a default public schema.
 > SHOW SCHEMAS FROM d
-name
-----
-public
+name    type
+------------
+public  user
 
 # New schemas in the database should appear in the output of SHOW SCHEMAS FROM.
 > CREATE SCHEMA d.s
 > SHOW SCHEMAS FROM d
-name
-------
-public
-s
+name    type
+------------
+public  user
+s       user
 
 # SHOW SCHEMAS should filter its output based on the provided LIKE or WHERE
 # clause.
 > SHOW SCHEMAS LIKE 'pub%'
-public
+public  user
 > SHOW SCHEMAS LIKE 'private'
 > SHOW SCHEMAS WHERE name = 'public'
-public
+public  user
 
 # New views in the database should work.
 > CREATE VIEW d.public.v1 AS SELECT 1
 > SHOW VIEWS FROM d.public
-name
-----
-v1
+name    type
+------------
+v1      user
 
 # Setting the session database should update name resolution appropriately.
 > SET DATABASE = d
 > SHOW DATABASE
-d
+d user
 > SHOW SCHEMAS
 public
-s
+s user
 > CREATE VIEW v2 AS SELECT 2
 > SHOW VIEWS
-v1
-v2
+v1 user
+v2 user
 > SELECT * FROM v1 UNION ALL SELECT * FROM v2
 1
 2
 
 > SHOW OBJECTS
-name
-----
-v1
-v2
+name    type
+------------
+v1      user
+v2      user
 
 # Test minimizing name qualification
 
@@ -237,7 +233,7 @@ public.bool
 ! DROP OBJECT v1
 contains:Expected one of CONNECTION or CLUSTER or DATABASE or INDEX or MATERIALIZED or ROLE or SECRET or SCHEMA or SINK or SOURCE or TABLE or TYPE or USER or VIEW, found identifier
 
-> SHOW FULL OBJECTS
+> SHOW OBJECTS
 name            type
 --------------------------
 bool            user
@@ -274,7 +270,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-catalog-sink-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
-> SHOW FULL OBJECTS
+> SHOW OBJECTS
 name            type
 --------------------------
 bool            user
@@ -303,7 +299,7 @@ type
 function
 secret
 
-> SELECT * FROM (SHOW FULL OBJECTS) ORDER BY name DESC
+> SELECT * FROM (SHOW OBJECTS) ORDER BY name DESC
 bool user
 csr_conn user
 int_list user
@@ -334,20 +330,20 @@ contains:database 'd' cannot be dropped with RESTRICT while it contains schemas
 > DROP DATABASE d
 # SHOW DATABASES should work, even if the current database has been dropped.
 > SHOW DATABASES
-name
-----
-materialize
+name        type
+----------------
+materialize user
 
 > SELECT name FROM mz_databases
-name
------------
-materialize
+name        type
+----------------
+materialize user
 
 # The session database should remain set to the dropped database, but future
 # queries that depend on the session database should fail with sensible error
 # messages.
 > SHOW DATABASE
-d
+d   user
 ! SELECT * FROM v
 contains:unknown catalog item 'v'
 
@@ -405,65 +401,25 @@ contains:unknown database 'noexist_db'
 > CREATE VIEW d2.public.t AS SELECT * FROM d1.public.t;
 > DROP DATABASE d1;
 > SHOW DATABASES
-name
-----
-d
-d2
-materialize
+name        type
+----------------
+d           user
+d2          user
+materialize user
 > SELECT name FROM mz_databases
-name
------------
-materialize
-d
-d2
+name        type
+----------------
+materialize user
+d           user
+d2          user
 
 > SHOW VIEWS FROM d2.public;
- name
-------
+ name   type
+------------
 
 # Check default sources, tables, and views in mz_catalog.
 
 > SHOW SOURCES FROM mz_catalog
-mz_arrangement_batches_internal
-mz_arrangement_batches_internal_1
-mz_arrangement_records_internal
-mz_arrangement_records_internal_1
-mz_arrangement_sharing_internal
-mz_arrangement_sharing_internal_1
-mz_dataflow_channels
-mz_dataflow_channels_1
-mz_dataflow_addresses
-mz_dataflow_addresses_1
-mz_dataflow_operator_reachability_internal
-mz_dataflow_operator_reachability_internal_1
-mz_dataflow_operators
-mz_dataflow_operators_1
-mz_materialization_dependencies
-mz_materialization_dependencies_1
-mz_materializations
-mz_materializations_1
-mz_message_counts_received_internal
-mz_message_counts_received_internal_1
-mz_message_counts_sent_internal
-mz_message_counts_sent_internal_1
-mz_peek_active
-mz_peek_active_1
-mz_peek_durations
-mz_peek_durations_1
-mz_scheduling_elapsed_internal
-mz_scheduling_elapsed_internal_1
-mz_scheduling_histogram_internal
-mz_scheduling_histogram_internal_1
-mz_scheduling_parks_internal
-mz_scheduling_parks_internal_1
-mz_worker_materialization_delays
-mz_worker_materialization_delays_1
-mz_worker_materialization_frontiers
-mz_worker_materialization_frontiers_1
-mz_worker_materialization_source_frontiers
-mz_worker_materialization_source_frontiers_1
-
-> SHOW FULL SOURCES FROM mz_catalog
 name                                          type   type
 ---------------------------------------------------------
 mz_arrangement_batches_internal               system log
@@ -506,38 +462,6 @@ mz_worker_materialization_source_frontiers    system log
 mz_worker_materialization_source_frontiers_1  system log
 
 > SHOW TABLES FROM mz_catalog
-mz_array_types
-mz_audit_events
-mz_base_types
-mz_clusters
-mz_cluster_replicas_base
-mz_cluster_replica_heartbeats
-mz_cluster_replica_statuses
-mz_columns
-mz_connections
-mz_databases
-mz_functions
-mz_index_columns
-mz_indexes
-mz_kafka_sinks
-mz_list_types
-mz_map_types
-mz_materialized_views
-mz_pseudo_types
-mz_roles
-mz_schemas
-mz_secrets
-mz_sinks
-mz_sources
-mz_ssh_tunnel_connections
-mz_storage_usage
-mz_tables
-mz_types
-mz_view_foreign_keys
-mz_view_keys
-mz_views
-
-> SHOW FULL TABLES FROM mz_catalog
 name                        type
 ----------------------------------
 mz_array_types                system
@@ -563,7 +487,7 @@ mz_schemas                    system
 mz_secrets                    system
 mz_sinks                      system
 mz_sources                    system
-mz_ssh_tunnel_connections system
+mz_ssh_tunnel_connections     system
 mz_storage_usage              system
 mz_tables                     system
 mz_types                      system
@@ -575,74 +499,9 @@ mz_views                      system
 
 > SHOW TABLES FROM tester
 
-> SHOW EXTENDED tables FROM tester
-mz_array_types
-mz_audit_events
-mz_base_types
-mz_clusters
-mz_cluster_replicas_base
-mz_cluster_replica_heartbeats
-mz_cluster_replica_statuses
-mz_columns
-mz_connections
-mz_databases
-mz_functions
-mz_index_columns
-mz_indexes
-mz_kafka_sinks
-mz_list_types
-mz_map_types
-mz_materialized_views
-mz_pseudo_types
-mz_roles
-mz_schemas
-mz_secrets
-mz_sinks
-mz_sources
-mz_ssh_tunnel_connections
-mz_storage_usage
-mz_tables
-mz_types
-mz_view_foreign_keys
-mz_view_keys
-mz_views
-
 > CREATE TABLE tester.test_table (a int)
 
 > SHOW TABLES FROM tester
-test_table
-
-> SHOW EXTENDED tables FROM tester
-mz_array_types
-mz_audit_events
-mz_base_types
-mz_clusters
-mz_cluster_replicas_base
-mz_cluster_replica_heartbeats
-mz_cluster_replica_statuses
-mz_columns
-mz_connections
-mz_databases
-mz_functions
-mz_index_columns
-mz_indexes
-mz_kafka_sinks
-mz_list_types
-mz_map_types
-mz_materialized_views
-mz_pseudo_types
-mz_roles
-mz_schemas
-mz_secrets
-mz_sinks
-mz_sources
-mz_ssh_tunnel_connections
-mz_storage_usage
-mz_tables
-mz_types
-mz_view_foreign_keys
-mz_view_keys
-mz_views
 test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
@@ -654,39 +513,6 @@ test_table
 19
 
 > SHOW VIEWS FROM mz_catalog
-mz_arrangement_sharing
-mz_arrangement_sharing_1
-mz_arrangement_sizes
-mz_arrangement_sizes_1
-mz_catalog_names
-mz_cluster_replicas
-mz_dataflows
-mz_dataflows_1
-mz_dataflow_operator_dataflows
-mz_dataflow_operator_dataflows_1
-mz_dataflow_operator_reachability
-mz_dataflow_operator_reachability_1
-mz_materialization_frontiers
-mz_materialization_frontiers_1
-mz_materialization_source_frontiers
-mz_message_counts
-mz_message_counts_1
-mz_objects
-mz_records_per_dataflow
-mz_records_per_dataflow_1
-mz_records_per_dataflow_global
-mz_records_per_dataflow_global_1
-mz_records_per_dataflow_operator
-mz_records_per_dataflow_operator_1
-mz_relations
-mz_scheduling_elapsed
-mz_scheduling_elapsed_1
-mz_scheduling_histogram
-mz_scheduling_histogram_1
-mz_scheduling_parks
-mz_scheduling_parks_1
-
-> SHOW FULL VIEWS FROM mz_catalog
 name                                 type
 -------------------------------------------
 mz_arrangement_sharing               system
@@ -722,10 +548,10 @@ mz_scheduling_parks                  system
 mz_scheduling_parks_1                system
 
 > SHOW SOURCES FROM mz_catalog LIKE '%peek%';
-mz_peek_active
-mz_peek_active_1
-mz_peek_durations
-mz_peek_durations_1
+mz_peek_active      system
+mz_peek_active_1    system
+mz_peek_durations   system
+mz_peek_durations_1 system
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -30,12 +30,16 @@ Indexes:
 
 # What schemas do we have by default?
 > SHOW SCHEMAS FROM materialize
-public  system
+public              user
+information_schema  system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
 > SHOW SCHEMAS
 name                type
 --------------------------
 information_schema  system
-public              system
+public              user
 mz_catalog          system
 mz_internal         system
 pg_catalog          system
@@ -71,8 +75,13 @@ name   type
 > SHOW SCHEMAS
 name    type
 ------------
-public  user
-s       user
+public              user
+s                   user
+information_schema  system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
+
 
 # Creating a schema with a name that already exists should fail.
 ! CREATE SCHEMA s
@@ -92,9 +101,9 @@ contains:schema 'materialize.s' cannot be dropped without CASCADE while it conta
 
 # What databases do we have by default?
 > SHOW DATABASES
-name        type
-----------------
-materialize user
+name
+------------
+materialize
 
 > SELECT name FROM mz_databases
 name
@@ -104,10 +113,10 @@ materialize
 # Creating a database should be reflected in the output of SHOW DATABASES.
 > CREATE DATABASE d
 > SHOW DATABASES
-name        type
-----------------
-d           user
-materialize user
+name
+-----------
+d
+materialize
 
 # ...and also in `\l`
 $ psql-execute command="\l"
@@ -135,14 +144,14 @@ d
 # WHERE clause.
 > SHOW DATABASES LIKE 'foo'
 > SHOW DATABASES LIKE 'd'
-d   user
+d
 > SHOW DATABASES LIKE 'mat%'
-materialize user
+materialize
 > SHOW DATABASES WHERE (SELECT name = name)
 materialize
-d   user
+d
 > SHOW DATABASES WHERE (name = (SELECT min(name) FROM mz_databases))
-d   user
+d
 ! SHOW DATABASES WHERE 7
 contains:WHERE clause must have type boolean, not type integer
 
@@ -154,15 +163,23 @@ contains:database 'd' already exists
 > SHOW SCHEMAS FROM d
 name    type
 ------------
-public  user
+public              user
+information_schema  system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
 
 # New schemas in the database should appear in the output of SHOW SCHEMAS FROM.
 > CREATE SCHEMA d.s
 > SHOW SCHEMAS FROM d
 name    type
 ------------
-public  user
-s       user
+public              user
+s                   user
+information_schema  system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
 
 # SHOW SCHEMAS should filter its output based on the provided LIKE or WHERE
 # clause.
@@ -182,10 +199,14 @@ v1      user
 # Setting the session database should update name resolution appropriately.
 > SET DATABASE = d
 > SHOW DATABASE
-d user
+d
 > SHOW SCHEMAS
-public
-s user
+public              user
+s                   user
+information_schema  system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
 > CREATE VIEW v2 AS SELECT 2
 > SHOW VIEWS
 v1 user
@@ -330,20 +351,20 @@ contains:database 'd' cannot be dropped with RESTRICT while it contains schemas
 > DROP DATABASE d
 # SHOW DATABASES should work, even if the current database has been dropped.
 > SHOW DATABASES
-name        type
-----------------
-materialize user
+name
+-----------
+materialize
 
 > SELECT name FROM mz_databases
-name        type
-----------------
-materialize user
+name
+-----------
+materialize
 
 # The session database should remain set to the dropped database, but future
 # queries that depend on the session database should fail with sensible error
 # messages.
 > SHOW DATABASE
-d   user
+d
 ! SELECT * FROM v
 contains:unknown catalog item 'v'
 
@@ -401,17 +422,17 @@ contains:unknown database 'noexist_db'
 > CREATE VIEW d2.public.t AS SELECT * FROM d1.public.t;
 > DROP DATABASE d1;
 > SHOW DATABASES
-name        type
-----------------
-d           user
-d2          user
-materialize user
+name
+-----------
+d
+d2
+materialize
 > SELECT name FROM mz_databases
-name        type
-----------------
-materialize user
-d           user
-d2          user
+name
+-----------
+materialize
+d
+d2
 
 > SHOW VIEWS FROM d2.public;
  name   type
@@ -502,7 +523,7 @@ mz_views                      system
 > CREATE TABLE tester.test_table (a int)
 
 > SHOW TABLES FROM tester
-test_table
+test_table  user
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
@@ -548,10 +569,10 @@ mz_scheduling_parks                  system
 mz_scheduling_parks_1                system
 
 > SHOW SOURCES FROM mz_catalog LIKE '%peek%';
-mz_peek_active      system
-mz_peek_active_1    system
-mz_peek_durations   system
-mz_peek_durations_1 system
+mz_peek_active      system  log
+mz_peek_active_1    system  log
+mz_peek_durations   system  log
+mz_peek_durations_1 system  log
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -29,9 +29,9 @@ Indexes:
 > DROP TABLE tbl CASCADE
 
 # What schemas do we have by default?
-> SHOW SCHEMAS
+> SHOW SCHEMAS FROM materialize
 public  user
-> SELECT name, 'system' FROM mz_catalog.mz_schemas WHERE database_id IS NULL
+> SHOW SCHEMAS
 name                type
 --------------------------
 information_schema  system

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -30,7 +30,7 @@ Indexes:
 
 # What schemas do we have by default?
 > SHOW SCHEMAS FROM materialize
-public  user
+public  system
 > SHOW SCHEMAS
 name                type
 --------------------------

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -26,9 +26,6 @@ name       type
 testconn   kafka
 
 > SHOW CONNECTIONS
-testconn
-
-> SHOW FULL CONNECTIONS
 testconn user
 
 > SHOW CREATE CONNECTION testconn

--- a/test/testdrive/get-started.td
+++ b/test/testdrive/get-started.td
@@ -14,11 +14,11 @@
 > CREATE VIEWS FROM SOURCE demo
 
 > SHOW VIEWS
- accounts
- auctions
- bids
- organizations
- users
+ accounts       user
+ auctions       user
+ bids           user
+ organizations  user
+ users          user
 
 > SHOW COLUMNS FROM auctions
 end_time true "timestamp with time zone"

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -116,8 +116,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 contains:unexpected parameters for CREATE SOURCE: badoption
 
 > SHOW SOURCES
-name
-----
+name    type    type
+--------------------
 
 
 # Create a source using an inline schema.

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -34,13 +34,6 @@ user
 > CREATE TYPE test_schema.bool AS LIST (element_type=float4)
 
 > SHOW TYPES
-name
-----
-another_custom
-bool
-custom
-
-> SHOW FULL TYPES
 name             type
 ----------------------
 bool             user
@@ -48,9 +41,9 @@ custom           user
 another_custom   user
 
 > SHOW TYPES FROM test_schema
-name
-----
-bool
+name             type
+----------------------
+bool             user
 
 ! DROP TYPE bool
 contains:cannot drop item pg_catalog.bool because it is required by the database system

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -34,13 +34,6 @@ user
 > CREATE TYPE test_schema.bool AS MAP (key_type=text, value_type=float4)
 
 > SHOW TYPES
-name
-----
-another_custom
-bool
-custom
-
-> SHOW FULL TYPES
 name             type
 ----------------------
 bool             user
@@ -48,9 +41,9 @@ custom           user
 another_custom   user
 
 > SHOW TYPES FROM test_schema
-name
-----
-bool
+name    type
+------------
+bool    user
 
 ! DROP TYPE bool
 contains:cannot drop item pg_catalog.bool because it is required by the database system

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -41,15 +41,12 @@ $ kafka-create-topic topic=data
 > CREATE MATERIALIZED VIEW test1 AS
   SELECT b, sum(a) FROM data GROUP BY b
 
-> SHOW FULL VIEWS
+> SHOW VIEWS
 name        type
 ----------------
 data_view   user
 
 > SHOW MATERIALIZED VIEWS
-test1
-
-> SHOW FULL MATERIALIZED VIEWS
 cluster   name     type
 -----------------------
 default   test1    user
@@ -77,7 +74,7 @@ b     false   bigint
 sum   false   numeric
 
 > SHOW VIEWS LIKE '%data%'
-data_view
+data_view   user
 
 > SHOW CREATE MATERIALIZED VIEW test1
 "Materialized View"       "Create Materialized View"
@@ -336,12 +333,6 @@ a  b
 1  2
 
 > SHOW SOURCES
-name
---------
-data
-mat_data
-
-> SHOW FULL SOURCES
 name     type type
 -------------------
 data     user kafka

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -156,24 +156,24 @@ materialize.public.renamed_sink
 
 # Source was successfully renamed
 > SHOW SOURCES;
-name
-----
-renamed_mz_data
+name            type
+--------------------
+renamed_mz_data user
 
 # Sink was successfully renamed
 > SHOW SINKS
-name
-----
-renamed_sink
+name            type
+--------------------
+renamed_sink    user
 
 # View was successfully renamed
 > SHOW VIEWS
-name
-----
-byzantine_view
-dependent_view
-oppositional_view
-renamed_mz_view
+name                type
+------------------------
+byzantine_view      user
+dependent_view      user
+oppositional_view   user
+renamed_mz_view     user
 
 # Item's own `CREATE VIEW` statement updated
 > SHOW CREATE VIEW renamed_mz_view
@@ -773,16 +773,16 @@ materialize.public.count "CREATE VIEW \"materialize\".\"public\".\"count\" AS SE
 > CREATE TABLE j (b int)
 
 > SHOW TABLES
-name
-----
-j
+name    type
+------------
+j       user
 
 > ALTER TABLE j RENAME TO renamed_j
 
 > SHOW TABLES
-name
-----
-renamed_j
+name        type
+----------------
+renamed_j   user
 
 > SELECT name FROM mz_tables WHERE id like 'u%';
 name

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -156,9 +156,9 @@ materialize.public.renamed_sink
 
 # Source was successfully renamed
 > SHOW SOURCES;
-name            type
---------------------
-renamed_mz_data user
+name            type    type
+-----------------------------
+renamed_mz_data user    kafka
 
 # Sink was successfully renamed
 > SHOW SINKS

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -49,8 +49,8 @@ goofus,gallant
 contains:Expected one of SNAPSHOT
 
 > SHOW SINKS
-name
-----
+name   type
+-----------
 
 # # We should refuse to create a sink with an invalid schema registry URL.
 #
@@ -85,8 +85,8 @@ name
 # contains:v2 is a view, which cannot be exported as a sink
 
 > SHOW SINKS
-name
-----
+name    type
+------------
 
 # N.B. it is important to test sinks that depend on sources directly vs. sinks
 # that depend on views, as the code paths are different.
@@ -104,13 +104,6 @@ name
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > SHOW SINKS
-name
-----
-snk1
-snk2
-snk3
-
-> SHOW FULL SINKS
 name   type
 -----------
 snk1   user
@@ -189,7 +182,7 @@ $ kafka-verify format=avro sink=materialize.public.snk8 sort-messages=true
 {"before": null, "after": {"row":{"column1": 2}}, "transaction": {"id": "<TIMESTAMP>"}}
 {"before": null, "after": {"row":{"column1": 3}}, "transaction": {"id": "<TIMESTAMP>"}}
 
-> SHOW FULL SINKS
+> SHOW SINKS
 name        type
 ----------------
 snk1        user

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -46,13 +46,13 @@ contains:column "a" specified more than once
 > SELECT * FROM t;
 
 > SHOW TABLES;
-name
-----
-t
+name    type
+------------
+t       user
 
 > SHOW SOURCES;
-name
-----
+name    type    type
+--------------------
 
 > SHOW INDEXES FROM t;
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -213,19 +213,19 @@ contains:unknown catalog item 't'
 contains:unknown catalog item 't'
 
 > SHOW TABLES;
-name
-----
-v
+name    type
+------------
+v       user
 
 > SHOW TABLES LIKE 'foo'
 > SHOW TABLES LIKE 'v%'
-v
+v   user
 > SHOW TABLES WHERE name = 'v'
-v
+v   user
 
 > SHOW SOURCES;
-name
-----
+name    type    type
+--------------------
 
 > CREATE TABLE t (a int, b text NOT NULL)
 

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -12,80 +12,9 @@ $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdri
 # Without EXTENDED, SHOW TYPES shouldn't have anything to return.
 > SHOW TYPES
 
-> SHOW FULL TYPES
+> SHOW TYPES
 
-> SHOW EXTENDED TYPES
-name
-----
-_bool
-_bpchar
-_bytea
-_char
-_date
-_float4
-_float8
-_int2
-_int2vector
-_int4
-_int8
-_uint2
-_uint4
-_uint8
-_interval
-_jsonb
-_numeric
-_oid
-_record
-_regclass
-_regproc
-_regtype
-_text
-_time
-_timestamp
-_timestamptz
-_uuid
-_varchar
-any
-anyarray
-anycompatible
-anycompatiblearray
-anycompatiblelist
-anycompatiblemap
-anycompatiblenonarray
-anyelement
-anynonarray
-bool
-bpchar
-bytea
-char
-date
-float4
-float8
-int2
-int2vector
-int4
-int8
-uint2
-uint4
-uint8
-interval
-jsonb
-list
-map
-numeric
-oid
-record
-regclass
-regproc
-regtype
-text
-time
-timestamp
-timestamptz
-uuid
-varchar
-
-> SHOW EXTENDED FULL TYPES
+> SHOW TYPES FROM pg_catalog
 name             type
 ----------------------
 _bool                       system
@@ -227,7 +156,7 @@ ALTER SYSTEM SET max_tables = 10000
 > CREATE TYPE int_list_list_c AS LIST (element_type=int_list_c);
 > CREATE TYPE int_record_record_c AS (j1 int, j2 int_record_c);
 
-> SHOW FULL TYPES
+> SHOW TYPES
 name                type
 ------------------------
 int_list_c          user
@@ -258,7 +187,7 @@ int_record_record_c user
 > CREATE TYPE other.other_int_map_c AS MAP (key_type=text, value_type=int4);
 > CREATE TYPE other.other_record_c AS (a int, b text);
 
-> SHOW FULL TYPES FROM other;
+> SHOW TYPES FROM other;
 name                type
 -------------------------
 other_int_list_c    user

--- a/test/upgrade/check-from-current_source-database-schema.td
+++ b/test/upgrade/check-from-current_source-database-schema.td
@@ -12,8 +12,8 @@ materialize
 "some database"
 
 > SHOW SCHEMAS FROM "some database";
-public
-"some schema"
+public          user
+"some schema"   user
 
 > SELECT * FROM "some database"."some schema".t1;
 

--- a/test/upgrade/check-from-current_source-database-schema.td
+++ b/test/upgrade/check-from-current_source-database-schema.td
@@ -12,8 +12,12 @@ materialize
 "some database"
 
 > SHOW SCHEMAS FROM "some database";
-public          user
-"some schema"   user
+public              user
+"some schema"       user
+information_schema  system
+mz_catalog          system
+mz_internal         system
+pg_catalog          system
 
 > SELECT * FROM "some database"."some schema".t1;
 


### PR DESCRIPTION
Most of the various SHOW statements support two modifiers: FULL and EXTENDED. The FULL modifier typically adds additional columns to the output of the SHOW statement, while the EXTENDED modifier typically adds additional rows to the output of the SHOW statement with information about system objects.

These modifiers are not well loved by users. See, for example, #14540. The FULL modifier hides important information from users that ought to be displayed by default. The EXTENDED modifier shows system objects, but is redundant with showing objects FROM mz_catalog/pg_catalog.

We inherited these modifiers from MySQL in the very early days. Back then, we were not all-in on emulating PostgreSQL; we tried to follow MySQL when we inherited a statement from MySQL, and PostgreSQL when we inherited a statement from PostgreSQL. So we tried to map MySQL's FULL and EXTENDED modifiers to Materialize as best as we could, to faithfully match MySQL.

Nowadays we're all in on PostgreSQL, and so we have the freedom to break this loose compatibility with MySQL to redesign the SHOW commands to our liking.

Fixes #14639

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Remove `EXTENDED` and `FULL` modifiers from `SHOW` commands.
