### PR TITLE
storage: fix potential kafka sink bug

### DIFF
--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -53,7 +53,7 @@ class CreateSink(Action):
         c.testdrive(
             dedent(
                 f"""
-                > CREATE CONNECTION IF NOT EXISTS {self.sink.name}_kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
+                > CREATE CONNECTION IF NOT EXISTS {self.sink.name}_kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}', PROGRESS TOPIC 'zippy-{self.sink.name}-${{testdrive.seed}}';
                 > CREATE CONNECTION IF NOT EXISTS {self.sink.name}_csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
 
                 > CREATE SINK {self.sink.name} FROM {self.source_view.name}


### PR DESCRIPTION
### Tips for reviewer

The comments should explain it all, but please yell at me if they don't.

Also: I should probably downgrade the logging to `trace!` before merging, but these helped in debugging another bug (https://github.com/MaterializeInc/materialize/issues/14754)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
