### PR TITLE
adapter: remove unneeded clone of RowSetFinishing

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -460,13 +460,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                 literal_constraints,
                 map_filter_project,
             )) => (
-                (
-                    id,
-                    literal_constraints,
-                    timestamp,
-                    finishing.clone(),
-                    map_filter_project,
-                ),
+                (id, literal_constraints, timestamp, map_filter_project),
                 None,
             ),
             PeekPlan::SlowPath(PeekDataflowPlan {
@@ -516,7 +510,6 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
                         index_id, // transient identifier produced by `dataflow_plan`.
                         None,
                         timestamp,
-                        finishing.clone(),
                         map_filter_project,
                     ),
                     Some(index_id),
@@ -550,7 +543,7 @@ impl<S: Append + 'static> crate::coord::Coordinator<S> {
             .entry(conn_id)
             .or_default()
             .insert(uuid, compute_instance);
-        let (id, literal_constraints, timestamp, _finishing, map_filter_project) = peek_command;
+        let (id, literal_constraints, timestamp, map_filter_project) = peek_command;
 
         self.controller
             .active_compute()


### PR DESCRIPTION
In `Coordinator::implement_peek_plan` there are two places where we clone a `RowSetFinishing`, just to ignore it later. This PR removes these instances, for slightly improved readability. I doubt this will have any effect on runtime performance, as the compiler should optimize these clones away.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
