### PR TITLE
zippy: Add Debezium with a Postgres source

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -34,6 +34,7 @@ steps:
 #          - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
           - { value: zippy-user-tables }
+          - { value: zippy-debezium-postgres }
           - { value: secrets }
           - { value: checks-oneatatime-drop-create-default-replica }
           - { value: checks-oneatatime-restart-computed }
@@ -259,6 +260,17 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=UserTables, --actions=1000]
+
+  - id: zippy-debezium-postgres
+    label: "Zippy Debezium Postgres"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=DebeziumPostgres, --actions=1000]
+
 
   - id: secrets
     label: "Secrets"

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -1,0 +1,131 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import random
+from textwrap import dedent
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.debezium_capabilities import (
+    DebeziumRunning,
+    DebeziumSourceExists,
+    PostgresTableExists,
+)
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.kafka_capabilities import KafkaRunning
+from materialize.zippy.mz_capabilities import MzIsRunning
+
+
+class DebeziumStart(Action):
+    """Start a Debezium instance."""
+
+    def provides(self) -> List[Capability]:
+        return [DebeziumRunning()]
+
+    def run(self, c: Composition) -> None:
+        c.start_and_wait_for_tcp(services=["debezium"])
+
+
+class DebeziumStop(Action):
+    """Stop the Debezium instance."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {DebeziumRunning}
+
+    def removes(self) -> Set[Type[Capability]]:
+        return {DebeziumRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("debezium")
+
+
+class CreateDebeziumSource(Action):
+    """Creates a Debezium source in Materialized."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, KafkaRunning, PostgresTableExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        # To avoid conflicts, we make sure the postgres table and the debezium source have matching names
+        postgres_table = random.choice(capabilities.get(PostgresTableExists))
+        debezium_source_name = f"debezium_source_{postgres_table.name}"
+        this_debezium_source = DebeziumSourceExists(name=debezium_source_name)
+
+        existing_debezium_sources = [
+            s
+            for s in capabilities.get(DebeziumSourceExists)
+            if s.name == this_debezium_source.name
+        ]
+
+        if len(existing_debezium_sources) == 0:
+            self.new_debezium_source = True
+
+            self.debezium_source = this_debezium_source
+            self.postgres_table = postgres_table
+            self.debezium_source.postgres_table = self.postgres_table
+        elif len(existing_debezium_sources) == 1:
+            self.new_debezium_source = False
+
+            self.debezium_source = existing_debezium_sources[0]
+            assert self.debezium_source.postgres_table is not None
+            self.postgres_table = self.debezium_source.postgres_table
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if self.new_debezium_source:
+            upsert = "UPSERT" if self.postgres_table.has_pk else ""
+            c.testdrive(
+                dedent(
+                    f"""
+                    $ http-request method=POST url=http://debezium:8083/connectors content-type=application/json
+                    {{
+                      "name": "{self.debezium_source.name}",
+                      "config": {{
+                        "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+                        "database.hostname": "postgres",
+                        "database.port": "5432",
+                        "database.user": "postgres",
+                        "database.password": "postgres",
+                        "database.dbname" : "postgres",
+                        "database.server.name": "postgres",
+                        "schema.include.list": "public",
+                        "table.include.list": "public.{self.postgres_table.name}",
+                        "plugin.name": "pgoutput",
+                        "publication.name": "dbz_publication_{self.debezium_source.name}",
+                        "publication.autocreate.mode": "filtered",
+                        "slot.name" : "slot_{self.postgres_table.name}",
+                        "database.history.kafka.bootstrap.servers": "kafka:9092",
+                        "database.history.kafka.topic": "schema-changes.history",
+                        "truncate.handling.mode": "include",
+                        "decimal.handling.mode": "precise"
+                      }}
+                    }}
+
+                    $ schema-registry-wait-schema schema=postgres.public.{self.postgres_table.name}-value
+
+                    > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
+
+                    > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
+
+                    # UPSERT is requred due to https://github.com/MaterializeInc/materialize/issues/14211
+                    > CREATE SOURCE {self.debezium_source.name}
+                      FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.{self.postgres_table.name}')
+                      FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                      ENVELOPE DEBEZIUM
+                      {upsert}
+                    """
+                )
+            )
+
+    def provides(self) -> List[Capability]:
+        return [self.debezium_source] if self.new_debezium_source else []

--- a/misc/python/materialize/zippy/debezium_capabilities.py
+++ b/misc/python/materialize/zippy/debezium_capabilities.py
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Optional
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.postgres_capabilities import PostgresTableExists
+from materialize.zippy.watermarks import Watermarks
+
+
+class DebeziumRunning(Capability):
+    """Debezium is running in the environment."""
+
+    pass
+
+
+class DebeziumSourceExists(Capability):
+    """A Debezium source exists in Materialize."""
+
+    def __init__(
+        self, name: str, postgres_table: Optional[PostgresTableExists] = None
+    ) -> None:
+        self.name = name
+        self.postgres_table = postgres_table
+
+    def get_watermarks(self) -> Watermarks:
+        assert self.postgres_table is not None
+        return self.postgres_table.watermarks

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -78,6 +78,9 @@ class Action:
 
 
 class Scenario:
