### PR TITLE
sql: allow setting TOPIC option without unsafe mode

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -404,11 +404,15 @@ pub fn plan_create_source(
 
                         // Starting offsets are allowed out unsafe mode, as they are a simple,
                         // useful way to specify where to start reading a topic.
-                        if options.iter().any(|opt| {
+                        if let Some(opt) = options.iter().find(|opt| {
                             opt.name != KafkaConfigOptionName::StartOffset
                                 && opt.name != KafkaConfigOptionName::StartTimestamp
+                                && opt.name != KafkaConfigOptionName::Topic
                         }) {
-                            scx.require_unsafe_mode("KAFKA CONNECTION...WITH (...)")?;
+                            scx.require_unsafe_mode(&format!(
+                                "KAFKA CONNECTION option {}",
+                                opt.name
+                            ))?;
                         }
 
                         kafka_util::validate_options_for_context(


### PR DESCRIPTION
Otherwise it's impossible to use Kafka sources in production.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug @bobbyiliev reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a
