### PR TITLE
Move introspection sources into mz_internal

### DIFF
--- a/doc/user/content/ops/troubleshooting.md
+++ b/doc/user/content/ops/troubleshooting.md
@@ -32,7 +32,7 @@ This source provides timestamp-based progress, which reveals not the
 volume of data, but how closely the contents track source timestamps.
 ```sql
 -- For each materialization, the next timestamp to be added.
-select * from mz_materialization_frontiers;
+select * from mz_internal.mz_materialization_frontiers;
 ```
 
 ### Why is Materialize running so slowly?
@@ -44,8 +44,8 @@ take the largest total amount of time.
 ```sql
 -- Extract raw elapsed time information, by worker
 select mdo.id, mdo.name, mdo.worker_id, mse.elapsed_ns
-from mz_scheduling_elapsed as mse,
-     mz_dataflow_operators as mdo
+from mz_internal.mz_scheduling_elapsed as mse,
+     mz_internal.mz_dataflow_operators as mdo
 where
     mse.id = mdo.id and
     mse.worker_id = mdo.worker_id
@@ -55,8 +55,8 @@ order by elapsed_ns desc;
 ```sql
 -- Extract raw elapsed time information, summed across workers
 select mdo.id, mdo.name, sum(mse.elapsed_ns) as elapsed_ns
-from mz_scheduling_elapsed as mse,
-     mz_dataflow_operators as mdo
+from mz_internal.mz_scheduling_elapsed as mse,
+     mz_internal.mz_dataflow_operators as mdo
 where
     mse.id = mdo.id and
     mse.worker_id = mdo.worker_id
@@ -77,8 +77,8 @@ and incriminate the subject.
 ```sql
 -- Extract raw scheduling histogram information, by worker.
 select mdo.id, mdo.name, mdo.worker_id, msh.duration_ns, count
-from mz_scheduling_histogram as msh,
-     mz_dataflow_operators as mdo
+from mz_internal.mz_scheduling_histogram as msh,
+     mz_internal.mz_dataflow_operators as mdo
 where
     msh.id = mdo.id and
     msh.worker_id = mdo.worker_id
@@ -88,8 +88,8 @@ order by msh.duration_ns desc;
 ```sql
 -- Extract raw scheduling histogram information, summed across workers.
 select mdo.id, mdo.name, msh.duration_ns, sum(msh.count) count
-from mz_scheduling_histogram as msh,
-     mz_dataflow_operators as mdo
+from mz_internal.mz_scheduling_histogram as msh,
+     mz_internal.mz_dataflow_operators as mdo
 where
     msh.id = mdo.id and
     msh.worker_id = mdo.worker_id
@@ -110,8 +110,8 @@ number, and anything significantly larger is probably a bug.
 ```sql
 -- Extract arrangement records and batches, by worker.
 select mdo.id, mdo.name, mdo.worker_id, mas.records, mas.batches
-from mz_arrangement_sizes as mas,
-     mz_dataflow_operators as mdo
+from mz_internal.mz_arrangement_sizes as mas,
+     mz_internal.mz_dataflow_operators as mdo
 where
     mas.operator_id = mdo.id and
     mas.worker_id = mdo.worker_id
@@ -121,8 +121,8 @@ order by mas.records desc;
 ```sql
 -- Extract arrangement records and batches, summed across workers.
 select mdo.id, mdo.name, sum(mas.records) as records, sum(mas.batches) as batches
-from mz_arrangement_sizes as mas,
-     mz_dataflow_operators as mdo
+from mz_internal.mz_arrangement_sizes as mas,
+     mz_internal.mz_dataflow_operators as mdo
 where
     mas.operator_id = mdo.id and
     mas.worker_id = mdo.worker_id
@@ -138,7 +138,7 @@ by Materialize should correlate with the number of arrangement records that are
 displayed by either the visual interface or the SQL queries.
 
 The memory usage visualization is available at `http://<materialized
-host>:6875/memory`.
+host>:6876/memory`.
 
 ### Is work distributed equally across workers?
 
@@ -162,7 +162,7 @@ select
     id,
     avg(elapsed_ns) as avg_ns
 from
-    mz_scheduling_elapsed
+    mz_internal.mz_scheduling_elapsed
 group by
     id;
 
@@ -177,9 +177,9 @@ select
     avg_ns,
     elapsed_ns/avg_ns as ratio
 from
-    mz_scheduling_elapsed mse,
+    mz_internal.mz_scheduling_elapsed mse,
     avg_elapsed_by_id aebi,
-    mz_dataflow_operator_dataflows dod
+    mz_internal.mz_dataflow_operator_dataflows dod
 where
     mse.id = aebi.id and
     mse.elapsed_ns > 2 * aebi.avg_ns and
@@ -196,7 +196,7 @@ defined by positions `0..n-1`. The example SQL query and result below shows an
 operator whose `id` is 515 that belongs to "subregion 5 of region 1 of dataflow
 21".
 ```sql
-select * from mz_dataflow_addresses where id=515 and worker_id=0;
+select * from mz_internal.mz_dataflow_addresses where id=515 and worker_id=0;
 ```
 ```
  id  | worker_id | address
@@ -220,15 +220,15 @@ SELECT
     mdo.id as id,
     mdo.name as name
 FROM
-    mz_dataflow_addresses mda,
+    mz_internal.mz_dataflow_addresses mda,
     -- source of operator names
-    mz_dataflow_operators mdo,
+    mz_internal.mz_dataflow_operators mdo,
     -- view containing operators representing entire dataflows
     (SELECT
       mda.id as dataflow_operator,
       mda.address[1] as dataflow_address
     FROM
-      mz_dataflow_addresses mda
+      mz_internal.mz_dataflow_addresses mda
     WHERE
       mda.worker_id = 0
       AND list_length(mda.address) = 1) dataflows
@@ -267,7 +267,7 @@ Every time `TAIL` is invoked, a dataflow using the `Dataflow: tail` prefix is cr
 -- Report the number of tails running
 SELECT count(1) FROM (
     SELECT id
-    FROM mz_dataflows
+    FROM mz_internal.mz_dataflows
     WHERE substring(name, 0, 15) = 'Dataflow: tail'
     GROUP BY id
 );

--- a/doc/user/content/sql/system-catalog.md
+++ b/doc/user/content/sql/system-catalog.md
@@ -19,7 +19,7 @@ Backwards-incompatible changes to these tables may be made at any time.
 
 ## Details
 
