### PR TITLE
make stderr log filter dynamically configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "mz-ore",
  "prometheus",
  "serde",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -432,7 +432,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
     } else {
         None
     };
-    let otel_enable_callback =
+    let (otel_enable_callback, stderr_filter_callback) =
         runtime.block_on(mz_ore::tracing::configure("environmentd", &args.tracing))?;
 
     // Initialize fail crate for failpoint support
@@ -704,6 +704,7 @@ max log level: {max_log_level}",
             secrets_reader,
         ),
         otel_enable_callback,
+        stderr_filter_callback,
         storage_usage_collection_interval: args.storage_usage_collection_interval_sec,
     }))?;
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -37,7 +37,7 @@ use mz_frontegg_auth::FronteggAuthentication;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_ore::task;
-use mz_ore::tracing::OpenTelemetryEnableCallback;
+use mz_ore::tracing::{OpenTelemetryEnableCallback, StderrFilterCallback};
 use mz_persist_client::usage::StorageUsageClient;
 use mz_secrets::SecretsController;
 use mz_storage::types::connections::ConnectionContext;
@@ -113,6 +113,8 @@ pub struct Config {
     pub metrics_registry: MetricsRegistry,
     /// A callback to enable or disable the OpenTelemetry tracing collector.
     pub otel_enable_callback: OpenTelemetryEnableCallback,
+    /// A callback to modify the stderr log filter
+    pub stderr_filter_callback: StderrFilterCallback,
 
     // === Testing options. ===
     /// A now generation function for mocking time.
@@ -208,7 +210,11 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     // Listen on the internal HTTP API port.
     let internal_http_local_addr = {
         let metrics_registry = config.metrics_registry.clone();
-        let server = http::InternalServer::new(metrics_registry, config.otel_enable_callback);
+        let server = http::InternalServer::new(
+            metrics_registry,
+            config.otel_enable_callback,
+            config.stderr_filter_callback,
+        );
         let bound_server = server.bind(config.internal_http_listen_addr);
         let internal_http_local_addr = bound_server.local_addr();
         task::spawn(|| "internal_http_server", {

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -215,6 +215,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
             (Arc::clone(&orchestrator) as Arc<dyn SecretsController>).reader(),
         ),
         otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
+        stderr_filter_callback: mz_ore::tracing::StderrFilterCallback::none(),
         storage_usage_collection_interval: config.storage_usage_collection_interval,
     }))?;
     let server = Server {

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -11,6 +11,7 @@ askama = { version = "0.11.1", default-features = false, features = ["config", "
 axum = { version = "0.5.16", features = ["headers"] }
 headers = "0.3.7"
 serde = "1.0.144"
+tracing-subscriber = "0.3.15"
 include_dir = "0.7.2"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tracing_"] }
 prometheus = { version = "0.13.2", default-features = false, features = ["process"] }

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -682,6 +682,7 @@ impl Runner {
                 (Arc::clone(&orchestrator) as Arc<dyn SecretsController>).reader(),
             ),
             otel_enable_callback: mz_ore::tracing::OpenTelemetryEnableCallback::none(),
+            stderr_filter_callback: mz_ore::tracing::StderrFilterCallback::none(),
             storage_usage_collection_interval: Duration::from_secs(3600),
         };
         // We need to run the server on its own Tokio runtime, which in turn

--- a/src/storaged/src/bin/storaged.rs
+++ b/src/storaged/src/bin/storaged.rs
@@ -127,7 +127,8 @@ fn create_timely_config(args: &Args) -> Result<timely::Config, anyhow::Error> {
 
 async fn run(args: Args) -> Result<(), anyhow::Error> {
     mz_ore::panic::set_abort_on_panic();
-    let otel_enable_callback = mz_ore::tracing::configure("storaged", &args.tracing).await?;
+    let (otel_enable_callback, stderr_filter_callback) =
+        mz_ore::tracing::configure("storaged", &args.tracing).await?;
 
     let mut _pid_file = None;
     if let Some(pid_file_location) = &args.pid_file_location {
@@ -166,6 +167,16 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
                         "/api/opentelemetry/config",
                         routing::put(move |payload| async move {
                             mz_http_util::handle_enable_otel(otel_enable_callback, payload).await
+                        }),
+                    )
+                    .route(
+                        "/api/stderr/config",
+                        routing::put(move |payload| async move {
+                            mz_http_util::handle_modify_stderr_filter(
+                                stderr_filter_callback,
+                                payload,
+                            )
+                            .await
                         }),
                     )
                     .into_make_service(),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

It'd be very helpful to be able to toggle our log levels dynamically when debugging actively-running applications, so we can selectively dig deeper into app behavior without needing a deploy / to bounce a running pod with some filter override / introduce general log spam.

This PR follows @guswynn's work to [make opentelemetry tracing dynamically toggleable](https://github.com/MaterializeInc/materialize/pull/13361), and allows a user to pass in a log filter at runtime through the internal HTTP server. The cost of this flexibility is the RwLock inside the reload layer. I'm not sure how big of a performance impact this will make, nor am I quite sure how to measure it.

I've verified this changes works as expected through local calls such as:

```bash
> curl -X PUT -d '{"targets": "mz_persist_client=debug"}' -H 'Content-Type: application/json' localhost:6878/api/stderr/config
> curl -X PUT -d '{"targets": "info"}' -H 'Content-Type: application/json' localhost:6878/api/stderr/config
```

It'd also be helpful to make our tracing filter similarly configurable, but I think that deserves a separate PR if we pursue it.

### Motivation

* This PR adds a feature that has not yet been specified.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
