### PR TITLE
[testdrive] Increase parallelism to 6 jobs

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -138,7 +138,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    parallelism: 4
+    parallelism: 6
     artifact_paths: test/testdrive/junit_testdrive_*.xml
     plugins:
       - ./ci/plugins/scratch-aws-access: ~

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -138,7 +138,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    parallelism: 6
+    parallelism: 8
     artifact_paths: test/testdrive/junit_testdrive_*.xml
     plugins:
       - ./ci/plugins/scratch-aws-access: ~

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -138,7 +138,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    parallelism: 5
+    parallelism: 6
     artifact_paths: test/testdrive/junit_testdrive_*.xml
     plugins:
       - ./ci/plugins/scratch-aws-access: ~

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -138,7 +138,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    parallelism: 6
+    parallelism: 5
     artifact_paths: test/testdrive/junit_testdrive_*.xml
     plugins:
       - ./ci/plugins/scratch-aws-access: ~


### PR DESCRIPTION
Looking at some recent runs, the long path is:
- ~20 mins to build x86_64
- ~20 mins to run 2/4 testdrive shards.  Every other job seems to take ~10 mins.

Hopefully upping parallelism will distribute some of these tests better and we'll end up brining down end to end time