### PR TITLE
kafka-multi-broker: Fix the test

### DIFF
--- a/test/kafka-multi-broker/mzcompose.py
+++ b/test/kafka-multi-broker/mzcompose.py
@@ -28,13 +28,10 @@ SERVICES = [
     ),
     Materialized(),
     Testdrive(
-        entrypoint=[
-            "testdrive",
-            "--schema-registry-url=http://schema-registry:8081",
-            "--materialize-url=postgres://materialize@materialized:6875",
+        entrypoint_extra=[
             "--kafka-option=acks=all",
-            "--seed=1",
-        ]
+        ],
+        seed=1,
     ),
 ]
 


### PR DESCRIPTION
Ensure that the new --materialize-url-internal testdrive option is in effect

### Motivation

  * This PR fixes a previously unreported bug.
The kafka-multi-broker Nightly CI job was failing

@jkosh44 FYI