### PR TITLE
[BREAKING] persist: update Shard|Writer|ReaderId serde to use string representation

### DIFF
--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -35,10 +35,11 @@ use crate::fetch::{
 use crate::internal::machine::Machine;
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{HollowBatch, Since};
-use crate::{GarbageCollector, PersistConfig};
+use crate::{parse_id, GarbageCollector, PersistConfig};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
 pub struct ReaderId(pub(crate) [u8; 16]);
 
 impl std::fmt::Display for ReaderId {
@@ -50,6 +51,28 @@ impl std::fmt::Display for ReaderId {
 impl std::fmt::Debug for ReaderId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "ReaderId({})", Uuid::from_bytes(self.0))
+    }
+}
+
+impl std::str::FromStr for ReaderId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_id('r', "ReaderId", s).map(ReaderId)
+    }
+}
+
+impl From<ReaderId> for String {
+    fn from(reader_id: ReaderId) -> Self {
+        reader_id.to_string()
+    }
+}
+
+impl TryFrom<String> for ReaderId {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse()
     }
 }
 
@@ -752,6 +775,10 @@ where
 #[cfg(test)]
 mod tests {
     use crate::tests::new_test_client;
+    use crate::ReaderId;
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use std::str::FromStr;
 
     // Verifies `Subscribe` can be dropped while holding snapshot batches.
     #[tokio::test]
@@ -917,6 +944,38 @@ mod tests {
         }
 
         drop(subscribe);
+    }
+
+    #[test]
+    fn reader_id_human_readable_serde() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct Container {
+            reader_id: ReaderId,
+        }
+
+        // roundtrip through json
+        let id = ReaderId::from_str("r00000000-1234-5678-0000-000000000000").expect("valid id");
+        assert_eq!(
+            id,
+            serde_json::from_value(serde_json::to_value(id.clone()).expect("serializable"))
+                .expect("deserializable")
+        );
+
+        // deserialize a serialized string directly
+        assert_eq!(
+            id,
+            serde_json::from_str("\"r00000000-1234-5678-0000-000000000000\"")
+                .expect("deserializable")
+        );
+
+        // roundtrip id through a container type
+        let json = json!({ "reader_id": id });
+        assert_eq!(
+            "{\"reader_id\":\"r00000000-1234-5678-0000-000000000000\"}",
+            &json.to_string()
+        );
+        let container: Container = serde_json::from_value(json).expect("deserializable");
+        assert_eq!(container.reader_id, id);
     }
 }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -22,6 +22,7 @@ use mz_ore::task::RuntimeExt;
 use mz_persist::location::{Blob, Indeterminate};
 use mz_persist::retry::Retry;
 use mz_persist_types::{Codec, Codec64};
+use serde::{Deserialize, Serialize};
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::runtime::Handle;
@@ -37,7 +38,8 @@ use crate::internal::state::{HollowBatch, Upper};
 use crate::{parse_id, CpuHeavyRuntime, GarbageCollector, PersistConfig};
 
 /// An opaque identifier for a writer of a persist durable TVC (aka shard).
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(try_from = "String", into = "String")]
 pub struct WriterId(pub(crate) [u8; 16]);
 
 impl std::fmt::Display for WriterId {
@@ -57,6 +59,20 @@ impl std::str::FromStr for WriterId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         parse_id('w', "WriterId", s).map(WriterId)
+    }
+}
+
+impl From<WriterId> for String {
+    fn from(writer_id: WriterId) -> Self {
+        writer_id.to_string()
+    }
+}
+
+impl TryFrom<String> for WriterId {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        s.parse()
     }
 }
 
@@ -698,6 +714,8 @@ where
 #[cfg(test)]
 mod tests {
     use differential_dataflow::consolidation::consolidate_updates;
+    use serde_json::json;
+    use std::str::FromStr;
 
     use crate::tests::{all_ok, new_test_client};
     use crate::ShardId;
@@ -780,5 +798,37 @@ mod tests {
         let mut actual = read.expect_snapshot_and_fetch(3).await;
         consolidate_updates(&mut actual);
         assert_eq!(actual, all_ok(&expected, 3));
+    }
+
+    #[test]
+    fn writer_id_human_readable_serde() {
+        #[derive(Debug, Serialize, Deserialize)]
+        struct Container {
+            writer_id: WriterId,
+        }
+
+        // roundtrip through json
+        let id = WriterId::from_str("w00000000-1234-5678-0000-000000000000").expect("valid id");
+        assert_eq!(
+            id,
+            serde_json::from_value(serde_json::to_value(id.clone()).expect("serializable"))
+                .expect("deserializable")
+        );
+
+        // deserialize a serialized string directly
+        assert_eq!(
+            id,
+            serde_json::from_str("\"w00000000-1234-5678-0000-000000000000\"")
+                .expect("deserializable")
+        );
+
+        // roundtrip id through a container type
+        let json = json!({ "writer_id": id });
+        assert_eq!(
+            "{\"writer_id\":\"w00000000-1234-5678-0000-000000000000\"}",
+            &json.to_string()
+        );
+        let container: Container = serde_json::from_value(json).expect("deserializable");
+        assert_eq!(container.writer_id, id);
     }
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

**This is a breaking change and cannot be merged until the next breaking release**

Updates our serde Serialize/Deserialize impls for Shard|Writer|ReaderIds to use their string representation, rather than raw bytes. Currently when ShardIds are written into the catalog, they look like:

```json
{"data_shard": [211, 237, 132, 108, 246, 62, 69, 67, 174, 26, 232, 39, 244, 174, 38, 241]}
```

Rather than the expected:

```json
{"data_shard": "s00000000-1234-5678-0000-000000000000"}
```

### Motivation
  * This PR fixes a recognized bug.
https://github.com/MaterializeInc/materialize/issues/14723

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
