### PR TITLE
storage: make MzOffset 0-indexed

### DIFF
--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -144,7 +144,7 @@ message ProtoDebeziumSourceProjection {
 message ProtoKafkaSourceConnection {
     mz_storage.types.connections.ProtoKafkaConnection connection = 1;
     string topic = 2;
-    map<int32, ProtoMzOffset> start_offsets = 3;
+    map<int32, int64> start_offsets = 3;
     optional string group_id_prefix = 4;
     mz_proto.ProtoU128 environment_id = 5;
     ProtoIncludedColumnPos include_timestamp = 6;

--- a/src/storage/src/types/sources.rs
+++ b/src/storage/src/types/sources.rs
@@ -10,7 +10,6 @@
 //! Types and traits related to the introduction of changing collections into `dataflow`.
 
 use std::collections::{BTreeMap, HashMap};
-use std::num::TryFromIntError;
 use std::ops::{Add, AddAssign, Deref, DerefMut};
 use std::str::FromStr;
 use std::time::Duration;
@@ -238,24 +237,6 @@ impl AddAssign<u64> for MzOffset {
 impl AddAssign<Self> for MzOffset {
     fn add_assign(&mut self, x: Self) {
         self.offset += x.offset;
-    }
-}
-
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct KafkaOffset {
-    pub offset: i64,
-}
-
-/// Convert from KafkaOffset to MzOffset (1-indexed), failing if the offset
-/// is negative.
-impl TryFrom<KafkaOffset> for MzOffset {
-    type Error = TryFromIntError;
-    fn try_from(kafka_offset: KafkaOffset) -> Result<Self, Self::Error> {
-        Ok(MzOffset {
-            // If the offset is negative, or +1 overflows, then this
-            // fails
-            offset: (kafka_offset.offset + 1).try_into()?,
-        })
     }
 }
 
@@ -989,7 +970,7 @@ pub struct KafkaSourceConnection {
     pub options: BTreeMap<String, StringOrSecret>,
     pub topic: String,
     // Map from partition -> starting offset
-    pub start_offsets: HashMap<i32, MzOffset>,
+    pub start_offsets: HashMap<i32, i64>,
     pub group_id_prefix: Option<String>,
     pub environment_id: Uuid,
     /// If present, include the timestamp as an output column of the source with the given name
@@ -1018,7 +999,7 @@ impl Arbitrary for KafkaSourceConnection {
             any::<KafkaConnection>(),
             any::<BTreeMap<String, StringOrSecret>>(),
             any::<String>(),
-            any::<HashMap<i32, MzOffset>>(),
+            any::<HashMap<i32, i64>>(),
             any::<Option<String>>(),
             any_uuid(),
             any::<Option<IncludedColumnPos>>(),
@@ -1068,11 +1049,7 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection {
                 .map(|(k, v)| (k.clone(), v.into_proto()))
                 .collect(),
             topic: self.topic.clone(),
-            start_offsets: self
-                .start_offsets
-                .iter()
-                .map(|(k, v)| (*k, v.into_proto()))
-                .collect(),
+            start_offsets: self.start_offsets.clone(),
             group_id_prefix: self.group_id_prefix.clone(),
             environment_id: Some(self.environment_id.into_proto()),
             include_timestamp: self.include_timestamp.into_proto(),
@@ -1084,11 +1061,6 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection {
     }
 
     fn from_proto(proto: ProtoKafkaSourceConnection) -> Result<Self, TryFromProtoError> {
-        let start_offsets: Result<_, TryFromProtoError> = proto
-            .start_offsets
-            .into_iter()
-            .map(|(k, v)| MzOffset::from_proto(v).map(|v| (k, v)))
-            .collect();
         let options: Result<_, TryFromProtoError> = proto
             .options
             .into_iter()
@@ -1100,7 +1072,7 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection {
                 .into_rust_if_some("ProtoKafkaSourceConnection::connection")?,
             options: options?,
             topic: proto.topic,
-            start_offsets: start_offsets?,
+            start_offsets: proto.start_offsets,
             group_id_prefix: proto.group_id_prefix,
             environment_id: proto
                 .environment_id

--- a/test/kafka-resumption/verify-success.td
+++ b/test/kafka-resumption/verify-success.td
@@ -13,8 +13,8 @@ Hanover,PA,17331
 
 
 $ kafka-verify format=avro sink=materialize.public.output sort-messages=true
-{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "offset":4}}}
-{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "offset":5}}}
-{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "offset":2}}}
-{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "offset":1}}}
-{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "offset":3}}}
+{"before": null, "after": {"row": {"city": "Brooklyn", "state": "NY", "zip": "11217", "offset":3}}}
+{"before": null, "after": {"row": {"city": "Hanover", "state": "PA", "zip": "17331", "offset":4}}}
+{"before": null, "after": {"row": {"city": "New York", "state": "NY", "zip": "10004", "offset":1}}}
+{"before": null, "after": {"row": {"city": "Rochester", "state": "NY", "zip": "14618", "offset":0}}}
+{"before": null, "after": {"row": {"city": "San Francisco", "state": "CA", "zip": "94114", "offset":2}}}

