### PR TITLE
storage: compact the remap shard to just before the resumption frontier

### DIFF
--- a/src/storage/src/source/util.rs
+++ b/src/storage/src/source/util.rs
@@ -121,7 +121,8 @@ where
 /// Effectively the same as `source`, but the core logic expects a
 /// never-ending future, not a tick closure. Additionally, this
 /// operator also contains an input, primarily to inspect the
-/// frontier of an upstream operator.
+/// frontier of an upstream operator. This input
+/// does not participate in progress tracking.
 ///
 /// Note that this means the input and capabilities are communicated
 /// to the future by value, not by &mut reference.
@@ -160,7 +161,7 @@ where
     let remap_input = builder.new_input_connection(
         &input,
         Pipeline,
-        // As documented, the optional input does not
+        // As documented, the input does not
         // participate in progress tracking.
         vec![Antichain::new()],
     );


### PR DESCRIPTION
@petrosagg and I determined that the remap shard for any source can always be compacted to the just before the `resumption_frontier`. Technically, the way we obtain a resumption frontier is using `WriteHandle::fetch_recent_upper`, which is not guaranteed to be linearizable with the reads/write that the reclock operator is doing, but in practice, we either:
- Have enough time from the controller instantiating a source after calculating a `resume_upper` to avoid a race
- Are only calculating a `resume_upper` based on the output of our `ReclockOperator`
so we don't see problems.

Other than the complexities of async timely operators, this pr ended up being pretty simple!

### Motivation

  * This PR adds a known-desirable feature.
falls out of https://github.com/MaterializeInc/materialize/issues/13534


### Tips for reviewer

I recommend reading this pr as separate commits

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

