### PR TITLE
nightly: Increase the timeout of all testdrive-based tests to 3h

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -123,7 +123,7 @@ steps:
 
   - id: redpanda-testdrive
     label: ":panda_face: :racing_car: testdrive"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     agents:
       queue: linux-x86_64
     plugins:
@@ -134,7 +134,7 @@ steps:
 
   - id: redpanda-testdrive-aarch64
     label: ":panda_face: :racing_car: testdrive aarch64"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     agents:
       queue: linux-aarch64
     plugins:
@@ -183,7 +183,7 @@ steps:
 
   - id: cluster-testdrive
     label: "Full testdrive against Cluster"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     agents:
       queue: linux-x86_64
     plugins:
@@ -194,7 +194,7 @@ steps:
 
   - id: testdrive-workers-1
     label: ":racing_car: testdrive with --workers 1"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     agents:
       queue: linux-x86_64
     plugins:
@@ -208,7 +208,7 @@ steps:
   # - id: testdrive-workers-32
   #   label: ":racing_car: testdrive with --workers 32"
   #   depends_on: build-x86_64
-  #   timeout_in_minutes: 120
+  #   timeout_in_minutes: 180
   #   plugins:
   #     - ./ci/plugins/scratch-aws-access: ~
   #     - ./ci/plugins/mzcompose:
@@ -219,7 +219,7 @@ steps:
 
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"
-    timeout_in_minutes: 120
+    timeout_in_minutes: 180
     agents:
       queue: linux-x86_64
     plugins:


### PR DESCRIPTION
The testdrive-based jobs in Nightly are not internally parallized, so their execution time can go beyond 2 hours.
### Motivation

  * This PR fixes a previously unreported bug.
CI Nightly jobs were timing out