### PR TITLE
sql: Standardize output of SHOW CREATE commands

### DIFF
--- a/doc/user/content/sql/show-create-connection.md
+++ b/doc/user/content/sql/show-create-connection.md
@@ -23,9 +23,9 @@ SHOW CREATE CONNECTION kafka_connection;
 ```
 
 ```nofmt
-    Connection   |        Create Connection
------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- kafka_connection   | CREATE CONNECTION "materialize"."public"."kafka_connection" FOR KAFKA BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092', SASL MECHANISMS = 'PLAIN', SASL USERNAME = SECRET sasl_username, SASL PASSWORD = SECRET sasl_password
+    name          |    create_sql
+------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ kafka_connection | CREATE CONNECTION "materialize"."public"."kafka_connection" FOR KAFKA BROKER 'unique-jellyfish-0000-kafka.upstash.io:9092', SASL MECHANISMS = 'PLAIN', SASL USERNAME = SECRET sasl_username, SASL PASSWORD = SECRET sasl_password
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-create-index.md
+++ b/doc/user/content/sql/show-create-index.md
@@ -33,9 +33,9 @@ SHOW CREATE INDEX my_view_idx;
 ```
 
 ```nofmt
-             Index             |                                Create Index
--------------------------------|---------------------------------------------------------------------------
-materialize.public.my_view_idx | CREATE INDEX "my_view_idx" ON "materialize"."public"."my_view" ("a", "b");
+              name              |                                           create_sql
+--------------------------------+------------------------------------------------------------------------------------------------
+ materialize.public.my_view_idx | CREATE INDEX "my_view_idx" IN CLUSTER "default" ON "materialize"."public"."my_view" ("a", "b")
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-create-materialized-view.md
+++ b/doc/user/content/sql/show-create-materialized-view.md
@@ -19,12 +19,12 @@ _view&lowbar;name_ | The materialized view you want to use. You can find availab
 ## Examples
 
 ```sql
-SHOW CREATE MATERIALIZED VIEW my_materialized_view;
+SHOW CREATE MATERIALIZED VIEW winning_bids;
 ```
 ```nofmt
-            Materialized View            |        Create Materialized View
------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.winning_bids          | CREATE MATERIALIZED VIEW "materialize"."public"."winning_bids" IN CLUSTER "default" AS SELECT * FROM "materialize"."public"."highest_bid_per_auction" WHERE "pg_catalog"."extract"('epoch', "end_time") * 1000 < "mz_catalog"."mz_logical_timestamp"()
+              name               |                                                                                                                       create_sql
+---------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ materialize.public.winning_bids | CREATE MATERIALIZED VIEW "materialize"."public"."winning_bids" IN CLUSTER "default" AS SELECT * FROM "materialize"."public"."highest_bid_per_auction" WHERE "pg_catalog"."extract"('epoch', "end_time") * 1000 < "mz_catalog"."mz_logical_timestamp"()
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-create-sink.md
+++ b/doc/user/content/sql/show-create-sink.md
@@ -34,8 +34,8 @@ SHOW CREATE SINK my_view_sink;
 ```
 
 ```nofmt
-               Sink              |                                                                                                        Create Sink
----------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+               name              |                                                                                                        create_sql
+---------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  materialize.public.my_view_sink | CREATE SINK "materialize"."public"."my_view_sink" FROM "materialize"."public"."my_view" INTO KAFKA CONNECTION "materialize"."public"."kafka_conn" (TOPIC 'my_view_sink') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY 'http://localhost:8081'
 ```
 

--- a/doc/user/content/sql/show-create-source.md
+++ b/doc/user/content/sql/show-create-source.md
@@ -19,13 +19,13 @@ _source&lowbar;name_ | The source you want use. You can find available source na
 ## Examples
 
 ```sql
-SHOW CREATE SOURCE my_source;
+SHOW CREATE SOURCE market_orders_raw;
 ```
 
 ```nofmt
-    Source   |        Create Source
--------------+--------------------------
- my_source   | CREATE SOURCE "materialize"."public"."market_orders_raw" FROM LOAD GENERATOR counter;
+                 name                 |                                      create_sql
+--------------------------------------+--------------------------------------------------------------------------------------
+ materialize.public.market_orders_raw | CREATE SOURCE "materialize"."public"."market_orders_raw" FROM LOAD GENERATOR COUNTER
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-create-table.md
+++ b/doc/user/content/sql/show-create-table.md
@@ -26,9 +26,9 @@ CREATE TABLE t (a int, b text NOT NULL);
 SHOW CREATE TABLE t;
 ```
 ```nofmt
-        Table         |                             Create Table
-----------------------+----------------------------------------------------------------------
- materialize.public.t | CREATE TABLE "materialize"."public"."t" ("a" int, "b" text NOT NULL)
+         name         |                                             create_sql
+----------------------+-----------------------------------------------------------------------------------------------------
+ materialize.public.t | CREATE TABLE "materialize"."public"."t" ("a" "pg_catalog"."int4", "b" "pg_catalog"."text" NOT NULL)
 ```
 
 ## Related pages

