### PR TITLE
persist-maelstrom: Parameterize and add a Nightly CI job

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -42,6 +42,7 @@ steps:
           - { value: checks-oneatatime-restart-environmentd-storaged }
           - { value: checks-oneatatime-kill-storaged }
           - { value: checks-oneatatime-restart-postgres-backend }
+          - { value: persist-maelstrom-long }
           - { value: unused-deps }
         multiple: true
         required: false
@@ -340,6 +341,17 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
+
+  - id: persist-maelstrom-long
+    label: Long Maelstrom coverage of persist
+    timeout_in_minutes: 20
+    agents:
+      queue: linux-x86_64
+    artifact_paths: [test/persist/maelstrom/**/*.log, junit_mzcompose_*.xml]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persist
+          args: [--node-count=4, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
   - id: persistence-failpoints
     label: Persistence failpoints


### PR DESCRIPTION
- parameterize the test/persist/mzcompose.py default workflow
- increase the running time of the per-push CI job to 60 seconds, as we are already incurring significant startup costs anyway.
- add a Nightly 600-second job with increased concurrency
### Motivation

  * This PR adds a feature that has not yet been specified.
I received a request for a Nightly maelstrom job