### PR TITLE
Add support for LIKE filter in SHOW INDEXES command

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/show-indexes.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-indexes.svg
@@ -1,84 +1,100 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="537" height="255">
-   <polygon points="9 17 1 13 1 21"/>
-   <polygon points="17 17 9 13 9 21"/>
-   <rect x="31" y="3" width="64" height="32" rx="10"/>
-   <rect x="29"
+<svg xmlns="http://www.w3.org/2000/svg" width="559" height="267">
+   <polygon points="11 17 3 13 3 21"/>
+   <polygon points="19 17 11 13 11 21"/>
+   <rect x="33" y="3" width="64" height="32" rx="10"/>
+   <rect x="31"
          y="1"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="39" y="21">SHOW</text>
-   <rect x="115" y="3" width="80" height="32" rx="10"/>
-   <rect x="113"
+   <text class="terminal" x="41" y="21">SHOW</text>
+   <rect x="117" y="3" width="80" height="32" rx="10"/>
+   <rect x="115"
          y="1"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="123" y="21">INDEXES</text>
-   <rect x="255" y="35" width="60" height="32" rx="10"/>
-   <rect x="253"
+   <text class="terminal" x="125" y="21">INDEXES</text>
+   <rect x="257" y="35" width="60" height="32" rx="10"/>
+   <rect x="255"
          y="33"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="53">FROM</text>
-   <rect x="255" y="79" width="40" height="32" rx="10"/>
-   <rect x="253"
+   <text class="terminal" x="265" y="53">FROM</text>
+   <rect x="257" y="79" width="40" height="32" rx="10"/>
+   <rect x="255"
          y="77"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="97">ON</text>
-   <rect x="355" y="35" width="78" height="32"/>
-   <rect x="353" y="33" width="78" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="363" y="53">on_name</text>
-   <rect x="235" y="123" width="126" height="32" rx="10"/>
-   <rect x="233"
+   <text class="terminal" x="265" y="97">ON</text>
+   <rect x="357" y="35" width="78" height="32"/>
+   <rect x="355" y="33" width="78" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="365" y="53">on_name</text>
+   <rect x="237" y="123" width="126" height="32" rx="10"/>
+   <rect x="235"
          y="121"
          width="126"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="243" y="141">FROM SCHEMA</text>
-   <rect x="381" y="123" width="114" height="32"/>
-   <rect x="379" y="121" width="114" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="389" y="141">schema_name</text>
-   <rect x="65" y="221" width="34" height="32" rx="10"/>
-   <rect x="63"
+   <text class="terminal" x="245" y="141">FROM SCHEMA</text>
+   <rect x="383" y="123" width="114" height="32"/>
+   <rect x="381" y="121" width="114" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="391" y="141">schema_name</text>
+   <rect x="45" y="221" width="34" height="32" rx="10"/>
+   <rect x="43"
          y="219"
          width="34"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="73" y="239">IN</text>
-   <rect x="119" y="221" width="84" height="32" rx="10"/>
-   <rect x="117"
+   <text class="terminal" x="53" y="239">IN</text>
+   <rect x="99" y="221" width="84" height="32" rx="10"/>
+   <rect x="97"
          y="219"
          width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="127" y="239">CLUSTER</text>
-   <rect x="223" y="221" width="108" height="32"/>
-   <rect x="221" y="219" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="231" y="239">cluster_name</text>
-   <rect x="371" y="189" width="70" height="32" rx="10"/>
+   <text class="terminal" x="107" y="239">CLUSTER</text>
+   <rect x="203" y="221" width="108" height="32"/>
+   <rect x="201" y="219" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="211" y="239">cluster_name</text>
+   <rect x="371" y="189" width="50" height="32" rx="10"/>
    <rect x="369"
+         y="187"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="379" y="207">LIKE</text>
+   <rect x="441" y="189" width="70" height="32" rx="10"/>
+   <rect x="439"
          y="187"
          width="70"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="379" y="207">WHERE</text>
