### PR TITLE
storage: in reclock operator, heartbeat handle to hold back the remap since

### DIFF
--- a/test/cluster/pg-snapshot-resumption/03-while-storaged-down.td
+++ b/test/cluster/pg-snapshot-resumption/03-while-storaged-down.td
@@ -11,6 +11,9 @@
 # In strict serializable mode we may select a timestamp that is ahead of on of the table's upper and hang forever.
 > SET transaction_isolation = serializable
 
+# Increased from the default because of CI flakiness.
+$ set-sql-timeout duration=180s
+
 > SELECT COUNT(*) FROM t1;
 0
 

--- a/test/cluster/storaged/02-after-environmentd-restart.td
+++ b/test/cluster/storaged/02-after-environmentd-restart.td
@@ -10,6 +10,9 @@
 # Verify that the data ingested before `environmentd` was killed is still
 # present, then try ingesting more data.
 
+# Increased from the default because of CI flakiness.
+$ set-sql-timeout duration=180s
+
 > SELECT * from remote1
 one
 > SELECT * from remote2


### PR DESCRIPTION
Before, we never interacted with the handle that is meant to hold back the since, meaning it could be expired. Now, we make sure to heartbeat the handle whenever we interact with the other handle that we have (inside a listen).

Fixes #14740

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
