### PR TITLE
persist: clean up datadriven tests

### DIFF
--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -1,0 +1,199 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Common abstractions for persist datadriven tests.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use differential_dataflow::trace::Description;
+use timely::progress::Antichain;
+use tokio::sync::Mutex;
+
+use crate::internal::paths::PartialBatchKey;
+use crate::internal::state::{HollowBatch, HollowBatchPart};
+
+/// A [datadriven::TestCase] wrapper with helpers for parsing.
+pub struct DirectiveArgs<'a> {
+    pub args: &'a HashMap<String, Vec<String>>,
+    pub input: &'a str,
+}
+
+impl<'a> DirectiveArgs<'a> {
+    pub fn optional_str(&self, name: &str) -> Option<&'a str> {
+        self.args.get(name).map(|vals| {
+            if vals.len() != 1 {
+                panic!("unexpected values for {}: {:?}", name, vals);
+            }
+            vals[0].as_ref()
+        })
+    }
+
+    pub fn optional<T: FromStr>(&self, name: &str) -> Option<T> {
+        self.optional_str(name).map(|x| {
+            x.parse::<T>()
+                .unwrap_or_else(|_| panic!("invalid {}: {}", name, x))
+        })
+    }
+
+    pub fn expect_str(&self, name: &str) -> &str {
+        self.optional_str(name)
+            .unwrap_or_else(|| panic!("missing {}", name))
+    }
+
+    pub fn expect<T: FromStr>(&self, name: &str) -> T {
+        self.optional(name)
+            .unwrap_or_else(|| panic!("missing {}", name))
+    }
+
+    pub fn parse_update(x: &str) -> Option<((String, ()), u64, i64)> {
+        let x = x.trim();
+        if x.is_empty() {
+            return None;
+        }
+        let parts = x.split(' ').collect::<Vec<_>>();
+        if parts.len() != 3 {
+            panic!("unexpected update: {}", x);
+        }
+        let (key, ts, diff) = (parts[0], parts[1], parts[2]);
+        let ts = ts.parse::<u64>().expect("invalid ts");
+        let diff = diff.parse::<i64>().expect("invalid diff");
+        Some(((key.to_owned(), ()), ts, diff))
+    }
+
+    pub fn parse_hollow_batch(x: &str) -> HollowBatch<u64> {
+        let parts = x.trim().split(' ').collect::<Vec<_>>();
+        assert!(
+            parts.len() >= 2,
+            "usage: [<lower>][<upper>][<since>] <len> <key0> <key1> ... <keyN>"
+        );
+        let (desc, len, keys) = (parts[0], parts[1], &parts[2..]);
+        let desc = Self::parse_desc(desc);
+        let len = len.parse().expect("invalid len");
+        HollowBatch {
+            desc,
+            len,
+            parts: keys
+                .iter()
+                .map(|x| HollowBatchPart {
+                    key: PartialBatchKey((*x).to_owned()),
+                    encoded_size_bytes: 0,
+                })
+                .collect(),
+            runs: vec![],
+        }
+    }
+
+    pub fn parse_desc(x: &str) -> Description<u64> {
+        let parts = x
+            .strip_prefix('[')
+            .expect("usage: [<lower>][<upper>][<since>]")
+            .strip_suffix(']')
+            .expect("usage: [<lower>][<upper>][<since>]")
+            .split("][")
+            .collect::<Vec<_>>();
+        assert!(parts.len() == 3, "usage: [<lower>][<upper>][<since>]");
+        let lower = parts[0].parse().expect("invalid lower");
+        let upper = parts[1].parse().expect("invalid upper");
+        let since = parts[2].parse().expect("invalid since");
+        Description::new(
+            Antichain::from_elem(lower),
+            Antichain::from_elem(upper),
+            Antichain::from_elem(since),
+        )
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace() {
+        use crate::internal::trace::datadriven as trace_dd;
+
+        datadriven::walk("tests/trace", |f| {
+            let mut state = trace_dd::TraceState::default();
+            f.run(move |tc| -> String {
+                let args = DirectiveArgs {
+                    args: &tc.args,
+                    input: &tc.input,
+                };
+                let res = match tc.directive.as_str() {
+                    "apply-merge-res" => trace_dd::apply_merge_res(&mut state, args),
+                    "downgrade-since" => trace_dd::downgrade_since(&mut state, args),
+                    "push-batch" => trace_dd::insert(&mut state, args),
+                    "since-upper" => trace_dd::since_upper(&mut state, args),
+                    "spine-batches" => trace_dd::batches(&mut state, args),
+                    "take-merge-reqs" => trace_dd::take_merge_req(&mut state, args),
+                    _ => panic!("unknown directive {:?}", tc),
+                };
+                match res {
+                    Ok(x) if x.is_empty() => "<empty>\n".into(),
+                    Ok(x) => x,
+                    Err(err) => format!("error: {:?}\n", err),
+                }
+            })
+        });
+    }
+
+    #[tokio::test]
+    async fn machine() {
+        use crate::internal::machine::datadriven as machine_dd;
+
+        ::datadriven::walk_async("tests/machine", |mut f| {
+            let initial_state_fut = machine_dd::MachineState::new();
+            async move {
+                let state = Arc::new(Mutex::new(initial_state_fut.await));
+                f.run_async(move |tc| {
+                    let state = Arc::clone(&state);
+                    async move {
+                        let args = DirectiveArgs {
+                            args: &tc.args,
+                            input: &tc.input,
+                        };
+                        let mut state = state.lock().await;
+                        let res = match tc.directive.as_str() {
+                            "apply-merge-res" => {
+                                machine_dd::apply_merge_res(&mut state, args).await
+                            }
+                            "compact" => machine_dd::compact(&mut state, args).await,
+                            "compare-and-append" => {
+                                machine_dd::compare_and_append(&mut state, args).await
+                            }
+                            "consensus-scan" => machine_dd::consensus_scan(&mut state, args).await,
+                            "fetch-batch" => machine_dd::fetch_batch(&mut state, args).await,
+                            "gc" => machine_dd::gc(&mut state, args).await,
+                            "listen-through" => machine_dd::listen_through(&mut state, args).await,
+                            "register-listen" => {
+                                machine_dd::register_listen(&mut state, args).await
+                            }
+                            "set-batch-parts-size" => {
+                                machine_dd::set_batch_parts_size(&mut state, args).await
+                            }
+                            "truncate-batch-desc" => {
+                                machine_dd::truncate_batch_desc(&mut state, args).await
+                            }
+                            "write-batch" => machine_dd::write_batch(&mut state, args).await,
+                            _ => panic!("unknown directive {:?}", tc),
+                        };
+                        match res {
+                            Ok(x) if x.is_empty() => "<empty>\n".into(),
+                            Ok(x) => x,
+                            Err(err) => format!("error: {}\n", err),
+                        }
+                    }
+                })
+                .await;
+                f
+            }
+        })
+        .await;
+    }
+}

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -174,6 +174,9 @@ mod tests {
                             "register-listen" => {
                                 machine_dd::register_listen(&mut state, args).await
                             }
+                            "register-writer" => {
+                                machine_dd::register_writer(&mut state, args).await
+                            }
                             "set-batch-parts-size" => {
                                 machine_dd::set_batch_parts_size(&mut state, args).await
                             }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -772,397 +772,418 @@ where
 }
 
 #[cfg(test)]