-The system catalog consists of two schemas that are implicitly available in
+The system catalog consists of three schemas that are implicitly available in
 all databases:
 
   * [`mz_catalog`](#mz_catalog), which exposes metadata in Materialize's
@@ -27,6 +27,9 @@ all databases:
 
   * [`pg_catalog`](#pg_catalog), which presents the data in `mz_catalog` in
     the format used by PostgreSQL.
+
+  * [`mz_internal`](#mz_internal), which exposes internal metadata about
+    Materialize in an unstable format that is likely to change.
 
 These schemas contain sources, tables, and views that expose metadata like:
 
@@ -55,29 +58,6 @@ Field          | Type       | Meaning
 ---------------|------------|--------
 `type_id`      | [`text`]   | The ID of the array type.
 `element_id`   | [`text`]   | The ID of the array's element type.
-
-### `mz_arrangement_sharing`
-
-The `mz_arrangement_sharing` source describes how many times each [arrangement]
-in the system is used.
-
-Field         | Type       | Meaning
---------------|------------|--------
-`operator_id` | [`bigint`] | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
-`worker_id`   | [`bigint`] | The ID of the worker thread hosting the arrangement.
-`count`       | [`bigint`] | The number of operators that share the arrangement.
-
-### `mz_arrangement_sizes`
-
-The `mz_arrangement_sizes` source describes the size of each [arrangement] in
-the system.
-
-Field         | Type       | Meaning
---------------|------------|--------
-`operator_id` | [`bigint`] | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
-`worker_id`   | [`bigint`] | The ID of the worker thread hosting the arrangement.
-`records`     | [`bigint`] | The number of records in the arrangement.
-`batches`     | [`bigint`] | The number of batches in the arrangement.
 
 ### `mz_audit_events`
 
@@ -125,67 +105,6 @@ Field  | Type       | Meaning
 `id`   | [`bigint`] | Materialize's unique ID for the database.
 `oid`  | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the database.
 `name` | [`text`]   | The name of the database.
-
-### `mz_dataflow_channels`
-
-The `mz_dataflow_channels` source describes the communication channels between
-[dataflow] operators. A communication channel connects one of the outputs of a
-source operator to one of the inputs of a target operator.
-
-Field           | Type       | Meaning
-----------------|------------|--------
-`id`            | [`bigint`] | The ID of the channel.
-`worker_id`     | [`bigint`] | The ID of the worker thread hosting the channel.
-`from_index`    | [`bigint`] | The scope-local index of the source operator. Corresponds to an address in [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
-`from_port`      | [`bigint`] | The source operator's output port.
-`to_index`      | [`bigint`] | The scope-local index of the target operator. Corresponds to an address in [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
-`to_port`       | [`bigint`] | The target operator's input port.
-
-### `mz_dataflows`
-
-The `mz_dataflows` view describes the [dataflows][dataflow] in the system.
-
-Field      | Type       | Meaning
------------|------------|--------
-`id`       | [`bigint`] | The ID of the dataflow.
-`worker_id`| [`bigint`] | The ID of the worker thread hosting the dataflow.
-`local_id` | [`bigint`] | The scope-local index of the dataflow.
-`name`     | [`text`]   | The internal name of the dataflow.
-
-### `mz_dataflow_addresses`
-
-The `mz_dataflow_addresses` source describes how the dataflow channels
-and operators in the system are nested into scopes.
-
-Field       | Type            | Meaning
-------------|-----------------|--------
-`id`        | [`bigint`]      | The ID of the channel or operator. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels) or [`mz_dataflow_operators.id`](#mz_dataflow_operators).
-`worker_id` | [`bigint`]      | The ID of the worker thread hosting the channel or operator.
-`address`   | [`bigint list`] | A list of scope-local indexes indicating the path from the root to this channel or operator.
-
-### `mz_dataflow_operator_dataflows`
-
-The `mz_dataflow_operator_dataflows` view describes the [dataflow] to which each
-dataflow operator belongs.
-
-Field           | Type       | Meaning
-----------------|------------|--------
-`id`            | [`bigint`] | The ID of the operator.
-`name`          | [`text`]   | The internal name of the operator.
-`worker_id`     | [`bigint`] | The ID of the worker thread hosting the operator.
-`dataflow_id`   | [`bigint`] | The ID of the dataflow hosting the operator.
-`dataflow_name` | [`text`]   | The name of the dataflow hosting the operator.
-
-### `mz_dataflow_operators`
-
-The `mz_dataflow_operators` source describes the dataflow operators in the
-system.
-
-Field       | Type       | Meaning
-------------|------------|--------
-`id`        | [`bigint`] | The ID of the operator.
-`worker_id` | [`bigint`] | The ID of the worker thread hosting the operator.
-`name`      | [`text`]   | The name of the operator.
 
 ### `mz_functions`
 
@@ -249,71 +168,6 @@ Field        | Type     | Meaning
 `type_id`    | [`text`] | The ID of the list type.
 `element_id` | [`text`] | The IID of the list's element type.
 
-### `mz_message_counts`
-
-The `mz_message_counts` source describes the messages sent and received over the
-dataflow channels in the system.
-
-Field             | Type       | Meaning
-------------------|------------|--------
-`channel_id`      | [`bigint`] | The ID of the channel. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels).
-`from_worker_id`  | [`bigint`] | The ID of the worker thread sending the message.
-`to_worker_id`    | [`bigint`] | The ID of the worker thread receiving the message.
-`sent`            | [`bigint`] | The number of messages sent.
-`received`        | [`bigint`] | The number of messages received.
-
-### `mz_worker_materialization_dependencies`
-
-The `mz_worker_materialization_dependencies` source describes the dependency structure
-between each [dataflow] and the sources of their data. To create a complete dependency
-structure, the `import_id` column includes other dataflows.
-
-Field      | Type       | Meaning
------------|------------|--------
-`export_id`| [`text`]   | The ID of the object that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
-`import_id`| [`text`]   | The ID of the storage source. Corresponds to [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materializations.object_id`](#mz_materializations).
-`worker_id`| [`bigint`] | The ID of the worker thread hosting the dataflow.
-
-### `mz_materialization_frontiers`
-
-The `mz_materialization_frontiers` view describes the frontier for each
-[dataflow] in the system across all workers. The frontier describes the earliest
-timestamp at which the output of the dataflow may change; data prior to that
-timestamp is sealed.
-
-For per-worker frontier information, see
-[`mz_worker_materialization_frontiers`](#mz_worker_materialization_frontiers).
-
-Field        | Type       | Meaning
--------------|------------|--------
-`object_id ` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
-`time`       | [`mztimestamp`] | The next timestamp at which the materialization may change.
-
-### `mz_materialization_source_frontiers`
-
-The `mz_materialization_source_frontiers` view describes the frontiers for every
-storage source used in a [dataflow] in the system across all workers. The frontier
-describes the earliest timestamp at which the output of the source instantiation
-at the dataflow layer may change; data prior to that timestamp is sealed.
-
-For per-worker frontier information, see
-[`mz_worker_materialization_source_frontiers`](#mz_worker_materialization_source_frontiers).
-
-Field       | Type       | Meaning
-------------|------------|--------
-`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
-`source_id` | [`text`]   | The ID of the input storage source for the dataflow. Corresponds to either [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materialized_views.id`](#mz_materialized_views).
-`time`      | [`mztimestamp`] | The next timestamp at which the source instantiation may change.
-
-### `mz_materializations`
-
-The `mz_materializations` source describes the dataflows created by indexes and materialized views in the system.
-
-Field       | Type       | Meaning
-------------|------------|--------
-`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_indexes.id`](#mz_indexes) or [`mz_materialized_views.id`](#mz_materialized_views).
-`worker_id` | [`bigint`] | The ID of the worker thread hosting the corresponding [dataflow].
-
 ### `mz_materialized_views`
 
 The `mz_materialized_views` table contains a row for each materialized view in the system.
@@ -354,29 +208,6 @@ Field       | Type       | Meaning
 `name`      | [`text`]   | The name of the object.
 `type`      | [`text`]   | The type of the object: one of `table`, `source`, `view`, `materialized view`, `sink`, `index`, `connection`, `secret`, `type`, or `function`.
 
-### `mz_peek_active`
-
-The `mz_peek_active` source describes all read queries ("peeks") that are
-pending in the dataflow layer.
-
-Field      | Type       | Meaning
------------|------------|--------
-`id`       | [`uuid`]   | The ID of the peek request.
-`worker_id`| [`bigint`] | The ID of the worker thread servicing the peek.
-`index_id` | [`text`]   | The ID of the index the peek is targeting.
-`time`     | [`mztimestamp`] | The timestamp the peek has requested.
-
-### `mz_peek_durations`
-
-The `mz_peek_durations` source describes a histogram of the duration of read
-queries ("peeks") in the dataflow layer.
-
-Field         | Type       | Meaning
---------------|------------|--------
-`worker_id`   | [`bigint`] | The ID of the worker thread servicing the peek.
-`duration_ns` | [`bigint`] | The upper bound of the bucket in nanoseconds.
-`count`       | [`bigint`] | The (noncumulative) count of peeks in this bucket.
-
 ### `mz_pseudo_types`
 
 The `mz_pseudo_types` table contains a row for each pseudo type in the system.
@@ -384,48 +215,6 @@ The `mz_pseudo_types` table contains a row for each pseudo type in the system.
 Field          | Type       | Meaning
 ---------------|------------|----------
 `type_id`      | [`text`]   | The ID of the type.
-
-### `mz_records_per_dataflow`
-
-The `mz_records_per_dataflow` view describes the number of records in each
-[dataflow] on each worker in the system.
-
-For the same information aggregated across all workers, see
-[`mz_records_per_dataflow_global`](#mz_records_per_dataflow_global).
-
-Field       | Type        | Meaning
-------------|-------------|--------
-`id`        | [`bigint`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
-`name`      | [`text`]    | The internal name of the dataflow.
-`worker_id` | [`bigint`]  | The ID of the worker thread hosting the dataflow.
-`records`   | [`numeric`] | The number of records in the dataflow.
-
-### `mz_records_per_dataflow_global`
-
-The `mz_records_per_dataflow_global` view describes the number of records in each
-[dataflow] in the system.
-
-For the same information broken down across workers, see
-[`mz_records_per_dataflow`](#mz_records_per_dataflow).
-
-Field     | Type        | Meaning
-----------|-------------|--------
-`id`      | [`bigint`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
-`name`    | [`text`]    | The internal name of the dataflow.
-`records` | [`numeric`] | The number of records in the dataflow.
-
-### `mz_records_per_dataflow_operator`
-
-The `mz_records_per_dataflow_operator` view describes the number of records in
-each [dataflow] operator in the system.
-
-Field         | Type        | Meaning
---------------|-------------|--------
-`id`          | [`bigint`]  | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
-`name`        | [`text`]    | The internal name of the dataflow.
-`worker_id`   | [`bigint`]  | The ID of the worker thread hosting the dataflow.
-`dataflow_id` | [`bigint`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
-`records`     | [`numeric`] | The number of records in the dataflow.
 
 ### `mz_relations`
 
@@ -449,41 +238,6 @@ Field  | Type       | Meaning
 `id`   | [`bigint`] | Materialize's unique ID for the role.
 `oid`  | [`oid`]    | A [PostgreSQL-compatible OID][oid] for the role.
 `name` | [`text`]   | The name of the role.
-
-### `mz_scheduling_elapsed`
-
-The `mz_scheduling_elapsed` source describes the total amount of time spent in
-each [dataflow] operator.
-
-Field        | Type       | Meaning
--------------|------------|--------
-`id`         | [`bigint`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
-`worker_id`  | [`bigint`] | The ID of the worker thread hosting the operator.
-`elapsed_ns` | [`bigint`] | The total elapsed time spent in the operator in nanoseconds.
-
-### `mz_scheduling_histogram`
-
-The `mz_scheduling_histogram` source stores a histogram describing the
-duration of each invocation for each [dataflow] operator.
-
-Field         | Type       | Meaning
---------------|------------|--------
-`id`          | [`bigint`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
-`worker_id`   | [`bigint`] | The ID of the worker thread hosting the operator.
-`duration_ns` | [`bigint`] | The upper bound of the bucket.
-`count`       | [`bigint`] | The number of recordings in the bucket.
-
-### `mz_scheduling_parks`
-
-The `mz_scheduling_parks` source stores a histogram describing [dataflow] worker
-park events. A park event occurs when a worker has no outstanding work.
-
-Field       | Type       | Meaning
-------------|------------| -------
-`worker_id` | [`bigint`] | The ID of the worker thread.
-`slept_for` | [`bigint`] | The actual length of the park event.
-`requested` | [`bigint`] | The requested length of the park event.
-`count`     | [`bigint`] | The number of park events in this bucket.
 
 ### `mz_schemas`
 
@@ -566,54 +320,6 @@ Field          | Type        | Meaning
 `name`         | [`text`]    | The name of the view.
 `definition`   | [`text`]    | The view definition (a `SELECT` query).
 
-### `mz_worker_materialization_frontiers`
-
-The `mz_worker_materialization_frontiers` source describes each worker's
-frontier for each [dataflow] in the system. The frontier describes the earliest
-timestamp at which the output of the dataflow may change; data prior to that
-timestamp is sealed.
-
-For frontier information aggregated across all workers, see
-[`mz_materialization_frontiers`](#mz_materialization_frontiers).
-
-Field       | Type       | Meaning
-------------|------------|--------
-`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
-`worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
-`time`      | [`mztimestamp`] | The next timestamp at which the dataflow may change.
-
-### `mz_worker_materialization_source_frontiers`
-
-The `mz_worker_materialization_source_frontiers` source describes the frontiers that
-each worker is aware of for every storage source used in a [dataflow] in the system. The
-frontier describes the earliest timestamp at which the output of the source instantiation
-at the dataflow layer may change; data prior to that timestamp is sealed.
-
-For frontier information aggregated across all workers, see
-[`mz_materialization_source_frontiers`](#mz_materialization_source_frontiers).
-
-Field       | Type       | Meaning
-------------|------------|--------
-`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
-`source_id` | [`text`]   | The ID of the input storage source for the dataflow. Corresponds to either [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materialized_views.id`](#mz_materialized_views).
-`worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
-`time`      | [`mztimestamp`] | The next timestamp at which the source instantiation may change.
-
-### `mz_worker_materialization_delays`
-
-The `mz_worker_materialization_delays` source provides, for each worker,
-a histogram of wall-clock delays between observations of storage source frontier
-advancements at the dataflow layer and the advancements of the corresponding
-[dataflow] frontiers.
-
-Field       | Type       | Meaning
-------------|------------|--------
-`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
-`source_id` | [`text`]   | The ID of the input storage source for the dataflow. Corresponds to either [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materialized_views.id`](#mz_materialized_views).
-`worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
-`delay_ns`  | [`bigint`] | The upper bound of the bucket in nanoseconds.
-`count`     | [`bigint`] | The (noncumulative) count of delay measurements in this bucket.
-
 ## `pg_catalog`
 
 Materialize has compatibility shims for the following relations from [PostgreSQL's
@@ -650,6 +356,308 @@ the documented [`mz_catalog`](#mz_catalog) API instead.
 If you are having trouble making a PostgreSQL tool work with Materialize, please
 [file a GitHub issue][gh-issue]. Many PostgreSQL tools can be made to work with
 Materialize with minor changes to the `pg_catalog` compatibility shim.
+
+## `mz_internal`
+
+The following sections describe the available objects in the `mz_internal`
+schema.
+
+### `mz_arrangement_sharing`
+
+The `mz_arrangement_sharing` source describes how many times each [arrangement]
+in the system is used.
+
+Field         | Type       | Meaning
+--------------|------------|--------
+`operator_id` | [`bigint`] | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+`worker_id`   | [`bigint`] | The ID of the worker thread hosting the arrangement.
+`count`       | [`bigint`] | The number of operators that share the arrangement.
+
+### `mz_arrangement_sizes`
+
+The `mz_arrangement_sizes` source describes the size of each [arrangement] in
+the system.
+
+Field         | Type       | Meaning
+--------------|------------|--------
+`operator_id` | [`bigint`] | The ID of the operator that created the arrangement. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+`worker_id`   | [`bigint`] | The ID of the worker thread hosting the arrangement.
+`records`     | [`bigint`] | The number of records in the arrangement.
+`batches`     | [`bigint`] | The number of batches in the arrangement.
+
+### `mz_dataflows`
+
+The `mz_dataflows` view describes the [dataflows][dataflow] in the system.
+
+Field      | Type       | Meaning
+-----------|------------|--------
+`id`       | [`bigint`] | The ID of the dataflow.
+`worker_id`| [`bigint`] | The ID of the worker thread hosting the dataflow.
+`local_id` | [`bigint`] | The scope-local index of the dataflow.
+`name`     | [`text`]   | The internal name of the dataflow.
+
+### `mz_dataflow_addresses`
+
+The `mz_dataflow_addresses` source describes how the dataflow channels
+and operators in the system are nested into scopes.
+
+Field       | Type            | Meaning
+------------|-----------------|--------
+`id`        | [`bigint`]      | The ID of the channel or operator. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels) or [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+`worker_id` | [`bigint`]      | The ID of the worker thread hosting the channel or operator.
+`address`   | [`bigint list`] | A list of scope-local indexes indicating the path from the root to this channel or operator.
+
+### `mz_dataflow_channels`
+
+The `mz_dataflow_channels` source describes the communication channels between
+[dataflow] operators. A communication channel connects one of the outputs of a
+source operator to one of the inputs of a target operator.
+
+Field           | Type       | Meaning
+----------------|------------|--------
+`id`            | [`bigint`] | The ID of the channel.
+`worker_id`     | [`bigint`] | The ID of the worker thread hosting the channel.
+`from_index`    | [`bigint`] | The scope-local index of the source operator. Corresponds to an address in [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
+`from_port`      | [`bigint`] | The source operator's output port.
+`to_index`      | [`bigint`] | The scope-local index of the target operator. Corresponds to an address in [`mz_dataflow_addresses.address`](#mz_dataflow_addresses).
+`to_port`       | [`bigint`] | The target operator's input port.
+
+### `mz_dataflow_operators`
+
+The `mz_dataflow_operators` source describes the dataflow operators in the
+system.
+
+Field       | Type       | Meaning
+------------|------------|--------
+`id`        | [`bigint`] | The ID of the operator.
+`worker_id` | [`bigint`] | The ID of the worker thread hosting the operator.
+`name`      | [`text`]   | The name of the operator.
+
+### `mz_dataflow_operator_dataflows`
+
+The `mz_dataflow_operator_dataflows` view describes the [dataflow] to which each
+dataflow operator belongs.
+
+Field           | Type       | Meaning
+----------------|------------|--------
+`id`            | [`bigint`] | The ID of the operator.
+`name`          | [`text`]   | The internal name of the operator.
+`worker_id`     | [`bigint`] | The ID of the worker thread hosting the operator.
+`dataflow_id`   | [`bigint`] | The ID of the dataflow hosting the operator.
+`dataflow_name` | [`text`]   | The name of the dataflow hosting the operator.
+
+### `mz_materializations`
+
+The `mz_materializations` source describes the dataflows created by indexes and materialized views in the system.
+
+Field       | Type       | Meaning
+------------|------------|--------
+`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_indexes.id`](#mz_indexes) or [`mz_materialized_views.id`](#mz_materialized_views).
+`worker_id` | [`bigint`] | The ID of the worker thread hosting the corresponding [dataflow].
+
+### `mz_materialization_frontiers`
+
+The `mz_materialization_frontiers` view describes the frontier for each
+[dataflow] in the system across all workers. The frontier describes the earliest
+timestamp at which the output of the dataflow may change; data prior to that
+timestamp is sealed.
+
+For per-worker frontier information, see
+[`mz_worker_materialization_frontiers`](#mz_worker_materialization_frontiers).
+
+Field        | Type       | Meaning
+-------------|------------|--------
+`object_id ` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
+`time`       | [`mztimestamp`] | The next timestamp at which the materialization may change.
+
+### `mz_materialization_source_frontiers`
+
+The `mz_materialization_source_frontiers` view describes the frontiers for every
+storage source used in a [dataflow] in the system across all workers. The frontier
+describes the earliest timestamp at which the output of the source instantiation
+at the dataflow layer may change; data prior to that timestamp is sealed.
+
+For per-worker frontier information, see
+[`mz_worker_materialization_source_frontiers`](#mz_worker_materialization_source_frontiers).
+
+Field       | Type       | Meaning
+------------|------------|--------
+`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
+`source_id` | [`text`]   | The ID of the input storage source for the dataflow. Corresponds to either [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materialized_views.id`](#mz_materialized_views).
+`time`      | [`mztimestamp`] | The next timestamp at which the source instantiation may change.
+
+### `mz_message_counts`
+
+The `mz_message_counts` source describes the messages sent and received over the
+dataflow channels in the system.
+
+Field             | Type       | Meaning
+------------------|------------|--------
+`channel_id`      | [`bigint`] | The ID of the channel. Corresponds to [`mz_dataflow_channels.id`](#mz_dataflow_channels).
+`from_worker_id`  | [`bigint`] | The ID of the worker thread sending the message.
+`to_worker_id`    | [`bigint`] | The ID of the worker thread receiving the message.
+`sent`            | [`bigint`] | The number of messages sent.
+`received`        | [`bigint`] | The number of messages received.
+
+### `mz_peek_active`
+
+The `mz_peek_active` source describes all read queries ("peeks") that are
+pending in the dataflow layer.
+
+Field      | Type       | Meaning
+-----------|------------|--------
+`id`       | [`uuid`]   | The ID of the peek request.
+`worker_id`| [`bigint`] | The ID of the worker thread servicing the peek.
+`index_id` | [`text`]   | The ID of the index the peek is targeting.
+`time`     | [`mztimestamp`] | The timestamp the peek has requested.
+
+### `mz_peek_durations`
+
+The `mz_peek_durations` source describes a histogram of the duration of read
+queries ("peeks") in the dataflow layer.
+
+Field         | Type       | Meaning
+--------------|------------|--------
+`worker_id`   | [`bigint`] | The ID of the worker thread servicing the peek.
+`duration_ns` | [`bigint`] | The upper bound of the bucket in nanoseconds.
+`count`       | [`bigint`] | The (noncumulative) count of peeks in this bucket.
+
+### `mz_records_per_dataflow`
+
+The `mz_records_per_dataflow` view describes the number of records in each
+[dataflow] on each worker in the system.
+
+For the same information aggregated across all workers, see
+[`mz_records_per_dataflow_global`](#mz_records_per_dataflow_global).
+
+Field       | Type        | Meaning
+------------|-------------|--------
+`id`        | [`bigint`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+`name`      | [`text`]    | The internal name of the dataflow.
+`worker_id` | [`bigint`]  | The ID of the worker thread hosting the dataflow.
+`records`   | [`numeric`] | The number of records in the dataflow.
+
+### `mz_records_per_dataflow_global`
+
+The `mz_records_per_dataflow_global` view describes the number of records in each
+[dataflow] in the system.
+
+For the same information broken down across workers, see
+[`mz_records_per_dataflow`](#mz_records_per_dataflow).
+
+Field     | Type        | Meaning
+----------|-------------|--------
+`id`      | [`bigint`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+`name`    | [`text`]    | The internal name of the dataflow.
+`records` | [`numeric`] | The number of records in the dataflow.
+
+### `mz_records_per_dataflow_operator`
+
+The `mz_records_per_dataflow_operator` view describes the number of records in
+each [dataflow] operator in the system.
+
+Field         | Type        | Meaning
+--------------|-------------|--------
+`id`          | [`bigint`]  | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+`name`        | [`text`]    | The internal name of the dataflow.
+`worker_id`   | [`bigint`]  | The ID of the worker thread hosting the dataflow.
+`dataflow_id` | [`bigint`]  | The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+`records`     | [`numeric`] | The number of records in the dataflow.
+
+### `mz_scheduling_elapsed`
+
+The `mz_scheduling_elapsed` source describes the total amount of time spent in
+each [dataflow] operator.
+
+Field        | Type       | Meaning
+-------------|------------|--------
+`id`         | [`bigint`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+`worker_id`  | [`bigint`] | The ID of the worker thread hosting the operator.
+`elapsed_ns` | [`bigint`] | The total elapsed time spent in the operator in nanoseconds.
+
+### `mz_scheduling_histogram`
+
+The `mz_scheduling_histogram` source stores a histogram describing the
+duration of each invocation for each [dataflow] operator.
+
+Field         | Type       | Meaning
+--------------|------------|--------
+`id`          | [`bigint`] | The ID of the operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+`worker_id`   | [`bigint`] | The ID of the worker thread hosting the operator.
+`duration_ns` | [`bigint`] | The upper bound of the bucket.
+`count`       | [`bigint`] | The number of recordings in the bucket.
+
+### `mz_scheduling_parks`
+
+The `mz_scheduling_parks` source stores a histogram describing [dataflow] worker
+park events. A park event occurs when a worker has no outstanding work.
+
+Field       | Type       | Meaning
+------------|------------| -------
+`worker_id` | [`bigint`] | The ID of the worker thread.
+`slept_for` | [`bigint`] | The actual length of the park event.
+`requested` | [`bigint`] | The requested length of the park event.
+`count`     | [`bigint`] | The number of park events in this bucket.
+
+### `mz_worker_materialization_delays`
+
+The `mz_worker_materialization_delays` source provides, for each worker,
+a histogram of wall-clock delays between observations of storage source frontier
+advancements at the dataflow layer and the advancements of the corresponding
+[dataflow] frontiers.
+
+Field       | Type       | Meaning
+------------|------------|--------
+`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
+`source_id` | [`text`]   | The ID of the input storage source for the dataflow. Corresponds to either [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materialized_views.id`](#mz_materialized_views).
+`worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
+`delay_ns`  | [`bigint`] | The upper bound of the bucket in nanoseconds.
+`count`     | [`bigint`] | The (noncumulative) count of delay measurements in this bucket.
+
+### `mz_worker_materialization_dependencies`
+
+The `mz_worker_materialization_dependencies` source describes the dependency structure
+between each [dataflow] and the sources of their data. To create a complete dependency
+structure, the `import_id` column includes other dataflows.
+
+Field      | Type       | Meaning
+-----------|------------|--------
+`export_id`| [`text`]   | The ID of the object that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
+`import_id`| [`text`]   | The ID of the storage source. Corresponds to [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materializations.object_id`](#mz_materializations).
+`worker_id`| [`bigint`] | The ID of the worker thread hosting the dataflow.
+
+### `mz_worker_materialization_frontiers`
+
+The `mz_worker_materialization_frontiers` source describes each worker's
+frontier for each [dataflow] in the system. The frontier describes the earliest
+timestamp at which the output of the dataflow may change; data prior to that
+timestamp is sealed.
+
+For frontier information aggregated across all workers, see
+[`mz_materialization_frontiers`](#mz_materialization_frontiers).
+
+Field       | Type       | Meaning
+------------|------------|--------
+`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
+`worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
+`time`      | [`mztimestamp`] | The next timestamp at which the dataflow may change.
+
+### `mz_worker_materialization_source_frontiers`
+
+The `mz_worker_materialization_source_frontiers` source describes the frontiers that
+each worker is aware of for every storage source used in a [dataflow] in the system. The
+frontier describes the earliest timestamp at which the output of the source instantiation
+at the dataflow layer may change; data prior to that timestamp is sealed.
+
+For frontier information aggregated across all workers, see
+[`mz_materialization_source_frontiers`](#mz_materialization_source_frontiers).
+
+Field       | Type       | Meaning
+------------|------------|--------
+`object_id` | [`text`]   | The ID of the index or materialized view that created the dataflow. Corresponds to [`mz_materializations.object_id`](#mz_materializations).
+`source_id` | [`text`]   | The ID of the input storage source for the dataflow. Corresponds to either [`mz_sources.id`](#mz_sources) or [`mz_tables.id`](#mz_tables) or [`mz_materialized_views.id`](#mz_materialized_views).
+`worker_id` | [`bigint`] | The ID of the worker thread hosting the dataflow.
+`time`      | [`mztimestamp`] | The next timestamp at which the source instantiation may change.
 
 ## `information_schema`
 

--- a/doc/user/content/sql/tail.md
+++ b/doc/user/content/sql/tail.md
@@ -188,7 +188,7 @@ First, declare a `TAIL` cursor:
 
 ```sql
 BEGIN;
-DECLARE c CURSOR FOR TAIL (SELECT * FROM mz_scheduling_elapsed);
+DECLARE c CURSOR FOR TAIL (SELECT * FROM mz_internal.mz_scheduling_elapsed);
 ```
 
 Then, use [`FETCH`](/sql/fetch) in a loop to retrieve each batch of results as soon as it's ready:
@@ -222,7 +222,7 @@ FETCH ALL c WITH (timeout='0s');
 If you want to use `TAIL` from an interactive SQL session (e.g.`psql`), wrap the query in `COPY`:
 
 ```sql
-COPY (TAIL (SELECT * FROM mz_scheduling_elapsed)) TO STDOUT;
+COPY (TAIL (SELECT * FROM mz_internal.mz_scheduling_elapsed)) TO STDOUT;
 ```
 
 | Additional guides |

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2862,6 +2862,10 @@ impl<S: Append> Catalog<S> {
         self.state.get_information_schema_id()
     }
 
+    pub fn get_mz_internal_schema_id(&self) -> &SchemaId {
+        self.state.get_mz_internal_schema_id()
+    }
+
     pub fn get_database(&self, id: &DatabaseId) -> &Database {
         self.state.get_database(id)
     }

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -610,7 +610,7 @@ impl CatalogState {
                         qualifiers: ObjectQualifiers {
                             database_spec: ResolvedDatabaseSpecifier::Ambient,
                             schema_spec: SchemaSpecifier::Id(
-                                self.get_mz_catalog_schema_id().clone(),
+                                self.get_mz_internal_schema_id().clone(),
                             ),
                         },
                         item: index_name.clone(),

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -364,7 +364,7 @@ impl CatalogState {
             let source_name = QualifiedObjectName {
                 qualifiers: ObjectQualifiers {
                     database_spec: ResolvedDatabaseSpecifier::Ambient,
-                    schema_spec: SchemaSpecifier::Id(self.get_mz_catalog_schema_id().clone()),
+                    schema_spec: SchemaSpecifier::Id(self.get_mz_internal_schema_id().clone()),
                 },
                 item: format!("{}_{}", log.name, replica_id),
             };
@@ -377,7 +377,7 @@ impl CatalogState {
             assert!(name_template.find("{}").is_some());
             let name = name_template.replace("{}", &replica_id.to_string());
             let sql = "CREATE VIEW ".to_string()
-                + MZ_CATALOG_SCHEMA
+                + MZ_INTERNAL_SCHEMA
                 + "."
                 + &name
                 + " AS "
@@ -392,7 +392,7 @@ impl CatalogState {
                         qualifiers: ObjectQualifiers {
                             database_spec: ResolvedDatabaseSpecifier::Ambient,
                             schema_spec: SchemaSpecifier::Id(
-                                self.get_mz_catalog_schema_id().clone(),
+                                self.get_mz_internal_schema_id().clone(),
                             ),
                         },
                         item: name,
@@ -839,6 +839,10 @@ impl CatalogState {
 
     pub fn get_information_schema_id(&self) -> &SchemaId {
         &self.ambient_schemas_by_name[INFORMATION_SCHEMA]
+    }
+
+    pub fn get_mz_internal_schema_id(&self) -> &SchemaId {
+        &self.ambient_schemas_by_name[MZ_INTERNAL_SCHEMA]
     }
 
     pub fn is_system_schema(&self, schema: &str) -> bool {

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -927,115 +927,115 @@ pub const TYPE_MZTIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
 
 pub const MZ_DATAFLOW_OPERATORS: BuiltinLog = BuiltinLog {
     name: "mz_dataflow_operators",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Operates),
 };
 
 pub const MZ_DATAFLOW_OPERATORS_ADDRESSES: BuiltinLog = BuiltinLog {
     name: "mz_dataflow_addresses",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Addresses),
 };
 
 pub const MZ_DATAFLOW_CHANNELS: BuiltinLog = BuiltinLog {
     name: "mz_dataflow_channels",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Channels),
 };
 
 pub const MZ_SCHEDULING_ELAPSED_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_scheduling_elapsed_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Elapsed),
 };
 
 pub const MZ_SCHEDULING_HISTOGRAM_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_scheduling_histogram_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Histogram),
 };
 
 pub const MZ_SCHEDULING_PARKS_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_scheduling_parks_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Parks),
 };
 
 pub const MZ_ARRANGEMENT_BATCHES_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_arrangement_batches_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Differential(DifferentialLog::ArrangementBatches),
 };
 
 pub const MZ_ARRANGEMENT_SHARING_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_arrangement_sharing_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Differential(DifferentialLog::Sharing),
 };
 
 pub const MZ_MATERIALIZATIONS: BuiltinLog = BuiltinLog {
     name: "mz_materializations",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::DataflowCurrent),
 };
 
 pub const MZ_WORKER_MATERIALIZATION_DEPENDENCIES: BuiltinLog = BuiltinLog {
     name: "mz_worker_materialization_dependencies",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::DataflowDependency),
 };
 
 pub const MZ_WORKER_MATERIALIZATION_FRONTIERS: BuiltinLog = BuiltinLog {
     name: "mz_worker_materialization_frontiers",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::FrontierCurrent),
 };
 
 pub const MZ_WORKER_MATERIALIZATION_SOURCE_FRONTIERS: BuiltinLog = BuiltinLog {
     name: "mz_worker_materialization_source_frontiers",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::SourceFrontierCurrent),
 };
 
 pub const MZ_WORKER_MATERIALIZATION_DELAYS: BuiltinLog = BuiltinLog {
     name: "mz_worker_materialization_delays",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::FrontierDelay),
 };
 
 pub const MZ_PEEK_ACTIVE: BuiltinLog = BuiltinLog {
     name: "mz_peek_active",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::PeekCurrent),
 };
 
 pub const MZ_PEEK_DURATIONS: BuiltinLog = BuiltinLog {
     name: "mz_peek_durations",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::PeekDuration),
 };
 
 pub const MZ_MESSAGE_COUNTS_RECEIVED_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_message_counts_received_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::MessagesReceived),
 };
 
 pub const MZ_MESSAGE_COUNTS_SENT_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_message_counts_sent_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::MessagesSent),
 };
 
 pub const MZ_DATAFLOW_OPERATOR_REACHABILITY_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_dataflow_operator_reachability_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Reachability),
 };
 
 pub const MZ_ARRANGEMENT_RECORDS_INTERNAL: BuiltinLog = BuiltinLog {
     name: "mz_arrangement_records_internal",
-    schema: MZ_CATALOG_SCHEMA,
+    schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Differential(DifferentialLog::ArrangementRecords),
 };
 
@@ -1371,15 +1371,15 @@ UNION ALL
 
 pub const MZ_DATAFLOWS: BuiltinView = BuiltinView {
     name: "mz_dataflows",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_dataflows AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_dataflows AS SELECT
     mz_dataflow_addresses.id,
     mz_dataflow_addresses.worker_id,
     mz_dataflow_addresses.address[1] AS local_id,
     mz_dataflow_operators.name
 FROM
-    mz_catalog.mz_dataflow_addresses,
-    mz_catalog.mz_dataflow_operators
+    mz_internal.mz_dataflow_addresses,
+    mz_internal.mz_dataflow_operators
 WHERE
     mz_dataflow_addresses.id = mz_dataflow_operators.id AND
     mz_dataflow_addresses.worker_id = mz_dataflow_operators.worker_id AND
@@ -1388,17 +1388,17 @@ WHERE
 
 pub const MZ_DATAFLOW_OPERATOR_DATAFLOWS: BuiltinView = BuiltinView {
     name: "mz_dataflow_operator_dataflows",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_dataflow_operator_dataflows AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_dataflow_operator_dataflows AS SELECT
     mz_dataflow_operators.id,
     mz_dataflow_operators.name,
     mz_dataflow_operators.worker_id,
     mz_dataflows.id as dataflow_id,
     mz_dataflows.name as dataflow_name
 FROM
-    mz_catalog.mz_dataflow_operators,
-    mz_catalog.mz_dataflow_addresses,
-    mz_catalog.mz_dataflows
+    mz_internal.mz_dataflow_operators,
+    mz_internal.mz_dataflow_addresses,
+    mz_internal.mz_dataflows
 WHERE
     mz_dataflow_operators.id = mz_dataflow_addresses.id AND
     mz_dataflow_operators.worker_id = mz_dataflow_addresses.worker_id AND
@@ -1435,33 +1435,33 @@ LEFT OUTER JOIN counts
 
 pub const MZ_MATERIALIZATION_FRONTIERS: BuiltinView = BuiltinView {
     name: "mz_materialization_frontiers",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_materialization_frontiers AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_materialization_frontiers AS SELECT
     object_id, pg_catalog.min(time) AS time
-FROM mz_catalog.mz_worker_materialization_frontiers
+FROM mz_internal.mz_worker_materialization_frontiers
 GROUP BY object_id",
 };
 
 pub const MZ_MATERIALIZATION_SOURCE_FRONTIERS: BuiltinView = BuiltinView {
     name: "mz_materialization_source_frontiers",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_materialization_source_frontiers AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_materialization_source_frontiers AS SELECT
     object_id, source_id, pg_catalog.min(time) AS time
-FROM mz_catalog.mz_worker_materialization_source_frontiers
+FROM mz_internal.mz_worker_materialization_source_frontiers
 GROUP BY object_id, source_id",
 };
 
 pub const MZ_RECORDS_PER_DATAFLOW_OPERATOR: BuiltinView = BuiltinView {
     name: "mz_records_per_dataflow_operator",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_records_per_dataflow_operator AS
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_records_per_dataflow_operator AS
 WITH records_cte AS (
     SELECT
         operator_id,
         worker_id,
         pg_catalog.count(*) AS records
     FROM
-        mz_catalog.mz_arrangement_records_internal
+        mz_internal.mz_arrangement_records_internal
     GROUP BY
         operator_id, worker_id
 )
@@ -1473,7 +1473,7 @@ SELECT
     records_cte.records
 FROM
     records_cte,
-    mz_catalog.mz_dataflow_operator_dataflows
+    mz_internal.mz_dataflow_operator_dataflows
 WHERE
     mz_dataflow_operator_dataflows.id = records_cte.operator_id AND
     mz_dataflow_operator_dataflows.worker_id = records_cte.worker_id",
@@ -1481,15 +1481,15 @@ WHERE
 
 pub const MZ_RECORDS_PER_DATAFLOW: BuiltinView = BuiltinView {
     name: "mz_records_per_dataflow",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_records_per_dataflow AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_records_per_dataflow AS SELECT
     mz_records_per_dataflow_operator.dataflow_id as id,
     mz_dataflows.name,
     mz_records_per_dataflow_operator.worker_id,
     pg_catalog.SUM(mz_records_per_dataflow_operator.records) as records
 FROM
-    mz_catalog.mz_records_per_dataflow_operator,
-    mz_catalog.mz_dataflows
+    mz_internal.mz_records_per_dataflow_operator,
+    mz_internal.mz_dataflows
 WHERE
     mz_records_per_dataflow_operator.dataflow_id = mz_dataflows.id AND
     mz_records_per_dataflow_operator.worker_id = mz_dataflows.worker_id
@@ -1501,13 +1501,13 @@ GROUP BY
 
 pub const MZ_RECORDS_PER_DATAFLOW_GLOBAL: BuiltinView = BuiltinView {
     name: "mz_records_per_dataflow_global",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_records_per_dataflow_global AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_records_per_dataflow_global AS SELECT
     mz_records_per_dataflow.id,
     mz_records_per_dataflow.name,
     pg_catalog.SUM(mz_records_per_dataflow.records) as records
 FROM
-    mz_catalog.mz_records_per_dataflow
+    mz_internal.mz_records_per_dataflow
 GROUP BY
     mz_records_per_dataflow.id,
     mz_records_per_dataflow.name",
@@ -1808,41 +1808,41 @@ FROM (VALUES
 
 pub const MZ_SCHEDULING_ELAPSED: BuiltinView = BuiltinView {
     name: "mz_scheduling_elapsed",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_scheduling_elapsed AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_scheduling_elapsed AS SELECT
     id, worker_id, pg_catalog.count(*) AS elapsed_ns
 FROM
-    mz_catalog.mz_scheduling_elapsed_internal
+    mz_internal.mz_scheduling_elapsed_internal
 GROUP BY
     id, worker_id",
 };
 
 pub const MZ_SCHEDULING_HISTOGRAM: BuiltinView = BuiltinView {
     name: "mz_scheduling_histogram",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_scheduling_histogram AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_scheduling_histogram AS SELECT
     id, worker_id, duration_ns, pg_catalog.count(*) AS count
 FROM
-    mz_catalog.mz_scheduling_histogram_internal
+    mz_internal.mz_scheduling_histogram_internal
 GROUP BY
     id, worker_id, duration_ns",
 };
 
 pub const MZ_SCHEDULING_PARKS: BuiltinView = BuiltinView {
     name: "mz_scheduling_parks",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_scheduling_parks AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_scheduling_parks AS SELECT
     worker_id, slept_for, requested, pg_catalog.count(*) AS count
 FROM
-    mz_catalog.mz_scheduling_parks_internal
+    mz_internal.mz_scheduling_parks_internal
 GROUP BY
     worker_id, slept_for, requested",
 };
 
 pub const MZ_MESSAGE_COUNTS: BuiltinView = BuiltinView {
     name: "mz_message_counts",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_message_counts AS
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_message_counts AS
 WITH sent_cte AS (
     SELECT
         channel_id,
@@ -1850,7 +1850,7 @@ WITH sent_cte AS (
         to_worker_id,
         pg_catalog.count(*) AS sent
     FROM
-        mz_catalog.mz_message_counts_sent_internal
+        mz_internal.mz_message_counts_sent_internal
     GROUP BY
         channel_id, from_worker_id, to_worker_id
 ),
@@ -1861,7 +1861,7 @@ received_cte AS (
         to_worker_id,
         pg_catalog.count(*) AS received
     FROM
-        mz_catalog.mz_message_counts_received_internal
+        mz_internal.mz_message_counts_received_internal
     GROUP BY
         channel_id, from_worker_id, to_worker_id
 )
@@ -1876,8 +1876,8 @@ FROM sent_cte JOIN received_cte USING (channel_id, from_worker_id, to_worker_id)
 
 pub const MZ_DATAFLOW_OPERATOR_REACHABILITY: BuiltinView = BuiltinView {
     name: "mz_dataflow_operator_reachability",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_dataflow_operator_reachability AS SELECT
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_dataflow_operator_reachability AS SELECT
     address,
     port,
     worker_id,
@@ -1885,21 +1885,21 @@ pub const MZ_DATAFLOW_OPERATOR_REACHABILITY: BuiltinView = BuiltinView {
     timestamp,
     pg_catalog.count(*) as count
 FROM
-    mz_catalog.mz_dataflow_operator_reachability_internal
+    mz_internal.mz_dataflow_operator_reachability_internal
 GROUP BY address, port, worker_id, update_type, timestamp",
 };
 
 pub const MZ_ARRANGEMENT_SIZES: BuiltinView = BuiltinView {
     name: "mz_arrangement_sizes",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_arrangement_sizes AS
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_arrangement_sizes AS
 WITH batches_cte AS (
     SELECT
         operator_id,
         worker_id,
         pg_catalog.count(*) AS batches
     FROM
-        mz_catalog.mz_arrangement_batches_internal
+        mz_internal.mz_arrangement_batches_internal
     GROUP BY
         operator_id, worker_id
 ),
@@ -1909,7 +1909,7 @@ records_cte AS (
         worker_id,
         pg_catalog.count(*) AS records
     FROM
-        mz_catalog.mz_arrangement_records_internal
+        mz_internal.mz_arrangement_records_internal
     GROUP BY
         operator_id, worker_id
 )
@@ -1923,13 +1923,13 @@ FROM batches_cte JOIN records_cte USING (operator_id, worker_id)",
 
 pub const MZ_ARRANGEMENT_SHARING: BuiltinView = BuiltinView {
     name: "mz_arrangement_sharing",
-    schema: MZ_CATALOG_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_arrangement_sharing AS
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_arrangement_sharing AS
 SELECT
     operator_id,
     worker_id,
     pg_catalog.count(*) AS count
-FROM mz_catalog.mz_arrangement_sharing_internal
+FROM mz_internal.mz_arrangement_sharing_internal
 GROUP BY operator_id, worker_id",
 };
 

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -590,6 +590,10 @@ impl<S: Append + 'static> Coordinator<S> {
                 &ResolvedDatabaseSpecifier::Ambient,
                 &SchemaSpecifier::Id(self.catalog.get_information_schema_id().clone()),
             ),
+            (
+                &ResolvedDatabaseSpecifier::Ambient,
+                &SchemaSpecifier::Id(self.catalog.get_mz_internal_schema_id().clone()),
+            ),
         ];
         if system_schemas.iter().any(|s| schemas.contains(s)) {
             schemas.extend(system_schemas);

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -329,7 +329,7 @@ impl LogView {
                     operator_id,
                     worker_id,
                     pg_catalog.count(*) AS count
-                FROM mz_catalog.mz_arrangement_sharing_internal_{}
+                FROM mz_internal.mz_arrangement_sharing_internal_{}
                 GROUP BY operator_id, worker_id",
                 "mz_arrangement_sharing_{}",
             ),
@@ -341,7 +341,7 @@ impl LogView {
                         worker_id,
                         pg_catalog.count(*) AS batches
                     FROM
-                        mz_catalog.mz_arrangement_batches_internal_{}
+                        mz_internal.mz_arrangement_batches_internal_{}
                     GROUP BY
                         operator_id, worker_id
                 ),
@@ -351,7 +351,7 @@ impl LogView {
                         worker_id,
                         pg_catalog.count(*) AS records
                     FROM
-                        mz_catalog.mz_arrangement_records_internal_{}
+                        mz_internal.mz_arrangement_records_internal_{}
                     GROUP BY
                         operator_id, worker_id
                 )
@@ -370,8 +370,8 @@ impl LogView {
                         mz_dataflow_addresses_{}.address[1] AS local_id,
                         mz_dataflow_operators_{}.name
                  FROM
-                        mz_catalog.mz_dataflow_addresses_{},
-                        mz_catalog.mz_dataflow_operators_{}
+                        mz_internal.mz_dataflow_addresses_{},
+                        mz_internal.mz_dataflow_operators_{}
                  WHERE
                         mz_dataflow_addresses_{}.id = mz_dataflow_operators_{}.id AND
                         mz_dataflow_addresses_{}.worker_id = mz_dataflow_operators_{}.worker_id AND
@@ -387,9 +387,9 @@ impl LogView {
                     mz_dataflows_{}.id as dataflow_id,
                     mz_dataflows_{}.name as dataflow_name
                 FROM
-                    mz_catalog.mz_dataflow_operators_{},
-                    mz_catalog.mz_dataflow_addresses_{},
-                    mz_catalog.mz_dataflows_{}
+                    mz_internal.mz_dataflow_operators_{},
+                    mz_internal.mz_dataflow_addresses_{},
+                    mz_internal.mz_dataflows_{}
                 WHERE
                     mz_dataflow_operators_{}.id = mz_dataflow_addresses_{}.id AND
                     mz_dataflow_operators_{}.worker_id = mz_dataflow_addresses_{}.worker_id AND
@@ -407,7 +407,7 @@ impl LogView {
                     timestamp,
                     pg_catalog.count(*) as count
                  FROM
-                    mz_catalog.mz_dataflow_operator_reachability_internal_{}
+                    mz_internal.mz_dataflow_operator_reachability_internal_{}
                  GROUP BY address, port, worker_id, update_type, timestamp",
                 "mz_dataflow_operator_reachability_{}",
             ),
@@ -415,7 +415,7 @@ impl LogView {
             LogView::MzMaterializationFrontiers => (
                 "SELECT
                     object_id, pg_catalog.min(time) AS time
-                FROM mz_catalog.mz_worker_materialization_frontiers_{}
+                FROM mz_internal.mz_worker_materialization_frontiers_{}
                 GROUP BY object_id",
                 "mz_materialization_frontiers_{}",
             ),
@@ -428,7 +428,7 @@ impl LogView {
                         to_worker_id,
                         pg_catalog.count(*) AS sent
                     FROM
-                        mz_catalog.mz_message_counts_sent_internal_{}
+                        mz_internal.mz_message_counts_sent_internal_{}
                     GROUP BY
                         channel_id, from_worker_id, to_worker_id
                 ),
@@ -439,7 +439,7 @@ impl LogView {
                         to_worker_id,
                         pg_catalog.count(*) AS received
                     FROM
-                        mz_catalog.mz_message_counts_received_internal_{}
+                        mz_internal.mz_message_counts_received_internal_{}
                     GROUP BY
                         channel_id, from_worker_id, to_worker_id
                 )
@@ -460,7 +460,7 @@ impl LogView {
                         worker_id,
                         pg_catalog.count(*) AS records
                     FROM
-                        mz_catalog.mz_arrangement_records_internal_{}
+                        mz_internal.mz_arrangement_records_internal_{}
                     GROUP BY
                         operator_id, worker_id
                 )
@@ -472,7 +472,7 @@ impl LogView {
                     records_cte.records
                 FROM
                     records_cte,
-                    mz_catalog.mz_dataflow_operator_dataflows_{}
+                    mz_internal.mz_dataflow_operator_dataflows_{}
                 WHERE
                     mz_dataflow_operator_dataflows_{}.id = records_cte.operator_id AND
                     mz_dataflow_operator_dataflows_{}.worker_id = records_cte.worker_id",
@@ -486,8 +486,8 @@ impl LogView {
                     mz_records_per_dataflow_operator_{}.worker_id,
                     pg_catalog.SUM(mz_records_per_dataflow_operator_{}.records) as records
                 FROM
-                    mz_catalog.mz_records_per_dataflow_operator_{},
-                    mz_catalog.mz_dataflows_{}
+                    mz_internal.mz_records_per_dataflow_operator_{},
+                    mz_internal.mz_dataflows_{}
                 WHERE
                     mz_records_per_dataflow_operator_{}.dataflow_id = mz_dataflows_{}.id AND
                     mz_records_per_dataflow_operator_{}.worker_id = mz_dataflows_{}.worker_id
@@ -504,7 +504,7 @@ impl LogView {
                     mz_records_per_dataflow_{}.name,
                     pg_catalog.SUM(mz_records_per_dataflow_{}.records) as records
                 FROM
-                    mz_catalog.mz_records_per_dataflow_{}
+                    mz_internal.mz_records_per_dataflow_{}
                 GROUP BY
                     mz_records_per_dataflow_{}.id,
                     mz_records_per_dataflow_{}.name",
@@ -515,7 +515,7 @@ impl LogView {
                 "SELECT
                     id, worker_id, pg_catalog.count(*) AS elapsed_ns
                 FROM
-                    mz_catalog.mz_scheduling_elapsed_internal_{}
+                    mz_internal.mz_scheduling_elapsed_internal_{}
                 GROUP BY
                     id, worker_id",
                 "mz_scheduling_elapsed_{}",
@@ -525,7 +525,7 @@ impl LogView {
                 "SELECT
                     id, worker_id, duration_ns, pg_catalog.count(*) AS count
                 FROM
-                    mz_catalog.mz_scheduling_histogram_internal_{}
+                    mz_internal.mz_scheduling_histogram_internal_{}
                 GROUP BY
                     id, worker_id, duration_ns",
                 "mz_scheduling_histogram_{}",
@@ -535,7 +535,7 @@ impl LogView {
                 "SELECT
                     worker_id, slept_for, requested, pg_catalog.count(*) AS count
                 FROM
-                    mz_catalog.mz_scheduling_parks_internal_{}
+                    mz_internal.mz_scheduling_parks_internal_{}
                 GROUP BY
                     worker_id, slept_for, requested",
                 "mz_scheduling_parks_{}",

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -293,6 +293,7 @@ pub enum LogView {
     MzDataflowOperatorDataflows,
     MzDataflowOperatorReachability,
     MzMaterializationFrontiers,
+    MzMaterializationSourceFrontiers,
     MzMessageCounts,
     MzRecordsPerDataflowOperator,
     MzRecordsPerDataflow,
@@ -311,6 +312,7 @@ pub static DEFAULT_LOG_VIEWS: Lazy<Vec<LogView>> = Lazy::new(|| {
         LogView::MzDataflowOperatorDataflows,
         LogView::MzDataflowOperatorReachability,
         LogView::MzMaterializationFrontiers,
+        LogView::MzMaterializationSourceFrontiers,
         LogView::MzMessageCounts,
         LogView::MzRecordsPerDataflowOperator,
         LogView::MzRecordsPerDataflow,
@@ -418,6 +420,14 @@ impl LogView {
                 FROM mz_internal.mz_worker_materialization_frontiers_{}
                 GROUP BY object_id",
                 "mz_materialization_frontiers_{}",
+            ),
+
+            LogView::MzMaterializationSourceFrontiers => (
+                "SELECT
+                    object_id, source_id, pg_catalog.min(time) AS time
+                FROM mz_internal.mz_worker_materialization_source_frontiers_{}
+                GROUP BY object_id, source_id",
+                "mz_materialization_source_frontiers_{}",
             ),
 
             LogView::MzMessageCounts => (

--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -52,25 +52,25 @@ function Dataflows() {
                 SELECT DISTINCT
                     id, address
                 FROM
-                    mz_catalog.mz_dataflow_addresses;
+                    mz_internal.mz_dataflow_addresses;
 
                 SELECT DISTINCT
                     id, name
                 FROM
-                    mz_catalog.mz_dataflow_operators;
+                    mz_internal.mz_dataflow_operators;
 
                 SELECT
                     id, from_index, to_index, from_port, to_port, sum(sent) as sent
                 FROM
-                    mz_catalog.mz_dataflow_channels AS channels
-                    LEFT JOIN mz_catalog.mz_message_counts AS counts
+                    mz_internal.mz_dataflow_channels AS channels
+                    LEFT JOIN mz_internal.mz_message_counts AS counts
                         ON channels.id = counts.channel_id AND channels.worker_id = counts.from_worker_id
                 GROUP BY id, from_index, to_index, from_port, to_port;
 
                 SELECT
                     operator_id as id, sum(records)
                 FROM
-                    mz_catalog.mz_arrangement_sizes
+                    mz_internal.mz_arrangement_sizes
                 GROUP BY
                     id;
             `);

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -66,7 +66,7 @@ function Views() {
     SELECT
       id, name, records
     FROM
-      mz_catalog.mz_records_per_dataflow_global
+      mz_internal.mz_records_per_dataflow_global
     ${where_fragment}
     ORDER BY
       records DESC
@@ -165,7 +165,7 @@ function View(props) {
         SELECT
           name, records
         FROM
-          mz_catalog.mz_records_per_dataflow_global
+          mz_internal.mz_records_per_dataflow_global
         WHERE
           id = ${props.dataflow_id};
 
@@ -177,21 +177,21 @@ function View(props) {
         SELECT DISTINCT
           id, address
         FROM
-          mz_catalog.mz_dataflow_addresses
+          mz_internal.mz_dataflow_addresses
         WHERE
           id
           IN (
               SELECT
                 id
               FROM
-                mz_catalog.mz_dataflow_addresses
+                mz_internal.mz_dataflow_addresses
               WHERE
                 address[1]
                   = (
                       SELECT DISTINCT
                         address[1]
                       FROM
-                        mz_catalog.mz_dataflow_addresses
+                        mz_internal.mz_dataflow_addresses
                       WHERE
                         id = ${props.dataflow_id}
                     )
@@ -200,21 +200,21 @@ function View(props) {
         SELECT DISTINCT
           id, name
         FROM
-          mz_catalog.mz_dataflow_operators
+          mz_internal.mz_dataflow_operators
         WHERE
           id
           IN (
               SELECT
                 id
               FROM
-                mz_catalog.mz_dataflow_addresses
+                mz_internal.mz_dataflow_addresses
               WHERE
                 address[1]
                   = (
                       SELECT DISTINCT
                         address[1]
                       FROM
-                        mz_catalog.mz_dataflow_addresses
+                        mz_internal.mz_dataflow_addresses
                       WHERE
                         id = ${props.dataflow_id}
                     )
@@ -223,8 +223,8 @@ function View(props) {
         SELECT
           id, from_index, to_index, sum(sent) as sent
         FROM
-          mz_catalog.mz_dataflow_channels AS channels
-          LEFT JOIN mz_catalog.mz_message_counts AS counts
+          mz_internal.mz_dataflow_channels AS channels
+          LEFT JOIN mz_internal.mz_message_counts AS counts
               ON channels.id = counts.channel_id AND channels.worker_id = counts.from_worker_id
         WHERE
           id
@@ -232,14 +232,14 @@ function View(props) {
               SELECT
                 id
               FROM
-                mz_catalog.mz_dataflow_addresses
+                mz_internal.mz_dataflow_addresses
               WHERE
                 address[1]
                   = (
                       SELECT DISTINCT
                         address[1]
                       FROM
-                        mz_catalog.mz_dataflow_addresses
+                        mz_internal.mz_dataflow_addresses
                       WHERE
                         id = ${props.dataflow_id}
                     )
@@ -250,21 +250,21 @@ function View(props) {
         SELECT
           id, sum(elapsed_ns)
         FROM
-          mz_catalog.mz_scheduling_elapsed
+          mz_internal.mz_scheduling_elapsed
         WHERE
           id
           IN (
               SELECT
                 id
               FROM
-                mz_catalog.mz_dataflow_addresses
+                mz_internal.mz_dataflow_addresses
               WHERE
                 address[1]
                   = (
                       SELECT DISTINCT
                         address[1]
                       FROM
-                        mz_catalog.mz_dataflow_addresses
+                        mz_internal.mz_dataflow_addresses
                       WHERE
                         id = ${props.dataflow_id}
                     )
@@ -275,7 +275,7 @@ function View(props) {
         SELECT
           id, sum(records)
         FROM
-          mz_catalog.mz_records_per_dataflow_operator
+          mz_internal.mz_records_per_dataflow_operator
         WHERE
           dataflow_id = ${props.dataflow_id}
         GROUP BY

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -61,7 +61,7 @@ fn test_persistence() -> Result<(), Box<dyn Error>> {
         )?;
         client.batch_execute("CREATE VIEW constant AS SELECT 1")?;
         client.batch_execute(
-            "CREATE VIEW logging_derived AS SELECT * FROM mz_catalog.mz_arrangement_sizes",
+            "CREATE VIEW logging_derived AS SELECT * FROM mz_internal.mz_arrangement_sizes",
         )?;
         client.batch_execute(
             "CREATE VIEW mat (a, a_data, c, c_data) AS SELECT 'a', data, 'c' AS c, data FROM src",
@@ -594,7 +594,10 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
     // No dataflows expected at startup.
     assert_eq!(
         client1
-            .query_one("SELECT count(*) FROM mz_dataflow_operators", &[])?
+            .query_one(
+                "SELECT count(*) FROM mz_internal.mz_dataflow_operators",
+                &[]
+            )?
             .get::<_, i64>(0),
         0
     );
@@ -604,7 +607,10 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
         Retry::default()
             .retry(|_state| {
                 let count: i64 = client2
-                    .query_one("SELECT count(*) FROM mz_dataflow_operators", &[])
+                    .query_one(
+                        "SELECT count(*) FROM mz_internal.mz_dataflow_operators",
+                        &[],
+                    )
                     .map_err(|_| ())?
                     .get(0);
                 if count == 0 {
@@ -626,7 +632,10 @@ fn test_cancel_dataflow_removal() -> Result<(), Box<dyn Error>> {
     Retry::default()
         .retry(|_state| {
             let count: i64 = client1
-                .query_one("SELECT count(*) FROM mz_dataflow_operators", &[])
+                .query_one(
+                    "SELECT count(*) FROM mz_internal.mz_dataflow_operators",
+                    &[],
+                )
                 .map_err(|_| ())?
                 .get(0);
             if count == 0 {

--- a/test/sqllogictest/cluster_log_compaction.slt
+++ b/test/sqllogictest/cluster_log_compaction.slt
@@ -22,7 +22,7 @@ BEGIN
 
 # Transaction will force a read hold on this index.
 query T rowsort
-SELECT * FROM mz_arrangement_batches_internal_2;
+SELECT * FROM mz_internal.mz_arrangement_batches_internal_2;
 ----
 
 statement ok

--- a/test/sqllogictest/cluster_log_drop.slt
+++ b/test/sqllogictest/cluster_log_drop.slt
@@ -30,7 +30,7 @@ SELECT (SELECT COUNT(*) FROM mz_catalog.mz_sources WHERE name NOT LIKE '%_1') - 
 query T rowsort
 SELECT (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name NOT LIKE '%_1') - (SELECT COUNT(*) FROM mz_catalog.mz_views WHERE name LIKE '%_1');
 ----
-28
+27
 
 
 # The default cluster also has log sources, thus we should have one set active at boot.
@@ -93,10 +93,10 @@ CREATE CLUSTER c1 REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'));
 
 # We have to guess the identifier 4 here, it should match c1.r1 at this point
 statement ok
-CREATE VIEW v1 AS SELECT * FROM mz_catalog.mz_peek_active_4;
+CREATE VIEW v1 AS SELECT * FROM mz_internal.mz_peek_active_4;
 
 statement ok
-CREATE VIEW w1 AS SELECT * FROM mz_catalog.mz_materialization_frontiers_4;
+CREATE VIEW w1 AS SELECT * FROM mz_internal.mz_materialization_frontiers_4;
 
 statement ok
 CREATE VIEW v11 AS SELECT * FROM v1;
@@ -105,10 +105,10 @@ statement ok
 CREATE VIEW w11 AS SELECT * FROM w1;
 
 statement ok
-CREATE VIEW v2 AS SELECT * FROM mz_catalog.mz_peek_active_5;
+CREATE VIEW v2 AS SELECT * FROM mz_internal.mz_peek_active_5;
 
 statement ok
-CREATE VIEW w2 AS SELECT * FROM mz_catalog.mz_materialization_frontiers_5;
+CREATE VIEW w2 AS SELECT * FROM mz_internal.mz_materialization_frontiers_5;
 
 statement ok
 CREATE VIEW v21 AS SELECT * FROM v2;

--- a/test/sqllogictest/cluster_log_sinks.slt
+++ b/test/sqllogictest/cluster_log_sinks.slt
@@ -9,92 +9,98 @@
 
 ###   This file has been generated from the following python script:
 ###
-###   SRC=[
-###   "mz_arrangement_batches_internal",
-###   "mz_arrangement_records_internal",
-###   "mz_arrangement_sharing_internal",
-###   "mz_dataflow_channels",
-###   "mz_dataflow_addresses",
-###   "mz_dataflow_operator_reachability_internal",
-###   "mz_dataflow_operators",
-###   "mz_worker_materialization_dependencies",
-###   "mz_materializations",
-###   "mz_message_counts_received_internal",
-###   "mz_message_counts_sent_internal",
-###   "mz_peek_active",
-###   "mz_peek_durations",
-###   "mz_scheduling_elapsed_internal",
-###   "mz_scheduling_histogram_internal",
-###   "mz_scheduling_parks_internal",
-###   "mz_worker_materialization_frontiers"
-###    "mz_message_counts",
-###    "mz_records_per_dataflow",
-###    "mz_records_per_dataflow_global",
-###    "mz_records_per_dataflow_operator",
-###    "mz_scheduling_elapsed",
-###    "mz_scheduling_histogram"
-###   ]
-###   STAR_OVERRIDE = {
-###           "mz_dataflow_addresses" : "id,worker_id",
-###           "mz_dataflow_operator_reachability_internal" : "port,worker_id,update_type",
-###           "mz_dataflow_operator_reachability" : "port,worker_id,update_type",
-###   }
+### SRC = [
+###     "mz_arrangement_batches_internal",
+###     "mz_arrangement_records_internal",
+###     "mz_arrangement_sharing_internal",
+###     "mz_dataflow_channels",
+###     "mz_dataflow_addresses",
+###     "mz_dataflow_operator_reachability_internal",
+###     "mz_dataflow_operators",
+###     "mz_worker_materialization_dependencies",
+###     "mz_materializations",
+###     "mz_message_counts_received_internal",
+###     "mz_message_counts_sent_internal",
+###     "mz_peek_active",
+###     "mz_peek_durations",
+###     "mz_scheduling_elapsed_internal",
+###     "mz_scheduling_histogram_internal",
+###     "mz_scheduling_parks_internal",
+###     "mz_worker_materialization_delays",
+###     "mz_worker_materialization_frontiers",
+###     "mz_worker_materialization_source_frontiers",
+###     "mz_arrangement_sharing",
+###     "mz_arrangement_sizes",
+###     "mz_dataflows",
+###     "mz_dataflow_operator_dataflows",
+###     "mz_dataflow_operator_reachability",
+###     "mz_materialization_frontiers",
+###     "mz_materialization_source_frontiers",
+###     "mz_message_counts",
+###     "mz_records_per_dataflow",
+###     "mz_records_per_dataflow_global",
+###     "mz_records_per_dataflow_operator",
+###     "mz_scheduling_elapsed",
+###     "mz_scheduling_histogram",
+###     "mz_scheduling_parks",
+### ]
+### STAR_OVERRIDE = {
+###     "mz_dataflow_addresses": "id,worker_id",
+###     "mz_dataflow_operator_reachability_internal": "port,worker_id,update_type",
+###     "mz_dataflow_operator_reachability": "port,worker_id,update_type",
+### }
 ###
-###   def query_empty(q):
-###       return "query T\n{q};\n----\n\n".format(q=q)
+### def query_empty(q):
+###     return "query T\n{q};\n----\n\n".format(q=q)
 ###
-###   def stmt_ok(q):
-###       return "statement ok\n{q};\n\n".format(q=q)
+### def stmt_ok(q):
+###     return "statement ok\n{q};\n\n".format(q=q)
 ###
-###   def equal(postfix):
-###       res = ""
-###       for x in SRC:
-###           p = query_empty("SELECT * FROM ((SELECT * FROM {x}) EXCEPT (SELECT * FROM {x}_{postfix}))".format(x=x, postfix=postfix))
-###           p += query_empty("SELECT * FROM ((SELECT * FROM {x}_{postfix}) EXCEPT (SELECT * FROM {x}))".format(x=x, postfix=postfix))
-###           if x in STAR_OVERRIDE:
-###               p = p.replace("*", STAR_OVERRIDE[x])
-###           res += p
-###       return res
+### def equal(postfix):
+###     res = ""
+###     for x in SRC:
+###         p = query_empty("SELECT * FROM ((SELECT * FROM mz_internal.{x}) EXCEPT (SELECT * FROM mz_internal.{x}_{postfix}))".format(x=x, postfix=postfix))
+###         p += query_empty("SELECT * FROM ((SELECT * FROM mz_internal.{x}_{postfix}) EXCEPT (SELECT * FROM mz_internal.{x}))".format(x=x, postfix=postfix))
+###         if x in STAR_OVERRIDE:
+###             p = p.replace("*", STAR_OVERRIDE[x])
+###         res += p
+###     return res
 ###
-###   print("""
-###   # Check that no log source has been created initially
-###   query T
-###   SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_peek_active_%';
-###   ----
-###   1
-###   """)
+### print("""
+### # Check that no log source has been created initially
+### query T
+### SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_peek_active_%';
+### ----
+### 1
+### """)
 ###
-###   print(stmt_ok("CREATE CLUSTER c1 REPLICAS (r (SIZE '1'))"))
-###   print("""
-###   query T
-###   SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_peek_active_%';
-###   ----
-###   2
-###   """)
-###   print(stmt_ok("CREATE TABLE t1(f1 int, f2 int)"))
-###   print(stmt_ok("INSERT INTO t1 VALUES (1,1),(2,3),(4,5)"))
-###   print(stmt_ok("CREATE MATERIALIZED VIEW ma1 AS SELECT COUNT(*) FROM t1"))
-###   print(equal("1"))
+### print(stmt_ok("CREATE CLUSTER c1 REPLICAS (r (SIZE '1'))"))
+### print("""
+### query T
+### SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_peek_active_%';
+### ----
+### 2
+### """)
+### print(stmt_ok("CREATE TABLE t1(f1 int, f2 int)"))
+### print(stmt_ok("INSERT INTO t1 VALUES (1,1),(2,3),(4,5)"))
+### print(stmt_ok("CREATE MATERIALIZED VIEW ma1 AS SELECT COUNT(*) FROM t1"))
+### print(equal("1"))
 ###
-###   print(stmt_ok("SET CLUSTER TO c1"))
-###   print(stmt_ok("CREATE MATERIALIZED VIEW ma2 AS SELECT COUNT(*) FROM t1"))
-###   print(equal("2"))
+### print(stmt_ok("SET CLUSTER TO c1"))
+### print(stmt_ok("CREATE MATERIALIZED VIEW ma2 AS SELECT COUNT(*) FROM t1"))
+### print(equal("2"))
 ###
-###   print(stmt_ok("CREATE CLUSTER c2 REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'))"))
-###   print("""
-###   query T
-###   SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_peek_active_%';
-###   ----
-###   4
-###   """)
+### print(stmt_ok("CREATE CLUSTER c2 REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'))"))
+### print("""
+### query T
+### SELECT COUNT(*) FROM mz_sources WHERE name LIKE 'mz_peek_active_%';
+### ----
+### 4
+### """)
 ###
-###   print(stmt_ok("set cluster = c2"))
-###   print(stmt_ok("set cluster_replica = r1"))
-###   print(equal("3"))
-
-
-
-
+### print(stmt_ok("set cluster = c2"))
+### print(stmt_ok("set cluster_replica = r1"))
+### print(equal("3"))
 
 
 # Check that no log source has been created initially
@@ -126,235 +132,267 @@ CREATE MATERIALIZED VIEW ma1 AS SELECT COUNT(*) FROM t1;
 
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_arrangement_batches_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_batches_internal_1) EXCEPT (SELECT * FROM mz_arrangement_batches_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_arrangement_records_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_records_internal_1) EXCEPT (SELECT * FROM mz_arrangement_records_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_arrangement_sharing_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_internal_1) EXCEPT (SELECT * FROM mz_arrangement_sharing_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_channels) EXCEPT (SELECT * FROM mz_dataflow_channels_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_channels_1) EXCEPT (SELECT * FROM mz_dataflow_channels));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_1) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_dataflow_addresses_1));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_1));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_dataflow_addresses_1) EXCEPT (SELECT id,worker_id FROM mz_dataflow_addresses));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_1) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal_1));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_1));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal_1) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_1) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operators) EXCEPT (SELECT * FROM mz_dataflow_operators_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operators_1) EXCEPT (SELECT * FROM mz_dataflow_operators));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_1) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_dependencies) EXCEPT (SELECT * FROM mz_worker_materialization_dependencies_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_dependencies_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_dependencies_1) EXCEPT (SELECT * FROM mz_worker_materialization_dependencies));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_dependencies_1) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_dependencies));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materializations) EXCEPT (SELECT * FROM mz_materializations_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materializations) EXCEPT (SELECT * FROM mz_internal.mz_materializations_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materializations_1) EXCEPT (SELECT * FROM mz_materializations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materializations_1) EXCEPT (SELECT * FROM mz_internal.mz_materializations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_message_counts_received_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_received_internal_1) EXCEPT (SELECT * FROM mz_message_counts_received_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_message_counts_sent_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_sent_internal_1) EXCEPT (SELECT * FROM mz_message_counts_sent_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_active) EXCEPT (SELECT * FROM mz_peek_active_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_active) EXCEPT (SELECT * FROM mz_internal.mz_peek_active_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_active_1) EXCEPT (SELECT * FROM mz_peek_active));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_active_1) EXCEPT (SELECT * FROM mz_internal.mz_peek_active));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_durations) EXCEPT (SELECT * FROM mz_peek_durations_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_durations_1) EXCEPT (SELECT * FROM mz_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_1) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_scheduling_elapsed_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_internal_1) EXCEPT (SELECT * FROM mz_scheduling_elapsed_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_internal) EXCEPT (SELECT * FROM mz_scheduling_histogram_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_internal_1) EXCEPT (SELECT * FROM mz_scheduling_histogram_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_scheduling_parks_internal_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_parks_internal_1) EXCEPT (SELECT * FROM mz_scheduling_parks_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_1) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_frontiers) EXCEPT (SELECT * FROM mz_worker_materialization_frontiers_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_delays_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_frontiers_1) EXCEPT (SELECT * FROM mz_worker_materialization_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_delays_1) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_arrangement_sharing_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_frontiers_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_1) EXCEPT (SELECT * FROM mz_arrangement_sharing));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_frontiers_1) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_arrangement_sizes_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sizes_1) EXCEPT (SELECT * FROM mz_arrangement_sizes));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers_1) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflows) EXCEPT (SELECT * FROM mz_dataflows_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflows_1) EXCEPT (SELECT * FROM mz_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_1) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_dataflow_operator_dataflows_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operator_dataflows_1) EXCEPT (SELECT * FROM mz_dataflow_operator_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_1) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_1));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_1) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_1) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materialization_frontiers) EXCEPT (SELECT * FROM mz_materialization_frontiers_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materialization_frontiers_1) EXCEPT (SELECT * FROM mz_materialization_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_1) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts) EXCEPT (SELECT * FROM mz_message_counts_1));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_1) EXCEPT (SELECT * FROM mz_message_counts));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_1) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_records_per_dataflow_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_materialization_frontiers_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_1) EXCEPT (SELECT * FROM mz_records_per_dataflow));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_frontiers_1) EXCEPT (SELECT * FROM mz_internal.mz_materialization_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_records_per_dataflow_global_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_source_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_materialization_source_frontiers_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_global_1) EXCEPT (SELECT * FROM mz_records_per_dataflow_global));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_source_frontiers_1) EXCEPT (SELECT * FROM mz_internal.mz_materialization_source_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_records_per_dataflow_operator_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_operator_1) EXCEPT (SELECT * FROM mz_records_per_dataflow_operator));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_1) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_scheduling_elapsed_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_1) EXCEPT (SELECT * FROM mz_scheduling_elapsed));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_1) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram) EXCEPT (SELECT * FROM mz_scheduling_histogram_1));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_1));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_1) EXCEPT (SELECT * FROM mz_scheduling_histogram));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_1) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_1));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_1) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_1));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_1) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_1));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_1) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_1));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_1) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
 ----
 
 
