### PR TITLE
sql: misc. txn handling corner case fixes

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -123,14 +123,11 @@ impl<S: Append + 'static> Coordinator<S> {
                 tx,
             } => {
                 let now = self.now_datetime();
-                let session = match implicit {
+                let (session, result) = match implicit {
                     None => session.start_transaction(now, None, None),
-                    Some(stmts) => session.start_transaction_implicit(now, stmts),
+                    Some(stmts) => (session.start_transaction_implicit(now, stmts), Ok(())),
                 };
-                let _ = tx.send(Response {
-                    result: Ok(()),
-                    session,
-                });
+                let _ = tx.send(Response { result, session });
             }
 
             Command::Commit {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -213,13 +213,13 @@ impl<S: Append + 'static> Coordinator<S> {
             Plan::StartTransaction(plan) => {
                 let duplicated =
                     matches!(session.transaction(), TransactionStatus::InTransaction(_));
-                let session = session.start_transaction(
+                let (session, result) = session.start_transaction(
                     self.now_datetime(),
                     plan.access,
                     plan.isolation_level,
                 );
                 tx.send(
-                    Ok(ExecuteResponse::StartedTransaction { duplicated }),
+                    result.map(|_| ExecuteResponse::StartedTransaction { duplicated }),
                     session,
                 )
             }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -106,6 +106,8 @@ pub enum AdapterError {
     ReadOnlyTransaction,
     /// The specified session parameter is read-only.
     ReadOnlyParameter(&'static (dyn Var + Send + Sync)),
+    /// The transaction in in read-only mode and a read already occurred.
+    ReadWriteUnavailable,
     /// The recursion limit of some operation was exceeded.
     RecursionLimit(RecursionLimitError),
     /// A query in a transaction referenced a relation outside the first query's
@@ -354,6 +356,9 @@ impl fmt::Display for AdapterError {
             AdapterError::ReadOnlyTransaction => f.write_str("transaction in read-only mode"),
             AdapterError::ReadOnlyParameter(p) => {
                 write!(f, "parameter {} cannot be changed", p.name().quoted())
+            }
+            AdapterError::ReadWriteUnavailable => {
+                f.write_str("transaction read-write mode must be set before any query")
             }
             AdapterError::StatementTimeout => {
                 write!(f, "canceling statement due to statement timeout")

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -197,8 +197,9 @@ impl<T: CoordTimestamp> Session<T> {
         &self.transaction
     }
 
-    /// Adds operations to the current transaction. An error is produced if they
-    /// cannot be merged (i.e., a read cannot be merged to an insert).
+    /// Adds operations to the current transaction. An error is produced if
+    /// they cannot be merged (i.e., a timestamp-dependent read cannot be
+    /// merged to an insert).
     pub fn add_transaction_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), AdapterError> {
         match &mut self.transaction {
             TransactionStatus::Started(Transaction { ops, access, .. })
@@ -215,7 +216,17 @@ impl<T: CoordTimestamp> Session<T> {
                     }
                     TransactionOps::Peeks(txn_ts) => match add_ops {
                         TransactionOps::Peeks(add_ts) => {
-                            assert_eq!(*txn_ts, add_ts);
+                            match (&txn_ts, add_ts) {
+                                (Some(txn_ts), Some(add_ts)) => assert_eq!(*txn_ts, add_ts),
+                                (None, Some(add_ts)) => *txn_ts = Some(add_ts),
+                                _ => {}
+                            };
+                        }
+                        // Iff peeks thus far do not have a timestamp (i.e.
+                        // they are constant), we can switch to a write
+                        // transaction.
+                        writes @ TransactionOps::Writes(..) if txn_ts.is_none() => {
+                            *ops = writes;
                         }
                         _ => return Err(AdapterError::ReadOnlyTransaction),
                     },
@@ -237,6 +248,9 @@ impl<T: CoordTimestamp> Session<T> {
                                 return Err(AdapterError::MultiTableWriteTransaction);
                             }
                         }
+                        // Iff peeks do not have a timestamp (i.e. they are
+                        // constant), we can permit them.
+                        TransactionOps::Peeks(None) => {}
                         _ => {
                             return Err(AdapterError::WriteOnlyTransaction);
                         }
@@ -279,7 +293,7 @@ impl<T: CoordTimestamp> Session<T> {
                 ops: TransactionOps::Peeks(ts),
                 write_lock_guard: _,
                 access: _,
-            }) => Some(ts.clone()),
+            }) => ts.clone(),
             _ => None,
         }
     }
@@ -671,12 +685,15 @@ pub enum TransactionOps<T> {
     /// The transaction has been initiated, but no statement has yet been executed
     /// in it.
     None,
-    /// This transaction has had a peek (`SELECT`, `TAIL`) and must only do other peeks.
-    Peeks(T),
+    /// This transaction has had a peek (`SELECT`, `TAIL`). If the inner value
+    /// is Some, it must only do other peeks. However, if the value is None
+    /// (i.e. the values are constants), the transaction can still perform
+    /// writes.
+    Peeks(Option<T>),
     /// This transaction has done a TAIL and must do nothing else.
     Tail,
-    /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must only do
-    /// other writes.
+    /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must
+    /// only do other writes, or reads whose timestamp is None (i.e. constants).
     Writes(Vec<WriteOp>),
 }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -104,7 +104,7 @@ impl<T: CoordTimestamp> Session<T> {
         isolation_level: Option<TransactionIsolationLevel>,
     ) -> Self {
         match self.transaction {
-            TransactionStatus::Default | TransactionStatus::Started(_) => {
+            TransactionStatus::Default => {
                 self.transaction = TransactionStatus::InTransaction(Transaction {
                     pcx: PlanContext::new(wall_time, self.vars.qgm_optimizations()),
                     ops: TransactionOps::None,
@@ -112,7 +112,7 @@ impl<T: CoordTimestamp> Session<T> {
                     access,
                 });
             }
-            TransactionStatus::InTransactionImplicit(txn) => {
+            TransactionStatus::Started(txn) | TransactionStatus::InTransactionImplicit(txn) => {
                 self.transaction = TransactionStatus::InTransaction(txn);
             }
             TransactionStatus::InTransaction(_) => {}

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -399,6 +399,7 @@ impl ErrorResponse {
             AdapterError::QGM(_) => SqlState::INTERNAL_ERROR,
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::ReadOnlyParameter(_) => SqlState::CANT_CHANGE_RUNTIME_PARAM,
+            AdapterError::ReadWriteUnavailable => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::StatementTimeout => SqlState::IDLE_IN_TRANSACTION_SESSION_TIMEOUT,
             AdapterError::RecursionLimit(_) => SqlState::INTERNAL_ERROR,
             AdapterError::RelationOutsideTimeDomain { .. } => SqlState::INVALID_TRANSACTION_STATE,

--- a/test/pgtest-mz/transactions.pt
+++ b/test/pgtest-mz/transactions.pt
@@ -1,0 +1,55 @@
+# Test implicit and explicit transaction semantics in ways that
+# MZ differs from PG.
+# See pgtest/transactions.pt for more details
+
+# Verify implicit transactions are properly upgraded
+send
+Query {"query": "CREATE TABLE t (a INT)"}
+Parse {"query": "INSERT INTO t VALUES (1)"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ReadyForQuery {"status":"I"}
+
+# PG permits commits writes that are part of read-only txns, but
+# we do not if the read involves a timestamp
+send
+Parse {"query": "INSERT INTO t VALUES (2)"}
+Bind
+Execute
+Parse {"query": "BEGIN READ ONLY"}
+Bind
+Execute
+Parse {"query": "SELECT * FROM t"}
+Bind
+Execute
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"transaction in write-only mode"}]}
+ReadyForQuery {"status":"E"}

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -473,3 +473,93 @@ ReadyForQuery {"status":"I"}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
+
+# Verify implicit transactions are properly upgraded
+send
+Query {"query": "CREATE TABLE t (a INT)"}
+Parse {"query": "INSERT INTO t VALUES (1)"}
+Bind
+Execute
+Parse {"query": "BEGIN"}
+Bind
+Execute
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# Verify implicit transactions are properly upgraded, and share fate
+# with upgraded txn; the insert of 2 should get discarded
+send
+Parse {"query": "INSERT INTO t VALUES (2)"}
+Bind
+Execute
+Parse {"query": "BEGIN"}
+Bind
+Execute
+Parse {"query": "SELECT 0/0"}
+Bind
+Execute
+Sync
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"E"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -563,3 +563,97 @@ BindComplete
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
+
+# PG permits starting a read only txn with writes blended into its ops;
+# evidence of this behavior by an errored txn does not commit write
+send
+Parse {"query": "INSERT INTO t VALUES (2)"}
+Bind
+Execute
+Parse {"query": "BEGIN READ ONLY"}
+Bind
+Execute
+Parse {"query": "SELECT 0/0"}
+Bind
+Execute
+Sync
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+ErrorResponse {"fields":[{"typ":"M","value":"division by zero"}]}
+ReadyForQuery {"status":"E"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"ROLLBACK"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ReadyForQuery {"status":"I"}
+
+# PG permits commits writes that are part of read-only txns
+send
+Parse {"query": "INSERT INTO t VALUES (2)"}
+Bind
+Execute
+Parse {"query": "BEGIN READ ONLY"}
+Bind
+Execute
+Parse {"query": "SELECT 1"}
+Bind
+Execute
+Parse {"query": "COMMIT"}
+Bind
+Execute
+Sync
+Parse {"query": "SELECT a FROM t"}
+Bind
+Execute
+Sync
+----
+
+until err_field_typs=M ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"INSERT 0 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"BEGIN"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"COMMIT"}
+ReadyForQuery {"status":"I"}
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+DataRow {"fields":["2"]}
+CommandComplete {"tag":"SELECT 2"}
+ReadyForQuery {"status":"I"}

--- a/test/pgtest/transactions.pt
+++ b/test/pgtest/transactions.pt
@@ -565,7 +565,7 @@ CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 
 # PG permits starting a read only txn with writes blended into its ops;
-# evidence of this behavior by an errored txn does not commit write
+# evidence of this behavior by an errored txn does not commit write.
 send
 Parse {"query": "INSERT INTO t VALUES (2)"}
 Bind
@@ -613,6 +613,8 @@ CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
 
 # PG permits commits writes that are part of read-only txns
+# n.b. this is possible only because we support selecting constants
+# in write-only txns
 send
 Parse {"query": "INSERT INTO t VALUES (2)"}
 Bind

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -451,6 +451,67 @@ INSERT INTO t (a) VALUES (1)
 statement ok
 ROLLBACK
 
+## BEGIN does not lose READ ONLY bit
+
+statement ok
+BEGIN READ ONLY
+
+statement ok
+BEGIN
+
+statement error transaction in read-only mode
+INSERT INTO t (a) VALUES (1)
+
+statement ok
+ROLLBACK
+
+## READ ONLY -> READ WRITE valid only if no queries issued yet
+
+statement ok
+BEGIN READ ONLY
+
+statement ok
+BEGIN READ WRITE
+
+statement ok
+INSERT INTO t (a) VALUES (1)
+
+statement ok
+ROLLBACK
+
+statement ok
+BEGIN READ ONLY
+
+query I
+SELECT 1
+----
+1
+
+statement error transaction read-write mode must be set before any query
+BEGIN READ WRITE
+
+statement ok
+COMMIT
+
+## READ WRITE -> READ ONLY valid, but cannot switch back if any queries issued
+
+statement ok
+BEGIN READ WRITE
+
+query I
+SELECT 1
+----
+1
+
+statement ok
+BEGIN READ ONLY
+
+statement error transaction read-write mode must be set before any query
+BEGIN READ WRITE
+
+statement ok
+COMMIT
+
 # Test that multi-table write transactions aren't supported
 
 statement ok

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -512,6 +512,23 @@ BEGIN READ WRITE
 statement ok
 COMMIT
 
+# Test read-only -> read-write with tail
+statement ok
+BEGIN READ ONLY
+
+simple
+DECLARE c CURSOR FOR TAIL t;
+FETCH 0 c;
+----
+COMPLETE 0
+COMPLETE 0
+
+statement error transaction read-write mode must be set before any query
+BEGIN READ WRITE
+
+statement ok
+COMMIT
+
 # Test that multi-table write transactions aren't supported
 
 statement ok


### PR DESCRIPTION
superseding #14722 with this

We have a few corner cases of txn handling that were undertested or had different behavior than PG. The ordering of commits here doesn't tell a clear story and don't have time to change it because I'm OOO today, but wanted to get some eyes on this.

- When upgrading an implicit txn to an explicit one, we were dropping the implicit txn's ops; this commit changes that and adds tests to ensure upgraded operations are retained
- We were not honoring the switch in explicit txns from `READ WRITE` to `READ ONLY`, or vice versa.
- We were not emulating PG's behavior when toggling between `READ ONLY` and `READ WRITE` txns; namely, you cannot switch to `READ WRITE` from `READ ONLY` if you issue any queries.
- We ceased tracking if a read occurred in a txn if it didn't involve a timestamp. This is necessary to understand to provide the same `BEGIN` behavior as PG in the case of going from `READ ONLY` to `READ WRITE`. I don't know if this change is correct, but it is illustrative of an approach that should work. Would love to get your eyes on this, @jkosh44 

However, in doing this, I've noticed that what we used to call "write only transactions" have an unclear meaning––they are no longer write only (which is very cool, Joe!), but instead cannot support timestamp-dependent reads. I think the error messaging around this should change––doesn't need to be this PR, but it's no longer true that they're write-only. I'd propose something for this but don't have time today.

@mjibson @jkosh44 If either of you have any interest in tackling this, that's very cool––I'm very open to any kind of restructuring you suggest. I was doing this late last night so apologies if the code quality isn't there.

### Motivation

This PR fixes a previously unreported bug. See issue description.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Fix a bug where commands to toggle between `READ WRITE` and `READ ONLY` were ignored. The new behavior of these commands is aligns with PostgreSQL's behavior.
  - Fix a bug where implicit transactions upgraded to explicit ones dropped the implicit transaction's operations.
