### PR TITLE
storage: make the source reader operator async

### DIFF
--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -82,18 +82,12 @@ impl KinesisMetrics {
 
 #[derive(Clone, Debug)]
 pub(super) struct SourceSpecificMetrics {
-    pub(super) operator_scheduled_counter: IntCounterVec,
     pub(super) capability: UIntGaugeVec,
 }
 
 impl SourceSpecificMetrics {
     fn register_with(registry: &MetricsRegistry) -> Self {
         Self {
-            operator_scheduled_counter: registry.register(metric!(
-                name: "mz_operator_scheduled_total",
-                help: "The number of times the kafka client got invoked for this source",
-                var_labels: ["topic", "source_id", "worker_id"],
-            )),
             capability: registry.register(metric!(
                 name: "mz_capability",
                 help: "The current capability for this dataflow. This corresponds to min(mz_partition_closed_ts)",

--- a/src/storage/src/source/persist_source.rs
+++ b/src/storage/src/source/persist_source.rs
@@ -205,14 +205,13 @@ where
     let (inner, token) = crate::source::util::source(
         scope,
         format!("persist_source {}: part distribution", source_id),
-        None,
         move |info| {
             let waker_activator = Arc::new(scope.sync_activator_for(&info.address[..]));
             let waker = futures::task::waker(waker_activator);
 
             let mut current_ts = timely::progress::Timestamp::minimum();
 
-            move |cap_set, output, _optional_input| {
+            move |cap_set, output| {
                 let mut context = Context::from_waker(&waker);
 
                 while let Poll::Ready(item) = pinned_stream.as_mut().poll_next(&mut context) {

--- a/src/storage/src/source/util.rs
+++ b/src/storage/src/source/util.rs
@@ -7,23 +7,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::future::Future;
 use std::rc::Rc;
 
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::channels::pushers::Tee;
+use timely::dataflow::channels::pushers::{Tee, TeeCore};
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
-use timely::dataflow::operators::generic::{OperatorInfo, OutputHandle};
+use timely::dataflow::operators::generic::{OperatorInfo, OutputHandle, OutputWrapper};
 use timely::dataflow::operators::CapabilitySet;
 use timely::dataflow::{Scope, Stream};
-use timely::progress::frontier::MutableAntichain;
 use timely::progress::Antichain;
 use timely::scheduling::ActivateOnDrop;
 use timely::Data;
 
 use mz_ore::collections::CollectionExt;
 use mz_repr::Timestamp;
+use mz_timely_util::builder_async::{AsyncInputHandle, OperatorBuilder as AsyncOperatorBuilder};
 
-use crate::source::types::SourceToken;
+use crate::source::types::{AsyncSourceToken, SourceToken};
 
 /// Constructs a source named `name` in `scope` whose lifetime is controlled
 /// both internally and externally.
@@ -52,20 +53,7 @@ use crate::source::types::SourceToken;
 ///
 /// When the source token is dropped, the timestamping_flag is set to false
 /// to terminate any spawned threads in the source operator
-///
-/// `input` is an OPTIONAL input stream. If `Some`, then the logic constructor
-/// will get the input's _frontier_ only (inside a `Some`), as the third
-/// argument. Otherwise, the operator just gets `None`. Inspection of the
-/// data of this input remains unimplemented. Note that this input also
-/// does not effect the progress tracking of the `source` operator.
-//
-// TODO(guswynn): refactor this to clean up its various callsites
-pub fn source<G, D, B, L>(
-    scope: &G,
-    name: String,
-    input: Option<Stream<G, ()>>,
-    construct: B,
-) -> (Stream<G, D>, SourceToken)
+pub fn source<G, D, B, L>(scope: &G, name: String, construct: B) -> (Stream<G, D>, SourceToken)
 where
     G: Scope<Timestamp = Timestamp>,
     D: Data,
@@ -73,7 +61,6 @@ where
     L: FnMut(
             &mut CapabilitySet<Timestamp>,
             &mut OutputHandle<G::Timestamp, D, Tee<G::Timestamp, D>>,
-            Option<&MutableAntichain<Timestamp>>,
         ) -> ()
         + 'static,
 {
@@ -84,16 +71,6 @@ where
 
     let (mut data_output, data_stream) = builder.new_output();
     builder.set_notify(false);
-
-    let input = input.map(|input| {
-        builder.new_input_connection(
-            &input,
-            Pipeline,
-            // As documented, the optional input does not
-            // participate in progress tracking.
-            vec![Antichain::new()],
-        )
-    });
 
     builder.build(|capabilities| {
         let cap_set = CapabilitySet::from_elem(capabilities.into_element());
@@ -113,7 +90,7 @@ where
         let tick = construct(operator_info);
         let mut cap_and_tick = Some((cap_set, tick));
 
-        move |frontier| {
+        move |_| {
             // Drop all capabilities if `token` is dropped.
             if drop_activator_weak.upgrade().is_none() {
                 // Drop the tick closure, too, in case dropping anything it owns
@@ -127,11 +104,7 @@ where
             if let Some((cap, tick)) = &mut cap_and_tick {
                 // We still have our capability, so the source is still alive.
                 // Delegate to the inner source.
-                tick(
-                    cap,
-                    &mut data_output.activate(),
-                    input.as_ref().map(|_| &frontier[0]),
-                );
+                tick(cap, &mut data_output.activate());
                 if cap.is_empty() {
                     // The inner source is finished. Drop our capability.
                     cap_and_tick = None;
@@ -143,4 +116,73 @@ where
     // `build()` promises to call the provided closure before returning,
     // so we are guaranteed that `token` is non-None.
     (data_stream, token.unwrap())
+}
+
+/// Effectively the same as `source`, but the core logic expects a
+/// never-ending future, not a tick closure. Additionally, this
+/// operator also contains an input, primarily to inspect the
+/// frontier of an upstream operator.
+///
+/// Note that this means the input and capabilities are communicated
+/// to the future by value, not by &mut reference.
+///
+/// Returns an `AsyncSourceToken`, which, upon drop, will cause the
+/// shutdown of the operator.
+pub fn async_source<G, D, B, L>(
+    scope: &G,
+    name: String,
+    input: &Stream<G, ()>,
+    construct: B,
+) -> (Stream<G, D>, AsyncSourceToken)
+where
+    G: Scope<Timestamp = Timestamp>,
+    D: Data,
+    B: FnOnce(
+        OperatorInfo,
+        CapabilitySet<Timestamp>,
+        AsyncInputHandle<
+            Timestamp,
+            Vec<()>,
+            <Pipeline as timely::dataflow::channels::pact::ParallelizationContractCore<
+                G::Timestamp,
+                Vec<()>,
+            >>::Puller,
+        >,
+        OutputWrapper<G::Timestamp, Vec<D>, TeeCore<G::Timestamp, Vec<D>>>,
+    ) -> L,
+    L: Future + 'static,
+{
+    let mut builder = AsyncOperatorBuilder::new(name, scope.clone());
+    let operator_info = builder.operator_info();
+
+    let (data_output, data_stream) = builder.new_output();
+
+    let remap_input = builder.new_input_connection(
+        &input,
+        Pipeline,
+        // As documented, the optional input does not
+        // participate in progress tracking.
+        vec![Antichain::new()],
+    );
+
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+    let token = AsyncSourceToken {
+        _drop_closes_the_oneshot: tx,
+    };
+
+    builder.build(|capabilities| {
+        let cap_set = CapabilitySet::from_elem(capabilities.into_element());
+
+        let tick = construct(operator_info, cap_set, remap_input, data_output);
+        async move {
+            tokio::pin!(tick);
+            tokio::select! {
+                biased;
+                _ = &mut rx => {},
+                _ = &mut tick => {},
+            }
+        }
+    });
+
+    (data_stream, token)
 }

--- a/src/timely-util/src/builder_async.rs
+++ b/src/timely-util/src/builder_async.rs
@@ -326,11 +326,11 @@ impl<G: Scope> OperatorBuilder<G> {
                     if operator_waker.task_ready.load(Ordering::SeqCst) {
                         let waker = futures_util::task::waker_ref(&operator_waker);
                         let mut cx = Context::from_waker(&waker);
+                        operator_waker.task_ready.store(false, Ordering::SeqCst);
                         if Pin::new(fut).poll(&mut cx).is_ready() {
                             // We're done with logic so deallocate the task
                             logic_fut = None;
                         }
-                        operator_waker.task_ready.store(false, Ordering::SeqCst);
                     }
                 }
                 // The timely operator needs to be kept alive if the task is pending


### PR DESCRIPTION
A straightforward translation. I removed some stats that make no sense, fixed a bug in the async timely operator, and also
left the 10ms forced yield (even though its likely not necessary anymore).

### Motivation

   * This PR refactors existing code.



### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