--- a/test/persistence/kafka-sources/upsert-modification-after.td
+++ b/test/persistence/kafka-sources/upsert-modification-after.td
@@ -43,31 +43,31 @@ mammal1:mouse
 > select * from texttext
 key           text  kafka_partition  mz_offset
 ----------------------------------------------
-fish          fish  0                1
-bírdmore      géese 0                6
-mammal1       mouse 0                9
-mammalmore    moose 0                7
+fish          fish  0                0
+bírdmore      géese 0                5
+mammal1       mouse 0                8
+mammalmore    moose 0                6
 
 > select * from textbytes
 key           data            kafka_partition  mz_offset
 -------------------------------------------------------
-fish          fish            0                1
-bírdmore      g\xc3\xa9ese    0                6
-mammal1       mouse           0                9
-mammalmore    moose           0                7
+fish          fish            0                0
+bírdmore      g\xc3\xa9ese    0                5
+mammal1       mouse           0                8
+mammalmore    moose           0                6
 
 > select * from bytestext
 key             text  kafka_partition  mz_offset
 ------------------------------------------------
-fish            fish  0                1
-b\xc3\xadrdmore géese 0                6
-mammal1         mouse 0                9
-mammalmore      moose 0                7
+fish            fish  0                0
+b\xc3\xadrdmore géese 0                5
+mammal1         mouse 0                8
+mammalmore      moose 0                6
 
 > select * from bytesbytes
 key                data            kafka_partition  mz_offset
 -------------------------------------------------------------
-fish               fish            0                1
-b\xc3\xadrdmore    g\xc3\xa9ese    0                6
-mammal1            mouse           0                9
-mammalmore         moose           0                7
+fish               fish            0                0
+b\xc3\xadrdmore    g\xc3\xa9ese    0                5
+mammal1            mouse           0                8
+mammalmore         moose           0                6

--- a/test/persistence/kafka-sources/upsert-modification-before.td
+++ b/test/persistence/kafka-sources/upsert-modification-before.td
@@ -84,27 +84,27 @@ bìrd1:
 > select * from texttext
 key           text  kafka_partition  mz_offset
 ----------------------------------------------
-fish          fish  0                1
-bírdmore      geese 0                3
-mammal1       moose 0                4
+fish          fish  0                0
+bírdmore      geese 0                2
+mammal1       moose 0                3
 
 > select * from textbytes
 key           data  kafka_partition  mz_offset
 ----------------------------------------------
-fish          fish  0                1
-bírdmore      geese 0                3
-mammal1       moose 0                4
+fish          fish  0                0
+bírdmore      geese 0                2
+mammal1       moose 0                3
 
 > select * from bytestext
 key             text  kafka_partition  mz_offset
 ------------------------------------------------
