### PR TITLE
adapter: init audit log with replicas

### DIFF
--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -90,7 +90,7 @@ Field           | Type                         | Meaning
 `event_type`    | [`text`]                     | The type of the event: `create`, `drop`, `alter`, or `rename`.
 `object_type`   | [`text`]                     | The type of the affected object: `cluster`, `cluster-replica`, `index`, `materialized-view`, `sink`, `source`, or `view`.
 `event_details` | [`jsonb`]                    | Additional details about the event. The shape of the details varies based on `event_type` and `object_type`.
-`user`          | [`text`]                     | The user who triggered the event.
+`user`          | [`text`]                     | The user who triggered the event, or `NULL` if triggered by the system.
 `occurred_at`   | [`timestamp with time zone`] | The time at which the event occurred.
 
 ### `mz_base_types`

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2567,6 +2567,7 @@ impl<S: Append> Catalog<S> {
         let storage = storage::Connection::open(
             stash,
             &BootstrapArgs {
+                now: (now)(),
                 default_cluster_replica_size: "1".into(),
                 default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
             },
@@ -3015,11 +3016,7 @@ impl<S: Append> Catalog<S> {
         object_type: ObjectType,
         event_details: EventDetails,
     ) -> Result<(), Error> {
-        let session = match session {
-            Some(session) => session,
-            None => return Ok(()),
-        };
-        let user = session.user().to_string();
+        let user = session.map(|session| session.user().to_string());
         let occurred_at = (self.state.config.now)();
         let id = tx.get_and_increment_id(storage::AUDIT_LOG_ID_ALLOC_KEY.to_string())?;
         let event = VersionedEvent::new(

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1305,7 +1305,7 @@ pub static MZ_AUDIT_EVENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("event_type", ScalarType::String.nullable(false))
         .with_column("object_type", ScalarType::String.nullable(false))
         .with_column("event_details", ScalarType::Jsonb.nullable(false))
-        .with_column("user", ScalarType::String.nullable(false))
+        .with_column("user", ScalarType::String.nullable(true))
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false)),
 });
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -674,7 +674,7 @@ impl CatalogState {
             &EventType,
             &ObjectType,
             &EventDetails,
-            &str,
+            &Option<String>,
             u64,
         ) = match event {
             VersionedEvent::V1(ev) => (
@@ -703,7 +703,10 @@ impl CatalogState {
                 Datum::String(&format!("{}", event_type)),
                 Datum::String(&format!("{}", object_type)),
                 event_details,
-                Datum::String(user),
+                match user {
+                    Some(user) => Datum::String(user),
+                    None => Datum::Null,
+                },
                 Datum::TimestampTz(DateTime::from_utc(dt, Utc)),
             ]),
             diff: 1,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -232,6 +232,7 @@ pub async fn serve(config: Config) -> Result<Server, anyhow::Error> {
     let adapter_storage = mz_adapter::catalog::storage::Connection::open(
         stash,
         &BootstrapArgs {
+            now: (config.now)(),
             default_cluster_replica_size: config.bootstrap_default_cluster_replica_size,
             // TODO(benesch, brennan): remove this after v0.27.0-alpha.4 has
             // shipped to cloud since all clusters will have had a default

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -50,17 +50,19 @@ DROP CLUSTER foo;
 query ITTTT
 SELECT id, event_type, object_type, event_details, user FROM mz_audit_events ORDER BY id
 ----
-1  create  cluster  {"id":2,"name":"foo"}  materialize
-2  create  cluster-replica  {"cluster_id":2,"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
-3  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
-4  create  view  {"database":"materialize","item":"unmat","schema":"public"}  materialize
-5  create  index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
-6  alter  view  {"new_name":"renamed","previous_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
-7  drop  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
-8  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
-9  create  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
-10  drop  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
-11  drop  view  {"database":"materialize","item":"renamed","schema":"public"}  materialize
-12  create  source  {"database":"materialize","item":"s","schema":"public"}  materialize
-13  drop  cluster-replica  {"cluster_id":2,"cluster_name":"foo","replica_name":"r"}  materialize
-14  drop  cluster  {"id":2,"name":"foo"}  materialize
+1  create  cluster  {"id":1,"name":"default"}  NULL
+2  create  cluster-replica  {"cluster_id":1,"cluster_name":"default","logical_size":"1","replica_name":"default_replica"}  NULL
+3  create  cluster  {"id":2,"name":"foo"}  materialize
+4  create  cluster-replica  {"cluster_id":2,"cluster_name":"foo","logical_size":"1","replica_name":"r"}  materialize
+5  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
+6  create  view  {"database":"materialize","item":"unmat","schema":"public"}  materialize
+7  create  index  {"database":"materialize","item":"t_primary_idx","schema":"public"}  materialize
+8  alter  view  {"new_name":"renamed","previous_name":{"database":"materialize","item":"unmat","schema":"public"}}  materialize
+9  drop  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
+10  create  materialized-view  {"database":"materialize","item":"v2","schema":"public"}  materialize
+11  create  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
+12  drop  index  {"database":"materialize","item":"renamed_primary_idx","schema":"public"}  materialize
+13  drop  view  {"database":"materialize","item":"renamed","schema":"public"}  materialize
+14  create  source  {"database":"materialize","item":"s","schema":"public"}  materialize
+15  drop  cluster-replica  {"cluster_id":2,"cluster_name":"foo","replica_name":"r"}  materialize
+16  drop  cluster  {"id":2,"name":"foo"}  materialize


### PR DESCRIPTION
This additionally allows a null user to indicate it's from the system.

Fixes #14854

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - n/a