### PR TITLE
ci: Force csv-sources.td to use 1 partition

### DIFF
--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -216,7 +216,7 @@ contains:Decode error: Text: CSV error at record number 2: invalid UTF-8
 
 # Declare a key constraint (PRIMARY KEY NOT ENFORCED)
 
-$ kafka-create-topic topic=static-csv-pkne-sink
+$ kafka-create-topic topic=static-csv-pkne-sink partitions=1
 
 > CREATE SOURCE static_csv_pkne (PRIMARY KEY (zip) NOT ENFORCED)
   FROM S3 CONNECTION s3_conn


### PR DESCRIPTION
Force the static-csv-pkne-sink topic to use 1 partition even when testdrive is run with --kafka-default-partitions 5 . This removes the "topic reports 5 partitions, but expected 1 partitions" error seen in the Nightly CI job.

### Motivation
  * This PR fixes a previously unreported bug.

Nightly CI was failing.