### PR TITLE
sql: correlate statements to execute responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,7 @@ dependencies = [
  "dec",
  "derivative",
  "differential-dataflow",
+ "enum-kinds",
  "fail",
  "futures",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4052,6 +4052,7 @@ dependencies = [
  "aws-sdk-sts",
  "chrono",
  "datadriven",
+ "enum-kinds",
  "globset",
  "hex",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,6 +4096,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "datadriven",
+ "enum-kinds",
  "itertools",
  "mz-ore",
  "mz-walkabout",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -14,6 +14,7 @@ const_format = "0.2.26"
 dec = "0.4.8"
 derivative = "2.2.0"
 differential-dataflow = { git = "https://github.com/TimelyDataflow/differential-dataflow.git" }
+enum-kinds = "0.5.1"
 fail = { version = "0.5.0", features = ["failpoints"] }
 futures = "0.3.24"
 itertools = "0.10.4"

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -611,6 +611,7 @@ impl ExecuteResponse {
     pub fn generated_from(plan: PlanKind) -> Vec<ExecuteResponseKind> {
         use ExecuteResponseKind::*;
         use PlanKind::*;
+
         match plan {
             AbortTransaction | CommitTransaction => vec![TransactionExited],
             AlterItemRename | AlterNoop | AlterSecret | AlterSource | RotateKeys => {
@@ -634,7 +635,8 @@ impl ExecuteResponse {
             CreateSecret => vec![CreatedSecret],
             CreateSink => vec![CreatedSink],
             CreateTable => vec![CreatedTable],
-            CreateView | CreateViews => vec![CreatedView],
+            CreateView => vec![CreatedView],
+            CreateViews => vec![CreatedViews],
             CreateMaterializedView => vec![CreatedMaterializedView],
             CreateIndex => vec![CreatedIndex],
             CreateType => vec![CreatedType],
@@ -660,14 +662,13 @@ impl ExecuteResponse {
             ],
             PlanKind::EmptyQuery => vec![ExecuteResponseKind::EmptyQuery],
             Explain | Peek | SendRows | ShowAllVariables | ShowVariable => {
-                vec![SendingRows]
+                vec![CopyTo, SendingRows]
             }
-            Execute => vec![],
+            Execute | ReadThenWrite | SendDiffs => vec![Deleted, Inserted, SendingRows, Updated],
             PlanKind::Fetch => vec![ExecuteResponseKind::Fetch],
             Insert => vec![Inserted, SendingRows],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],
             PlanKind::Raise => vec![ExecuteResponseKind::Raise],
-            ReadThenWrite | SendDiffs => vec![Deleted, Inserted, SendingRows, Updated],
             PlanKind::SetVariable | ResetVariable => vec![ExecuteResponseKind::SetVariable],
             Tail => vec![Tailing, CopyTo],
             StartTransaction => vec![StartedTransaction],

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -7,6 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
+// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
+#![allow(clippy::extra_unused_lifetimes)]
+
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -46,8 +46,8 @@ pub mod session;
 
 pub use crate::client::{Client, ConnClient, Handle, SessionClient};
 pub use crate::command::{
-    Canceled, ExecuteResponse, ExecuteResponsePartialError, RowsFuture, StartupMessage,
-    StartupResponse,
+    Canceled, ExecuteResponse, ExecuteResponseKind, ExecuteResponsePartialError, RowsFuture,
+    StartupMessage, StartupResponse,
 };
 pub use crate::coord::peek::PeekResponseUnary;
 pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -23,7 +23,8 @@
 
 //! Logic handling the intermediate representation of Avro values.
 
-// `EnumKind` unconditionally introduces a lifetime.
+// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
+// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
 #![allow(clippy::extra_unused_lifetimes)]
 
 use std::collections::HashMap;

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -543,15 +543,19 @@ impl AuthedClient {
                     col_names,
                 }
             }
-            ExecuteResponse::Fetch { .. }
+            res @ (ExecuteResponse::Fetch { .. }
             | ExecuteResponse::SetVariable { .. }
             | ExecuteResponse::Tailing { .. }
             | ExecuteResponse::CopyTo { .. }
             | ExecuteResponse::CopyFrom { .. }
             | ExecuteResponse::Raise { .. }
             | ExecuteResponse::DeclaredCursor
-            | ExecuteResponse::ClosedCursor => {
-                unreachable!("already prohibited statements with these responses")
+            | ExecuteResponse::ClosedCursor) => {
+                SimpleResult::err(
+                    format!("internal error: encountered prohibited ExecuteResponse {:?}.\n\n
+This is a bug. Can you please file an issue letting us know?\n
+https://github.com/MaterializeInc/materialize/issues/new?assignees=&labels=C-bug%2CC-triage&template=01-bug.yml",
+                ExecuteResponseKind::from(res)))
             }
         }
     }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -120,206 +120,206 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         server.inner.http_local_addr()
     ))?;
 
-    struct TestCase {
+    struct TestCaseSimple {
         query: &'static str,
         status: StatusCode,
         body: &'static str,
     }
 
-    let tests = vec![
+    let simple_test_cases = vec![
         // Regular query works.
-        TestCase {
+        TestCaseSimple {
             query: "select 1+2 as col",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[3]],"col_names":["col"]}]}"#,
         },
         // Multiple queries are ok.
-        TestCase {
+        TestCaseSimple {
             query: "select 1; select 2",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"rows":[[2]],"col_names":["?column?"]}]}"#,
         },
         // Arrays + lists work
-        TestCase {
+        TestCaseSimple {
             query: "select array[1], list[2]",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[[1],[2]]],"col_names":["array","list"]}]}"#,
         },
         // Succeeding and failing queries can mix and match.
-        TestCase {
+        TestCaseSimple {
             query: "select 1; select * from noexist;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"error":"unknown catalog item 'noexist'"}]}"#,
         },
         // CREATEs should work when provided alone.
-        TestCase {
+        TestCaseSimple {
             query: "create view v as select 1",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"CREATE VIEW"}]}"#,
         },
         // Partial errors make it to the client.
-        TestCase {
+        TestCaseSimple {
             query: "create view if not exists v as select 1",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"CREATE VIEW","partial_err":{"severity":"notice","message":"view already exists, skipping"}}]}"#,
         },
         // Multiple CREATEs do not work.
-        TestCase {
+        TestCaseSimple {
             query: "create view v1 as select 1; create view v2 as select 1",
             status: StatusCode::OK,
             body: r#"{"results":[{"error":"CREATE VIEW v1 AS SELECT 1 cannot be run inside a transaction block"}]}"#,
         },
         // Syntax errors fail the request.
-        TestCase {
+        TestCaseSimple {
             query: "'",
             status: StatusCode::BAD_REQUEST,
             body: r#"unterminated quoted string"#,
         },
         // Tables
-        TestCase {
+        TestCaseSimple {
             query: "create table t (a int);",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"CREATE TABLE"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "insert into t values (1)",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"INSERT 0 1"}]}"#,
         },
         // n.b. this used to fail because the insert was treated as an
         // uncommitted explicit transaction
-        TestCase {
+        TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "delete from t",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "delete from t",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
         },
         // # Txns
         // ## Txns, read only
-        TestCase {
+        TestCaseSimple {
             query: "begin; select 1; commit",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "begin; select 1; commit; select 2;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"rows":[[2]],"col_names":["?column?"]}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "select 1; begin; select 2; commit;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"rows":[[2]],"col_names":["?column?"]},{"ok":"COMMIT"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "begin; select 1/0; commit; select 2;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "begin; select 1; commit; select 1/0;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"rows":[[1]],"col_names":["?column?"]},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "select 1/0; begin; select 2; commit;",
             status: StatusCode::OK,
             body: r#"{"results":[{"error":"division by zero"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "select 1; begin; select 1/0; commit;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["?column?"]},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
         },
         // ## Txns w/ writes
         // Implicit txn aborted on first error
-        TestCase {
+        TestCaseSimple {
             query: "insert into t values (1); select 1/0; insert into t values (2)",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
         },
         // Values not successfully written due to aborted txn
-        TestCase {
+        TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
         },
         // Explicit txn invocation commits values w/in txn, irrespective of results outside txn
-        TestCase {
+        TestCaseSimple {
             query: "begin; insert into t values (1); commit; insert into t values (2); select 1/0;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["a"]}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "delete from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"DELETE 1"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "delete from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"DELETE 0"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "insert into t values (1); begin; insert into t values (2); insert into t values (3); commit;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "delete from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"DELETE 3"}]}"#,
         },
         // Explicit txn must be terminated to commit
-        TestCase {
+        TestCaseSimple {
             query: "begin; insert into t values (1)",
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "select * from t;",
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
         },
         // Emtpy query OK.
-        TestCase {
+        TestCaseSimple {
             query: "",
             status: StatusCode::OK,
             body: r#"{"results":[]}"#,
         },
         // Does not support parameters
-        TestCase {
+        TestCaseSimple {
             query: "select $1",
             status: StatusCode::OK,
             body: r#"{"results":[{"error":"request supplied 0 parameters, but SELECT $1 requires 1"}]}"#,
         },
-        TestCase {
+        TestCaseSimple {
             query: "tail (select * from t)",
             status: StatusCode::BAD_REQUEST,
             body: r#"unsupported via this API: TAIL (SELECT * FROM t)"#,
         },
     ];
 
-    for tc in tests {
+    for tc in simple_test_cases {
         let res = Client::new()
             .post(url.clone())
             .json(&json!({"query": tc.query}))
@@ -330,27 +330,27 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
 
     // Parameter-based queries
 
-    struct TestCaseParams {
+    struct TestCaseExtended {
         requests: Vec<(&'static str, Vec<Option<&'static str>>)>,
         status: StatusCode,
         body: &'static str,
     }
 
-    let param_test_cases = vec![
+    let extended_test_cases = vec![
         // Parameterized queries work
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select $1+$2::int as col", vec![Some("1"), Some("2")])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[3]],"col_names":["col"]}]}"#,
         },
         // Parameters can be present and empty
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select 3 as col", vec![])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[3]],"col_names":["col"]}]}"#,
         },
         // Multiple statements
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("select 1 as col", vec![]),
                 ("select $1+$2::int as col", vec![Some("1"), Some("2")]),
@@ -358,7 +358,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1]],"col_names":["col"]},{"rows":[[3]],"col_names":["col"]}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("select $1+$2::int as col", vec![Some("1"), Some("2")]),
                 ("select 1 as col", vec![]),
@@ -366,7 +366,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[3]],"col_names":["col"]},{"rows":[[1]],"col_names":["col"]}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("select $1+$2::int as col", vec![Some("1"), Some("2")]),
                 ("select $1*$2::int as col", vec![Some("2"), Some("3")]),
@@ -375,7 +375,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             body: r#"{"results":[{"rows":[[3]],"col_names":["col"]},{"rows":[[6]],"col_names":["col"]}]}"#,
         },
         // Quotes escaped
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![(
                 "select length($1), length($2)",
                 vec![Some("abc"), Some("'abc'")],
@@ -384,7 +384,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             body: r#"{"results":[{"rows":[[3,5]],"col_names":["length","length"]}]}"#,
         },
         // All parameters values treated as strings
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![(
                 "select length($1), length($2)",
                 vec![Some("sum(a)"), Some("SELECT * FROM t;")],
@@ -393,48 +393,48 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             body: r#"{"results":[{"rows":[[6,16]],"col_names":["length","length"]}]}"#,
         },
         // Too many parameters
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select $1 as col", vec![Some("1"), Some("2")])],
             status: StatusCode::OK,
             body: r#"{"results":[{"error":"request supplied 2 parameters, but SELECT $1 AS col requires 1"}]}"#,
         },
         // Too few parameters
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select $1+$2::int as col", vec![Some("1")])],
             status: StatusCode::OK,
             body: r#"{"results":[{"error":"request supplied 1 parameters, but SELECT $1 + ($2)::int4 AS col requires 2"}]}"#,
         },
         // NaN
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select $1::decimal+2 as col", vec![Some("nan")])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[["NaN"]],"col_names":["col"]}]}"#,
         },
         // Null string value parameters
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select $1+$2::int as col", vec![Some("1"), None])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[null]],"col_names":["col"]}]}"#,
         },
         // Empty query
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("", vec![])],
             status: StatusCode::BAD_REQUEST,
             body: r#"each query must contain exactly 1 statement, but "" contains 0"#,
         },
         // Empty query w/ param
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("", vec![Some("1")])],
             status: StatusCode::BAD_REQUEST,
             body: r#"each query must contain exactly 1 statement, but "" contains 0"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select 1 as col", vec![]), ("", vec![None])],
             status: StatusCode::BAD_REQUEST,
             body: r#"each query must contain exactly 1 statement, but "" contains 0"#,
         },
         // Multiple statements
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("select 1 as col", vec![]),
                 ("select 1; select 2;", vec![None]),
