### PR TITLE
mzcompose: Run with SIZE 4 / --workers 4 by default

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -26,11 +26,10 @@ steps:
           - { value: limits }
           - { value: cluster-limits }
           - { value: limits-instance-size }
-          - { value: testdrive-workers-1 }
-          - { value: testdrive-workers-32 }
+          - { value: testdrive-size-1 }
+          - { value: testdrive-size-32 }
           - { value: testdrive-partitions-5 }
           - { value: testdrive-replicas-4}
-          - { value: testdrive-replica-size-4}
           - { value: testdrive-in-cloudtest}
 #          - { value: feature-benchmark-single-node }
 #          - { value: feature-benchmark-cluster }
@@ -194,8 +193,8 @@ steps:
           run: instance-size
     timeout_in_minutes: 50
 
-  - id: testdrive-workers-1
-    label: ":racing_car: testdrive with --workers 1"
+  - id: testdrive-size-1
+    label: ":racing_car: testdrive with --size=1"
     timeout_in_minutes: 600
     agents:
       queue: linux-x86_64
@@ -203,21 +202,18 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/mzcompose:
           composition: testdrive
-          # TODO(benesch): set --workers=1 again.
-          args: [--aws-region=us-east-2]
+          args: [--aws-region=us-east-2, --size=1]
 
-  # TODO(benesch): reenable.
-  # - id: testdrive-workers-32
-  #   label: ":racing_car: testdrive with --workers 32"
-  #   depends_on: build-x86_64
-  #   timeout_in_minutes: 600
-  #   plugins:
-  #     - ./ci/plugins/scratch-aws-access: ~
-  #     - ./ci/plugins/mzcompose:
-  #         composition: testdrive
-  #         args: [--aws-region=us-east-2, --workers=32]
-  #   agents:
-  #     queue: linux-x86_64-large
+  - id: testdrive-size-32
+    label: ":racing_car: testdrive with --size=32"
+    timeout_in_minutes: 600
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/scratch-aws-access: ~
+      - ./ci/plugins/mzcompose:
+          composition: testdrive
+          args: [--aws-region=us-east-2, --size=32]
 
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"
@@ -240,17 +236,6 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-2, --replicas=4]
-
-  - id: testdrive-replica-size-4
-    label: ":racing_car: testdrive replica SIZE 4"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--aws-region=us-east-2, --replica-size=4]
 
   - id: testdrive-in-cloudtest
     label: Full Testdrive in Cloudtest (K8s)

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -44,6 +44,7 @@ class Materialized(Service):
         persist_blob_url: Optional[str] = None,
         data_directory: str = "/mzdata",
         workers: Optional[int] = None,
+        size: Optional[str] = "4",
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         environment_extra: Optional[List[str]] = None,
@@ -83,6 +84,17 @@ class Materialized(Service):
                 "AWS_SESSION_TOKEN",
             ]
 
+        if size:
+            environment += [
+                f"MZ_BOOTSTRAP_DEFAULT_CLUSTER_REPLICA_SIZE={size}",
+                f"MZ_DEFAULT_STORAGE_HOST_SIZE={size}",
+            ]
+
+        if workers:
+            environment += [
+                f"MZ_WORKERS={workers}",
+            ]
+
         if environment_extra:
             environment.extend(environment_extra)
 
@@ -104,9 +116,6 @@ class Materialized(Service):
                 config_ports.pop()
 
         command_list = []
-
-        if workers:
-            command_list.append(f"--workers {workers}")
 
         if options:
             if isinstance(options, str):
