### PR TITLE
test: Fix syntax in instance size test

### DIFF
--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1375,9 +1375,9 @@ def workflow_instance_size(c: Composition, parser: WorkflowArgumentParser) -> No
                     replica_definitions.append(
                         f"{replica_name} (REMOTE ["
                         + ", ".join(f"'{n}:2100'" for n in nodes)
-                        + "] COMPUTE ["
+                        + "], COMPUTE ["
                         + ", ".join(f"'{n}:2100'" for n in nodes)
-                        + f"] WORKERS {args.workers})"
+                        + f"], WORKERS {args.workers})"
                     )
 
                 c.sql(


### PR DESCRIPTION
There is a comma missing in the `CREATE REPLICA` statement in the instance size test.

### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - None