### PR TITLE
environmentd: improve hierarchical addr check

### DIFF
--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -162,7 +162,7 @@ function Dataflows() {
       // Meant to render the scope identifier by addr, and its children recursively.
       async function render_scope(addr) {
 
-        if (scope_channels.get(addr) != null) {
+        if (scope_channels.get(addr) != null && scope_children.get(addr) != undefined) {
 
           let ids_seen = [];
           const edges = scope_channels.get(addr).map(([source, target, source_port, target_port, sent]) => {


### PR DESCRIPTION
`scope_children.get(addr)` would sometimes return `undefined`, so also check for it in the block at the top. I'm not sure what this script does, and I didn't investigate further what the root cause was here.

Fixes #14866

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a