### PR TITLE
storage: pg: handle excessive WAL lag edge-cases

### DIFF
--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -48,6 +48,12 @@ static PG_EPOCH: Lazy<SystemTime> = Lazy::new(|| UNIX_EPOCH + Duration::from_sec
 /// How often a status update message should be sent to the server
 static FEEDBACK_INTERVAL: Duration = Duration::from_secs(30);
 
+/// The amount of time we should wait after the last received message before worrying about WAL lag
+static WAL_LAG_GRACE_PERIOD: Duration = Duration::from_secs(5 * 60); // 5 minutes
+
+/// The maximum amount of WAL lag allowed before restarting the replication process
+static MAX_WAL_LAG: u64 = 100 * 1024 * 1024;
+
 trait ErrorExt {
     fn is_recoverable(&self) -> bool;
 }
@@ -642,6 +648,60 @@ impl PostgresTaskInfo {
 
         let client = try_recoverable!(self.connection_config.clone().connect_replication().await);
 
+        // Before consuming the replication stream we will peek into the replication slot using a
+        // normal SQL query and the `pg_logical_slot_peek_binary_changes` administrative function.
+        //
+        // By doing so we can get a positive statement about existence or absence of relevant data
+        // from the LSN we wish to restart from until the last known LSN end of the database. If
+        // there are no message then it is safe to fast forward to the end WAL LSN and start the
+        // replication stream from there.
+        let cur_lsn = {
+            let rows = try_recoverable!(
+                client
+                    .simple_query("SELECT pg_current_wal_flush_lsn()")
+                    .await
+            );
+            match rows.first().expect("query returns exactly one row") {
+                SimpleQueryMessage::Row(row) => row
+                    .get(0)
+                    .expect("query returns one column")
+                    .parse::<PgLsn>()
+                    .expect("pg_current_wal_flush_lsn returned invalid lsn"),
+                _ => panic!(),
+            }
+        };
+
+        self.lsn = {
+            let query = format!(
+                "SELECT COUNT(*) FROM pg_logical_slot_peek_binary_changes(
+                     '{name}', '{lsn}', 1,
+                     'proto_version', '1',
+                     'publication_names', '{publication}'
+                )",
+                name = &self.slot,
+                lsn = cur_lsn,
+                publication = self.publication
+            );
+            let rows = try_recoverable!(client.simple_query(&query).await);
+
+            match rows.first().expect("query returns exactly one row") {
+                SimpleQueryMessage::Row(row) => {
+                    let changes: u64 = row
+                        .get(0)
+                        .expect("query returns one column")
+                        .parse()
+                        .expect("count returned invalid number");
+                    if changes == 0 {
+                        // If there are no changes until the end of the WAL it's safe to fast forward
+                        cur_lsn
+                    } else {
+                        self.lsn
+                    }
+                }
+                _ => panic!(),
+            }
+        };
+
         let query = format!(
             r#"START_REPLICATION SLOT "{name}" LOGICAL {lsn}
               ("proto_version" '1', "publication_names" '{publication}')"#,
@@ -654,6 +714,7 @@ impl PostgresTaskInfo {
         let stream = LogicalReplicationStream::new(copy_stream).take_until(self.sender.closed());
         tokio::pin!(stream);
 
+        let mut last_data_message = Instant::now();
         let mut last_feedback = Instant::now();
         let mut inserts = vec![];
         let mut deletes = vec![];
@@ -676,6 +737,7 @@ impl PostgresTaskInfo {
             match &item {
                 XLogData(xlog_data) => match xlog_data.data() {
                     Begin(_) => {
+                        last_data_message = Instant::now();
                         if !inserts.is_empty() || !deletes.is_empty() {
                             return Err(Fatal(anyhow!(
                                 "got BEGIN statement after uncommitted data"
@@ -683,6 +745,7 @@ impl PostgresTaskInfo {
                         }
                     }
                     Insert(insert) if self.source_tables.contains_key(&insert.rel_id()) => {
+                        last_data_message = Instant::now();
                         self.metrics.inserts.inc();
                         let rel_id = insert.rel_id();
                         let new_tuple = insert.tuple().tuple_data();
@@ -690,6 +753,7 @@ impl PostgresTaskInfo {
                         inserts.push(row);
                     }
                     Update(update) if self.source_tables.contains_key(&update.rel_id()) => {
+                        last_data_message = Instant::now();
                         self.metrics.updates.inc();
                         let rel_id = update.rel_id();
                         let err = || {
@@ -720,6 +784,7 @@ impl PostgresTaskInfo {
                         inserts.push(new_row);
                     }
                     Delete(delete) if self.source_tables.contains_key(&delete.rel_id()) => {
+                        last_data_message = Instant::now();
                         self.metrics.deletes.inc();
                         let rel_id = delete.rel_id();
                         let err = || {
@@ -734,6 +799,7 @@ impl PostgresTaskInfo {
                         deletes.push(row);
                     }
                     Commit(commit) => {
+                        last_data_message = Instant::now();
                         self.metrics.transactions.inc();
                         self.lsn = commit.end_lsn().into();
 
@@ -748,6 +814,7 @@ impl PostgresTaskInfo {
                         self.metrics.lsn.set(self.lsn.into());
                     }
                     Relation(relation) => {
+                        last_data_message = Instant::now();
                         let rel_id = relation.rel_id();
                         if let Some(source_table) = self.source_tables.get(&rel_id) {
                             // Start with the cheapest check first, this will catch the majority of alters
@@ -807,6 +874,7 @@ impl PostgresTaskInfo {
                         }
                     }
                     Insert(_) | Update(_) | Delete(_) | Origin(_) | Type(_) => {
+                        last_data_message = Instant::now();
                         self.metrics.ignored.inc();
                     }
                     Truncate(truncate) => {
@@ -828,6 +896,12 @@ impl PostgresTaskInfo {
                 },
                 PrimaryKeepAlive(keepalive) => {
                     needs_status_update = needs_status_update || keepalive.reply() == 1;
+
+                    if last_data_message.elapsed() > WAL_LAG_GRACE_PERIOD
+                        && keepalive.wal_end().saturating_sub(self.lsn.into()) > MAX_WAL_LAG
+                    {
+                        return Err(Recoverable(anyhow!("reached maximum WAL lag")));
+                    }
                 }
                 // The enum is marked non_exhaustive, better be conservative
                 _ => return Err(Fatal(anyhow!("Unexpected replication message"))),


### PR DESCRIPTION
When we consume the replication stream from a postgres database we only get messages when there is data that is relevant to the publication that we're interested in.

This can become problematic because receiving a message is the only way we learn about progress statements, i.e the fact that up until a certain LSN we have seen all the messages and we can therefore advance our cursor.

One way this can happen is when the PostgreSQL instance contains multiple databases and one of them is a high-traffic database but the one we're streaming from is idle. In this case the WAL grows continuously but we never advance our replication slot cursor, eventually leading the instance to run out of disk space.

This PR fixes that by peeking into the replication slot changes on initialization using a normal SQL query that invokes the `pg_logical_slot_peek_binary_changes` administrative function. Since this is a normal query we know when it has finished (as opposed to the never ending replication stream) and we can observe if the result was empty. If that's the case we know it's safe to fast-forward our WAL cursor.

The source will continuously monitor replication lag and trigger a replication restart if the lag grows beyond 100MB and we haven't received any data message for more than 5 minutes.

Fixes #14694

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