+    def bootstrap(self) -> List[Type[Action]]:
+        return []
+
     def config(self) -> Dict[Type[Action], float]:
         assert False
 
@@ -95,6 +98,12 @@ class Test:
         self._scenario = scenario
         self._actions: List[Action] = []
         self._capabilities = Capabilities()
+
+        for action_class in self._scenario.bootstrap():
+            action = action_class(capabilities=self._capabilities)
+            self._actions.append(action)
+            self._capabilities._extend(action.provides())
+            self._capabilities._remove(action.removes())
 
         for i in range(0, actions):
             action_class = self._pick_action_class()

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -1,0 +1,187 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from textwrap import dedent
+from typing import List, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
+
+
+class PostgresStart(Action):
+    """Start a PostgresInstance instance."""
+
+    def provides(self) -> List[Capability]:
+        return [PostgresRunning()]
+
+    def run(self, c: Composition) -> None:
+        c.start_and_wait_for_tcp(services=["postgres"])
+
+
+class PostgresStop(Action):
+    """Stop the Postgres instance."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {PostgresRunning}
+
+    def removes(self) -> Set[Type[Capability]]:
+        return {PostgresRunning}
+
+    def run(self, c: Composition) -> None:
+        c.kill("postgres")
+
+
+class CreatePostgresTable(Action):
+    """Creates a table on the Postgres instance. 50% of the tables have a PK."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, PostgresRunning}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        this_postgres_table = PostgresTableExists(
+            name="table" + str(random.randint(1, 10))
+        )
+
+        existing_postgres_tables = [
+            t
+            for t in capabilities.get(PostgresTableExists)
+            if t.name == this_postgres_table.name
+        ]
+
+        if len(existing_postgres_tables) == 0:
+            self.new_postgres_table = True
+            this_postgres_table.has_pk = random.choice([True, False])
+
+            self.postgres_table = this_postgres_table
+        elif len(existing_postgres_tables) == 1:
+            self.new_postgres_table = False
+            self.postgres_table = existing_postgres_tables[0]
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if self.new_postgres_table:
+            primary_key = f"PRIMARY KEY" if self.postgres_table.has_pk else ""
+            c.testdrive(
+                dedent(
+                    f"""
+                    $ postgres-execute connection=postgres://postgres:postgres@postgres
+                    CREATE TABLE {self.postgres_table.name} (f1 INTEGER {primary_key});
+                    ALTER TABLE {self.postgres_table.name} REPLICA IDENTITY FULL;
+                    INSERT INTO {self.postgres_table.name} VALUES ({self.postgres_table.watermarks.max});
+                    """
+                )
+            )
+
+    def provides(self) -> List[Capability]:
+        return [self.postgres_table] if self.new_postgres_table else []
+
+
+class PostgresDML(Action):
+    """Performs an INSERT, DELETE or UPDATE against a Postgres table."""
+
+    # We use smaller batches in Pg then in Mz because Pg will fill up much faster
+    MAX_BATCH_SIZE = 10000
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, PostgresRunning, PostgresTableExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        self.postgres_table = random.choice(capabilities.get(PostgresTableExists))
+        self.delta = random.randint(1, PostgresDML.MAX_BATCH_SIZE)
+
+
+class PostgresInsert(PostgresDML):
+    """Inserts rows into a Postgres table."""
+
+    def run(self, c: Composition) -> None:
+        prev_max = self.postgres_table.watermarks.max
+        self.postgres_table.watermarks.max = prev_max + self.delta
+        c.testdrive(
+            dedent(
+                f"""
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                INSERT INTO {self.postgres_table.name} SELECT * FROM generate_series({prev_max + 1}, {self.postgres_table.watermarks.max});
+                """
+            )
+        )
+
+
+class PostgresShiftForward(PostgresDML):
+    """Update all rows from a Postgres table by incrementing their values by a constant (tables with a PK only)"""
+
+    def run(self, c: Composition) -> None:
+        if not self.postgres_table.has_pk:
+            self.postgres_table.watermarks.shift(self.delta)
+            c.testdrive(
+                dedent(
+                    f"""
+                    $ postgres-execute connection=postgres://postgres:postgres@postgres
+                    UPDATE {self.postgres_table.name} SET f1 = f1 + {self.delta};
+                    """
+                )
+            )
+
+
+class PostgresShiftBackward(PostgresDML):
+    """Update all rows from a Postgres table by decrementing their values by a constant (tables with a PK only)"""
+
+    def run(self, c: Composition) -> None:
+        if not self.postgres_table.has_pk:
+            self.postgres_table.watermarks.shift(-self.delta)
+            c.testdrive(
+                dedent(
+                    f"""
+                    $ postgres-execute connection=postgres://postgres:postgres@postgres
+                    UPDATE {self.postgres_table.name} SET f1 = f1 - {self.delta};
+                    """
+                )
+            )
+
+
+class PostgresDeleteFromHead(PostgresDML):
+    """Delete the largest values from a Postgres table"""
+
+    def run(self, c: Composition) -> None:
+        self.postgres_table.watermarks.max = max(
+            self.postgres_table.watermarks.max - self.delta,
+            self.postgres_table.watermarks.min,
+        )
+        c.testdrive(
+            dedent(
+                f"""
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                DELETE FROM {self.postgres_table.name} WHERE f1 > {self.postgres_table.watermarks.max};
+                """
+            )
+        )
+
+
+class PostgresDeleteFromTail(PostgresDML):
+    """Delete the smallest values from a Postgres table"""
+
+    def run(self, c: Composition) -> None:
+        self.postgres_table.watermarks.min = min(
+            self.postgres_table.watermarks.min + self.delta,
+            self.postgres_table.watermarks.max,
+        )
+        c.testdrive(
+            dedent(
+                f"""
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                DELETE FROM {self.postgres_table.name} WHERE f1 < {self.postgres_table.watermarks.min};
+                """
+            )
+        )

