### PR TITLE
storage: implement the core bounded input reliance logic

### DIFF
--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -111,13 +111,13 @@ where
         name: source_name,
         upstream_name: connection.upstream_name().map(ToOwned::to_owned),
         id,
-        scope,
         timestamp_interval,
         worker_id: scope.index(),
         worker_count: scope.peers(),
         encoding: encoding.clone(),
         now: storage_state.now.clone(),
-        base_metrics: &storage_state.source_metrics,
+        // TODO(guswynn): avoid extra clones here
+        base_metrics: storage_state.source_metrics.clone(),
         resume_upper: resume_upper.clone(),
         storage_metadata: description.storage_metadata.clone(),
         persist_clients: Arc::clone(&storage_state.persist_clients),
@@ -133,6 +133,7 @@ where
     let ((ok_source, err_source), capability) = match connection {
         SourceConnection::Kafka(connection) => {
             let ((ok, err), cap) = source::create_raw_source::<_, KafkaSourceReader, _>(
+                scope,
                 base_source_config,
                 connection,
                 storage_state.connection_context.clone(),
@@ -143,6 +144,7 @@ where
         SourceConnection::Kinesis(connection) => {
             let ((ok, err), cap) =
                 source::create_raw_source::<_, DelimitedValueSource<KinesisSourceReader>, _>(
+                    scope,
                     base_source_config,
                     connection,
                     storage_state.connection_context.clone(),
@@ -152,6 +154,7 @@ where
         }
         SourceConnection::S3(connection) => {
             let ((ok, err), cap) = source::create_raw_source::<_, S3SourceReader, _>(
+                scope,
                 base_source_config,
                 connection,
                 storage_state.connection_context.clone(),
@@ -161,6 +164,7 @@ where
         }
         SourceConnection::Postgres(connection) => {
             let ((ok, err), cap) = source::create_raw_source::<_, PostgresSourceReader, _>(
+                scope,
                 base_source_config,
                 connection,
                 storage_state.connection_context.clone(),
@@ -170,6 +174,7 @@ where
         }
         SourceConnection::LoadGenerator(connection) => {
             let ((ok, err), cap) = source::create_raw_source::<_, LoadGeneratorSourceReader, _>(
+                scope,
                 base_source_config,
                 connection,
                 storage_state.connection_context.clone(),

--- a/src/storage/src/source/antichain.rs
+++ b/src/storage/src/source/antichain.rs
@@ -1,0 +1,165 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Drivers for upstream commit
+use std::collections::HashMap;
+
+use mz_expr::PartitionId;
+
+use crate::types::sources::MzOffset;
+
+/// OffsetAntichain is similar to a timely `Antichain<(PartitionId, T: TotalOrder)>`,
+/// but additionally:
+///
+/// - Uses a HashMap as the implementation to allow absence of a `PartitionId` to mean
+/// that `PartitionId` is at `T::minimum`. This helps avoid needing to hold onto a HUGE
+/// `Antichain` for all possible `PartitionId`s
+///     - Note this means that a partition being "finished" (like a normal "empty"
+///     `Antichain`, is not currently supported, but could be added
+///     - Note that this `Antichain` can also have been filtered, as in, missing some
+///     partitions for which data exists but we don't care about. This is semantically
+///     different than if we just don't have data, but it is represented the same
+/// - Is not generic over `T`, but instead uses `MzOffset`, which we have
+/// - Allows users to go from a _frontier_ to an actual set of offsets that are
+/// connected to real data.
+///     - This is a consequence of implementation, where the _frontier_ is ALWAYS
+///     generated from real data offsets, in an invertible way.
+///
+/// `OffsetAntichain` has 4 sets of Api's:
+/// - "read" apis like `get` and `as_vec`
+/// - "mutation" apis (currently only `filter_by_partition`)
+/// - And 2 "write" apis, that should primarily be used separately from each other:
+///   - "Frontier" apis, which directly manipulate the underlying frontier.
+///   Useful for implementing primitives like reclocking
+///   - "Data" apis, that maintain special invariants:
+///     - `insert_data_up_to` updates the frontier based a given offset
+///     that
+///     - `as_data_offsets` inverts the behavior of `insert_data_up_to`
+///     and returns a `HashMap<PartitionId, MzOffset>` of offets
+///     of real committed data.
+#[derive(Debug, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+pub struct OffsetAntichain {
+    inner: HashMap<PartitionId, MzOffset>,
+}
+
+impl PartialEq<HashMap<PartitionId, MzOffset>> for OffsetAntichain {
+    fn eq(&self, other: &HashMap<PartitionId, MzOffset>) -> bool {
+        other == &self.inner
+    }
+}
+
+impl OffsetAntichain {
+    /// Initialize an Antichain where all partitions have made no progress.
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+        }
+    }
+
+    /// Initialize an Antichain where all partitions have made no progress,
+    /// but with `cap` capacity in the underlying data structure.
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: HashMap::with_capacity(cap),
+        }
+    }
+
+    // Data apis
+
+    /// Advance the frontier represented by this `OffsetAntichain` for `pid`
+    /// to a value that contains `offset`.
+    pub fn insert_data_up_to(&mut self, pid: PartitionId, offset: MzOffset) {
+        *self.inner.entry(pid).or_default() = offset + 1;
+    }
+
+    /// Produce offsets for all partitions in this `OffsetAntichain` that
+    /// were at one point given by `insert_data_up_to`.
+    ///
+    /// If the partition is yet to make any progress, it may be filtered out.
+    ///
+    /// Invariant: After initialization, only `insert_data_up_to`
+    /// (not `insert` and friends) may be used with this `OffsetAntichain`
+    /// for this function to produce meaningful values, unless you are very
+    /// careful.
+    // TODO(guswynn): better document how source uppers flow through the
+    // source reader pipeline.
+    pub fn as_data_offsets(&self) -> HashMap<PartitionId, MzOffset> {
+        self.inner
+            .iter()
+            .filter_map(|(pid, offset)| {
+                offset
+                    .checked_sub(MzOffset::from(1))
+                    .map(|offset| (pid.clone(), offset))
+            })
+            .collect()
+    }
+
+    // Frontier apis
+
+    /// Insert a new `MzOffset` frontier value for the `pid`, returning
+    /// the old one if it wasn't there.
+    pub fn insert(&mut self, pid: PartitionId, m: MzOffset) -> Option<MzOffset> {
+        self.inner.insert(pid, m)
+    }
+    /// The same as `insert`, but for many values.
+    pub fn extend<T: IntoIterator<Item = (PartitionId, MzOffset)>>(&mut self, iter: T) {
+        self.inner.extend(iter)
+    }
+    /// Advance the frontier for `PartitionId` by `diff`
+    /// Initializes the offset for `pid` if it doesn't exist.
+    pub fn advance(&mut self, pid: PartitionId, diff: MzOffset) {
+        *self.inner.entry(pid).or_default() += diff;
+    }
+
+    // Read Api's
+
+    /// Attempt to the the `MzOffset` value for `pid`'s frontier
+    pub fn get(&self, pid: &PartitionId) -> Option<&MzOffset> {
+        self.inner.get(pid)
+    }
+
+    /// List the contained partitions.
+    pub fn partitions(&self) -> impl Iterator<Item = &PartitionId> {
+        self.inner.keys()
+    }
+
+    /// Iterate over the entire frontier.
+    pub fn iter(&self) -> impl Iterator<Item = (&PartitionId, &MzOffset)> {
+        self.inner.iter()
+    }
+
+    /// Convert the frontier into a vector. Useful for certain
+    /// old apis in the storage crate.
+    pub fn as_vec(&self) -> Vec<(PartitionId, Option<MzOffset>)> {
+        let mut vec = Vec::with_capacity(self.inner.len());
+        for (pid, offset) in self.inner.iter() {
+            vec.push((pid.clone(), Some(offset.clone())));
+        }
+        vec
+    }
+
+    // Mutation Api's
+
+    /// Scope this `OffsetAntichain` down to only partitions that pass
+    /// this filter callback.
+    pub fn filter_by_partition<F>(&mut self, mut filter: F)
+    where
+        F: FnMut(&PartitionId) -> bool,
+    {
+        self.inner.retain(|pid, _| filter(pid))
+    }
+
+    /// Build an `OffsetAntichain` from a direct iterator. Useful for tests.
+    #[cfg(test)]
+    pub fn from_iter<T: IntoIterator<Item = (PartitionId, MzOffset)>>(iter: T) -> Self {
+        Self {
+            inner: HashMap::from_iter(iter),
+        }
+    }
+}

--- a/src/storage/src/source/commit.rs
+++ b/src/storage/src/source/commit.rs
@@ -1,0 +1,112 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Drivers for upstream commit
+use std::collections::HashMap;
+use std::marker::{Send, Sync};
+
+use async_trait::async_trait;
+use tokio::sync::watch;
+
+use mz_expr::PartitionId;
+use mz_ore::task;
+use mz_repr::GlobalId;
+
+use crate::source::types::OffsetCommitter;
+use crate::types::sources::MzOffset;
+
+/// An OffsetCommitter that simply logs its callbacks.
+pub struct LogCommitter {
+    pub(crate) source_id: GlobalId,
+    pub(crate) worker_id: usize,
+    pub(crate) worker_count: usize,
+}
+
+#[async_trait]
+impl OffsetCommitter for LogCommitter {
+    async fn commit_offsets(
+        &self,
+        offsets: HashMap<PartitionId, MzOffset>,
+    ) -> Result<(), anyhow::Error> {
+        tracing::trace!(
+            ?offsets,
+            "source reader({}) \
+            {}/{} received offsets to commit",
+            self.source_id,
+            self.worker_id,
+            self.worker_count,
+        );
+        Ok(())
+    }
+}
+
+pub(crate) struct OffsetCommitHandle {
+    sender: watch::Sender<HashMap<PartitionId, MzOffset>>,
+}
+
+impl OffsetCommitHandle {
+    pub(crate) fn commit_offsets(&self, offsets: HashMap<PartitionId, MzOffset>) {
+        self.sender
+            .send(offsets)
+            .expect("the receiver to drop first")
+    }
+}
+
+pub(crate) fn drive_offset_committer<S: OffsetCommitter + Send + Sync + 'static>(
+    sc: S,
+    source_id: GlobalId,
+    worker_id: usize,
+    worker_count: usize,
+) -> OffsetCommitHandle {
+    let (tx, mut rx): (_, watch::Receiver<HashMap<PartitionId, MzOffset>>) =
+        watch::channel(Default::default());
+    let _ = task::spawn(
+        || format!("offset commiter({source_id}) {worker_id}/{worker_count}"),
+        async move {
+            // loop waiting on changes. Note we could miss updates,
+            // but this is fine: we work on committing of offsets
+            // as fast as the `OffsetCommitter` allows us.
+            while let Ok(()) = rx.changed().await {
+                // Clone out of the watch to avoid holding the read lock
+                // for longer that necessary.
+                let new_offsets: HashMap<PartitionId, MzOffset> = {
+                    let new_offsets = rx.borrow();
+
+                    // Convert the _frontier_ into actual offsets to be committed
+                    // A _frontier_ offset value of 0 is simply skipped, as it
+                    // represents beginning with nothing.
+                    //
+                    // TODO(guswynn): factor this into its own structure
+                    new_offsets
+                        .iter()
+                        .filter_map(|(pid, offset)| {
+                            offset
+                                .checked_sub(MzOffset::from(1))
+                                .map(|offset| (pid.clone(), offset))
+                        })
+                        .collect()
+                };
+
+                // TODO(guswynn): avoid committing the same exact frontier multiple times
+                if !new_offsets.is_empty() {
+                    if let Err(e) = sc.commit_offsets(new_offsets).await {
+                        tracing::error!(
+                            %e,
+                            "Failed to commit offsets for {source_id} ({worker_id}/{worker_count}"
+                        );
+                    }
+                }
+            }
+
+            // Error's mean the send side has dropped, so we silently shutdown.
+        },
+    );
+
+    OffsetCommitHandle { sender: tx }
+}

--- a/src/storage/src/source/commit.rs
+++ b/src/storage/src/source/commit.rs
@@ -77,20 +77,7 @@ pub(crate) fn drive_offset_committer<S: OffsetCommitter + Send + Sync + 'static>
                 // for longer that necessary.
                 let new_offsets: HashMap<PartitionId, MzOffset> = {
                     let new_offsets = rx.borrow();
-
-                    // Convert the _frontier_ into actual offsets to be committed
-                    // A _frontier_ offset value of 0 is simply skipped, as it
-                    // represents beginning with nothing.
-                    //
-                    // TODO(guswynn): factor this into its own structure
-                    new_offsets
-                        .iter()
-                        .filter_map(|(pid, offset)| {
-                            offset
-                                .checked_sub(MzOffset::from(1))
-                                .map(|offset| (pid.clone(), offset))
-                        })
-                        .collect()
+                    new_offsets.clone()
                 };
 
                 // TODO(guswynn): avoid committing the same exact frontier multiple times

--- a/src/storage/src/source/delimited_value_reader.rs
+++ b/src/storage/src/source/delimited_value_reader.rs
@@ -33,6 +33,7 @@ where
     type Key = Option<Vec<u8>>;
     type Value = Option<Vec<u8>>;
     type Diff = D;
+    type OffsetCommitter = S::OffsetCommitter;
     type Connection = S::Connection;
 
     fn new(
@@ -46,7 +47,7 @@ where
         encoding: SourceDataEncoding,
         metrics: crate::source::metrics::SourceBaseMetrics,
         connection_context: ConnectionContext,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<(Self, Self::OffsetCommitter), anyhow::Error> {
         S::new(
             source_name,
             source_id,
@@ -59,7 +60,7 @@ where
             metrics,
             connection_context,
         )
-        .map(Self)
+        .map(|(s, sc)| (Self(s), sc))
     }
 
     fn get_next_message(

--- a/src/storage/src/source/kinesis.rs
+++ b/src/storage/src/source/kinesis.rs
@@ -26,6 +26,7 @@ use mz_ore::metrics::{DeleteOnDropGauge, GaugeVecExt};
 use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 
+use crate::source::commit::LogCommitter;
 use crate::source::metrics::KinesisMetrics;
 use crate::source::{
     NextMessage, SourceMessage, SourceMessageType, SourceReader, SourceReaderError,
@@ -133,6 +134,7 @@ impl SourceReader for KinesisSourceReader {
     type Key = ();
     type Value = Option<Vec<u8>>;
     type Diff = ();
+    type OffsetCommitter = LogCommitter;
     type Connection = KinesisSourceConnection;
 
     fn new(
@@ -146,7 +148,7 @@ impl SourceReader for KinesisSourceReader {
         _encoding: SourceDataEncoding,
         metrics: crate::source::metrics::SourceBaseMetrics,
         connection_context: ConnectionContext,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<(Self, Self::OffsetCommitter), anyhow::Error> {
         let active_read_worker =
             crate::source::responsible_for(&source_id, worker_id, worker_count, &PartitionId::None);
 
@@ -160,19 +162,26 @@ impl SourceReader for KinesisSourceReader {
             &*connection_context.secrets_reader,
         ));
         match state {
-            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok(KinesisSourceReader {
-                tokio_handle: TokioHandle::current(),
-                kinesis_client,
-                shard_queue,
-                last_checked_shards: Instant::now(),
-                buffered_messages: VecDeque::new(),
-                shard_set,
-                stream_name,
-                processed_message_count: 0,
-                base_metrics: metrics.kinesis,
-                active_read_worker,
-                reported_unconsumed_partitions: false,
-            }),
+            Ok((kinesis_client, stream_name, shard_set, shard_queue)) => Ok((
+                KinesisSourceReader {
+                    tokio_handle: TokioHandle::current(),
+                    kinesis_client,
+                    shard_queue,
+                    last_checked_shards: Instant::now(),
+                    buffered_messages: VecDeque::new(),
+                    shard_set,
+                    stream_name,
+                    processed_message_count: 0,
+                    base_metrics: metrics.kinesis,
+                    active_read_worker,
+                    reported_unconsumed_partitions: false,
+                },
+                LogCommitter {
+                    source_id,
+                    worker_id,
+                    worker_count,
+                },
+            )),
             Err(e) => Err(anyhow!("{}", e)),
         }
     }

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -37,6 +37,7 @@ use crate::source::types::SourceMessageType;
 use crate::source::types::SourceReaderError;
 use crate::source::types::{NextMessage, SourceMessage, SourceReader};
 
+mod antichain;
 mod commit;
 mod delimited_value_reader;
 pub mod generator;

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -37,6 +37,7 @@ use crate::source::types::SourceMessageType;
 use crate::source::types::SourceReaderError;
 use crate::source::types::{NextMessage, SourceMessage, SourceReader};
 
+mod commit;
 mod delimited_value_reader;
 pub mod generator;
 mod healthcheck;

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -73,6 +73,19 @@ impl ReclockFollower {
         }
     }
 
+    /// Ensure the `ReclockFollower` has been initialized with trace
+    /// up to the given upper.
+    pub async fn ensure_initialized_to(&self, upper: Antichain<Timestamp>) {
+        // Careful not to hold a `Ref` over and await point.
+        loop {
+            if PartialOrder::less_equal(&upper, &RefCell::borrow(&self.inner).upper) {
+                return;
+            }
+            // Some short but non-0 amount of time
+            tokio::time::sleep(Duration::from_millis(100)).await
+        }
+    }
+
     pub fn source_upper(&self) -> Ref<OffsetAntichain> {
         // `borrow` overlaps with `std::borrow::Borrow` so we have to do this
         Ref::map(RefCell::borrow(&self.inner), |inner| &inner.source_upper)

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -34,6 +34,7 @@ use mz_repr::Timestamp;
 use tracing::trace;
 
 use crate::controller::CollectionMetadata;
+use crate::source::antichain::OffsetAntichain;
 use crate::types::sources::MzOffset;
 
 /// A "follower" for the ReclockOperator, that maintains
@@ -56,7 +57,7 @@ struct ReclockFollowerInner {
     upper: Antichain<Timestamp>,
     /// The upper frontier in terms of `SourceTime`. Any attempt to reclock messages beyond this
     /// frontier will lead to minting new bindings.
-    source_upper: HashMap<PartitionId, MzOffset>,
+    source_upper: OffsetAntichain,
 }
 
 impl ReclockFollower {
@@ -67,12 +68,12 @@ impl ReclockFollower {
                 remap_trace: HashMap::new(),
                 since: as_of,
                 upper: Antichain::from_elem(Timestamp::minimum()),
-                source_upper: HashMap::new(),
+                source_upper: OffsetAntichain::new(),
             })),
         }
     }
 
-    pub fn source_upper(&self) -> Ref<HashMap<PartitionId, MzOffset>> {
+    pub fn source_upper(&self) -> Ref<OffsetAntichain> {
         // `borrow` overlaps with `std::borrow::Borrow` so we have to do this
         Ref::map(RefCell::borrow(&self.inner), |inner| &inner.source_upper)
     }
@@ -88,7 +89,7 @@ impl ReclockFollower {
                 let bindings = inner.remap_trace.entry(pid.clone()).or_default();
                 bindings.push((ts, diff));
 
-                *inner.source_upper.entry(pid.clone()).or_default() += diff;
+                inner.source_upper.advance(pid.clone(), diff);
             }
         }
     }
@@ -162,15 +163,15 @@ impl ReclockFollower {
     /// The error will contain the offending `SourceTime`.
     pub fn reclock_frontier(
         &self,
-        source_frontier: &HashMap<PartitionId, MzOffset>,
+        source_frontier: &OffsetAntichain,
     ) -> Result<Antichain<Timestamp>, (PartitionId, MzOffset)> {
         let inner = RefCell::borrow(&self.inner);
         // The upper is the greatest frontier that we can ever return
         let mut dest_frontier = inner.upper.clone();
 
         let mut partitions = HashSet::new();
-        partitions.extend(inner.source_upper.keys());
-        partitions.extend(source_frontier.keys());
+        partitions.extend(inner.source_upper.partitions());
+        partitions.extend(source_frontier.partitions());
         // To refine it we have to go through all the partitions we know about and:
         for pid in partitions {
             let offset = source_frontier.get(pid).copied().unwrap_or_default();
@@ -208,7 +209,7 @@ impl ReclockFollower {
     pub fn source_upper_at_frontier(
         &self,
         ts_upper: AntichainRef<Timestamp>,
-    ) -> anyhow::Result<HashMap<PartitionId, MzOffset>> {
+    ) -> anyhow::Result<OffsetAntichain> {
         RefCell::borrow(&self.inner).source_upper_at_frontier(ts_upper)
     }
 
@@ -284,7 +285,7 @@ impl ReclockFollowerInner {
     pub fn source_upper_at_frontier(
         &self,
         ts_upper: AntichainRef<Timestamp>,
-    ) -> anyhow::Result<HashMap<PartitionId, MzOffset>> {
+    ) -> anyhow::Result<OffsetAntichain> {
         source_upper_at_frontier_impl(
             &self.remap_trace,
             &self.since,
@@ -399,14 +400,14 @@ impl ReclockOperator {
     /// The error will contain the offending `SourceTime`.
     pub fn reclock_frontier(
         &self,
-        source_frontier: &HashMap<PartitionId, MzOffset>,
+        source_frontier: &OffsetAntichain,
     ) -> Result<Antichain<Timestamp>, (PartitionId, MzOffset)> {
         // The upper is the greatest frontier that we can ever return
         let mut dest_frontier = self.upper.clone();
 
         let mut partitions = HashSet::new();
         partitions.extend(self.source_upper.keys());
-        partitions.extend(source_frontier.keys());
+        partitions.extend(source_frontier.partitions());
         // To refine it we have to go through all the partitions we know about and:
         for pid in partitions {
             let offset = source_frontier.get(pid).copied().unwrap_or_default();
@@ -468,7 +469,7 @@ impl ReclockOperator {
     pub fn source_upper_at_frontier(
         &self,
         ts_upper: AntichainRef<Timestamp>,
-    ) -> anyhow::Result<HashMap<PartitionId, MzOffset>> {
+    ) -> anyhow::Result<OffsetAntichain> {
         source_upper_at_frontier_impl(
             &self.remap_trace,
             &self.since,
@@ -552,16 +553,16 @@ impl ReclockOperator {
     /// When this function returns the local dTVC view of the remap collection will contain
     /// definite timestamp bindings that can be used to reclock messages at offsets that are not
     /// beyond the provided frontier.
-    pub async fn mint<P: Borrow<PartitionId>>(
+    pub async fn mint(
         &mut self,
-        source_frontier: &HashMap<P, MzOffset>,
+        source_frontier: &OffsetAntichain,
     ) -> HashMap<PartitionId, Vec<(Timestamp, MzOffset)>> {
         // Any updates to the remap trace that occured during minting.
         let mut trace_updates: HashMap<PartitionId, Vec<(Timestamp, MzOffset)>> = HashMap::new();
 
         loop {
             let mut updates = vec![];
-            for (pid, upper) in source_frontier {
+            for (pid, upper) in source_frontier.iter() {
                 let pid = pid.borrow();
                 let part_upper = self.source_upper.get(pid).copied().unwrap_or_default();
 
@@ -770,7 +771,7 @@ fn source_upper_at_frontier_impl<'a, F>(
     cur_upper: &Antichain<Timestamp>,
     upper_to_invert: AntichainRef<Timestamp>,
     partition_bindings: &'a F,
-) -> anyhow::Result<HashMap<PartitionId, MzOffset>>
+) -> anyhow::Result<OffsetAntichain>
 where
     F: Fn(&PartitionId) -> PartitionBindings<'a>,
 {
@@ -789,7 +790,7 @@ where
     if PartialOrder::less_equal(since, &zero)
         && PartialOrder::less_equal(&upper_to_invert, &zero.borrow())
     {
-        return Ok(HashMap::new());
+        return Ok(OffsetAntichain::new());
     }
 
     // Assert we haven't compacted too far, and that we aren't (somehow) asking about the
@@ -809,7 +810,7 @@ where
         ));
     }
 
-    let mut source_upper = HashMap::with_capacity(remap_trace.len());
+    let mut source_upper = OffsetAntichain::with_capacity(remap_trace.len());
     for pid in remap_trace.keys() {
         let binding = partition_bindings(pid)
             .take_while(|(ts, _)| ts < &ts_to_invert)
@@ -894,7 +895,7 @@ mod tests {
     async fn mint_and_follow(
         operator: &mut ReclockOperator,
         follower: &mut ReclockFollower,
-        source_upper: &mut HashMap<PartitionId, MzOffset>,
+        source_upper: &mut OffsetAntichain,
     ) {
         let trace_updates = operator.mint(source_upper).await;
         let reclock_upper = operator
@@ -909,7 +910,7 @@ mod tests {
         const PART_ID: PartitionId = PartitionId::None;
         let (mut operator, mut follower) =
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
-        let mut source_upper = HashMap::new();
+        let mut source_upper = OffsetAntichain::new();
 
         tokio::time::advance(Duration::from_secs(1)).await;
 
@@ -940,7 +941,7 @@ mod tests {
 
         // This will return the antichain containing 1000 because that's where future messages will
         // offset 1 will be reclocked to
-        let query = HashMap::from_iter([(PART_ID, MzOffset::from(1))]);
+        let query = OffsetAntichain::from_iter([(PART_ID, MzOffset::from(1))]);
         assert_eq!(
             Ok(Antichain::from_elem(1000.into())),
             follower.reclock_frontier(&query)
@@ -961,7 +962,7 @@ mod tests {
 
         // We're done with offset 3. Now the reclocking the source upper will result to the overall
         // target upper (1001) because any new bindings will be minted beyond that timestamp.
-        let query = HashMap::from_iter([(PART_ID, MzOffset::from(4))]);
+        let query = OffsetAntichain::from_iter([(PART_ID, MzOffset::from(4))]);
 
         assert_eq!(
             Ok(Antichain::from_elem(1001.into())),
@@ -1006,7 +1007,7 @@ mod tests {
         let (mut operator, _follower) =
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
 
-        let query = HashMap::new();
+        let query = OffsetAntichain::new();
         // This is the initial source frontier so we should get the initial ts upper
         assert_eq!(
             Ok(Antichain::from_elem(0.into())),
@@ -1017,10 +1018,10 @@ mod tests {
 
         // Mint a couple of bindings for multiple partitions
         operator
-            .mint(&HashMap::from_iter([(PART1, MzOffset::from(10))]))
+            .mint(&OffsetAntichain::from_iter([(PART1, MzOffset::from(10))]))
             .await;
         operator
-            .mint(&HashMap::from_iter([(PART2, MzOffset::from(10))]))
+            .mint(&OffsetAntichain::from_iter([(PART2, MzOffset::from(10))]))
             .await;
         assert_eq!(
             operator.remap_trace[&PART1],
@@ -1032,25 +1033,26 @@ mod tests {
         );
 
         // The initial frontier should now map to the minimum between the two partitions
-        let query = HashMap::new();
+        let query = OffsetAntichain::new();
         assert_eq!(
             Ok(Antichain::from_elem(1000.into())),
             operator.reclock_frontier(&query)
         );
 
         // Map a frontier that advances only one of the partitions
-        let query = HashMap::from_iter([(PART1, MzOffset::from(9))]);
+        let query = OffsetAntichain::from_iter([(PART1, MzOffset::from(9))]);
         assert_eq!(
             Ok(Antichain::from_elem(1000.into())),
             operator.reclock_frontier(&query)
         );
-        let query = HashMap::from_iter([(PART1, MzOffset::from(10))]);
+        let query = OffsetAntichain::from_iter([(PART1, MzOffset::from(10))]);
         assert_eq!(
             Ok(Antichain::from_elem(2000.into())),
             operator.reclock_frontier(&query)
         );
         // A frontier that is the upper of both partitions should map to the timestamp upper
-        let query = HashMap::from_iter([(PART1, MzOffset::from(10)), (PART2, MzOffset::from(10))]);
+        let query =
+            OffsetAntichain::from_iter([(PART1, MzOffset::from(10)), (PART2, MzOffset::from(10))]);
         assert_eq!(
             Ok(Antichain::from_elem(2001.into())),
             operator.reclock_frontier(&query)
@@ -1059,7 +1061,8 @@ mod tests {
         // Advance the operator and confirm that we get to the next timestamp
         tokio::time::advance(Duration::from_secs(1)).await;
         operator.advance().await;
-        let query = HashMap::from_iter([(PART1, MzOffset::from(10)), (PART2, MzOffset::from(10))]);
+        let query =
+            OffsetAntichain::from_iter([(PART1, MzOffset::from(10)), (PART2, MzOffset::from(10))]);
         assert_eq!(
             Ok(Antichain::from_elem(3001.into())),
             operator.reclock_frontier(&query)
@@ -1067,7 +1070,7 @@ mod tests {
 
         // Compact but not enough to change the bindings
         operator.compact(Antichain::from_elem(900.into())).await;
-        let query = HashMap::from_iter([(PART1, MzOffset::from(9))]);
+        let query = OffsetAntichain::from_iter([(PART1, MzOffset::from(9))]);
         assert_eq!(
             Ok(Antichain::from_elem(1000.into())),
             operator.reclock_frontier(&query)
@@ -1075,12 +1078,12 @@ mod tests {
 
         // Compact enough to compact bindings
         operator.compact(Antichain::from_elem(1500.into())).await;
-        let query = HashMap::from_iter([(PART1, MzOffset::from(9))]);
+        let query = OffsetAntichain::from_iter([(PART1, MzOffset::from(9))]);
         assert_eq!(
             Err((PART1, MzOffset::from(9))),
             operator.reclock_frontier(&query)
         );
-        let query = HashMap::from_iter([(PART1, MzOffset::from(10))]);
+        let query = OffsetAntichain::from_iter([(PART1, MzOffset::from(10))]);
         assert_eq!(
             Ok(Antichain::from_elem(2000.into())),
             operator.reclock_frontier(&query)
@@ -1095,7 +1098,7 @@ mod tests {
             make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
 
         let mut batch = HashMap::new();
-        let mut source_upper = HashMap::new();
+        let mut source_upper = OffsetAntichain::new();
 
         // Reclock offsets 1 and 2 to timestamp 0
         batch.insert(
@@ -1204,7 +1207,7 @@ mod tests {
             make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
 
         let mut batch = HashMap::new();
-        let mut source_upper = HashMap::new();
+        let mut source_upper = OffsetAntichain::new();
 
         tokio::time::advance(Duration::from_secs(1)).await;
 
@@ -1302,7 +1305,7 @@ mod tests {
 
         // Reclock a batch from one of the operators
         let mut batch = HashMap::new();
-        let mut source_upper = HashMap::new();
+        let mut source_upper = OffsetAntichain::new();
 
         tokio::time::advance(Duration::from_secs(1)).await;
 
@@ -1369,7 +1372,7 @@ mod tests {
             make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
 
         let mut batch = HashMap::new();
-        let mut source_upper = HashMap::new();
+        let mut source_upper = OffsetAntichain::new();
 
         tokio::time::advance(Duration::from_secs(1)).await;
 
@@ -1517,7 +1520,7 @@ mod tests {
         let (mut operator, _follower) =
             make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
 
-        let mut source_upper = HashMap::new();
+        let mut source_upper = OffsetAntichain::new();
 
         // We do multiple rounds of minting. This will downgrade the since of
         // the internal listen. If we didn't make sure to also heartbeat the

--- a/src/storage/src/source/resumption.rs
+++ b/src/storage/src/source/resumption.rs
@@ -38,7 +38,8 @@ use mz_timely_util::operators_async_ext::OperatorBuilderExt;
 ///
 /// This is useful when a source is finite or finishes for other reasons.
 pub fn resumption_operator<G, R>(
-    config: RawSourceCreationConfig<G>,
+    scope: &G,
+    config: RawSourceCreationConfig,
     calc: R,
 ) -> (timely::dataflow::Stream<G, ()>, Handle<G, ()>)
 where
@@ -47,7 +48,6 @@ where
 {
     let RawSourceCreationConfig {
         id: source_id,
-        scope,
         worker_count,
         worker_id,
         storage_metadata,
@@ -61,7 +61,7 @@ where
     // TODO(guswynn): remove this clone, `Feedback::feedback` erroneously requires `&mut Scope`,
     // but only needs to clone the scope.
     let (source_reader_feedback_handle, source_reader_feedback_stream) =
-        config.scope.clone().feedback(Timestamp::new(1));
+        scope.clone().feedback(Timestamp::new(1));
 
     let chosen_worker = (source_id.hashed() % worker_count as u64) as usize;
     let active_worker = chosen_worker == worker_id;

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -528,6 +528,13 @@ where
                                 crate::source::responsible_for(&id, worker_id, worker_count, &pid)
                             });
                             offset_commit_handle.commit_offsets(offset_upper.as_data_offsets());
+
+                            // Compact the in-memory remap trace shared between this
+                            // operator the reclock operator. We do this here for convenience! The
+                            // ordering doesn't really matter.
+                            let upper_ts = resume_upper.as_option().copied().unwrap();
+                            let as_of = Antichain::from_elem(upper_ts.saturating_sub(1));
+                            reclock_follower.compact(as_of);
                             continue;
                         }
                         _ => {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR implements the core BIR logic, as described in https://github.com/MaterializeInc/materialize/pull/14314, epic: https://github.com/MaterializeInc/materialize/issues/13534. It does NOT implement the source-specific behavior to actually commit offsets, that will come later; instead, it builds on previous PR's to be able to thread the _offset resumption frontier_ (actually, its no longer a frontier at this point) to the source implementations.

I highly recommend reading the commits separately, at least once. They are, from bottom to top, as follows (with some additional notes for each):

- The first commit is just refactoring. It moves the source stream creation into a separate function.
  - To manage this (ie, remove lifetime errors), `scope` is removed from `RawSourceCreationConfig`, and `BaseMetrics` is cloned more than before. This can probably be worked around, but I felt it wasn't worth it
- The second commit is the core logic. It:
  - Adds `OffsetCommitter` as an associated type to `SourceReader`s, which are now required to return one on construction.
  - Drives this offset committer with a separate task, which means the core operation can be async, but our use of a `tokio::sync::watch` makes committing effectively instantaneous. This logic is implemented in the new `source::commit` module
  - Note that because the source reader operator is now async, we _could_ drive the `OffsetCommitter` directly, but that would delay source ingestion based on the throughput of committing. The current scheme allows an offset committer to be slow, and "miss" new _offset resumption frontier_ updates but always make progress (i.e. it decouples the commit sped with the interval we produce new frontiers at) cc @petrosagg 
  - Splitting the `SourceReader` and `OffsetCommitter` into 2 pieces has 2 advantages:
    - It allows sources that require coordination between the stream and the committing to operate (with a channel), while also allowing simpler ones like kafka that can just create a new client nice and simple!
    - Cleans up the `source_reader_operator` A LOT, by allowing the main `SourceReader` to still just act as a `Stream`
  - connects everything together, and defaults ALL sources to the `LogCommitter` implementation, that just logs when it receives new frontiers
- The third commit turns `HashMap<PartitionId, MzOffset>`'s into `OffsetAntichain`'s, defined in the new `source::antichain` module
  - This is a more clear description of what is going on, and allows us to encapsulate weird logic (like adding and subtracting from frontiers to get real offset values) in one module.
  - Note that this attempts to cleanup all uses of a "source frontier" concept, but there are still some subtleties. The docs in the module attempt to describe them.
  - There is an outstanding TODO to move the logic here: https://github.com/MaterializeInc/materialize/blob/main/src/storage/src/source/source_reader_pipeline.rs#L513-L522 into this module. However, I admit I don't really understand how this works, and how it interacts with `reclock_frontier`, so @aljoscha and I will have to discuss and clean that up later
- The fourth commit ensures we have initialized the `ReclockFollower` we use for `source_upper_at_frontier` in the source reader operator.
  - This also resolves a TODO where we were doing extra persist reads in initialization of this operator. Nice and clean! 
- The fifth commit adds simple logic to avoid re-committing the same offsets 
- The 6th commit compact the in-memory trace of the `ReclockOperator` after we commit. The ordering here doesn't really matter, but its convenient

### Motivation
  * This PR adds a known-desirable feature.

### Tips for reviewer
Commits should probably be viewed separately. See above for details

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
