### PR TITLE
[WIP] extra logging for persist gc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "mz-compute"
-version = "0.26.1-dev"
+version = "0.27.0-alpha.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.26.1-dev"
+version = "0.27.0-alpha.19"
 dependencies = [
  "anyhow",
  "askama",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "mz-storaged"
-version = "0.26.1-dev"
+version = "0.27.0-alpha.19"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "mz-compute"
-version = "0.27.0-alpha.19"
+version = "0.27.0-alpha.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "mz-environmentd"
-version = "0.27.0-alpha.19"
+version = "0.27.0-alpha.20"
 dependencies = [
  "anyhow",
  "askama",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "mz-storaged"
-version = "0.27.0-alpha.19"
+version = "0.27.0-alpha.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version v0.27.0-alpha.19
+Licensed Work:             Materialize Version v0.27.0-alpha.20
                            The Licensed Work is © 2022 Materialize, Inc.
 
 Additional Use Grant:      You may use one single server instance of the

--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ Business Source License 1.1
 
 Licensor:                  Materialize, Inc.
 
-Licensed Work:             Materialize Version 20220906
+Licensed Work:             Materialize Version v0.27.0-alpha.19
                            The Licensed Work is © 2022 Materialize, Inc.
 
 Additional Use Grant:      You may use one single server instance of the

--- a/doc/user/content/integrations/aws-msk.md
+++ b/doc/user/content/integrations/aws-msk.md
@@ -150,7 +150,7 @@ The process to connect Materialize to Amazon MSK consists of the following steps
           SASL PASSWORD = SECRET msk_password;
 
       CREATE SOURCE <source-name>
-      FROM KAFKA CONNECTION kafka_connection (TOPIC '<topic-name>')
+      FROM KAFKA CONNECTION kafka_connection TOPIC '<topic-name>'
       FORMAT text;
     ```
 

--- a/doc/user/content/integrations/cdc-mysql.md
+++ b/doc/user/content/integrations/cdc-mysql.md
@@ -108,7 +108,7 @@ Debezium emits change events using an envelope that contains detailed informatio
 
 ```sql
 CREATE SOURCE kafka_repl
-    FROM KAFKA CONNECTION kafka_connection (TOPIC 'dbserver1.db1.table1')
+    FROM KAFKA CONNECTION kafka_connection TOPIC 'dbserver1.db1.table1'
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
     ENVELOPE DEBEZIUM;
 ```

--- a/doc/user/content/integrations/cdc-postgres.md
+++ b/doc/user/content/integrations/cdc-postgres.md
@@ -226,7 +226,7 @@ Debezium emits change events using an envelope that contains detailed informatio
 
 ```sql
 CREATE SOURCE kafka_repl
-    FROM KAFKA CONNECTION kafka_connection (TOPIC 'pg_repl.public.table1')
+    FROM KAFKA CONNECTION kafka_connection TOPIC 'pg_repl.public.table1'
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
     ENVELOPE DEBEZIUM UPSERT;
 ```
@@ -237,7 +237,7 @@ If the original Postgres table uses `REPLICA IDENTITY FULL`:
 
 ```sql
 CREATE SOURCE kafka_repl
-    FROM KAFKA CONNECTION kafka_connection (TOPIC 'pg_repl.public.table1')
+    FROM KAFKA CONNECTION kafka_connection TOPIC 'pg_repl.public.table1'
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
     ENVELOPE DEBEZIUM;
 ```

--- a/doc/user/content/integrations/redpanda-cloud.md
+++ b/doc/user/content/integrations/redpanda-cloud.md
@@ -96,7 +96,7 @@ The process to connect Materialize to Redpanda Cloud consists of the following s
           SASL PASSWORD = SECRET redpanda_password,
           SSL CERTIFICATE AUTHORITY = SECRET redpanda_ca_cert;
       CREATE SOURCE <topic-name>
-        FROM KAFKA CONNECTION redpanda_cloud (TOPIC '<topic-name>')
+        FROM KAFKA CONNECTION redpanda_cloud TOPIC '<topic-name>'
         FORMAT BYTES;
     ```
 

--- a/doc/user/content/sql/create-sink.md
+++ b/doc/user/content/sql/create-sink.md
@@ -191,7 +191,7 @@ CREATE CONNECTION kafka_connection
 
 CREATE SINK quotes_sink
 FROM quotes
-INTO KAFKA CONNECTION kafka_connection (TOPIC 'quotes-eo-sink')
+INTO KAFKA CONNECTION kafka_connection TOPIC 'quotes-eo-sink'
 CONSISTENCY (TOPIC 'quotes-eo-sink-consistency'
              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081')
 WITH (reuse_topic=true)
@@ -322,14 +322,14 @@ _data&lowbar;collections_ | This field is null for `BEGIN` records, and for `END
 
 ```sql
 CREATE SOURCE quotes
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'quotes')
+FROM KAFKA CONNECTION kafka_connection TOPIC 'quotes'
 FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
 ```sql
 CREATE SINK quotes_sink
 FROM quotes
-INTO KAFKA CONNECTION kafka_connection (TOPIC 'quotes-sink')
+INTO KAFKA CONNECTION kafka_connection TOPIC 'quotes-sink'
 FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
@@ -338,7 +338,7 @@ FORMAT AVRO USING
 
 ```sql
 CREATE SOURCE quotes
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'quotes')
+FROM KAFKA CONNECTION kafka_connection TOPIC 'quotes'
 FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
@@ -350,7 +350,7 @@ CREATE MATERIALIZED VIEW frank_quotes AS
 ```sql
 CREATE SINK frank_quotes_sink
 FROM frank_quotes
-INTO KAFKA CONNECTION kafka_connection (TOPIC 'frank-quotes-sink')
+INTO KAFKA CONNECTION kafka_connection TOPIC 'frank-quotes-sink'
 FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
@@ -376,14 +376,14 @@ JOIN mz_kafka_sinks ON mz_sinks.id = mz_kafka_sinks.sink_id
 
 ```sql
 CREATE SOURCE quotes
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'quotes')
+FROM KAFKA CONNECTION kafka_connection TOPIC 'quotes'
 FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
 ```sql
 CREATE SINK quotes_sink
 FROM quotes
-INTO KAFKA CONNECTION kafka_connection (TOPIC 'quotes-sink')
+INTO KAFKA CONNECTION kafka_connection TOPIC 'quotes-sink'
 FORMAT JSON;
 ```
 
@@ -391,7 +391,7 @@ FORMAT JSON;
 
 ```sql
 CREATE SOURCE quotes
-FROM KAFKA CONNECTION kafka_connection (TOPIC 'quotes')
+FROM KAFKA CONNECTION kafka_connection TOPIC 'quotes'
 FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
 ```
@@ -403,7 +403,7 @@ CREATE MATERIALIZED VIEW frank_quotes AS
 ```sql
 CREATE SINK frank_quotes_sink
 FROM frank_quotes
-INTO KAFKA CONNECTION kafka_connection (TOPIC 'frank-quotes-sink')
+INTO KAFKA CONNECTION kafka_connection TOPIC 'frank-quotes-sink'
 FORMAT JSON;
 ```
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -87,7 +87,7 @@ To create a source that uses the standard key-value convention to support insert
 
 ```sql
 CREATE SOURCE current_predictions
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'events')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'events'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   ENVELOPE UPSERT;
 ```
@@ -112,7 +112,7 @@ Materialize provides a dedicated envelope (`ENVELOPE DEBEZIUM`) to decode Kafka 
 
 ```sql
 CREATE SOURCE kafka_repl
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'pg_repl.public.table1')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'pg_repl.public.table1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   ENVELOPE DEBEZIUM;
 ```
@@ -135,7 +135,7 @@ The message key is exposed via the `INCLUDE KEY` option. Composite keys are also
 
 ```sql
 CREATE SOURCE kafka_metadata
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'data')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'data'
   KEY FORMAT TEXT
   VALUE FORMAT TEXT
   INCLUDE KEY AS renamed_id;
@@ -155,7 +155,7 @@ Message headers are exposed via the `INCLUDE HEADERS` option, and are included a
 
 ```sql
 CREATE SOURCE kafka_metadata
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'data')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'data'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   INCLUDE HEADERS
   ENVELOPE NONE;
@@ -207,7 +207,7 @@ These metadata fields are exposed via the `INCLUDE PARTITION`, `INCLUDE OFFSET` 
 
 ```sql
 CREATE SOURCE kafka_metadata
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'data')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'data'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
   INCLUDE PARTITION, OFFSET, TIMESTAMP AS ts
   ENVELOPE NONE;
@@ -233,7 +233,7 @@ To start consuming a Kafka stream from a specific offset, you can use the `start
 
 ```sql
 CREATE SOURCE kafka_offset
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'data')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'data'
   -- Start reading from the earliest offset in the first partition,
   -- the second partition at 10, and the third partition at 100
   WITH (start_offset=[0,10,100])
@@ -334,7 +334,7 @@ CREATE CONNECTION csr_ssl
 ```sql
 CREATE SOURCE avro_source
   FROM KAFKA
-    CONNECTION kafka_connection (TOPIC 'test_topic')
+    CONNECTION kafka_connection TOPIC 'test_topic'
     FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection;
 ```
 
@@ -343,7 +343,7 @@ CREATE SOURCE avro_source
 
 ```sql
 CREATE SOURCE json_source
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'test_topic'
   FORMAT BYTES;
 ```
 
@@ -362,7 +362,7 @@ CREATE VIEW jsonified_kafka_source AS
 
 ```sql
 CREATE SOURCE proto_source
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'test_topic'
   WITH (cache = true)
   FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection;
 ```
@@ -372,7 +372,7 @@ CREATE SOURCE proto_source
 
 ```sql
 CREATE SOURCE text_source
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'test_topic'
   FORMAT TEXT
   ENVELOPE UPSERT;
 ```
@@ -382,7 +382,7 @@ CREATE SOURCE text_source
 
 ```sql
 CREATE SOURCE csv_source (col_foo, col_bar, col_baz)
-  FROM KAFKA CONNECTION kafka_connection (TOPIC 'test_topic')
+  FROM KAFKA CONNECTION kafka_connection TOPIC 'test_topic'
   FORMAT CSV WITH 3 COLUMNS;
 ```
 

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -36,7 +36,7 @@ SHOW CREATE SINK my_view_sink;
 ```nofmt
                Sink              |                                                                                                        Create Sink
 ---------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- materialize.public.my_view_sink | CREATE SINK "materialize"."public"."my_view_sink" FROM "materialize"."public"."my_view" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" (TOPIC 'my_view_sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
+ materialize.public.my_view_sink | CREATE SINK "materialize"."public"."my_view_sink" FROM "materialize"."public"."my_view" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" TOPIC 'my_view_sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ```
 
 ## Related pages

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -47,7 +47,7 @@ test_source = {
         }}
 
         CREATE SOURCE {{ this }}
-        FROM KAFKA CONNECTION kafka_connection (TOPIC 'test-source')
+        FROM KAFKA CONNECTION kafka_connection TOPIC 'test-source'
         FORMAT BYTES
         """,
     "materialize_binary": """
@@ -67,7 +67,7 @@ test_source_index = {
         ) }}
 
         CREATE SOURCE {{ this }}
