### PR TITLE
sql: Add type column to SHOW CONNECTIONS

### DIFF
--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -26,9 +26,9 @@ SHOW CONNECTIONS;
 
 ```nofmt
        name          | type
----------------------+------
- kafka_connection      kafka
- postgres_connection   postgres
+---------------------+---------
+ kafka_connection    | kafka
+ postgres_connection | postgres
 ```
 
 ```sql
@@ -36,9 +36,9 @@ SHOW CONNECTIONS LIKE 'kafka%';
 ```
 
 ```nofmt
-       name      | type
------------------+------
- kafka_connection  kafka
+       name       | type
+------------------+------
+ kafka_connection | kafka
 ```
 
 

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -27,8 +27,8 @@ SHOW CONNECTIONS;
 ```nofmt
        name          | type
 ---------------------+------
- kafka_connection
- postgres_connection
+ kafka_connection      kafka
+ postgres_connection   postgres
 ```
 
 ```sql
@@ -38,7 +38,7 @@ SHOW CONNECTIONS LIKE 'kafka%';
 ```nofmt
        name      | type
 -----------------+------
- kafka_connection
+ kafka_connection  kafka
 ```
 
 

--- a/doc/user/content/sql/show-connections.md
+++ b/doc/user/content/sql/show-connections.md
@@ -25,8 +25,8 @@ SHOW CONNECTIONS;
 ```
 
 ```nofmt
-       name
----------------------
+       name          | type
+---------------------+------
  kafka_connection
  postgres_connection
 ```
@@ -36,8 +36,8 @@ SHOW CONNECTIONS LIKE 'kafka%';
 ```
 
 ```nofmt
-       name
------------------
+       name      | type
+-----------------+------
  kafka_connection
 ```
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -318,7 +318,7 @@ fn show_connections<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let query = format!(
-        "SELECT t.name
+        "SELECT t.name, t.type
         FROM mz_catalog.mz_connections t
         JOIN mz_catalog.mz_schemas s on t.schema_id = s.id
         WHERE schema_id = {schema_spec}",

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -26,7 +26,7 @@ name       type
 testconn   kafka
 
 > SHOW CONNECTIONS
-testconn
+testconn    kafka
 
 > SHOW CREATE CONNECTION testconn
 Connection   "Create Connection"


### PR DESCRIPTION
Fixes: #14643

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds type column to `SHOW CONNECTIONS`
