### PR TITLE
Regions around LIR operators

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -267,7 +267,7 @@ where
     T: Timestamp + Lattice,
     S::Timestamp: Lattice + Refines<T>,
 {
-    /// A reference to the scope containing the collection bundle.
+    /// The scope containing the collection bundle.
     pub fn scope(&self) -> S {
         match self {
             ArrangementFlavor::Local(oks, _errs) => oks.stream.scope(),
@@ -364,7 +364,7 @@ where
         Self::from_expressions(keys, arrangements)
     }
 
-    /// A reference to the scope containing the collection bundle.
+    /// The scope containing the collection bundle.
     pub fn scope(&self) -> S {
         if let Some((oks, _errs)) = &self.collection {
             oks.inner.scope()

--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -34,7 +34,7 @@ where
         let until = self.until.clone();
         let mfp_plan = mfp.into_plan().expect("MapFilterProject planning failed");
         let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
-        let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
+        let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMap", {
             let mut datums = DatumVec::new();
             let mut row_builder = Row::default();
             move |(input_row, mut time, diff)| {

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -48,7 +48,7 @@ where
         let mut err_dedup = HashSet::new();
 
         // We create a new region to contain the dataflow paths for the delta join.
-        let (oks, errs) = scope.clone().region_named("delta query", |inner| {
+        let (oks, errs) = scope.clone().region_named("Join(Delta)", |inner| {
             // Our plan is to iterate through each input relation, and attempt
             // to find a plan that maximally uses existing keys (better: uses
             // existing arrangements, to which we have access).

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -58,41 +58,83 @@ where
         linear_plan: LinearJoinPlan,
         scope: &mut G,
     ) -> CollectionBundle<G, Row, T> {
-        // Collect all error streams, and concatenate them at the end.
-        let mut errors = Vec::new();
+        scope.clone().region_named("Join(Linear)", |inner| {
+            // Collect all error streams, and concatenate them at the end.
+            let mut errors = Vec::new();
 
-        // Determine which form our maintained spine of updates will initially take.
-        // First, just check out the availability of an appropriate arrangement.
-        // This will be `None` in the degenerate single-input join case, which ensures
-        // that we do not panic if we never go around the `stage_plans` loop.
-        let arrangement = linear_plan
-            .stage_plans
-            .get(0)
-            .and_then(|stage| inputs[linear_plan.source_relation].arrangement(&stage.stream_key));
-        // We can use an arrangement if it exists and an initial closure does not.
-        let mut joined = match (arrangement, linear_plan.initial_closure) {
-            (Some(ArrangementFlavor::Local(oks, errs)), None) => {
-                errors.push(errs.as_collection(|k, _v| k.clone()));
-                JoinedFlavor::Local(oks)
-            }
-            (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
-                errors.push(errs.as_collection(|k, _v| k.clone()));
-                JoinedFlavor::Trace(oks)
-            }
-            (_, initial_closure) => {
-                // TODO: extract closure from the first stage in the join plan, should it exist.
-                // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
-                let (mut joined, errs) = inputs[linear_plan.source_relation]
-                    .as_specific_collection(linear_plan.source_key.as_deref());
-                errors.push(errs);
+            // Determine which form our maintained spine of updates will initially take.
+            // First, just check out the availability of an appropriate arrangement.
+            // This will be `None` in the degenerate single-input join case, which ensures
+            // that we do not panic if we never go around the `stage_plans` loop.
+            let arrangement = linear_plan.stage_plans.get(0).and_then(|stage| {
+                inputs[linear_plan.source_relation].arrangement(&stage.stream_key)
+            });
+            // We can use an arrangement if it exists and an initial closure does not.
+            let mut joined = match (arrangement, linear_plan.initial_closure) {
+                (Some(ArrangementFlavor::Local(oks, errs)), None) => {
+                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                    JoinedFlavor::Local(oks.enter_region(inner))
+                }
+                (Some(ArrangementFlavor::Trace(_gid, oks, errs)), None) => {
+                    errors.push(errs.as_collection(|k, _v| k.clone()).enter_region(inner));
+                    JoinedFlavor::Trace(oks.enter_region(inner))
+                }
+                (_, initial_closure) => {
+                    // TODO: extract closure from the first stage in the join plan, should it exist.
+                    // TODO: apply that closure in `flat_map_ref` rather than calling `.collection`.
+                    let (joined, errs) = inputs[linear_plan.source_relation]
+                        .as_specific_collection(linear_plan.source_key.as_deref());
+                    errors.push(errs.enter_region(inner));
+                    let mut joined = joined.enter_region(inner);
 
-                // In the current code this should always be `None`, but we have this here should
-                // we change that and want to know what we should be doing.
-                if let Some(closure) = initial_closure {
-                    // If there is no starting arrangement, then we can run filters
-                    // directly on the starting collection.
-                    // If there is only one input, we are done joining, so run filters
-                    let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
+                    // In the current code this should always be `None`, but we have this here should
+                    // we change that and want to know what we should be doing.
+                    if let Some(closure) = initial_closure {
+                        // If there is no starting arrangement, then we can run filters
+                        // directly on the starting collection.
+                        // If there is only one input, we are done joining, so run filters
+                        let (j, errs) = joined.flat_map_fallible("LinearJoinInitialization", {
+                            // Reuseable allocation for unpacking.
+                            let mut datums = DatumVec::new();
+                            let mut row_builder = Row::default();
+                            move |row| {
+                                let temp_storage = RowArena::new();
+                                let mut datums_local = datums.borrow_with(&row);
+                                // TODO(mcsherry): re-use `row` allocation.
+                                closure
+                                    .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                                    .map_err(DataflowError::from)
+                                    .transpose()
+                            }
+                        });
+                        joined = j;
+                        errors.push(errs);
+                    }
+
+                    JoinedFlavor::Collection(joined)
+                }
+            };
+
+            // progress through stages, updating partial results and errors.
+            for stage_plan in linear_plan.stage_plans.into_iter() {
+                // Different variants of `joined` implement this differently,
+                // and the logic is centralized there.
+                let stream = differential_join(
+                    joined,
+                    inputs[stage_plan.lookup_relation].enter_region(inner),
+                    stage_plan,
+                    &mut errors,
+                );
+                // Update joined results and capture any errors.
+                joined = JoinedFlavor::Collection(stream);
+            }
+
+            // We have completed the join building, but may have work remaining.
+            // For example, we may have expressions not pushed down (e.g. literals)
+            // and projections that could not be applied (e.g. column repetition).
+            if let JoinedFlavor::Collection(mut joined) = joined {
+                if let Some(closure) = linear_plan.final_closure {
+                    let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
                         // Reuseable allocation for unpacking.
                         let mut datums = DatumVec::new();
                         let mut row_builder = Row::default();
@@ -106,203 +148,169 @@ where
                                 .transpose()
                         }
                     });
-                    joined = j;
+
+                    joined = updates;
                     errors.push(errs);
                 }
 
-                JoinedFlavor::Collection(joined)
+                // Return joined results and all produced errors collected together.
+                CollectionBundle::from_collections(
+                    joined,
+                    differential_dataflow::collection::concatenate(inner, errors),
+                )
+            } else {
+                panic!("Unexpectedly arranged join output");
             }
-        };
+            .leave_region()
+        })
+    }
+}
 
-        // progress through stages, updating partial results and errors.
-        for stage_plan in linear_plan.stage_plans.into_iter() {
-            // Different variants of `joined` implement this differently,
-            // and the logic is centralized there.
-            let stream = self.differential_join(
-                joined,
-                inputs[stage_plan.lookup_relation].clone(),
-                stage_plan,
-                &mut errors,
-            );
-            // Update joined results and capture any errors.
-            joined = JoinedFlavor::Collection(stream);
-        }
-
-        // We have completed the join building, but may have work remaining.
-        // For example, we may have expressions not pushed down (e.g. literals)
-        // and projections that could not be applied (e.g. column repetition).
-        if let JoinedFlavor::Collection(mut joined) = joined {
-            if let Some(closure) = linear_plan.final_closure {
-                let (updates, errs) = joined.flat_map_fallible("LinearJoinFinalization", {
-                    // Reuseable allocation for unpacking.
-                    let mut datums = DatumVec::new();
-                    let mut row_builder = Row::default();
-                    move |row| {
-                        let temp_storage = RowArena::new();
-                        let mut datums_local = datums.borrow_with(&row);
-                        // TODO(mcsherry): re-use `row` allocation.
-                        closure
-                            .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                            .map_err(DataflowError::from)
-                            .transpose()
-                    }
-                });
-
-                joined = updates;
-                errors.push(errs);
+/// Looks up the arrangement for the next input and joins it to the arranged
+/// version of the join of previous inputs. This is split into its own method
+/// to enable reuse of code with different types of `prev_keyed`.
+fn differential_join<G, T>(
+    mut joined: JoinedFlavor<G, T>,
+    lookup_relation: CollectionBundle<G, Row, T>,
+    LinearStagePlan {
+        stream_key,
+        stream_thinning,
+        lookup_key,
+        closure,
+        lookup_relation: _,
+    }: LinearStagePlan,
+    errors: &mut Vec<Collection<G, DataflowError, Diff>>,
+) -> Collection<G, Row, Diff>
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+{
+    // If we have only a streamed collection, we must first form an arrangement.
+    if let JoinedFlavor::Collection(stream) = joined {
+        let mut row_buf = Row::default();
+        let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
+            // Reuseable allocation for unpacking.
+            let mut datums = DatumVec::new();
+            move |row| {
+                let temp_storage = RowArena::new();
+                let datums_local = datums.borrow_with(&row);
+                row_buf.packer().try_extend(
+                    stream_key
+                        .iter()
+                        .map(|e| e.eval(&datums_local, &temp_storage)),
+                )?;
+                let key = row_buf.clone();
+                row_buf
+                    .packer()
+                    .extend(stream_thinning.iter().map(|e| datums_local[*e]));
+                let value = row_buf.clone();
+                Ok((key, value))
             }
+        });
 
-            // Return joined results and all produced errors collected together.
-            CollectionBundle::from_collections(
-                joined,
-                differential_dataflow::collection::concatenate(scope, errors),
-            )
-        } else {
-            panic!("Unexpectedly arranged join output");
-        }
+        errors.push(errs);
+        let arranged = keyed.arrange_named::<RowSpine<_, _, _, _>>("JoinStage");
+        joined = JoinedFlavor::Local(arranged);
     }
 
-    /// Looks up the arrangement for the next input and joins it to the arranged
-    /// version of the join of previous inputs. This is split into its own method
-    /// to enable reuse of code with different types of `prev_keyed`.
-    fn differential_join(
-        &mut self,
-        mut joined: JoinedFlavor<G, T>,
-        lookup_relation: CollectionBundle<G, Row, T>,
-        LinearStagePlan {
-            stream_key,
-            stream_thinning,
-            lookup_key,
-            closure,
-            lookup_relation: _,
-        }: LinearStagePlan,
-        errors: &mut Vec<Collection<G, DataflowError, Diff>>,
-    ) -> Collection<G, Row, Diff> {
-        // If we have only a streamed collection, we must first form an arrangement.
-        if let JoinedFlavor::Collection(stream) = joined {
-            let mut row_buf = Row::default();
-            let (keyed, errs) = stream.map_fallible("LinearJoinKeyPreparation", {
-                // Reuseable allocation for unpacking.
-                let mut datums = DatumVec::new();
-                move |row| {
-                    let temp_storage = RowArena::new();
-                    let datums_local = datums.borrow_with(&row);
-                    row_buf.packer().try_extend(
-                        stream_key
-                            .iter()
-                            .map(|e| e.eval(&datums_local, &temp_storage)),
-                    )?;
-                    let key = row_buf.clone();
-                    row_buf
-                        .packer()
-                        .extend(stream_thinning.iter().map(|e| datums_local[*e]));
-                    let value = row_buf.clone();
-                    Ok((key, value))
-                }
-            });
-
-            errors.push(errs);
-            let arranged = keyed.arrange_named::<RowSpine<_, _, _, _>>("JoinStage");
-            joined = JoinedFlavor::Local(arranged);
+    // Demultiplex the four different cross products of arrangement types we might have.
+    let arrangement = lookup_relation
+        .arrangement(&lookup_key[..])
+        .expect("Arrangement absent despite explicit construction");
+    match joined {
+        JoinedFlavor::Collection(_) => {
+            unreachable!("JoinedFlavor::Collection variant avoided at top of method");
         }
-
-        // Demultiplex the four different cross products of arrangement types we might have.
-        let arrangement = lookup_relation
-            .arrangement(&lookup_key[..])
-            .expect("Arrangement absent despite explicit construction");
-        match joined {
-            JoinedFlavor::Collection(_) => {
-                unreachable!("JoinedFlavor::Collection variant avoided at top of method");
+        JoinedFlavor::Local(local) => match arrangement {
+            ArrangementFlavor::Local(oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(local, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
             }
-            JoinedFlavor::Local(local) => match arrangement {
-                ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(local, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-                ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(local, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-            },
-            JoinedFlavor::Trace(trace) => match arrangement {
-                ArrangementFlavor::Local(oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-                ArrangementFlavor::Trace(_gid, oks, errs1) => {
-                    let (oks, errs2) = self.differential_join_inner(trace, oks, closure);
-                    errors.push(errs1.as_collection(|k, _v| k.clone()));
-                    errors.extend(errs2);
-                    oks
-                }
-            },
-        }
+            ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(local, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+        },
+        JoinedFlavor::Trace(trace) => match arrangement {
+            ArrangementFlavor::Local(oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(trace, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+            ArrangementFlavor::Trace(_gid, oks, errs1) => {
+                let (oks, errs2) = differential_join_inner(trace, oks, closure);
+                errors.push(errs1.as_collection(|k, _v| k.clone()));
+                errors.extend(errs2);
+                oks
+            }
+        },
     }
+}
 
-    /// Joins the arrangement for `next_input` to the arranged version of the
-    /// join of previous inputs. This is split into its own method to enable
-    /// reuse of code with different types of `next_input`.
-    ///
-    /// The return type includes an optional error collection, which may be
-    /// `None` if we can determine that `closure` cannot error.
-    fn differential_join_inner<J, Tr2>(
-        &mut self,
-        prev_keyed: J,
-        next_input: Arranged<G, Tr2>,
-        closure: JoinClosure,
-    ) -> (
-        Collection<G, Row, Diff>,
-        Option<Collection<G, DataflowError, Diff>>,
-    )
-    where
-        J: JoinCore<G, Row, Row, mz_repr::Diff>,
-        Tr2: TraceReader<Key = Row, Val = Row, Time = G::Timestamp, R = mz_repr::Diff>
-            + Clone
-            + 'static,
-    {
-        use differential_dataflow::AsCollection;
-        use timely::dataflow::operators::OkErr;
+/// Joins the arrangement for `next_input` to the arranged version of the
+/// join of previous inputs. This is split into its own method to enable
+/// reuse of code with different types of `next_input`.
+///
+/// The return type includes an optional error collection, which may be
+/// `None` if we can determine that `closure` cannot error.
+fn differential_join_inner<G, T, J, Tr2>(
+    prev_keyed: J,
+    next_input: Arranged<G, Tr2>,
+    closure: JoinClosure,
+) -> (
+    Collection<G, Row, Diff>,
+    Option<Collection<G, DataflowError, Diff>>,
+)
+where
+    G: Scope,
+    G::Timestamp: Lattice + Refines<T>,
+    T: Timestamp + Lattice,
+    J: JoinCore<G, Row, Row, mz_repr::Diff>,
+    Tr2:
+        TraceReader<Key = Row, Val = Row, Time = G::Timestamp, R = mz_repr::Diff> + Clone + 'static,
+{
+    use differential_dataflow::AsCollection;
+    use timely::dataflow::operators::OkErr;
 
-        // Reuseable allocation for unpacking.
-        let mut datums = DatumVec::new();
-        let mut row_builder = Row::default();
+    // Reuseable allocation for unpacking.
+    let mut datums = DatumVec::new();
+    let mut row_builder = Row::default();
 
-        if closure.could_error() {
-            let (oks, err) = prev_keyed
-                .join_core(&next_input, move |key, old, new| {
-                    let temp_storage = RowArena::new();
-                    let mut datums_local = datums.borrow_with_many(&[key, old, new]);
-                    closure
-                        .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                        .map_err(DataflowError::from)
-                        .transpose()
-                })
-                .inner
-                .ok_err(|(x, t, d)| {
-                    // TODO(mcsherry): consider `ok_err()` for `Collection`.
-                    match x {
-                        Ok(x) => Ok((x, t, d)),
-                        Err(x) => Err((x, t, d)),
-                    }
-                });
-
-            (oks.as_collection(), Some(err.as_collection()))
-        } else {
-            let oks = prev_keyed.join_core(&next_input, move |key, old, new| {
+    if closure.could_error() {
+        let (oks, err) = prev_keyed
+            .join_core(&next_input, move |key, old, new| {
                 let temp_storage = RowArena::new();
                 let mut datums_local = datums.borrow_with_many(&[key, old, new]);
                 closure
                     .apply(&mut datums_local, &temp_storage, &mut row_builder)
-                    .expect("Closure claimed to never error")
+                    .map_err(DataflowError::from)
+                    .transpose()
+            })
+            .inner
+            .ok_err(|(x, t, d)| {
+                // TODO(mcsherry): consider `ok_err()` for `Collection`.
+                match x {
+                    Ok(x) => Ok((x, t, d)),
+                    Err(x) => Err((x, t, d)),
+                }
             });
 
-            (oks, None)
-        }
+        (oks.as_collection(), Some(err.as_collection()))
+    } else {
+        let oks = prev_keyed.join_core(&next_input, move |key, old, new| {
+            let temp_storage = RowArena::new();
+            let mut datums_local = datums.borrow_with_many(&[key, old, new]);
+            closure
+                .apply(&mut datums_local, &temp_storage, &mut row_builder)
+                .expect("Closure claimed to never error")
+        });
+
+        (oks, None)
     }
 }

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -543,7 +543,7 @@ where
     G::Timestamp: Lattice,
 {
     input.scope().region_named("ReduceHierarchical", |inner| {
-        let input = input.enter(inner);
+        let input = input.enter_region(inner);
 
         // Gather the relevant values into a vec of rows ordered by aggregation_index
         let mut row_buf = Row::default();

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -125,16 +125,19 @@ where
         input: CollectionBundle<G, Row, T>,
         threshold_plan: ThresholdPlan,
     ) -> CollectionBundle<G, Row, T> {
-        match threshold_plan {
-            ThresholdPlan::Basic(BasicThresholdPlan { ensure_arrangement }) => {
-                // We do not need to apply the permutation here,
-                // since threshold doesn't inspect the values, but only
-                // their counts.
-                build_threshold_basic(input, ensure_arrangement.0)
+        input.scope().region_named("Threshold", |inner| {
+            match threshold_plan {
+                ThresholdPlan::Basic(BasicThresholdPlan { ensure_arrangement }) => {
+                    // We do not need to apply the permutation here,
+                    // since threshold doesn't inspect the values, but only
+                    // their counts.
+                    build_threshold_basic(input.enter_region(inner), ensure_arrangement.0)
+                }
+                ThresholdPlan::Retractions(RetractionsThresholdPlan { ensure_arrangement }) => {
+                    build_threshold_retractions(input.enter_region(inner), ensure_arrangement.0)
+                }
             }
-            ThresholdPlan::Retractions(RetractionsThresholdPlan { ensure_arrangement }) => {
-                build_threshold_retractions(input, ensure_arrangement.0)
-            }
-        }
+            .leave_region()
+        })
     }
 }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -44,7 +44,7 @@ where
 
         // We create a new region to compartmentalize the topk logic.
         let ok_result = ok_input.scope().region_named("TopK", |inner| {
-            let ok_input = ok_input.enter(inner);
+            let ok_input = ok_input.enter_region(inner);
             let ok_result = match top_k_plan {
                 TopKPlan::MonotonicTop1(MonotonicTop1Plan {
                     group_key,


### PR DESCRIPTION
This PR adds regions around all non-primitive LIR operators. Some operators are less clear that they should be wrapped, e.g. `Let` and `Get`, and some turn in to a single operator and so a whole region didn't seem all that helpful (e.g. `negate` which is a single `map_in_place` operator). 

The PR also cleans up various uses of regions, attempting to thread errors through regions that already exist, and to use `enter_region()` and `leave_region()` in place of `enter()` and `leave()`.

It is not clear that we should do this, as it introduces a bit of noise and runtime overhead into the works. It might make sense, for example, to put regions on any subgraphs of unbounded size (e.g. `Reduce` and `Join(Linear)`, which are not currently wrapped in regions in `main`).

Example new hierarchical view: 

<img width="1393" alt="Screen Shot 2022-09-20 at 3 58 19 PM" src="https://user-images.githubusercontent.com/5741500/191352861-dbf0f3a0-5ce4-4b5c-9c3c-34b837da5563.png">

The non-hierarchical visualizer doesn't seem to report the dataflow as existing; not sure what is up with that, otherwise I would show it looking worse (because it doesn't grok the regions as operators and gets tangled up with them).

### Motivation

  * This PR adds a maybe-desirable feature.

### Tips for reviewer

Ignore whitespace to reduce the diff size substantially (the regions change indentation levels throughout).

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - The hierarchical memory visualizer gets more hierarchical structure, and the non-hierarchical visualizer becomes more unreadable.
