### PR TITLE
sql: Update output format of EXPLAIN TIMESTAMP

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2561,8 +2561,9 @@ impl<S: Append + 'static> Coordinator<S> {
                     compute_instance,
                 )?;
                 let since = self.least_valid_read(&id_bundle).elements().to_vec();
-                let upper = self.least_valid_write(&id_bundle).elements().to_vec();
-                let respond_immediately = upper.iter().all(|upper| upper > &timestamp);
+                let upper = self.least_valid_write(&id_bundle);
+                let respond_immediately = !upper.less_equal(&timestamp);
+                let upper = upper.elements().to_vec();
                 let mut sources = Vec::new();
                 {
                     for id in id_bundle.storage_ids.iter() {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2614,6 +2614,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     timestamp,
                     since,
                     upper,
+                    global_timestamp: self.get_local_read_ts(),
                     respond_immediately,
                     sources,
                 };

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2562,12 +2562,7 @@ impl<S: Append + 'static> Coordinator<S> {
                 )?;
                 let since = self.least_valid_read(&id_bundle).elements().to_vec();
                 let upper = self.least_valid_write(&id_bundle).elements().to_vec();
-                let has_table = id_bundle.iter().any(|id| self.catalog.uses_tables(id));
-                let table_read_ts = if has_table {
-                    Some(self.get_local_read_ts())
-                } else {
-                    None
-                };
+                let respond_immediately = upper.iter().all(|upper| upper > &timestamp);
                 let mut sources = Vec::new();
                 {
                     for id in id_bundle.storage_ids.iter() {
@@ -2619,8 +2614,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     timestamp,
                     since,
                     upper,
-                    has_table,
-                    table_read_ts,
+                    respond_immediately,
                     sources,
                 };
                 explanation.to_string()

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -235,10 +235,8 @@ impl<'a> ViewFormatter<OptimizedMirRelationExpr> for DataflowGraphFormatter<'a> 
 pub struct TimestampExplanation<T> {
     /// The chosen timestamp from `determine_timestamp`.
     pub timestamp: T,
-    /// Whether the query contains a table.
-    pub has_table: bool,
-    /// If the query contains a table, the global table read timestamp.
-    pub table_read_ts: Option<T>,
+    /// Whether the query can responded immediately or if it has to block.
+    pub respond_immediately: bool,
     /// The read frontier of all involved sources.
     pub since: Vec<T>,
     /// The write frontier of all involved sources.
@@ -255,13 +253,10 @@ pub struct TimestampSource<T> {
 
 impl<T: fmt::Display + fmt::Debug> fmt::Display for TimestampExplanation<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "     timestamp: {:13}", self.timestamp)?;
-        writeln!(f, "         since:{:13?}", self.since)?;
-        writeln!(f, "         upper:{:13?}", self.upper)?;
-        writeln!(f, "     has table: {}", self.has_table)?;
-        if let Some(ts) = &self.table_read_ts {
-            writeln!(f, " table read ts: {:13}", ts)?;
-        }
+        writeln!(f, "                timestamp: {:13}", self.timestamp)?;
+        writeln!(f, "                    since:{:13?}", self.since)?;
+        writeln!(f, "                    upper:{:13?}", self.upper)?;
+        writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
         for source in &self.sources {
             writeln!(f, "")?;
             writeln!(f, "source {}:", source.name)?;

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -235,12 +235,14 @@ impl<'a> ViewFormatter<OptimizedMirRelationExpr> for DataflowGraphFormatter<'a> 
 pub struct TimestampExplanation<T> {
     /// The chosen timestamp from `determine_timestamp`.
     pub timestamp: T,
-    /// Whether the query can responded immediately or if it has to block.
-    pub respond_immediately: bool,
     /// The read frontier of all involved sources.
     pub since: Vec<T>,
     /// The write frontier of all involved sources.
     pub upper: Vec<T>,
+    /// Whether the query can responded immediately or if it has to block.
+    pub respond_immediately: bool,
+    /// The current value of the global timestamp.
+    pub global_timestamp: T,
     /// Details about each source.
     pub sources: Vec<TimestampSource<T>>,
 }
@@ -253,9 +255,10 @@ pub struct TimestampSource<T> {
 
 impl<T: fmt::Display + fmt::Debug> fmt::Display for TimestampExplanation<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "                timestamp: {:13}", self.timestamp)?;
+        writeln!(f, "          query timestamp: {:13}", self.timestamp)?;
         writeln!(f, "                    since:{:13?}", self.since)?;
         writeln!(f, "                    upper:{:13?}", self.upper)?;
+        writeln!(f, "         global timestamp: {:13?}", self.upper)?;
         writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
         for source in &self.sources {
             writeln!(f, "")?;

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -258,7 +258,11 @@ impl<T: fmt::Display + fmt::Debug> fmt::Display for TimestampExplanation<T> {
         writeln!(f, "          query timestamp: {:13}", self.timestamp)?;
         writeln!(f, "                    since:{:13?}", self.since)?;
         writeln!(f, "                    upper:{:13?}", self.upper)?;
-        writeln!(f, "         global timestamp: {:13?}", self.upper)?;
+        writeln!(
+            f,
+            "         global timestamp: {:13?}",
+            self.global_timestamp
+        )?;
         writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
         for source in &self.sources {
             writeln!(f, "")?;

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1041,14 +1041,14 @@ fn test_explain_timestamp_table() -> Result<(), Box<dyn Error>> {
     let server = util::start_server(config)?;
     let mut client = server.connect(postgres::NoTls)?;
     let timestamp_re = Regex::new(r"\d{4}").unwrap();
+    let bool_re = Regex::new(r"true|false").unwrap();
 
     client.batch_execute("CREATE TABLE t1 (i1 INT)")?;
 
-    let expect = "     timestamp:          <TIMESTAMP>
-         since:[         <TIMESTAMP>]
-         upper:[         <TIMESTAMP>]
-     has table: true
- table read ts:          <TIMESTAMP>
+    let expect = "                timestamp:          <TIMESTAMP>
+                    since:[         <TIMESTAMP>]
+                    upper:[         <TIMESTAMP>]
+  can respond immediately: <BOOL>
 
 source materialize.public.t1 (u1, storage):
  read frontier:[         <TIMESTAMP>]
@@ -1062,6 +1062,7 @@ write frontier:[         <TIMESTAMP>]\n";
                 .unwrap();
             let explain: String = row.get(0);
             let explain = timestamp_re.replace_all(&explain, "<TIMESTAMP>");
+            let explain = bool_re.replace_all(&explain, "<BOOL>");
             if explain != expect {
                 Err(format!("expected {expect}, got {explain}"))
             } else {

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1045,9 +1045,10 @@ fn test_explain_timestamp_table() -> Result<(), Box<dyn Error>> {
 
     client.batch_execute("CREATE TABLE t1 (i1 INT)")?;
 
-    let expect = "                timestamp:          <TIMESTAMP>
+    let expect = "          query timestamp:          <TIMESTAMP>
                     since:[         <TIMESTAMP>]
                     upper:[         <TIMESTAMP>]
+         global timestamp:          <TIMESTAMP>
   can respond immediately: <BOOL>
 
 source materialize.public.t1 (u1, storage):
@@ -1619,7 +1620,7 @@ fn get_explain_timestamp(table: &str, client: &mut postgres::Client) -> EpochMil
         .query_one(&format!("EXPLAIN TIMESTAMP FOR SELECT * FROM {table}"), &[])
         .unwrap();
     let explain: String = row.get(0);
-    let timestamp_re = Regex::new(r"^\s+timestamp:\s+(\d+)\n").unwrap();
+    let timestamp_re = Regex::new(r"^\s+query timestamp:\s+(\d+)\n").unwrap();
     let timestamp_caps = timestamp_re.captures(&explain).unwrap();
     timestamp_caps.get(1).unwrap().as_str().parse().unwrap()
 }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1040,37 +1040,28 @@ fn test_explain_timestamp_table() -> Result<(), Box<dyn Error>> {
     let config = util::Config::default().with_now(now);
     let server = util::start_server(config)?;
     let mut client = server.connect(postgres::NoTls)?;
-    let timestamp_re = Regex::new(r"\d{4}").unwrap();
+    let timestamp_re = Regex::new(r"\s*(\d{4}|0)").unwrap();
     let bool_re = Regex::new(r"true|false").unwrap();
 
     client.batch_execute("CREATE TABLE t1 (i1 INT)")?;
 
-    let expect = "          query timestamp:          <TIMESTAMP>
-                    since:[         <TIMESTAMP>]
-                    upper:[         <TIMESTAMP>]
-         global timestamp:          <TIMESTAMP>
+    let expect = "          query timestamp:<TIMESTAMP>
+                    since:[<TIMESTAMP>]
+                    upper:[<TIMESTAMP>]
+         global timestamp:<TIMESTAMP>
   can respond immediately: <BOOL>
 
 source materialize.public.t1 (u1, storage):
- read frontier:[         <TIMESTAMP>]
-write frontier:[         <TIMESTAMP>]\n";
+ read frontier:[<TIMESTAMP>]
+write frontier:[<TIMESTAMP>]\n";
 
-    // Upper starts at 0, which the regex doesn't cover. Wait until it moves ahead.
-    Retry::default()
-        .retry(|_| {
-            let row = client
-                .query_one("EXPLAIN TIMESTAMP FOR SELECT * FROM t1;", &[])
-                .unwrap();
-            let explain: String = row.get(0);
-            let explain = timestamp_re.replace_all(&explain, "<TIMESTAMP>");
-            let explain = bool_re.replace_all(&explain, "<BOOL>");
-            if explain != expect {
-                Err(format!("expected {expect}, got {explain}"))
-            } else {
-                Ok(())
-            }
-        })
+    let row = client
+        .query_one("EXPLAIN TIMESTAMP FOR SELECT * FROM t1;", &[])
         .unwrap();
+    let explain: String = row.get(0);
+    let explain = timestamp_re.replace_all(&explain, "<TIMESTAMP>");
+    let explain = bool_re.replace_all(&explain, "<BOOL>");
+    assert_eq!(explain, expect);
 
     Ok(())
 }

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -126,9 +126,9 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=(\d{13}|u\d{1,3}) replacement=<>
+$ set-regex match=(\d{13}|u\d{1,3}|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-"     timestamp: <>\n         since:[<>]\n         upper:[]\n     has table: false\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<>]\nwrite frontier:[]\n"
+"          query timestamp: <>\n                    since:[<>]\n                    upper:[]\n         global timestamp: <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<>]\nwrite frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=(\d{13}|u\d{1,3}) replacement=<REDACTED>
+$ set-regex match=(\d{13}|u\d{1,3}|true|false) replacement=<REDACTED>
 
 > CREATE TABLE t1 (a INT);
 
@@ -16,9 +16,9 @@ $ set-regex match=(\d{13}|u\d{1,3}) replacement=<REDACTED>
 # Strict serializable doesn't look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'STRICT SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"     timestamp: <REDACTED>\n         since:[<REDACTED>]\n         upper:[<REDACTED>]\n     has table: true\n table read ts: <REDACTED>\n\nsource materialize.public.t1 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n"
+"          query timestamp: <REDACTED>\n                    since:[<REDACTED>]\n                    upper:[<REDACTED>]\n         global timestamp: <REDACTED>\n  can respond immediately: <REDACTED>\n\nsource materialize.public.t1 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n"
 
 # Serializable does look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"     timestamp: <REDACTED>\n         since:[<REDACTED>]\n         upper:[<REDACTED>]\n     has table: true\n table read ts: <REDACTED>\n\nsource materialize.public.t1 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n\nsource materialize.public.t2 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n"
+"          query timestamp: <REDACTED>\n                    since:[<REDACTED>]\n                    upper:[<REDACTED>]\n         global timestamp: <REDACTED>\n  can respond immediately: <REDACTED>\n\nsource materialize.public.t1 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n\nsource materialize.public.t2 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n"


### PR DESCRIPTION
This commit updates the output format of EXPLAIN TIMESTAMP. It removes the "has tables" and "table read ts" fields from the output because they are no longer relevant in determining a timestamp. It also adds a field to indicate if the query can respond immediately or if it needs to block. This can help with debugging and help avoid misreading the timestamps.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
