### PR TITLE
compute-client: ignore flaking test

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -1208,7 +1208,9 @@ mod tests {
             assert_eq!(actual.unwrap(), expect);
         }
 
+        // TODO: Unignore after fixing #14543.
         #[test]
+        #[ignore]
         fn compute_command_protobuf_roundtrip(expect in any::<ComputeCommand<mz_repr::Timestamp>>() ) {
             let actual = protobuf_roundtrip::<_, ProtoComputeCommand>(&expect);
             assert!(actual.is_ok());


### PR DESCRIPTION
Ignore flaking `compute_command_protobuf_roundtrip`. See #14543.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a