-fish            fish  0                1
-b\xc3\xadrdmore geese 0                3
-mammal1         moose 0                4
+fish            fish  0                0
+b\xc3\xadrdmore geese 0                2
+mammal1         moose 0                3
 
 > select * from bytesbytes
 key             data  kafka_partition  mz_offset
 ------------------------------------------------
-fish            fish  0                1
-b\xc3\xadrdmore geese 0                3
-mammal1         moose 0                4
+fish            fish  0                0
+b\xc3\xadrdmore geese 0                2
+mammal1         moose 0                3

--- a/test/testdrive/bytes.td
+++ b/test/testdrive/bytes.td
@@ -32,8 +32,8 @@ offset     false     bigint
 > SELECT * FROM data
 data           offset
 ------------------------
-"\\xc2\\xa91"  1
-"\\xc2\\xa92"  2
+"\\xc2\\xa91"  0
+"\\xc2\\xa92"  1
 
 # Test that CREATE SOURCE can specify a custom name for the column.
 
@@ -54,7 +54,7 @@ named_col  false     bytea
 > SELECT * FROM data_offset
 data           offset
 ------------------------
-"\\xc2\\xa92"  2
+"\\xc2\\xa92"  1
 
 $ kafka-create-topic topic=bytes-partitions partitions=2
 
@@ -72,4 +72,4 @@ $ kafka-ingest format=bytes topic=bytes-partitions timestamp=1 partition=1
 > SELECT * FROM data_offset_2
 data           offset
 ------------------------
-"\\xc2\\xa91"  1
+"\\xc2\\xa91"  0

--- a/test/testdrive/github-12005.td
+++ b/test/testdrive/github-12005.td
@@ -17,7 +17,6 @@ goofus,gallant
   FROM KAFKA BROKER '${testdrive.kafka-addr}'
   TOPIC 'testdrive-test-${testdrive.seed}'
   FORMAT CSV WITH 2 COLUMNS
-  INCLUDE OFFSET
 
 > CREATE MATERIALIZED VIEW v AS
   SELECT column1 || column2 AS c FROM src

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -207,8 +207,8 @@ contains:INCLUDE TOPIC not yet supported
 > SELECT * FROM non_dbz_data_metadata
 a b partition offset
 --------------------
-1 2 0         1
-2 3 0         2
+1 2 0         0
+2 3 0         1
 
 > CREATE SOURCE non_dbz_data_metadata_named
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-non-dbz-data-${testdrive.seed}')
@@ -219,8 +219,8 @@ a b partition offset
 > SELECT * FROM non_dbz_data_metadata_named
 a b  part  mzo
 --------------
-1 2  0     1
-2 3  0     2
+1 2  0     0
+2 3  0     1
 
 # Test an Avro source without a Debezium envelope starting at specified partition offsets.
 

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -116,44 +116,44 @@ grape:grape
 > SELECT * FROM append_time_offset_0
 text      offset
 -------------------
-apple     1
-banana    2
-cherry    1
-date      2
-eggfruit  3
-fig       4
-grape     1
+apple     0
+banana    1
+cherry    0
+date      1
+eggfruit  2
+fig       3
+grape     0
 
 > SELECT * FROM append_time_offset_1
 text      offset
 -------------------
-apple     1
-banana    2
-cherry    1
-date      2
-eggfruit  3
-fig       4
-grape     1
+apple     0
+banana    1
+cherry    0
+date      1
+eggfruit  2
+fig       3
+grape     0
 
 > SELECT * FROM append_time_offset_2
 text      offset
 -------------------
-cherry    1
-date      2
-eggfruit  3
-fig       4
-grape     1
+cherry    0
+date      1
+eggfruit  2
+fig       3
+grape     0
 
 > SELECT * FROM append_time_offset_3
 text      offset
 -------------------
-fig       4
-grape     1
+fig       3
+grape     0
 
 > SELECT * FROM append_time_offset_4
 text      offset
 -------------------
-grape     1
+grape     0
 
 > SELECT * FROM append_time_offset_5
 text      offset
