### PR TITLE
sql: Add type column to SHOW OBJECTS

### DIFF
--- a/doc/user/content/sql/show-objects.md
+++ b/doc/user/content/sql/show-objects.md
@@ -23,7 +23,7 @@ _schema&lowbar;name_ | The schema to show objects from. Defaults to `public` in 
 
 ### Output format
 
-`SHOW OBJECTS` will output a table with one column, `name`.
+`SHOW OBJECTS` will output a table with two columns, `name`and `type`.
 
 ## Examples
 
@@ -39,22 +39,22 @@ SHOW SCHEMAS;
 SHOW OBJECTS FROM public;
 ```
 ```nofmt
-  name
-----------------
-my_table
-my_source
-my_view
-my_other_source
+  name          | type
+----------------+-------
+my_table        | table
+my_source       | source
+my_view         | view
+my_other_source | source
 ```
 ```sql
 SHOW OBJECTS;
 ```
 ```nofmt
-  name
-----------
-my_table
-my_source
-my_view
+  name    | type
+----------+-------
+my_table  | table
+my_source | source
+my_view   | view
 ```
 
 ## Related pages

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -439,7 +439,7 @@ fn show_all_objects<'a>(
 ) -> Result<ShowSelect<'a>, PlanError> {
     let schema_spec = scx.resolve_optional_schema(&from)?;
     let query = format!(
-        "SELECT o.name
+        "SELECT o.name, o.type
         FROM mz_catalog.mz_objects o
         JOIN mz_catalog.mz_schemas s ON o.schema_id = s.id
         WHERE o.schema_id = {schema_spec}",

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -318,13 +318,18 @@ SELECT count(*) FROM mz_materialized_views
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT 1
 
-query T colnames,rowsort
+mode standard
+
+query TT colnames,rowsort
 SHOW OBJECTS
 ----
-name
+name type
 mv
+materialized view
 t
+table
 
+mode cockroach
 
 # Test: Indexes on materialized views show in `SHOW INDEXES`.
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -67,8 +67,8 @@ $ psql-execute command="\dn mz_*"
 
 # What objects do we have by default?
 > SHOW OBJECTS
-name
-----
+name    type
+-------------
 
 # Creating a schema should be reflected in the output of SHOW SCHEMAS.
 > CREATE SCHEMA s
@@ -216,10 +216,10 @@ v2
 2
 
 > SHOW OBJECTS
-name
-----
-v1
-v2
+name    type
+-------------
+v1      view
+v2      view
 
 # Test minimizing name qualification
 
@@ -255,12 +255,12 @@ public.bool
 contains:Expected one of CONNECTION or CLUSTER or DATABASE or INDEX or MATERIALIZED or ROLE or SECRET or SCHEMA or SINK or SOURCE or TABLE or TYPE or USER or VIEW, found identifier
 
 > SHOW OBJECTS
-name
---------
-bool
-int_list
-v1
-v2
+name        type
+-----------------
+bool        type
+int_list    type
+v1          view
+v2          view
 
 # Create one of every mz_object type
 $ set schema={
@@ -292,19 +292,19 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
 > SHOW OBJECTS
-name
------------
-bool
-csr_conn
-int_list
-v1
-v2
-tbl
-pass_secret
-kafka_conn
-mv
-source_data
-snk
+name        type
+----------------
+bool        type
+csr_conn    connection
+int_list    type
+v1          view
+v2          view
+tbl         table
+pass_secret secret
+kafka_conn  connection
+mv          "materialized view"
+source_data source
+snk         sink
 
 > SELECT DISTINCT(TYPE) FROM mz_objects
 type
@@ -321,17 +321,17 @@ function
 secret
 
 > SELECT * FROM (SHOW OBJECTS) ORDER BY name DESC
-bool
-csr_conn
-int_list
-kafka_conn
-mv
-pass_secret
-snk
-source_data
-tbl
-v1
-v2
+bool        type
+csr_conn    connection
+int_list    type
+kafka_conn  connection
+mv          "materialized view"
+pass_secret secret
+snk         sink
+source_data source
+tbl         table
+v1          view
+v2          view
 
 > SELECT "Create Table" FROM (SHOW CREATE TABLE tbl)
 "CREATE TABLE \"d\".\"public\".\"tbl\" (\"a\" \"pg_catalog\".\"int4\", \"b\" \"pg_catalog\".\"text\")"


### PR DESCRIPTION
Fixes #14644

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Adds type column to SHOW OBJECTS
