### PR TITLE
zippy: Add replica support to Zippy

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -36,6 +36,7 @@ steps:
           - { value: zippy-kafka-sources }
           - { value: zippy-user-tables }
           - { value: zippy-debezium-postgres }
+          - { value: zippy-cluster-replicas }
           - { value: secrets }
           - { value: checks-oneatatime-drop-create-default-replica }
           - { value: checks-oneatatime-restart-computed }
@@ -284,6 +285,15 @@ steps:
           composition: zippy
           args: [--scenario=DebeziumPostgres, --actions=1000]
 
+  - id: zippy-cluster-replicas
+    label: "Zippy Cluster Replicas"
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=ClusterReplicas, --actions=1000]
 
   - id: secrets
     label: "Secrets"

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -40,7 +40,7 @@ class DebeziumStop(Action):
     def requires(self) -> Set[Type[Capability]]:
         return {DebeziumRunning}
 
-    def removes(self) -> Set[Type[Capability]]:
+    def withholds(self) -> Set[Type[Capability]]:
         return {DebeziumRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -36,8 +36,16 @@ class Capabilities:
         """Add new capabilities."""
         self._capabilities.extend(capabilities)
 
+    def remove_capability_instance(self, capability: T) -> None:
+        """Remove a specific capability."""
+
+        self._capabilities = [
+            cap for cap in self._capabilities if not cap == capability
+        ]
+
     def _remove(self, capabilities: Set[Type[T]]) -> None:
         """Remove all existing capabilities of the specified types."""
+
         self._capabilities = [
             cap for cap in self._capabilities if type(cap) not in capabilities
         ]
@@ -64,7 +72,7 @@ class Action:
         """Compute the capability classes that this action requires."""
         return set()
 
-    def removes(self) -> Set[Type[Capability]]:
+    def withholds(self) -> Set[Type[Capability]]:
         """Compute the capability classes that this action will make unavailable."""
         return set()
 
@@ -103,14 +111,14 @@ class Test:
             action = action_class(capabilities=self._capabilities)
             self._actions.append(action)
             self._capabilities._extend(action.provides())
-            self._capabilities._remove(action.removes())
+            self._capabilities._remove(action.withholds())
 
         for i in range(0, actions):
             action_class = self._pick_action_class()
             action = action_class(capabilities=self._capabilities)
             self._actions.append(action)
             self._capabilities._extend(action.provides())
-            self._capabilities._remove(action.removes())
+            self._capabilities._remove(action.withholds())
 
     def run(self, c: Composition) -> None:
         """Run the Zippy test."""
@@ -129,6 +137,10 @@ class Test:
                 if self._can_run(leaf):
                     action_classes.append(leaf)
                     class_weights.append(self._scenario.config()[action_class])
+
+        assert (
+            len(action_classes) > 0
+        ), "No actions available to take. You may be stopping or deleting items without starting them again."
 
         return random.choices(action_classes, weights=class_weights, k=1)[0]
 

--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -51,7 +51,7 @@ class KafkaStop(Action):
     def requires(self) -> Set[Type[Capability]]:
         return {KafkaRunning}
 
-    def removes(self) -> Set[Type[Capability]]:
+    def withholds(self) -> Set[Type[Capability]]:
         return {KafkaRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -36,7 +36,7 @@ class MzStop(Action):
     def run(self, c: Composition) -> None:
         c.kill("materialized")
 
-    def removes(self) -> Set[Type[Capability]]:
+    def withholds(self) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
 

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -34,7 +34,7 @@ class PostgresStop(Action):
     def requires(self) -> Set[Type[Capability]]:
         return {PostgresRunning}
 
-    def removes(self) -> Set[Type[Capability]]:
+    def withholds(self) -> Set[Type[Capability]]:
         return {PostgresRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -1,0 +1,97 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import random
+from typing import List, Optional, Set, Type
+
+from materialize.mzcompose import Composition
+from materialize.zippy.framework import Action, Capabilities, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.replica_capabilities import ReplicaExists, ReplicaSizeType
+
+
+class DropDefaultReplica(Action):
+    """Drops the default replica."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}
+
+    def run(self, c: Composition) -> None:
+        c.testdrive("> DROP CLUSTER REPLICA default.default_replica;")
+
+
+class CreateReplica(Action):
+    """Creates a replica on the default cluster."""
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        this_replica = ReplicaExists(name="replica" + str(random.randint(1, 3)))
+
+        existing_replicas = [
+            t for t in capabilities.get(ReplicaExists) if t.name == this_replica.name
+        ]
+
+        if len(existing_replicas) == 0:
+            self.new_replica = True
+
+            size = str(random.choice([1, 2, 4, 8]))
+            size_type = random.choice([ReplicaSizeType.Nodes, ReplicaSizeType.Workers])
+
+            if size_type is ReplicaSizeType.Nodes:
+                this_replica.size = size + "-1"
+            elif size_type is ReplicaSizeType.Workers:
+                this_replica.size = size
+            else:
+                assert False
+
+            if this_replica.size == "1-1":
+                this_replica.size = "1"
+
+            self.replica = this_replica
+        elif len(existing_replicas) == 1:
+            self.new_replica = False
+            self.replica = existing_replicas[0]
+        else:
+            assert False
+
+    def run(self, c: Composition) -> None:
+        if self.new_replica:
+            c.testdrive(
+                f"> CREATE CLUSTER REPLICA default.{self.replica.name} SIZE '{self.replica.size}'"
+            )
+
+    def provides(self) -> List[Capability]:
+        return [self.replica] if self.new_replica else []
+
+
+class DropReplica(Action):
+    """Drops a replica from the default cluster."""
+
+    replica: Optional[ReplicaExists]
+
+    @classmethod
+    def requires(self) -> Set[Type[Capability]]:
+        return {MzIsRunning, ReplicaExists}
+
+    def __init__(self, capabilities: Capabilities) -> None:
+        existing_replicas = capabilities.get(ReplicaExists)
+
+        if len(existing_replicas) > 1:
+            self.replica = random.choice(existing_replicas)
+            capabilities.remove_capability_instance(self.replica)
+        else:
+            self.replica = None
+
+    def run(self, c: Composition) -> None:
+        if self.replica is not None:
+            c.testdrive(f"> DROP CLUSTER REPLICA IF EXISTS default.{self.replica.name}")

--- a/misc/python/materialize/zippy/replica_capabilities.py
+++ b/misc/python/materialize/zippy/replica_capabilities.py
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from enum import Enum
+
+from materialize.zippy.framework import Capability
+
+
+class ReplicaSizeType(Enum):
+    Nodes = 1
+    Workers = 2
+
+
+class ReplicaExists(Capability):
+    """A replica exists in the Mz instance."""
+
+    name: str
+    size_type: ReplicaSizeType
+    size: str
+
+    def __init__(self, name: str) -> None:
+        self.name = name


### PR DESCRIPTION
Zippy will now create and drop replicas to the default cluster while the test is running. At least one replica will remain available at any given time

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
