### PR TITLE
sql-parser: date() cast support; temp hack

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -609,6 +609,27 @@ impl<'a> Parser<'a> {
             None
         };
 
+        // TODO: This is a temporary hack to allow us to support the special
+        // `date(expr)` cast function without needing to write a migration. It
+        // will be removed during a wipe week.
+        if let (FunctionArgs::Args { args, order_by }, None, None, false) =
+            (&args, &filter, &over, distinct)
+        {
+            if order_by.is_empty()
+                && args.len() == 1
+                && name.0.len() == 1
+                && name.0[0].as_str().eq_ignore_ascii_case("date")
+            {
+                return Ok(Expr::Cast {
+                    expr: Box::new(args[0].clone()),
+                    data_type: RawDataType::Other {
+                        name: RawObjectName::Name(name),
+                        typ_mod: Vec::new(),
+                    },
+                });
+            }
+        }
+
         Ok(Expr::Function(Function {
             name,
             args,

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -194,6 +194,11 @@ CAST(id AS decimal)
 ----
 id::numeric
 
+parse-scalar roundtrip
+date('t')
+----
+'t'::date
+
 # Extract
 
 parse-scalar

--- a/test/sqllogictest/cast.slt
+++ b/test/sqllogictest/cast.slt
@@ -101,3 +101,19 @@ query T
 SELECT pg_typeof('{1}'::int4_list_list_too::int4_list_list)
 ----
 int4_list_list
+
+# Postgres also supports `typename ( expression )` cast expressions with some limitations.
+# TODO: Support these more generally instead of just `date`.
+
+query TTT
+SELECT date('2020-01-01'), date('2020-01-01'::timestamp), date('2020-01-01'::timestamptz)
+----
+2020-01-01
+2020-01-01
+2020-01-01
+
+query error invalid input syntax
+SELECT date('2000')
+
+query error function .* does not exist
+SELECT date('2000', 'a')


### PR DESCRIPTION
This is a temporary hack to support #14803 until full support can be added, which may require a migration. We are using this to not write the migration, and instead wait and add full support on a wipe week.

### Motivation

  * This PR adds a known-desirable feature. #14803

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Support the `date(expression)` cast function.