-        FROM KAFKA CONNECTION kafka_connection (TOPIC 'test-source')
+        FROM KAFKA CONNECTION kafka_connection TOPIC 'test-source'
         FORMAT BYTES
         """,
     "materialize_binary": """

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -55,7 +55,8 @@ class AlterIndex(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE alter_index_source
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-index-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-alter-index-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -55,7 +55,8 @@ class DebeziumPostgres(Check):
 
                 # UPSERT is requred due to https://github.com/MaterializeInc/materialize/issues/14211
                 > CREATE SOURCE debezium_source1
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.debezium_table')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'postgres.public.debezium_table'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM UPSERT;
 
@@ -83,7 +84,7 @@ class DebeziumPostgres(Check):
                 COMMIT;
 
                 > CREATE SOURCE debezium_source2
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.debezium_table')
+                  FROM KAFKA CONNECTION kafka_conn TOPIC 'postgres.public.debezium_table'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM UPSERT;
 
@@ -103,7 +104,7 @@ class DebeziumPostgres(Check):
                 COMMIT;
 
                 > CREATE SOURCE debezium_source3
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.debezium_table')
+                  FROM KAFKA CONNECTION kafka_conn TOPIC 'postgres.public.debezium_table'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM UPSERT;
 

--- a/misc/python/materialize/checks/error.py
+++ b/misc/python/materialize/checks/error.py
@@ -153,7 +153,8 @@ class DecodeError(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE decode_error
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-decode-error-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-decode-error-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
             """

--- a/misc/python/materialize/checks/rename_source.py
+++ b/misc/python/materialize/checks/rename_source.py
@@ -42,7 +42,8 @@ class RenameSource(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE rename_source1
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rename-source-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-rename-source-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -62,14 +62,16 @@ class SinkUpsert(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE sink_source
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-source-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-sink-source-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE UPSERT
 
                 > CREATE MATERIALIZED VIEW sink_source_view AS SELECT LEFT(key1, 2) as l_k, LEFT(f1, 1) AS l_v, COUNT(*) AS c FROM sink_source GROUP BY LEFT(key1, 2), LEFT(f1, 1);
 
                 > CREATE SINK sink_sink1 FROM sink_source_view
-                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink1')
+                  INTO KAFKA CONNECTION kafka_conn
+                  TOPIC 'sink-sink1'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                 """
             )
@@ -90,7 +92,8 @@ class SinkUpsert(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SINK sink_sink2 FROM sink_source_view
-                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink2')
+                  INTO KAFKA CONNECTION kafka_conn
+                  TOPIC 'sink-sink2'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                 """,
                 """
@@ -100,7 +103,8 @@ class SinkUpsert(Check):
                 {"key1": "D3${kafka-ingest.iteration}"}
 
                 > CREATE SINK sink_sink3 FROM sink_source_view
-                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink3')
+                  INTO KAFKA CONNECTION kafka_conn
+                  TOPIC 'sink-sink3'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                 """,
             ]
@@ -123,17 +127,20 @@ class SinkUpsert(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE sink_view1
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink1')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'sink-sink1'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 
                 > CREATE SOURCE sink_view2
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink2')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'sink-sink2'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 
                 > CREATE SOURCE sink_view3
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink3')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'sink-sink3'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 
@@ -204,7 +211,8 @@ class SinkTables(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SINK sink_large_transaction_sink1 FROM sink_large_transaction_view
-                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}')
+                  INTO KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
                 """
             )
@@ -233,7 +241,8 @@ class SinkTables(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE sink_large_transaction_source
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
 

--- a/misc/python/materialize/checks/top_k.py
+++ b/misc/python/materialize/checks/top_k.py
@@ -93,7 +93,8 @@ class MonotonicTopK(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE monotonic_topk_source
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-monotonic-topk-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-monotonic-topk-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
             """
@@ -159,7 +160,8 @@ class MonotonicTop1(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE monotonic_top1_source
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-monotonic-top1-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-monotonic-top1-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE NONE
             """

--- a/misc/python/materialize/checks/upsert.py
+++ b/misc/python/materialize/checks/upsert.py
@@ -53,7 +53,8 @@ class UpsertInsert(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE upsert_insert
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-insert-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-upsert-insert-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE UPSERT
 
@@ -107,7 +108,8 @@ class UpsertUpdate(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE upsert_update
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-update-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-upsert-update-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE UPSERT
 
@@ -158,7 +160,8 @@ class UpsertDelete(Check):
                 > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE upsert_delete
-                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-delete-${testdrive.seed}')
+                  FROM KAFKA CONNECTION kafka_conn
+                  TOPIC 'testdrive-upsert-delete-${testdrive.seed}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE UPSERT
 

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -57,13 +57,15 @@ class CreateSink(Action):
                 > CREATE CONNECTION IF NOT EXISTS {self.sink.name}_csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
 
                 > CREATE SINK {self.sink.name} FROM {self.source_view.name}
-                  INTO KAFKA CONNECTION {self.sink.name}_kafka_conn (TOPIC 'sink-{self.sink.name}')
+                  INTO KAFKA CONNECTION {self.sink.name}_kafka_conn
+                  TOPIC 'sink-{self.sink.name}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn;
 
                 # Ingest the sink again in order to be able to validate its contents
 
                 > CREATE SOURCE {self.sink.name}_source
-                  FROM KAFKA CONNECTION {self.sink.name}_kafka_conn (TOPIC 'sink-{self.sink.name}')
+                  FROM KAFKA CONNECTION {self.sink.name}_kafka_conn
+                  TOPIC 'sink-{self.sink.name}'
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn
                   ENVELOPE NONE
 

--- a/src/billing-demo/src/bin/billing-demo/mz.rs
+++ b/src/billing-demo/src/bin/billing-demo/mz.rs
@@ -79,7 +79,7 @@ pub async fn create_kafka_sink(
     mz_client::execute(&mz_client, &query).await?;
 
     let query = format!(
-            "CREATE SINK {sink} FROM billing_monthly_statement INTO KAFKA CONNECTION {sink}_kafka_conn (TOPIC '{topic}') \
+            "CREATE SINK {sink} FROM billing_monthly_statement INTO KAFKA CONNECTION {sink}_kafka_conn TOPIC '{topic}' \
              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {sink}_csr_conn",
              sink = sink_name,
              topic = sink_topic_name,

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-compute"
 description = "Materialize's compute layer."
-version = "0.27.0-alpha.19"
+version = "0.27.0-alpha.20"
 edition = "2021"
 rust-version = "1.63.0"
 publish = false

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-compute"
 description = "Materialize's compute layer."
-version = "0.26.1-dev"
+version = "0.27.0-alpha.19"
 edition = "2021"
 rust-version = "1.63.0"
 publish = false

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.26.1-dev"
+version = "0.27.0-alpha.19"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition = "2021"

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-environmentd"
 description = "Manages a single Materialize environment."
-version = "0.27.0-alpha.19"
+version = "0.27.0-alpha.20"
 authors = ["Materialize, Inc."]
 license = "proprietary"
 edition = "2021"

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -602,7 +602,7 @@ where
                             writers: expired_writers,
                         });
 
-                        if let Some(gc) = garbage_collection {
+                        if let Some(gc) = garbage_collection.as_ref() {
                             info!("Assigned gc request: {:?}", gc);
                         }
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -602,6 +602,10 @@ where
                             writers: expired_writers,
                         });
 
+                        if let Some(gc) = garbage_collection {
+                            info!("Assigned gc request: {:?}", gc);
+                        }
+
                         let maintenance = RoutineMaintenance {
                             garbage_collection,
                             lease_expiration,

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -833,7 +833,6 @@ pub enum KafkaConfigOptionName {
     GroupIdPrefix,
     IsolationLevel,
     StatisticsIntervalMs,
-    Topic,
     TopicMetadataRefreshIntervalMs,
     TransactionTimeoutMs,
     StartTimestamp,
@@ -855,7 +854,6 @@ impl AstDisplay for KafkaConfigOptionName {
             KafkaConfigOptionName::GroupIdPrefix => "GROUP ID PREFIX",
             KafkaConfigOptionName::IsolationLevel => "ISOLATION LEVEL",
             KafkaConfigOptionName::StatisticsIntervalMs => "STATISTICS INTERVAL MS",
-            KafkaConfigOptionName::Topic => "TOPIC",
             KafkaConfigOptionName::TopicMetadataRefreshIntervalMs => {
                 "TOPIC METADATA REFRESH INTERVAL MS"
             }
@@ -928,7 +926,7 @@ impl_display_t!(KafkaConnection);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KafkaSourceConnection<T: AstInfo> {
     pub connection: KafkaConnection<T>,
-    pub topic: Option<String>,
+    pub topic: String,
     pub key: Option<Vec<Ident>>,
 }
 
@@ -973,11 +971,9 @@ impl<T: AstInfo> AstDisplay for CreateSourceConnection<T> {
             }) => {
                 f.write_str("KAFKA ");
                 f.write_node(connection);
-                if let Some(topic) = topic {
-                    f.write_str(" TOPIC '");
-                    f.write_node(&display::escape_single_quote_string(topic));
-                    f.write_str("'");
-                }
+                f.write_str(" TOPIC '");
+                f.write_node(&display::escape_single_quote_string(topic));
+                f.write_str("'");
                 if let Some(key) = key.as_ref() {
                     f.write_str(" KEY (");
                     f.write_node(&display::comma_separated(&key));
@@ -1090,6 +1086,7 @@ impl_display_t!(LoadGeneratorOption);
 pub enum CreateSinkConnection<T: AstInfo> {
     Kafka {
         connection: KafkaConnection<T>,
+        topic: String,
         key: Option<KafkaSinkKey>,
     },
 }
@@ -1097,9 +1094,16 @@ pub enum CreateSinkConnection<T: AstInfo> {
 impl<T: AstInfo> AstDisplay for CreateSinkConnection<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
-            CreateSinkConnection::Kafka { connection, key } => {
+            CreateSinkConnection::Kafka {
+                connection,
+                topic,
+                key,
+            } => {
                 f.write_str("KAFKA ");
                 f.write_node(connection);
+                f.write_str(" TOPIC '");
+                f.write_node(&display::escape_single_quote_string(topic));
+                f.write_str("'");
                 if let Some(key) = key.as_ref() {
                     f.write_node(key);
                 }

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -407,42 +407,42 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS crobat ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("crobat")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("crobat")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TIMESTAMP ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Timestamp, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Timestamp, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE PARTITION ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Partition, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Partition, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE TOPIC ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Topic, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Topic, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC as kafka_topic ENVELOPE NONE
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY AS mykey, TIMESTAMP, PARTITION, TOPIC AS kafka_topic ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("mykey")) }, SourceIncludeMetadata { ty: Timestamp, alias: None }, SourceIncludeMetadata { ty: Partition, alias: None }, SourceIncludeMetadata { ty: Topic, alias: Some(Ident("kafka_topic")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: Some(Ident("mykey")) }, SourceIncludeMetadata { ty: Timestamp, alias: None }, SourceIncludeMetadata { ty: Partition, alias: None }, SourceIncludeMetadata { ty: Topic, alias: Some(Ident("kafka_topic")) }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081' INCLUDE KEY ENVELOPE NONE
@@ -470,7 +470,7 @@ CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USIN
 ----
 CREATE SOURCE crobat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' FORMAT AVRO USING SCHEMA 'string' (CONFLUENT WIRE FORMAT = false) ENVELOPE NONE
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Avro(InlineSchema { schema: Inline("string"), with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] })), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("crobat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Avro(InlineSchema { schema: Inline("string"), with_options: [AvroSchemaOption { name: ConfluentWireFormat, value: Some(Value(Boolean(false))) }] })), envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [] })
 
 
 parse-statement
@@ -478,21 +478,21 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SE
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = sekret)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("sekret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("sekret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = secret)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("secret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Ident(Ident("secret"))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a)
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement roundtrip
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET)
@@ -509,35 +509,35 @@ CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SE
 ----
 CREATE SOURCE source FROM KAFKA BROKER 'broker' TOPIC 'topic' LEGACYWITH (a = SECRET a.b.c)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [WithOption { key: Ident("a"), value: Some(Secret(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))) }], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
 
 parse-statement
 CREATE SOURCE source (a, PRIMARY KEY (a) NOT ENFORCED, b) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (a, b, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("a"), Ident("b")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
 
 parse-statement
 CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
 
 parse-statement
 CREATE SOURCE source (PRIMARY, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 ----
 CREATE SOURCE source (primary, PRIMARY KEY (a) NOT ENFORCED) FROM KAFKA BROKER 'broker' TOPIC 'topic'
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: Some("topic"), key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("source")]), col_names: [Ident("primary")], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "broker" }, topic: "topic", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("a")] }), with_options: [] })
 
 parse-statement
 CREATE SOURCE source PRIMARY KEY (a) NOT ENFORCED FROM KAFKA BROKER 'broker' TOPIC 'topic'
@@ -575,39 +575,39 @@ CREATE SOURCE psychic FROM POSTGRES CONNECTION pgconn PUBLICATION 'red'
 CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("psychic")]), col_names: [], connection: Postgres { connection: Name(UnresolvedObjectName([Ident("pgconn")])), publication: "red", details: None }, legacy_with_options: [], include_metadata: [], format: None, envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000, TOPIC 'topic') FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000) TOPIC 'topic' FORMAT BYTES
 ----
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000, TOPIC = 'topic') FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (REPLICATION FACTOR = 7, RETENTION MS = 10000, RETENTION BYTES = 10000000000) TOPIC 'topic' FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: ReplicationFactor, value: Some(Value(Number("7"))) }, KafkaConfigOption { name: RetentionMs, value: Some(Value(Number("10000"))) }, KafkaConfigOption { name: RetentionBytes, value: Some(Value(Number("10000000000"))) }, KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: None }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: ReplicationFactor, value: Some(Value(Number("7"))) }, KafkaConfigOption { name: RetentionMs, value: Some(Value(Number("10000"))) }, KafkaConfigOption { name: RetentionBytes, value: Some(Value(Number("10000000000"))) }] }, topic: "topic", key: None }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY (a, b) FORMAT BYTES
 ----
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') KEY (a, b) FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY (a, b) FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }) }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [] }, topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }) }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) NOT ENFORCED FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY (a, b) NOT ENFORCED FORMAT BYTES
 ----
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC = 'topic') KEY (a, b) NOT ENFORCED FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY (a, b) NOT ENFORCED FORMAT BYTES
 =>
-CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("topic"))) }] }, key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }) }, format: Some(Bytes), envelope: None, with_options: [] })
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [] }, topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: true }) }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY (a, b) FORMAT BYTES
 ----
-error: Expected end of statement, found identifier "consistency"
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY (a, b) CONSISTENCY (TOPIC 'consistency' FORMAT BYTES) FORMAT BYTES
-                                                                              ^
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY (a, b) FORMAT BYTES
+=>
+CreateSink(CreateSinkStatement { name: UnresolvedObjectName([Ident("foo")]), if_not_exists: false, from: Name(UnresolvedObjectName([Ident("bar")])), connection: Kafka { connection: Reference { connection: Name(UnresolvedObjectName([Ident("baz")])), options: [] }, topic: "topic", key: Some(KafkaSinkKey { key_columns: [Ident("a"), Ident("b")], not_enforced: false }) }, format: Some(Bytes), envelope: None, with_options: [] })
 
 parse-statement
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY FORMAT BYTES
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY FORMAT BYTES
 ----
 error: Expected end of statement, found KEY
-CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz (TOPIC 'topic') KEY FORMAT BYTES
-                                                                   ^
+CREATE SINK foo FROM bar INTO KAFKA CONNECTION baz TOPIC 'topic' KEY FORMAT BYTES
+                                                                 ^
 
 parse-statement
 CREATE SINK IF EXISTS foo FROM bar INTO 'baz'
@@ -1336,11 +1336,11 @@ DROP CONNECTION conn1
 DropObjects(DropObjectsStatement { object_type: Connection, if_exists: false, names: [UnresolvedObjectName([Ident("conn1")])], cascade: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' LEGACYWITH (consistency = 'lug') FORMAT BYTES
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') LEGACYWITH (consistency = 'lug') FORMAT BYTES
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' LEGACYWITH (consistency = 'lug') FORMAT BYTES
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, topic: None, key: None }), legacy_with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [] }, topic: "baz", key: None }), legacy_with_options: [WithOption { key: Ident("consistency"), value: Some(Value(String("lug"))) }], include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
 CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word'
