### PR TITLE
storage: attempt to deflake publication-with-publish-option.td

### DIFF
--- a/test/pg-cdc/publication-with-publish-option.td
+++ b/test/pg-cdc/publication-with-publish-option.td
@@ -45,9 +45,19 @@ CREATE PUBLICATION mz_source_delete FOR TABLE t1 WITH ( publish = 'delete') ;
   FROM POSTGRES CONNECTION pg
   PUBLICATION 'mz_source_delete';
 
-# Make sure that the above sources are fully instantiated so that the DML statements below
-# are sent as actual replication events post-snapshot.
-
+# Make sure that the above sources are fully instantiated
+# (that is, we have finished absorbing their snapshots),
+# so that the DML statements below are sent as actual replication
+# events post-snapshot.
+#
+# Currently there is no good way to do this other than sleeping.
+# <https://github.com/MaterializeInc/materialize/issues/14914> tracks
+# making this better
+$ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=10s
+> SELECT COUNT(*) FROM mz_source_insert;
+0
+> SELECT COUNT(*) FROM mz_source_update;
+0
 > SELECT COUNT(*) FROM mz_source_delete;
 0
 


### PR DESCRIPTION
The `select count(*) == 0` statement here no longer ensures that we have actually made it past snapshotting (perhaps @aljoscha or @petrosagg knows why), and succeeds instantaneously (even if I make `produce_snapshot` pend forever they still succeed)

This pr attempts to at least reduce flakiness by sleeping to wait for snapshots to have a high chance of being finished before moving on. Sleeping is an unfortunate choice, but unless we ensure that the `select`'s on un-snapshotted pg source hang forever (i dont know if this is what we want), then i cant think of a better way to assert snapshotting being done. Perhaps in the future we will have stats on pg source snapshot progress.

In my testing I saw one flake with this change still appear, but I could have been looking at my logs wrong

Closes https://github.com/MaterializeInc/materialize/issues/14861


### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