--- a/doc/user/content/sql/show-create-view.md
+++ b/doc/user/content/sql/show-create-view.md
@@ -22,7 +22,7 @@ _view&lowbar;name_ | The view you want to use. You can find available view names
 SHOW CREATE VIEW my_view;
 ```
 ```nofmt
-            View            |                                           Create View
+            name            |                                            create_sql
 ----------------------------+--------------------------------------------------------------------------------------------------
  materialize.public.my_view | CREATE VIEW "materialize"."public"."my_view" AS SELECT * FROM "materialize"."public"."my_source"
 ```

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -43,8 +43,8 @@ pub fn describe_show_create_view(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("View", ScalarType::String.nullable(false))
-            .with_column("Create View", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -77,11 +77,8 @@ pub fn describe_show_create_materialized_view(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Materialized View", ScalarType::String.nullable(false))
-            .with_column(
-                "Create Materialized View",
-                ScalarType::String.nullable(false),
-            ),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -111,8 +108,8 @@ pub fn describe_show_create_table(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Table", ScalarType::String.nullable(false))
-            .with_column("Create Table", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -141,8 +138,8 @@ pub fn describe_show_create_source(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Source", ScalarType::String.nullable(false))
-            .with_column("Create Source", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -171,8 +168,8 @@ pub fn describe_show_create_sink(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Sink", ScalarType::String.nullable(false))
-            .with_column("Create Sink", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -201,8 +198,8 @@ pub fn describe_show_create_index(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Index", ScalarType::String.nullable(false))
-            .with_column("Create Index", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 
@@ -231,8 +228,8 @@ pub fn describe_show_create_connection(
 ) -> Result<StatementDesc, PlanError> {
     Ok(StatementDesc::new(Some(
         RelationDesc::empty()
-            .with_column("Connection", ScalarType::String.nullable(false))
-            .with_column("Create Connection", ScalarType::String.nullable(false)),
+            .with_column("name", ScalarType::String.nullable(false))
+            .with_column("create_sql", ScalarType::String.nullable(false)),
     )))
 }
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -253,7 +253,7 @@ CREATE MATERIALIZED VIEW mv AS SELECT 1
 query TT colnames
 SHOW CREATE MATERIALIZED VIEW mv
 ----
-Materialized␠View     Create␠Materialized␠View
+name                  create_sql
 materialize.public.mv CREATE␠MATERIALIZED␠VIEW␠"materialize"."public"."mv"␠IN␠CLUSTER␠"default"␠AS␠SELECT␠1
 
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -333,7 +333,7 @@ tbl         table
 v1          view
 v2          view
 
-> SELECT "Create Table" FROM (SHOW CREATE TABLE tbl)
+> SELECT create_sql FROM (SHOW CREATE TABLE tbl)
 "CREATE TABLE \"d\".\"public\".\"tbl\" (\"a\" \"pg_catalog\".\"int4\", \"b\" \"pg_catalog\".\"text\")"
 
 ! SHOW COLUMNS FROM pass_secret

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -29,7 +29,7 @@ testconn   kafka
 testconn    kafka
 
 > SHOW CREATE CONNECTION testconn
-Connection   "Create Connection"
+name   create_sql
 ---------------------------------
 materialize.public.testconn   "CREATE CONNECTION \"materialize\".\"public\".\"testconn\" FOR KAFKA BROKER = '${testdrive.kafka-addr}'"
 

--- a/test/testdrive/createdrop.td
+++ b/test/testdrive/createdrop.td
@@ -182,7 +182,7 @@ contains:unknown catalog item 'nonexistent'
 > CREATE VIEW IF NOT EXISTS test1 AS SELECT 42 AS a
 
 > SHOW CREATE VIEW test1
-View                      "Create View"
+name                      create_sql
 --------------------------------------------------------------------------------------------------
 materialize.public.test1  "CREATE VIEW \"materialize\".\"public\".\"test1\" AS SELECT 42 AS \"a\""
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -154,7 +154,7 @@ name                    on          cluster             key
 data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 
 > SHOW CREATE INDEX data_view_primary_idx
-Index                                    "Create Index"
+name                                     create_sql
 --------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.data_view_primary_idx "CREATE INDEX \"data_view_primary_idx\" IN CLUSTER \"<VARIABLE_OUTPUT>\" ON \"materialize\".\"public\".\"data_view\" (\"b\" - \"a\", \"a\")"
 

--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -131,7 +131,7 @@ name    type
   ENVELOPE DEBEZIUM
 
 > SHOW CREATE SOURCE data_schema_inline
-Source   "Create Source"
+name   create_sql
 ------------------------
 materialize.public.data_schema_inline "CREATE SOURCE \"materialize\".\"public\".\"data_schema_inline\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-data-${testdrive.seed}') FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE DEBEZIUM"
 

--- a/test/testdrive/materializations.td
+++ b/test/testdrive/materializations.td
@@ -77,7 +77,7 @@ sum   false   numeric
 data_view
 
 > SHOW CREATE MATERIALIZED VIEW test1
-"Materialized View"       "Create Materialized View"
+name                      create_sql
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.test1  "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"test1\" IN CLUSTER \"default\" AS SELECT \"b\", \"pg_catalog\".\"sum\"(\"a\") FROM \"materialize\".\"public\".\"data\" GROUP BY \"b\""
 

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -184,7 +184,7 @@ renamed_mz_view
 
 # Item's own `CREATE VIEW` statement updated
 > SHOW CREATE VIEW renamed_mz_view
-View                                "Create View"
+name                                create_sql
 ---------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.renamed_mz_view  "CREATE VIEW \"materialize\".\"public\".\"renamed_mz_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_data\""
 
@@ -195,30 +195,30 @@ name            on              cluster             key
 renamed_index   renamed_mz_view <VARIABLE_OUTPUT>   {a,b}
 
 > SHOW CREATE INDEX renamed_index
-Index               "Create Index"
+name                             create_sql
 ---------------------------------------------------------------------------------------------------------------------
 materialize.public.renamed_index "CREATE INDEX \"renamed_index\" IN CLUSTER \"<VARIABLE_OUTPUT>\" ON \"materialize\".\"public\".\"renamed_mz_view\" (\"a\", \"b\")"
 
 # Simple dependencies are renamed
 > SHOW CREATE VIEW dependent_view
-View                                "Create View"
+name                                create_sql
 ------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.dependent_view   "CREATE VIEW \"materialize\".\"public\".\"dependent_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\""
 
 > SHOW CREATE SINK renamed_sink
-Sink                            "Create Sink"
+name                            create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.renamed_sink "CREATE SINK \"materialize\".\"public\".\"renamed_sink\" FROM \"materialize\".\"public\".\"renamed_mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-snk1-${testdrive.seed}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\""
 
 # Simple dependencies with both fully qualified and unqualified item references are renamed
 > SHOW CREATE VIEW byzantine_view
-View                              "Create View"
+name                              create_sql
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.byzantine_view "CREATE VIEW \"materialize\".\"public\".\"byzantine_view\" AS SELECT \"renamed_mz_data\".\"a\", \"renamed_mz_view\".\"b\" FROM \"materialize\".\"public\".\"renamed_mz_data\" JOIN \"materialize\".\"public\".\"renamed_mz_view\" ON \"renamed_mz_data\".\"a\" = \"renamed_mz_view\".\"a\""
 
 # Strings containing old item name are not modified
 > SHOW CREATE VIEW oppositional_view
-View                                 "Create View"
+name                                 create_sql
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.oppositional_view "CREATE VIEW \"materialize\".\"public\".\"oppositional_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\" WHERE \"b\" = '   an adversarial string   \"materialize\".\"public\".\"mz_data\"   '"
 
@@ -379,7 +379,7 @@ contains:renaming conflict
 > ALTER VIEW db2.scm1.v RENAME TO v2
 
 > SHOW CREATE VIEW db1_db2_scm1_valid_qual
-View                                       "Create View"
+name                                       create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.db1_db2_scm1_valid_qual "CREATE VIEW \"materialize\".\"public\".\"db1_db2_scm1_valid_qual\" AS SELECT * FROM (SELECT \"db1\".\"scm1\".\"v1\".\"a\" FROM \"db1\".\"scm1\".\"v1\") AS \"l\" JOIN (SELECT \"db2\".\"scm1\".\"v2\".\"b\" FROM \"db2\".\"scm1\".\"v2\") AS \"r\" ON \"l\".\"a\" = \"r\".\"b\""
 
@@ -414,7 +414,7 @@ contains:renaming conflict
 > ALTER VIEW db1.scm1.v1 RENAME TO v4;
 
 > SHOW CREATE VIEW db_db_qual_diff_s_v
-View                          "Create View"
+name                                   create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.db_db_qual_diff_s_v "CREATE VIEW \"materialize\".\"public\".\"db_db_qual_diff_s_v\" AS SELECT \"db2\".\"scm2\".\"v3\".\"z\" FROM \"db2\".\"scm2\".\"v3\" JOIN \"db1\".\"scm1\".\"v4\" ON \"db2\".\"scm2\".\"v3\".\"z\" = \"db1\".\"scm1\".\"v4\".\"a\""
 
@@ -439,7 +439,7 @@ materialize.public.db_db_qual_diff_s_v "CREATE VIEW \"materialize\".\"public\".\
 > ALTER VIEW db1.scm1.v4 RENAME TO v5;
 
 > SHOW CREATE VIEW db_scm_qual
-View                           "Create View"
+name                           create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.db_scm_qual "CREATE VIEW \"materialize\".\"public\".\"db_scm_qual\" AS SELECT \"scm3\".\"v3\".\"z\", \"db1\".\"scm1\".\"v5\".\"a\" FROM \"materialize\".\"scm3\".\"v3\" JOIN \"db1\".\"scm1\".\"v5\" ON \"scm3\".\"v3\".\"z\" = \"db1\".\"scm1\".\"v5\".\"a\""
 
@@ -475,7 +475,7 @@ contains:renaming conflict
 > ALTER VIEW db1.scm1.v5 RENAME TO v6;
 
 > SHOW CREATE VIEW db_v_qual
-View                         "Create View"
+name                         create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.db_v_qual "CREATE VIEW \"materialize\".\"public\".\"db_v_qual\" AS SELECT \"v2\".\"z\", \"db1\".\"scm1\".\"v6\".\"a\" FROM \"materialize\".\"public\".\"v2\" JOIN \"db1\".\"scm1\".\"v6\" ON \"v2\".\"z\" = \"db1\".\"scm1\".\"v6\".\"a\""
 
@@ -548,7 +548,7 @@ contains:renaming conflict
 > ALTER VIEW db1.scm2.v RENAME TO v5
 
 > SHOW CREATE VIEW db1_scm1_scm2_valid_qual
-View                                       "Create View"
+name                                        create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.db1_scm1_scm2_valid_qual "CREATE VIEW \"materialize\".\"public\".\"db1_scm1_scm2_valid_qual\" AS SELECT * FROM (SELECT \"scm1\".\"v4\".\"a\" FROM \"db1\".\"scm1\".\"v4\") AS \"l\" JOIN (SELECT \"scm2\".\"v5\".\"b\" FROM \"db1\".\"scm2\".\"v5\") AS \"r\" ON \"l\".\"a\" = \"r\".\"b\""
 
@@ -589,7 +589,7 @@ contains:renaming conflict
 > ALTER VIEW scm5.v2 RENAME TO v4;
 
 > SHOW CREATE VIEW scm_scm_qual
-View                           "Create View"
+name                            create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.scm_scm_qual "CREATE VIEW \"materialize\".\"public\".\"scm_scm_qual\" AS SELECT \"scm4\".\"v3\".\"z\", \"scm5\".\"v4\".\"a\" FROM \"materialize\".\"scm4\".\"v3\" JOIN \"materialize\".\"scm5\".\"v4\" ON \"scm4\".\"v3\".\"z\" = \"scm5\".\"v4\".\"a\""
 
@@ -621,7 +621,7 @@ contains:renaming conflict
 > ALTER VIEW scm5.v4 RENAME TO v6;
 
 > SHOW CREATE VIEW scm_v_qual
-View                          "Create View"
+name                          create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.scm_v_qual "CREATE VIEW \"materialize\".\"public\".\"scm_v_qual\" AS SELECT \"v3\".\"z\", \"scm5\".\"v6\".\"a\" FROM \"materialize\".\"public\".\"v3\" JOIN \"materialize\".\"scm5\".\"v6\" ON \"v3\".\"z\" = \"scm5\".\"v6\".\"a\""
 
@@ -648,7 +648,7 @@ contains:renaming conflict
 > ALTER VIEW v3 RENAME TO v5;
 
 > SHOW CREATE VIEW v_v_qual
-View                          "Create View"
+name                        create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.v_v_qual "CREATE VIEW \"materialize\".\"public\".\"v_v_qual\" AS SELECT \"v5\".\"z\", \"v6\".\"a\" FROM \"materialize\".\"public\".\"v5\" JOIN \"materialize\".\"public\".\"v6\" ON \"v5\".\"z\" = \"v6\".\"a\""
 
@@ -664,7 +664,7 @@ materialize.public.v_v_qual "CREATE VIEW \"materialize\".\"public\".\"v_v_qual\"
 > ALTER VIEW v5 RENAME TO v7
 
 > SHOW CREATE VIEW qualified_wildcard
-View                                  "Create View"
+name                                  create_sql
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.qualified_wildcard "CREATE VIEW \"materialize\".\"public\".\"qualified_wildcard\" AS SELECT \"v7\".* FROM \"materialize\".\"public\".\"v7\""
 
@@ -687,7 +687,7 @@ contains:renaming conflict
 > ALTER VIEW v8 RENAME TO v9
 
 > SHOW CREATE VIEW v9
-View                   "Create View"
+name                  create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.v9 "CREATE VIEW \"materialize\".\"public\".\"v9\" AS SELECT \"b\" FROM \"materialize\".\"public\".\"t1\" WHERE \"b\" IN ('v8')"
 
@@ -717,7 +717,7 @@ contains:renaming conflict
 > ALTER VIEW "already has space" RENAME TO "still has space"
 
 > SHOW CREATE VIEW space_dependent
-View                               "Create View"
+name                               create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.space_dependent "CREATE VIEW \"materialize\".\"public\".\"space_dependent\" AS SELECT * FROM \"materialize\".\"public\".\"now has space\" JOIN \"materialize\".\"public\".\"still has space\" ON \"still has space\".\"my_space\" = \"now has space\".\"has space\""
 
@@ -732,7 +732,7 @@ materialize.public.space_dependent "CREATE VIEW \"materialize\".\"public\".\"spa
 > ALTER VIEW natural RENAME TO unnatural
 
 > SHOW CREATE VIEW unnatural
-View                         "Create View"
+name                         create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.unnatural "CREATE VIEW \"materialize\".\"public\".\"unnatural\" AS SELECT * FROM \"materialize\".\"public\".\"t1\" NATURAL JOIN \"materialize\".\"public\".\"t1\" AS \"a\""
 
@@ -761,14 +761,14 @@ contains:renaming conflict
 > ALTER VIEW no_func RENAME TO count
 
 > SHOW CREATE VIEW func_dependency
-View                                "Create View"
+name                               create_sql
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 materialize.public.func_dependency "CREATE VIEW \"materialize\".\"public\".\"func_dependency\" (\"a\", \"x_a\") AS SELECT * FROM \"materialize\".\"public\".\"count\" JOIN (SELECT * FROM \"materialize\".\"public\".\"count\") AS \"x\" ON \"count\".\"a\" = \"x\".\"a\""
 
 > CREATE VIEW "materialize"."public"."func_dependency_test" ("a", "x_a") AS SELECT * FROM count JOIN (SELECT * FROM count) AS x ON count.a = x.a
 
 > SHOW CREATE VIEW count
-View                     "Create View"
+name                     create_sql
 ---------------------------------------------------------------------------------------
 materialize.public.count "CREATE VIEW \"materialize\".\"public\".\"count\" AS SELECT 1 AS \"a\""
 

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -18,7 +18,7 @@ contains:unknown catalog item 't'
 > CREATE TABLE t (a int, b text NOT NULL)
 
 > SHOW CREATE TABLE t;
-Table   "Create Table"
+name   create_sql
 ------------------------
 materialize.public.t  "CREATE TABLE \"materialize\".\"public\".\"t\" (\"a\" \"pg_catalog\".\"int4\", \"b\" \"pg_catalog\".\"text\" NOT NULL)"
 


### PR DESCRIPTION
This commit changes the columns of all SHOW CREATE commands to be 'name' and 'create_sql'. This makes is so all the SHOW CREATE commands have the same columns, and those column names are snake case which matches the other SHOW commands.

Fixes #14876

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Changes the columns of all `SHOW CREATE` commands to `name` and `create_sql`.