@@ -367,235 +405,267 @@ CREATE MATERIALIZED VIEW ma2 AS SELECT COUNT(*) FROM t1;
 
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_arrangement_batches_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_batches_internal_2) EXCEPT (SELECT * FROM mz_arrangement_batches_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_arrangement_records_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_records_internal_2) EXCEPT (SELECT * FROM mz_arrangement_records_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_arrangement_sharing_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_internal_2) EXCEPT (SELECT * FROM mz_arrangement_sharing_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_channels) EXCEPT (SELECT * FROM mz_dataflow_channels_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_channels_2) EXCEPT (SELECT * FROM mz_dataflow_channels));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_dataflow_addresses_2));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_2));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_dataflow_addresses_2) EXCEPT (SELECT id,worker_id FROM mz_dataflow_addresses));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_2) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal_2));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_2));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal_2) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_2) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operators) EXCEPT (SELECT * FROM mz_dataflow_operators_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operators_2) EXCEPT (SELECT * FROM mz_dataflow_operators));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_dependencies) EXCEPT (SELECT * FROM mz_worker_materialization_dependencies_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_dependencies_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_dependencies_2) EXCEPT (SELECT * FROM mz_worker_materialization_dependencies));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_dependencies_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_dependencies));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materializations) EXCEPT (SELECT * FROM mz_materializations_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materializations) EXCEPT (SELECT * FROM mz_internal.mz_materializations_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materializations_2) EXCEPT (SELECT * FROM mz_materializations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materializations_2) EXCEPT (SELECT * FROM mz_internal.mz_materializations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_message_counts_received_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_received_internal_2) EXCEPT (SELECT * FROM mz_message_counts_received_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_message_counts_sent_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_sent_internal_2) EXCEPT (SELECT * FROM mz_message_counts_sent_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_active) EXCEPT (SELECT * FROM mz_peek_active_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_active) EXCEPT (SELECT * FROM mz_internal.mz_peek_active_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_active_2) EXCEPT (SELECT * FROM mz_peek_active));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_active_2) EXCEPT (SELECT * FROM mz_internal.mz_peek_active));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_durations) EXCEPT (SELECT * FROM mz_peek_durations_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_durations_2) EXCEPT (SELECT * FROM mz_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_2) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_scheduling_elapsed_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_internal_2) EXCEPT (SELECT * FROM mz_scheduling_elapsed_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_internal) EXCEPT (SELECT * FROM mz_scheduling_histogram_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_internal_2) EXCEPT (SELECT * FROM mz_scheduling_histogram_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_scheduling_parks_internal_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_parks_internal_2) EXCEPT (SELECT * FROM mz_scheduling_parks_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_frontiers) EXCEPT (SELECT * FROM mz_worker_materialization_frontiers_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_delays_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_frontiers_2) EXCEPT (SELECT * FROM mz_worker_materialization_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_delays_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_arrangement_sharing_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_frontiers_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_2) EXCEPT (SELECT * FROM mz_arrangement_sharing));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_arrangement_sizes_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sizes_2) EXCEPT (SELECT * FROM mz_arrangement_sizes));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflows) EXCEPT (SELECT * FROM mz_dataflows_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflows_2) EXCEPT (SELECT * FROM mz_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_dataflow_operator_dataflows_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operator_dataflows_2) EXCEPT (SELECT * FROM mz_dataflow_operator_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_2) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_2));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_2) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materialization_frontiers) EXCEPT (SELECT * FROM mz_materialization_frontiers_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materialization_frontiers_2) EXCEPT (SELECT * FROM mz_materialization_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_2) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts) EXCEPT (SELECT * FROM mz_message_counts_2));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_2) EXCEPT (SELECT * FROM mz_message_counts));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_2) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_records_per_dataflow_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_materialization_frontiers_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_2) EXCEPT (SELECT * FROM mz_records_per_dataflow));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_materialization_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_records_per_dataflow_global_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_source_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_materialization_source_frontiers_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_global_2) EXCEPT (SELECT * FROM mz_records_per_dataflow_global));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_source_frontiers_2) EXCEPT (SELECT * FROM mz_internal.mz_materialization_source_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_records_per_dataflow_operator_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_operator_2) EXCEPT (SELECT * FROM mz_records_per_dataflow_operator));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_2) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_scheduling_elapsed_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_2) EXCEPT (SELECT * FROM mz_scheduling_elapsed));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_2) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram) EXCEPT (SELECT * FROM mz_scheduling_histogram_2));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_2));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_2) EXCEPT (SELECT * FROM mz_scheduling_histogram));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_2) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_2));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_2) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_2));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_2));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_2));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_2) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
 ----
 
 
