### PR TITLE
[sinks] Generate updated as_of in rehydrating client

### DIFF
--- a/src/storage/src/controller/rehydration.rs
+++ b/src/storage/src/controller/rehydration.rs
@@ -35,13 +35,15 @@ use mz_ore::retry::Retry;
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_types::Codec64;
-use mz_repr::GlobalId;
+use mz_repr::{Diff, GlobalId};
 use mz_service::client::GenericClient;
 
 use crate::protocol::client::{
     ExportSinkCommand, IngestSourceCommand, StorageClient, StorageCommand, StorageGrpcClient,
     StorageResponse,
 };
+use crate::types::sinks::SinkAsOf;
+use crate::types::sources::SourceData;
 
 /// A storage client that replays the command stream on failure.
 ///
@@ -181,6 +183,39 @@ where
                 .storage_metadata
                 .get_resume_upper::<T>(&persist_client, &ingest.description.desc.envelope)
                 .await;
+        }
+
+        for export in self.exports.values_mut() {
+            let mut persist_clients = self.persist.lock().await;
+            let persist_client = persist_clients
+                .open(
+                    export
+                        .description
+                        .from_storage_metadata
+                        .persist_location
+                        .clone(),
+                )
+                .await
+                .expect("error creating persist client");
+            let from_read_handle = persist_client
+                .open_reader::<SourceData, (), T, Diff>(
+                    export.description.from_storage_metadata.data_shard,
+                )
+                .await
+                .expect("from collection disappeared");
+
+            let cached_as_of = &export.description.as_of.frontier;
+            // The controller has the dependency recorded in it's `exported_collections` so this
+            // should not change at least until the sink is started up (because the storage
+            // controller will not downgrade the source's since).
+            let from_since = from_read_handle.since();
+            if PartialOrder::less_equal(cached_as_of, from_since) {
+                export.description.as_of = SinkAsOf {
+                    frontier: from_since.to_owned(),
+                    // If we're using the since, never read the snapshot
+                    strict: true,
+                };
+            }
         }
 
         // Rehydrate all commands.


### PR DESCRIPTION
Previously, we always used the same as_of when the storaged instance was rehydrated.  This meant that the following sequence would result in a panic:
- CREATE SINK FROM SOURCE `s` (which has as_of `t_source`)
- We create the sink with AS OF `now() = t_sink > t_source`
- the persistent collection for source `s` is compacted so that `t_source_1 > `t_sink`
- the storaged process crashes and is rehydrated
- we recreate the sink using the cached command that uses `t_sink`
- This panics when trying to read from the persist collection for the source `s`

We handled the case when the source was recreated on restart of `environmentd` by looking at the current since of the source in the storage controller.  However, in this case, the storage controller doesn't instruct the client to restart -- the rehydrating task does.  So we simply move the logic down a layer

### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/14555

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
