### PR TITLE
persist-maelstrom: cover high-throughput mem + multi-node postgres

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -43,7 +43,8 @@ steps:
           - { value: checks-oneatatime-restart-environmentd-storaged }
           - { value: checks-oneatatime-kill-storaged }
           - { value: checks-oneatatime-restart-postgres-backend }
-          - { value: persist-maelstrom-long }
+          - { value: persist-maelstrom-single-node }
+          - { value: persist-maelstrom-multi-node }
           - { value: unused-deps }
         multiple: true
         required: false
@@ -354,8 +355,8 @@ steps:
           composition: platform-checks
           args: [--scenario=RestartPostgresBackend, --execution-mode=oneatatime]
 
-  - id: persist-maelstrom-long
-    label: Long Maelstrom coverage of persist
+  - id: persist-maelstrom-single-node
+    label: Long single-node Maelstrom coverage of persist
     timeout_in_minutes: 20
     agents:
       queue: linux-x86_64
@@ -363,7 +364,18 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persist
-          args: [--node-count=4, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+          args: [--node-count=1, --consensus=mem, --blob-uri=mem, --time-limit=600, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+
+  - id: persist-maelstrom-multi-node
+    label: Long multi-node Maelstrom coverage of persist with postgres consensus
+    timeout_in_minutes: 20
+    agents:
+      queue: linux-x86_64
+    artifact_paths: [test/persist/maelstrom/**/*.log, junit_mzcompose_*.xml]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persist
+          args: [--node-count=4, --consensus=postgres, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
   - id: persistence-failpoints
     label: Persistence failpoints

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -462,6 +462,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persist
+          args: [--consensus=mem, --blob=mem]
     agents:
       queue: linux-x86_64
 

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -78,11 +78,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"--rate={args.rate}",
         "--",
         "maelstrom",
-        *(
-            f"--blob-uri={blob_uri}" if blob_uri else "",
-            f"--consensus-uri={consensus_uri}" if consensus_uri else "",
-            f"--unreliability={args.unreliability}" if args.unreliability else "",
-        ),
+        *([f"--blob-uri={blob_uri}"] if blob_uri else []),
+        *([f"--consensus-uri={consensus_uri}"] if consensus_uri else []),
+        *([f"--unreliability={args.unreliability}"] if args.unreliability else []),
     )
 
     # TODO: Reenable this when we un-break MaelstromConsensus

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -35,14 +35,21 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--rate", type=int, default=100)
     parser.add_argument("--max-txn-length", type=int, default=4)
     parser.add_argument("--unreliability", type=float, default=None)
-    parser.add_argument("--consensus", type=str, choices=["mem", "postgres", "maelstrom"], default=None)
-    parser.add_argument("--blob", type=str, choices=["mem", "maelstrom"], default=None)
+    parser.add_argument(
+        "--consensus",
+        type=str,
+        choices=["mem", "postgres", "maelstrom"],
+        default="maelstrom",
+    )
+    parser.add_argument(
+        "--blob", type=str, choices=["mem", "maelstrom"], default="maelstrom"
+    )
 
     args = parser.parse_args()
 
     if args.consensus == "mem":
         consensus_uri = "mem://consensus"
-    elif args.consensus_uri == "postgres":
+    elif args.consensus == "postgres":
         consensus_uri = "postgresql://postgres:postgres@postgres:5432?options=--search_path=consensus"
         c.start_and_wait_for_tcp(services=["postgres"])
         c.wait_for_postgres(service="postgres")
@@ -72,9 +79,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--",
         "maelstrom",
         *(
-              f"--blob-uri={blob_uri}" if blob_uri else "",
-              f"--consensus-uri={consensus_uri}" if consensus_uri else "",
-              f"--unreliability={args.unreliability}" if args.unreliability else "",
+            f"--blob-uri={blob_uri}" if blob_uri else "",
+            f"--consensus-uri={consensus_uri}" if consensus_uri else "",
+            f"--unreliability={args.unreliability}" if args.unreliability else "",
         ),
     )
 

--- a/test/persist/mzcompose.py
+++ b/test/persist/mzcompose.py
@@ -35,18 +35,33 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--rate", type=int, default=100)
     parser.add_argument("--max-txn-length", type=int, default=4)
     parser.add_argument("--unreliability", type=float, default=None)
+    parser.add_argument("--consensus", type=str, choices=["mem", "postgres", "maelstrom"], default=None)
+    parser.add_argument("--blob", type=str, choices=["mem", "maelstrom"], default=None)
 
     args = parser.parse_args()
 
-    c.start_and_wait_for_tcp(services=["postgres"])
-    c.wait_for_postgres(service="postgres")
+    if args.consensus == "mem":
+        consensus_uri = "mem://consensus"
+    elif args.consensus_uri == "postgres":
+        consensus_uri = "postgresql://postgres:postgres@postgres:5432?options=--search_path=consensus"
+        c.start_and_wait_for_tcp(services=["postgres"])
+        c.wait_for_postgres(service="postgres")
 
-    c.sql(
-        sql="CREATE SCHEMA IF NOT EXISTS consensus;",
-        service="postgres",
-        user="postgres",
-        password="postgres",
-    )
+        c.sql(
+            sql="CREATE SCHEMA IF NOT EXISTS consensus;",
+            service="postgres",
+            user="postgres",
+            password="postgres",
+        )
+    else:
+        # empty consensus uri defaults to Maelstrom consensus implementation
+        consensus_uri = ""
+
+    if args.blob == "mem":
+        blob_uri = "mem://blob"
+    else:
+        # empty blob uri defaults to Maelstrom blob implementation
+        blob_uri = ""
 
     c.run(
         "maelstrom-persist",
@@ -56,8 +71,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         f"--rate={args.rate}",
         "--",
         "maelstrom",
-        "--consensus-uri=postgresql://postgres:postgres@postgres:5432?options=--search_path=consensus",
-        *([f"--unreliability={args.unreliability}"] if args.unreliability else []),
+        *(
+              f"--blob-uri={blob_uri}" if blob_uri else "",
+              f"--consensus-uri={consensus_uri}" if consensus_uri else "",
+              f"--unreliability={args.unreliability}" if args.unreliability else "",
+        ),
     )
 
     # TODO: Reenable this when we un-break MaelstromConsensus


### PR DESCRIPTION

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

@philip-stoev super helpfully added in [a longer Maelstrom nightly test](https://github.com/MaterializeInc/materialize/pull/14796). This PR adds in a second nightly, splitting the coverage into a throughput-focused test from a single node using the memory blob/consensus implementations, along with the existing multi-node test against Postgres which will cover high contention cases but not run through as many iterations.

### Motivation

   * This PR refactors existing code.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

My Python is bad and I don't know how to actually test whether this does the right thing or not

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

cc @danhhz 