### PR TITLE
buildkite: More agressive cleanup in the mzcompose plugin

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -51,6 +51,8 @@ fi
 # Docker Compose run, which can leave old containers or volumes around that will
 # interfere with this build.
 echo "--- :docker: Purging containers and volumes from previous builds"
+mzcompose --mz-quiet kill
+mzcompose --mz-quiet rm --force -v
 mzcompose --mz-quiet down --volumes
 
 echo "--- :docker: Rebuilding non-mzbuild containers"


### PR DESCRIPTION
Clean up old containers more aggressively before starting a mzcompose job by using the 3-step cleanup procedure from the 'pre-exit' hook in the 'command' hook as well.

Fixes:
- #14668
- 
 ## Motivation

  * This PR fixes a recognized bug.
A CI flake was reported that seems to be due to incomplete container cleanup from a previous run.