@@ -150,6 +159,7 @@ class Computed(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
+        workers: Optional[int] = 4,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:
@@ -209,7 +219,7 @@ class Storaged(Service):
         options: Optional[Union[str, List[str]]] = "",
         environment: Optional[List[str]] = None,
         volumes: Optional[List[str]] = None,
-        workers: Optional[int] = None,
+        workers: Optional[int] = 4,
         secrets_reader: str = "process",
         secrets_reader_process_dir: str = "mzdata/secrets",
     ) -> None:

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -365,12 +365,8 @@ pub struct Args {
     /// A map from size name to resource allocations for storage hosts.
     #[clap(long, env = "STORAGE_HOST_SIZES")]
     storage_host_sizes: Option<String>,
-    /// Default storage host size, should be a key from storage_host_sizes.
-    #[clap(
-        long,
-        env = "DEFAULT_STORAGE_HOST_SIZE",
-        requires = "storage-host-sizes"
-    )]
+    /// Default storage host size
+    #[clap(long, env = "DEFAULT_STORAGE_HOST_SIZE")]
     default_storage_host_size: Option<String>,
     /// The interval in seconds at which to collect storage usage information.
     #[clap(

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -85,7 +85,12 @@ pub fn render<G>(
             // to. Data from the source not beyond this time will be dropped, as it has already
             // been persisted.
             // In the future, sources will avoid passing through data not beyond this upper
-            *current_upper.borrow_mut() = write.upper().clone();
+            if active_write_worker {
+                // VERY IMPORTANT: Only the active write worker must change the
+                // shared upper. All other workers have already cleared this
+                // upper above.
+                *current_upper.borrow_mut() = write.upper().clone();
+            }
 
             while scheduler.notified().await {
                 let input_upper = frontiers.borrow()[0].clone();

--- a/src/storage/src/source/antichain.rs
+++ b/src/storage/src/source/antichain.rs
@@ -74,11 +74,8 @@ impl OffsetAntichain {
 
     // Data apis
 
-    /// Advance the frontier represented by this `OffsetAntichain` for `pid`
-    /// to a value that contains `offset`.
-    pub fn insert_data_up_to(&mut self, pid: PartitionId, offset: MzOffset) {
-        *self.inner.entry(pid).or_default() = offset + 1;
-    }
+    // TODO(aljoscha): These "data" APIs might be more confusing than they are
+    // worth.
 
     /// Produce offsets for all partitions in this `OffsetAntichain` that
     /// were at one point given by `insert_data_up_to`.

--- a/src/storage/src/source/antichain.rs
+++ b/src/storage/src/source/antichain.rs
@@ -106,6 +106,16 @@ impl OffsetAntichain {
     pub fn insert(&mut self, pid: PartitionId, m: MzOffset) -> Option<MzOffset> {
         self.inner.insert(pid, m)
     }
+
+    /// Insert a new `MzOffset` frontier value for `pid` if it is larger than
+    /// the previously stored value.
+    pub fn maybe_insert(&mut self, pid: PartitionId, offset: MzOffset) {
+        self.inner
+            .entry(pid)
+            .and_modify(|prev| *prev = std::cmp::max(*prev, offset))
+            .or_insert(offset);
+    }
+
     /// The same as `insert`, but for many values.
     pub fn extend<T: IntoIterator<Item = (PartitionId, MzOffset)>>(&mut self, iter: T) {
         self.inner.extend(iter)

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -1252,8 +1252,10 @@ where
                 if !cap_set.is_empty() {
                     trace!(
                         "reclock({id}) {worker_id}/{worker_count}: \
-                        downgrading to {:?}",
-                        new_ts_upper
+                        downgrading to {:?} \
+                        global_source_upper {:?}",
+                        new_ts_upper,
+                        global_source_upper
                     );
 
                     cap_set

--- a/test/cluster/storaged/03-while-storaged-down.td
+++ b/test/cluster/storaged/03-while-storaged-down.td
@@ -10,6 +10,9 @@
 # Verify that the data ingested before `storaged` crashed is still present but
 # that newly ingested data does not appear.
 
+# Increased from the default because of CI flakiness.
+$ set-sql-timeout duration=180s
+
 # With storaged down, the upper of remote1 and remote2 will not advance. However, the global timestamp will advance.
 # In strict serializable mode we may select a timestamp that is ahead of on of the sources uppers and hang forever.
 > SET transaction_isolation = serializable

--- a/test/cluster/storaged/04-after-storaged-restart.td
+++ b/test/cluster/storaged/04-after-storaged-restart.td
@@ -10,6 +10,9 @@
 # Verify that the data ingested while `storaged` was down eventually appears,
 # then try ingesting new data.
 
+# Increased from the default because of CI flakiness.
+$ set-sql-timeout duration=180s
+
 > SELECT * from remote1
 one
 two

--- a/test/testdrive/avro-cdcv2.td
+++ b/test/testdrive/avro-cdcv2.td
@@ -152,7 +152,7 @@ id price
 
 # The ouput of SUBSCRIBE is dependent on the replica size
 $ skip-if
-SELECT ${arg.replica-size} > 1;
+SELECT ${arg.size} > 1;
 
 > BEGIN
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -493,7 +493,7 @@ mz_storage_usage
 
 # The sources in the catalog depend on the number of replicas and computeds
 $ skip-if
-SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
+SELECT ${arg.replicas} > 1 OR ${arg.size} > 1;
 
 > SHOW SOURCES FROM mz_internal
 name                                           type   size


### PR DESCRIPTION
- have all mzcompose jobs use default SIZE 4 for replicas and sources
- use --workers 4 for all independently-started computeds and storageds
- add CI jobs for SIZE 1 and SIZE 32

### Motivation

  * This PR adds a feature that has not yet been specified.

CI was running with --workers 1 / SIZE 1 , which limits concurrency and performance