### PR TITLE
[environmentd] Thread through a environment string

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -122,11 +122,25 @@ def main() -> int:
                 if args.reset:
                     _run_sql(args.postgres, f"DROP SCHEMA IF EXISTS {schema} CASCADE")
                 _run_sql(args.postgres, f"CREATE SCHEMA IF NOT EXISTS {schema}")
+
+            os.mkdir(ROOT / "mzdata")
+            environment_file = ROOT / "mzdata" / "environment-id"
+            try:
+                with open(environment_file, "r") as file:
+                    environment_id = file.read().rstrip()
+            except FileNotFoundError:
+                import uuid
+
+                environment_id = f"environment-{uuid.uuid4()}-0"
+                with open(environment_file, "w+") as file:
+                    file.write(environment_id)
+
             command += [
                 f"--persist-consensus-url={args.postgres}?options=--search_path=consensus",
                 f"--persist-blob-url=file://{ROOT}/mzdata/persist/blob",
                 f"--adapter-stash-url={args.postgres}?options=--search_path=adapter",
                 f"--storage-stash-url={args.postgres}?options=--search_path=storage",
+                f"--environment-id={environment_id}",
             ]
         elif args.program == "sqllogictest":
             _handle_lingering_services(kill=True)

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2575,7 +2575,7 @@ impl<S: Append> Catalog<S> {
             storage,
             unsafe_mode: true,
             build_info: &DUMMY_BUILD_INFO,
-            environment_id: Uuid::from_u128(0),
+            environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
             now,
             skip_migrations: true,
             metrics_registry,

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -12,7 +12,6 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use serde::Deserialize;
-use uuid::Uuid;
 
 use mz_build_info::BuildInfo;
 use mz_compute_client::controller::ComputeInstanceReplicaAllocation;
@@ -31,8 +30,8 @@ pub struct Config<'a, S> {
     pub unsafe_mode: bool,
     /// Information about this build of Materialize.
     pub build_info: &'static BuildInfo,
-    /// A persistent UUID associated with the environment.
-    pub environment_id: Uuid,
+    /// A persistent ID associated with the environment.
+    pub environment_id: String,
     /// Function to generate wall clock now; can be mocked.
     pub now: mz_ore::now::NowFn,
     /// Whether or not to skip catalog migrations.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -220,7 +220,7 @@ pub struct Config<S> {
     pub storage: storage::Connection<S>,
     pub unsafe_mode: bool,
     pub build_info: &'static BuildInfo,
-    pub environment_id: Uuid,
+    pub environment_id: String,
     pub metrics_registry: MetricsRegistry,
     pub now: NowFn,
     pub secrets_controller: Arc<dyn SecretsController>,

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -638,7 +638,7 @@ fn eval_unmaterializable_func(
         }
         UnmaterializableFunc::CurrentTimestamp => pack(Datum::from(session.pcx().wall_time)),
         UnmaterializableFunc::CurrentUser => pack(Datum::from(session.user())),
-        UnmaterializableFunc::MzEnvironmentId => pack(Datum::from(state.config().environment_id)),
+        UnmaterializableFunc::MzEnvironmentId => pack(Datum::from(&*state.config().environment_id)),
         UnmaterializableFunc::MzLogicalTimestamp => match logical_time {
             None => coord_bail!("cannot call mz_logical_timestamp in this context"),
             Some(logical_time) => pack(Datum::from(Numeric::from(logical_time))),

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -34,6 +34,7 @@ use once_cell::sync::Lazy;
 use sysinfo::{CpuExt, SystemExt};
 use tokio::sync::Mutex;
 use tower_http::cors::{self, AllowOrigin};
+
 use url::Url;
 use uuid::Uuid;
 
@@ -328,10 +329,10 @@ pub struct Args {
     #[clap(
         long,
         env = "ENVIRONMENT_ID",
-        value_name = "UUID",
-        default_value = "00000000-0000-0000-0000-000000000000"
+        value_name = "ID",
+        default_value = "environment-00000000-0000-0000-0000-000000000000-0"
     )]
-    environment_id: Uuid,
+    environment_id: String,
     /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
     ///
     /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -28,7 +28,6 @@ use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
 use tower_http::cors::AllowOrigin;
 use tracing::error;
-use uuid::Uuid;
 
 use mz_adapter::catalog::storage::BootstrapArgs;
 use mz_adapter::catalog::{ClusterReplicaSizeMap, StorageHostSizeMap};
@@ -94,7 +93,7 @@ pub struct Config {
 
     // === Cloud options. ===
     /// The cloud ID of this environment.
-    pub environment_id: Uuid,
+    pub environment_id: String,
     /// Availability zones in which storage and compute resources may be
     /// deployed.
     pub availability_zones: Vec<String>,

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -204,7 +204,7 @@ pub fn start_server(config: Config) -> Result<Server, anyhow::Error> {
         unsafe_mode: config.unsafe_mode,
         metrics_registry: metrics_registry.clone(),
         now: config.now,
-        environment_id: Uuid::from_u128(0),
+        environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
         cors_allowed_origin: AllowOrigin::list([]),
         cluster_replica_sizes: Default::default(),
         bootstrap_default_cluster_replica_size: "1".into(),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -90,7 +90,7 @@ impl UnmaterializableFunc {
             }
             UnmaterializableFunc::CurrentTimestamp => ScalarType::TimestampTz.nullable(false),
             UnmaterializableFunc::CurrentUser => ScalarType::String.nullable(false),
-            UnmaterializableFunc::MzEnvironmentId => ScalarType::Uuid.nullable(false),
+            UnmaterializableFunc::MzEnvironmentId => ScalarType::String.nullable(false),
             UnmaterializableFunc::MzLogicalTimestamp => ScalarType::Numeric {
                 max_scale: Some(NumericMaxScale::ZERO),
             }

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -205,8 +205,8 @@ pub struct CatalogConfig {
     /// NOTE(benesch): this is only necessary for producing unique Kafka sink
     /// topics. Perhaps we can remove this when #2915 is complete.
     pub nonce: u64,
-    /// A persistent UUID associated with the environment.
-    pub environment_id: Uuid,
+    /// A persistent ID associated with the environment.
+    pub environment_id: String,
     /// A transient UUID associated with this process.
     pub session_id: Uuid,
     /// Whether the server is running in unsafe mode.
@@ -603,7 +603,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     start_time: DateTime::<Utc>::MIN_UTC,
     start_instant: Instant::now(),
     nonce: 0,
-    environment_id: Uuid::from_u128(0),
+    environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
     session_id: Uuid::from_u128(0),
     unsafe_mode: true,
     build_info: &DUMMY_BUILD_INFO,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -484,7 +484,7 @@ pub fn plan_create_source(
                 topic,
                 start_offsets,
                 group_id_prefix,
-                environment_id: scx.catalog.config().environment_id,
+                environment_id: scx.catalog.config().environment_id.clone(),
                 include_timestamp: None,
                 include_partition: None,
                 include_topic: None,
@@ -2168,11 +2168,12 @@ fn kafka_sink_builder(
         None => bail_unsupported!("sink without format"),
     };
 
+    let environment_id = &scx.catalog.config().environment_id;
     let consistency_config = KafkaConsistencyConfig::Progress {
         topic: connection
             .progress_topic
             .clone()
-            .unwrap_or_else(|| format!("_materialize-progress-{connection_id}")),
+            .unwrap_or_else(|| format!("_materialize-progress-{environment_id}-{connection_id}")),
     };
 
     if partition_count == 0 || partition_count < -1 {

--- a/src/sql/src/query_model/test/catalog.rs
+++ b/src/sql/src/query_model/test/catalog.rs
@@ -43,7 +43,7 @@ static DUMMY_CONFIG: Lazy<CatalogConfig> = Lazy::new(|| CatalogConfig {
     start_time: DateTime::<Utc>::MIN_UTC,
     start_instant: Instant::now(),
     nonce: 0,
-    environment_id: Uuid::from_u128(0),
+    environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
     session_id: Uuid::from_u128(0),
     unsafe_mode: false,
     build_info: &DUMMY_BUILD_INFO,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -669,7 +669,7 @@ impl Runner {
             unsafe_mode: true,
             metrics_registry,
             now,
-            environment_id: Uuid::from_u128(0),
+            environment_id: format!("environment-{}-0", Uuid::from_u128(0)),
             cluster_replica_sizes: Default::default(),
             bootstrap_default_cluster_replica_size: "1".into(),
             storage_host_sizes: Default::default(),

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -22,7 +22,6 @@ use rdkafka::{ClientConfig, ClientContext, Message, TopicPartitionList};
 use timely::scheduling::activate::SyncActivator;
 use tokio::runtime::Handle as TokioHandle;
 use tracing::{error, info, warn};
-use uuid::Uuid;
 
 use mz_expr::PartitionId;
 use mz_kafka_util::{client::create_new_client_config, client::MzClientContext};
@@ -536,7 +535,7 @@ impl KafkaSourceReader {
 async fn create_kafka_config(
     name: &str,
     group_id_prefix: Option<String>,
-    environment_id: Uuid,
+    environment_id: String,
     kafka_connection: &KafkaConnection,
     options: &BTreeMap<String, StringOrSecret>,
     connection_context: &ConnectionContext,

--- a/src/storage/src/types/sources.proto
+++ b/src/storage/src/types/sources.proto
@@ -146,7 +146,8 @@ message ProtoKafkaSourceConnection {
     string topic = 2;
     map<int32, ProtoMzOffset> start_offsets = 3;
     optional string group_id_prefix = 4;
-    mz_proto.ProtoU128 environment_id = 5;
+    optional mz_proto.ProtoU128 environment_id = 5;
+    optional string environment_name = 12;
     ProtoIncludedColumnPos include_timestamp = 6;
     ProtoIncludedColumnPos include_partition = 7;
     ProtoIncludedColumnPos include_topic = 8;

--- a/test/testdrive/system-functions.td
+++ b/test/testdrive/system-functions.td
@@ -23,7 +23,7 @@ true
 true
 
 > SELECT length(cast(mz_environment_id() as text));
-36
+50
 
 > SELECT length(cast(mz_internal.mz_session_id() as text));
 36


### PR DESCRIPTION
This changes the type of environment_id to `String` (formerly UUID) and coins one as part of the `environmentd` script.

### Motivation
Necessary for known-desirable improvement https://github.com/MaterializeInc/materialize/issues/14728

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