@@ -1350,49 +1350,49 @@ CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL = 'http://localhost:80
 CreateConnection(CreateConnectionStatement { name: UnresolvedObjectName([Ident("conn1")]), connection: Csr { with_options: [CsrConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, CsrConnectionOption { name: Username, value: Some(Value(String("user"))) }, CsrConnectionOption { name: Password, value: Some(Value(String("word"))) }] }, if_not_exists: false })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, topic: None, key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Avro(Csr { csr_connection: CsrConnectionAvro { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, key_strategy: None, value_strategy: None, seed: None } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, key_constraint: None, with_options: [] })
 
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' FORMAT PROTOBUF USING CONFLUENT SCHEMA REGISTRY CONNECTION conn2 ENVELOPE DEBEZIUM
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, topic: None, key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, seed: None } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: Bare(Protobuf(Csr { csr_connection: CsrConnectionProtobuf { connection: CsrConnection { connection: Name(UnresolvedObjectName([Ident("conn2")])), options: [] }, seed: None } })), envelope: Some(Debezium(Plain { tx_metadata: [] })), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (SOURCE a.b.c, COLLECTION 'foo'))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, topic: None, key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")]))), Collection(Value(String("foo")))] })), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")]))), Collection(Value(String("foo")))] })), if_not_exists: false, key_constraint: None, with_options: [] })
 
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (TOPIC = 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, topic: None, key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, key_constraint: None, with_options: [] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [] }, topic: "baz", key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, key_constraint: None, with_options: [] })
 
 # Note that this will error in planninf, as you cannot specify START OFFSET and START TIMESTAMP at the same time
 parse-statement
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (START OFFSET=1, START TIMESTAMP=2, TOPIC 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET=1, START TIMESTAMP=2) TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
-CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 (START OFFSET = 1, START TIMESTAMP = 2, TOPIC = 'baz') ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
-=>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("src1")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Reference { connection: Name(UnresolvedObjectName([Ident("conn1")])), options: [KafkaConfigOption { name: StartOffset, value: Some(Value(Number("1"))) }, KafkaConfigOption { name: StartTimestamp, value: Some(Value(Number("2"))) }, KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, topic: None, key: None }), legacy_with_options: [], include_metadata: [], format: None, envelope: Some(Debezium(Plain { tx_metadata: [Collection(Value(String("foo"))), Source(Name(UnresolvedObjectName([Ident("a"), Ident("b"), Ident("c")])))] })), if_not_exists: false, key_constraint: None, with_options: [] })
+error: Expected TOPIC, found WITH
+CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET=1, START TIMESTAMP=2) TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
+                                               ^
 
 # Note that this will error in planning, as START OFFSET must be an array of nums
 parse-statement
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
 ----
-error: Expected one of IGNORE or REMOTE or SIZE or TIMELINE or TIMESTAMP, found START
+error: Expected TOPIC, found WITH
 CREATE SOURCE src1 FROM KAFKA CONNECTION conn1 WITH (START OFFSET="hmm") TOPIC 'baz' ENVELOPE DEBEZIUM (TRANSACTION METADATA (COLLECTION 'foo', SOURCE a.b.c))
-                                                     ^
+                                               ^
 
 parse-statement
 CREATE CONNECTION my_ssh_tunnel FOR SSH TUNNEL HOST 'ssh-bastion', PORT 1234, USER 'blah'
@@ -1434,35 +1434,35 @@ CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = 2)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(Number("2"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(Number("2"))) }] })
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = '2')
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = '2')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("2"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Value(String("2"))) }] })
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = large)
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = large)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE large)
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = large)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (REMOTE 'johto:42')
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (REMOTE = 'johto:42')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
 
 parse-statement
@@ -1470,14 +1470,14 @@ CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT 
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (SIZE = large, REMOTE = 'johto:42')
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }, CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }, CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }] })
 
 parse-statement
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (REMOTE 'johto:42', SIZE large)
 ----
 CREATE SOURCE golbat FROM KAFKA BROKER 'zubat' TOPIC 'hoothoot' KEY FORMAT TEXT VALUE FORMAT TEXT INCLUDE KEY ENVELOPE NONE WITH (REMOTE = 'johto:42', SIZE = large)
 =>
-CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: Some("hoothoot"), key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }, CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
+CreateSource(CreateSourceStatement { name: UnresolvedObjectName([Ident("golbat")]), col_names: [], connection: Kafka(KafkaSourceConnection { connection: Inline { broker: "zubat" }, topic: "hoothoot", key: None }), legacy_with_options: [], include_metadata: [SourceIncludeMetadata { ty: Key, alias: None }], format: KeyValue { key: Text, value: Text }, envelope: Some(None), if_not_exists: false, key_constraint: None, with_options: [CreateSourceOption { name: Remote, value: Some(Value(String("johto:42"))) }, CreateSourceOption { name: Size, value: Some(Ident(Ident("large"))) }] })
 
 # Ensure that we can parse REMOTE with pg
 parse-statement

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -54,7 +54,6 @@ pub fn validate_options_for_context<T: AstInfo>(
             GroupIdPrefix => None,
             IsolationLevel => None,
             StatisticsIntervalMs => None,
-            Topic => None,
             TopicMetadataRefreshIntervalMs => None,
             TransactionTimeoutMs => None,
             StartTimestamp => Some(Source),
@@ -93,7 +92,6 @@ generate_extracted_config!(
         Default(String::from("read_committed"))
     ),
     (StatisticsIntervalMs, i32, Default(1_000)),
-    (Topic, String),
     (TopicMetadataRefreshIntervalMs, i32),
     (TransactionTimeoutMs, i32),
     (StartTimestamp, i64),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -12,7 +12,7 @@
 //! This module houses the handlers for statements that modify the catalog, like
 //! `ALTER`, `CREATE`, and `DROP`.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 use std::str::FromStr;
 
@@ -366,79 +366,62 @@ pub fn plan_create_source(
     }
 
     let (external_connection, encoding) = match connection {
-        CreateSourceConnection::Kafka(mz_sql_parser::ast::KafkaSourceConnection {
-            connection: connection_inner,
-            topic,
-            key: _,
-        }) => {
-            let (kafka_connection, topic, options, optional_start_offset, group_id_prefix) =
-                match &connection_inner {
-                    mz_sql_parser::ast::KafkaConnection::Inline { broker } => {
-                        scx.require_unsafe_mode("creating Kafka sources with inline connections")?;
-                        let connection = KafkaConnection {
-                            brokers: vec![broker.clone()],
-                            progress_topic: None,
-                            security: None,
-                        };
+        CreateSourceConnection::Kafka(kafka) => {
+            let (kafka_connection, options, optional_start_offset, group_id_prefix) = match &kafka
+                .connection
+            {
+                mz_sql_parser::ast::KafkaConnection::Inline { broker } => {
+                    scx.require_unsafe_mode("creating Kafka sources with inline connections")?;
+                    let mut options = BTreeMap::new();
+                    options.insert(
+                        "bootstrap.servers".into(),
+                        KafkaAddrs::from_str(broker)
+                            .map_err(|e| sql_err!("parsing kafka broker: {e}"))?
+                            .to_string()
+                            .into(),
+                    );
+                    let connection = KafkaConnection::try_from(&mut options)?;
+                    (connection, options, None, None)
+                }
+                mz_sql_parser::ast::KafkaConnection::Reference {
+                    connection,
+                    options: with_options,
+                } => {
+                    let item = scx.get_item_by_resolved_name(&connection)?;
+                    let connection = match item.connection()? {
+                        Connection::Kafka(connection) => connection.clone(),
+                        _ => sql_bail!("{} is not a kafka connection", item.name()),
+                    };
 
-                        let options = connection.clone().into();
-                        (
-                            connection,
-                            topic
-                                .clone()
-                                .expect("inline definitions always parse a topic"),
-                            options,
-                            None,
-                            None,
-                        )
+                    // Starting offsets are allowed out unsafe mode, as they are a simple,
+                    // useful way to specify where to start reading a topic.
+                    if with_options.iter().any(|opt| {
+                        opt.name != KafkaConfigOptionName::StartOffset
+                            && opt.name != KafkaConfigOptionName::StartTimestamp
+                    }) {
+                        scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
                     }
-                    mz_sql_parser::ast::KafkaConnection::Reference {
+
+                    kafka_util::validate_options_for_context(
+                        &with_options,
+                        kafka_util::KafkaOptionCheckContext::Source,
+                    )?;
+
+                    let extracted_options: KafkaConfigOptionExtracted =
+                        with_options.clone().try_into()?;
+                    let optional_start_offset =
+                        Option::<kafka_util::KafkaStartOffsetType>::try_from(&extracted_options)?;
+                    let config_options =
+                        kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
+
+                    (
                         connection,
-                        options,
-                    } => {
-                        let item = scx.get_item_by_resolved_name(&connection)?;
-                        let connection = match item.connection()? {
-                            Connection::Kafka(connection) => connection.clone(),
-                            _ => sql_bail!("{} is not a kafka connection", item.name()),
-                        };
-
-                        // Starting offsets are allowed out unsafe mode, as they are a simple,
-                        // useful way to specify where to start reading a topic.
-                        if options.iter().any(|opt| {
-                            opt.name != KafkaConfigOptionName::StartOffset
-                                && opt.name != KafkaConfigOptionName::StartTimestamp
-                        }) {
-                            scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
-                        }
-
-                        kafka_util::validate_options_for_context(
-                            &options,
-                            kafka_util::KafkaOptionCheckContext::Source,
-                        )?;
-
-                        let extracted_options: KafkaConfigOptionExtracted =
-                            options.clone().try_into()?;
-
-                        let optional_start_offset =
-                            Option::<kafka_util::KafkaStartOffsetType>::try_from(
-                                &extracted_options,
-                            )?;
-                        let config_options =
-                            kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
-
-                        let topic = extracted_options
-                            .topic
-                            .ok_or_else(|| sql_err!("KAFKA CONNECTION without TOPIC"))?;
-
-                        (
-                            connection,
-                            topic,
-                            config_options,
-                            optional_start_offset,
-                            extracted_options.group_id_prefix,
-                        )
-                    }
-                };
+                        config_options,
+                        optional_start_offset,
+                        extracted_options.group_id_prefix,
+                    )
+                }
+            };
 
             let parse_offset = |s: i64| {
                 // we parse an i64 here, because we don't yet support u64's in
@@ -476,12 +459,12 @@ pub fn plan_create_source(
                 sql_bail!("START OFFSET is not supported with ENVELOPE {}", envelope)
             }
 
-            let encoding = get_encoding(scx, format, &envelope, connection)?;
+            let encoding = get_encoding(scx, format, &envelope, &connection)?;
 
             let mut connection = KafkaSourceConnection {
                 connection: kafka_connection,
                 options,
-                topic,
+                topic: kafka.topic.clone(),
                 start_offsets,
                 group_id_prefix,
                 cluster_id: scx.catalog.config().cluster_id,
@@ -1963,10 +1946,13 @@ pub fn plan_create_sink(
     }
 
     let connection_builder = match connection {
-        CreateSinkConnection::Kafka { connection, .. } => kafka_sink_builder(
+        CreateSinkConnection::Kafka {
+            connection, topic, ..
+        } => kafka_sink_builder(
             scx,
             connection,
             format,
+            topic,
             relation_key_indices,
             key_desc_and_indices,
             desc.into_owned(),
@@ -2047,6 +2033,7 @@ fn kafka_sink_builder(
     scx: &StatementContext,
     connection: mz_sql_parser::ast::KafkaConnection<Aug>,
     format: Option<Format<Aug>>,
+    topic_name: String,
     relation_key_indices: Option<Vec<usize>>,
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     value_desc: RelationDesc,
@@ -2057,7 +2044,6 @@ fn kafka_sink_builder(
         connection,
         config_options,
         KafkaConfigOptionExtracted {
-            topic,
             partition_count,
             replication_factor,
             retention_ms,
@@ -2076,13 +2062,8 @@ fn kafka_sink_builder(
                 _ => sql_bail!("{} is not a kafka connection", item.name()),
             };
 
-            if with_options
-                .iter()
-                .any(|mz_sql_parser::ast::KafkaConfigOption { name, .. }| {
-                    !matches!(name, KafkaConfigOptionName::Topic)
-                })
-            {
-                scx.require_unsafe_mode("KAFKA CONNECTION options besides TOPIC")?;
+            if !with_options.is_empty() {
+                scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
             }
 
             kafka_util::validate_options_for_context(
@@ -2096,8 +2077,6 @@ fn kafka_sink_builder(
         }
         mz_sql_parser::ast::KafkaConnection::Inline { .. } => unreachable!(),
     };
-
-    let topic_name = topic.ok_or_else(|| sql_err!("KAFKA CONNECTION must specify TOPIC"))?;
 
     let format = match format {
         Some(Format::Avro(AvroSchema::Csr {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -78,7 +78,9 @@ pub async fn purify_create_source(
     let mut with_options_map = normalize::options(with_options)?;
 
     match connection {
-        CreateSourceConnection::Kafka(KafkaSourceConnection { connection, .. }) => {
+        CreateSourceConnection::Kafka(KafkaSourceConnection {
+            connection, topic, ..
+        }) => {
             match connection {
                 KafkaConnection::Reference {
                     connection,
@@ -101,8 +103,6 @@ pub async fn purify_create_source(
                         Option::<kafka_util::KafkaStartOffsetType>::try_from(&extracted_options)?;
                     let config_options =
                         kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
-
-                    let topic = extracted_options.topic.expect("validated topic exists");
 
                     let consumer = kafka_util::create_consumer(
                         &topic,
@@ -350,20 +350,8 @@ async fn purify_csr_connection_proto(
     connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
     let topic =
-        if let CreateSourceConnection::Kafka(KafkaSourceConnection {
-            connection, topic, ..
-        }) = connection
-        {
-            match connection {
-                KafkaConnection::Inline { .. } => topic.clone().unwrap(),
-                KafkaConnection::Reference { options, .. } => {
-                    let KafkaConfigOptionExtracted { topic, .. } = options
-                        .clone()
-                        .try_into()
-                        .expect("already verified options valid provided");
-                    topic.expect("already validated topic provided")
-                }
-            }
+        if let CreateSourceConnection::Kafka(KafkaSourceConnection { topic, .. }) = connection {
+            topic
         } else {
             bail!("Confluent Schema Registry is only supported with Kafka sources")
         };
@@ -413,26 +401,17 @@ async fn purify_csr_connection_avro(
     connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
     let topic =
-        if let CreateSourceConnection::Kafka(KafkaSourceConnection {
-            connection, topic, ..
-        }) = connection
-        {
-            match connection {
-                KafkaConnection::Inline { .. } => topic.clone().unwrap(),
-                KafkaConnection::Reference { options, .. } => {
-                    let KafkaConfigOptionExtracted { topic, .. } = options
-                        .clone()
-                        .try_into()
-                        .expect("already verified options valid provided");
-                    topic.expect("already validated topic provided")
-                }
-            }
+        if let CreateSourceConnection::Kafka(KafkaSourceConnection { topic, .. }) = connection {
+            topic
         } else {
             bail!("Confluent Schema Registry is only supported with Kafka sources")
         };
 
     let CsrConnectionAvro {
-        connection: CsrConnection { connection, .. },
+        connection: CsrConnection {
+            connection,
+            options: _,
+        },
         seed,
         key_strategy,
         value_strategy,
@@ -446,7 +425,6 @@ async fn purify_csr_connection_avro(
         let ccsr_client = csr_connection
             .connect(&*connection_context.secrets_reader)
             .await?;
-
         let Schema {
             key_schema,
             value_schema,
@@ -454,7 +432,7 @@ async fn purify_csr_connection_avro(
             &ccsr_client,
             key_strategy.clone().unwrap_or_default(),
             value_strategy.clone().unwrap_or_default(),
-            topic,
+            topic.clone(),
         )
         .await?;
         if matches!(envelope, Some(Envelope::Debezium(DbzMode::Upsert))) && key_schema.is_none() {

--- a/src/storage/src/types/connections.rs
+++ b/src/storage/src/types/connections.rs
@@ -10,9 +10,10 @@
 //! Connection types.
 
 use std::collections::{BTreeMap, HashSet};
-
+use std::str::FromStr;
 use std::sync::Arc;
 
+use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
@@ -21,7 +22,7 @@ use tokio_postgres::config::SslMode;
 use url::Url;
 
 use mz_ccsr::tls::{Certificate, Identity};
-
+use mz_kafka_util::KafkaAddrs;
 use mz_proto::tokio_postgres::any_ssl_mode;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::url::any_url;
@@ -277,6 +278,72 @@ impl From<KafkaConnection> for BTreeMap<String, StringOrSecret> {
         }
 
         r
+    }
+}
+
+impl TryFrom<&mut BTreeMap<String, StringOrSecret>> for KafkaConnection {
+    type Error = anyhow::Error;
+    /// Extracts only the options necessary to create a `KafkaConnection` from
+    /// a `BTreeMap<String, StringOrSecret>`, and returns the remaining
+    /// options.
+    ///
+    /// # Panics
+    /// - If `value` was not sufficiently or incorrectly type checked and
+    ///   parameters expected to reference objects (i.e. secrets) are instead
+    ///   `String`s, or vice versa.
+    fn try_from(map: &mut BTreeMap<String, StringOrSecret>) -> Result<Self, Self::Error> {
+        use KafkaConnectionOptionName::*;
+
+        let key_or_err = |config: &str,
+                          map: &mut BTreeMap<String, StringOrSecret>,
+                          key: KafkaConnectionOptionName| {
+            map.remove(&key.config_key()).ok_or_else(|| {
+                anyhow!(
+                    "invalid {} config: missing {} ({})",
+                    config.to_uppercase(),
+                    key,
+                    key.config_key(),
+                )
+            })
+        };
+
+        let security = if let Some(v) = map.remove("security.protocol") {
+            match v.unwrap_string().to_lowercase().as_str() {
+                config @ "ssl" => Some(KafkaSecurity::Tls(KafkaTlsConfig {
+                    identity: Some(TlsIdentity {
+                        key: key_or_err(config, map, SslKey)?.unwrap_secret(),
+                        cert: key_or_err(config, map, SslCertificate)?,
+                    }),
+                    root_cert: map.remove(&SslCertificateAuthority.config_key()),
+                })),
+                config @ "sasl_ssl" => Some(KafkaSecurity::Sasl(SaslConfig {
+                    mechanisms: key_or_err(config, map, SaslMechanisms)?
+                        .unwrap_string()
+                        .to_string(),
+                    username: key_or_err(config, map, SaslUsername)?,
+                    password: key_or_err(config, map, SaslPassword)?.unwrap_secret(),
+                    tls_root_cert: map.remove(&SslCertificateAuthority.config_key()),
+                })),
+                o => bail!("unsupported security.protocol: {}", o),
+            }
+        } else {
+            None
+        };
+
+        let brokers = match map.remove(&Broker.config_key()) {
+            Some(v) => KafkaAddrs::from_str(&v.unwrap_string())?
+                .to_string()
+                .split(',')
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>(),
+            None => bail!("must specify {}", Broker.config_key()),
+        };
+
+        Ok(KafkaConnection {
+            brokers,
+            security,
+            progress_topic: None,
+        })
     }
 }
 

--- a/src/storaged/Cargo.toml
+++ b/src/storaged/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-storaged"
 description = "Materialize's storage server."
-version = "0.27.0-alpha.19"
+version = "0.27.0-alpha.20"
 edition = "2021"
 rust-version = "1.63.0"
 publish = false

--- a/src/storaged/Cargo.toml
+++ b/src/storaged/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-storaged"
 description = "Materialize's storage server."
-version = "0.26.1-dev"
+version = "0.27.0-alpha.19"
 edition = "2021"
 rust-version = "1.63.0"
 publish = false

--- a/test/cloudtest/test_computed_shared_fate.py
+++ b/test/cloudtest/test_computed_shared_fate.py
@@ -33,7 +33,8 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
             > CREATE CONNECTION kafka FOR KAFKA BROKER '${{testdrive.kafka-addr}}'
 
             > CREATE SOURCE s1
-              FROM KAFKA CONNECTION kafka (TOPIC 'testdrive-shared-fate-${{testdrive.seed}}')
+              FROM KAFKA CONNECTION kafka
+              TOPIC 'testdrive-shared-fate-${{testdrive.seed}}'
               FORMAT BYTES
               ENVELOPE NONE;
 

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -30,7 +30,8 @@ def test_secrets(mz: MaterializeApplication) -> None:
             # Our Redpanda instance is not configured for SASL, so we can not
             # really establish a successful connection. Hence the expectation for an SSL error
             ! CREATE SOURCE secrets_source
-              FROM KAFKA CONNECTION secrets_conn (TOPIC 'foo_bar');
+              FROM KAFKA CONNECTION secrets_conn
+              TOPIC 'foo_bar';
             contains: SSL handshake failed
             """
         )

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -185,7 +185,7 @@ $ kafka-ingest format=bytes topic=source1
 A
 
 > CREATE SOURCE source1
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-source1-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-source1-${testdrive.seed}'
   FORMAT BYTES
 
 > SELECT * FROM source1
@@ -193,7 +193,7 @@ A
 
 # Sinks
 > CREATE SINK sink1 FROM v1mat
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink1')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'sink1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.sink1 sort-messages=true

--- a/test/cluster/storaged/01-create-sources.td
+++ b/test/cluster/storaged/01-create-sources.td
@@ -21,13 +21,13 @@ one
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE remote1
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-remote1-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-remote1-${testdrive.seed}'
   FORMAT TEXT
   WITH (
     REMOTE 'storaged:2100'
   )
 > CREATE SOURCE remote2
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-remote2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-remote2-${testdrive.seed}'
   FORMAT TEXT
   WITH (
     REMOTE 'storaged:2100'

--- a/test/cluster/upsert/01-create-sources.td
+++ b/test/cluster/upsert/01-create-sources.td
@@ -61,7 +61,7 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE upsert
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 

--- a/test/debezium/mysql/40-check-smoke.td.gh13629
+++ b/test/debezium/mysql/40-check-smoke.td.gh13629
@@ -29,12 +29,12 @@ $ schema-registry-wait-schema schema=mysql.transaction-value
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE mysql_tx_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'mysql.transaction')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'mysql.transaction'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE;
 
 > CREATE SOURCE t1
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'mysql.test.t1')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'mysql.test.t1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM (
       TRANSACTION METADATA (SOURCE mysql_tx_metadata, COLLECTION 'test.t1')

--- a/test/debezium/postgres/02-add-primary-key.td.gh6570
+++ b/test/debezium/postgres/02-add-primary-key.td.gh6570
@@ -23,7 +23,7 @@ INSERT INTO alter_add_primary_key VALUES (123), (234);
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE alter_add_primary_key
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.alter_add_primary_key')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'postgres.public.alter_add_primary_key'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -682,7 +682,8 @@ FOR CONFLUENT SCHEMA REGISTRY
 URL '${{testdrive.schema-registry-url}}';
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-kafka-raw-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-kafka-raw-${{testdrive.seed}}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_csr_conn
   ENVELOPE NONE
   /* A */
@@ -717,7 +718,8 @@ $ kafka-ingest format=bytes topic=kafka-envelope-none-bytes repeat={self.n()}
   FOR KAFKA BROKER '${{testdrive.kafka-addr}}'
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-kafka-envelope-none-bytes-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-kafka-envelope-none-bytes-${{testdrive.seed}}'
   FORMAT BYTES
   ENVELOPE NONE
   /* A */
@@ -758,7 +760,8 @@ $ kafka-ingest format=avro topic=kafka-upsert key-format=avro key-schema=${{keys
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-kafka-upsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-kafka-upsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
   /* A */
@@ -799,7 +802,8 @@ URL '${{testdrive.schema-registry-url}}';
 
   /* A */
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-upsert-unique-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-upsert-unique-${{testdrive.seed}}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_csr_conn'
   ENVELOPE UPSERT
 
@@ -839,7 +843,8 @@ FOR CONFLUENT SCHEMA REGISTRY
 URL '${{testdrive.schema-registry-url}}';
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-kafka-recovery-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-kafka-recovery-${{testdrive.seed}}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_csr_conn
   ENVELOPE UPSERT;
 
@@ -914,7 +919,8 @@ class KafkaRestartBig(ScenarioBig):
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-kafka-recovery-big-${testdrive.seed}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-kafka-recovery-big-${testdrive.seed}'
   FORMAT BYTES
   ENVELOPE UPSERT;
 
@@ -975,7 +981,8 @@ $ kafka-create-topic topic=kafka-scalability partitions=8
   FOR KAFKA BROKER '${{testdrive.kafka-addr}}'
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-kafka-scalability-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-kafka-scalability-${{testdrive.seed}}'
   FORMAT BYTES
   ENVELOPE NONE
   /* A */
@@ -1025,7 +1032,8 @@ FOR CONFLUENT SCHEMA REGISTRY
 URL '${{testdrive.schema-registry-url}}';
 
 > CREATE SOURCE source1
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-sink-input-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-sink-input-${{testdrive.seed}}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_csr_conn
   ENVELOPE UPSERT;
 
@@ -1044,14 +1052,15 @@ URL '${{testdrive.schema-registry-url}}';
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
 > CREATE SINK sink1 FROM source1
-  INTO KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
+  INTO KAFKA CONNECTION s1_kafka_conn TOPIC 'testdrive-sink-output-${testdrive.seed}'
   KEY (f1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # Wait until all the records have been emited from the sink, as observed by the sink1_check source
 
 > CREATE SOURCE sink1_check
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-sink-output-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT;
@@ -1287,7 +1296,8 @@ FOR CONFLUENT SCHEMA REGISTRY
 URL '${{testdrive.schema-registry-url}}';
 
 > CREATE SOURCE source{i}
-  FROM KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-startup-time-${{testdrive.seed}}')
+  FROM KAFKA CONNECTION s1_kafka_conn
+  TOPIC 'testdrive-startup-time-${{testdrive.seed}}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_kafka_conn
   ENVELOPE NONE
 """
@@ -1305,7 +1315,7 @@ URL '${{testdrive.schema-registry-url}}';
         create_sinks = "\n".join(
             f"""
 > CREATE SINK sink{i} FROM source{i}
-  INTO KAFKA CONNECTION s1_kafka_conn (TOPIC 'testdrive-sink-output-${{testdrive.seed}}')
+  INTO KAFKA CONNECTION s1_kafka_conn TOPIC 'testdrive-sink-output-${{testdrive.seed}}'
   KEY (f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION s1_csr_conn
 """

--- a/test/kafka-exactly-once/before-restart.td
+++ b/test/kafka-exactly-once/before-restart.td
@@ -90,11 +90,11 @@ $ kafka-create-topic topic=input
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK output FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-ingest format=avro topic=input schema=${schema}

--- a/test/kafka-multi-broker/01-init.td
+++ b/test/kafka-multi-broker/01-init.td
@@ -28,7 +28,7 @@ $ kafka-ingest format=avro topic=kafka-multi-broker schema=${schema} timestamp=3
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
 > CREATE SOURCE kafka_multi_broker
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-multi-broker-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-kafka-multi-broker-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE NONE
 
@@ -47,5 +47,6 @@ $ kafka-ingest format=avro topic=kafka-multi-broker schema=${schema} timestamp=6
 
 > CREATE SINK multi_broker_sink
   FROM kafka_multi_broker
-  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = 2, PARTITION COUNT = 2, TOPIC 'testdrive-kafka-multi-broker-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = 2, PARTITION COUNT = 2)
+  TOPIC 'testdrive-kafka-multi-broker-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-resumption/setup.td
+++ b/test/kafka-resumption/setup.td
@@ -24,7 +24,7 @@ New York,NY,10004
 
 # The source intentionally does not go through toxiproxy.
 > CREATE SOURCE input (city, state, zip)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input-${testdrive.seed}'
   FORMAT CSV WITH 3 COLUMNS
   INCLUDE OFFSET
 
@@ -33,5 +33,5 @@ New York,NY,10004
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK output FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output-byo-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output-byo-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -39,7 +39,8 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     SSL CERTIFICATE AUTHORITY = '${arg.ca}'
 
 > CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_sasl (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_sasl
+  TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
 
 > SELECT * FROM data
@@ -58,7 +59,7 @@ a
 
 > CREATE SINK data_snk
   FROM data
-  INTO KAFKA CONNECTION kafka_sasl (TOPIC 'testdrive-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_sasl TOPIC 'testdrive-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
 
 $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
@@ -67,7 +68,8 @@ $ kafka-verify format=avro sink=materialize.public.data_snk sort-messages=true
 
 # Old with options do not work
 ! CREATE SOURCE connector_source
-  FROM KAFKA CONNECTION kafka_sasl (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_sasl
+  TOPIC 'testdrive-data-${testdrive.seed}'
   LEGACYWITH (
     security_protocol = 'sasl_ssl'
   )
@@ -85,6 +87,7 @@ contains:unexpected parameters for CREATE SOURCE: security_protocol
 # This ensures that the error is not that the CA was required, but simply that
 # not providing it prohibits connecting.
 ! CREATE SOURCE connector_source
-  FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_sasl_no_ca
+  TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_sasl
 contains: broker certificate could not be verified

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -43,7 +43,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     PASSWORD = SECRET password_csr;
 
 > CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
 
 > SELECT * FROM data
@@ -62,7 +62,7 @@ a
 
 # test sinks with multiple things to
 > CREATE SINK snk FROM data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
 
 $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -55,7 +55,7 @@ contains: cannot drop
 contains: materialize.public.not_a_secret is not a secret
 
 > CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_ssl TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl;
 
 > SELECT * FROM data
@@ -73,7 +73,7 @@ a
 2
 
 > CREATE SINK snk FROM data
-  INTO KAFKA CONNECTION kafka_ssl (TOPIC 'snk')
+  INTO KAFKA CONNECTION kafka_ssl TOPIC 'snk'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
 
 $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
@@ -89,7 +89,7 @@ $ kafka-verify format=avro sink=materialize.public.snk sort-messages=true
 
 # not basic_auth
 ! CREATE SINK no_basic_auth FROM data
-  INTO KAFKA CONNECTION kafka_ssl (TOPIC 'snk')
+  INTO KAFKA CONNECTION kafka_ssl TOPIC 'snk'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION no_basic_auth_conn
 contains:error publishing kafka schemas for sink: unable to publish value schema to registry in kafka sink: server error 401: Unauthorized
 
@@ -101,7 +101,7 @@ contains:error publishing kafka schemas for sink: unable to publish value schema
 
 # Ensure that we get an ssl error if we forget to set certs
 ! CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_ssl TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_without_ssl
 contains:self signed certificate in certificate chain
 
@@ -113,7 +113,8 @@ contains:self signed certificate in certificate chain
 contains:invalid CONNECTION: under-specified security configuration
 
 > CREATE SOURCE kafka_csr_connector_source
-  FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_ssl
+    TOPIC 'testdrive-data-${testdrive.seed}'
     FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl
 
@@ -126,7 +127,8 @@ a
 
 # Old with_options do not work
 ! CREATE SOURCE IF NOT EXISTS duplicate_option_specified
-  FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_ssl
+  TOPIC 'testdrive-data-${testdrive.seed}'
   LEGACYWITH (
     security_protocol = 'ssl'
   )
@@ -152,7 +154,8 @@ contains:unexpected parameters for CREATE SOURCE: security_protocol
 # This ensures that the error is not that the CA was required, but simply that
 # not providing it prohibits connecting.
 ! CREATE SOURCE kafka_ssl_no_ca
-  FROM KAFKA CONNECTION kafka_sasl_no_ca (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_sasl_no_ca
+    TOPIC 'testdrive-data-${testdrive.seed}'
     FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_ssl_no_ca
 contains: broker certificate could not be verified

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -430,7 +430,7 @@ class KafkaSinks(Generator):
                      > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
                      > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
                      > CREATE SINK s{i} FROM v{i}
-                       INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink-same-source-{i}')
+                       INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-sink-same-source-{i}'
                        FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
                      """
                 )
@@ -468,7 +468,7 @@ class KafkaSinksSameSource(Generator):
                      > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
                      > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
                      > CREATE SINK s{i} FROM v1
-                       INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink-same-source-{i}')
+                       INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-sink-same-source-{i}'
                        FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
                      """
                 )

--- a/test/persistence/failpoints/before.td
+++ b/test/persistence/failpoints/before.td
@@ -44,14 +44,14 @@ $ kafka-ingest format=avro topic=failpoint key-format=avro key-schema=${keyschem
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE failpoint
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-failpoint-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-failpoint-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE KEY AS f1
   ENVELOPE UPSERT
 
 > CREATE SINK failpoint_sink FROM failpoint
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-failpoint-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-failpoint-sink-${testdrive.seed}'
   KEY (f1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 

--- a/test/persistence/kafka-sources/exactly-once-sink-before.td
+++ b/test/persistence/kafka-sources/exactly-once-sink-before.td
@@ -35,7 +35,7 @@ $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keysc
 > CREATE CONNECTION kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE exactly_once
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-exactly-once-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-exactly-once-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
@@ -44,7 +44,7 @@ $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keysc
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK exactly_once_sink FROM exactly_once
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
 $ kafka-ingest format=avro topic=exactly-once key-format=avro key-schema=${keyschema} schema=${schema} repeat=2 start-iteration=10

--- a/test/persistence/kafka-sources/partition-change-before.td
+++ b/test/persistence/kafka-sources/partition-change-before.td
@@ -40,10 +40,8 @@ $ kafka-ingest format=avro topic=partition-change key-format=avro key-schema=${k
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE partition_change
-  FROM KAFKA CONNECTION kafka_conn (
-    TOPIC 'testdrive-partition-change-${testdrive.seed}',
-    TOPIC METADATA REFRESH INTERVAL MS = 100
-  )
+  FROM KAFKA CONNECTION kafka_conn (TOPIC METADATA REFRESH INTERVAL MS = 100)
+  TOPIC 'testdrive-partition-change-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 

--- a/test/persistence/kafka-sources/start-offset-before.td
+++ b/test/persistence/kafka-sources/start-offset-before.td
@@ -49,12 +49,14 @@ $ kafka-ingest format=avro topic=offset key-format=avro key-schema=${keyschema} 
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE start_offset
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET = [100], TOPIC 'testdrive-offset-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET = [100])
+  TOPIC 'testdrive-offset-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
 > CREATE SOURCE kafka_time_offset
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=2, TOPIC 'testdrive-offset-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=2)
+  TOPIC 'testdrive-offset-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 

--- a/test/persistence/kafka-sources/wide-data-before.td
+++ b/test/persistence/kafka-sources/wide-data-before.td
@@ -48,20 +48,20 @@ $ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keys
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE wide_data_ten
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-wide-data-ten-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-wide-data-ten-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE;
 
 > CREATE MATERIALIZED VIEW wide_data_view AS SELECT wide_data_ten.f2 AS key, REPEAT('x', 512 * 1024) AS value FROM wide_data_ten;
 
 > CREATE SINK wide_data_sink FROM wide_data_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-wide-data-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-wide-data-${testdrive.seed}'
   KEY (key) NOT ENFORCED
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT;
 
 > CREATE SOURCE wide_data_source
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-wide-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-wide-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE KEY AS key2
   ENVELOPE UPSERT;

--- a/test/persistence/user-tables/table-persistence-before-sinks.td
+++ b/test/persistence/user-tables/table-persistence-before-sinks.td
@@ -22,7 +22,8 @@
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK sink_sink FROM sink_table
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-exactly-once-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
 > INSERT INTO sink_table VALUES (2);

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -19,7 +19,7 @@ $ kafka-ingest format=bytes topic=bytes timestamp=1
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET
 
@@ -38,7 +38,7 @@ data           offset
 # Test that CREATE SOURCE can specify a custom name for the column.
 
 > CREATE SOURCE data_named_col (named_col)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
 
 > SHOW COLUMNS FROM data_named_col
@@ -47,7 +47,8 @@ name       nullable  type
 named_col  false     bytea
 
 > CREATE SOURCE data_offset
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-bytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1])
+  TOPIC 'testdrive-bytes-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET
 
@@ -65,7 +66,8 @@ $ kafka-ingest format=bytes topic=bytes-partitions timestamp=1 partition=1
 ©2
 
 > CREATE SOURCE data_offset_2
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[0,1], TOPIC 'testdrive-bytes-partitions-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[0,1])
+  TOPIC 'testdrive-bytes-partitions-${testdrive.seed}'
   FORMAT BYTES
   INCLUDE OFFSET
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -271,7 +271,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 > CREATE SINK snk FROM source_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-catalog-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-catalog-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn;
 
 > SHOW FULL OBJECTS

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -46,7 +46,8 @@ materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"te
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
 > CREATE SOURCE connection_source (first, second)
-  FROM KAFKA CONNECTION testconn (TOPIC 'testdrive-connection_test-${testdrive.seed}')
+  FROM KAFKA CONNECTION testconn
+  TOPIC 'testdrive-connection_test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
 
 > SELECT * FROM connection_source
@@ -133,11 +134,14 @@ id creature
 -----------
 1  lizard
 
+
 > CREATE CONNECTION broker_connection
   FOR KAFKA BROKER '${testdrive.kafka-addr}'
 
+
 > CREATE SOURCE two_connection_source
-  FROM KAFKA CONNECTION broker_connection (TOPIC 'testdrive-csr_test-${testdrive.seed}')
+  FROM KAFKA CONNECTION broker_connection
+  TOPIC 'testdrive-csr_test-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 
@@ -152,7 +156,8 @@ contains:depended upon by catalog item 'materialize.public.csr_source'
 > DROP CONNECTION csr_conn CASCADE
 
 ! CREATE SOURCE should_fail
-  FROM KAFKA CONNECTION does_not_exist (TOPIC 'error_topic')
+  FROM KAFKA CONNECTION does_not_exist
+  TOPIC 'error_topic'
   FORMAT TEXT
 contains: unknown catalog item 'does_not_exist'
 

--- a/test/testdrive/consolidation.td
+++ b/test/testdrive/consolidation.td
@@ -95,7 +95,7 @@ $ kafka-create-topic topic=nums
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE nums
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-nums-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-nums-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${nums-schema}'
   ENVELOPE MATERIALIZE
 
@@ -111,7 +111,7 @@ $ kafka-create-topic topic=nums
 
 # Create a sink before we ingest any data, to ensure the sink starts AS OF 0
 > CREATE SINK nums_sink FROM nums
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'nums-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'nums-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # ==> Test consolidation.
@@ -148,7 +148,7 @@ $ kafka-verify format=avro sink=materialize.public.nums_sink sort-messages=true
 # # Test that a Debezium sink created `AS OF 3` (the latest completed timestamp)
 # # is fully consolidated.
 # > CREATE SINK nums_sink FROM nums
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'nums-sink')
+#   INTO KAFKA CONNECTION kafka_conn TOPIC 'nums-sink'
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 #   AS OF 3
 #

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -155,7 +155,7 @@ $ kafka-create-topic topic=dynamic
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE dynamic_csv (city, state, zip)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dynamic-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dynamic-${testdrive.seed}'
   FORMAT CSV WITH 3 COLUMNS
 
 > SELECT * FROM dynamic_csv
@@ -232,7 +232,7 @@ $ kafka-create-topic topic=static-csv-pkne-sink
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK static_csv_pkne_sink FROM static_csv_pkne
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'static-csv-pkne-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'static-csv-pkne-sink'
   KEY (zip)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -29,16 +29,16 @@ $ set schema={
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE s
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 ! CREATE SOURCE s
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-blah-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-blah-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 contains:catalog item 's' already exists
 
 > CREATE SOURCE IF NOT EXISTS s
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-blah-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-blah-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE VIEW test1 AS SELECT 1;
@@ -106,24 +106,24 @@ contains:unknown catalog item 'test2'
 contains:unknown catalog item 'test4'
 
 > CREATE SOURCE s
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE SINK s1 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'v'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 ! CREATE SINK s1 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'v'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:catalog item 's1' already exists
 
 > CREATE SINK IF NOT EXISTS s1 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v2')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'v2'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK s2 FROM s
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'v3')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'v3'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # Test that sinks cannot be depended upon.
@@ -247,7 +247,7 @@ contains:unknown catalog item 'i4'
 # Materialized source tests
 
 > CREATE SOURCE s3
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 # Test that dependent indexes do not prevent source deletion when restrict is specified
@@ -269,7 +269,7 @@ contains:unknown catalog item 'j1'
 # Test cascade deletes all indexes associated with cascaded sources and views
 
 > CREATE SOURCE s4
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE INDEX j2 on s4(x+2);
@@ -305,7 +305,7 @@ contains:unknown catalog item 'j2'
 # Test that dropping indexes even with cascade does not cause the underlying source to be dropped
 
 > CREATE SOURCE s5
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE DEFAULT INDEX ON s5;

--- a/test/testdrive/disabled/kafka-avro-debezium-transaction.td
+++ b/test/testdrive/disabled/kafka-avro-debezium-transaction.td
@@ -166,7 +166,7 @@ $ kafka-create-topic topic=data-txdata
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE data_txdata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-txdata-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-txdata-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${txschema}'
   ENVELOPE NONE
 
@@ -188,14 +188,14 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 # Create a source using an inline schema.
 #
 > CREATE SOURCE data_schema_inline
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM (
       TRANSACTION METADATA (SOURCE data_txdata, COLLECTION 'testdrive-data-${testdrive.seed}')
   )
 
 > CREATE SOURCE data2_schema_inline
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data2-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM (
       TRANSACTION METADATA (SOURCE data_txdata, COLLECTION 'testdrive-data2-${testdrive.seed}')
@@ -225,7 +225,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK data_sink FROM data_schema_inline
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-sink-${testdrive.seed}'
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
@@ -337,7 +337,7 @@ $ unset-regex
 
 # Reingest to verify that we keep transactionality
 > CREATE SOURCE data_sink_reingest
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-sink-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
@@ -362,7 +362,7 @@ $ kafka-create-topic topic=data-txdata-bad-schema
 $ kafka-create-topic topic=data-bad-schema
 
 > CREATE SOURCE data_txdata_bad_schema
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-txdata-bad-schema-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-txdata-bad-schema-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${txschema-bad-schema}'
   ENVELOPE NONE
 
@@ -372,7 +372,7 @@ $ kafka-ingest format=avro topic=data-txdata-bad-schema schema=${txschema-bad-sc
 {"status": "END", "id": {"string": "1"}, "event_count": {"long": 3}, "data_collections": {"array": [{"event_count": 3, "data_collection": "testdrive-data-${testdrive.seed}"}]}}
 
 ! CREATE SOURCE data_schema_inline_with_bad_schema_tx_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-bad-schema-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-bad-schema-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM (
       TRANSACTION METADATA (
@@ -383,7 +383,7 @@ $ kafka-ingest format=avro topic=data-txdata-bad-schema schema=${txschema-bad-sc
 contains:'id' column must be of type non-nullable string
 
 ! CREATE SOURCE data_schema_inline_with_sink
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM (
       TRANSACTION METADATA (SOURCE data_sink, COLLECTION 'testdrive-data-${testdrive.seed}')

--- a/test/testdrive/kafka-avro-debezium-sinks.td
+++ b/test/testdrive/kafka-avro-debezium-sinks.td
@@ -23,7 +23,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK data_sink FROM data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.data_sink sort-messages=true
@@ -115,11 +115,11 @@ $ kafka-create-topic topic=input
 # input is processed in consistency batches and not all at once
 
 > CREATE SOURCE input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK non_keyed_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'non-keyed-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'non-keyed-sink-${testdrive.seed}'
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
@@ -128,22 +128,22 @@ $ kafka-create-topic topic=input
 # the sinked relation has the natural primary key (a)
 
 > CREATE SINK non_keyed_sink_of_keyed_relation FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'non-keyed-sink-of-keyed-relation-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'non-keyed-sink-of-keyed-relation-${testdrive.seed}'
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK keyed_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'keyed-sink-${testdrive.seed}') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'keyed-sink-${testdrive.seed}' KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK keyed_sink_of_keyed_relation FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'keyed-sink-of-keyed-relation-${testdrive.seed}') KEY (b)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'keyed-sink-of-keyed-relation-${testdrive.seed}' KEY (b)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK multi_keyed_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'multi-keyed-sink-${testdrive.seed}') KEY (b, a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'multi-keyed-sink-${testdrive.seed}' KEY (b, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 

--- a/test/testdrive/kafka-avro-sinks.td
+++ b/test/testdrive/kafka-avro-sinks.td
@@ -25,7 +25,7 @@
 #> CREATE MATERIALIZED VIEW unnamed_cols AS SELECT 1, 2 AS b, 3;
 #
 #> CREATE SINK unnamed_cols_sink FROM unnamed_cols
-#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-cols-sink')
+#  INTO KAFKA CONNECTION kafka_conn TOPIC 'unnamed-cols-sink'
 #  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 #
 #$ kafka-verify format=avro sink=materialize.public.unnamed_cols_sink
@@ -37,7 +37,7 @@
 #> CREATE MATERIALIZED VIEW clashing_cols AS SELECT 1, 2 AS column1, 3 as b, 4 as b2, 5 as b3;
 #
 #> CREATE SINK clashing_cols_sink FROM clashing_cols
-#  INTO KAFKA CONNECTION kafka_conn (TOPIC 'clashing-cols-sink')
+#  INTO KAFKA CONNECTION kafka_conn TOPIC 'clashing-cols-sink'
 #  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 #
 #$ kafka-verify format=avro sink=materialize.public.clashing_cols_sink
@@ -52,7 +52,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   (DATE '2000-02-01', TIMESTAMP '2000-02-01 10:10:10.111', TIMESTAMPTZ '2000-02-01 10:10:10.111+02')
 
 > CREATE SINK datetime_data_sink FROM datetime_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'datetime-data-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'datetime-data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messages=true
@@ -62,7 +62,7 @@ $ kafka-verify format=avro sink=materialize.public.datetime_data_sink sort-messa
 > CREATE MATERIALIZED VIEW time_data (time) AS VALUES (TIME '01:02:03'), (TIME '01:02:04')
 
 > CREATE SINK time_data_sink FROM time_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'time-data-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'time-data-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=true
@@ -75,7 +75,7 @@ $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=
 
 # Sinks with JSON columns should not crash - see https://github.com/MaterializeInc/materialize/issues/4722
 > CREATE SINK json_data_sink FROM json_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'json-data-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'json-data-sink'
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
@@ -84,7 +84,7 @@ $ kafka-verify format=avro sink=materialize.public.time_data_sink sort-messages=
 > CREATE MATERIALIZED VIEW map_data (map) AS SELECT '{a => 1, b => 2}'::map[text=>int];
 
 > CREATE SINK map_sink FROM map_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'map-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'map-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.map_sink sort-messages=true
@@ -93,7 +93,7 @@ $ kafka-verify format=avro sink=materialize.public.map_sink sort-messages=true
 > CREATE MATERIALIZED VIEW list_data (list) AS SELECT LIST[1, 2];
 
 > CREATE SINK list_sink FROM list_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'list-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'list-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.list_sink sort-messages=true
@@ -103,7 +103,8 @@ $ kafka-verify format=avro sink=materialize.public.list_sink sort-messages=true
 > CREATE MATERIALIZED VIEW namespace_value_data (namespace) AS SELECT 1;
 
 > CREATE SINK namespace_value_sink FROM namespace_value_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'namespace-value-sink')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'namespace-value-sink'
   FORMAT AVRO USING
     CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'abc.def.ghi')
 
@@ -117,7 +118,8 @@ $ kafka-verify format=avro sink=materialize.public.namespace_value_sink sort-mes
 > CREATE MATERIALIZED VIEW namespace_key_value_data (a, b) AS SELECT * FROM (VALUES (1, 2));
 
 > CREATE SINK namespace_key_value_sink FROM namespace_key_value_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'namespace-key-value-sink')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'namespace-key-value-sink'
   KEY (b)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.foo', AVRO VALUE FULLNAME = 'some.neat.class.bar')
 
@@ -133,27 +135,31 @@ $ kafka-verify format=avro sink=materialize.public.namespace_key_value_sink sort
 > CREATE MATERIALIZED VIEW input (a, b) AS SELECT * FROM (VALUES (1, 2))
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a, a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink' KEY (a, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Repeated column name in sink key: a
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'input-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'some.neat.class.foo', AVRO KEY FULLNAME = 'some.neat.class.bar')
 contains:Cannot specify AVRO KEY FULLNAME without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'input-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.bar')
 contains:Cannot specify AVRO KEY FULLNAME without a corresponding KEY field
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'input-sink' KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO KEY FULLNAME = 'some.neat.class.bar')
 contains:Must specify both AVRO KEY FULLNAME and AVRO VALUE FULLNAME when specifying generated schema names
 
 ! CREATE SINK bad_sink FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'input-sink' KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn (AVRO VALUE FULLNAME = 'some.neat.class.bar')
 contains:Must specify both AVRO KEY FULLNAME and AVRO VALUE FULLNAME when specifying generated schema names

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -126,14 +126,14 @@ name
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE data_schema_inline
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
 
 > SHOW CREATE SOURCE data_schema_inline
 Source   "Create Source"
 ------------------------
-materialize.public.data_schema_inline "CREATE SOURCE \"materialize\".\"public\".\"data_schema_inline\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-data-${testdrive.seed}') FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM"
+materialize.public.data_schema_inline "CREATE SOURCE \"materialize\".\"public\".\"data_schema_inline\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" TOPIC 'testdrive-data-${testdrive.seed}' FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM"
 
 > SELECT a, b, json, c, d, e::text, f::text FROM data_schema_inline
 a  b  json                     c            d             e                   f
@@ -143,7 +143,8 @@ a  b  json                     c            d             e                   f
 -1  7 "[1,2,3]"                FileNotFound True          <null>              <null>
 
 ! CREATE SOURCE fast_forwarded
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[2], TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[2])
+  TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM
 contains:START OFFSET is not supported with ENVELOPE DEBEZIUM
@@ -179,7 +180,7 @@ $ kafka-ingest format=avro topic=non-dbz-data schema=${non-dbz-schema} timestamp
 {"a": 2, "b": 3}
 
 > CREATE SOURCE non_dbz_data
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -192,14 +193,14 @@ a b
 # test INCLUDE metadata
 
 ! CREATE SOURCE non_dbz_data_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   INCLUDE TOPIC
   ENVELOPE NONE
 contains:INCLUDE TOPIC not yet supported
 
 > CREATE SOURCE non_dbz_data_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   INCLUDE PARTITION, OFFSET
   ENVELOPE NONE
@@ -211,7 +212,7 @@ a b partition offset
 2 3 0         2
 
 > CREATE SOURCE non_dbz_data_metadata_named
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   INCLUDE PARTITION as part, OFFSET as mzo
   ENVELOPE NONE
@@ -233,7 +234,8 @@ $ kafka-ingest format=avro topic=non-dbz-data-multi-partition schema=${non-dbz-s
 {"a": 1, "b": 2}
 
 > CREATE SOURCE non_dbz_data_multi_partition
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -243,7 +245,8 @@ a  b
 4  1
 
 > CREATE SOURCE non_dbz_data_multi_partition_2
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[0,0], TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[0,0])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -254,7 +257,8 @@ a  b
 4  1
 
 > CREATE SOURCE non_dbz_data_multi_partition_fast_forwarded
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[0,1], TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[0,1])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -264,7 +268,8 @@ a  b
 1  2
 
 > CREATE SOURCE non_dbz_data_multi_partition_fast_forwarded_2
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1,0], TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1,0])
+  TOPIC 'testdrive-non-dbz-data-multi-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -282,10 +287,10 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 
 > CREATE SOURCE non_dbz_data_varying_partition
   FROM KAFKA CONNECTION kafka_conn (
-    TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}',
-    TOPIC METADATA REFRESH INTERVAL MS=10,
-    START OFFSET=[1]
-  )
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START OFFSET=[1]
+    )
+  TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -293,11 +298,12 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 
 # Erroneously adds START OFFSET for non-existent partitions.
 > CREATE SOURCE non_dbz_data_varying_partition_2
-  FROM KAFKA CONNECTION kafka_conn (
-    TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}',
-    TOPIC METADATA REFRESH INTERVAL MS=10,
-    START OFFSET=[0,1]
-  )
+  FROM KAFKA CONNECTION kafka_conn
+    (
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START OFFSET=[0,1]
+    )
+  TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -333,10 +339,10 @@ a  b
 
 > CREATE SOURCE non_dbz_data_varying_partition_3
   FROM KAFKA CONNECTION kafka_conn (
-    TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}',
-    TOPIC METADATA REFRESH INTERVAL MS=10,
-    START OFFSET=[1,1]
-  )
+      TOPIC METADATA REFRESH INTERVAL MS=10,
+      START OFFSET=[1,1]
+    )
+  TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
   ENVELOPE NONE
 
@@ -432,7 +438,7 @@ $ kafka-ingest format=avro topic=new-dbz-data schema=${new-dbz-schema} timestamp
 {"before": null, "after": {"row":{"a": -1, "b": 7}}, "source": {"file": "binlog", "pos": 1, "row": 1, "snapshot": {"string": "false"}}, "op": "c"}
 
 > CREATE SOURCE new_dbz
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-new-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-new-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${new-dbz-schema}'
   ENVELOPE DEBEZIUM
 
@@ -446,7 +452,7 @@ a b
 -1 7
 
 ! CREATE SOURCE recursive
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'ignored')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'ignored'
   FORMAT AVRO USING SCHEMA '{"type":"record","name":"a","fields":[{"name":"f","type":["a","null"]}]}'
 contains:validating avro schema: Recursive types are not supported: .a
 
@@ -463,7 +469,7 @@ $ kafka-ingest format=avro topic=non-subset-key key-format=avro key-schema=${key
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE non_subset_key
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-subset-key-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-subset-key-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
@@ -540,7 +546,7 @@ $ kafka-ingest format=avro topic=pg-dbz-data schema=${pg-dbz-schema} timestamp=1
 {"before": null, "after": {"row":{"a": 4, "b": 5}}, "source": {"lsn": {"long": 2}, "sequence": {"string": "[\"1\", \"2\"]"}, "snapshot": {"string": "false"}}, "op": "c"}
 
 > CREATE SOURCE pg_dbz
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-pg-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-pg-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${pg-dbz-schema}'
   ENVELOPE DEBEZIUM
 
@@ -651,7 +657,7 @@ $ kafka-ingest format=avro topic=ms-dbz-data schema=${ms-dbz-schema} timestamp=1
 {"before": null, "after": {"Value":{"a": -1, "b": 7}}, "source": {"change_lsn": {"string": "00000025:00000728:001a"}, "sequence": null, "event_serial_no": {"long": 1}, "snapshot": {"string": "false"}}, "op": "c"}
 
 > CREATE SOURCE ms_dbz
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-ms-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-ms-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${ms-dbz-schema}'
   ENVELOPE DEBEZIUM
 
@@ -662,7 +668,8 @@ a b
 2 3
 
 > CREATE SOURCE ms_dbz_uncommitted
-  FROM KAFKA CONNECTION kafka_conn (ISOLATION LEVEL = 'read_uncommitted', TOPIC 'testdrive-ms-dbz-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (ISOLATION LEVEL = 'read_uncommitted')
+  TOPIC 'testdrive-ms-dbz-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${ms-dbz-schema}'
   ENVELOPE DEBEZIUM
 

--- a/test/testdrive/kafka-avro-upsert-sinks.td
+++ b/test/testdrive/kafka-avro-upsert-sinks.td
@@ -45,12 +45,13 @@ $ kafka-ingest format=avro topic=upsert-avro key-format=avro key-schema=${upsert
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE upsert_input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-avro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC
+  'testdrive-upsert-avro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
 > CREATE SINK upsert_input_sink FROM upsert_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'upsert-input-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'upsert-input-sink'
   KEY (key1, key2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
@@ -142,20 +143,20 @@ $ kafka-create-topic topic=input
 
 # (PRIMARY KEY (id) NOT ENFORCED)
 > CREATE SOURCE input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE MATERIALIZED VIEW input_keyed AS SELECT a, max(b) as b FROM input GROUP BY a
 
 > CREATE SINK input_sink FROM input_keyed
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-${testdrive.seed}' KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
 # requesting to key by (a, b) is fine when (a) is a unique key
 
 > CREATE SINK input_sink_multiple_keys FROM input_keyed
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-multikey-${testdrive.seed}') KEY (b, a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-multikey-${testdrive.seed}' KEY (b, a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
@@ -212,13 +213,13 @@ $ kafka-verify format=avro sink=materialize.public.input_sink_multiple_keys sort
 $ kafka-create-topic topic=input-with-deletions
 
 > CREATE SOURCE input_with_deletions
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-with-deletions-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input-with-deletions-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE MATERIALIZED VIEW input_with_deletions_keyed AS SELECT a, max(b) as b FROM input_with_deletions GROUP BY a
 
 > CREATE SINK input_with_deletions_sink FROM input_with_deletions_keyed
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-with-deletions-${testdrive.seed}') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-with-deletions-${testdrive.seed}' KEY (a)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
 $ kafka-ingest format=avro topic=input-with-deletions schema=${schema}
@@ -272,23 +273,23 @@ $ kafka-verify format=avro sink=materialize.public.input_with_deletions_sink sor
 $ kafka-create-topic topic=non-keyed-input
 
 > CREATE SOURCE non_keyed_input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-keyed-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-non-keyed-input-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK not_enforced_key FROM non_keyed_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'not-enforced-sink-${testdrive.seed}') KEY (a) NOT ENFORCED
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'not-enforced-sink-${testdrive.seed}' KEY (a) NOT ENFORCED
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 
 # Bad upsert keys
 
 ! CREATE SINK invalid_key FROM input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-${testdrive.seed}' KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 contains:Invalid upsert key: (a), there are no valid keys
 
 ! CREATE SINK another_invalid_key FROM input_keyed
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (b)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-${testdrive.seed}' KEY (b)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 contains:Invalid upsert key: (b), valid keys are: (a)
@@ -296,25 +297,25 @@ contains:Invalid upsert key: (b), valid keys are: (a)
 > CREATE MATERIALIZED VIEW input_keyed_ab AS SELECT a, b FROM input GROUP BY a, b
 
 ! CREATE SINK invalid_sub_key FROM input_keyed_ab
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (a)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-${testdrive.seed}' KEY (a)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 contains:Invalid upsert key: (a), valid keys are: (a, b)
 
 ! CREATE SINK another_invalid_sub_key FROM input_keyed_ab
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'input-sink-${testdrive.seed}') KEY (b)
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'input-sink-${testdrive.seed}' KEY (b)
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 contains:Invalid upsert key: (b), valid keys are: (a, b)
 
 ! CREATE SINK invalid_key_from_upsert_input FROM upsert_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'data-sink-${testdrive.seed}'
   KEY (key1)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 contains:Invalid upsert key: (key1), valid keys are: (key1, key2)
 
 ! CREATE SINK invalid_key_from_upsert_input FROM upsert_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'data-sink-${testdrive.seed}'
   KEY (key2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE UPSERT
 contains:Invalid upsert key: (key2), valid keys are: (key1, key2)

--- a/test/testdrive/kafka-data-formats.td
+++ b/test/testdrive/kafka-data-formats.td
@@ -15,7 +15,8 @@ $ kafka-create-topic topic=input_proto
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE input_csv (first, second)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input_csv-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-input_csv-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS;
 
 $ kafka-ingest format=bytes topic=input_csv
@@ -35,7 +36,8 @@ $ kafka-ingest format=bytes topic=input_csv_partitioned partition=1
 2,3
 
 > CREATE SOURCE input_csv_partitioned (first, second)
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1,0], TOPIC 'testdrive-input_csv_partitioned-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1,0])
+  TOPIC 'testdrive-input_csv_partitioned-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS;
 
 > SELECT * FROM input_csv_partitioned

--- a/test/testdrive/kafka-duplicate-topic.td
+++ b/test/testdrive/kafka-duplicate-topic.td
@@ -37,12 +37,12 @@ $ kafka-ingest format=avro topic=topic1 schema=${schema} repeat=1
   ENVELOPE NONE
 
 > CREATE SINK sink0 FROM source0
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-sink-output-${testdrive.seed}'
   KEY (f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK sink1 FROM source1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-output-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-sink-output-${testdrive.seed}'
   KEY (f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 

--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -151,11 +151,11 @@ $ kafka-create-topic topic=input_cdcv2
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE input_kafka_cdcv2
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input_cdcv2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input_cdcv2-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${cdcv2-schema}' ENVELOPE MATERIALIZE
 
 > CREATE SOURCE input_kafka_dbz
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input_dbz-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-input_dbz-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${dbz-schema}' ENVELOPE DEBEZIUM
 
 > CREATE TABLE input_table (a bigint, b bigint)
@@ -184,61 +184,62 @@ New York,NY,10004
 "bad,place""",CA,92679
 
 > CREATE SOURCE input_csv
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-static-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-static-${testdrive.seed}'
   FORMAT CSV WITH 3 COLUMNS
 
 > CREATE SINK output1 FROM input_kafka_cdcv2
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output1-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output1-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output2 FROM input_kafka_dbz
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output2-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output2-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output3 FROM input_table
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output3-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output3-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output4 FROM input_kafka_cdcv2_mview
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output4-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output4-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output4_view FROM input_kafka_cdcv2_mview_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output4b-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output4b-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 ! CREATE SINK output5 FROM input_kafka_dbz_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output5-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output5-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:input_kafka_dbz_view is a view, which cannot be exported as a sink
 
 > CREATE SINK output5_view FROM input_kafka_dbz_view_mview
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output5b-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output5b-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output6 FROM input_table_mview
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output6-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output6-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 ! CREATE SINK output7 FROM input_values_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output7-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output7-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:input_values_view is a view, which cannot be exported as a sink
 
 > CREATE SINK output8 FROM input_values_mview
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output8-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output8-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output12 FROM input_kafka_dbz_derived_table
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output12-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output12-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output13 FROM input_csv
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output13-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output13-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK output14_custom_consistency_topic FROM input_kafka_cdcv2
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'output14-view-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'output14-view-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # We need some data -- any data -- to start creating timestamp bindings
@@ -258,11 +259,11 @@ $ kafka-create-topic topic=compaction-test-input
 $ kafka-create-topic topic=compaction-test-output-consistency compaction=true
 
 > CREATE SOURCE compaction_test_input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-compaction-test-input-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-compaction-test-input-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${cdcv2-schema}' ENVELOPE MATERIALIZE
 
 > CREATE SINK compaction_test_sink FROM compaction_test_input
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'compaction-test-output-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'compaction-test-output-${testdrive.seed}'
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE DEBEZIUM
 

--- a/test/testdrive/kafka-json-sinks.td
+++ b/test/testdrive/kafka-json-sinks.td
@@ -19,14 +19,14 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK simple_view_sink FROM simple_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-cols-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'unnamed-cols-sink-${testdrive.seed}'
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.simple_view_sink key=false
 {"before": null, "after": {"a": 1, "b": 2, "c": 3}, "transaction": {"id": "<TIMESTAMP>"}}
 
 > CREATE SINK simple_view_upsert FROM simple_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'unnamed-upsert')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'unnamed-upsert'
   KEY (b)
   FORMAT JSON
   ENVELOPE UPSERT
@@ -53,7 +53,7 @@ $ kafka-verify format=json sink=materialize.public.simple_view_upsert key=true
   '{"a": 2}'::jsonb c14
 
 > CREATE SINK types_sink FROM types_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'types-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'types-sink'
   FORMAT JSON
 
 # Due to limitations in $ kafka-verify, the entire expected JSON output needs to be provided on a single line
@@ -66,7 +66,7 @@ $ kafka-verify format=json sink=materialize.public.types_sink key=false
   SELECT 'текст' c1, '"' c2, '''' c3, '\' c4, E'a\n\tb' c5
 
 > CREATE SINK special_characters_sink FROM special_characters_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'special-characters-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'special-characters-sink'
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.special_characters_sink key=false
@@ -77,7 +77,7 @@ $ kafka-verify format=json sink=materialize.public.special_characters_sink key=f
 > CREATE MATERIALIZED VIEW record_view AS SELECT simple_view FROM simple_view;
 
 > CREATE SINK record_sink FROM record_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'record-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'record-sink'
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.record_sink key=false
@@ -103,7 +103,7 @@ contains:column "a" specified more than once
 > CREATE MATERIALIZED VIEW complex_type_view AS SELECT '{{1,2},{3,4}}'::int4_list_list c1, '{a=>{b=>1, c=>2}, d=> {e=>3, f=>4}}'::int4_map_map c2;
 
 > CREATE SINK complex_type_sink FROM complex_type_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'complex-type-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'complex-type-sink'
   FORMAT JSON
 
 $ kafka-verify format=json sink=materialize.public.complex_type_sink key=false

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -21,32 +21,38 @@
   URL '${testdrive.schema-registry-url}';
 
 ! CREATE SINK invalid_partition_count FROM v1
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT = a)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:invalid PARTITION COUNT: cannot use value as number
 
 ! CREATE SINK invalid_partition_count FROM v1
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT = -2)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:PARTION COUNT for sink topics must be a positive integer or -1 for broker default
 
 ! CREATE SINK invalid_replication_factor FROM v1
-  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = a)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:invalid REPLICATION FACTOR: cannot use value as number
 
 ! CREATE SINK invalid_replication_factor FROM v1
-  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR = -2)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:REPLICATION FACTOR for sink topics must be a positive integer or -1 for broker default
 
 ! CREATE SINK invalid_acks FROM v1
-  INTO KAFKA CONNECTION kafka_conn (ACKS = foo, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (ACKS = foo)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Invalid value for configuration property "request.required.acks" acks foo
 
 ! CREATE SINK invalid_key FROM v1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   KEY(f2)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:No such column: f2
@@ -55,22 +61,26 @@ contains:No such column: f2
 # Retention options
 #
 ! CREATE SINK invalid_retention_ms FROM v1
-  INTO KAFKA CONNECTION kafka_conn (RETENTION MS = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (RETENTION MS = a)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:invalid RETENTION MS: cannot use value as number
 
 ! CREATE SINK invalid_retention_ms FROM v1
-  INTO KAFKA CONNECTION kafka_conn (RETENTION MS = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (RETENTION MS = -2)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:RETENTION MS for sink topics must be greater than or equal to -1
 
 ! CREATE SINK invalid_retention_bytes FROM v1
-  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = a, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = a)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:invalid RETENTION BYTES: cannot use value as number
 
 ! CREATE SINK invalid_retention_bytes FROM v1
-  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = -2, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = -2)
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:RETENTION BYTES for sink topics must be greater than or equal to -1
 
@@ -79,11 +89,13 @@ contains:RETENTION BYTES for sink topics must be greater than or equal to -1
 #
 
 > CREATE SINK s1 FROM v1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 ! CREATE SINK s2 FROM s1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:catalog item 'materialize.public.s1' is a sink and so cannot be depended upon
 
@@ -103,11 +115,11 @@ nonsense
 #
 
 ! CREATE SINK invalid_format FROM v1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
 contains:sink without format not yet supported
 
 ! CREATE SINK invalid_format FROM v1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}'
   FORMAT NO_SUCH_FORMAT
 contains:found identifier "no_such_format"
 

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -24,20 +24,23 @@ $ kafka-create-topic topic=t0
   URL '${testdrive.schema-registry-url}';
 
 ! CREATE SOURCE missing_topic
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, TOPIC 'missing_topic')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1)
+  TOPIC 'missing_topic'
   FORMAT TEXT
   INCLUDE OFFSET
 contains:topic missing_topic does not exist
 
 ! CREATE SOURCE pick_one
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, START OFFSET=[1], TOPIC 'testdrive-t0-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, START OFFSET=[1])
+  TOPIC 'testdrive-t0-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 contains:cannot specify START TIMESTAMP and START OFFSET at same time
 
 
 ! CREATE SOURCE not_a_number
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP="not_a_number", TOPIC 'testdrive-t0-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP="not_a_number")
+  TOPIC 'testdrive-t0-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 contains:invalid START TIMESTAMP: cannot use value as number
@@ -64,52 +67,53 @@ $ kafka-ingest format=bytes topic=t1 key-format=bytes key-terminator=: timestamp
 grape:grape
 
 > CREATE SOURCE append_time_offset_0
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=0, TOPIC 'testdrive-t1-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=0)
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_1
   FROM KAFKA CONNECTION kafka_conn (
       TOPIC METADATA REFRESH INTERVAL MS=10,
-      START TIMESTAMP=1,
-      TOPIC 'testdrive-t1-${testdrive.seed}'
+      START TIMESTAMP=1
     )
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_2
   FROM KAFKA CONNECTION kafka_conn (
       TOPIC METADATA REFRESH INTERVAL MS=10,
-      START TIMESTAMP=2,
-      TOPIC 'testdrive-t1-${testdrive.seed}'
+      START TIMESTAMP=2
     )
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_3
   FROM KAFKA CONNECTION kafka_conn (
       TOPIC METADATA REFRESH INTERVAL MS=10,
-      START TIMESTAMP=3,
-      TOPIC 'testdrive-t1-${testdrive.seed}'
+      START TIMESTAMP=3
     )
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_4
   FROM KAFKA CONNECTION kafka_conn (
       TOPIC METADATA REFRESH INTERVAL MS=10,
-      START TIMESTAMP=4,
-      TOPIC 'testdrive-t1-${testdrive.seed}'
+      START TIMESTAMP=4
     )
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE append_time_offset_5
   FROM KAFKA CONNECTION kafka_conn (
       TOPIC METADATA REFRESH INTERVAL MS=10,
-      START TIMESTAMP=5,
-      TOPIC 'testdrive-t1-${testdrive.seed}'
+      START TIMESTAMP=5
     )
+  TOPIC 'testdrive-t1-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
@@ -197,37 +201,43 @@ $ kafka-ingest format=bytes topic=t2 key-format=bytes key-terminator=: timestamp
 grape:grape
 
 > CREATE SOURCE upsert_time_offset_0
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=0, TOPIC 'testdrive-t2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=0)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_1
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, TOPIC 'testdrive-t2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_2
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=2, TOPIC 'testdrive-t2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=2)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_3
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=3, TOPIC 'testdrive-t2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=3)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_4
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=4, TOPIC 'testdrive-t2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=4)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
 
 > CREATE SOURCE upsert_time_offset_5
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=5, TOPIC 'testdrive-t2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=5)
+  TOPIC 'testdrive-t2-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   INCLUDE OFFSET
   ENVELOPE UPSERT
@@ -307,12 +317,14 @@ $ kafka-ingest format=bytes topic=t3 timestamp=4084108700000
 cherry
 
 > CREATE SOURCE relative_time_offset_30_years_ago
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=-946100000000, TOPIC 'testdrive-t3-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=-946100000000)
+  TOPIC 'testdrive-t3-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
 > CREATE SOURCE relative_time_offset_today
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=-1, TOPIC 'testdrive-t3-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=-1)
+  TOPIC 'testdrive-t3-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
@@ -338,7 +350,8 @@ pie
 # A time offset of -1 specifies that we want to start from the end of the topic
 # (negative offsets are relative from the end).
 > CREATE SOURCE verify_no_fetch
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=-1, TOPIC 'testdrive-t4-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=-1)
+  TOPIC 'testdrive-t4-${testdrive.seed}'
   FORMAT TEXT
   INCLUDE OFFSET
 
@@ -415,7 +428,8 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": {"row": {"id": 4, "creature": "chicken"}}}
 
 > CREATE SOURCE upsert_time_skip
-  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=6, TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=6)
+  TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -96,13 +96,13 @@ $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschem
 {"id": 1} {"before": {"row": {"id": 1, "creature": "salamander"}}, "after": {"row": {"id": 1, "creature": "lizard"}}, "op": "u", "source": {"file": "binlog3", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
 
 ! CREATE SOURCE doin_upsert
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE DEBEZIUM UPSERT
 contains:ENVELOPE [DEBEZIUM] UPSERT requires that KEY FORMAT be specified
 
 > CREATE SOURCE doin_upsert
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 
@@ -149,14 +149,14 @@ creature
 moros
 
 ! CREATE SOURCE doin_upsert_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE OFFSET
   ENVELOPE DEBEZIUM
 contains:INCLUDE OFFSET with Debezium requires UPSERT semantics
 
 > CREATE SOURCE doin_upsert_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET AS test_kafka_offset
   ENVELOPE DEBEZIUM UPSERT
@@ -188,7 +188,8 @@ id creature
 
 # Test that `WITH (START OFFSET=<whatever>)` works
 > CREATE SOURCE upsert_fast_forward
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET = [6], TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET = [6])
+  TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
 
@@ -199,7 +200,7 @@ id creature
 
 # Test that it doesn't work with full deduplication
 ! CREATE SOURCE upsert_full_dedupe
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   LEGACYWITH (deduplication = 'full')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM UPSERT
@@ -208,7 +209,7 @@ contains:unexpected parameters for CREATE SOURCE: deduplication
 
 # test include metadata
 > CREATE SOURCE upsert_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE OFFSET, PARTITION
   ENVELOPE DEBEZIUM UPSERT
@@ -223,7 +224,7 @@ id   creature      offset  partition
 
 # test include metadata respects metadata order
 > CREATE SOURCE upsert_metadata_reordered
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-dbzupsert-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-dbzupsert-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET
   ENVELOPE DEBEZIUM UPSERT

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -47,7 +47,8 @@ $ kafka-ingest format=avro topic=avroavro key-format=avro key-schema=${keyschema
 {"key": "mammalmore"} {"f1":"moose", "f2": 2}
 
 > CREATE SOURCE avroavro
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-avroavro-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
 
@@ -67,13 +68,15 @@ birdmore: {"f1":"geese", "f2": 2}
 mammal1: {"f1": "moose", "f2": 1}
 
 > CREATE SOURCE bytesavro
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textavro-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT AVRO USING SCHEMA  '${schema}'
   ENVELOPE UPSERT
 
 > CREATE SOURCE textavro
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textavro-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE UPSERT
@@ -109,24 +112,28 @@ mammal1:moose
 bìrd1:
 
 > CREATE SOURCE texttext
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textbytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT TEXT VALUE FORMAT TEXT
   ENVELOPE UPSERT
 
 > CREATE SOURCE textbytes
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textbytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytesbytes
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textbytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT BYTES
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytestext
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textbytes-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textbytes-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT TEXT
   ENVELOPE UPSERT
@@ -186,13 +193,15 @@ $ protobuf-compile-descriptors inputs=test.proto output=test.pb
 $ kafka-create-topic topic=textproto partitions=1
 
 > CREATE SOURCE textproto
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textproto-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textproto-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA FILE '${testdrive.temp-dir}/test.pb'
   ENVELOPE UPSERT
 
 > CREATE SOURCE bytesproto
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-textproto-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-textproto-${testdrive.seed}'
   KEY FORMAT BYTES
   VALUE FORMAT PROTOBUF MESSAGE '.Test' USING SCHEMA FILE '${testdrive.temp-dir}/test.pb'
   ENVELOPE UPSERT
@@ -252,7 +261,8 @@ mammalmore:moose
 mammal1:
 
 > CREATE SOURCE nullkey
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-nullkey-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-nullkey-${testdrive.seed}'
   KEY FORMAT TEXT
   VALUE FORMAT TEXT
   ENVELOPE UPSERT
@@ -286,7 +296,8 @@ $ kafka-ingest format=avro topic=realtimeavroavro key-format=avro key-schema=${k
 {"f3": {"string": "earth"}, "f4":{"string": "dao"}}
 
 > CREATE SOURCE realtimeavroavro (f3, f4, f1, f2)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
@@ -302,7 +313,8 @@ water     <null>  crocodile      7
 
 # Ensure that Upsert sources work with START OFFSET
 > CREATE SOURCE realtimeavroavro_ff
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1])
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
@@ -363,7 +375,8 @@ $ kafka-ingest format=avro topic=realtimefilteravro key-format=avro key-schema=$
 {"k1": {"string": "boucherie"}, "k2": {"long": 5}} {"f1": {"string": "apple"}, "f2": {"long": 3}}
 
 > CREATE SOURCE realtimefilteravro
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-realtimefilteravro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-realtimefilteravro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT
@@ -507,7 +520,8 @@ k1        k2
 librairie 10
 
 > CREATE SOURCE include_metadata
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1])
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET
@@ -521,7 +535,8 @@ air       qi        chicken      47    0         13
 earth     dao       rhinoceros   211   0         12
 
 > CREATE SOURCE include_metadata_ts
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1])
+  TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}'
   KEY FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   INCLUDE PARTITION, OFFSET, TIMESTAMP as ts

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -29,7 +29,7 @@ $ kafka-create-topic topic=data
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > SELECT * FROM data
@@ -148,7 +148,7 @@ a  b
 
 # Cannot create sink from unmaterialized view.
 ! CREATE SINK not_mat_sink2 FROM data_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-view2-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'data-view2-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:data_view is a view, which cannot be exported as a sink
 
@@ -159,7 +159,7 @@ contains:data_view is a view, which cannot be exported as a sink
 
 # or from an indexed unmaterialized view
 ! CREATE SINK not_mat_sink2 FROM test5
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data-view2-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'data-view2-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:test5 is a view, which cannot be exported as a sink
 
@@ -314,7 +314,7 @@ b  c
 $ kafka-create-topic topic=mat
 
 > CREATE SOURCE mat_data
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-mat-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-mat-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE DEFAULT INDEX ON mat_data

--- a/test/testdrive/materialized-views.td
+++ b/test/testdrive/materialized-views.td
@@ -40,7 +40,8 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE s1
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-materialized-views-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC
+  'testdrive-materialized-views-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
@@ -59,13 +60,12 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
 3
 
 > CREATE SINK sink1 FROM v1
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-materialized-views-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-materialized-views-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SOURCE sink1_check
-  FROM KAFKA CONNECTION kafka_conn (
-    TOPIC 'testdrive-materialized-views-sink-${testdrive.seed}'
-  )
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-materialized-views-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -31,13 +31,13 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE mz_data
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > CREATE DEFAULT INDEX ON mz_data
 
 > CREATE SINK sink1 FROM mz_data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE VIEW mz_view AS
@@ -202,7 +202,7 @@ materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"de
 > SHOW CREATE SINK renamed_sink
 Sink                            "Create Sink"
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'snk1') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
+materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" TOPIC 'snk1' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -22,12 +22,14 @@ goofus,gallant
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SOURCE src (a, b)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-test-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
   INCLUDE OFFSET
 
 > CREATE SOURCE src_materialized (a, b)
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-test-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
   INCLUDE OFFSET
 
@@ -43,7 +45,7 @@ goofus,gallant
 # We should refuse to create a sink with invalid WITH options
 
 ! CREATE SINK invalid_with_option FROM src
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
   WITH (badoption=true)
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 contains:Expected one of SNAPSHOT
@@ -56,30 +58,30 @@ name
 #
 # # Invalid in that the address is not well formed
 # ! CREATE SINK bad_schema_registry FROM v3
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY '${testdrive.kafka-addr}'
 # contains:cannot construct a CCSR client with a cannot-be-a-base URL
 #
 # # Invalid in that the address points to an invalid host
 # ! CREATE SINK bad_schema_registry FROM v3
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://no-such-host'
 # contains:unable to publish value schema to registry in kafka sink
 #
 # # Invalid in that the address is not for a schema registry
 # ! CREATE SINK bad_schema_registry FROM v3
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://materialized:6875'
 # contains:unable to publish value schema to registry in kafka sink
 #
 # ! CREATE SINK bad_view FROM v1
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 # contains:v1 is a view, which cannot be exported as a sink
 #
 # # ...Even if that view is based on a materialized source
 # ! CREATE SINK bad_view2 FROM v2
-#   INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+#   INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
 #   WITH (retention_ms=1000000)
 #   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 # contains:v2 is a view, which cannot be exported as a sink
@@ -92,15 +94,16 @@ name
 # that depend on views, as the code paths are different.
 
 > CREATE SINK snk1 FROM src
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk1')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk1'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK snk2 FROM src_materialized
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk2')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk2'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > CREATE SINK snk3 FROM v3
-  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = 1000000000000, TOPIC 'snk3')
+  INTO KAFKA CONNECTION kafka_conn (RETENTION BYTES = 1000000000000)
+  TOPIC 'snk3'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 > SHOW SINKS
@@ -135,7 +138,7 @@ $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
   SELECT true AS c FROM src
 
 > CREATE SINK snk4 FROM v4
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk4')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk4'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.snk4
@@ -150,12 +153,12 @@ $ kafka-verify format=avro sink=materialize.public.snk4
 # exclude the old rows.
 
 > CREATE SINK snk5 FROM src_materialized
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk5')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk5'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT = false)
 
 > CREATE SINK snk6 FROM src_materialized
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk6')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk6'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT = true)
 
@@ -175,12 +178,12 @@ $ kafka-verify format=avro sink=materialize.public.snk6 sort-messages=true
 > CREATE MATERIALIZED VIEW foo AS VALUES (1), (2), (3);
 
 > CREATE SINK snk7 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk7')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk7'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT = false)
 
 > CREATE SINK snk8 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk8')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk8'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   WITH (SNAPSHOT)
 
@@ -203,25 +206,27 @@ snk8        user
 
 # test explicit partition count
 > CREATE SINK snk9 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, TOPIC 'snk9')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1)
+  TOPIC 'snk9'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test explicit replication factor
 > CREATE SINK snk10 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR=1, TOPIC 'snk10')
+  INTO KAFKA CONNECTION kafka_conn (REPLICATION FACTOR=1) TOPIC 'snk10'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test explicit partition count and replication factor
 > CREATE SINK snk11 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, REPLICATION FACTOR=1, TOPIC 'snk11')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=1, REPLICATION FACTOR=1)
+  TOPIC 'snk11'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test broker defaulted partition count and replication factor
 > CREATE SINK snk12 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'snk12')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'snk12'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 # test explicit request for broker defaulted partition count and replication factor
 > CREATE SINK snk13 FROM foo
-  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=-1, REPLICATION FACTOR=-1, TOPIC 'snk13')
+  INTO KAFKA CONNECTION kafka_conn (PARTITION COUNT=-1, REPLICATION FACTOR=-1) TOPIC 'snk13'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -93,7 +93,7 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > CREATE MATERIALIZED VIEW sort_messages (a) AS VALUES (2),(1),(3);
 
 > CREATE SINK sort_messages_sink FROM sort_messages
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'sort-messages-sink-${testdrive.seed}')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'sort-messages-sink-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.sort_messages_sink sort-messages=true
@@ -130,7 +130,8 @@ $ kafka-ingest format=avro topic=kafka-ingest-repeat schema=${kafka-ingest-repea
 {"f1": "fish"}
 
 > CREATE SOURCE kafka_ingest_repeat_input
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-ingest-repeat-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC
+  'testdrive-kafka-ingest-repeat-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
@@ -167,7 +168,7 @@ $ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-s
 "h" {"a": "h"}
 
 > CREATE SOURCE kafka_ingest_no_partition
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-ingest-no-partition-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-kafka-ingest-no-partition-${testdrive.seed}'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
@@ -179,7 +180,7 @@ $ kafka-ingest format=avro topic=kafka-ingest-no-partition key-format=avro key-s
 > CREATE MATERIALIZED VIEW kafka_verify_regexp (a) AS VALUES ('u123'), ('u234');
 
 > CREATE SINK kafka_verify_regexp_sink FROM kafka_verify_regexp
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-verify-regexp-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'kafka-verify-regexp-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sink=materialize.public.kafka_verify_regexp_sink sort-messages=true

--- a/test/testdrive/timestamps-kafka-avro-multi.td
+++ b/test/testdrive/timestamps-kafka-avro-multi.td
@@ -26,14 +26,12 @@ $ kafka-create-topic topic=data2 partitions=2
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE data_empty
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data2-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data2-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE SOURCE data_rt
-    FROM KAFKA CONNECTION kafka_conn (
-      TOPIC 'testdrive-data-${testdrive.seed}',
-      TOPIC METADATA REFRESH INTERVAL MS=50
-    )
+    FROM KAFKA CONNECTION kafka_conn (TOPIC METADATA REFRESH INTERVAL MS=50)
+    TOPIC 'testdrive-data-${testdrive.seed}'
     FORMAT AVRO USING SCHEMA '${schema}'
 
 > CREATE MATERIALIZED VIEW view_rt AS SELECT b, sum(a) FROM data_rt GROUP BY b

--- a/test/testdrive/uuid.td
+++ b/test/testdrive/uuid.td
@@ -37,7 +37,7 @@ $ kafka-ingest format=avro topic=data schema=${schema}
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE data FROM
-  KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
+  KAFKA CONNECTION kafka_conn TOPIC 'testdrive-data-${testdrive.seed}'
   FORMAT AVRO USING SCHEMA '${schema}'
 
 > SHOW COLUMNS FROM data
@@ -60,7 +60,7 @@ u      false     uuid
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK uuid_sink_${testdrive.seed} FROM data
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'data')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'data'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
 
 $ kafka-verify format=avro sort-messages=true sink=materialize.public.uuid_sink_${testdrive.seed}

--- a/test/testdrive/zstd-kafka-compression.td
+++ b/test/testdrive/zstd-kafka-compression.td
@@ -19,14 +19,16 @@ world
   FOR KAFKA BROKER '${testdrive.kafka-addr}';
 
 > CREATE SOURCE zstd
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-zstd-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn
+  TOPIC 'testdrive-zstd-${testdrive.seed}'
   FORMAT TEXT
 > SELECT text FROM zstd
 hello
 world
 
 > CREATE SOURCE zstd_fast_forwarded
-  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-zstd-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1])
+  TOPIC 'testdrive-zstd-${testdrive.seed}'
   FORMAT TEXT
 > SELECT text FROM zstd_fast_forwarded
 world

--- a/test/upgrade/check-from-current_source-kafka-sink.td
+++ b/test/upgrade/check-from-current_source-kafka-sink.td
@@ -10,4 +10,4 @@
 $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > SHOW CREATE SINK upgrade_kafka_sink;
-"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'upgrade-kafka-sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
+"materialize.public.upgrade_kafka_sink" "CREATE SINK \"materialize\".\"public\".\"upgrade_kafka_sink\" FROM \"materialize\".\"public\".\"static_view\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" TOPIC 'upgrade-kafka-sink' FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""

--- a/test/upgrade/create-in-current_source-kafka-sink.td
+++ b/test/upgrade/create-in-current_source-kafka-sink.td
@@ -17,5 +17,5 @@
   URL '${testdrive.schema-registry-url}';
 
 > CREATE SINK upgrade_kafka_sink FROM static_view
-  INTO KAFKA CONNECTION kafka_conn (TOPIC 'upgrade-kafka-sink')
+  INTO KAFKA CONNECTION kafka_conn TOPIC 'upgrade-kafka-sink'
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

WIP

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
