### PR TITLE
Consolidate compute controller

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -523,9 +523,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             vec![self.finalize_dataflow(dataflow, idx.compute_instance)];
                         self.controller
                             .active_compute()
-                            .instance(idx.compute_instance)
-                            .unwrap()
-                            .create_dataflows(dataflow_plan)
+                            .create_dataflows(idx.compute_instance, dataflow_plan)
                             .await
                             .unwrap();
                     }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -267,7 +267,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut compute = self.controller.active_compute();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Some(mut instance) = compute.instance(compute_instance) {
+            if let Ok(mut instance) = compute.instance(compute_instance) {
                 instance.drop_collections(ids).await.unwrap();
             }
         }
@@ -323,7 +323,7 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut compute = self.controller.active_compute();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Some(mut instance) = compute.instance(compute_instance) {
+            if let Ok(mut instance) = compute.instance(compute_instance) {
                 instance.drop_collections(ids).await.unwrap();
             }
         }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -267,8 +267,11 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut compute = self.controller.active_compute();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Ok(mut instance) = compute.instance(compute_instance) {
-                instance.drop_collections(ids).await.unwrap();
+            if compute.instance_exists(compute_instance) {
+                compute
+                    .drop_collections(compute_instance, ids)
+                    .await
+                    .unwrap();
             }
         }
     }
@@ -295,9 +298,7 @@ impl<S: Append + 'static> Coordinator<S> {
         for (compute_instance, ids) in by_compute_instance {
             self.controller
                 .active_compute()
-                .instance(compute_instance)
-                .unwrap()
-                .drop_collections(ids)
+                .drop_collections(compute_instance, ids)
                 .await
                 .unwrap();
         }
@@ -323,8 +324,11 @@ impl<S: Append + 'static> Coordinator<S> {
         let mut compute = self.controller.active_compute();
         for (compute_instance, ids) in by_compute_instance {
             // A cluster could have been dropped, so verify it exists.
-            if let Ok(mut instance) = compute.instance(compute_instance) {
-                instance.drop_collections(ids).await.unwrap();
+            if compute.instance_exists(compute_instance) {
+                compute
+                    .drop_collections(compute_instance, ids)
+                    .await
+                    .unwrap();
             }
         }
 

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeSet;
 
-use mz_compute_client::controller::{ComputeInstanceId, Instance as ComputeInstanceController};
+use mz_compute_client::controller::{ComputeInstanceId, ComputeInstanceRef};
 use mz_expr::MirScalarExpr;
 use mz_repr::GlobalId;
 use mz_stash::Append;
@@ -25,7 +25,7 @@ use crate::coord::{CollectionIdBundle, Coordinator};
 #[derive(Debug)]
 pub struct ComputeInstanceIndexOracle<'a, T> {
     catalog: &'a CatalogState,
-    compute: &'a ComputeInstanceController<T>,
+    compute: ComputeInstanceRef<'a, T>,
 }
 
 impl<S: Append> Coordinator<S> {
@@ -36,7 +36,7 @@ impl<S: Append> Coordinator<S> {
     ) -> ComputeInstanceIndexOracle<mz_repr::Timestamp> {
         ComputeInstanceIndexOracle {
             catalog: self.catalog.state(),
-            compute: self.controller.compute.instance(instance).unwrap(),
+            compute: self.controller.compute.instance_ref(instance).unwrap(),
         }
     }
 }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -604,7 +604,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             for (compute_instance, uuids) in inverse {
                 self.controller
                     .active_compute()
-                    .cancel_peeks(compute_instance, &uuids)
+                    .cancel_peeks(compute_instance, uuids)
                     .await
                     .unwrap();
             }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -484,9 +484,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 // Very important: actually create the dataflow (here, so we can destructure).
                 self.controller
                     .active_compute()
