### PR TITLE
doc/user: Add mention of where to find generated key

### DIFF
--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -142,6 +142,8 @@ Field                       | Value            | Required | Description
 `PORT`                      | `int4`           | ✓        | Port for the connection.
 `USER`                      | `text`           | ✓        | Username for the connection.
 
+After executing the `CREATE CONNECTION my_tunnel FOR SSH TUNNEL ...` command, the public keys to be placed on the bastion server can be found by running `SELECT * FROM mz_ssh_tunnel_connections;`.
+
 ##### Example
 
 ```sql

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -142,7 +142,12 @@ Field                       | Value            | Required | Description
 `PORT`                      | `int4`           | ✓        | Port for the connection.
 `USER`                      | `text`           | ✓        | Username for the connection.
 
-After executing the `CREATE CONNECTION my_tunnel FOR SSH TUNNEL ...` command, the public keys to be placed on the bastion server can be found by running `SELECT * FROM mz_ssh_tunnel_connections;`.
+#### Public key retrieval
+
+Once a connection is created, you can find and retrieve the public keys to be used in the bastion server by running:
+
+`SELECT * FROM mz_ssh_tunnel_connections;`
+
 
 ##### Example
 


### PR DESCRIPTION
### Motivation

We need to provide more information for creating SSH tunnels, the first issue I ran into was not knowing where to find the generated public key. 

This PR adds a quick mention of that, but we need to follow up with some more improvements, namely: 

- https://github.com/MaterializeInc/materialize/issues/14870
- https://github.com/MaterializeInc/materialize/issues/14871