### PR TITLE
Coord: Fix livelock in concurrent writes

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -343,7 +343,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     self.sequence_plan(ready.tx, ready.session, ready.plan, depends_on)
                         .await;
                 }
-                Deferred::GroupCommit => self.group_commit_initiate().await,
+                Deferred::GroupCommit => self.group_commit_initiate(Some(write_lock_guard)).await,
             }
         }
         // N.B. if no deferred plans, write lock is released by drop


### PR DESCRIPTION
If one writes tries to trigger a group commit, while another group commit is already executing and holding the write lock, then the second group commit will be deferred. A deferred group commit will wait and to acquire the lock in an asynchronous task.

Previously, when the deferred group commit would acquire the lock, it would immediately release the lock and immediately try and re-acquire the lock. If the re-acquire failed, then it would defer itself again. This would lead to a livelock situation where concurrent writes would cause repeated defers. Not only would the writes hang, but the global timestamp would be increased at an extremely rapid pace, eventually putting it far into the future.

This commit changes the deferred group commit logic, so that once the lock is acquired, it is not released until the group commit is complete. This removes the live lock issue from concurrent writes.

Fixes #14793

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
