### PR TITLE
postgres-util: refactor implementation to use openssh instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,18 +213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-ssh2-lite"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69832303b1bdcfa73a74e30632e227f1f49ecc9d5da23bc1f2e1c268a1e7aad9"
-dependencies = [
- "async-trait",
- "futures-util",
- "ssh2",
- "tokio",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,19 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssh2-sys"
-version = "0.2.23"
-source = "git+https://github.com/MaterializeInc/ssh2-rs#cf435572dec61b0bc0945b23121de23dc80aa75d"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,18 +3859,21 @@ name = "mz-postgres-util"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-ssh2-lite",
  "mz-ore",
  "mz-proto",
+ "openssh",
  "openssl",
  "postgres-openssl",
  "proptest",
  "prost",
  "protobuf-src",
+ "rand",
  "serde",
+ "tempfile",
  "tokio",
  "tokio-postgres",
  "tonic-build",
+ "tracing",
 ]
 
 [[package]]
@@ -4624,6 +4602,21 @@ checksum = "b4a3100141f1733ea40b53381b0ae3117330735ef22309a190ac57b9576ea716"
 dependencies = [
  "pathdiff",
  "windows-sys",
+]
+
+[[package]]
+name = "openssh"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cbcf081bc4d65a3ba0dd5bccccf89470e61d54142174f6c0b531e459aac8ff"
+dependencies = [
+ "dirs",
+ "once_cell",
+ "shell-escape",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tokio-pipe",
 ]
 
 [[package]]
@@ -5893,6 +5886,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6000,17 +5999,6 @@ dependencies = [
  "sha2",
  "signature",
  "zeroize",
-]
-
-[[package]]
-name = "ssh2"
-version = "0.9.3"
-source = "git+https://github.com/MaterializeInc/ssh2-rs#cf435572dec61b0bc0945b23121de23dc80aa75d"
-dependencies = [
- "bitflags",
- "libc",
- "libssh2-sys",
- "parking_lot",
 ]
 
 [[package]]