@@ -618,233 +688,265 @@ set cluster_replica = r1;
 
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_arrangement_batches_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_batches_internal_3) EXCEPT (SELECT * FROM mz_arrangement_batches_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_batches_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_batches_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_arrangement_records_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_records_internal_3) EXCEPT (SELECT * FROM mz_arrangement_records_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_records_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_records_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_arrangement_sharing_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_internal_3) EXCEPT (SELECT * FROM mz_arrangement_sharing_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_channels) EXCEPT (SELECT * FROM mz_dataflow_channels_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_channels_3) EXCEPT (SELECT * FROM mz_dataflow_channels));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_channels_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_channels));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_dataflow_addresses_3));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_3));
 ----
 
 query T
-SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_dataflow_addresses_3) EXCEPT (SELECT id,worker_id FROM mz_dataflow_addresses));
+SELECT id,worker_id FROM ((SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses_3) EXCEPT (SELECT id,worker_id FROM mz_internal.mz_dataflow_addresses));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal_3));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_3));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal_3) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_internal));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal_3) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operators) EXCEPT (SELECT * FROM mz_dataflow_operators_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operators_3) EXCEPT (SELECT * FROM mz_dataflow_operators));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operators_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operators));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_dependencies) EXCEPT (SELECT * FROM mz_worker_materialization_dependencies_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_dependencies) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_dependencies_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_dependencies_3) EXCEPT (SELECT * FROM mz_worker_materialization_dependencies));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_dependencies_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_dependencies));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materializations) EXCEPT (SELECT * FROM mz_materializations_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materializations) EXCEPT (SELECT * FROM mz_internal.mz_materializations_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materializations_3) EXCEPT (SELECT * FROM mz_materializations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materializations_3) EXCEPT (SELECT * FROM mz_internal.mz_materializations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_message_counts_received_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_received_internal_3) EXCEPT (SELECT * FROM mz_message_counts_received_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_received_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_received_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_message_counts_sent_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_sent_internal_3) EXCEPT (SELECT * FROM mz_message_counts_sent_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_sent_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_sent_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_active) EXCEPT (SELECT * FROM mz_peek_active_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_active) EXCEPT (SELECT * FROM mz_internal.mz_peek_active_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_active_3) EXCEPT (SELECT * FROM mz_peek_active));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_active_3) EXCEPT (SELECT * FROM mz_internal.mz_peek_active));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_durations) EXCEPT (SELECT * FROM mz_peek_durations_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_peek_durations_3) EXCEPT (SELECT * FROM mz_peek_durations));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_peek_durations_3) EXCEPT (SELECT * FROM mz_internal.mz_peek_durations));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_scheduling_elapsed_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_internal_3) EXCEPT (SELECT * FROM mz_scheduling_elapsed_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_internal) EXCEPT (SELECT * FROM mz_scheduling_histogram_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_internal_3) EXCEPT (SELECT * FROM mz_scheduling_histogram_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_scheduling_parks_internal_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_parks_internal_3) EXCEPT (SELECT * FROM mz_scheduling_parks_internal));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_internal_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_internal));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_frontiers) EXCEPT (SELECT * FROM mz_worker_materialization_frontiers_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_delays) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_delays_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_worker_materialization_frontiers_3) EXCEPT (SELECT * FROM mz_worker_materialization_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_delays_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_delays));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_arrangement_sharing_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_frontiers_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sharing_3) EXCEPT (SELECT * FROM mz_arrangement_sharing));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_arrangement_sizes_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_arrangement_sizes_3) EXCEPT (SELECT * FROM mz_arrangement_sizes));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_worker_materialization_source_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflows) EXCEPT (SELECT * FROM mz_dataflows_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflows_3) EXCEPT (SELECT * FROM mz_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sharing_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sharing));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_dataflow_operator_dataflows_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_dataflow_operator_dataflows_3) EXCEPT (SELECT * FROM mz_dataflow_operator_dataflows));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_arrangement_sizes_3) EXCEPT (SELECT * FROM mz_internal.mz_arrangement_sizes));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflows_3));
 ----
 
 query T
-SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability_3) EXCEPT (SELECT port,worker_id,update_type FROM mz_dataflow_operator_reachability));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflows_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materialization_frontiers) EXCEPT (SELECT * FROM mz_materialization_frontiers_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_materialization_frontiers_3) EXCEPT (SELECT * FROM mz_materialization_frontiers));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_dataflow_operator_dataflows_3) EXCEPT (SELECT * FROM mz_internal.mz_dataflow_operator_dataflows));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts) EXCEPT (SELECT * FROM mz_message_counts_3));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_message_counts_3) EXCEPT (SELECT * FROM mz_message_counts));
+SELECT port,worker_id,update_type FROM ((SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability_3) EXCEPT (SELECT port,worker_id,update_type FROM mz_internal.mz_dataflow_operator_reachability));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_records_per_dataflow_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_materialization_frontiers_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_3) EXCEPT (SELECT * FROM mz_records_per_dataflow));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_materialization_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_records_per_dataflow_global_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_source_frontiers) EXCEPT (SELECT * FROM mz_internal.mz_materialization_source_frontiers_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_global_3) EXCEPT (SELECT * FROM mz_records_per_dataflow_global));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_materialization_source_frontiers_3) EXCEPT (SELECT * FROM mz_internal.mz_materialization_source_frontiers));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_records_per_dataflow_operator_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts) EXCEPT (SELECT * FROM mz_internal.mz_message_counts_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_records_per_dataflow_operator_3) EXCEPT (SELECT * FROM mz_records_per_dataflow_operator));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_message_counts_3) EXCEPT (SELECT * FROM mz_internal.mz_message_counts));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_scheduling_elapsed_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_elapsed_3) EXCEPT (SELECT * FROM mz_scheduling_elapsed));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_3) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram) EXCEPT (SELECT * FROM mz_scheduling_histogram_3));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global_3));
 ----
 
 query T