-                    .instance(compute_instance)
-                    .unwrap()
-                    .create_dataflows(vec![dataflow])
+                    .create_dataflows(compute_instance, vec![dataflow])
                     .await
                     .unwrap();
                 self.initialize_compute_read_policies(
@@ -554,9 +552,8 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
 
         self.controller
             .active_compute()
-            .instance(compute_instance)
-            .unwrap()
             .peek(
+                compute_instance,
                 id,
                 literal_constraints,
                 uuid,
@@ -607,9 +604,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             for (compute_instance, uuids) in inverse {
                 self.controller
                     .active_compute()
-                    .instance(compute_instance)
-                    .unwrap()
-                    .cancel_peeks(&uuids)
+                    .cancel_peeks(compute_instance, &uuids)
                     .await
                     .unwrap();
             }

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -421,7 +421,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     policy_changes.push((*id, read_needs.policy()));
                 }
             }
-            if let Some(mut instance) = compute.instance(*compute_instance) {
+            if let Ok(mut instance) = compute.instance(*compute_instance) {
                 instance.set_read_policy(policy_changes).await.unwrap();
             }
         }

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -148,9 +148,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     let initial_frontier = self
                         .controller
                         .compute
-                        .instance(*compute_instance)
-                        .unwrap()
-                        .collection(*id)
+                        .collection(*compute_instance, *id)
                         .unwrap()
                         .read_frontier()
                         .to_owned();
@@ -181,9 +179,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             }
             self.controller
                 .active_compute()
-                .instance(*compute_instance)
-                .unwrap()
-                .set_read_policy(compute_policy_updates)
+                .set_read_policy(*compute_instance, compute_policy_updates)
                 .await
                 .unwrap();
         }
@@ -244,9 +240,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         capability.base_policy = base_policy;
         self.controller
             .active_compute()
-            .instance(compute_instance)
-            .unwrap()
-            .set_read_policy(vec![(id, capability.policy())])
+            .set_read_policy(compute_instance, vec![(id, capability.policy())])
             .await
             .unwrap();
     }
@@ -290,9 +284,8 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         for (compute_instance, compute_ids) in read_holds.id_bundle.compute_ids.iter() {
             let mut policy_changes = Vec::new();
             let mut compute = self.controller.active_compute();
-            let mut instance = compute.instance(*compute_instance).unwrap();
             for id in compute_ids.iter() {
-                let collection = instance.collection(*id).unwrap();
+                let collection = compute.collection(*compute_instance, *id).unwrap();
                 assert!(collection
                     .read_frontier()
                     .less_equal(&read_holds.time),
@@ -306,7 +299,10 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 read_needs.holds.update_iter(Some((read_holds.time, 1)));
                 policy_changes.push((*id, read_needs.policy()));
             }
-            instance.set_read_policy(policy_changes).await.unwrap();
+            compute
+                .set_read_policy(*compute_instance, policy_changes)
+                .await
+                .unwrap();
         }
     }
     /// Update the timestamp of the read holds on the indicated collections from the
@@ -357,9 +353,8 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
         let mut compute = self.controller.active_compute();
         for (compute_instance, compute_ids) in compute_ids.iter() {
             let mut policy_changes = Vec::new();
-            let mut instance = compute.instance(*compute_instance).unwrap();
             for id in compute_ids.iter() {
-                let collection = instance.collection(*id).unwrap();
+                let collection = compute.collection(*compute_instance, *id).unwrap();
                 assert!(collection
                     .read_frontier()
                     .less_equal(&new_time),
@@ -375,7 +370,10 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 read_needs.holds.update_iter(Some((*old_time, -1)));
                 policy_changes.push((*id, read_needs.policy()));
             }
-            instance.set_read_policy(policy_changes).await.unwrap();
+            compute
+                .set_read_policy(*compute_instance, policy_changes)
+                .await
+                .unwrap();
         }
 
         read_holds.time = new_time;
@@ -421,8 +419,11 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                     policy_changes.push((*id, read_needs.policy()));
                 }
             }
