### PR TITLE
Fix replicated compaction

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -671,6 +671,10 @@ where
 
         match response {
             ActiveReplicationResponse::FrontierUppers(updates) => {
+                let updates: Vec<_> = updates
+                    .into_iter()
+                    .map(|(id, bounds)| (id, bounds.upper))
+                    .collect();
                 instance.update_write_frontiers(&updates).await?;
                 Ok(None)
             }

--- a/src/compute-client/src/controller/replicated.rs
+++ b/src/compute-client/src/controller/replicated.rs
@@ -22,7 +22,7 @@
 //! compacted frontiers, as the underlying resources to rebuild them any earlier may not
 //! exist any longer.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::time::Duration;
 
 use anyhow::bail;
@@ -146,6 +146,112 @@ struct PendingPeek {
     otel_ctx: OpenTelemetryContext,
 }
 
+/// Reported upper frontiers for a single compute collection.
+///
+/// The type maintains the following invariants:
+///   * replica frontiers only advance
+///   * frontier bounds only advance
+///   * `bounds.lower` <= `bounds.upper`
+///   * `bounds.lower` is the lower bound of the frontiers of all active replicas
+///   * `bounds.upper` is the upper bound of the frontiers of all replicas
+#[derive(Debug)]
+struct ReportedUppers<T> {
+    /// The reported uppers per replica.
+    per_replica: HashMap<ReplicaId, Antichain<T>>,
+    /// The lower and upper bound of all reported uppers.
+    bounds: FrontierBounds<T>,
+}
+
+impl<T> ReportedUppers<T>
+where
+    T: Timestamp + Lattice,
+{
+    /// Construct a [`ReportedUppers`] that tracks frontiers of the given replicas.
+    fn new(replica_ids: &BTreeSet<ReplicaId>) -> Self {
+        let per_replica = replica_ids
+            .iter()
+            .map(|id| (*id, Antichain::from_elem(T::minimum())))
+            .collect();
+
+        Self {
+            per_replica,
+            bounds: FrontierBounds {
+                lower: Antichain::from_elem(T::minimum()),
+                upper: Antichain::from_elem(T::minimum()),
+            },
+        }
+    }
+
+    /// Start tracking the given replica.
+    ///
+    /// # Panics
+    /// - If the given `replica_id` is already tracked.
+    fn add_replica(&mut self, id: ReplicaId) {
+        let previous = self.per_replica.insert(id, self.bounds.lower.clone());
+        assert!(previous.is_none(), "replica already tracked");
+    }
+
+    /// Stop tracking the given replica.
+    ///
+    /// Returns `true` iff the update caused a change in any of the two bounds.
+    ///
+    /// # Panics
+    /// - If the given `replica_id` is not tracked.
+    fn remove_replica(&mut self, id: ReplicaId) -> bool {
+        self.per_replica.remove(&id).expect("replica not tracked");
+
+        self.update_lower_bound()
+    }
+
+    /// Apply a frontier update from a single replica.
+    ///
+    /// Returns `true` iff the update caused a change in any of the two bounds.
+    ///
+    /// # Panics
+    /// - If the given `replica_id` is not tracked.
+    fn update(&mut self, replica_id: ReplicaId, new_upper: Antichain<T>) -> bool {
+        let replica_upper = self
+            .per_replica
+            .get_mut(&replica_id)
+            .expect("replica not tracked");
+
+        // Replica frontiers only advance.
+        if PartialOrder::less_than(&new_upper, replica_upper) {
+            return false;
+        }
+
+        replica_upper.clone_from(&new_upper);
+
+        let upper_bound_changed = PartialOrder::less_than(&self.bounds.upper, &new_upper);
+        if upper_bound_changed {
+            self.bounds.upper = new_upper;
+        }
+
+        let lower_bound_changed = self.update_lower_bound();
+
+        upper_bound_changed || lower_bound_changed
+    }
+
+    /// Update `bounds.lower` to restore its invariants.
+    ///
+    /// Returns `true` iff the update caused a change in the lower bound.
+    fn update_lower_bound(&mut self) -> bool {
+        // This operation is linear in the number of replicas. We could do better, but since the
+        // number of replicas is expected to be small, this is fine.
+        let mut new_lower_bound = self.bounds.upper.clone();
+        for frontier in self.per_replica.values() {
+            new_lower_bound.meet_assign(frontier);
+        }
+
+        let lower_bound_changed = PartialOrder::less_than(&self.bounds.lower, &new_lower_bound);
+        if lower_bound_changed {
+            self.bounds.lower = new_lower_bound;
+        }
+
+        lower_bound_changed
+    }
+}
+
 /// The internal state of the client.
 ///
 /// This lives in a separate struct from the handles to the individual replica
@@ -153,12 +259,19 @@ struct PendingPeek {
 /// while holding mutable borrows to those.
 #[derive(Debug)]
 struct ActiveReplicationState<T> {
+    /// IDs of connected replicas.
+    replica_ids: BTreeSet<ReplicaId>,
     /// Outstanding peek identifiers, to guide responses (and which to suppress).
     peeks: HashMap<uuid::Uuid, PendingPeek>,
     /// Reported frontier of each in-progress subscribe.
     tails: HashMap<GlobalId, Antichain<T>>,
-    /// Frontier information, unioned across all replicas.
-    uppers: HashMap<GlobalId, Antichain<T>>,
+    /// Reported upper frontiers for replicated collections.
+    uppers: HashMap<GlobalId, ReportedUppers<T>>,
+    /// Reported upper frontiers for log collections.
+    ///
+    /// Log collections are special in that they are replica-specific. We therefore track their
+    /// frontiers separately from those of replicated collections.
+    log_uppers: HashMap<GlobalId, Antichain<T>>,
     /// The command history, used when introducing new replicas or restarting existing replicas.
     history: ComputeCommandHistory<T>,
     /// Responses that should be emitted on the next `recv` call.
@@ -172,6 +285,32 @@ impl<T> ActiveReplicationState<T>
 where
     T: Timestamp + Lattice,
 {
+    fn add_replica(&mut self, id: ReplicaId) {
+        self.replica_ids.insert(id);
+
+        for uppers in self.uppers.values_mut() {
+            uppers.add_replica(id);
+        }
+    }
+
+    fn remove_replica(&mut self, id: ReplicaId) {
+        self.replica_ids.remove(&id);
+
+        // Removing a replica might have elicit changes to collection frontiers, which we must
+        // report up the chain.
+        let mut new_uppers = Vec::new();
+        for (collection_id, uppers) in self.uppers.iter_mut() {
+            if uppers.remove_replica(id) {
+                new_uppers.push((*collection_id, uppers.bounds.clone()));
+            }
+        }
+
+        if !new_uppers.is_empty() {
+            self.pending_response
+                .push_back(ActiveReplicationResponse::FrontierUppers(new_uppers));
+        }
+    }
+
     #[tracing::instrument(level = "debug", skip(self))]
     fn handle_command(&mut self, cmd: &ComputeCommand<T>) {
         // Update our tracking of peek commands.
@@ -209,9 +348,8 @@ where
         let mut cease = Vec::new();
         cmd.frontier_tracking(&mut start, &mut cease);
         for id in start.into_iter() {
-            let frontier = timely::progress::Antichain::from_elem(T::minimum());
-
-            let previous = self.uppers.insert(id, frontier);
+            let uppers = ReportedUppers::new(&self.replica_ids);
+            let previous = self.uppers.insert(id, uppers);
             assert!(previous.is_none());
         }
         for id in cease.into_iter() {
@@ -254,9 +392,19 @@ where
 
                 for (id, new_upper) in list {
                     if let Some(reported) = self.uppers.get_mut(&id) {
+                        if reported.update(replica_id, new_upper) {
+                            new_uppers.push((id, reported.bounds.clone()));
+                        }
+                    } else if let Some(reported) = self.log_uppers.get_mut(&id) {
                         if PartialOrder::less_than(reported, &new_upper) {
                             reported.clone_from(&new_upper);
-                            new_uppers.push((id, new_upper));
+                            new_uppers.push((
+                                id,
+                                FrontierBounds {
+                                    lower: new_upper.clone(),
+                                    upper: new_upper,
+                                },
+                            ));
                         }
                     }
                 }
@@ -337,9 +485,11 @@ impl<T> ActiveReplication<T> {
             build_info,
             replicas: Default::default(),
             state: ActiveReplicationState {
+                replica_ids: Default::default(),
                 peeks: Default::default(),
                 tails: Default::default(),
                 uppers: Default::default(),
+                log_uppers: Default::default(),
                 history: Default::default(),
                 pending_response: Default::default(),
             },
@@ -455,12 +605,13 @@ where
         // Start tracking frontiers of persisted_logs collections.
         for (id, _) in replica_state.persisted_logs.values() {
             let frontier = Antichain::from_elem(Timestamp::minimum());
-            let previous = self.state.uppers.insert(*id, frontier);
+            let previous = self.state.log_uppers.insert(*id, frontier);
             assert!(previous.is_none());
         }
 
         // Add replica to tracked state.
         self.replicas.insert(id, replica_state);
+        self.state.add_replica(id);
     }
 
     /// Returns an iterator over the IDs of the replicas.
@@ -470,11 +621,12 @@ where
 
     /// Remove a replica by its identifier.
     pub(super) fn remove_replica(&mut self, id: ReplicaId) {
+        self.state.remove_replica(id);
         let replica_state = self.replicas.remove(&id).expect("replica not found");
 
         // Cease tracking frontiers of persisted_logs collections.
         for (id, _) in replica_state.persisted_logs.values() {
-            let previous = self.state.uppers.remove(id);
+            let previous = self.state.log_uppers.remove(id);
             assert!(previous.is_some());
         }
     }
@@ -556,8 +708,8 @@ where
 /// A response from the ActiveReplication client.
 #[derive(Debug, Clone)]
 pub(super) enum ActiveReplicationResponse<T = mz_repr::Timestamp> {
-    /// A list of identifiers of traces, with new upper frontiers.
-    FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
+    /// A list of identifiers of traces, with new lower and upper bounds of upper frontiers.
+    FrontierUppers(Vec<(GlobalId, FrontierBounds<T>)>),
     /// The compute instance's response to the specified peek.
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
     /// The compute instance's next response to the specified subscribe.
@@ -565,4 +717,81 @@ pub(super) enum ActiveReplicationResponse<T = mz_repr::Timestamp> {
     /// A notification that we heard a response from the given replica at the
     /// given time.
     ReplicaHeartbeat(ReplicaId, DateTime<Utc>),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct FrontierBounds<T> {
+    #[allow(dead_code)]
+    pub lower: Antichain<T>,
+    pub upper: Antichain<T>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_bounds {
+        ($uppers:expr, ($lower:expr, $upper:expr)) => {
+            assert_eq!(
+                $uppers.bounds.lower,
+                Antichain::from_elem($lower),
+                "lower mismatch"
+            );
+            assert_eq!(
+                $uppers.bounds.upper,
+                Antichain::from_elem($upper),
+                "upper mismatch"
+            );
+        };
+    }
+
+    #[test]
+    fn reported_uppers() {
+        let mut uppers = ReportedUppers::<u64>::new(&[1, 2].into());
+        assert_bounds!(uppers, (0, 0));
+
+        let changed = uppers.update(1, Antichain::from_elem(1));
+        assert!(changed);
+        assert_bounds!(uppers, (0, 1));
+
+        let changed = uppers.update(2, Antichain::from_elem(2));
+        assert!(changed);
+        assert_bounds!(uppers, (1, 2));
+
+        // Frontiers can only advance.
+        let changed = uppers.update(2, Antichain::from_elem(1));
+        assert!(!changed);
+        assert_bounds!(uppers, (1, 2));
+        assert_eq!(uppers.per_replica[&2], Antichain::from_elem(2));
+
+        // Adding a replica doesn't affect current bounds.
+        uppers.add_replica(3);
+        assert_bounds!(uppers, (1, 2));
+
+        let changed = uppers.update(3, Antichain::from_elem(3));
+        assert!(changed);
+        assert_bounds!(uppers, (1, 3));
+
+        // Removing the slowest replica advances the lower bound.
+        let changed = uppers.remove_replica(1);
+        assert!(changed);
+        assert_bounds!(uppers, (2, 3));
+
+        // Removing the fastest replica doesn't affect bounds.
+        let changed = uppers.remove_replica(3);
+        assert!(!changed);
+        assert_bounds!(uppers, (2, 3));
+
+        // Removing the last replica advances the lower bound to the upper.
+        let changed = uppers.remove_replica(2);
+        assert!(changed);
+        assert_bounds!(uppers, (3, 3));
+
+        // Bounds tracking resumes correctly with new replicas.
+        uppers.add_replica(4);
+        uppers.add_replica(5);
+        uppers.update(5, Antichain::from_elem(5));
+        uppers.update(4, Antichain::from_elem(4));
+        assert_bounds!(uppers, (4, 5));
+    }
 }


### PR DESCRIPTION
This PR changes the `ActiveReplication` client to report the lower bounds of upper frontiers reported by all replicas. Previously it reported only the upper bounds, which meant that the compute controller lacked sufficient information to correctly hold back compaction for dataflow inputs.

The compute controller can now base compaction decision on the lower bounds of reported uppers, thereby making sure that slow replicas don't get their sources compacted away beneath them. Meanwhile, it continues to use the upper bounds of reported uppers to report which times are available in the compute collections.

While the current implementation solves the issue of replicas crashing unexpectedly, it has the flaw that it allows slow replicas to hold back compaction arbitrarily far. We should have a limit to how far we allow slow replicas to hold back compaction, but I am unsure of how to best implement this (see comment).

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/12576.
Fixes https://github.com/MaterializeInc/materialize/issues/12885.
Fixes https://github.com/MaterializeInc/materialize/issues/13117.

### Tips for reviewer

Look at the commits and commit messages separately!

Also, I'm adding comments to the code at places that I deem discussion-worthy.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
