### PR TITLE
Reorder columns in SHOW MATERIALIZED VIEWS

### DIFF
--- a/doc/user/content/sql/drop-table.md
+++ b/doc/user/content/sql/drop-table.md
@@ -69,9 +69,9 @@ CREATE MATERIALIZED VIEW t_view AS SELECT sum(a) AS sum FROM t;
 SHOW MATERIALIZED VIEWS;
 ```
 ```
-  name
---------
- t_view
+name    | cluster
+--------+---------
+t_view  | default
 (1 row)
 ```
 

--- a/doc/user/content/sql/show-materialized-views.md
+++ b/doc/user/content/sql/show-materialized-views.md
@@ -25,9 +25,9 @@ SHOW MATERIALIZED VIEWS;
 ```
 
 ```nofmt
- cluster |     name
----------+--------------
- default | winning_bids
+     name     | cluster
+--------------+----------
+ winning_bids | default
 ```
 
 ```sql
@@ -35,9 +35,9 @@ SHOW MATERIALIZED VIEWS LIKE '%bid%';
 ```
 
 ```nofmt
- cluster |     name
----------+--------------
- default | winning_bids
+     name     | cluster
+--------------+----------
+ winning_bids | default
 ```
 
 ## Related pages

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -384,7 +384,7 @@ fn show_materialized_views<'a>(
     }
 
     let query = format!(
-        "SELECT clusters.name AS cluster, mviews.name
+        "SELECT mviews.name, clusters.name AS cluster
          FROM mz_materialized_views AS mviews
          JOIN mz_clusters AS clusters
             ON clusters.id = mviews.cluster_id

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -78,9 +78,9 @@ CREATE MATERIALIZED VIEW other_mv IN CLUSTER other AS SELECT 1
 query TT colnames,rowsort
 SHOW MATERIALIZED VIEWS
 ----
-cluster name
-default mv
-other   other_mv
+name      cluster
+mv        default
+other_mv  other
 
 statement ok
 DROP MATERIALIZED VIEW other_mv
@@ -265,15 +265,15 @@ CREATE MATERIALIZED VIEW other_mv IN CLUSTER other AS SELECT 1
 query TT colnames,rowsort
 SHOW MATERIALIZED VIEWS
 ----
-cluster name
-default mv
-other   other_mv
+name      cluster
+mv        default
+other_mv  other
 
 query TT colnames,rowsort
 SHOW MATERIALIZED VIEWS IN CLUSTER other
 ----
-cluster name
-other   other_mv
+name      cluster
+other_mv  other
 
 statement ok
 DROP MATERIALIZED VIEW other_mv

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -47,9 +47,9 @@ name
 data_view
 
 > SHOW MATERIALIZED VIEWS
-cluster   name
+name    cluster
 ---------------
-default   test1
+test1   default
 
 > SELECT * FROM test1
 b  sum


### PR DESCRIPTION
As per #14648, reorder columns to be `name`, `cluster` to be consistent with other `SHOW` commands.

### Motivation

   * This PR refactors existing code. #14648

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

`SHOW MATERIALIZED VIEWS` columns now ordered  `name`, `cluster` instead of `cluster`, `name`.