### PR TITLE
docker: add ssh to enviromentd and storage Docker images

### DIFF
--- a/src/environmentd/ci/Dockerfile
+++ b/src/environmentd/ci/Dockerfile
@@ -10,7 +10,7 @@
 MZFROM ubuntu-base
 
 RUN apt-get update \
-    && apt-get -qy install ca-certificates curl tini \
+    && apt-get -qy install ca-certificates curl tini ssh \
     && groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize \
     && mkdir /mzdata \

--- a/src/storage/ci/Dockerfile
+++ b/src/storage/ci/Dockerfile
@@ -10,7 +10,7 @@
 MZFROM ubuntu-base
 
 RUN apt-get update \
-    && apt-get -qy install ca-certificates curl tini \
+    && apt-get -qy install ca-certificates curl tini ssh \
     && groupadd --system --gid=999 materialize \
     && useradd --system --gid=999 --uid=999 --create-home materialize
 


### PR DESCRIPTION
Follow-up to #14887 adding OpenSSH to more Docker images, as apparently these are the Dockerfiles we use for Cloud.

### Motivation

  * This PR fixes a recognized bug: #14566

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):