--- a/misc/python/materialize/zippy/postgres_capabilities.py
+++ b/misc/python/materialize/zippy/postgres_capabilities.py
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from typing import Optional
+
+from materialize.zippy.framework import Capability
+from materialize.zippy.watermarks import Watermarks
+
+
+class PostgresRunning(Capability):
+    """Postgres is running in the environment."""
+
+    pass
+
+
+class PostgresTableExists(Capability):
+    """A table exists on the Postgres instance."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.has_pk: Optional[bool] = None
+        self.watermarks = Watermarks()
+
+    def get_watermarks(self) -> Watermarks:
+        return self.watermarks

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -7,11 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import Dict, Type
+from typing import Dict, List, Type
 
+from materialize.zippy.debezium_actions import CreateDebeziumSource, DebeziumStart
 from materialize.zippy.framework import Action, Scenario
 from materialize.zippy.kafka_actions import CreateTopic, Ingest, KafkaStart
 from materialize.zippy.mz_actions import KillComputed, KillStoraged, MzStart, MzStop
+from materialize.zippy.postgres_actions import (
+    CreatePostgresTable,
+    PostgresDML,
+    PostgresStart,
+)
 from materialize.zippy.sink_actions import CreateSink
 from materialize.zippy.source_actions import CreateSource
 from materialize.zippy.table_actions import DML, CreateTable, ValidateTable
@@ -52,4 +58,22 @@ class UserTables(Scenario):
             ValidateTable: 20,
             ValidateView: 20,
             DML: 30,
+        }
+
+
+class DebeziumPostgres(Scenario):
+    """A Zippy test using Debezium Postgres exclusively."""
+
+    def bootstrap(self) -> List[Type[Action]]:
+        return [KafkaStart, DebeziumStart, PostgresStart, MzStart]
+
+    def config(self) -> Dict[Type[Action], float]:
+        return {
+            CreatePostgresTable: 10,
+            CreateDebeziumSource: 10,
+            KillStoraged: 15,
+            KillComputed: 15,
+            CreateView: 10,
+            ValidateView: 20,
+            PostgresDML: 30,
         }

--- a/misc/python/materialize/zippy/view_capabilities.py
+++ b/misc/python/materialize/zippy/view_capabilities.py
@@ -9,12 +9,15 @@
 
 from typing import List, Optional, Union
 
+from materialize.zippy.debezium_capabilities import DebeziumSourceExists
 from materialize.zippy.framework import Capability
 from materialize.zippy.source_capabilities import SourceExists
 from materialize.zippy.table_capabilities import TableExists
 from materialize.zippy.watermarks import Watermarks
 
-WatermarkedObjects = List[Union[TableExists, SourceExists, "ViewExists"]]
+WatermarkedObjects = List[
+    Union[TableExists, SourceExists, "ViewExists", DebeziumSourceExists]
+]
 
 
 class ViewExists(Capability):

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -11,8 +11,10 @@ import random
 
 from materialize.mzcompose import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services import (
+    Debezium,
     Kafka,
     Materialized,
+    Postgres,
     SchemaRegistry,
     Testdrive,
     Zookeeper,
@@ -22,8 +24,10 @@ from materialize.zippy.scenarios import *  # noqa: F401 F403
 
 SERVICES = [
     Zookeeper(),
-    Kafka(),
+    Kafka(auto_create_topics=True),
     SchemaRegistry(),
+    Debezium(),
+    Postgres(),
     Materialized(),
     Testdrive(
         validate_data_dir=False,


### PR DESCRIPTION
A new DebeziumPostgres scenario is being added:
- A Postgres database will be started
- Postgres tables will be created with or without a PK
- DML statements will be executed against Postgres, with some DML not available for tables with a PK
- Whether the Debezium source is an UPSERT one or not is determined by the presence of a PK in the source Postgres table
- The sources then participate in the creation of views as usual which are then validated
- killing of storageds and computeds will also happen periodically

### Motivation

  * This PR adds a feature that has not yet been specified.

Debezium was missing from Zippy, which is a prerequisite for signing-off on Debezium-related epics