-SELECT * FROM ((SELECT * FROM mz_scheduling_histogram_3) EXCEPT (SELECT * FROM mz_scheduling_histogram));
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_global_3) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_global));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator_3));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_records_per_dataflow_operator_3) EXCEPT (SELECT * FROM mz_internal.mz_records_per_dataflow_operator));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed_3));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_elapsed_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_elapsed));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram_3));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_histogram_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_histogram));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks_3));
+----
+
+query T
+SELECT * FROM ((SELECT * FROM mz_internal.mz_scheduling_parks_3) EXCEPT (SELECT * FROM mz_internal.mz_scheduling_parks));
 ----

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -346,7 +346,7 @@ mv_primary_idx  mv  default {?column?}
 # Test: Creating materialized views that depend on log sources is forbidden.
 
 statement error materialized view objects cannot depend on log sources
-CREATE OR REPLACE MATERIALIZED VIEW mv AS SELECT * FROM mz_dataflow_operators;
+CREATE OR REPLACE MATERIALIZED VIEW mv AS SELECT * FROM mz_internal.mz_dataflow_operators;
 
 
 # Test: Attempting to use view commands on materialized views gives helpful errors.

--- a/test/sqllogictest/select_introspection.slt
+++ b/test/sqllogictest/select_introspection.slt
@@ -39,7 +39,7 @@ a b
 # Verify that SELECTs on introspection tables work.
 
 statement ok
