### PR TITLE
[kafka sink] Don't emit updates until input frontier passes AS OF

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -37,7 +37,6 @@ use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::generic::{InputHandle, OutputHandle};
 use timely::dataflow::operators::Capability;
 use timely::dataflow::{Scope, Stream};
-use timely::progress::frontier::AntichainRef;
 use timely::progress::{Antichain, Timestamp as _};
 use timely::scheduling::Activator;
 use timely::PartialOrder;


### PR DESCRIPTION
The following sequence causes a crash:
- `CREATE SINK sink FROM source with AS OF t1`.  The input frontier from `source` also equals `t1`.
- With the input frontier equal to `t1`, no rows at `t1` are moved from `pending_rows` to `ready_rows` in the kafka implementation
- We do, however, call `maybe_emit_progress` and write out `t1 - 1` indicating that all future writes to the topic will happen at `t1` or later
- Some error occurs and we crash
- We restart.  The input frontier hasn't moved forward so we re-run the `CREATE SINK` command with the same `AS OF = t1`.
- We read that the gate_ts (highest timestamp written to the progress topic) equals `t1 - 1` but the AS OF is `t1`.  This trips an assert

Distilled down, the issue here is that we write out times to the progress topic that are earlier than the initial AS OF meaning that it is possible to trip the assert that the gate_ts is at or after the AS OF.  However, we don't actually need to record this -- so we should better handle this boundary condition.

To address this, we avoid writing out to the progress topic until the input frontier has passed the AS OF.  Currently this invariant exists for progress updates that accompany a data write -- so we're just delaying those periodic progress messages that are linked only to the input frontier advancing.

### Motivation
Fixes #14754 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - I've done some zippy testing and didn't see a failure.  We don't have a great framework (yet!) to inject a fault at a specific point so it's hard to write a test for this specific failure.
