### PR TITLE
storage: enrich persist_source error message

### DIFF
--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -166,9 +166,14 @@ where
             .expect("could not open persist shard");
 
         let mut subscription = read
-            .subscribe(as_of_stream)
+            .subscribe(as_of_stream.clone())
             .await
-            .expect("cannot serve requested as_of");
+            .unwrap_or_else(|e| {
+                panic!(
+                    "{source_id}: cannot serve requested as_of {:?}: {:?}",
+                    as_of_stream, e
+                )
+            });
 
         let mut done = false;
         while !done {


### PR DESCRIPTION
In hope of sussing out the reason behind
https://github.com/MaterializeInc/materialize/issues/12885

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