@@ -444,7 +444,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
         },
         // Txns
         // - Rolledback
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("begin;", vec![]),
                 ("insert into t values (1);", vec![]),
@@ -454,7 +454,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"ROLLBACK"}]}"#,
         },
         // - Implicit txn
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("insert into t values (1);", vec![]),
                 ("select 1/0;", vec![]),
@@ -463,7 +463,7 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             body: r#"{"results":[{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
         },
         // - Errors prevent commit + further execution
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("begin;", vec![]),
                 ("insert into t values (1);", vec![]),
@@ -475,18 +475,18 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"error":"division by zero"}]}"#,
         },
         // - Requires explicit commit in explicit txn
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("begin;", vec![]), ("insert into t values (1);", vec![])],
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"BEGIN"},{"ok":"INSERT 0 1"}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select * from t", vec![])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[],"col_names":["a"]}]}"#,
         },
         // Writes
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("insert into t values ($1);", vec![Some("1")]),
                 ("begin;", vec![]),
@@ -498,12 +498,12 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"ok":"INSERT 0 1"},{"ok":"INSERT 0 1"},{"ok":"COMMIT"},{"error":"division by zero"}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select * from t", vec![])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![
                 ("insert into t values ($1);", vec![Some("4")]),
                 ("begin;", vec![]),
@@ -513,19 +513,19 @@ fn test_http_sql() -> Result<(), Box<dyn Error>> {
             status: StatusCode::OK,
             body: r#"{"results":[{"ok":"INSERT 0 1"},{"ok":"BEGIN"},{"error":"division by zero"}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("select * from t", vec![])],
             status: StatusCode::OK,
             body: r#"{"results":[{"rows":[[1],[2],[3]],"col_names":["a"]}]}"#,
         },
-        TestCaseParams {
+        TestCaseExtended {
             requests: vec![("tail (select * from t)", vec![])],
             status: StatusCode::BAD_REQUEST,
             body: r#"unsupported via this API: TAIL (SELECT * FROM t)"#,
         },
     ];
 