-   <rect x="461" y="189" width="48" height="32"/>
-   <rect x="459" y="187" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="469" y="207">expr</text>
+   <text class="terminal" x="449" y="207">pattern</text>
+   <rect x="371" y="233" width="70" height="32" rx="10"/>
+   <rect x="369"
+         y="231"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="379" y="251">WHERE</text>
+   <rect x="461" y="233" width="48" height="32"/>
+   <rect x="459" y="231" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="469" y="251">expr</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h270 m-300 0 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v12 m300 0 v-12 m-300 12 q0 10 10 10 m280 0 q10 0 10 -10 m-270 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m40 0 h10 m0 0 h20 m20 -44 h10 m78 0 h10 m0 0 h62 m-290 -10 v20 m300 0 v-20 m-300 20 v68 m300 0 v-68 m-300 68 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m126 0 h10 m0 0 h10 m114 0 h10 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-514 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m70 0 h10 m0 0 h10 m48 0 h10 m3 0 h-3"/>
-   <polygon points="527 203 535 199 535 207"/>
-   <polygon points="527 203 519 199 519 207"/>
+         d="m19 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h270 m-300 0 h20 m280 0 h20 m-320 0 q10 0 10 10 m300 0 q0 -10 10 -10 m-310 10 v12 m300 0 v-12 m-300 12 q0 10 10 10 m280 0 q10 0 10 -10 m-270 10 h10 m60 0 h10 m-100 0 h20 m80 0 h20 m-120 0 q10 0 10 10 m100 0 q0 -10 10 -10 m-110 10 v24 m100 0 v-24 m-100 24 q0 10 10 10 m80 0 q10 0 10 -10 m-90 10 h10 m40 0 h10 m0 0 h20 m20 -44 h10 m78 0 h10 m0 0 h62 m-290 -10 v20 m300 0 v-20 m-300 20 v68 m300 0 v-68 m-300 68 q0 10 10 10 m280 0 q10 0 10 -10 m-290 10 h10 m126 0 h10 m0 0 h10 m114 0 h10 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-536 186 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h276 m-306 0 h20 m286 0 h20 m-326 0 q10 0 10 10 m306 0 q0 -10 10 -10 m-316 10 v12 m306 0 v-12 m-306 12 q0 10 10 10 m286 0 q10 0 10 -10 m-296 10 h10 m34 0 h10 m0 0 h10 m84 0 h10 m0 0 h10 m108 0 h10 m40 -32 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -44 h-3"/>
+   <polygon points="549 203 557 199 557 207"/>
+   <polygon points="549 203 541 199 541 207"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -318,7 +318,7 @@ show_indexes ::=
     'SHOW' 'INDEXES'
     ((('FROM' | 'ON') on_name) | ('FROM SCHEMA' schema_name))?
     ('IN' 'CLUSTER' cluster_name)?
-    ('WHERE' expr)
+    ('LIKE' 'pattern' | 'WHERE' expr)
 show_materialized_views ::=
     'SHOW' 'MATERIALIZED VIEWS' ('FROM' schema_name)? ('IN CLUSTER' cluster_name)?
 show_secrets ::=

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4716,16 +4716,11 @@ impl<'a> Parser<'a> {
             }
             let in_cluster = self.parse_optional_in_cluster()?;
 
-            let filter = if self.parse_keyword(WHERE) {
-                Some(ShowStatementFilter::Where(self.parse_expr()?))
-            } else {
-                None
-            };
             Ok(ShowStatement::ShowIndexes(ShowIndexesStatement {
                 on_object,
                 from_schema,
                 in_cluster,
-                filter,
+                filter: self.parse_show_statement_filter()?,
             }))
         } else if self.parse_keywords(&[CREATE, VIEW]) {
             Ok(ShowStatement::ShowCreateView(ShowCreateViewStatement {

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -229,6 +229,13 @@ SHOW INDEXES FROM SCHEMA s IN CLUSTER c
 Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: Some(UnresolvedSchemaName([Ident("s")])), in_cluster: Some(Unresolved(Ident("c"))), filter: None }))
 
 parse-statement
+SHOW INDEXES LIKE 'pattern'
+----
+SHOW INDEXES LIKE 'pattern'
+=>
+Show(ShowIndexes(ShowIndexesStatement { on_object: None, from_schema: None, in_cluster: None, filter: Some(Like("pattern")) }))
+
+parse-statement
 SHOW INDEXES FROM SCHEMA s ON t
 ----
 error: Cannot specify both FROM SCHEMA and FROM or ON

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -173,8 +173,9 @@ foo_expr_idx1   foo <VARIABLE_OUTPUT>   "{pg_catalog.substr(z, 3)}"
 > SHOW INDEXES FROM foo WHERE name = 'noexist'
 > SHOW INDEXES FROM foo WHERE name = 'foo_expr_idx'
 foo_expr_idx    foo <VARIABLE_OUTPUT>   "{a + b}"
-# TODO(justin): not handled in parser yet:
-#   SHOW INDEXES FROM v LIKE '%v'
+
+> SHOW INDEXES FROM foo LIKE 'foo_primary%'
+foo_primary_idx foo <VARIABLE_OUTPUT>   {a,b,z}
 
 ! SHOW INDEXES FROM nonexistent
 contains:unknown catalog item 'nonexistent'


### PR DESCRIPTION
As a follow up to #14890, we realized `SHOW INDEXES` was not using the shared `parse_show_statement_filter` and was thus only supporting the `WHERE` filter, not `LIKE`. Move the command to use the shared filter parser which supports `LIKE`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

Support filtering `SHOW INDEXES` commands with `LIKE`.