### PR TITLE
persist: fix bug in gc that breaks later calls to gc

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -680,6 +680,7 @@ pub struct StateMetrics {
     pub(crate) apply_spine_slow_path: IntCounter,
     pub(crate) update_state_fast_path: IntCounter,
     pub(crate) update_state_slow_path: IntCounter,
+    pub(crate) rollup_at_seqno_migration: IntCounter,
 }
 
 impl StateMetrics {
@@ -700,6 +701,10 @@ impl StateMetrics {
             update_state_slow_path: registry.register(metric!(
                 name: "mz_persist_state_update_state_slow_path",
                 help: "count of state update applications that hit the slow path",
+            )),
+            rollup_at_seqno_migration: registry.register(metric!(
+                name: "mz_persist_state_rollup_at_seqno_migration",
+                help: "count of fetch_rollup_at_seqno calls that only worked because of the migration",
             )),
         }
     }


### PR DESCRIPTION
We maintain an invariant that the _current state_ contains a rollup for the _earliest live diff_ in consensus (and that the referenced rollup exists). This commit fixes a bug that could lead to that invariant being violated.

If the earliest live diff is X and we receive a gc req for X+Y to X+Y+Z (this can happen e.g. if some cmd ignores an earlier req for X to X+Y, or if they're processing concurrently and the X to X+Y req loses the race), then the buggy version of gc would delete any rollups strictly less than old_seqno_since (X+Y in this example). But our invariant is that the rollup exists for the earliest live diff, in this case X. So if the first call to gc was interrupted after this but before truncate (when all the blob deletes happen), later calls to gc would attempt to call `fetch_live_states` and end up infinitely in its loop.

The fix was to base which rollups are deleteable on the earliest live diff, not old_seqno_since.

Sadly, some envs in prod now violate this invariant. So, even with the fix, existing shards will never successfully run gc. We add a temporary migration to fix them in `fetch_rollup_at_seqno`. This method normally looks in the latest version of state for the specifically requested seqno. In the invariant violation case, some version of state in the range `[earliest, current]` has a rollup for earliest, but current doesn't. So, for the migration, if fetch_rollup_at_seqno doesn't find a rollup in current, then we fall back to sniffing one out of raw diffs. If this success, we increment a counter and log, so we can track how often this migration is bailing us out. After the next deploy, this should initially start at
> 0 and then settle down to 0. After the next prod envs wipe, we can
remove the migration.

Touches #14719

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Manually verified the fix with a local, dry-run version of gc pointed at the prod devex env.

As always, regression test is annoying because we don't yet have the tooling to inject Blob/Consensus failures at just the right times.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