-SELECT * FROM mz_materializations
+SELECT * FROM mz_internal.mz_materializations
 
 # Verify that we see no prior peeks when targeting another replica.
 
@@ -47,7 +47,7 @@ statement ok
 SET cluster_replica = replica_b
 
 query I
-SELECT sum(count) FROM mz_peek_durations
+SELECT sum(count) FROM mz_internal.mz_peek_durations
 ----
 NULL
 
@@ -65,17 +65,17 @@ statement ok
 RESET cluster_replica
 
 query error log source reads must target a replica
-SELECT * FROM mz_materializations
+SELECT * FROM mz_internal.mz_materializations
 
 statement ok
-CREATE VIEW introspection_view AS SELECT * FROM mz_materializations
+CREATE VIEW introspection_view AS SELECT * FROM mz_internal.mz_materializations
 
 query error log source reads must target a replica
 SELECT * FROM introspection_view
 
 # Verify that the logic does not apply to persisted logs
 statement ok
-SELECT * FROM mz_peek_active_1
+SELECT * FROM mz_internal.mz_peek_active_1
 
 # Verify that untargeted introspection queries on unreplicated clusters are
 # allowed.
@@ -84,7 +84,7 @@ statement ok
 DROP CLUSTER REPLICA test.replica_b;
 
 statement ok
-SELECT * FROM mz_materializations
+SELECT * FROM mz_internal.mz_materializations
 
 statement ok
 SELECT * FROM introspection_view
@@ -101,7 +101,7 @@ CREATE CLUSTER test
   INTROSPECTION INTERVAL 0
 
 query error cannot read log sources on cluster with disabled introspection
-SELECT * FROM mz_materializations
+SELECT * FROM mz_internal.mz_materializations
 
 # Clean up.
 

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -447,51 +447,9 @@ d2
 
 # Check default sources, tables, and views in mz_catalog.
 
-# The sources in the catalog depend on the number of replicas and computeds
-$ skip-if
-SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
-
 > SHOW SOURCES FROM mz_catalog
 name                                          type
 --------------------------------------------------
-mz_arrangement_batches_internal               log
-mz_arrangement_batches_internal_1             log
-mz_arrangement_records_internal               log
-mz_arrangement_records_internal_1             log
-mz_arrangement_sharing_internal               log
-mz_arrangement_sharing_internal_1             log
-mz_dataflow_channels                          log
-mz_dataflow_channels_1                        log
-mz_dataflow_addresses                         log
-mz_dataflow_addresses_1                       log
-mz_dataflow_operator_reachability_internal    log
-mz_dataflow_operator_reachability_internal_1  log
-mz_dataflow_operators                         log
-mz_dataflow_operators_1                       log
-mz_worker_materialization_dependencies        log
-mz_worker_materialization_dependencies_1      log
-mz_materializations                           log
-mz_materializations_1                         log
-mz_message_counts_received_internal           log
-mz_message_counts_received_internal_1         log
-mz_message_counts_sent_internal               log
-mz_message_counts_sent_internal_1             log
-mz_peek_active                                log
-mz_peek_active_1                              log
-mz_peek_durations                             log
-mz_peek_durations_1                           log
-mz_scheduling_elapsed_internal                log
-mz_scheduling_elapsed_internal_1              log
-mz_scheduling_histogram_internal              log
-mz_scheduling_histogram_internal_1            log
-mz_scheduling_parks_internal                  log
-mz_scheduling_parks_internal_1                log
-mz_worker_materialization_delays              log
-mz_worker_materialization_delays_1            log
-mz_worker_materialization_frontiers           log
-mz_worker_materialization_frontiers_1         log
-mz_worker_materialization_source_frontiers    log
-mz_worker_materialization_source_frontiers_1  log
 
 > SHOW TABLES FROM mz_catalog
 name
@@ -527,6 +485,97 @@ mz_view_foreign_keys
 mz_view_keys
 mz_views
 
+> SHOW VIEWS FROM mz_catalog
+name
+-----------------------------------
+mz_cluster_replicas
+mz_objects
+mz_relations
+
+# Check default sources, tables, and views in mz_internal.
+
+# The sources in the catalog depend on the number of replicas and computeds
+$ skip-if
+SELECT ${arg.replicas} > 1 OR ${arg.replica-size} > 1;
+
+> SHOW SOURCES FROM mz_internal
+name                                           type
+---------------------------------------------------
+mz_arrangement_batches_internal                 log
+mz_arrangement_batches_internal_1               log
+mz_arrangement_records_internal                 log
+mz_arrangement_records_internal_1               log
+mz_arrangement_sharing_internal                 log
+mz_arrangement_sharing_internal_1               log
+mz_dataflow_channels                            log
+mz_dataflow_channels_1                          log
+mz_dataflow_addresses                           log
+mz_dataflow_addresses_1                         log
+mz_dataflow_operator_reachability_internal      log
+mz_dataflow_operator_reachability_internal_1    log
+mz_dataflow_operators                           log
+mz_dataflow_operators_1                         log
+mz_worker_materialization_dependencies          log
+mz_worker_materialization_dependencies_1        log
+mz_materializations                             log
+mz_materializations_1                           log
+mz_message_counts_received_internal             log
+mz_message_counts_received_internal_1           log
+mz_message_counts_sent_internal                 log
+mz_message_counts_sent_internal_1               log
+mz_peek_active                                  log
+mz_peek_active_1                                log
+mz_peek_durations                               log
+mz_peek_durations_1                             log
+mz_scheduling_elapsed_internal                  log
+mz_scheduling_elapsed_internal_1                log
+mz_scheduling_histogram_internal                log
+mz_scheduling_histogram_internal_1              log
+mz_scheduling_parks_internal                    log
+mz_scheduling_parks_internal_1                  log
+mz_worker_materialization_delays                log
+mz_worker_materialization_delays_1              log
+mz_worker_materialization_frontiers             log
+mz_worker_materialization_frontiers_1           log
+mz_worker_materialization_source_frontiers      log
+mz_worker_materialization_source_frontiers_1    log
+
+> SHOW TABLES FROM mz_internal
+name
+----
+
+> SHOW VIEWS FROM mz_internal
+name
+-------------------------------------
+mz_arrangement_sharing
+mz_arrangement_sharing_1
+mz_arrangement_sizes
+mz_arrangement_sizes_1
+mz_dataflows
+mz_dataflows_1
+mz_dataflow_operator_dataflows
+mz_dataflow_operator_dataflows_1
+mz_dataflow_operator_reachability
+mz_dataflow_operator_reachability_1
+mz_materialization_frontiers
+mz_materialization_frontiers_1
+mz_materialization_source_frontiers
+mz_materialization_source_frontiers_1
+mz_message_counts
+mz_message_counts_1
+mz_records_per_dataflow
+mz_records_per_dataflow_1
+mz_records_per_dataflow_global
+mz_records_per_dataflow_global_1
+mz_records_per_dataflow_operator
+mz_records_per_dataflow_operator_1
+mz_scheduling_elapsed
+mz_scheduling_elapsed_1
+mz_scheduling_histogram
+mz_scheduling_histogram_1
+mz_scheduling_parks
+mz_scheduling_parks_1
+
 > CREATE SCHEMA tester
 
 > SHOW TABLES FROM tester
@@ -543,46 +592,6 @@ test_table
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
 19
