### PR TITLE
pgtest: add test for multiple DDL statements in one extended req

### DIFF
--- a/test/pgtest/ddl-extended.pt
+++ b/test/pgtest/ddl-extended.pt
@@ -1,3 +1,44 @@
+# Test that multiple DDL statements in the same extended request are supported
+send
+Parse {"query": "CREATE TABLE a (a int)"}
+Bind
+Execute
+Parse {"query": "ROLLBACK"}
+Bind
+Execute
+Parse {"query": "CREATE TABLE b (a int)"}
+Bind
+Execute
+Parse {"query": "SELECT * FROM a"}
+Bind
+Execute
+Parse {"query": "SELECT * FROM b"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"25P01"},{"typ":"M","value":"there is no transaction in progress"}]}
+CommandComplete {"tag":"ROLLBACK"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"CREATE TABLE"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"SELECT 0"}
+ParseComplete
+BindComplete
+CommandComplete {"tag":"SELECT 0"}
+ReadyForQuery {"status":"I"}
+
 # Test what happens with rollback'd DDLs in extended protocol.
 #
 # Note: This only works in versions of Postgres with


### PR DESCRIPTION
Support for this came up in https://github.com/MaterializeInc/materialize/pull/14790#discussion_r975785947

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - there are no user-facing behavior changes
