### PR TITLE
doc/user: add reference documentation for load generator sources

### DIFF
--- a/doc/user/content/releases/v0.27.0.md
+++ b/doc/user/content/releases/v0.27.0.md
@@ -34,7 +34,7 @@ substantial breaking changes from [v0.26 LTS].
 
 * Change sinks to have exactly-once behavior by default.
 
-* Add the `LOAD GENERATOR` source connector.
+* Add [load generator sources](/sql/create-source/load-generator).
 
 * Remove the `PUBNUB` source connector.
 

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -27,6 +27,9 @@ Materialize bundles **native connectors** for the following external systems:
 {{< linkbox title="Databases (CDC)" >}}
 - [PostgreSQL](/sql/create-source/postgres)
 {{</ linkbox >}}
+{{< linkbox title="Datagen" >}}
+- [Load generator](/sql/create-source/load-generator)
+{{</ linkbox >}}
 {{</ multilinkbox >}}
 
 For details on the syntax, supported formats and features of each connector, check out the dedicated `CREATE SOURCE` documentation pages.

--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -1,0 +1,171 @@
+---
+title: "CREATE SOURCE: Load generator"
+description: "Using Materialize's built-in load generators"
+pagerank: 10
+menu:
+  main:
+    parent: 'create-source'
+    identifier: load-generator
+    name: Load generator
+    weight: 20
+---
+
+{{% create-source/intro %}}
+Load generator sources produce synthetic data for use in demos and performance
+tests.
+{{% /create-source/intro %}}
+
+## Syntax
+
+{{< diagram "create-source-load-generator.svg" >}}
+
+#### `load_generator_option`
+
+{{< diagram "load-generator-option.svg" >}}
+
+Field | Use
+------|-----
+_src_name_  | The name for the source.
+**COUNTER** | Use the [counter](#counter) load generator.
+**AUCTION** | Use the [auction](#auction) load generator.
+**IF NOT EXISTS**  | Do nothing (except issuing a notice) if a source with the same name already exists.
+**TICK INTERVAL**  | The interval at which the next datum should be emitted. Defaults to one second.
+
+## Description
+
+Materialize has several built-in load generators, which provide a quick way to
+get up and running with no external dependencies before plugging in your own
+data sources. If you would like to see an additional load generator, please
+submit a [feature request].
+
+### Counter
+
+The counter load generator produces the sequence `1`, `2`, `3`, …. Each tick
+interval, the next number in the sequence is emitted.
+
+### Auction
+
+The auction load generator simulates an auction house, where users are bidding
+on an ongoing series of auctions. The auction source is meant to be used
+with [`CREATE VIEWS`](/sql/create-views), which will create the following five
+views:
+
+  * `organizations` describes the organizations known to the auction
+    house.
+
+    Field | Type       | Describes
+    ------|------------|----------
+    id    | [`bigint`] | A unique identifier for the organization.
+    name  | [`text`]   | The organization's name.
+
+  * `users` describes the users that belong to each organization.
+
+    Field     | Type       | Describes
+    ----------|------------|----------
+    `id`      | [`bigint`] | A unique identifier for the user.
+    `org_id`  | [`bigint`] | The identifier of the organization to which the user belongs. References `organizations.id`.
+    `name`    | [`text`]   | The user's name.
+
+  * `accounts` describes the account associated with each organization.
+
+    Field     | Type       | Describes
+    ----------|------------|----------
+    `id`      | [`bigint`] | A unique identifier for the account.
+    `org_id`  | [`bigint`] | The identifier of the organization to which the account belongs. References `organizations.id`.
+    `balance` | [`bigint`] | The balance of the account in dollars.
+
+  * `auctions` describes all past and ongoing auctions.
+
+    Field      | Type                         | Describes
+    -----------|------------------------------|----------
+    `id`       | [`bigint`]                   | A unique identifier for the auction.
+    `seller`   | [`bigint`]                   | The identifier of the user selling the item. References `users.id`.
+    `item`     | [`text`]                     | The name of the item being sold.
+    `end_time` | [`timestamp with time zone`] | The time at which the auction closes.
+
+  * `bids` describes the bids placed in each auction.
+
+    Field        | Type                         | Describes
+    -------------|------------------------------|----------
+    `id`         | [`bigint`]                   | A unique identifier for the bid.
+    `buyer`      | [`bigint`]                   | The identifier vof the user placing the bid. References `users.id`.
+    `auction_id` | [`text`]                     | The identifier of the auction in which the bid is placed. References `auctions.id`.
+    `amount`     | [`bigint`]                   | The bid amount in dollars.
+    `bid_time`   | [`timestamp with time zone`] | The time at which the bid was placed.
+
+The organizations, users, and accounts are fixed at the time the auction source
+is created. Each tick interval, either a new auction is started, or a new bid
+is placed in the currently ongoing auction.
+
+## Examples
+
+### Creating a counter load generator
+
+To create a load generator source that emits the next number in the sequence every
+second:
+
+```sql
+CREATE SOURCE counter FROM LOAD GENERATOR COUNTER;
+```
+
+To examine the counter:
+
+```sql
+SELECT * FROM counter;
+```
+```nofmt
+ counter
+---------
+       1
+       2
+       3
+(3 rows)
+```
+
+### Creating an auction load generator
+
+To create the load generator source and its associated views:
+
+```sql
+CREATE SOURCE auction_load FROM LOAD GENERATOR AUCTION;
+CREATE VIEWS FROM SOURCE auction_load;
+```
+
+To display the created views:
+
+```sql
+SHOW VIEWS;
+```
+```nofmt
+     name
+---------------
+ accounts
+ auctions
+ bids
+ organizations
+ users
+(5 rows)
+```
+
+To examine the simulated bids:
+
+```sql
+SELECT * from bids;
+```
+```nofmt
+ id | buyer | auction_id | amount |          bid_time
+----+-------+------------+--------+----------------------------
+ 10 |  3844 |          1 |     59 | 2022-09-16 23:24:07.332+00
+ 11 |  1861 |          1 |     40 | 2022-09-16 23:24:08.332+00
+ 12 |  3338 |          1 |     97 | 2022-09-16 23:24:09.332+00
+(3 rows)
+```
+
+## Related pages
+
+- [`CREATE VIEWS`](/sql/create-views/)
+
+[`bigint`]: /sql/types/bigint
+[`text`]: /sql/types/text
+[`timestamp with time zone`]: /sql/types/timestamp
+[feature request]: https://github.com/MaterializeInc/materialize/issues/new?assignees=&labels=A-integration&template=02-feature.yml

--- a/doc/user/content/sql/create-views.md
+++ b/doc/user/content/sql/create-views.md
@@ -42,6 +42,11 @@ CREATE VIEWS FROM "mz_source"
 ("public"."foo" AS "foo", "otherschema"."foo" AS "foo2");
 ```
 
+### Load generators
+
+For certain [load generator sources](/sql/create-source/load-generator), `CREATE
+VIEWS` will split the source into multiple views.
+
 ### Temporary views
 
 The `TEMP`/`TEMPORARY` keyword creates temporary views. Temporary views are
@@ -78,3 +83,4 @@ CREATE VIEWS FROM "mz_source"
 ## Related pages
 
 - [`CREATE SOURCE FROM POSTGRES`](/sql/create-source/postgres/)
+- [`CREATE SOURCE FROM LOAD GENERATOR`](/sql/create-source/load-generator/)

--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="539" height="349">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="140" height="32" rx="10"/>
+   <rect x="31"
+         y="1"
+         width="140"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="41" y="21">CREATE SOURCE</text>
+   <rect x="213" y="35" width="120" height="32" rx="10"/>
+   <rect x="211"
+         y="33"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="221" y="53">IF NOT EXISTS</text>
+   <rect x="373" y="3" width="82" height="32"/>
+   <rect x="371" y="1" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="381" y="21">src_name</text>
+   <rect x="80" y="145" width="26" height="32" rx="10"/>
+   <rect x="78"
+         y="143"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="88" y="163">(</text>
+   <rect x="146" y="145" width="82" height="32"/>
+   <rect x="144" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="154" y="163">col_name</text>
+   <rect x="146" y="101" width="24" height="32" rx="10"/>
+   <rect x="144"
+         y="99"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="154" y="119">,</text>
+   <rect x="288" y="145" width="196" height="32" rx="10"/>
+   <rect x="286"
+         y="143"
+         width="196"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="296" y="163">FROM LOAD GENERATOR</text>
+   <rect x="45" y="271" width="86" height="32" rx="10"/>
+   <rect x="43"
+         y="269"
+         width="86"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="289">AUCTION</text>
+   <rect x="45" y="315" width="88" height="32" rx="10"/>
+   <rect x="43"
+         y="313"
+         width="88"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="333">COUNTER</text>
+   <rect x="193" y="271" width="26" height="32" rx="10"/>
+   <rect x="191"
+         y="269"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="201" y="289">(</text>
+   <rect x="259" y="271" width="166" height="32"/>
+   <rect x="257" y="269" width="166" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="267" y="289">load_generator_option</text>
+   <rect x="259" y="227" width="24" height="32" rx="10"/>
+   <rect x="257"
+         y="225"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="267" y="245">,</text>
+   <rect x="465" y="271" width="26" height="32" rx="10"/>
+   <rect x="463"
+         y="269"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="473" y="289">)</text>
+   <path class="line"
+         d="m19 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-439 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m-188 44 h20 m188 0 h20 m-228 0 q10 0 10 10 m208 0 q0 -10 10 -10 m-218 10 v14 m208 0 v-14 m-208 14 q0 10 10 10 m188 0 q10 0 10 -10 m-198 10 h10 m0 0 h178 m20 -34 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-503 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h2 m-128 0 h20 m108 0 h20 m-148 0 q10 0 10 10 m128 0 q0 -10 10 -10 m-138 10 v24 m128 0 v-24 m-128 24 q0 10 10 10 m108 0 q10 0 10 -10 m-118 10 h10 m88 0 h10 m40 -44 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m23 -34 h-3"/>
+   <polygon points="529 285 537 281 537 289"/>
+   <polygon points="529 285 521 281 521 289"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/load-generator-option.svg
+++ b/doc/user/layouts/partials/sql-grammar/load-generator-option.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="275" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="128" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="128"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">TICK INTERVAL</text>
+   <rect x="179" y="3" width="68" height="32"/>
+   <rect x="177" y="1" width="68" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="187" y="21">interval</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m128 0 h10 m0 0 h10 m68 0 h10 m3 0 h-3"/>
+   <polygon points="265 17 273 13 273 21"/>
+   <polygon points="265 17 257 13 257 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -87,6 +87,13 @@ create_source_kinesis ::=
   'FROM' 'KINESIS ARN' arn with_options?
   'FORMAT' format_spec
   ('ENVELOPE NONE')?
+create_source_load_generator ::=
+  'CREATE SOURCE' ('IF NOT EXISTS')? src_name
+  ('(' (col_name) ( ( ',' col_name ) )*)?
+  'FROM LOAD GENERATOR' ('AUCTION' | 'COUNTER')
+  ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
+load_generator_option ::=
+    'TICK INTERVAL' interval
 create_source_postgres ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   'FROM' 'POSTGRES' 'CONNECTION' connection_name


### PR DESCRIPTION
Load generator sources were added in #13764 and #13812 and mentioned in getting started documentation, but we never wrote user-facing reference documentation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR adds missing documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