@@ -169,7 +169,7 @@ $ set-sql-timeout duration=60s
 > SELECT * FROM append_time_offset_5
 text      offset
 -------------------
-hazelnut  1
+hazelnut  0
 
 #
 # Upsert
@@ -235,39 +235,39 @@ grape:grape
 > SELECT * FROM upsert_time_offset_0
 key       text      offset
 -----------------------------
-banana    banana    2
-date      date      2
-eggfruit  eggfruit  3
-fig       fig       5
-grape     grape     1
+banana    banana    1
+date      date      1
+eggfruit  eggfruit  2
+fig       fig       4
+grape     grape     0
 
 > SELECT * FROM upsert_time_offset_1
 key       text      offset
 -----------------------------
-banana    banana    2
-date      date      2
-eggfruit  eggfruit  3
-fig       fig       5
-grape     grape     1
+banana    banana    1
+date      date      1
+eggfruit  eggfruit  2
+fig       fig       4
+grape     grape     0
 
 > SELECT * FROM upsert_time_offset_2
 key       text      offset
 -----------------------------
-date      date      2
-eggfruit  eggfruit  3
-fig       fig       5
-grape     grape     1
+date      date      1
+eggfruit  eggfruit  2
+fig       fig       4
+grape     grape     0
 
 > SELECT * FROM upsert_time_offset_3
 key       text      offset
 -----------------------------
-fig       fig       5
-grape     grape     1
+fig       fig       4
+grape     grape     0
 
 > SELECT * FROM upsert_time_offset_4
 key       text      offset
 -----------------------------
-grape     grape     1
+grape     grape     0
 
 > SELECT * FROM upsert_time_offset_5
 key       text      offset
@@ -284,7 +284,7 @@ $ set-sql-timeout duration=60s
 > SELECT * FROM upsert_time_offset_5
 key       text      offset
 -----------------------------
-hazelnut  hazelnut  1
+hazelnut  hazelnut  0
 
 #
 # Relative timestamps
@@ -319,13 +319,13 @@ cherry
 > SELECT * FROM relative_time_offset_30_years_ago
 text      offset
 -------------------
-banana    2
-cherry    3
+banana    1
+cherry    2
 
 > SELECT * FROM relative_time_offset_today
 text      offset
 -------------------
-cherry    3
+cherry    2
 
 # Make sure that we don't fetch any messages that we don't want to fetch
 

--- a/test/testdrive/kafka-upsert-debezium-sources.td
+++ b/test/testdrive/kafka-upsert-debezium-sources.td
@@ -164,7 +164,7 @@ contains:INCLUDE OFFSET with Debezium requires UPSERT semantics
 > SELECT * FROM doin_upsert_metadata WHERE id = 4
 id creature partition test_kafka_offset
 ---------------------------------------
-4  moros    0         9
+4  moros    0         8
 
 $ kafka-ingest format=avro topic=dbzupsert key-format=avro key-schema=${keyschema} schema=${schema} timestamp=6
 {"id": 4} {"before": {"row": {"id": 4, "creature": "trex"}}, "after": null, "op": "d", "source": {"file": "binlog10", "pos": 1, "row": 1, "snapshot": {"boolean": false}}}
@@ -216,10 +216,10 @@ contains:unexpected parameters for CREATE SOURCE: deduplication
 > SELECT * FROM upsert_metadata
 id   creature      offset  partition
 ------------------------------------
-1    dino          4       0
-2    velociraptor  6       0
-3    triceratops   8       0
-4    chicken       11      0
+1    dino          3       0
+2    velociraptor  5       0
+3    triceratops   7       0
+4    chicken       10      0
 
 # test include metadata respects metadata order
 > CREATE SOURCE upsert_metadata_reordered
@@ -231,7 +231,7 @@ id   creature      offset  partition
 > SELECT * FROM upsert_metadata_reordered
 id   creature      partition  offset
 ------------------------------------
-1    dino          0          4
-2    velociraptor  0          6
-3    triceratops   0          8
-4    chicken       0          11
+1    dino          0          3
+2    velociraptor  0          5
+3    triceratops   0          7
+4    chicken       0          10

