### PR TITLE
Move ComputeSinkId into mz-adapter

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -18,7 +18,7 @@ use timely::progress::Antichain;
 use tracing::Level;
 use tracing::{event, warn};
 
-use mz_compute_client::controller::{ComputeInstanceId, ComputeSinkId};
+use mz_compute_client::controller::ComputeInstanceId;
 use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_repr::{GlobalId, Timestamp};
@@ -36,6 +36,7 @@ use crate::coord::appends::BuiltinTableUpdateSource;
 use crate::coord::Coordinator;
 use crate::session::vars::SystemVars;
 use crate::session::Session;
+use crate::util::ComputeSinkId;
 use crate::{catalog, AdapterError};
 
 /// State provided to a catalog transaction closure.

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -23,8 +23,7 @@ use mz_compute_client::command::{
     BuildDesc, DataflowDesc, DataflowDescription, IndexDesc, ReplicaId,
 };
 use mz_compute_client::controller::{
-    ComputeInstanceId, ComputeSinkId, ConcreteComputeInstanceReplicaConfig,
-    ConcreteComputeInstanceReplicaLogging,
+    ComputeInstanceId, ConcreteComputeInstanceReplicaConfig, ConcreteComputeInstanceReplicaLogging,
 };
 use mz_compute_client::explain::{
     DataflowGraphFormatter, Explanation, JsonViewFormatter, TimestampExplanation, TimestampSource,
@@ -81,7 +80,7 @@ use crate::session::{
     WriteOp,
 };
 use crate::tail::PendingTail;
-use crate::util::{send_immediate_rows, ClientTransmitter};
+use crate::util::{send_immediate_rows, ClientTransmitter, ComputeSinkId};
 use crate::{guard_write_critical_section, session, sink_connection, PeekResponseUnary};
 
 impl<S: Append + 'static> Coordinator<S> {

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -20,7 +20,6 @@ use derivative::Derivative;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::OwnedMutexGuard;
 
-use mz_compute_client::controller::ComputeSinkId;
 use mz_pgrepr::Format;
 use mz_repr::{Datum, Diff, GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement, TransactionAccessMode};
@@ -33,6 +32,7 @@ use crate::coord::peek::PeekResponseUnary;
 use crate::coord::CoordTimestamp;
 use crate::error::AdapterError;
 use crate::session::vars::IsolationLevel;
+use crate::util::ComputeSinkId;
 
 pub use self::vars::{
     ClientSeverity, SessionVars, Var, DEFAULT_DATABASE_NAME, SERVER_MAJOR_VERSION,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
 use mz_compute_client::controller::ComputeInstanceId;
-use mz_repr::{RelationDesc, Row, ScalarType};
+use mz_repr::{GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql::names::FullObjectName;
 use mz_sql::plan::StatementDesc;
 use mz_sql_parser::ast::display::AstDisplay;
@@ -181,4 +181,11 @@ pub fn describe<S: Append>(
             )?)
         }
     }
+}
+
+/// Type identifying a sink maintained by a compute instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ComputeSinkId {
+    pub compute_instance: ComputeInstanceId,
+    pub global_id: GlobalId,
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -79,12 +79,6 @@ pub struct ComputeInstanceEvent {
     pub time: DateTime<Utc>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ComputeSinkId {
-    pub compute_instance: ComputeInstanceId,
-    pub global_id: GlobalId,
-}
-
 /// Responses from the compute controller.
 pub enum ComputeControllerResponse<T> {
     /// See [`ComputeResponse::PeekResponse`].


### PR DESCRIPTION
This type is only used within mz-adapter, so there is no reason why it should be defined in mz-compute-client.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
