### PR TITLE
sql: improve syntax and output of SHOW INDEXES

### DIFF
--- a/doc/user/content/sql/drop-index.md
+++ b/doc/user/content/sql/drop-index.md
@@ -67,11 +67,11 @@ SHOW VIEWS;
 SHOW INDEXES FROM q01;
 ```
 ```nofmt
-+------------------------+--------------------------------+-----
-| View                   | Key_name                       | ...
-|------------------------+--------------------------------+----
-| materialize.public.q01 | materialize.public.q01_geo_idx | ...
-+------------------------+--------------------------------+-----
++--------------------------------+------------------------+-----
+| name                           | on                     | ...
+|--------------------------------+------------------------+----
+| materialize.public.q01_geo_idx | materialize.public.q01 | ...
++--------------------------------+------------------------+-----
 ```
 
 You can use the unqualified index name (`q01_geo_idx`) rather the fully qualified name (`materialize.public.q01_geo_idx`).

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -23,9 +23,9 @@ SHOW INDEXES FROM my_view;
 ```
 
 ```nofmt
- cluster | on_name |  key_name   | seq_in_index | column_name | expression | nullable
----------+---------+-------------+--------------+-------------+------------+----------
- default | t       | my_view_idx | 1            | a           |            | t
+     name    | on  | cluster | key
+-------------+-----+---------+--------------------------------------------
+ my_view_idx | t   | default | {a, b}
 ```
 
 ```sql

--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -24,20 +24,17 @@ _cluster&lowbar;name_ | The cluster to show indexes from. If omitted, indexes fr
 `SHOW INDEX`'s output is a table with the following structure:
 
 ```nofmt
-cluster | on_name | key_name | seq_in_index | column_name | expression | nullable | enabled
---------+---------+----------+--------------+-------------+------------+----------+--------
- ...    | ...     | ...      | ...          | ...         | ...        | ...      | ...
+name | on  | cluster | key
+-----+-----+---------+----
+ ... | ... | ...     | ...
 ```
 
 Field | Meaning
 ------|--------
+**name** | The name of the index.
+**on** | The name of the table, source, or view the index belongs to.
 **cluster** | The name of the [cluster](/overview/key-concepts/#clusters) containing the index.
-**on_name** | The name of the table, source, or view the index belongs to.
-**key_name** | The name of the index.
-**seq_in_index** | The column's position in the index.
-**column_name** | The indexed column.
-**expression** | An expression used to generate the column in the index.
-**null** | Is the column nullable?
+**key** | A text array describing the expressions in the index key.
 
 ## Examples
 
@@ -55,9 +52,9 @@ SHOW VIEWS;
 SHOW INDEXES FROM my_materialized_view;
 ```
 ```nofmt
- on_name | key_name | seq_in_index | column_name | expression | nullable | enabled
----------+----------+--------------+-------------+------------+----------+--------
- ...     | ...      | ...          | ...         | ...        | ...      | ...
+ name | on  | cluster | key
+------+-----+---------+----
+ ...  | ... | ...     | ...
 ```
 
 ## Related pages

