### PR TITLE
docs: Escape <> characters in isolation docs

### DIFF
--- a/doc/user/content/sql/isolation-level.md
+++ b/doc/user/content/sql/isolation-level.md
@@ -63,9 +63,9 @@ The SQL standard defines the Serializable isolation level as preventing the foll
 
 - **P3 (”Phantom”):**
 
-  > "SQL-transaction T1 reads the set of rows N that satisfy some <search condition>. SQL-transaction
-  T2 then executes SQL-statements that generate one or more rows that satisfy the <search condition> used by
-  SQL-transaction T1. If SQL-transaction T1 then repeats the initial read with the same <search condition>, it obtains a
+  > "SQL-transaction T1 reads the set of rows N that satisfy some \<search condition\>. SQL-transaction
+  T2 then executes SQL-statements that generate one or more rows that satisfy the \<search condition\> used by
+  SQL-transaction T1. If SQL-transaction T1 then repeats the initial read with the same \<search condition\>, it obtains a
   different collection of rows."
   (ISO/IEC 9075-2:1999 (E) 4.32 SQL-transactions)
 


### PR DESCRIPTION
The '<' and '>' characters indicate a comment in markdown, so they were not being properly rendered on the isolation level docs. This commit escapes those characters so they can be properly rendered.


### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