-            if let Ok(mut instance) = compute.instance(*compute_instance) {
-                instance.set_read_policy(policy_changes).await.unwrap();
+            if compute.instance_exists(*compute_instance) {
+                compute
+                    .set_read_policy(*compute_instance, policy_changes)
+                    .await
+                    .unwrap();
             }
         }
     }

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2575,9 +2575,12 @@ impl<S: Append + 'static> Coordinator<S> {
                 }
                 {
                     if let Some(compute_ids) = id_bundle.compute_ids.get(&compute_instance) {
-                        let compute = self.controller.compute.instance(compute_instance).unwrap();
                         for id in compute_ids {
-                            let state = compute.collection(*id).unwrap();
+                            let state = self
+                                .controller
+                                .compute
+                                .collection(compute_instance, *id)
+                                .unwrap();
                             let name = self
                                 .catalog
                                 .try_get_entry(id)
@@ -3329,10 +3332,12 @@ impl<S: Append + 'static> Coordinator<S> {
     async fn update_max_result_size(&mut self) {
         let mut compute = self.controller.active_compute();
         for compute_instance in self.catalog.compute_instances() {
-            let mut instance = compute.instance(compute_instance.id).unwrap();
-            instance
-                .update_max_result_size(self.catalog.system_config().max_result_size())
-                .await;
+            compute
+                .update_max_result_size(
+                    compute_instance.id,
+                    self.catalog.system_config().max_result_size(),
+                )
+                .unwrap();
         }
     }
 

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -130,9 +130,7 @@ impl<S: Append + 'static> Coordinator<S> {
                             let since = self
                                 .controller
                                 .compute
-                                .instance(compute_instance)
-                                .unwrap()
-                                .collection(*id)
+                                .collection(compute_instance, *id)
                                 .unwrap()
                                 .read_frontier()
                                 .to_owned();
@@ -187,9 +185,9 @@ impl<S: Append + 'static> Coordinator<S> {
         }
         {
             for (instance, compute_ids) in &id_bundle.compute_ids {
-                let compute = self.controller.compute.instance(*instance).unwrap();
                 for id in compute_ids.iter() {
-                    since.join_assign(&compute.collection(*id).unwrap().read_capability())
+                    let collection = self.controller.compute.collection(*instance, *id).unwrap();
+                    since.join_assign(&collection.read_capability())
                 }
             }
         }
@@ -220,16 +218,9 @@ impl<S: Append + 'static> Coordinator<S> {
         }
         {
             for (instance, compute_ids) in &id_bundle.compute_ids {
-                let compute = self.controller.compute.instance(*instance).unwrap();
                 for id in compute_ids.iter() {
-                    since.extend(
-                        compute
-                            .collection(*id)
-                            .unwrap()
-                            .write_frontier()
-                            .iter()
-                            .cloned(),
-                    );
+                    let collection = self.controller.compute.collection(*instance, *id).unwrap();
+                    since.extend(collection.write_frontier().iter().cloned());
                 }
             }
         }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -323,22 +323,22 @@ where
     /// Create a compute instance.
     pub fn create_instance(
         &mut self,
-        instance: ComputeInstanceId,
+        id: ComputeInstanceId,
         logging: Option<LoggingConfig>,
         max_result_size: u32,
     ) -> Result<(), ComputeError> {
-        if self.instances.contains_key(&instance) {
-            return Err(ComputeError::InstanceExists(instance));
+        if self.instances.contains_key(&id) {
+            return Err(ComputeError::InstanceExists(id));
         }
 
         self.instances.insert(
-            instance,
-            Instance::new(instance, self.build_info, &logging, max_result_size),
+            id,
+            Instance::new(id, self.build_info, &logging, max_result_size),
         );
 
         if self.initialized {
             self.instances
-                .get_mut(&instance)
+                .get_mut(&id)
                 .expect("instance just added")
                 .initialization_complete();
         }
@@ -350,8 +350,8 @@ where
     ///
     /// # Panics
     /// - If the identified `instance` still has active replicas.
-    pub fn drop_instance(&mut self, instance: ComputeInstanceId) {
-        if let Some(compute_state) = self.instances.remove(&instance) {
+    pub fn drop_instance(&mut self, id: ComputeInstanceId) {
+        if let Some(compute_state) = self.instances.remove(&id) {
             compute_state.drop();
         }
     }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -13,19 +13,21 @@
 //! This involves ensuring the intended service state with the orchestrator, as well as maintaining
 //! a dedicated compute instance controller for each active compute instance.
 //!
-//! An instance controller curates the creation of indexes and sinks installed on its instance, the
-//! progress of readers through these collections, and their eventual dropping and resource
-//! reclamation.
+//! For each compute instance, the compute controller curates the creation of indexes and sinks
+//! installed on the instance, the progress of readers through these collections, and their
+//! eventual dropping and resource reclamation.
 //!
-//! An instance controller can be viewed as a partial map from `GlobalId` to collection. It is an error to
-//! use an identifier before it has been "created" with `create_dataflows()`. Once created, the controller holds
-//! a read capability for each output collection of a dataflow, which is manipulated with `allow_compaction()`.
-//! Eventually, a collection is dropped with either `drop_sources()` or by allowing compaction to the empty frontier.
+//! The state maintained for a compute instance can be viewed as a partial map from `GlobalId` to
+//! collection. It is an error to use an identifier before it has been "created" with
+//! `create_dataflows()`. Once created, the controller holds a read capability for each output
+//! collection of a dataflow, which is manipulated with `set_read_policy()`. Eventually, a
+//! collection is dropped with either `drop_collections()` or by allowing compaction to the empty
+//! frontier.
 //!
-//! Created dataflows will prevent the compaction of their inputs, including other compute collections but also
-//! collections managed by the storage layer. Each dataflow input is prevented from compacting beyond the allowed
-//! compaction of each of its outputs, ensuring that we can recover each dataflow to its current state in case of
-//! failure or other reconfiguration.
+//! Created dataflows will prevent the compaction of their inputs, including other compute
+//! collections but also collections managed by the storage layer. Each dataflow input is prevented
+//! from compacting beyond the allowed compaction of each of its outputs, ensuring that we can
+//! recover each dataflow to its current state in case of failure or other reconfiguration.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::error::Error;
@@ -296,11 +298,42 @@ impl<T> ComputeController<T> {
         }
     }
 
-    /// Return a handle to the indicated compute instance.
-    pub fn instance(&self, id: ComputeInstanceId) -> Result<&Instance<T>, ComputeError> {
+    pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
+        self.instances.contains_key(&id)
+    }
+
+    /// Return a reference to the indicated compute instance.
+    fn instance(&self, id: ComputeInstanceId) -> Result<&Instance<T>, ComputeError> {
         self.instances
             .get(&id)
             .ok_or(ComputeError::InstanceMissing(id))
+    }
+
+    /// Return a mutable reference to the indicated compute instance.
+    fn instance_mut(&mut self, id: ComputeInstanceId) -> Result<&mut Instance<T>, ComputeError> {
+        self.instances
+            .get_mut(&id)
+            .ok_or(ComputeError::InstanceMissing(id))
+    }
+
+    /// Return a read-only handle to the indicated compute instance.
+    pub fn instance_ref(
+        &self,
+        id: ComputeInstanceId,
+    ) -> Result<ComputeInstanceRef<T>, ComputeError> {
+        self.instance(id).map(|instance| ComputeInstanceRef {
+            instance_id: id,
+            instance,
+        })
+    }
+
+    /// Return a read-only handle to the indicated collection.
+    pub fn collection(
+        &self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+    ) -> Result<&CollectionState<T>, ComputeError> {
+        self.instance(instance_id)?.collection(collection_id)
     }
 
     /// Acquire an [`ActiveComputeController`] by supplying a storage connection.
@@ -333,7 +366,7 @@ where
 
         self.instances.insert(
             id,
-            Instance::new(id, self.build_info, &logging, max_result_size),
+            Instance::new(self.build_info, &logging, max_result_size),
         );
 
         if self.initialized {
@@ -413,12 +446,23 @@ pub struct ActiveComputeController<'a, T> {
 }
 
 impl<T> ActiveComputeController<'_, T> {
+    pub fn instance_exists(&self, id: ComputeInstanceId) -> bool {
+        self.compute.instance_exists(id)
+    }
+
+    /// Return a read-only handle to the indicated collection.
+    pub fn collection(
+        &self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+    ) -> Result<&CollectionState<T>, ComputeError> {
+        self.compute.collection(instance_id, collection_id)
+    }
+
     /// Return a handle to the indicated compute instance.
-    pub fn instance(&mut self, id: ComputeInstanceId) -> Result<ActiveInstance<T>, ComputeError> {
+    fn instance(&mut self, id: ComputeInstanceId) -> Result<ActiveInstance<T>, ComputeError> {
         self.compute
-            .instances
-            .get_mut(&id)
-            .ok_or(ComputeError::InstanceMissing(id))
+            .instance_mut(id)
             .map(|c| c.activate(self.storage))
     }
 }
@@ -490,6 +534,106 @@ where
         Ok(())
     }
 
+    /// Create and maintain the described dataflows, and initialize state for their output.
+    ///
+    /// This method creates dataflows whose inputs are still readable at the dataflow `as_of`
+    /// frontier, and initializes the outputs as readable from that frontier onward.
+    /// It installs read dependencies from the outputs to the inputs, so that the input read
+    /// capabilities will be held back to the output read capabilities, ensuring that we are
+    /// always able to return to a state that can serve the output read capabilities.
+    pub async fn create_dataflows(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        dataflows: Vec<DataflowDescription<crate::plan::Plan<T>, (), T>>,
+    ) -> Result<(), ComputeError> {
+        self.instance(instance_id)?
+            .create_dataflows(dataflows)
+            .await
+    }
+
+    /// Drop the read capability for the given collections and allow their resources to be
+    /// reclaimed.
+    pub async fn drop_collections(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        collection_ids: Vec<GlobalId>,
+    ) -> Result<(), ComputeError> {
+        self.instance(instance_id)?
+            .drop_collections(collection_ids)
+            .await
+    }
+
+    /// Initiate a peek request for the contents of the given collection at `timestamp`.
+    pub async fn peek(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        collection_id: GlobalId,
+        literal_constraints: Option<Vec<Row>>,
+        uuid: Uuid,
+        timestamp: T,
+        finishing: RowSetFinishing,
+        map_filter_project: mz_expr::SafeMfpPlan,
+        target_replica: Option<ReplicaId>,
+    ) -> Result<(), ComputeError> {
+        self.instance(instance_id)?
+            .peek(
+                collection_id,
+                literal_constraints,
+                uuid,
+                timestamp,
+                finishing,
+                map_filter_project,
+                target_replica,
+            )
+            .await
+    }
+
+    /// Cancel existing peek requests.
+    ///
+    /// Canceling a peek is best effort. The caller may see any of the following
+    /// after canceling a peek request:
+    ///
+    ///   * A `PeekResponse::Rows` indicating that the cancellation request did
+    ///    not take effect in time and the query succeeded.
+    ///
+    ///   * A `PeekResponse::Canceled` affirming that the peek was canceled.
+    ///
+    ///   * No `PeekResponse` at all.
+    pub async fn cancel_peeks(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        uuids: &BTreeSet<Uuid>,
+    ) -> Result<(), ComputeError> {
+        self.instance(instance_id)?.cancel_peeks(uuids).await
+    }
+
+    /// Assign a read policy to specific identifiers.
+    ///
+    /// The policies are assigned in the order presented, and repeated identifiers should
+    /// conclude with the last policy. Changing a policy will immediately downgrade the read
+    /// capability if appropriate, but it will not "recover" the read capability if the prior
+    /// capability is already ahead of it.
+    ///
+    /// Identifiers not present in `policies` retain their existing read policies.
+    pub async fn set_read_policy(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        policies: Vec<(GlobalId, ReadPolicy<T>)>,
+    ) -> Result<(), ComputeError> {
+        self.instance(instance_id)?.set_read_policy(policies).await
+    }
+
+    /// Update the max size in bytes of any result.
+    pub fn update_max_result_size(
+        &mut self,
+        instance_id: ComputeInstanceId,
+        max_result_size: u32,
+    ) -> Result<(), ComputeError> {
+        self.instance(instance_id)?
+            .update_max_result_size(max_result_size);
+        Ok(())
+    }
+
     /// Processes the work queued by [`ComputeController::ready`].
     ///
     /// This method is guaranteed to return "quickly" unless doing so would
@@ -553,11 +697,9 @@ where
     }
 }
 
-/// A controller for a compute instance.
+/// The state we keep for a compute instance.
 #[derive(Debug)]
-pub struct Instance<T> {
-    /// The ID of the compute instance.
-    instance_id: ComputeInstanceId,
+struct Instance<T> {
     /// The replicas of this compute instance.
     replicas: ActiveReplication<T>,
     /// Tracks expressed `since` and received `upper` frontiers for indexes and sinks.
@@ -566,30 +708,23 @@ pub struct Instance<T> {
     peeks: BTreeMap<uuid::Uuid, (GlobalId, T)>,
 }
 
-/// A wrapper around [`Instance`] with a live storage controller.
-#[derive(Debug)]
-pub struct ActiveInstance<'a, T> {
-    compute: &'a mut Instance<T>,
-    storage_controller: &'a mut dyn StorageController<Timestamp = T>,
-}
-
-// Public interface
-
 impl<T> Instance<T> {
-    /// Returns this controller's compute instance ID.
-    pub fn instance_id(&self) -> ComputeInstanceId {
-        self.instance_id
-    }
-
     /// Acquire a handle to the collection state associated with `id`.
-    pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, ComputeError> {
+    fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, ComputeError> {
         self.collections
             .get(&id)
             .ok_or(ComputeError::IdentifierMissing(id))
     }
 
+    /// Acquire a mutable handle to the collection state associated with `id`.
+    fn collection_mut(&mut self, id: GlobalId) -> Result<&mut CollectionState<T>, ComputeError> {
+        self.collections
+            .get_mut(&id)
+            .ok_or(ComputeError::IdentifierMissing(id))
+    }
+
     /// Acquire an [`ActiveInstance`] by providing a storage controller.
-    pub fn activate<'a>(
+    fn activate<'a>(
         &'a mut self,
         storage_controller: &'a mut dyn StorageController<Timestamp = T>,
     ) -> ActiveInstance<'a, T> {
@@ -605,8 +740,7 @@ where
     T: Timestamp + Lattice,
     ComputeGrpcClient: ComputeClient<T>,
 {
-    pub fn new(
-        instance_id: ComputeInstanceId,
+    fn new(
         build_info: &'static BuildInfo,
         logging: &Option<LoggingConfig>,
         max_result_size: u32,
@@ -632,7 +766,6 @@ where
         }));
 
         Self {
-            instance_id,
             replicas,
             collections,
             peeks: Default::default(),
@@ -642,7 +775,7 @@ where
     /// Marks the end of any initialization commands.
     ///
     /// Intended to be called by `Controller`, rather than by other code (to avoid repeated calls).
-    pub fn initialization_complete(&mut self) {
+    fn initialization_complete(&mut self) {
         self.replicas.send(ComputeCommand::InitializationComplete);
     }
 
@@ -650,7 +783,7 @@ where
     ///
     /// # Panics
     /// - If the compute instance still has active replicas.
-    pub fn drop(mut self) {
+    fn drop(mut self) {
         assert!(
             self.replicas.get_replica_ids().next().is_none(),
             "cannot drop instances with provisioned replicas"
@@ -659,18 +792,20 @@ where
     }
 }
 
+/// A wrapper around [`Instance`] with a live storage controller.
+#[derive(Debug)]
+struct ActiveInstance<'a, T> {
+    compute: &'a mut Instance<T>,
+    storage_controller: &'a mut dyn StorageController<Timestamp = T>,
+}
+
 impl<'a, T> ActiveInstance<'a, T>
 where
     T: Timestamp + Lattice,
     ComputeGrpcClient: ComputeClient<T>,
 {
-    /// Acquire a handle to the collection state associated with `id`.
-    pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, ComputeError> {
-        self.compute.collection(id)
-    }
-
-    /// Adds a new instance replica, by name.
-    pub fn add_replica(
+    /// Add a new instance replica, by ID.
+    fn add_replica(
         &mut self,
         id: ReplicaId,
         addrs: Vec<String>,
@@ -702,19 +837,13 @@ where
         self.compute.replicas.add_replica(id, addrs, persisted_logs);
     }
 
-    /// Removes an existing instance replica, by name.
-    pub fn remove_replica(&mut self, id: ReplicaId) {
+    /// Remove an existing instance replica, by ID.
+    fn remove_replica(&mut self, id: ReplicaId) {
         self.compute.replicas.remove_replica(id);
     }
 
-    /// Creates and maintains the described dataflows, and initializes state for their output.
-    ///
-    /// This method creates dataflows whose inputs are still readable at the dataflow `as_of`
-    /// frontier, and initializes the outputs as readable from that frontier onward.
-    /// It installs read dependencies from the outputs to the inputs, so that the input read
-    /// capabilities will be held back to the output read capabilities, ensuring that we are
-    /// always able to return to a state that can serve the output read capabilities.
-    pub async fn create_dataflows(
+    /// Create the described dataflows and initializes state for their output.
+    async fn create_dataflows(
         &mut self,
         dataflows: Vec<DataflowDescription<crate::plan::Plan<T>, (), T>>,
     ) -> Result<(), ComputeError> {
@@ -872,7 +1001,7 @@ where
 
     /// Drops the read capability for the given collections and allows their resources to be
     /// reclaimed.
-    pub async fn drop_collections(&mut self, ids: Vec<GlobalId>) -> Result<(), ComputeError> {
+    async fn drop_collections(&mut self, ids: Vec<GlobalId>) -> Result<(), ComputeError> {
         // Validate that the ids exist.
         self.validate_ids(ids.iter().cloned())?;
 
@@ -883,7 +1012,7 @@ where
 
     /// Initiate a peek request for the contents of `id` at `timestamp`.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn peek(
+    async fn peek(
         &mut self,
         id: GlobalId,
         literal_constraints: Option<Vec<Row>>,
@@ -922,17 +1051,7 @@ where
     }
 
     /// Cancels existing peek requests.
-    ///
-    /// Canceling a peek is best effort. The caller may see any of the following
-    /// after canceling a peek request:
-    ///
-    ///   * A `PeekResponse::Rows` indicating that the cancellation request did
-    ///    not take effect in time and the query succeeded.
-    ///
-    ///   * A `PeekResponse::Canceled` affirming that the peek was canceled.
-    ///
-    ///   * No `PeekResponse` at all.
-    pub async fn cancel_peeks(&mut self, uuids: &BTreeSet<Uuid>) -> Result<(), ComputeError> {
+    async fn cancel_peeks(&mut self, uuids: &BTreeSet<Uuid>) -> Result<(), ComputeError> {
         self.remove_peeks(uuids.iter().cloned()).await?;
         self.compute.replicas.send(ComputeCommand::CancelPeeks {
             uuids: uuids.clone(),
@@ -949,7 +1068,7 @@ where
     ///
     /// Identifiers not present in `policies` retain their existing read policies.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn set_read_policy(
+    async fn set_read_policy(
         &mut self,
         policies: Vec<(GlobalId, ReadPolicy<T>)>,
     ) -> Result<(), ComputeError> {
@@ -984,29 +1103,12 @@ where
     }
 
     /// Update the max size in bytes of any result.
-    pub async fn update_max_result_size(&mut self, max_result_size: u32) {
+    fn update_max_result_size(&mut self, max_result_size: u32) {
         self.compute
             .replicas
             .send(ComputeCommand::UpdateMaxResultSize(max_result_size))
     }
-}
 
-// Internal interface
-
-impl<T> Instance<T> {
-    /// Acquire a mutable handle to the collection state associated with `id`.
-    fn collection_mut(&mut self, id: GlobalId) -> Result<&mut CollectionState<T>, ComputeError> {
-        self.collections
-            .get_mut(&id)
-            .ok_or(ComputeError::IdentifierMissing(id))
-    }
-}
-
-impl<'a, T> ActiveInstance<'a, T>
-where
-    T: Timestamp + Lattice,
-    ComputeGrpcClient: ComputeClient<T>,
-{
     /// Validate that a collection exists for all identifiers, and error if any do not.
     fn validate_ids(&self, ids: impl Iterator<Item = GlobalId>) -> Result<(), ComputeError> {
         for id in ids {
@@ -1190,6 +1292,25 @@ where
             .map(|(id, frontier)| (id, ReadPolicy::ValidFrom(frontier)));
         self.set_read_policy(policies.collect()).await?;
         Ok(())
+    }
+}
+
+/// A read-only handle to a compute instance.
+#[derive(Debug, Clone, Copy)]
+pub struct ComputeInstanceRef<'a, T> {
+    instance_id: ComputeInstanceId,
+    instance: &'a Instance<T>,
+}
+
+impl<T> ComputeInstanceRef<'_, T> {
+    /// Return the ID of this compute instance.
+    pub fn instance_id(&self) -> ComputeInstanceId {
+        self.instance_id
+    }
+
+    /// Return a read-only handle to the indicated collection.
+    pub fn collection(&self, id: GlobalId) -> Result<&CollectionState<T>, ComputeError> {
+        self.instance.collection(id)
     }
 }
 

--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -512,6 +512,8 @@ where
     }
 
     /// Receives the next response from any replica.
+    ///
+    /// This method is cancellation safe.
     pub(super) async fn recv(&mut self) -> ActiveReplicationResponse<T> {
         // If we have a pending response, we should send it immediately.
         if let Some(response) = self.state.pending_response.pop_front() {

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 use mz_build_info::BuildInfo;
 use mz_compute_client::command::ReplicaId;
 use mz_compute_client::controller::{
-    ActiveComputeController, ComputeController, ComputeControllerResponse, ComputeInstanceId,
+    ActiveComputeController, ComputeController, ComputeControllerResponse,
 };
 use mz_compute_client::response::{PeekResponse, TailResponse};
 use mz_compute_client::service::{ComputeClient, ComputeGrpcClient};
@@ -114,7 +114,7 @@ enum Readiness {
     /// The storage controller is ready.
     Storage,
     /// The compute controller is ready.
-    Compute(ComputeInstanceId),
+    Compute,
 }
 
 /// A client that maintains soft state and validates commands, in addition to forwarding them.
@@ -161,8 +161,8 @@ where
                 () = self.storage.ready() => {
                     self.readiness = Readiness::Storage;
                 }
-                id = self.compute.ready() => {
-                    self.readiness = Readiness::Compute(id);
+                () = self.compute.ready() => {
+                    self.readiness = Readiness::Compute;
                 }
             }
         }
@@ -182,8 +182,8 @@ where
                 self.storage.process().await?;
                 Ok(None)
             }
-            Readiness::Compute(id) => {
-                let response = self.active_compute().process(id).await?;
+            Readiness::Compute => {
+                let response = self.active_compute().process().await?;
                 Ok(response.map(Into::into))
             }
         }


### PR DESCRIPTION
This PR refactors the compute controller to prepare it for the introduction of compute controller commands that record all state changes. The key change is that `Instance` and `ActiveInstance` are made private, so clients cannot change their state directly anymore. Instead, all state changes must now go through `ComputeController` and `ActiveComputeController`, allowing us to add the command boundary there in a follow-up PR.

### Motivation

  * This PR adds a known-desirable feature.

Part of #13222.

### Tips for reviewer

Look at the commits separately!

To get an idea of how introducing the controller commands will look like, check out https://github.com/MaterializeInc/materialize/pull/14682. This draft introduces compute controller commands, but only for per-instance controllers. It won't get merged but I will use the same approach for the whole compute controller.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