@@ -6477,6 +6465,16 @@ dependencies = [
  "futures-util",
  "openssl",
  "openssl-sys",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-pipe"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f213a84bffbd61b8fa0ba8a044b4bbe35d471d0b518867181e82bd5c15542784"
+dependencies = [
+ "libc",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,5 +105,4 @@ mysql_common = { git = "https://github.com/blackbeam/rust_mysql_common.git" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tungstenite = { git = "https://github.com/snapview/tungstenite-rs.git" }
 serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
-ssh2 = { git = "https://github.com/MaterializeInc/ssh2-rs" }
 vte = { git = "https://github.com/alacritty/vte" }

--- a/deny.toml
+++ b/deny.toml
@@ -184,7 +184,4 @@ allow-git = [
     "https://github.com/TimelyDataflow/timely-dataflow",
     "https://github.com/TimelyDataflow/differential-dataflow.git",
     "https://github.com/fede1024/rust-rdkafka.git",
-
-    # Waiting on https://github.com/alexcrichton/ssh2-rs/pull/257
-    "https://github.com/MaterializeInc/ssh2-rs",
 ]

--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update \
         curl \
         postgresql-client-14 \
         tini \
+        ssh \
     && groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize \
     && mkdir /mzdata \

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -8,16 +8,19 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.65"
-async-ssh2-lite = { version = "0.3.2", features = ["tokio"] }
 mz-ore = { path = "../ore", features = ["task"] }
 mz-proto = { path = "../proto" }
 openssl = { version = "0.10.41", features = ["vendored"] }
+openssh = "0.9.7"
 postgres-openssl = { git = "https://github.com/MaterializeInc/rust-postgres" }
 proptest = { git = "https://github.com/MaterializeInc/proptest.git", default-features = false, features = ["std"]}
 prost = { version = "0.11.0", features = ["no-recursion-limit"] }
+rand = "0.8.5"
 serde = { version = "1.0.144", features = ["derive"] }
+tempfile = "3.3.0"
 tokio = { version = "1.19.2", features = ["fs", "rt", "sync"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
+tracing = "0.1.36"
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -9,20 +9,23 @@
 
 //! PostgreSQL utility library.
 
+use std::fs::File;
+use std::io::Write;
+use std::os::unix::prelude::PermissionsExt;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
-use async_ssh2_lite::{AsyncChannel, AsyncSession, SessionConfiguration};
-use mz_ore::ssh_key::SshKeypair;
 use openssl::pkey::PKey;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use openssl::x509::X509;
 use postgres_openssl::MakeTlsConnector;
+use rand::Rng;
 use tokio::net::TcpStream as TokioTcpStream;
 use tokio_postgres::config::{ReplicationMode, SslMode};
 use tokio_postgres::tls::MakeTlsConnect;
 use tokio_postgres::{Client, Config as PostgresConfig};
 
+use mz_ore::ssh_key::SshKeypair;
 use mz_ore::task;
 
 use crate::desc::{PostgresColumnDesc, PostgresTableDesc};
@@ -287,16 +290,29 @@ impl Config {
                 Ok(client)
             }
             SshTunnelConfig::Tunnel { .. } => {
+                let (session, local_port) = self.establish_openssh_connection().await?;
                 let tls = MakeTlsConnect::<TokioTcpStream>::make_tls_connect(&mut tls, &self.host)?;
-                let channel = self.establish_ssh_connection().await?;
-                let (client, connection) = self.postgres_config.connect_raw(channel, tls).await?;
-                task::spawn(|| connection_task_name, connection);
+                let tcp_stream = TokioTcpStream::connect(("localhost", local_port)).await?;
+                let (client, connection) =
+                    self.postgres_config.connect_raw(tcp_stream, tls).await?;
+                task::spawn(|| connection_task_name, async {
+                    _ = connection
+                        .await
+                        .err()
+                        .map(|e| tracing::error!("Postgres connection failed: {e}"));
+                    _ = session
+                        .close()
+                        .await
+                        .err()
+                        .map(|e| tracing::error!("failed to close ssh tunnel: {e}"));
+                });
                 Ok(client)
             }
         }
     }
 
     /// Starts a replication connection to the upstream database
+    // TODO(guswynn): explore how to merge this function with `connect`
     pub async fn connect_replication(mut self) -> Result<Client, anyhow::Error> {
         let mut tls = make_tls(&self.postgres_config)?;
         match self.ssh_tunnel {
@@ -312,24 +328,37 @@ impl Config {
                 Ok(client)
             }
             SshTunnelConfig::Tunnel { .. } => {
+                let (session, local_port) = self.establish_openssh_connection().await?;
                 let tls = MakeTlsConnect::<TokioTcpStream>::make_tls_connect(&mut tls, &self.host)?;
-                let channel = self.establish_ssh_connection().await?;
+                let tcp_stream = TokioTcpStream::connect(("localhost", local_port)).await?;
                 let (client, connection) = self
                     .postgres_config
                     .replication_mode(ReplicationMode::Logical)
                     .connect_timeout(Duration::from_secs(30))
                     .keepalives_idle(Duration::from_secs(10 * 60))
-                    .connect_raw(channel, tls)
+                    .connect_raw(tcp_stream, tls)
                     .await?;
-                task::spawn(|| "postgres_connect_replication", connection);
+                task::spawn(|| "postgres_connect_replication", async {
+                    _ = connection
+                        .await
+                        .err()
+                        .map(|e| tracing::error!("Postgres connection failed: {e}"));
+                    _ = session
+                        .close()
+                        .await
+                        .err()
+                        .map(|e| tracing::error!("failed to close ssh tunnel: {e}"));
+                });
                 Ok(client)
             }
         }
     }
 
-    async fn establish_ssh_connection(
-        &self,
-    ) -> Result<AsyncChannel<TokioTcpStream>, anyhow::Error> {
+    /// Sets up an ssh tunnel
+    ///
+    /// Returns the `Session` value you must keep alive to keep the tunnel
+    /// open and the local port the tunnel is listening on.
+    async fn establish_openssh_connection(&self) -> Result<(openssh::Session, u16), anyhow::Error> {
         match &self.ssh_tunnel {
             SshTunnelConfig::Tunnel {
                 host,
@@ -337,31 +366,72 @@ impl Config {
                 user,
                 keypair,
             } => {
-                let tcp_stream = TokioTcpStream::connect((host.as_str(), *port)).await?;
-                let mut session = AsyncSession::new(tcp_stream, Some(SessionConfiguration::new()))?;
-                session.handshake().await?;
+                let tempdir = tempfile::Builder::new()
+                    .prefix("ssh-tunnel-key")
+                    .tempdir()?;
+                let path = tempdir.path().join("key");
+                let mut tempfile = File::create(&path)?;
+                // Give read+write permissions on the file
+                tempfile.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+                // let private_key = keypair.ssh_private_key();
+                tempfile.write_all(keypair.ssh_private_key().as_bytes())?;
+                // Remove write permissions as soon as the key is written
+                // Mostly helpful to ensure the file is not accidentally overwritten.
+                tempfile.set_permissions(std::fs::Permissions::from_mode(0o400))?;
 
-                let private_key = keypair.ssh_private_key();
-                session
-                    .userauth_pubkey_memory(
-                        user,
-                        Some(&keypair.ssh_public_key()),
-                        private_key.as_ref(),
-                        None,
-                    )
-                    .await?;
-                drop(private_key);
+                let mut builder = openssh::SessionBuilder::default();
+                builder.user(user.clone()).port(*port).keyfile(&path);
+                let session = builder.connect(host).await?;
 
-                if !session.authenticated() {
-                    bail!("failed SSH authentication")
+                // Delete the private key for safety: since `ssh` still has an open handle to it,
+                // it still has access to the key.
+                drop(tempfile);
+                std::fs::remove_file(&path)?;
+                drop(tempdir);
+
+                // Ensure session is healthy
+                session.check().await?;
+
+                // Loop trying to find an open port
+                let mut attempts = 0;
+                let local_port = loop {
+                    if attempts > 50 {
+                        // If we failed to find an open port after 50 attempts, something is seriously wrong
+                        bail!("failed to find an open port to open the SSH tunnel")
+                    } else {
+                        attempts += 1;
+                    }
+
+                    let mut rng: rand::rngs::StdRng = rand::SeedableRng::from_entropy();
+                    // Choosing a dynamic port according to RFC 6335
+                    let local_port: u16 = rng.gen_range(49152..65535);
+
+                    let local = openssh::Socket::new(&("localhost", local_port))?;
+                    let remote = (self.host.as_str(), self.port);
+                    let remote = openssh::Socket::new(&remote)?;
+
+                    match session
+                        .request_port_forward(openssh::ForwardType::Local, local, remote)
+                        .await
+                    {
+                        Err(err) => match err {
+                            openssh::Error::Ssh(err)
+                                if err.to_string().contains("forwarding request failed") =>
+                            {
+                                tracing::warn!(
+                                    "Port {local_port} already in use, testing another port"
+                                );
+                            }
+                            _ => {
+                                tracing::error!("SSH connection failed: {err}");
+                                bail!("failed to open SSH tunnel")
+                            }
+                        },
+                        Ok(_) => break local_port,
+                    };
                 };
 
-                // Advertise the source connection to Postgres as coming from the bastion host
-                let src = Some((host.as_str(), *port));
-
-                Ok(session
-                    .channel_direct_tcpip(&self.host, self.port, src)
-                    .await?)
+                Ok((session, local_port))
             }
             SshTunnelConfig::Direct => bail!("connection not setup to use SSH"),
         }

--- a/test/ssh-connection/pg-source-ssl.td
+++ b/test/ssh-connection/pg-source-ssl.td
@@ -1,0 +1,51 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test creating a Postgres source using SSH
+
+> CREATE SECRET pgpass AS 'postgres'
+> CREATE CONNECTION pg FOR POSTGRES
+  HOST postgres,
+  DATABASE postgres,
+  USER postgres,
+  PASSWORD SECRET pgpass,
+  SSL MODE require,
+  SSH TUNNEL thancred
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER USER postgres WITH replication;
+DROP SCHEMA IF EXISTS public CASCADE;
+DROP PUBLICATION IF EXISTS mz_source;
+CREATE SCHEMA public;
+
+CREATE TABLE t1 (f1 INTEGER);
+ALTER TABLE t1 REPLICA IDENTITY FULL;
+INSERT INTO t1 VALUES (1);
+
+CREATE PUBLICATION mz_source FOR ALL TABLES;
+
+> CREATE SOURCE mz_source
+  FROM POSTGRES CONNECTION pg
+  PUBLICATION 'mz_source';
+
+> SELECT COUNT(*) = 1 FROM mz_source;
+true
+
+> CREATE VIEWS FROM SOURCE mz_source;
+
+> SELECT f1 FROM t1;
+1
+
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+INSERT INTO t1 VALUES (1), (2);
+
+> SELECT f1 FROM t1 ORDER BY f1 ASC;
+1
+1
+2


### PR DESCRIPTION
Refactor implementation of SSH tunnels to use `openssh` instead of `async-ssh2-lite` due to the issues we've been facing so far.

I'll add tests here soon, I just wanted to get more eyes on it soon, because jetlag.

### Motivation

  * This PR fixes a recognized bug: #14566

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
