### PR TITLE
Disable pg-snapshot-resumption/03-while-storaged-down cluster smoke test

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -372,8 +372,10 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
         c.run("testdrive", "pg-snapshot-resumption/01-configure-postgres.td")
         c.run("testdrive", "pg-snapshot-resumption/02-create-sources.td")
 
-        # storaged should crash
-        c.run("testdrive", "pg-snapshot-resumption/03-while-storaged-down.td")
+        # Temporarily disabled because it is timing out.
+        # https://github.com/MaterializeInc/materialize/issues/14533
+        # # storaged should crash
+        # c.run("testdrive", "pg-snapshot-resumption/03-while-storaged-down.td")
 
         print("Sleeping to ensure that storaged crashes")
         time.sleep(10)


### PR DESCRIPTION
It is causing consistent CI failures, blocking people from merging their PRs.
Issue is being tracked at #14533.
It does not seem like a quick fix, so we are disabling until someone can dedicate time to investigating, fixing, and re-enabling.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):