--- a/misc/python/materialize/checks/rename_index.py
+++ b/misc/python/materialize/checks/rename_index.py
@@ -52,8 +52,8 @@ class RenameIndex(Check):
             dedent(
                 """
                 > SHOW INDEXES FROM rename_index_table;
-                default rename_index_table rename_index_index2 1 f2 <null> true
-                default rename_index_table rename_index_index3 1 f2 <null> true
+                rename_index_index2 rename_index_table default {f2}
+                rename_index_index3 rename_index_table default {f2}
 
                 > SELECT * FROM rename_index_view1;
                 1

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -81,19 +81,9 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
     );
     assert_eq!(
         client
-            .query("SHOW INDEXES FROM mat", &[])?
-            .into_iter()
-            .map(|row| (
-                row.get("Column_name"),
-                row.get::<_, UInt8>("Seq_in_index").0
-            ))
-            .collect::<Vec<(String, u64)>>(),
-        &[
-            ("a".into(), 1),
-            ("a_data".into(), 2),
-            ("c".into(), 3),
-            ("c_data".into(), 4),
-        ],
+            .query_one("SHOW INDEXES FROM mat", &[])?
+            .get::<_, Vec<String>>("key"),
+        &["a", "a_data", "c", "c_data"],
     );
     assert_eq!(
         client

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -93,18 +93,18 @@ SELECT * FROM v
 ----
 1
 
-query TTTTTTT
+query TTTT
 SHOW INDEXES ON v IN CLUSTER bar;
 ----
-bar v v_primary_idx 1 ?column? NULL false
+v_primary_idx v bar {?column?}
 
 statement ok
 CREATE DEFAULT INDEX foo_v_idx IN CLUSTER foo ON v
 
-query TTTTTTT
+query TTTT
 SHOW INDEXES IN CLUSTER bar;
 ----
-bar  v  v_primary_idx  1  ?column?  NULL  false
+v_primary_idx v bar {?column?}
 
 query TTTTTTT
 SELECT
@@ -178,11 +178,11 @@ bar  mz_worker_materialization_source_frontiers  mz_worker_materialization_sourc
 bar  mz_worker_materialization_source_frontiers  mz_worker_materialization_source_frontiers_4_primary_idx  4  time  NULL  false
 bar  v  v_primary_idx  1  ?column?  NULL  false
 
-query TTTTTTT
+query TTTT
 SHOW INDEXES;
 ----
-bar  v  v_primary_idx  1  ?column?  NULL  false
-foo  v  foo_v_idx  1  ?column?  NULL  false
+foo_v_idx v foo {?column?}
+v_primary_idx v bar {?column?}
 
 query T
 SELECT
@@ -225,11 +225,11 @@ v_primary_idx
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER bar ON v
 
-query TTTTTTT
+query TTTT
 SHOW INDEXES ON v IN CLUSTER bar;
 ----
-bar v v_primary_idx 1 ?column? NULL false
-bar v v_primary_idx1 1 ?column? NULL false
+v_primary_idx v bar {?column?}
+v_primary_idx1 v bar {?column?}
 
 statement error unknown cluster 'noexist'
 CREATE DEFAULT INDEX IN CLUSTER noexist ON v
@@ -247,11 +247,11 @@ DROP CLUSTER baz
 statement error cannot drop cluster with active indexes or materialized views
 DROP CLUSTER bar
 
-query TTTTTTT
-SHOW INDEXES IN CLUSTER bar WHERE on_name = 'v';
+query TTTT
+SHOW INDEXES IN CLUSTER bar WHERE on = 'v';
 ----
-bar v v_primary_idx 1 ?column? NULL false
-bar v v_primary_idx1 1 ?column? NULL false
+v_primary_idx v bar {?column?}
+v_primary_idx1 v bar {?column?}
 
 statement ok
 DROP INDEX v_primary_idx

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -331,11 +331,11 @@ t
 statement ok
 CREATE DEFAULT INDEX ON mv
 
-query TTTITTT colnames
+query TTTT colnames
 SHOW INDEXES ON mv
 ----
-cluster on_name key_name       seq_in_index column_name expression nullable
-default mv      mv_primary_idx 1            ?column?    NULL       false
+name            on  cluster key
+mv_primary_idx  mv  default {?column?}
 
 
 # Test: Creating materialized views that depend on log sources is forbidden.

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -144,14 +144,14 @@ contains:catalog item 'materialize.public.i1' is an index and so cannot be depen
 > CREATE INDEX i2 ON v2a(x*2);
 
 > SHOW INDEXES FROM v2a;
-cluster        on_name   key_name         seq_in_index column_name expression  nullable
+name    on  cluster         key
 ---------------------------------------------------------------------------------------
-<CLUSTER_NAME> v2a       i2               1            <null>      "x * 2"     false
+i2      v2a <CLUSTER_NAME>  {"x * 2"}
 
 > SHOW INDEXES FROM v2;
-cluster        on_name  key_name        seq_in_index column_name expression nullable
+name    on  cluster         key
 ------------------------------------------------------------------------------------
-<CLUSTER_NAME> v2       i1              1            x           <null>     false
+i1      v2  <CLUSTER_NAME>  {x}
 
 # Test that dependent indexes do not prevent view deletion when restrict is specified
 # but do not cause deletion of dependent views
@@ -161,9 +161,9 @@ cluster        on_name  key_name        seq_in_index column_name expression null
 contains:unknown catalog item 'v2a'
 
 > SHOW INDEXES FROM v2;
-cluster on_name  key_name        seq_in_index   column_name expression nullable
+name    on  cluster         key
 -----------------------------------------------------------------------------------
-<CLUSTER_NAME> v2       i1              1              x           <null>     false
+i1      v2  <CLUSTER_NAME>  {x}
 
 ! DROP INDEX i2;
 contains:unknown catalog item 'i2'
@@ -175,16 +175,16 @@ contains:unknown catalog item 'i2'
 > CREATE INDEX i3 ON v4a(y);
 
 > SHOW INDEXES FROM v4a;
-cluster on_name  key_name         seq_in_index   column_name expression nullable
+name    on  cluster         key
 ------------------------------------------------------------------------------------
-<CLUSTER_NAME> v4a      i3               1              y           <null>     false
+i3      v4a <CLUSTER_NAME>  {y}
 
 > CREATE INDEX i4 ON v4(x);
 
 > SHOW INDEXES FROM v4;
-cluster on_name  key_name        seq_in_index  column_name expression nullable
+name    on  cluster         key
 ----------------------------------------------------------------------------------
-<CLUSTER_NAME> v4       i4              1             x           <null>     false
+i4      v4  <CLUSTER_NAME>  {x}
 
 # Test cascade deletes associated indexes as well
 > DROP VIEW v4a CASCADE;
@@ -196,32 +196,25 @@ contains:unknown catalog item 'v4a'
 contains:unknown catalog item 'i3'
 
 > SHOW INDEXES FROM v4;
-cluster on_name  key_name        seq_in_index  column_name expression nullable
+name    on  cluster         key
 ----------------------------------------------------------------------------------
-<CLUSTER_NAME> v4       i4              1             x           <null>     false
+i4      v4  <CLUSTER_NAME>  {x}
 
 > CREATE VIEW v5 AS SELECT substr(y, 3, 2) as substr from v4;
 
 > CREATE INDEX i5 ON v5(substr);
 
 > SHOW INDEXES FROM v5;
-cluster on_name   key_name        seq_in_index  column_name expression nullable
+name    on  cluster         key
 ----------------------------------------------------------------------------------
-<CLUSTER_NAME> v5        i5              1             substr      <null>     true
+i5      v5  <CLUSTER_NAME>  {substr}
 
 > CREATE VIEW multicol AS SELECT 'a' AS a, 'b' AS b, 'c' AS c, 'd' AS d
 > CREATE INDEX i6 ON multicol (2, a, 4)
 > SHOW INDEXES FROM multicol
-cluster on_name   key_name  seq_in_index column_name  expression   nullable
+name    on          cluster         key
 -------------------------------------------------------------------------------
-<CLUSTER_NAME> multicol  i6        1            b            <null>       false
-<CLUSTER_NAME> multicol  i6        2            a            <null>       false
-<CLUSTER_NAME> multicol  i6        3            d            <null>       false
-
-> SHOW INDEXES FROM multicol WHERE column_name = 'a'
-cluster on_name   key_name  seq_in_index column_name  expression   nullable
--------------------------------------------------------------------------------
-<CLUSTER_NAME> multicol  i6        2            a            <null>       false
+i6      multicol    <CLUSTER_NAME>  {b, a, d}
 
 # Test cascade deletes all indexes associated with cascaded views
 > DROP VIEW v4 CASCADE;
@@ -254,9 +247,9 @@ contains:unknown catalog item 'i4'
 > CREATE INDEX j1 on s3(ascii(y))
 
 > SHOW INDEXES FROM s3;
-cluster on_name  key_name        seq_in_index  column_name expression             nullable
+name    on  cluster         key
 ----------------------------------------------------------------------------------------------
-<CLUSTER_NAME> s3       j1              1             <null>      "pg_catalog.ascii(y)"  false
+j1      s3  <CLUSTER_NAME>  {"pg_catalog.ascii(y)"}
 
 > DROP SOURCE s3;
 
@@ -279,14 +272,14 @@ contains:unknown catalog item 'j1'
 > CREATE INDEX j3 on w(z);
 
 > SHOW INDEXES FROM s4;
-cluster on_name  key_name        seq_in_index   column_name expression  nullable
+name    on  cluster         key
 ------------------------------------------------------------------------------------
-<CLUSTER_NAME> s4       j2              1               <null>      "x + 2"    false
+j2      s4  <CLUSTER_NAME>  {"x + 2"}
 
 > SHOW INDEXES FROM w;
-cluster on_name  key_name   seq_in_index  column_name expression nullable
+name    on          cluster         key
 -----------------------------------------------------------------------------
-<CLUSTER_NAME> w        j3         1             z           <null>     false
+j3      w           <CLUSTER_NAME>  {z}
 
 > DROP SOURCE s4 CASCADE;
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -214,7 +214,7 @@ i5      v5  <CLUSTER_NAME>  {substr}
 > SHOW INDEXES FROM multicol
 name    on          cluster         key
 -------------------------------------------------------------------------------
-i6      multicol    <CLUSTER_NAME>  {b, a, d}
+i6      multicol    <CLUSTER_NAME>  {b,a,d}
 
 # Test cascade deletes all indexes associated with cascaded views
 > DROP VIEW v4 CASCADE;
@@ -249,7 +249,7 @@ contains:unknown catalog item 'i4'
 > SHOW INDEXES FROM s3;
 name    on  cluster         key
 ----------------------------------------------------------------------------------------------
-j1      s3  <CLUSTER_NAME>  {"pg_catalog.ascii(y)"}
+j1      s3  <CLUSTER_NAME>  "{pg_catalog.ascii(y)}"
 
 > DROP SOURCE s3;
 
@@ -274,7 +274,7 @@ contains:unknown catalog item 'j1'
 > SHOW INDEXES FROM s4;
 name    on  cluster         key
 ------------------------------------------------------------------------------------
-j2      s4  <CLUSTER_NAME>  "{x * 2}"
+j2      s4  <CLUSTER_NAME>  "{x + 2}"
 
 > SHOW INDEXES FROM w;
 name    on          cluster         key

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -146,7 +146,7 @@ contains:catalog item 'materialize.public.i1' is an index and so cannot be depen
 > SHOW INDEXES FROM v2a;
 name    on  cluster         key
 ---------------------------------------------------------------------------------------
-i2      v2a <CLUSTER_NAME>  {"x * 2"}
+i2      v2a <CLUSTER_NAME>  "{x * 2}"
 
 > SHOW INDEXES FROM v2;
 name    on  cluster         key
@@ -274,7 +274,7 @@ contains:unknown catalog item 'j1'
 > SHOW INDEXES FROM s4;
 name    on  cluster         key
 ------------------------------------------------------------------------------------
-j2      s4  <CLUSTER_NAME>  {"x + 2"}
+j2      s4  <CLUSTER_NAME>  "{x * 2}"
 
 > SHOW INDEXES FROM w;
 name    on          cluster         key

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -129,7 +129,7 @@ data_view_a_idx data_view   <VARIABLE_OUTPUT>   {a}
 name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
 data_view_b_a_idx       data_view   <VARIABLE_OUTPUT>   {b,a}
-data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   {"b - a", a}
+data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 
 > DROP INDEX data_view_b_a_idx
 > DROP INDEX data_view_expr_a_idx
@@ -141,7 +141,7 @@ data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   {"b - a", a}
 cluster on_name    key_name    seq_in_index  column_name  expression  nullable
 name        on          cluster             key
 ---------------------------------------------------------------------------------------------
-named_idx   data_view   <VARIABLE_OUTPUT>   {"b - a", a}
+named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 
 > DROP INDEX named_idx
 
@@ -152,7 +152,7 @@ named_idx   data_view   <VARIABLE_OUTPUT>   {"b - a", a}
 > SHOW INDEXES FROM data_view
 name                    on          cluster             key
 ------------------------------------------------------------------------------------------------------
-data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {"b - a", a}
+data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 
 > SHOW CREATE INDEX data_view_primary_idx
 Index                                    "Create Index"
@@ -169,11 +169,11 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE INDEX ON foo (substr(z, 3))
 > SHOW INDEXES FROM foo
 foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
-foo_expr_idx    foo <VARIABLE_OUTPUT>   {"a + b"}
+foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
 foo_expr_idx1   foo <VARIABLE_OUTPUT>   {"pg_catalog.substr(z, 3)"}
 > SHOW INDEXES FROM foo WHERE Column_name = 'noexist'
 > SHOW INDEXES FROM foo WHERE name = 'foo_expr_idx'
-foo_expr_idx    foo <VARIABLE_OUTPUT>   {"a + b"}
+foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
 # TODO(justin): not handled in parser yet:
 #   SHOW INDEXES FROM v LIKE '%v'
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -138,7 +138,6 @@ data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 > CREATE INDEX named_idx ON data_view (b - a, a)
 
 > SHOW INDEXES FROM data_view
-cluster on_name    key_name    seq_in_index  column_name  expression  nullable
 name        on          cluster             key
 ---------------------------------------------------------------------------------------------
 named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
@@ -170,8 +169,8 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > SHOW INDEXES FROM foo
 foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
 foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
-foo_expr_idx1   foo <VARIABLE_OUTPUT>   {"pg_catalog.substr(z, 3)"}
-> SHOW INDEXES FROM foo WHERE Column_name = 'noexist'
+foo_expr_idx1   foo <VARIABLE_OUTPUT>   "{pg_catalog.substr(z, 3)}"
+> SHOW INDEXES FROM foo WHERE name = 'noexist'
 > SHOW INDEXES FROM foo WHERE name = 'foo_expr_idx'
 foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
 # TODO(justin): not handled in parser yet:

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -28,17 +28,16 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
   FORMAT AVRO USING SCHEMA '${writer-schema}'
 
 > SHOW INDEXES FROM data
-cluster on_name  key_name  seq_in_index  column_name  expression  nullable
+name    on  cluster key
 --------------------------------------------------------------------------
 
 # Sources can have default indexes added
 > CREATE DEFAULT INDEX ON data
 
 > SHOW INDEXES FROM data
-cluster           on_name  key_name          seq_in_index column_name  expression  nullable
+name                on      cluster             key
 -------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data     data_primary_idx  1            a            <null>      false
-<VARIABLE_OUTPUT> data     data_primary_idx  2            b            <null>      false
+data_primary_idx    data    <VARIABLE_OUTPUT>   {a,b}
 
 > SELECT index_position FROM mz_index_columns WHERE index_id LIKE '%u%'
 index_position
@@ -56,62 +55,58 @@ position         name
 > CREATE VIEW data_view as SELECT * from data
 
 > SHOW INDEXES FROM data_view
-cluster on_name  key_name  seq_in_index  column_name  expression  nullable
+name    on  cluster key
 --------------------------------------------------------------------------
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
 
 > SHOW INDEXES FROM data_view
-cluster           on_name    key_name               seq_in_index  column_name  expression  nullable
+name                    on          cluster             key
 ---------------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  1             a            <null>      false
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  2             b            <null>      false
+data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 
 # Materialized views do not have indexes automatically created
 > CREATE MATERIALIZED VIEW matv AS
   SELECT b, sum(a) FROM data GROUP BY b
 
 > SHOW INDEXES FROM matv
-cluster on_name  key_name  seq_in_index  column_name  expression  nullable
+name    on  cluster key
 --------------------------------------------------------------------------
 
 # Materialized views can have default indexes added
 > CREATE DEFAULT INDEX ON matv
 
 > SHOW INDEXES FROM matv
-cluster           on_name   key_name          seq_in_index column_name  expression  nullable
+name                on      cluster             key
 --------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> matv      matv_primary_idx  1            b            <null>      false
+matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
 
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-cluster on_name    key_name               seq_in_index  column_name  expression  nullable
+name                    on          cluster             key
 -------------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  1             a            <null>      false
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  2             b            <null>      false
+data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
 
 > SHOW INDEXES FROM matv
-cluster on_name  key_name           seq_in_index  column_name  expression  nullable
+name                on      cluster             key
 ------------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> matv     matv_primary_idx   1             b            <null>      false
-<VARIABLE_OUTPUT> matv     matv_primary_idx1  1             b            <null>      false
+matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
+matv_primary_idx1   matv    <VARIABLE_OUTPUT>   {b}
 
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
 
 > SHOW INDEXES FROM data_view
-cluster on_name    key_name               seq_in_index  column_name  expression  nullable
+name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  1             a            <null>      false
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx  2             b            <null>      false
-<VARIABLE_OUTPUT> data_view  named_idx              1             a            <null>      false
-<VARIABLE_OUTPUT> data_view  named_idx              2             b            <null>      false
+data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
+named_idx               data_view   <VARIABLE_OUTPUT>   {a,b}
 
 > DROP INDEX data_view_primary_idx
 > DROP INDEX named_idx
@@ -120,9 +115,9 @@ cluster on_name    key_name               seq_in_index  column_name  expression 
 > CREATE INDEX ON data_view(a)
 
 > SHOW INDEXES FROM data_view
-cluster on_name    key_name           seq_in_index  column_name  expression  nullable
+name            on          cluster             key
 -------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  data_view_a_idx    1             a            <null>      false
+data_view_a_idx data_view   <VARIABLE_OUTPUT>   {a}
 
 > DROP INDEX data_view_a_idx
 
@@ -131,12 +126,10 @@ cluster on_name    key_name           seq_in_index  column_name  expression  nul
 > CREATE INDEX ON data_view(b - a, a)
 
 > SHOW INDEXES FROM data_view
-cluster on_name    key_name               seq_in_index  column_name  expression  nullable
+name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  data_view_b_a_idx      2             a            <null>      false
-<VARIABLE_OUTPUT> data_view  data_view_b_a_idx      1             b            <null>      false
-<VARIABLE_OUTPUT> data_view  data_view_expr_a_idx   1             <null>       "b - a"     false
-<VARIABLE_OUTPUT> data_view  data_view_expr_a_idx   2             a            <null>      false
+data_view_b_a_idx       data_view   <VARIABLE_OUTPUT>   {b,a}
+data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   {"b - a", a}
 
 > DROP INDEX data_view_b_a_idx
 > DROP INDEX data_view_expr_a_idx
@@ -146,9 +139,9 @@ cluster on_name    key_name               seq_in_index  column_name  expression 
 
 > SHOW INDEXES FROM data_view
 cluster on_name    key_name    seq_in_index  column_name  expression  nullable
+name        on          cluster             key
 ---------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  named_idx   1             <null>       "b - a"     false
-<VARIABLE_OUTPUT> data_view  named_idx   2             a            <null>      false
+named_idx   data_view   <VARIABLE_OUTPUT>   {"b - a", a}
 
 > DROP INDEX named_idx
 
@@ -157,10 +150,9 @@ cluster on_name    key_name    seq_in_index  column_name  expression  nullable
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
 
 > SHOW INDEXES FROM data_view
-cluster on_name    key_name                seq_in_index  column_name  expression  nullable
+name                    on          cluster             key
 ------------------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx   1             <null>       "b - a"     false
-<VARIABLE_OUTPUT> data_view  data_view_primary_idx   2             a            <null>      false
+data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {"b - a", a}
 
 > SHOW CREATE INDEX data_view_primary_idx
 Index                                    "Create Index"
@@ -176,16 +168,12 @@ materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\"
 > CREATE INDEX ON foo (a + b)
 > CREATE INDEX ON foo (substr(z, 3))
 > SHOW INDEXES FROM foo
-<VARIABLE_OUTPUT> foo  foo_primary_idx   1  a       <null>                     false
-<VARIABLE_OUTPUT> foo  foo_primary_idx   2  b       <null>                     true
-<VARIABLE_OUTPUT> foo  foo_primary_idx   3  z       <null>                     true
-<VARIABLE_OUTPUT> foo  foo_expr_idx      1  <null>  "a + b"                    true
-<VARIABLE_OUTPUT> foo  foo_expr_idx1     1  <null>  "pg_catalog.substr(z, 3)"  true
-> SHOW INDEXES FROM foo WHERE Column_name = 'b'
-<VARIABLE_OUTPUT> foo  foo_primary_idx   2  b       <null>          true
+foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
+foo_expr_idx    foo <VARIABLE_OUTPUT>   {"a + b"}
+foo_expr_idx1   foo <VARIABLE_OUTPUT>   {"pg_catalog.substr(z, 3)"}
 > SHOW INDEXES FROM foo WHERE Column_name = 'noexist'
-> SHOW INDEXES FROM foo WHERE Key_name = 'foo_expr_idx'
-<VARIABLE_OUTPUT> foo  foo_expr_idx      1  <null>  "a + b"         true
+> SHOW INDEXES FROM foo WHERE name = 'foo_expr_idx'
+foo_expr_idx    foo <VARIABLE_OUTPUT>   {"a + b"}
 # TODO(justin): not handled in parser yet:
 #   SHOW INDEXES FROM v LIKE '%v'
 
@@ -197,7 +185,5 @@ contains:cannot show indexes on materialize.public.foo_primary_idx because it is
 
 > CREATE CLUSTER clstr REPLICAS (r1 (REMOTE ['localhost:1234']))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
-> SHOW INDEXES IN CLUSTER clstr WHERE on_name = 'foo'
-clstr foo  foo_primary_idx1   1  a       <null>                     false
-clstr foo  foo_primary_idx1   2  b       <null>                     true
-clstr foo  foo_primary_idx1   3  z       <null>                     true
+> SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
+foo_primary_idx1    foo clstr   {a,b,z}

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -46,10 +46,9 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
 > CREATE DEFAULT INDEX ON mz_view
 
 > SHOW INDEXES FROM mz_view
-cluster on_name  key_name             seq_in_index  column_name  expression  nullable
+name                on          cluster             key
 --------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> mz_view  mz_view_primary_idx  1             a            <null>      false
-<VARIABLE_OUTPUT> mz_view  mz_view_primary_idx  2             b            <null>      false
+mz_view_primary_idx mz_view     <VARIABLE_OUTPUT>   {a,b}
 
 > CREATE VIEW dependent_view AS
     SELECT * FROM mz_view;
@@ -183,10 +182,9 @@ materialize.public.renamed_mz_view  "CREATE VIEW \"materialize\".\"public\".\"re
 
 # Item's indexes are properly re-attributed
 > SHOW INDEXES FROM renamed_mz_view
-cluster on_name          key_name       seq_in_index  column_name expression nullable
+name            on              cluster             key
 --------------------------------------------------------------------------------------------
-<VARIABLE_OUTPUT> renamed_mz_view  renamed_index  1             a           <null>     false
-<VARIABLE_OUTPUT> renamed_mz_view  renamed_index  2             b           <null>     false
+renamed_index   renamed_mz_view <VARIABLE_OUTPUT>   {a,b}
 
 > SHOW CREATE INDEX renamed_index
 Index               "Create Index"

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -59,10 +59,9 @@ name    type
 > CREATE DEFAULT INDEX on t
 
 > SHOW INDEXES FROM t
-cluster on_name  key_name       seq_in_index  column_name  expression  nullable
+name            on          cluster         key
 -----------------------------------------------------------------------------------
-<CLUSTER_NAME> t        t_primary_idx  1             a            <null>      true
-<CLUSTER_NAME> t        t_primary_idx  2             b            <null>      false
+t_primary_idx   t           <CLUSTER_NAME>  {a,b}
 
 > DROP INDEX t_primary_idx
 

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -113,9 +113,9 @@ contains:catalog item 'temp_t' already exists
 #
 # > SHOW INDEXES FROM temp_t
 #  on_name    key_name            seq_in_index  column_name  expression  nullable
+#  name                 on          cluster         key
 # --------------------------------------------------------------------------------
-#  temp_t     temp_t_primary_idx  1             a            <null>      true
-#  temp_t     temp_t_primary_idx  2             b            <null>      false
+#  temp_t_primary_idx   d           default         {a, b}
 
 > DROP TABLE temp_t
 


### PR DESCRIPTION
This commit updates the output of SHOW INDEXES to contain the following columns:
  * name: the name of the index.
  * on: the name of the relation upon which the index is built.
  * cluster: the name of the cluster in which the index is maintained.
  * key: a text array describing the expressions in the index key. Each expression is usually a simple column reference.

This format is more clear for users.

Fixes #12700

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Changes the output of `SHOW INDEXES`