### PR TITLE
Add FROM SCHEMA to SHOW INDEXES sql command

### DIFF
--- a/doc/user/content/sql/show-indexes.md
+++ b/doc/user/content/sql/show-indexes.md
@@ -15,6 +15,7 @@ menu:
 Field | Use
 ------|-----
 _on&lowbar;name_ | The name of the object whose indexes you want to show. If omitted, all indexes in the cluster are shown.
+_schema&lowbar;name_ | The schema to show objects from. Defaults to `public` in the current database. For available schemas, see [`SHOW SCHEMAS`](../show-schemas).
 _cluster&lowbar;name_ | The cluster to show indexes from. If omitted, indexes from all clusters are shown.
 
 ## Details

--- a/doc/user/layouts/partials/sql-grammar/show-indexes.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-indexes.svg
@@ -1,76 +1,71 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="559" height="223">
-   <polygon points="11 17 3 13 3 21"/>
-   <polygon points="19 17 11 13 11 21"/>
-   <rect x="33" y="3" width="64" height="32" rx="10"/>
-   <rect x="31"
+<svg xmlns="http://www.w3.org/2000/svg" width="537" height="255">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="41" y="21">SHOW</text>
-   <rect x="117" y="3" width="80" height="32" rx="10"/>
-   <rect x="115"
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="80" height="32" rx="10"/>
+   <rect x="113"
          y="1"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="125" y="21">INDEXES</text>
-   <rect x="257" y="35" width="60" height="32" rx="10"/>
-   <rect x="255"
+   <text class="terminal" x="123" y="21">INDEXES</text>
+   <rect x="255" y="35" width="60" height="32" rx="10"/>
+   <rect x="253"
          y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="53">FROM</text>
-   <rect x="257" y="79" width="40" height="32" rx="10"/>
-   <rect x="255"
+   <text class="terminal" x="263" y="53">FROM</text>
+   <rect x="255" y="79" width="40" height="32" rx="10"/>
+   <rect x="253"
          y="77"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="265" y="97">ON</text>
-   <rect x="357" y="35" width="78" height="32"/>
-   <rect x="355" y="33" width="78" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="365" y="53">on_name</text>
-   <rect x="45" y="177" width="34" height="32" rx="10"/>
-   <rect x="43"
-         y="175"
+   <text class="terminal" x="263" y="97">ON</text>
+   <rect x="355" y="35" width="78" height="32"/>
+   <rect x="353" y="33" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="363" y="53">on_name</text>
+   <rect x="235" y="123" width="126" height="32" rx="10"/>
+   <rect x="233"
+         y="121"
+         width="126"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="243" y="141">FROM SCHEMA</text>
+   <rect x="381" y="123" width="114" height="32"/>
+   <rect x="379" y="121" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="389" y="141">schema_name</text>
+   <rect x="65" y="221" width="34" height="32" rx="10"/>
+   <rect x="63"
+         y="219"
          width="34"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="195">IN</text>
-   <rect x="99" y="177" width="84" height="32" rx="10"/>
-   <rect x="97"
-         y="175"
+   <text class="terminal" x="73" y="239">IN</text>
+   <rect x="119" y="221" width="84" height="32" rx="10"/>
+   <rect x="117"
+         y="219"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="107" y="195">CLUSTER</text>
-   <rect x="203" y="177" width="108" height="32"/>
-   <rect x="201" y="175" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="211" y="195">cluster_name</text>
-   <rect x="371" y="145" width="50" height="32" rx="10"/>
-   <rect x="369"
-         y="143"
-         width="50"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="379" y="163">LIKE</text>
-   <rect x="441" y="145" width="70" height="32" rx="10"/>
-   <rect x="439"
-         y="143"
-         width="70"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="449" y="163">pattern</text>
+   <text class="terminal" x="127" y="239">CLUSTER</text>
+   <rect x="223" y="221" width="108" height="32"/>
+   <rect x="221" y="219" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="231" y="239">cluster_name</text>
    <rect x="371" y="189" width="70" height="32" rx="10"/>
    <rect x="369"
          y="187"
@@ -83,7 +78,7 @@
    <rect x="459" y="187" width="48" height="32" class="nonterminal"/>
    <text class="nonterminal" x="469" y="207">expr</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h208 m-238 0 h20 m218 0 h20 m-258 0 q10 0 10 10 m238 0 q0 -10 10 -10 m-248 10 v12 m238 0 v-12 m-238 12 q0 10 10 10 m218 0 q10 0 10 -10 m-208 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m40 0 h10 m0 0 h20 m20 -44 h10 m78 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-474 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
-   <polygon points="549 159 557 155 557 163"/>
-   <polygon points="549 159 541 155 541 163"/>
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h270 m-300 0 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v12 m300 0 v-12 m-300 12 q0 10 10 10 m280 0 q10 0 10 -10 m-270 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m40 0 h10 m0 0 h20 m20 -44 h10 m78 0 h10 m0 0 h62 m-290 -10 v20 m300 0 v-20 m-300 20 v68 m300 0 v-68 m-300 68 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m126 0 h10 m0 0 h10 m114 0 h10 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-514 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m70 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"/>
+   <polygon points="527 203 535 199 535 207"/>
+   <polygon points="527 203 519 199 519 207"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -316,9 +316,9 @@ show_databases ::=
     'SHOW' 'DATABASES' ('LIKE' 'pattern' | 'WHERE' expr)?
 show_indexes ::=
     'SHOW' 'INDEXES'
