### PR TITLE
sql: check type of referenced object in SHOW COLUMNS

### DIFF
--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -336,6 +336,11 @@ v2          view
 > SELECT "Create Table" FROM (SHOW CREATE TABLE tbl)
 "CREATE TABLE \"d\".\"public\".\"tbl\" (\"a\" \"pg_catalog\".\"int4\", \"b\" \"pg_catalog\".\"text\")"
 
+! SHOW COLUMNS FROM pass_secret
+contains:d.public.pass_secret is a secret and so does not have columns
+! SHOW COLUMNS FROM kafka_conn
+contains:d.public.kafka_conn is a connection and so does not have columns
+
 # DROP DATABASE does not support both RESTRICT and CASCADE.
 ! DROP DATABASE d RESTRICT CASCADE
 contains:Cannot specify both RESTRICT and CASCADE in DROP


### PR DESCRIPTION
`SHOW COLUMNS` should only work on object types which have columns. It would previously silently return an empty result set for connections, indexes, functions, secrets, types, and sinks; now it correctly reports a usage error.

A future commit will make `SHOW COLUMNS` work with indexes, because indexes are treated as having columns in PostgreSQL, and it makes sense to be able to show the columns in an index.

Touches #14646.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes (part of) a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
