### PR TITLE
compute-client: reduce allocations

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -357,7 +357,7 @@ impl CatalogState {
             // CatalogItem::Log. For now  we just use the log variant to lookup the unique CatalogItem
             // in BUILTINS.
             let log = BUILTINS::logs()
-                .find(|log| log.variant == variant)
+                .find(|log| log.variant == *variant)
                 .expect("variant must be included in builtins");
 
             let source_name = QualifiedObjectName {
@@ -367,7 +367,7 @@ impl CatalogState {
                 },
                 item: format!("{}_{}", log.name, replica_id),
             };
-            self.insert_item(source_id, oid, source_name, CatalogItem::Log(log));
+            self.insert_item(*source_id, oid, source_name, CatalogItem::Log(log));
         }
 
         for (logview, id) in persisted_logs.get_views() {
@@ -397,7 +397,7 @@ impl CatalogState {
                         item: name,
                     };
 
-                    self.insert_item(id, oid, view_name, item);
+                    self.insert_item(*id, oid, view_name, item);
                 }
                 Err(e) => {
                     // This error should never happen, but if we add a logging
@@ -3966,7 +3966,8 @@ impl<S: Append> Catalog<S> {
                     config,
                 } => {
                     let compute_instance_id = state.compute_instances_by_name[&on_cluster_name];
-                    let introspection_ids = config.persisted_logs.get_source_and_view_ids();
+                    let introspection_ids: Vec<_> =
+                        config.persisted_logs.get_source_and_view_ids().collect();
                     state.insert_compute_instance_replica(
                         compute_instance_id,
                         name.clone(),
@@ -4960,8 +4961,8 @@ impl mz_sql::catalog::CatalogComputeInstance<'_> for ComputeInstance {
             .replicas_by_id
             .get(self.replica_id_by_name.get(name)?)?;
         Some((
-            replica.config.persisted_logs.get_source_ids(),
-            replica.config.persisted_logs.get_view_ids(),
+            replica.config.persisted_logs.get_source_ids().collect(),
+            replica.config.persisted_logs.get_view_ids().collect(),
         ))
     }
 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -392,7 +392,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     .await
                     .unwrap();
 
-                persisted_source_ids.extend(replica.config.persisted_logs.get_source_ids().iter());
+                persisted_source_ids.extend(replica.config.persisted_logs.get_source_ids());
 
                 self.controller
                     .active_compute()

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -9,7 +9,7 @@
 
 //! Logic for executing a planned SQL query.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 use std::num::{NonZeroI64, NonZeroUsize};
 use std::time::{Duration, Instant};
@@ -805,7 +805,7 @@ impl<S: Append + 'static> Coordinator<S> {
             ConcreteComputeInstanceReplicaLogging::ConcreteViews(Vec::new(), Vec::new())
         };
 
-        let persisted_source_ids = persisted_logs.get_source_ids();
+        let persisted_source_ids = persisted_logs.get_source_ids().collect();
         let persisted_sources = persisted_logs
             .get_sources()
             .iter()
@@ -1502,7 +1502,7 @@ impl<S: Append + 'static> Coordinator<S> {
             for replica in instance.replicas_by_id.values() {
                 let persisted_logs = replica.config.persisted_logs.clone();
                 let log_and_view_ids = persisted_logs.get_source_and_view_ids();
-                let view_ids = persisted_logs.get_view_ids();
+                let view_ids: HashSet<_> = persisted_logs.get_view_ids().collect();
                 for log_id in log_and_view_ids {
                     // We consider the dependencies of both views and logs, but remove the
                     // views itself. The views are included as they depend on the source,
@@ -1567,7 +1567,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 .clone();
 
             let log_and_view_ids = persisted_logs.get_source_and_view_ids();
-            let view_ids = persisted_logs.get_view_ids();
+            let view_ids: HashSet<_> = persisted_logs.get_view_ids().collect();
 
             for log_id in log_and_view_ids {
                 // We consider the dependencies of both views and logs, but remove the


### PR DESCRIPTION
This commit refactors the methods of `ConcreteComputeInstanceReplicaLogging` to make them allocation-free.

### Motivation

   * This PR refactors existing code.

Motivated by [this comment](https://github.com/MaterializeInc/materialize/pull/14721#discussion_r968103979) on https://github.com/MaterializeInc/materialize/pull/14721.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