-
-> SHOW VIEWS FROM mz_catalog
-name
------------------------------------
-mz_arrangement_sharing
-mz_arrangement_sharing_1
-mz_arrangement_sizes
-mz_arrangement_sizes_1
-mz_cluster_replicas
-mz_dataflows
-mz_dataflows_1
-mz_dataflow_operator_dataflows
-mz_dataflow_operator_dataflows_1
-mz_dataflow_operator_reachability
-mz_dataflow_operator_reachability_1
-mz_materialization_frontiers
-mz_materialization_frontiers_1
-mz_materialization_source_frontiers
-mz_message_counts
-mz_message_counts_1
-mz_objects
-mz_records_per_dataflow
-mz_records_per_dataflow_1
-mz_records_per_dataflow_global
-mz_records_per_dataflow_global_1
-mz_records_per_dataflow_operator
-mz_records_per_dataflow_operator_1
-mz_relations
-mz_scheduling_elapsed
-mz_scheduling_elapsed_1
-mz_scheduling_histogram
-mz_scheduling_histogram_1
-mz_scheduling_parks
-mz_scheduling_parks_1
-
-> SHOW SOURCES FROM mz_catalog LIKE '%peek%';
-mz_peek_active      log
-mz_peek_active_1    log
-mz_peek_durations   log
-mz_peek_durations_1 log
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/github-13790.td
+++ b/test/testdrive/github-13790.td
@@ -22,9 +22,9 @@ SELECT ${arg.replica-size} > 1 OR ${arg.replicas} > 1;
 
 > SELECT time > 0
   FROM
-    mz_materialized_views AS views,
-    mz_materializations AS mats,
-    mz_materialization_frontiers AS frontiers
+    mz_catalog.mz_materialized_views AS views,
+    mz_internal.mz_materializations AS mats,
+    mz_internal.mz_materialization_frontiers AS frontiers
   WHERE
     views.name = 'mv' AND
     views.id = mats.object_id AND

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -27,8 +27,8 @@ SELECT ${arg.replica-size} > 1 OR ${arg.replicas} > 1;
   FROM (SELECT SUM(count) as count_all
         FROM
             mz_materialized_views AS views,
-            mz_materializations as mats,
-            mz_worker_materialization_delays AS delays
+            mz_internal.mz_materializations as mats,
+            mz_internal.mz_worker_materialization_delays AS delays
         WHERE
             views.name = 'mv' AND
             views.id = mats.object_id AND
@@ -38,8 +38,8 @@ true
 > SELECT time > 0
   FROM
     mz_materialized_views AS views,
-    mz_materializations AS mats,
-    mz_materialization_source_frontiers AS sf
+    mz_internal.mz_materializations AS mats,
+    mz_internal.mz_materialization_source_frontiers AS sf
   WHERE
     views.name = 'mv' AND
     views.id = mats.object_id AND
@@ -51,13 +51,13 @@ true
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT delays.object_id, delays.source_id
         FROM
-            mz_worker_materialization_delays AS delays)
+            mz_internal.mz_worker_materialization_delays AS delays)
 1
 
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT sf.object_id, sf.source_id
         FROM
-            mz_worker_materialization_source_frontiers AS sf)
+            mz_internal.mz_worker_materialization_source_frontiers AS sf)
 1
 
 > CREATE DEFAULT INDEX ON vv
@@ -65,13 +65,13 @@ true
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT delays.object_id, delays.source_id
         FROM
-            mz_worker_materialization_delays AS delays)
+            mz_internal.mz_worker_materialization_delays AS delays)
 2
 
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT sf.object_id, sf.source_id
         FROM
-            mz_worker_materialization_source_frontiers AS sf)
+            mz_internal.mz_worker_materialization_source_frontiers AS sf)
 2
 
 > SELECT count_all > 0
@@ -79,8 +79,8 @@ true
         FROM
             mz_views AS views,
             mz_indexes AS indexes,
-            mz_materializations AS mats,
-            mz_worker_materialization_delays AS delays
+            mz_internal.mz_materializations AS mats,
+            mz_internal.mz_worker_materialization_delays AS delays
         WHERE
             views.name = 'vv' AND
             views.id = indexes.on_id AND
@@ -92,8 +92,8 @@ true
   FROM
     mz_views AS views,
     mz_indexes AS indexes,
-    mz_materializations mats,
-    mz_materialization_source_frontiers AS sf
+    mz_internal.mz_materializations mats,
+    mz_internal.mz_materialization_source_frontiers AS sf
   WHERE
     views.name = 'vv' AND
     views.id = indexes.on_id AND
@@ -106,13 +106,13 @@ true
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT delays.object_id, delays.source_id
         FROM
-            mz_worker_materialization_delays AS delays)
+            mz_internal.mz_worker_materialization_delays AS delays)
 1
 
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT sf.object_id, sf.source_id
         FROM
-            mz_worker_materialization_source_frontiers AS sf)
+            mz_internal.mz_worker_materialization_source_frontiers AS sf)
 1
 
 > DROP MATERIALIZED VIEW mv
@@ -120,11 +120,11 @@ true
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT delays.object_id, delays.source_id
         FROM
-            mz_worker_materialization_delays AS delays)
+            mz_internal.mz_worker_materialization_delays AS delays)
 0
 
 > SELECT COUNT(*)
   FROM (SELECT DISTINCT sf.object_id, sf.source_id
         FROM
-            mz_worker_materialization_source_frontiers AS sf)
+            mz_internal.mz_worker_materialization_source_frontiers AS sf)
 0

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -16,66 +16,66 @@ SELECT ${arg.replicas} > 1
 
 $ set-regex match=s\d+ replacement=SID
 
-> CREATE VIEW count_operates AS SELECT count(*) FROM mz_dataflow_operators;
+> CREATE VIEW count_operates AS SELECT count(*) FROM mz_internal.mz_dataflow_operators;
 > SELECT count(*) FROM count_operates;
 1
 
-> CREATE VIEW count_channels AS SELECT count(*) FROM mz_dataflow_channels;
+> CREATE VIEW count_channels AS SELECT count(*) FROM mz_internal.mz_dataflow_channels;
 > SELECT count(*) FROM count_channels;
 1
 
-> CREATE VIEW count_elapsed AS SELECT count(*) FROM mz_scheduling_elapsed;
+> CREATE VIEW count_elapsed AS SELECT count(*) FROM mz_internal.mz_scheduling_elapsed;
 > SELECT count(*) FROM count_elapsed;
 1
 
-> CREATE VIEW count_histogram AS SELECT count(*) FROM mz_scheduling_histogram;
+> CREATE VIEW count_histogram AS SELECT count(*) FROM mz_internal.mz_scheduling_histogram;
 > SELECT count(*) FROM count_histogram;
 1
 
-> CREATE VIEW count_arrangement AS SELECT count(*) FROM mz_arrangement_sizes;
+> CREATE VIEW count_arrangement AS SELECT count(*) FROM mz_internal.mz_arrangement_sizes;
 > SELECT count(*) FROM count_arrangement;
 1
 
-> CREATE VIEW count_materializations AS SELECT count(*) FROM mz_materializations;
+> CREATE VIEW count_materializations AS SELECT count(*) FROM mz_internal.mz_materializations;
 > SELECT count(*) FROM count_materializations;
 1
 
-> CREATE VIEW count_frontiers AS SELECT count(*) FROM mz_materialization_frontiers;
+> CREATE VIEW count_frontiers AS SELECT count(*) FROM mz_internal.mz_materialization_frontiers;
 > SELECT count(*) FROM count_frontiers;
 1
 
-> CREATE VIEW count_source_frontiers AS SELECT count(*) FROM mz_materialization_source_frontiers;
+> CREATE VIEW count_source_frontiers AS SELECT count(*) FROM mz_internal.mz_materialization_source_frontiers;
 > SELECT count(*) FROM count_source_frontiers;
 1
 
-> CREATE VIEW count_frontier_delays AS SELECT count(*) FROM mz_worker_materialization_delays;
+> CREATE VIEW count_frontier_delays AS SELECT count(*) FROM mz_internal.mz_worker_materialization_delays;
 > SELECT count(*) FROM count_frontier_delays;
 1
 
-> CREATE VIEW count_dependencies AS SELECT count(*) FROM mz_worker_materialization_dependencies;
+> CREATE VIEW count_dependencies AS SELECT count(*) FROM mz_internal.mz_worker_materialization_dependencies;
 > SELECT count(*) FROM count_dependencies;
 1
 
-> CREATE VIEW count_peeks AS SELECT count(*) FROM mz_peek_active;
+> CREATE VIEW count_peeks AS SELECT count(*) FROM mz_internal.mz_peek_active;
 > SELECT count(*) FROM count_peeks;
 1
 
-> CREATE VIEW count_peek_durations AS SELECT count(*) FROM mz_peek_durations;
+> CREATE VIEW count_peek_durations AS SELECT count(*) FROM mz_internal.mz_peek_durations;
 > SELECT count(*) FROM count_peek_durations;
 1
 
-> CREATE VIEW count_messages AS SELECT count(*) FROM mz_message_counts;
+> CREATE VIEW count_messages AS SELECT count(*) FROM mz_internal.mz_message_counts;
 > SELECT count(*) FROM count_messages;
 1
 
-! DROP SCHEMA mz_catalog
-contains:cannot drop schema mz_catalog because it is required by the database system
+! DROP SCHEMA mz_internal
+contains:cannot drop schema mz_internal because it is required by the database system
 
-! DROP VIEW mz_peek_durations
-contains:cannot drop item mz_catalog.mz_peek_durations because it is required by the database system
+! DROP VIEW mz_internal.mz_peek_durations
+contains:cannot drop item mz_internal.mz_peek_durations because it is required by the database system
 
-! DROP SOURCE mz_worker_materialization_delays
-contains:cannot drop item mz_catalog.mz_worker_materialization_delays because it is required by the database system
+! DROP SOURCE mz_internal.mz_worker_materialization_delays
+contains:cannot drop item mz_internal.mz_worker_materialization_delays because it is required by the database system
 
 > SELECT mz_columns.id, mz_columns.name, position, type
   FROM mz_views JOIN mz_columns USING (id)

--- a/test/testdrive/render-delta-join.td
+++ b/test/testdrive/render-delta-join.td
@@ -51,18 +51,18 @@ SELECT ${arg.replicas} > 1
 > SELECT
     sum(sent) as sent
   FROM
-    mz_catalog.mz_dataflow_channels AS channels
-    LEFT JOIN mz_catalog.mz_message_counts AS counts
+    mz_internal.mz_dataflow_channels AS channels
+    LEFT JOIN mz_internal.mz_message_counts AS counts
         ON channels.id = counts.channel_id AND channels.worker_id = counts.from_worker_id
   WHERE id IN
         (SELECT id
-         FROM mz_catalog.mz_dataflow_addresses
+         FROM mz_internal.mz_dataflow_addresses
          WHERE address[1] =
              (SELECT DISTINCT address[1]
-              FROM mz_catalog.mz_dataflow_addresses
+              FROM mz_internal.mz_dataflow_addresses
               WHERE id =
                   (SELECT DISTINCT id
-                   FROM mz_catalog.mz_dataflows
+                   FROM mz_internal.mz_dataflows
                    WHERE name LIKE '%.delta_join%')))
   GROUP BY id, from_index, to_index, from_port, to_port
   HAVING sum(sent) > 100

--- a/test/testdrive/shared-timestamp-bindings.td
+++ b/test/testdrive/shared-timestamp-bindings.td
@@ -157,5 +157,5 @@ $ kafka-ingest format=avro topic=data partition=15 schema=${schema}
 $ skip-if
 SELECT ${arg.replicas} > 1
 
-> SELECT COUNT(*) FROM mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
+> SELECT COUNT(*) FROM mz_internal.mz_records_per_dataflow_global WHERE name LIKE '%check_v%' AND records > 0;
 0

--- a/test/testdrive/tables.td
+++ b/test/testdrive/tables.td
@@ -118,7 +118,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 $ skip-if
 SELECT ${arg.replicas} > 1
 
-> SELECT * FROM t CROSS JOIN mz_dataflow_operators LIMIT 0
+> SELECT * FROM t CROSS JOIN mz_internal.mz_dataflow_operators LIMIT 0
 
 > DROP SOURCE data
 

--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -155,16 +155,17 @@ contains:multiple timelines within one dataflow are not supported
 > CREATE VIEW values_system_view AS SELECT * FROM input_values_view, source_system;
 > CREATE VIEW values_system_user_view AS SELECT * FROM input_values_view, source_system_user;
 > CREATE VIEW values_cdcv2_view AS SELECT * FROM input_values_view, source_cdcv2;
-> CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_relations, input_values_view, mz_views, mz_dataflow_operators;
+> CREATE VIEW values_mz_catalog_view (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_relations, input_values_view, mz_views, mz_internal.mz_dataflow_operators;
 
 # System sources, tables, and logs should be joinable with eachother.
-> CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_relations, mz_views, mz_dataflow_operators;
+> CREATE VIEW various_system (a, b, c, d, e, f, g, h, i, j, k, l, m) AS SELECT * FROM mz_relations, mz_views, mz_internal.mz_dataflow_operators;
 
 # System things should be joinable only with system sources.
-! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_relations, mz_views, mz_dataflow_operators, source_cdcv2;
+! CREATE VIEW must_fail (a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) AS SELECT * FROM mz_relations, mz_views, mz_internal.mz_dataflow_operators, source_cdcv2;
 contains:multiple timelines within one dataflow are not supported
-> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_relations, mz_views, mz_dataflow_operators, source_system;
-> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_relations, mz_views, mz_dataflow_operators, input_table;
+> CREATE VIEW various_system_no_cdcv2 (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_relations, mz_views, mz_internal.mz_dataflow_operators, source_system;
+
+> CREATE VIEW various_system_table (a, b, c, d, e, f, g, h, i, j, k, l, m, n) AS SELECT * FROM mz_relations, mz_views, mz_internal.mz_dataflow_operators, input_table;
 
 # EXPLAIN should complain too.
 ! EXPLAIN SELECT * FROM source_system, source_cdcv2;


### PR DESCRIPTION
This PR moves the introspection sources (both persisted and index-based), and their views, into the mz_internal schema, to better reflect that they should be considered unstable and likely to change in the future.

It also adds the view `mz_materialization_source_frontiers_*` for persisted introspection sources, which was probably missed when its equivalent was introduced for index-based introspection sources.

### Motivation

  * This PR adds a known-desirable feature.

Closes #14888.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Move the introspection sources, and the views defined over them, from mz_catalog into the mz_internal schema. 