--- a/test/testdrive/kafka-upsert-sources.td
+++ b/test/testdrive/kafka-upsert-sources.td
@@ -516,9 +516,9 @@ librairie 10
 > SELECT * FROM include_metadata
 f3        f4        f1           f2   partition  offset
 -------------------------------------------------------
-<null>    yin       dog          243   0         15
-air       qi        chicken      47    0         13
-earth     dao       rhinoceros   211   0         12
+<null>    yin       dog          243   0         14
+air       qi        chicken      47    0         12
+earth     dao       rhinoceros   211   0         11
 
 > CREATE SOURCE include_metadata_ts
   FROM KAFKA CONNECTION kafka_conn (START OFFSET=[1], TOPIC 'testdrive-realtimeavroavro-${testdrive.seed}')
@@ -530,9 +530,9 @@ earth     dao       rhinoceros   211   0         12
 > SELECT "offset" FROM include_metadata_ts WHERE ts > '2021-01-01'
 offset
 ------
-15
-13
+14
 12
+11
 
 > SELECT "offset" FROM include_metadata_ts WHERE ts < '2021-01-01'
 offset

--- a/test/testdrive/regex-sources.td
+++ b/test/testdrive/regex-sources.td
@@ -55,10 +55,9 @@ product_detail_id  true      text
 code               true      text
 
 # verify metadata column renaming
-> CREATE SOURCE regex_source_renamed_cols (ip, ts, path, search_kw, product_detail_id, code, lineno)
+> CREATE SOURCE regex_source_renamed_cols (ip, ts, path, search_kw, product_detail_id, code)
   FROM KAFKA BROKER '${testdrive.kafka-addr}' TOPIC 'testdrive-request-log-${testdrive.seed}'
   FORMAT REGEX '(?P<foo1>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) - - \[(?P<foo2>[^]]+)\] "(?P<foo3>(?:GET /search/\?kw=(?P<foo4>[^ ]*) HTTP/\d\.\d)|(?:GET /detail/(?P<foo5>[a-zA-Z0-9]+) HTTP/\d\.\d)|(?:[^"]+))" (?P<foo6>\d{3}) -'
-  INCLUDE OFFSET
 
 > SHOW COLUMNS FROM regex_source_renamed_cols
 name               nullable  type
@@ -69,7 +68,6 @@ path               true      text
 search_kw          true      text
 product_detail_id  true      text
 code               true      text
-lineno             false     bigint
 
 > SELECT * FROM regex_source_named_cols
 ip            ts                      path                                           search_kw           product_detail_id  code

--- a/test/testdrive/sinks.td
+++ b/test/testdrive/sinks.td
@@ -111,12 +111,12 @@ snk2
 snk3
 
 $ kafka-verify format=avro sink=materialize.public.snk1 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 1}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 0}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk2 sort-messages=true
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 1}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 0}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk3 sort-messages=true
 {"before": null, "after": {"row":{"c": "goofusgallant"}}}
@@ -156,12 +156,12 @@ $ kafka-ingest topic=test format=bytes
 extra,row
 
 $ kafka-verify format=avro sink=materialize.public.snk5
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 3}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 2}}}
 
 $ kafka-verify format=avro sink=materialize.public.snk6 sort-messages=true
-{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 3}}}
-{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 2}}}
-{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 1}}}
+{"before": null, "after": {"row":{"a": "extra", "b": "row", "offset": 2}}}
+{"before": null, "after": {"row":{"a": "goofus", "b": "gallant", "offset": 1}}}
+{"before": null, "after": {"row":{"a": "jack", "b": "jill", "offset": 0}}}
 
 # Test that we are correctly handling SNAPSHOT on views with empty upper
 # frontier


### PR DESCRIPTION
The `MzOffset` type was 1-indexed, which was a historical accident that we regret. Make it 0-indexed while we still permit backwards incompatilbe changes.

Fix #4037.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
