### PR TITLE
audit-log: add ids to cluster operations

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3458,7 +3458,10 @@ impl<S: Append> Catalog<S> {
                         &mut builtin_table_updates,
                         EventType::Create,
                         ObjectType::Cluster,
-                        EventDetails::NameV1(mz_audit_log::NameV1 { name: name.clone() }),
+                        EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                            id,
+                            name: name.clone(),
+                        }),
                     )?;
                     vec![Action::CreateComputeInstance {
                         id,
@@ -3477,11 +3480,17 @@ impl<S: Append> Catalog<S> {
                             ErrorKind::ReservedReplicaName(name),
                         )));
                     }
+                    let id = tx.insert_compute_instance_replica(
+                        &on_cluster_name,
+                        &name,
+                        &config.clone().into(),
+                    )?;
                     if let ConcreteComputeInstanceReplicaLocation::Managed { size, .. } =
                         &config.location
                     {
                         let details = EventDetails::CreateComputeInstanceReplicaV1(
                             mz_audit_log::CreateComputeInstanceReplicaV1 {
+                                cluster_id: id,
                                 cluster_name: on_cluster_name.clone(),
                                 replica_name: name.clone(),
                                 logical_size: size.clone(),
@@ -3497,11 +3506,7 @@ impl<S: Append> Catalog<S> {
                         )?;
                     }
                     vec![Action::CreateComputeInstanceReplica {
-                        id: tx.insert_compute_instance_replica(
-                            &on_cluster_name,
-                            &name,
-                            &config.clone().into(),
-                        )?,
+                        id,
                         name,
                         on_cluster_name,
                         config,
@@ -3594,7 +3599,8 @@ impl<S: Append> Catalog<S> {
                     vec![Action::DropRole { name }]
                 }
                 Op::DropComputeInstance { name } => {
-                    let introspection_source_index_ids = tx.remove_compute_instance(&name)?;
+                    let (instance_id, introspection_source_index_ids) =
+                        tx.remove_compute_instance(&name)?;
                     builtin_table_updates.push(self.state.pack_compute_instance_update(&name, -1));
                     for id in &introspection_source_index_ids {
                         builtin_table_updates.extend(self.state.pack_item_update(*id, -1));
@@ -3605,7 +3611,10 @@ impl<S: Append> Catalog<S> {
                         &mut builtin_table_updates,
                         EventType::Drop,
                         ObjectType::Cluster,
-                        EventDetails::NameV1(mz_audit_log::NameV1 { name: name.clone() }),
+                        EventDetails::IdNameV1(mz_audit_log::IdNameV1 {
+                            id: instance_id,
+                            name: name.clone(),
+                        }),
                     )?;
                     vec![Action::DropComputeInstance {
                         name,
@@ -3636,6 +3645,7 @@ impl<S: Append> Catalog<S> {
 
                     let details = EventDetails::DropComputeInstanceReplicaV1(
                         mz_audit_log::DropComputeInstanceReplicaV1 {
+                            cluster_id: instance.id,
                             cluster_name: instance.name.clone(),
                             replica_name: name.clone(),
                         },

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1037,7 +1037,7 @@ impl<'a, S: Append> Transaction<'a, S> {
         }
     }
 
-    pub fn remove_compute_instance(&mut self, name: &str) -> Result<Vec<GlobalId>, Error> {
+    pub fn remove_compute_instance(&mut self, name: &str) -> Result<(u64, Vec<GlobalId>), Error> {
         let deleted = self.compute_instances.delete(|_k, v| v.name == name);
         if deleted.is_empty() {
             Err(SqlCatalogError::UnknownComputeInstance(name.to_owned()).into())
@@ -1050,10 +1050,13 @@ impl<'a, S: Append> Transaction<'a, S> {
             let introspection_source_indexes = self
                 .introspection_sources
                 .delete(|k, _v| k.compute_id == id);
-            Ok(introspection_source_indexes
-                .into_iter()
-                .map(|(_, v)| GlobalId::System(v.index_id))
-                .collect())
+            Ok((
+                id,
+                introspection_source_indexes
+                    .into_iter()
+                    .map(|(_, v)| GlobalId::System(v.index_id))
+                    .collect(),
+            ))
         }
     }
 

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -105,6 +105,7 @@ pub enum EventDetails {
     FullNameV1(FullNameV1),
     NameV1(NameV1),
     RenameItemV1(RenameItemV1),
+    IdNameV1(IdNameV1),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
@@ -120,6 +121,12 @@ pub struct NameV1 {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
+pub struct IdNameV1 {
+    pub id: u64,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct RenameItemV1 {
     pub previous_name: FullNameV1,
     pub new_name: String,
@@ -127,12 +134,14 @@ pub struct RenameItemV1 {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct DropComputeInstanceReplicaV1 {
+    pub cluster_id: u64,
     pub cluster_name: String,
     pub replica_name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash)]
 pub struct CreateComputeInstanceReplicaV1 {
+    pub cluster_id: u64,
     pub cluster_name: String,
     pub replica_name: String,
     pub logical_size: String,
@@ -149,6 +158,7 @@ impl EventDetails {
             }
             EventDetails::RenameItemV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::NameV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::IdNameV1(v) => serde_json::to_value(v).expect("must serialize"),
             EventDetails::FullNameV1(v) => serde_json::to_value(v).expect("must serialize"),
         }
     }

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -41,11 +41,17 @@ DROP VIEW renamed
 statement ok
 CREATE SOURCE s FROM LOAD GENERATOR COUNTER;
 
+statement ok
+DROP CLUSTER REPLICA foo.r;
+
+statement ok
+DROP CLUSTER foo;
+
 query ITTTT
 SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORDER BY id
 ----
-1  create  cluster  {"name":"foo"}  materialize
-2  create  cluster-replica  {"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+1  create  cluster  {"id":2,"name":"foo"}  materialize
+2  create  cluster-replica  {"cluster_id":2,"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
 3  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
 4  create  view  {"database":"materialize","item":"unmat","schema":"public"}  materialize
 5  create  index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
@@ -56,3 +62,5 @@ SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORD
 10  drop  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
 11  drop  view  {"database":"materialize","item":"renamed","schema":"public"}  materialize
 12  create  source  {"database":"materialize","item":"s","schema":"public"}  materialize
+13  drop  cluster-replica  {"cluster_id":2,"cluster_name":"foo","replica_name":"r"}  materialize
+14  drop  cluster  {"id":2,"name":"foo"}  materialize


### PR DESCRIPTION
Fixes #14852

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a