### PR TITLE
persist: spin off separate compaction worker per shard

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -107,7 +107,7 @@ where
                 let should_compact = req.inputs.len()
                     >= machine.cfg.compaction_heuristic_min_inputs
                     || req.inputs.iter().map(|x| x.len).sum::<usize>()
-                    >= machine.cfg.compaction_heuristic_min_updates;
+                        >= machine.cfg.compaction_heuristic_min_updates;
                 if !should_compact {
                     machine.metrics.compaction.skipped.inc();
                     // we can safely ignore errors here, it's possible the caller
@@ -139,7 +139,7 @@ where
                         req,
                         writer_id.clone(),
                     )
-                        .await;
+                    .await;
 
                     metrics
                         .compaction
@@ -160,16 +160,18 @@ where
                                         &metrics.retries.external.compaction_noop_delete,
                                         || blob.delete(&key),
                                     )
-                                        .await;
+                                    .await;
                                 }
                             }
-                        },
+                        }
                         Err(err) => {
                             metrics.compaction.failed.inc();
                             warn!("compaction for {} failed: {:#}", machine.shard_id(), err);
                         }
                     };
-                }.instrument(compact_span).await;
+                }
+                .instrument(compact_span)
+                .await;
 
                 // we can safely ignore errors here, it's possible the caller
                 // wasn't interested in waiting and dropped their receiver

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -126,7 +126,7 @@ where
                                 Arc::clone(&metrics),
                                 Arc::clone(&cpu_heavy_runtime),
                                 req,
-                                writer_id.clone(),
+                                writer_id,
                             )
                             .instrument(compact_span),
                         )
@@ -192,11 +192,9 @@ where
         // were just written, but it does result in non-trivial blob traffic
         // (especially in aggregate). This heuristic is something we'll need to
         // tune over time.
-        let should_compact = req.inputs.len()
-            >= self.cfg.compaction_heuristic_min_inputs
+        let should_compact = req.inputs.len() >= self.cfg.compaction_heuristic_min_inputs
             || req.inputs.iter().map(|x| x.len).sum::<usize>()
-            >= self.cfg.compaction_heuristic_min_updates;
-
+                >= self.cfg.compaction_heuristic_min_updates;
         if !should_compact {
             self.metrics.compaction.skipped.inc();
             return None;

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1044,7 +1044,7 @@ pub mod datadriven {
             ),
             inputs,
         };
-        let res = Compactor::compact::<u64, i64>(
+        let res = Compactor::<u64, i64>::compact(
             cfg,
             Arc::clone(&datadriven.client.blob),
             Arc::clone(&datadriven.client.metrics),

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -530,7 +530,7 @@ impl CompactionMetrics {
         CompactionMetrics {
             requested: registry.register(metric!(
                 name: "mz_persist_compaction_requested",
-                help: "count of total compactions requests",
+                help: "count of total compaction requests",
             )),
             skipped: registry.register(metric!(
                 name: "mz_persist_compaction_skipped",

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -513,6 +513,7 @@ impl BatchWriteMetrics {
 
 #[derive(Debug)]
 pub struct CompactionMetrics {
+    pub(crate) requested: IntCounter,
     pub(crate) skipped: IntCounter,
     pub(crate) started: IntCounter,
     pub(crate) applied: IntCounter,
@@ -527,6 +528,10 @@ pub struct CompactionMetrics {
 impl CompactionMetrics {
     fn new(registry: &MetricsRegistry) -> Self {
         CompactionMetrics {
+            requested: registry.register(metric!(
+                name: "mz_persist_compaction_requested",
+                help: "count of total compactions requests",
+            )),
             skipped: registry.register(metric!(
                 name: "mz_persist_compaction_skipped",
                 help: "count of compactions skipped due to heuristics",

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -443,9 +443,7 @@ impl PersistClient {
         let writer_id = WriterId::new();
         let compact = self.cfg.compaction_enabled.then(|| {
             Compactor::new(
-                self.cfg.clone(),
-                Arc::clone(&self.blob),
-                Arc::clone(&self.metrics),
+                machine.clone(),
                 Arc::clone(&self.cpu_heavy_runtime),
                 writer_id.clone(),
             )

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -94,7 +94,7 @@ where
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) machine: Machine<K, V, T, D>,
     pub(crate) gc: GarbageCollector<K, V, T, D>,
-    pub(crate) compact: Option<Compactor>,
+    pub(crate) compact: Option<Compactor<T, D>>,
     pub(crate) blob: Arc<dyn Blob + Send + Sync>,
     pub(crate) cpu_heavy_runtime: Arc<CpuHeavyRuntime>,
     pub(crate) writer_id: WriterId,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

With [bounded memory compaction](https://github.com/MaterializeInc/materialize/pull/14527), we can now be assured that a single compaction operation does not exceed a particular amount of memory. However! It's still possible for compaction operations of a single process to overlap one another, especially when compacting many batches at once, which means that we can't yet guarantee a particular memory usage for a given shard.

Similar to https://github.com/MaterializeInc/materialize/pull/14064, this PR spins out a separate background compaction worker per shard, each ensuring only 1 compaction request is executed at a time. To keep things simple at the start, no effort to merge compaction requests is made. A new metric `compaction.requested` has been added that will help give visibility into whether we're accumulating a backlog of compaction reqs or not.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