-mod tests {
+pub mod datadriven {
     use std::collections::HashMap;
     use std::sync::Arc;
 
     use differential_dataflow::trace::Description;
     use mz_build_info::DUMMY_BUILD_INFO;
-    use mz_ore::cast::CastFrom;
-    use mz_ore::now::SYSTEM_TIME;
-    use mz_ore::task::spawn;
-    use mz_persist::intercept::{InterceptBlob, InterceptHandle};
-    use mz_persist::location::Blob;
-    use timely::progress::Antichain;
-    use tokio::sync::Mutex;
 
-    use crate::async_runtime::CpuHeavyRuntime;
     use crate::batch::{validate_truncate_batch, BatchBuilder};
     use crate::fetch::fetch_batch_part;
     use crate::internal::compact::{CompactReq, Compactor};
+    use crate::internal::datadriven::DirectiveArgs;
     use crate::internal::gc::GcReq;
     use crate::read::{Listen, ListenEvent};
     use crate::tests::new_test_client;
-    use crate::{GarbageCollector, PersistConfig, ShardId};
+    use crate::{GarbageCollector, PersistClient};
 
     use super::*;
 
-    #[derive(Debug, Default)]
-    struct DatadrivenState {
-        batches: HashMap<String, HollowBatch<u64>>,
-        listens: HashMap<String, Listen<String, (), u64, i64>>,
+    /// Shared state for a single [crate::internal::machine] [datadriven::TestFile].
+    #[derive(Debug)]
+    pub struct MachineState {
+        pub client: PersistClient,
+        pub shard_id: ShardId,
+        pub state_versions: Arc<StateVersions>,
+        pub writer_id: WriterId,
+        pub machine: Machine<String, (), u64, i64>,
+        pub batches: HashMap<String, HollowBatch<u64>>,
+        pub listens: HashMap<String, Listen<String, (), u64, i64>>,
     }
 
-    #[tokio::test]
-    async fn machine_datadriven() {
-        fn get_arg<'a>(args: &'a HashMap<String, Vec<String>>, name: &str) -> Option<&'a str> {
-            args.get(name).map(|vals| {
-                if vals.len() != 1 {
-                    panic!("unexpected values for {}: {:?}", name, vals);
-                }
-                vals[0].as_ref()
-            })
-        }
-        fn get_u64<'a>(args: &'a HashMap<String, Vec<String>>, name: &str) -> Option<u64> {
-            get_arg(args, name).map(|x| {
-                x.parse::<u64>()
-                    .unwrap_or_else(|_| panic!("invalid {}: {}", name, x))
-            })
-        }
-
-        datadriven::walk_async("tests/machine", |mut f| async {
+    impl MachineState {
+        pub async fn new() -> Self {
             let shard_id = ShardId::new();
             let mut client = new_test_client().await;
             // Reset blob_target_size. Individual batch writes and compactions
             // can override it with an arg.
             client.cfg.blob_target_size =
                 PersistConfig::new(&DUMMY_BUILD_INFO, client.cfg.now.clone()).blob_target_size;
-
-            let state = Arc::new(Mutex::new(DatadrivenState::default()));
-            let cpu_heavy_runtime = Arc::new(CpuHeavyRuntime::new());
-            let write = Arc::new(Mutex::new(
-                client
-                    .open_writer::<String, (), u64, i64>(shard_id)
-                    .await
-                    .expect("invalid shard types"),
+            let state_versions = Arc::new(StateVersions::new(
+                client.cfg.clone(),
+                Arc::clone(&client.consensus),
+                Arc::clone(&client.blob),
+                Arc::clone(&client.metrics),
             ));
-            let now = SYSTEM_TIME.clone();
+            let mut machine = Machine::new(
+                client.cfg.clone(),
+                shard_id,
+                Arc::clone(&client.metrics),
+                Arc::clone(&state_versions),
+            )
+            .await
+            .expect("codecs should match");
+            let writer_id = WriterId::new();
+            let _ = machine
+                .register_writer(
+                    &writer_id,
+                    client.cfg.writer_lease_duration,
+                    (client.cfg.now)(),
+                )
+                .await;
+            MachineState {
+                shard_id,
+                client,
+                state_versions,
+                writer_id,
+                machine,
+                batches: HashMap::default(),
+                listens: HashMap::default(),
+            }
+        }
+    }
 
-            f.run_async(move |tc| {
-                let shard_id = shard_id.clone();
-                let client = client.clone();
-                let state = Arc::clone(&state);
-                let cpu_heavy_runtime = Arc::clone(&cpu_heavy_runtime);
-                let write = Arc::clone(&write);
-                let now = now.clone();
-                async move {
-                    let mut state = state.lock().await;
+    /// Scans consensus and returns all states with their SeqNos
+    /// and which batches they reference
+    pub async fn consensus_scan(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let from = SeqNo(args.expect("from_seqno"));
 
-                    match tc.directive.as_str() {
-                        // Scans consensus and returns all states with their SeqNos
-                        // and which batches they reference
-                        "consensus-scan" => {
-                            let from =
-                                SeqNo(get_u64(&tc.args, "from_seqno").expect("missing from_seqno"));
-
-                            let mut s = String::new();
-
-                            let mut states = write
-                                .lock()
-                                .await
-                                .machine
-                                .state_versions
-                                .fetch_live_states::<String, (), u64, i64>(&shard_id)
-                                .await
-                                .expect("shard codecs should not change");
-                            while let Some(x) = states.next() {
-                                if x.seqno < from {
-                                    continue;
-                                }
-                                let mut batches = vec![];
-                                x.collections.trace.map_batches(|b| {
-                                    for (batch_name, original_batch) in &state.batches {
-                                        if original_batch.parts == b.parts {
-                                            batches.push(batch_name.to_owned());
-                                            break;
-                                        }
-                                    }
-                                });
-                                write!(s, "seqno={} batches={}\n", x.seqno, batches.join(","));
-                            }
-                            s
-                        }
-                        "write-batch" => {
-                            let output = get_arg(&tc.args, "output").expect("missing output");
-                            let lower = get_u64(&tc.args, "lower").expect("missing lower");
-                            let upper = get_u64(&tc.args, "upper").expect("missing upper");
-                            let target_size = get_arg(&tc.args, "target_size")
-                                .map(|x| x.parse::<usize>().expect("invalid target_size"));
-                            let parts_size_override = get_arg(&tc.args, "parts_size_override")
-                                .map(|x| x.parse::<usize>().expect("invalid parts_size_override"));
-
-                            let updates = tc
-                                .input
-                                .trim()
-                                .split('\n')
-                                .filter(|x| !x.is_empty())
-                                .map(|x| {
-                                    let parts = x.split(' ').collect::<Vec<_>>();
-                                    if parts.len() != 3 {
-                                        panic!("unexpected update: {}", x);
-                                    }
-                                    let (key, ts, diff) = (parts[0], parts[1], parts[2]);
-                                    let ts = ts.parse::<u64>().expect("invalid ts");
-                                    let diff = diff.parse::<i64>().expect("invalid diff");
-                                    (key.to_owned(), ts, diff)
-                                })
-                                .collect::<Vec<_>>();
-
-                            let mut cfg = client.cfg.clone();
-                            if let Some(target_size) = target_size {
-                                cfg.blob_target_size = target_size;
-                            };
-                            let mut builder = BatchBuilder::new(
-                                cfg,
-                                Arc::clone(&client.metrics),
-                                0,
-                                Antichain::from_elem(lower),
-                                Arc::clone(&client.blob),
-                                Arc::clone(&cpu_heavy_runtime),
-                                shard_id.clone(),
-                                WriterId::new(),
-                            );
-                            for (k, t, d) in updates {
-                                builder.add(&k, &(), &t, &d).await.expect("invalid batch");
-                            }
-                            let batch = builder
-                                .finish(Antichain::from_elem(upper))
-                                .await
-                                .expect("invalid batch")
-                                .into_hollow_batch();
-
-                            if let Some(size) = parts_size_override {
-                                let mut batch = batch.clone();
-                                for part in batch.parts.iter_mut() {
-                                    part.encoded_size_bytes = size;
-                                }
-                                state.batches.insert(output.to_owned(), batch);
-                            } else {
-                                state.batches.insert(output.to_owned(), batch.clone());
-                            }
-
-                            format!("parts={} len={}\n", batch.parts.len(), batch.len)
-                        }
-                        "fetch-batch" => {
-                            let input = get_arg(&tc.args, "input").expect("missing input");
-                            let batch = state.batches.get(input).expect("unknown batch").clone();
-
-                            let mut s = String::new();
-                            for (idx, part) in batch.parts.iter().enumerate() {
-                                write!(s, "<part {idx}>\n");
-                                let blob_batch =
-                                    client.blob.get(&part.key.complete(&shard_id)).await;
-                                match blob_batch {
-                                    Ok(Some(_)) | Err(_) => {}
-                                    // don't try to fetch/print the keys of the batch part
-                                    // if the blob store no longer has it
-                                    Ok(None) => {
-                                        s.push_str("<empty>\n");
-                                        continue;
-                                    }
-                                };
-                                let mut part = fetch_batch_part(
-                                    &shard_id,
-                                    client.blob.as_ref(),
-                                    client.metrics.as_ref(),
-                                    &part.key,
-                                    &batch.desc,
-                                )
-                                .await
-                                .expect("invalid batch part");
-                                while let Some((k, _v, t, d)) = part.next() {
-                                    let (k, d) = (String::decode(k).unwrap(), i64::decode(d));
-                                    write!(s, "{k} {t} {d}\n");
-                                }
-                            }
-                            if !s.is_empty() {
-                                for (idx, run) in batch.runs().enumerate() {
-                                    write!(s, "<run {idx}>\n");
-                                    for part in run {
-                                        let part_idx = batch
-                                            .parts
-                                            .iter()
-                                            .position(|p| p == part)
-                                            .expect("part should exist");
-                                        write!(s, "part {part_idx}\n");
-                                    }
-                                }
-                            } else {
-                                s.push_str("<empty>\n");
-                            }
-                            s
-                        }
-                        "truncate-batch-desc" => {
-                            let input = get_arg(&tc.args, "input").expect("missing input");
-                            let output = get_arg(&tc.args, "output").expect("missing output");
-                            let lower = get_u64(&tc.args, "lower").expect("missing lower");
-                            let upper = get_u64(&tc.args, "upper").expect("missing upper");
-
-                            let mut batch =
-                                state.batches.get(input).expect("unknown batch").clone();
-                            let truncated_desc = Description::new(
-                                Antichain::from_elem(lower),
-                                Antichain::from_elem(upper),
-                                batch.desc.since().clone(),
-                            );
-                            match validate_truncate_batch(&batch.desc, &truncated_desc) {
-                                Ok(()) => {
-                                    batch.desc = truncated_desc;
-                                    state.batches.insert(output.to_owned(), batch.clone());
-                                    format!("parts={} len={}\n", batch.parts.len(), batch.len)
-                                }
-                                Err(err) => format!("error: {}\n", err),
-                            }
-                        }
-                        "set-batch-parts-size" => {
-                            let input = get_arg(&tc.args, "input").expect("missing input");
-                            let size = get_u64(&tc.args, "size").expect("missing size");
-                            let batch = state.batches.get_mut(input).expect("unknown batch");
-                            for part in batch.parts.iter_mut() {
-                                part.encoded_size_bytes = usize::cast_from(size);
-                            }
-                            format!("ok\n")
-                        }
-                        "compact" => {
-                            let output = get_arg(&tc.args, "output").expect("missing output");
-                            let lower = get_u64(&tc.args, "lower").expect("missing lower");
-                            let upper = get_u64(&tc.args, "upper").expect("missing upper");
-                            let since = get_u64(&tc.args, "since").expect("missing since");
-                            let target_size = get_arg(&tc.args, "target_size")
-                                .map(|x| x.parse::<usize>().expect("invalid target_size"));
-                            let memory_bound = get_arg(&tc.args, "memory_bound")
-                                .map(|x| x.parse::<usize>().expect("invalid memory_bound"));
-
-                            let mut inputs = Vec::new();
-                            for input in tc.args.get("inputs").expect("missing inputs") {
-                                inputs
-                                    .push(state.batches.get(input).expect("unknown batch").clone());
-                            }
-
-                            let mut cfg = client.cfg.clone();
-                            if let Some(target_size) = target_size {
-                                cfg.blob_target_size = target_size;
-                            };
-                            if let Some(memory_bound) = memory_bound {
-                                cfg.compaction_memory_bound_bytes = memory_bound;
-                            }
-                            let req = CompactReq {
-                                shard_id,
-                                desc: Description::new(
-                                    Antichain::from_elem(lower),
-                                    Antichain::from_elem(upper),
-                                    Antichain::from_elem(since),
-                                ),
-                                inputs,
-                            };
-                            let res = Compactor::compact::<u64, i64>(
-                                cfg.clone(),
-                                Arc::clone(&client.blob),
-                                Arc::clone(&client.metrics),
-                                Arc::clone(&cpu_heavy_runtime),
-                                req,
-                                WriterId::new(),
-                            )
-                            .await;
-                            match res {
-                                Ok(res) => {
-                                    state.batches.insert(output.to_owned(), res.output.clone());
-                                    format!(
-                                        "parts={} len={}\n",
-                                        res.output.parts.len(),
-                                        res.output.len
-                                    )
-                                }
-                                Err(err) => format!("error: {}\n", err),
-                            }
-                        }
-                        "gc" => {
-                            let new_seqno_since =
-                                SeqNo(get_u64(&tc.args, "to_seqno").expect("missing to_seqno"));
-
-                            GarbageCollector::gc_and_truncate(
-                                &mut write.lock().await.machine,
-                                GcReq {
-                                    shard_id,
-                                    new_seqno_since,
-                                },
-                            )
-                            .await;
-
-                            "ok\n".into()
-                        }
-                        "register-listen" => {
-                            let output = get_arg(&tc.args, "output").expect("missing output");
-                            let as_of = get_u64(&tc.args, "as-of").expect("missing as-of");
-                            let read = client
-                                .open_reader::<String, (), u64, i64>(shard_id)
-                                .await
-                                .expect("invalid shard types");
-                            let listen = read.expect_listen(as_of).await;
-                            state.listens.insert(output.to_owned(), listen);
-                            "ok\n".into()
-                        }
-                        "listen-through" => {
-                            let input = get_arg(&tc.args, "input").expect("missing input");
-                            let frontier = get_u64(&tc.args, "frontier").expect("missing frontier");
-                            let listen = state.listens.get_mut(input).expect("unknown listener");
-                            let mut s = String::new();
-                            'outer: loop {
-                                for event in listen.next().await {
-                                    match event {
-                                        ListenEvent::Updates(x) => {
-                                            for ((k, _v), t, d) in x.iter() {
-                                                write!(s, "{} {} {}\n", k.as_ref().unwrap(), t, d);
-                                            }
-                                        }
-                                        ListenEvent::Progress(x) => {
-                                            if !x.less_than(&frontier) {
-                                                break 'outer;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            if s.is_empty() {
-                                s.push_str("<empty>\n");
-                            }
-                            s
-                        }
-                        "compare-and-append" => {
-                            let input = get_arg(&tc.args, "input").expect("missing input");
-                            let batch = state.batches.get(input).expect("unknown batch");
-                            let mut write = write.lock().await;
-                            let writer_id = write.writer_id.clone();
-                            let (_, _) = write
-                                .machine
-                                .compare_and_append(batch, &writer_id, now())
-                                .await
-                                .expect("indeterminate")
-                                .expect("invalid usage")
-                                .expect("upper mismatch");
-                            format!("ok\n")
-                        }
-                        "apply-merge-res" => {
-                            let input = get_arg(&tc.args, "input").expect("missing input");
-                            let batch = state.batches.get(input).expect("unknown batch");
-                            let mut write = write.lock().await;
-                            let applied = write
-                                .machine
-                                .merge_res(&FueledMergeRes {
-                                    output: batch.clone(),
-                                })
-                                .await;
-                            format!("{}\n", applied)
-                        }
-                        _ => panic!("unknown directive {:?}", tc),
+        let mut states = datadriven
+            .state_versions
+            .fetch_live_states::<String, (), u64, i64>(&datadriven.shard_id)
+            .await
+            .expect("shard codecs should not change");
+        let mut s = String::new();
+        while let Some(x) = states.next() {
+            if x.seqno < from {
+                continue;
+            }
+            let mut batches = vec![];
+            x.collections.trace.map_batches(|b| {
+                for (batch_name, original_batch) in &datadriven.batches {
+                    if original_batch.parts == b.parts {
+                        batches.push(batch_name.to_owned());
+                        break;
                     }
                 }
-            })
-            .await;
-            f
-        })
-        .await;
+            });
+            write!(s, "seqno={} batches={}\n", x.seqno, batches.join(","));
+        }
+        Ok(s)
     }
+
+    pub async fn write_batch(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let output = args.expect_str("output");
+        let lower = args.expect("lower");
+        let upper = args.expect("upper");
+        let target_size = args.optional("target_size");
+        let parts_size_override = args.optional("parts_size_override");
+        let updates = args.input.split('\n').flat_map(DirectiveArgs::parse_update);
+
+        let mut cfg = datadriven.client.cfg.clone();
+        if let Some(target_size) = target_size {
+            cfg.blob_target_size = target_size;
+        };
+        let mut builder = BatchBuilder::new(
+            cfg,
+            Arc::clone(&datadriven.client.metrics),
+            0,
+            Antichain::from_elem(lower),
+            Arc::clone(&datadriven.client.blob),
+            Arc::clone(&datadriven.client.cpu_heavy_runtime),
+            datadriven.shard_id.clone(),
+            WriterId::new(),
+        );
+        for ((k, ()), t, d) in updates {
+            builder.add(&k, &(), &t, &d).await.expect("invalid batch");
+        }
+        let batch = builder
+            .finish(Antichain::from_elem(upper))
+            .await
+            .expect("invalid batch")
+            .into_hollow_batch();
+
+        if let Some(size) = parts_size_override {
+            let mut batch = batch.clone();
+            for part in batch.parts.iter_mut() {
+                part.encoded_size_bytes = size;
+            }
+            datadriven.batches.insert(output.to_owned(), batch);
+        } else {
+            datadriven.batches.insert(output.to_owned(), batch.clone());
+        }
+        Ok(format!("parts={} len={}\n", batch.parts.len(), batch.len))
+    }
+
+    pub async fn fetch_batch(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let batch = datadriven.batches.get(input).expect("unknown batch");
+
+        let mut s = String::new();
+        for (idx, part) in batch.parts.iter().enumerate() {
+            write!(s, "<part {idx}>\n");
+            let blob_batch = datadriven
+                .client
+                .blob
+                .get(&part.key.complete(&datadriven.shard_id))
+                .await;
+            match blob_batch {
+                Ok(Some(_)) | Err(_) => {}
+                // don't try to fetch/print the keys of the batch part
+                // if the blob store no longer has it
+                Ok(None) => {
+                    s.push_str("<empty>\n");
+                    continue;
+                }
+            };
+            let mut part = fetch_batch_part(
+                &datadriven.shard_id,
+                datadriven.client.blob.as_ref(),
+                datadriven.client.metrics.as_ref(),
+                &part.key,
+                &batch.desc,
+            )
+            .await
+            .expect("invalid batch part");
+            while let Some((k, _v, t, d)) = part.next() {
+                let (k, d) = (String::decode(k).unwrap(), i64::decode(d));
+                write!(s, "{k} {t} {d}\n");
+            }
+        }
+        if !s.is_empty() {
+            for (idx, run) in batch.runs().enumerate() {
+                write!(s, "<run {idx}>\n");
+                for part in run {
+                    let part_idx = batch
+                        .parts
+                        .iter()
+                        .position(|p| p == part)
+                        .expect("part should exist");
+                    write!(s, "part {part_idx}\n");
+                }
+            }
+        }
+        Ok(s)
+    }
+
+    #[allow(clippy::unused_async)]
+    pub async fn truncate_batch_desc(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let output = args.expect_str("output");
+        let lower = args.expect("lower");
+        let upper = args.expect("upper");
+
+        let mut batch = datadriven
+            .batches
+            .get(input)
+            .expect("unknown batch")
+            .clone();
+        let truncated_desc = Description::new(
+            Antichain::from_elem(lower),
+            Antichain::from_elem(upper),
+            batch.desc.since().clone(),
+        );
+        let () = validate_truncate_batch(&batch.desc, &truncated_desc)?;
+        batch.desc = truncated_desc;
+        datadriven.batches.insert(output.to_owned(), batch.clone());
+        Ok(format!("parts={} len={}\n", batch.parts.len(), batch.len))
+    }
+
+    #[allow(clippy::unused_async)]
+    pub async fn set_batch_parts_size(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let size = args.expect("size");
+        let batch = datadriven.batches.get_mut(input).expect("unknown batch");
+        for part in batch.parts.iter_mut() {
+            part.encoded_size_bytes = size;
+        }
+        Ok(format!("ok\n"))
+    }
+
+    pub async fn compact(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let output = args.expect_str("output");
+        let lower = args.expect("lower");
+        let upper = args.expect("upper");
+        let since = args.expect("since");
+        let target_size = args.optional("target_size");
+        let memory_bound = args.optional("memory_bound");
+
+        let mut inputs = Vec::new();
+        for input in args.args.get("inputs").expect("missing inputs") {
+            inputs.push(
+                datadriven
+                    .batches
+                    .get(input)
+                    .expect("unknown batch")
+                    .clone(),
+            );
+        }
+
+        let mut cfg = datadriven.client.cfg.clone();
+        if let Some(target_size) = target_size {
+            cfg.blob_target_size = target_size;
+        };
+        if let Some(memory_bound) = memory_bound {
+            cfg.compaction_memory_bound_bytes = memory_bound;
+        }
+        let req = CompactReq {
+            shard_id: datadriven.shard_id,
+            desc: Description::new(
+                Antichain::from_elem(lower),
+                Antichain::from_elem(upper),
+                Antichain::from_elem(since),
+            ),
+            inputs,
+        };
+        let res = Compactor::compact::<u64, i64>(
+            cfg,
+            Arc::clone(&datadriven.client.blob),
+            Arc::clone(&datadriven.client.metrics),
+            Arc::clone(&datadriven.client.cpu_heavy_runtime),
+            req,
+            WriterId::new(),
+        )
+        .await?;
+
+        datadriven
+            .batches
+            .insert(output.to_owned(), res.output.clone());
+        Ok(format!(
+            "parts={} len={}\n",
+            res.output.parts.len(),
+            res.output.len
+        ))
+    }
+
+    pub async fn gc(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let new_seqno_since = SeqNo(args.expect("to_seqno"));
+
+        let req = GcReq {
+            shard_id: datadriven.shard_id,
+            new_seqno_since,
+        };
+        GarbageCollector::gc_and_truncate(&mut datadriven.machine, req).await;
+
+        Ok("ok\n".into())
+    }
+
+    pub async fn register_listen(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let output = args.expect_str("output");
+        let as_of = args.expect("as-of");
+        let read = datadriven
+            .client
+            .open_reader::<String, (), u64, i64>(datadriven.shard_id)
+            .await
+            .expect("invalid shard types");
+        let listen = read.expect_listen(as_of).await;
+        datadriven.listens.insert(output.to_owned(), listen);
+        Ok("ok\n".into())
+    }
+
+    pub async fn listen_through(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let frontier = args.expect("frontier");
+        let listen = datadriven.listens.get_mut(input).expect("unknown listener");
+        let mut s = String::new();
+        loop {
+            for event in listen.next().await {
+                match event {
+                    ListenEvent::Updates(x) => {
+                        for ((k, _v), t, d) in x.iter() {
+                            write!(s, "{} {} {}\n", k.as_ref().unwrap(), t, d);
+                        }
+                    }
+                    ListenEvent::Progress(x) => {
+                        if !x.less_than(&frontier) {
+                            return Ok(s);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn compare_and_append(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let batch = datadriven
+            .batches
+            .get(input)
+            .expect("unknown batch")
+            .clone();
+        let writer_id = datadriven.writer_id.clone();
+        let now = (datadriven.client.cfg.now)();
+        let (_, _) = datadriven
+            .machine
+            .compare_and_append(&batch, &writer_id, now)
+            .await
+            .expect("indeterminate")
+            .expect("invalid usage")
+            .expect("upper mismatch");
+        Ok(format!("ok\n"))
+    }
+
+    pub async fn apply_merge_res(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let input = args.expect_str("input");
+        let batch = datadriven
+            .batches
+            .get(input)
+            .expect("unknown batch")
+            .clone();
+        let applied = datadriven
+            .machine
+            .merge_res(&FueledMergeRes { output: batch })
+            .await;
+        Ok(format!("{}\n", applied))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+
+    use mz_ore::cast::CastFrom;
+    use mz_ore::task::spawn;
+    use mz_persist::intercept::{InterceptBlob, InterceptHandle};
+    use mz_persist::location::{Blob, SeqNo};
+    use timely::progress::Antichain;
+
+    use crate::internal::gc::{GarbageCollector, GcReq};
+    use crate::tests::new_test_client;
+    use crate::ShardId;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn apply_unbatched_cmd_truncate() {

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -1059,148 +1059,142 @@ impl<T: Timestamp + Lattice> MergeVariant<T> {
 }
 
 #[cfg(test)]
+pub mod datadriven {
+    use super::*;
+    use crate::internal::datadriven::DirectiveArgs;
+
+    /// Shared state for a single [crate::internal::trace] [datadriven::TestFile].
+    #[derive(Debug, Default)]
+    pub struct TraceState {
+        pub trace: Trace<u64>,
+        pub merge_reqs: Vec<FueledMergeReq<u64>>,
+    }
+
+    pub fn since_upper(
+        datadriven: &mut TraceState,
+        _args: DirectiveArgs,
+    ) -> Result<String, anyhow::Error> {
+        Ok(format!(
+            "{:?}{:?}\n",
+            datadriven.trace.since().elements(),
+            datadriven.trace.upper().elements()
+        ))
+    }
+
+    pub fn batches(
+        datadriven: &mut TraceState,
+        _args: DirectiveArgs,
+    ) -> Result<String, anyhow::Error> {
+        let mut s = String::new();
+        datadriven.trace.spine.map_batches(|b| {
+            let b = match b {
+                SpineBatch::Merged(HollowBatch {
+                    desc,
+                    len,
+                    parts,
+                    runs: _runs,
+                }) => format!(
+                    "{:?}{:?}{:?} {}{}\n",
+                    desc.lower().elements(),
+                    desc.upper().elements(),
+                    desc.since().elements(),
+                    len,
+                    parts
+                        .iter()
+                        .map(|x| format!(" {}", x.key))
+                        .collect::<Vec<_>>()
+                        .join(""),
+                ),
+                SpineBatch::Fueled { desc, parts } => format!(
+                    "{:?}{:?}{:?} {}/{}{}\n",
+                    desc.lower().elements(),
+                    desc.upper().elements(),
+                    desc.since().elements(),
+                    parts.len(),
+                    parts.iter().map(|x| x.len).sum::<usize>(),
+                    parts
+                        .iter()
+                        .flat_map(|x| x.parts.iter())
+                        .map(|x| format!(" {}", x.key))
+                        .collect::<Vec<_>>()
+                        .join("")
+                ),
+            };
+            s.push_str(&b);
+        });
+        Ok(s)
+    }
+
+    pub fn insert(
+        datadriven: &mut TraceState,
+        args: DirectiveArgs,
+    ) -> Result<String, anyhow::Error> {
+        for x in args
+            .input
+            .trim()
+            .split('\n')
+            .map(DirectiveArgs::parse_hollow_batch)
+        {
+            datadriven
+                .merge_reqs
+                .append(&mut datadriven.trace.push_batch(x));
+        }
+        Ok("ok\n".to_owned())
+    }
+
+    pub fn downgrade_since(
+        datadriven: &mut TraceState,
+        args: DirectiveArgs,
+    ) -> Result<String, anyhow::Error> {
+        let since = args.expect("since");
+        datadriven
+            .trace
+            .downgrade_since(&Antichain::from_elem(since));
+        Ok("ok\n".to_owned())
+    }
+
+    pub fn take_merge_req(
+        datadriven: &mut TraceState,
+        _args: DirectiveArgs,
+    ) -> Result<String, anyhow::Error> {
+        let mut s = String::new();
+        for merge_req in std::mem::take(&mut datadriven.merge_reqs) {
+            write!(
+                s,
+                "{:?}{:?}{:?} {}\n",
+                merge_req.desc.lower().elements(),
+                merge_req.desc.upper().elements(),
+                merge_req.desc.since().elements(),
+                merge_req
+                    .inputs
+                    .iter()
+                    .flat_map(|x| x.parts.iter())
+                    .map(|x| x.key.0.clone())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+        }
+        Ok(s)
+    }
+
+    pub fn apply_merge_res(
+        datadriven: &mut TraceState,
+        args: DirectiveArgs,
+    ) -> Result<String, anyhow::Error> {
+        let res = FueledMergeRes {
+            output: DirectiveArgs::parse_hollow_batch(&args.input),
+        };
+        if datadriven.trace.apply_merge_res(&res) {
+            Ok("applied\n".into())
+        } else {
+            Ok("no-op\n".into())
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::internal::paths::PartialBatchKey;
-    use crate::internal::state::HollowBatchPart;
-
-    #[test]
-    fn trace_datadriven() {
-        fn parse_batch(x: &str) -> HollowBatch<u64> {
-            let parts = x.split(' ').collect::<Vec<_>>();
-            assert!(
-                parts.len() >= 4,
-                "usage: insert <lower> <upper> <since> <len> <keys>"
-            );
-            let (lower, upper, since, len, keys) =
-                (parts[0], parts[1], parts[2], parts[3], &parts[4..]);
-            let lower = lower.parse().expect("invalid lower");
-            let upper = upper.parse().expect("invalid upper");
-            let since = since.parse().expect("invalid since");
-            let len = len.parse().expect("invalid len");
-            HollowBatch {
-                desc: Description::new(
-                    Antichain::from_elem(lower),
-                    Antichain::from_elem(upper),
-                    Antichain::from_elem(since),
-                ),
-                len,
-                parts: keys
-                    .iter()
-                    .map(|x| HollowBatchPart {
-                        key: PartialBatchKey((*x).to_owned()),
-                        encoded_size_bytes: 0,
-                    })
-                    .collect(),
-                runs: vec![],
-            }
-        }
-
-        datadriven::walk("tests/trace", |f| {
-            let mut trace = Trace::default();
-            let mut merge_reqs = Vec::new();
-
-            f.run(move |tc| -> String {
-                match tc.directive.as_str() {
-                    "since-upper" => {
-                        assert!(tc.input.is_empty());
-                        format!(
-                            "{:?}{:?}\n",
-                            trace.since().elements(),
-                            trace.upper().elements()
-                        )
-                    }
-                    "batches" => {
-                        assert!(tc.input.is_empty());
-                        let mut s = String::new();
-                        trace.spine.map_batches(|b| {
-                            let b = match b {
-                                SpineBatch::Merged(HollowBatch {
-                                    desc,
-                                    len,
-                                    parts,
-                                    runs: _runs,
-                                }) => format!(
-                                    "{:?}{:?}{:?} {}{}\n",
-                                    desc.lower().elements(),
-                                    desc.upper().elements(),
-                                    desc.since().elements(),
-                                    len,
-                                    parts
-                                        .iter()
-                                        .map(|x| format!(" {}", x.key))
-                                        .collect::<Vec<_>>()
-                                        .join(""),
-                                ),
-                                SpineBatch::Fueled { desc, parts } => format!(
-                                    "{:?}{:?}{:?} {}/{}{}\n",
-                                    desc.lower().elements(),
-                                    desc.upper().elements(),
-                                    desc.since().elements(),
-                                    parts.len(),
-                                    parts.iter().map(|x| x.len).sum::<usize>(),
-                                    parts
-                                        .iter()
-                                        .flat_map(|x| x.parts.iter())
-                                        .map(|x| format!(" {}", x.key))
-                                        .collect::<Vec<_>>()
-                                        .join("")
-                                ),
-                            };
-                            s.push_str(&b);
-                        });
-                        s
-                    }
-                    "insert" => {
-                        for x in tc.input.trim().split('\n') {
-                            merge_reqs.append(&mut trace.push_batch(parse_batch(x)));
-                        }
-                        "ok\n".to_owned()
-                    }
-                    "downgrade-since" => {
-                        let since = tc.input.trim().parse().expect("invalid since");
-                        trace.downgrade_since(&Antichain::from_elem(since));
-                        "ok\n".to_owned()
-                    }
-                    "take-merge-reqs" => {
-                        assert!(tc.input.is_empty());
-                        let mut s = String::new();
-                        for merge_req in std::mem::take(&mut merge_reqs) {
-                            write!(
-                                s,
-                                "{:?}{:?}{:?} {}\n",
-                                merge_req.desc.lower().elements(),
-                                merge_req.desc.upper().elements(),
-                                merge_req.desc.since().elements(),
-                                merge_req
-                                    .inputs
-                                    .iter()
-                                    .flat_map(|x| x.parts.iter())
-                                    .map(|x| x.key.0.clone())
-                                    .collect::<Vec<_>>()
-                                    .join(" ")
-                            );
-                        }
-                        if s.is_empty() {
-                            s.push_str("<empty>\n");
-                        }
-                        s
-                    }
-                    "apply-merge-res" => {
-                        let res = FueledMergeRes {
-                            output: parse_batch(&tc.input.trim()),
-                        };
-                        if trace.apply_merge_res(&res) {
-                            "applied\n".into()
-                        } else {
-                            "no-op\n".into()
-                        }
-                    }
-                    _ => panic!("unknown directive {:?}", tc),
-                }
-            })
-        });
-    }
 
     #[test]
     fn remove_redundant_merge_reqs() {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -71,6 +71,9 @@ pub(crate) mod internal {
     pub mod state_diff;
     pub mod state_versions;
     pub mod trace;
+
+    #[cfg(test)]
+    pub mod datadriven;
 }
 
 // TODO: Remove this in favor of making it possible for all PersistClients to be

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -31,7 +31,11 @@ k4 2 1
 parts=1 len=2
 
 # insert our first batch into state
-compare-and-append input=b0
+register-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+[0]
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 
@@ -48,7 +52,7 @@ consensus-scan from_seqno=3
 seqno=v3 batches=b0
 
 # insert a second batch into state
-compare-and-append input=b1
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 
@@ -71,7 +75,7 @@ seqno=v4 batches=b0,b1
 seqno=v5 batches=b0,b1
 
 # insert another batch
-compare-and-append input=b2
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 

--- a/src/persist-client/tests/machine/regression_gc_behind
+++ b/src/persist-client/tests/machine/regression_gc_behind
@@ -17,7 +17,11 @@ k1 0 1
 ----
 parts=1 len=1
 
-compare-and-append input=b0
+register-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+[0]
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -17,7 +17,11 @@ one 1 1
 ----
 parts=1 len=1
 
-compare-and-append input=b0
+register-writer writer_id=w11111111-1111-1111-1111-111111111111
+----
+[0]
+
+compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 
@@ -35,7 +39,7 @@ two 2 1
 ----
 parts=1 len=1
 
-compare-and-append input=b1
+compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 
@@ -53,7 +57,7 @@ threeD 3 1
 ----
 parts=1 len=4
 
-compare-and-append input=b2
+compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
 ok
 

--- a/src/persist-client/tests/trace/compaction
+++ b/src/persist-client/tests/trace/compaction
@@ -8,16 +8,17 @@
 # by the Apache License, Version 2.0.
 
 # Batches start empty
-batches
+spine-batches
 ----
+<empty>
 
 # Insert a len=1 batch.
-insert
-0 1 0 1 k0
+push-batch
+[0][1][0] 1 k0
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][1][0] 1 k0
 
@@ -26,18 +27,18 @@ take-merge-reqs
 <empty>
 
 # Insert more len=1 batches.
-insert
-1 2 0 1 k1
-2 3 0 1 k2
-3 4 0 1 k3
-4 5 0 1 k4
-5 6 0 1 k5
-6 7 0 1 k6
-7 8 0 1 k7
+push-batch
+[1][2][0] 1 k1
+[2][3][0] 1 k2
+[3][4][0] 1 k3
+[4][5][0] 1 k4
+[5][6][0] 1 k5
+[6][7][0] 1 k6
+[7][8][0] 1 k7
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][4][0] 4/4 k0 k1 k2 k3
 [4][6][0] 2/2 k4 k5
@@ -53,12 +54,12 @@ take-merge-reqs
 # Insert a large batch, which because of spine's invariants, must be inserted at
 # a higher level. This causes the len=1 batches to smash together at the level
 # above it and generate a merge.
-insert
-8 9 0 100 k8
+push-batch
+[8][9][0] 100 k8
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][8][0] 8/8 k0 k1 k2 k3 k4 k5 k6 k7
 [8][9][0] 100 k8
@@ -69,7 +70,7 @@ take-merge-reqs
 
 # Merge responses that we didn't generate are ignored.
 apply-merge-res
-1 3 0 0 nope
+[1][3][0] 0 nope
 ----
 no-op
 
@@ -77,23 +78,23 @@ no-op
 # SpineBatch. In practice, this means a merge req that is outdated when it
 # arrives will be a no-op.
 apply-merge-res
-0 2 0 2 nope
+[0][2][0] 2 nope
 ----
 no-op
 
 # Verify that nothing has been changed by the no-op.
-batches
+spine-batches
 ----
 [0][8][0] 8/8 k0 k1 k2 k3 k4 k5 k6 k7
 [8][9][0] 100 k8
 
 # Successfully apply a merge res
 apply-merge-res
-0 8 0 5 k0-7
+[0][8][0] 5 k0-7
 ----
 applied
 
-batches
+spine-batches
 ----
 [0][8][0] 5 k0-7
 [8][9][0] 100 k8

--- a/src/persist-client/tests/trace/compaction_apply_res_since
+++ b/src/persist-client/tests/trace/compaction_apply_res_since
@@ -9,25 +9,24 @@
 
 # Insert some len=1 batches followed by a larger batch to squish them up and
 # force a compaction. In the middle, advance the since so our merge req has a non-zero since.
-insert
-0 1 0 1 k0
-1 2 0 1 k1
-2 3 0 1 k2
-3 4 0 1 k3
+push-batch
+[0][1][0] 1 k0
+[1][2][0] 1 k1
+[2][3][0] 1 k2
+[3][4][0] 1 k3
 ----
 ok
 
-downgrade-since
-4
+downgrade-since since=4
 ----
 ok
 
-insert
-4 5 4 100 k4
+push-batch
+[4][5][4] 100 k4
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][4][4] 4/4 k0 k1 k2 k3
 [4][5][4] 100 k4
@@ -40,7 +39,7 @@ take-merge-reqs
 
 # We cannot use a compaction response with a since in advance of the spine batch
 apply-merge-res
-0 4 5 0 nope
+[0][4][5] 0 nope
 ----
 no-op
 
@@ -48,11 +47,11 @@ no-op
 # compaction response's since (we've simply lost more fidelity than we're
 # allowed to).
 apply-merge-res
-0 4 3 2 k0-4
+[0][4][3] 2 k0-4
 ----
 applied
 
-batches
+spine-batches
 ----
 [0][4][3] 2 k0-4
 [4][5][4] 100 k4

--- a/src/persist-client/tests/trace/compaction_regression_size_reduction
+++ b/src/persist-client/tests/trace/compaction_regression_size_reduction
@@ -21,14 +21,14 @@
 
 # Insert two batches and then a big batch so that 0-1 and 1-2 are fueled to
 # merge. This also creates a FuelingMerge(0-2,2-3).
-insert
-0 1 0 500 k0
-1 2 0 500 k1
-2 3 0 1000 k2
+push-batch
+[0][1][0] 500 k0
+[1][2][0] 500 k1
+[2][3][0] 1000 k2
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][2][0] 2/1000 k0 k1
 [2][3][0] 1000 k2
@@ -38,8 +38,8 @@ take-merge-reqs
 [0][2][0] k0 k1
 
 # Give the FuelingMerge(0-2,2-3) some fuel, but not enough to finish.
-insert
-3 4 0 100 k3
+push-batch
+[3][4][0] 100 k3
 ----
 ok
 
@@ -47,13 +47,13 @@ ok
 # the pre compacted version (1000 vs 1). This creates a scenario where
 # FuelingMerge(0-2,2-3) suddenly has more fuel than it needs.
 apply-merge-res
-0 2 0 1 k0-1
+[0][2][0] 1 k0-1
 ----
 applied
 
 # Insert a batch that would force FuelingMerge(0-2,2-3) to finish and move up a
 # few levels. In the regression, this would panic.
-insert
-4 5 0 10000 k4
+push-batch
+[4][5][0] 10000 k4
 ----
 ok

--- a/src/persist-client/tests/trace/empty_batch_optimization
+++ b/src/persist-client/tests/trace/empty_batch_optimization
@@ -11,42 +11,43 @@
 # completely empty batches to save space in the state.
 
 # Batches start empty
-batches
+spine-batches
 ----
+<empty>
 
 # Insert a bunch of empty batches. These happen to all get merged, even without
 # compaction.
-insert
-0 1 0 0
-1 2 0 0
-2 3 0 0
+push-batch
+[0][1][0] 0
+[1][2][0] 0
+[2][3][0] 0
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][3][0] 0
 
 # Now insert a non-empty batch to fence off the optimization.
-insert
-3 4 0 10 k0
+push-batch
+[3][4][0] 10 k0
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][3][0] 0
 [3][4][0] 10 k0
 
 # Insert some more empty batches, they again get merged together.
-insert
-4 5 0 0
-5 6 0 0
-6 7 0 0
+push-batch
+[4][5][0] 0
+[5][6][0] 0
+[6][7][0] 0
 ----
 ok
 
-batches
+spine-batches
 ----
 [0][3][0] 0
 [3][4][0] 10 k0

--- a/src/persist-client/tests/trace/since_upper
+++ b/src/persist-client/tests/trace/since_upper
@@ -13,8 +13,8 @@ since-upper
 [0][0]
 
 # A [0,1) batch advances the upper to [1]
-insert
-0 1 0 0
+push-batch
+[0][1][0] 0
 ----
 ok
 
@@ -23,8 +23,7 @@ since-upper
 [0][1]
 
 # Downgrade the since to [1]
-downgrade-since
-1
+downgrade-since since=1
 ----
 ok
 
@@ -33,8 +32,7 @@ since-upper
 [1][1]
 
 # It's legal (though of unclear benefit) to advance the since past the upper
-downgrade-since
-2
+downgrade-since since=2
 ----
 ok
 
@@ -44,8 +42,8 @@ since-upper
 
 
 # Advance the upper again
-insert
-1 3 0 0
+push-batch
+[1][3][0] 0
 ----
 ok
 


### PR DESCRIPTION
- Spin out a new datadriven module with some common parsing helpers.
- Move the actual tests to the new datadriven module (for ease of selection in `cargo test`), but leave the "directive" impls as free-functions next to machine, trace (so they continue to have access to stuff that isn't `pub(crate)`).
- Standardize the HollowBatch input format the trace tests to match the output format. Previously the input looked like `0 1 2 3 k1 k2`, but now it looks like `[0][1][2] 3 k1 k2`. Paul mentioned a while ago that this was confusing, but no-one had a better idea at the time.
- A few small tweaks to the "trace" language to make things more clear between datadriven files:
  - Pass "since" as an arg to "downgrade-since" instead of an input.
  - Rename "batches" to "spine-batches".
  - Rename "insert" to "push-batch" (to match the method name).

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

I'm about to write some new datadriven tests for #14704, so wanted to clean things up a bit while I was in here.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