-    (('FROM' | 'ON') on_name)?
+    ((('FROM' | 'ON') on_name) | ('FROM SCHEMA' schema_name))?
     ('IN' 'CLUSTER' cluster_name)?
-    ('LIKE' 'pattern' | 'WHERE' expr)
+    ('WHERE' expr)
 show_materialized_views ::=
     'SHOW' 'MATERIALIZED VIEWS' ('FROM' schema_name)? ('IN CLUSTER' cluster_name)?
 show_secrets ::=

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1596,7 +1596,8 @@ impl_display_t!(ShowObjectsStatement);
 /// `SHOW INDEX|INDEXES|KEYS`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShowIndexesStatement<T: AstInfo> {
-    pub table_name: Option<T::ObjectName>,
+    pub on_object: Option<T::ObjectName>,
+    pub from_schema: Option<T::SchemaName>,
     pub in_cluster: Option<T::ClusterName>,
     pub filter: Option<ShowStatementFilter<T>>,
 }
@@ -1605,9 +1606,13 @@ impl<T: AstInfo> AstDisplay for ShowIndexesStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW ");
         f.write_str("INDEXES");
-        if let Some(table_name) = &self.table_name {
+        if let Some(on_object) = &self.on_object {
             f.write_str(" FROM ");
-            f.write_node(table_name);
+            f.write_node(on_object);
+        }
+        if let Some(from_schema) = &self.from_schema {
+            f.write_str(" FROM SCHEMA ");
+            f.write_node(from_schema);
         }
         if let Some(in_cluster) = &self.in_cluster {
             f.write_str(" IN CLUSTER ");

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -184,35 +184,56 @@ SHOW INDEXES FROM foo
 ----
 SHOW INDEXES FROM foo
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { on_object: Some(Name(UnresolvedObjectName([Ident("foo")]))), from_schema: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW INDEXES ON foo
 ----
 SHOW INDEXES FROM foo
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("foo")]))), in_cluster: None, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { on_object: Some(Name(UnresolvedObjectName([Ident("foo")]))), from_schema: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW INDEXES
 ----
 SHOW INDEXES
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: None, filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: None, in_cluster: None, filter: None }))
 
 parse-statement
 SHOW INDEXES IN CLUSTER c
 ----
 SHOW INDEXES IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: None, in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: None, in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
 
 parse-statement
-SHOW INDEXES FROM c IN CLUSTER c
+SHOW INDEXES FROM t IN CLUSTER c
 ----
-SHOW INDEXES FROM c IN CLUSTER c
+SHOW INDEXES FROM t IN CLUSTER c
 =>
-Show(ShowIndexes(ShowIndexesStatement { table_name: Some(Name(UnresolvedObjectName([Ident("c")]))), in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+Show(ShowIndexes(ShowIndexesStatement { on_object: Some(Name(UnresolvedObjectName([Ident("t")]))), from_schema: None, in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+
+parse-statement
+SHOW INDEXES FROM SCHEMA s
+----
+SHOW INDEXES FROM SCHEMA s
+=>
+Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: Some(UnresolvedSchemaName([Ident("s")])), in_cluster: None, filter: None }))
+
+parse-statement
+SHOW INDEXES FROM SCHEMA s IN CLUSTER c
+----
+SHOW INDEXES FROM SCHEMA s IN CLUSTER c
+=>
+Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: Some(UnresolvedSchemaName([Ident("s")])), in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
+
+parse-statement
+SHOW INDEXES FROM SCHEMA s ON t
+----
+error: Cannot specify both FROM SCHEMA and FROM or ON
+SHOW INDEXES FROM SCHEMA s ON t
+                              ^
 
 parse-statement
 SHOW CREATE VIEW foo

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -186,3 +186,12 @@ contains:cannot show indexes on materialize.public.foo_primary_idx because it is
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
 > SHOW INDEXES IN CLUSTER clstr WHERE on = 'foo'
 foo_primary_idx1    foo clstr   {a,b,z}
+
+> SHOW INDEXES FROM SCHEMA public WHERE name = 'foo_primary_idx1'
+foo_primary_idx1    foo clstr   {a,b,z}
+
+! SHOW INDEXES FROM SCHEMA public FROM foo
+contains:Cannot specify both FROM SCHEMA and FROM or ON
+
+! SHOW INDEXES FROM SCHEMA nonexistent
+contains:unknown schema 'nonexistent'


### PR DESCRIPTION
Add new `FROM SCHEMA` parameter to `SHOW INDEXES` sql command.
Disallow combining `FROM SCHEMA` and `FROM`/`ON` `on_name`.
Also, clean up the docs.

Fixes #14727 .

New docs:
<img width="826" alt="Screen Shot 2022-09-21 at 11 03 09 AM" src="https://user-images.githubusercontent.com/4186354/191540253-1e48afbc-35b3-4986-bb89-6161ce0e13d1.png">

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

Adds `FROM SCHEMA` statement option to `SHOW INDEXES`.
