### PR TITLE
nighly: Add CI jobs with REPLICA SIZE '4' and 4 replicas

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -26,10 +26,11 @@ steps:
           - { value: limits }
           - { value: cluster-limits }
           - { value: limits-instance-size }
-          - { value: cluster-testdrive }
           - { value: testdrive-workers-1 }
           - { value: testdrive-workers-32 }
           - { value: testdrive-partitions-5 }
+          - { value: testdrive-replicas-4}
+          - { value: testdrive-replica-size-4}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
           - { value: zippy-kafka-sources }
@@ -182,17 +183,6 @@ steps:
           run: instance-size
     timeout_in_minutes: 50
 
-  - id: cluster-testdrive
-    label: "Full testdrive against Cluster"
-    timeout_in_minutes: 180
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: cluster
-          run: default
-          args: [testdrive/*.td]
-
   - id: testdrive-workers-1
     label: ":racing_car: testdrive with --workers 1"
     timeout_in_minutes: 180
@@ -228,6 +218,28 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-2, --kafka-default-partitions=5]
+
+  - id: testdrive-replicas-4
+    label: ":racing_car: testdrive 4 replicas"
+    timeout_in_minutes: 180
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          args: [--aws-region=us-east-2, --replicas=4]
+
+  - id: testdrive-replica-size-4
+    label: ":racing_car: testdrive replica SIZE 4"
+    timeout_in_minutes: 180
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          args: [--aws-region=us-east-2, --replica-size=4]
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -9,6 +9,9 @@
 
 # Test support for Avro sources without using the Confluent Schema Registry.
 
+$ skip-if
+SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
+
 $ set schema=[
   {
     "type": "array",
@@ -146,6 +149,11 @@ id price
 6 10
 
 # Test that tails report progress messages even without new data
+
+# The ouput of TAIL is dependent on the replica size
+$ skip-if
+SELECT ${arg.replica-size} > 1;
+
 > BEGIN
 
 > DECLARE c CURSOR FOR TAIL data_schema_inline WITH (SNAPSHOT = FALSE, PROGRESS = TRUE);

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -440,6 +440,10 @@ d2
 
 # Check default sources, tables, and views in mz_catalog.
 
+# The sources in the catalog depend on the number of replicas and computeds
+$ skip-if
+SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
+
 > SHOW SOURCES FROM mz_catalog
 name                                          type
 --------------------------------------------------

--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -9,6 +9,10 @@
 
 # Regression test for https://github.com/MaterializeInc/materialize/issues/13790
 
+# The contents of the introspection tables depend on the replica size and number of replicas
+$ skip-if
+SELECT ${arg.replica-size} > 1 OR ${arg.replicas} > 1;
+
 > CREATE TABLE t (a int)
 
 > CREATE MATERIALIZED VIEW mv AS SELECT * FROM t

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -15,6 +15,10 @@
 # Note that we count on the retry behavior of testdrive in this test
 # since introspection sources may take some time to catch up.
 
+# The contents of the introspection tables depend on the replica size and number of replicas
+$ skip-if
+SELECT ${arg.replica-size} > 1 OR ${arg.replicas} > 1;
+
 > CREATE TABLE t (a int)
 
 > CREATE MATERIALIZED VIEW mv AS SELECT * FROM t

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -10,6 +10,10 @@
 # This test only verifies that the log relations are published, not that they
 # have any specific output.
 
+# log sources require a single replica
+$ skip-if
+SELECT ${arg.replicas} > 1
+
 $ set-regex match=s\d+ replacement=SID
 
 > CREATE VIEW count_operates AS SELECT count(*) FROM mz_dataflow_operators;

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -50,6 +50,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         help="set the default number of kafka partitions per topic",
     )
     parser.add_argument(
+        "--replica-size", type=int, default=1, help="use REPLICA SIZE 'N'"
+    )
+
+    parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
+
+    parser.add_argument(
         "files",
         nargs="*",
         default=["*.td"],
@@ -76,9 +82,24 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     with c.override(testdrive):
         c.start_and_wait_for_tcp(services=dependencies)
         c.wait_for_materialized("materialized")
+
+        if args.replicas > 1 or args.replica_size > 1:
+            c.sql("DROP CLUSTER default CASCADE")
+            replica_string = ",".join(
+                f"replica{r} (SIZE '{args.replica_size}')"
+                for r in range(0, args.replicas)
+            )
+            c.sql(f"CREATE CLUSTER default REPLICAS ({replica_string})")
+
         try:
             junit_report = ci_util.junit_report_filename(c.name)
-            c.run("testdrive", f"--junit-report={junit_report}", *args.files)
+            c.run(
+                "testdrive",
+                f"--junit-report={junit_report}",
+                f"--var=replicas={args.replicas}",
+                f"--var=replica-size={args.replica_size}",
+                *args.files,
+            )
         finally:
             ci_util.upload_junit_report(
                 "testdrive", Path(__file__).parent / junit_report

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -43,6 +43,11 @@ count
 # the delta path for t2 won't see the 2000 rows in t2. 100 is used as an arbitrary
 # threshold since the actual number of messages sent depends on the number of
 # workers.
+
+# log sources require a single replica
+$ skip-if
+SELECT ${arg.replicas} > 1
+
 > SELECT
     sum(sent) as sent
   FROM

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -150,5 +150,9 @@ $ kafka-ingest format=avro topic=data partition=15 schema=${schema}
 
 # Make sure that none of the 'EXCEPT ALL' views above has ever produced any records.
 
+# log sources require a single replica
+$ skip-if
+SELECT ${arg.replicas} > 1
+
 > SELECT COUNT(*) FROM mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
 0

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -111,6 +111,11 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 # joining a table with a logging source selects some reasonable timestamp,
 # rather than e.g. blocking forever, or producing an error about being
 # unable to select a timestamp.
+
+# log sources require a single replica
+$ skip-if
+SELECT ${arg.replicas} > 1
+
 > SELECT * FROM t CROSS JOIN mz_dataflow_operators LIMIT 0
 
 > DROP SOURCE data


### PR DESCRIPTION
- parameterize testdrive/mzcompose.py to allow the replica SIZE and number of replicas to be specified
- add Nightly CI jobs that run all tests against multiple replicas and against a replica of SIZE '4'

Relates to #12808

### Motivation

  * This PR adds a known-desirable feature.
- #12808
