### PR TITLE
storage: in upsert operator, fix hashing of previous and current updates

### DIFF
--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -10,7 +10,6 @@
 use std::any::Any;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
-use std::convert::Infallible;
 use std::rc::Rc;
 
 use differential_dataflow::hashable::Hashable;
@@ -295,10 +294,30 @@ where
         key_indices_sorted.clone(),
         &upsert_envelope.key_indices,
     );
+
+    // It's very important to hash the right thing. We have nested `Option` and
+    // `Result` here. And, for example, `Some(key).hashed()` is not the same as
+    // `key.hashed()`.
+    //
+    // We make sure  to hash the same thing for both previous updates and new
+    // updates.
+    //
+    // Also: this problem was only showing up when trying to use upsert-style
+    // sources with multiple storaged workers.
     let result_stream = stream.binary_frontier(
         &previous_ok.inner,
-        Exchange::new(move |DecodeResult { key, .. }| key.hashed()),
-        Exchange::new(|((key, _v), _t, _r)| Ok::<_, Infallible>(key).hashed()),
+        Exchange::new(move |DecodeResult { key, .. }| {
+            // N.B. We make the expected type explicit here to make sure it
+            // cannot change by accident.
+            let key: &Option<Result<Row, DecodeError>> = key;
+            key.hashed()
+        }),
+        Exchange::new(|((key, _v), _t, _r)| {
+            // N.B.  We make the expected type explicit here to make sure it
+            // cannot change by accident.
+            let key: &Result<Row, DecodeError> = key;
+            Some(key).hashed()
+        }),
         "Upsert",
         move |_cap, _info| {
             // This is a map of (time) -> (capability, ((key) -> (value with max offset)))


### PR DESCRIPTION
### Motivation

This is one of the issues that @philip-stoev discovered when trying to run CI with `workers > 1` (see #14273)

### Notes for reviewers

It's very important to hash the right thing. We have nested `Option` and `Result` here. And, for example, `Some(key).hashed()` is not the same as `key.hashed()`.

This change makes sure that we hash the same thing for both pervious updates and new updates.

Also: this problem was only showing up when trying to use upsert-style sources with multiple storaged workers.

Partially fixes #14273

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
