### PR TITLE
pgetst: test behavior of empty queries in extended protocol

### DIFF
--- a/test/pgtest/empty.pt
+++ b/test/pgtest/empty.pt
@@ -41,3 +41,32 @@ RowDescription {"fields":[{"name":"?column?"}]}
 DataRow {"fields":["1"]}
 CommandComplete {"tag":"SELECT 1"}
 ReadyForQuery {"status":"I"}
+
+# Empty queries in extended protocol
+send
+Parse {"query": ""}
+Bind
+Execute
+Parse {"query": "SELECT 1"}
+Bind
+Execute
+Parse {"query": ""}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+EmptyQueryResponse
+ParseComplete
+BindComplete
+DataRow {"fields":["1"]}
+CommandComplete {"tag":"SELECT 1"}
+ParseComplete
+BindComplete
+EmptyQueryResponse
+ReadyForQuery {"status":"I"}


### PR DESCRIPTION
We previously did not have any tests of the behavior of the extended protocol handling empty queries.

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