-    for tc in param_test_cases {
+    for tc in extended_test_cases {
         let mut queries = vec![];
         for (query, params) in tc.requests.into_iter() {
             queries.push(mz_environmentd::http::ExtendedRequest {

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -7,7 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// `EnumKind` and various macros unconditionally introduce lifetimes.
+// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
+// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
 #![allow(clippy::extra_unused_lifetimes)]
 
 use std::fmt::{self, Write};

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.63.0"
 publish = false
 
 [dependencies]
+enum-kinds = "0.5.1"
 itertools = "0.10.4"
 mz-ore = { path = "../ore", default-features = false, features = ["stack"] }
 phf = { version = "0.11.1", features = ["uncased"] }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -18,6 +18,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
+// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
+#![allow(clippy::extra_unused_lifetimes)]
+
 use std::fmt;
 
 use enum_kinds::EnumKind;

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -20,6 +20,8 @@
 
 use std::fmt;
 
+use enum_kinds::EnumKind;
+
 use crate::ast::display::{self, AstDisplay, AstFormatter};
 use crate::ast::{
     AstInfo, ColumnDef, CreateConnection, CreateSinkConnection, CreateSourceConnection,
@@ -30,7 +32,8 @@ use crate::ast::{
 
 /// A top-level statement (SELECT, INSERT, CREATE, etc.)
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, EnumKind)]
+#[enum_kind(StatementKind)]
 pub enum Statement<T: AstInfo> {
     Select(SelectStatement<T>),
     Insert(InsertStatement<T>),

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.65"
 aws-arn = "0.3.1"
 aws-sdk-sts = { version = "0.18.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std"] }
+enum-kinds = "0.5.1"
 globset = "0.4.9"
 hex = "0.4.3"
 itertools = "0.10.4"

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -45,7 +45,8 @@ use mz_storage::types::sources::{SourceDesc, Timeline};
 
 use crate::ast::{
     ExplainOptions, ExplainStageNew, ExplainStageOld, Expr, FetchDirection, IndexOptionName,
-    NoticeSeverity, ObjectType, Raw, SetVariableValue, Statement, TransactionAccessMode,
+    NoticeSeverity, ObjectType, Raw, SetVariableValue, Statement, StatementKind,
+    TransactionAccessMode,
 };
 use crate::catalog::{CatalogType, IdReference};
 use crate::names::{
@@ -136,6 +137,86 @@ pub enum Plan {
     Deallocate(DeallocatePlan),
     Raise(RaisePlan),
     RotateKeys(RotateKeysPlan),
+}
+
+impl Plan {
+    /// Expresses which [`StatementKind`] can generate which set of
+    /// [`PlanKind`].
+    pub fn generated_from(stmt: StatementKind) -> Vec<PlanKind> {
+        match stmt {
+            StatementKind::AlterConnection => vec![PlanKind::AlterNoop, PlanKind::RotateKeys],
+            StatementKind::AlterIndex => vec![
+                PlanKind::AlterIndexResetOptions,
+                PlanKind::AlterIndexSetOptions,
+                PlanKind::AlterNoop,
+            ],
+            StatementKind::AlterObjectRename => {
+                vec![PlanKind::AlterItemRename, PlanKind::AlterNoop]
+            }
+            StatementKind::AlterSecret => vec![PlanKind::AlterNoop, PlanKind::AlterSecret],
+            StatementKind::AlterSource => vec![PlanKind::AlterNoop, PlanKind::AlterSource],
+            StatementKind::AlterSystemReset => {
+                vec![PlanKind::AlterNoop, PlanKind::AlterSystemReset]
+            }
+            StatementKind::AlterSystemResetAll => {
+                vec![PlanKind::AlterNoop, PlanKind::AlterSystemResetAll]
+            }
+            StatementKind::AlterSystemSet => vec![PlanKind::AlterNoop, PlanKind::AlterSystemSet],
+            StatementKind::Close => vec![PlanKind::Close],
+            StatementKind::Commit => vec![PlanKind::CommitTransaction],
+            StatementKind::Copy => vec![
+                PlanKind::CopyFrom,
+                PlanKind::Peek,
+                PlanKind::SendDiffs,
+                PlanKind::Tail,
+            ],
+            StatementKind::CreateCluster => vec![PlanKind::CreateComputeInstance],
+            StatementKind::CreateClusterReplica => vec![PlanKind::CreateComputeInstanceReplica],
+            StatementKind::CreateConnection => vec![PlanKind::CreateConnection],
+            StatementKind::CreateDatabase => vec![PlanKind::CreateDatabase],
+            StatementKind::CreateIndex => vec![PlanKind::CreateIndex],
+            StatementKind::CreateMaterializedView => vec![PlanKind::CreateMaterializedView],
+            StatementKind::CreateRole => vec![PlanKind::CreateRole],
+            StatementKind::CreateSchema => vec![PlanKind::CreateSchema],
+            StatementKind::CreateSecret => vec![PlanKind::CreateSecret],
+            StatementKind::CreateSink => vec![PlanKind::CreateSink],
+            StatementKind::CreateSource => vec![PlanKind::CreateSource],
+            StatementKind::CreateTable => vec![PlanKind::CreateTable],
+            StatementKind::CreateType => vec![PlanKind::CreateType],
+            StatementKind::CreateView => vec![PlanKind::CreateView],
+            StatementKind::CreateViews => vec![PlanKind::CreateViews],
+            StatementKind::Deallocate => vec![PlanKind::Deallocate],
+            StatementKind::Declare => vec![PlanKind::Declare],
+            StatementKind::Delete => vec![PlanKind::ReadThenWrite],
+            StatementKind::Discard => vec![PlanKind::DiscardAll, PlanKind::DiscardTemp],
+            StatementKind::DropClusterReplicas => vec![PlanKind::DropComputeInstanceReplica],
+            StatementKind::DropClusters => vec![PlanKind::DropComputeInstances],
+            StatementKind::DropDatabase => vec![PlanKind::DropDatabase],
+            StatementKind::DropObjects => vec![PlanKind::DropItems],
+            StatementKind::DropRoles => vec![PlanKind::DropRoles],
+            StatementKind::DropSchema => vec![PlanKind::DropSchema],
+            StatementKind::Execute => vec![PlanKind::Execute],
+            StatementKind::Explain => vec![PlanKind::Explain],
+            StatementKind::Fetch => vec![PlanKind::Fetch],
+            StatementKind::Insert => vec![PlanKind::Insert],
+            StatementKind::Prepare => vec![PlanKind::Prepare],
+            StatementKind::Raise => vec![PlanKind::Raise],
+            StatementKind::ResetVariable => vec![PlanKind::ResetVariable],
+            StatementKind::Rollback => vec![PlanKind::AbortTransaction],
+            StatementKind::Select => vec![PlanKind::Peek],
+            StatementKind::SetTransaction => vec![],
+            StatementKind::SetVariable => vec![PlanKind::SetVariable],
+            StatementKind::Show => vec![
+                PlanKind::Peek,
+                PlanKind::SendRows,
+                PlanKind::ShowVariable,
+                PlanKind::ShowAllVariables,
+            ],
+            StatementKind::StartTransaction => vec![PlanKind::StartTransaction],
+            StatementKind::Tail => vec![PlanKind::Tail],
+            StatementKind::Update => vec![PlanKind::ReadThenWrite, PlanKind::SendRows],
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -26,6 +26,10 @@
 // `plan_root_query` and fanning out based on the contents of the `SELECT`
 // statement.
 
+// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
+// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
+#![allow(clippy::extra_unused_lifetimes)]
+
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::num::NonZeroUsize;
 use std::time::Duration;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -31,13 +31,14 @@ use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use mz_repr::explain_new::{ExplainConfig, ExplainFormat};
+use enum_kinds::EnumKind;
 use serde::{Deserialize, Serialize};
 
 use mz_compute_client::controller::ComputeInstanceId;
 use mz_expr::{MirRelationExpr, MirScalarExpr, RowSetFinishing};
 use mz_ore::now::{self, NOW_ZERO};
 use mz_pgcopy::CopyFormatParams;
+use mz_repr::explain_new::{ExplainConfig, ExplainFormat};
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 use mz_storage::types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
 use mz_storage::types::sources::{SourceDesc, Timeline};
@@ -76,7 +77,8 @@ pub use query::{QueryContext, QueryLifetime};
 pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
 
 /// Instructions for executing a SQL query.
-#[derive(Debug)]
+#[derive(Debug, EnumKind)]
+#[enum_kind(PlanKind)]
 pub enum Plan {
     CreateConnection(CreateConnectionPlan),
     CreateDatabase(CreateDatabasePlan),

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -31,7 +31,7 @@ use crate::names::{
 };
 use crate::plan::error::PlanError;
 use crate::plan::query;
-use crate::plan::{Params, Plan, PlanContext};
+use crate::plan::{Params, Plan, PlanContext, PlanKind};
 use crate::{normalize, DEFAULT_SCHEMA};
 
 mod ddl;
@@ -236,13 +236,15 @@ pub fn plan(
         .map(|(i, ty)| (i + 1, ty.clone()))
         .collect();
 
+    let permitted_plans = Plan::generated_from((&stmt).into());
+
     let scx = &mut StatementContext {
         pcx,
         catalog,
         param_types: RefCell::new(param_types),
     };
 
-    match stmt {
+    let plan = match stmt {
         // DDL statements.
         Statement::AlterConnection(stmt) => ddl::plan_alter_connection(scx, stmt),
         Statement::AlterIndex(stmt) => ddl::plan_alter_index_options(scx, stmt),
@@ -335,7 +337,18 @@ pub fn plan(
 
         // Other statements.
         Statement::Raise(stmt) => raise::plan_raise(scx, stmt),
+    };
+
+    if let Ok(plan) = &plan {
+        mz_ore::soft_assert!(
+            permitted_plans.contains(&PlanKind::from(plan)),
+            "plan {:?}, permitted plans {:?}",
+            plan,
+            permitted_plans
+        );
     }
+
+    plan
 }
 
 pub fn plan_copy_from(


### PR DESCRIPTION
Design based on [this comment](https://github.com/MaterializeInc/materialize/pull/14400#issuecomment-1227643158), which @mjibson greenlit.

### Motivation

This PR adds a known-desirable feature. #14070

### Tips for reviewer

The commits are not totally pure, so to review the intended statement -> plan, plan -> response mapping, please see the sum of all commits.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
