### PR TITLE
orchestrator: drop created k8s service 

### DIFF
--- a/misc/python/materialize/cloudtest/exists.py
+++ b/misc/python/materialize/cloudtest/exists.py
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+import subprocess
+
+from materialize import ui
+from materialize.ui import UIError
+
+
+def exists(resource: str, context: str = "kind-kind") -> None:
+    _exists(resource, True, context)
+
+
+def not_exists(resource: str, context: str = "kind-kind") -> None:
+    _exists(resource, False, context)
+
+
+def _exists(resource: str, should_exist: bool, context: str = "kind-kind") -> None:
+    cmd = ["kubectl", "get", "--output", "name", resource, "--context", context]
+    ui.progress(f'running {" ".join(cmd)} ... ')
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, encoding="ascii")
+        result.check_returncode()
+        if should_exist:
+            ui.progress("success!", finish=True)
+        else:
+            raise UIError(f"{resource} exists, but expected it not to")
+    except subprocess.CalledProcessError as e:
+        # A bit gross, but it should be safe enough in practice.
+        if "(NotFound)" in e.stderr:
+            if should_exist:
+                ui.progress("error!", finish=True)
+                raise UIError(f"{resource} does not exist, but expected it to")
+            else:
+                ui.progress("success!", finish=True)
+        else:
+            ui.progress(finish=True)
+            raise UIError(f"kubectl failed: {e}")

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -462,6 +462,16 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             .delete(&name, &DeleteParams::default())
             .await;
         match res {
+            Ok(_) => (),
+            Err(Error::Api(e)) if e.code == 404 => (),
+            Err(e) => return Err(e.into()),
+        }
+
+        let res = self
+            .service_api
+            .delete(&name, &DeleteParams::default())
+            .await;
+        match res {
             Ok(_) => Ok(()),
             Err(Error::Api(e)) if e.code == 404 => Ok(()),
             Err(e) => Err(e.into()),

--- a/test/cloudtest/test_computed.py
+++ b/test/cloudtest/test_computed.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.exists import exists, not_exists
 from materialize.cloudtest.wait import wait
 
 
@@ -50,6 +51,7 @@ def test_computed_shutdown(mz: MaterializeApplication) -> None:
     assert cluster_id is not None
 
     compute_pods = {}
+    compute_svcs = {}
     for replica_name in ["shutdown_replica1", "shutdown_replica2"]:
         replica_id = mz.environmentd.sql_query(
             f"SELECT id FROM mz_cluster_replicas WHERE name = '{replica_name}'"
@@ -60,8 +62,14 @@ def test_computed_shutdown(mz: MaterializeApplication) -> None:
         compute_pods[replica_name] = compute_pod
         wait(condition="condition=Ready", resource=compute_pod)
 
+        compute_svc = f"service/compute-cluster-{cluster_id}-replica-{replica_id}"
+        compute_svcs[replica_name] = compute_svc
+        exists(resource=compute_svc)
+
     mz.environmentd.sql("DROP CLUSTER REPLICA shutdown1.shutdown_replica1")
     wait(condition="delete", resource=compute_pods["shutdown_replica1"])
+    not_exists(resource=compute_svcs["shutdown_replica1"])
 
     mz.environmentd.sql("DROP CLUSTER shutdown1 CASCADE")
     wait(condition="delete", resource=compute_pods["shutdown_replica2"])
+    not_exists(resource=compute_svcs["shutdown_replica2"])

--- a/test/cloudtest/test_storaged.py
+++ b/test/cloudtest/test_storaged.py
@@ -10,6 +10,7 @@
 from textwrap import dedent
 
 from materialize.cloudtest.application import MaterializeApplication
+from materialize.cloudtest.exists import exists, not_exists
 from materialize.cloudtest.wait import wait
 
 
@@ -130,10 +131,13 @@ def test_storaged_shutdown(mz: MaterializeApplication) -> None:
     ][0]
     assert id is not None
 
-    storaged = f"pod/storage-{id}-0"
+    storaged_pod = f"pod/storage-{id}-0"
+    storaged_svc = f"service/storage-{id}"
 
-    wait(condition="condition=Ready", resource=storaged)
+    wait(condition="condition=Ready", resource=storaged_pod)
+    exists(storaged_svc)
 
     mz.environmentd.sql("DROP SOURCE source1")
 
-    wait(condition="delete", resource=storaged)
+    wait(condition="delete", resource=storaged_pod)
+    not_exists(storaged_svc)


### PR DESCRIPTION
We create a Kubernetes service and stateful set, but never delete the service on drop. I added the service delete call to the orchestrator and updated the existing smoketests to verify that services are cleaned up.

Fixes #14188.

### Motivation

  * This PR fixes a recognized bug.

    #14188 

### Tips for reviewer

@benesch Please feel free to close this PR directly and rewrite. I was only curious to use cloudtest and check the local testing setup. Take this PR mainly as a confirmation of the reported issue.

I haven't written Rust or Python in a while. I added `exists.py` and followed the lead from `wait.py`, but it doesn't feel terribly idiomatic to me.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
