### PR TITLE
persist: record storage usage as prometheus metrics

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -752,10 +752,7 @@ pub struct ShardsMetrics {
     upper: mz_ore::metrics::IntGaugeVec,
     encoded_rollup_size: mz_ore::metrics::UIntGaugeVec,
     encoded_diff_size: mz_ore::metrics::IntCounterVec,
-    // _batch_count is somewhat redundant with _encoded_state_size. It's nice to
-    // see directly as we're getting started, perhaps we're able to drop it
-    // later in favor of only having the latter.
-    batch_count: mz_ore::metrics::UIntGaugeVec,
+    batch_part_count: mz_ore::metrics::UIntGaugeVec,
     update_count: mz_ore::metrics::UIntGaugeVec,
     encoded_batch_size: mz_ore::metrics::UIntGaugeVec,
     seqnos_held: mz_ore::metrics::UIntGaugeVec,
@@ -811,10 +808,10 @@ impl ShardsMetrics {
                     var_labels: ["shard"],
                 ),
             ),
-            batch_count: registry.register(
+            batch_part_count: registry.register(
                 metric!(
-                    name: "mz_persist_shard_batch_count",
-                    help: "count of batches in all active shards on this process",
+                    name: "mz_persist_shard_batch_part_count",
+                    help: "count of batch parts in all active shards on this process",
                     var_labels: ["shard"],
                 ),
             ),
@@ -899,7 +896,7 @@ pub struct ShardMetrics {
     upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     encoded_rollup_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     encoded_diff_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
-    batch_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    batch_part_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     update_count: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     encoded_batch_size: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     seqnos_held: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
@@ -926,8 +923,8 @@ impl ShardMetrics {
             encoded_diff_size: shards_metrics
                 .encoded_diff_size
                 .get_delete_on_drop_counter(vec![shard.clone()]),
-            batch_count: shards_metrics
-                .batch_count
+            batch_part_count: shards_metrics
+                .batch_part_count
                 .get_delete_on_drop_gauge(vec![shard.clone()]),
             update_count: shards_metrics
                 .update_count
@@ -981,8 +978,8 @@ impl ShardMetrics {
             .inc_by(u64::cast_from(encoded_diff_size))
     }
 
-    pub fn set_batch_count(&self, batch_count: usize) {
-        self.batch_count.set(u64::cast_from(batch_count))
+    pub fn set_batch_part_count(&self, batch_count: usize) {
+        self.batch_part_count.set(u64::cast_from(batch_count))
     }
 
     pub fn set_update_count(&self, update_count: usize) {

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -19,7 +19,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::{
     ComputedGauge, ComputedIntGauge, Counter, CounterVecExt, DeleteOnDropCounter,
-    DeleteOnDropGauge, GaugeVecExt, IntCounter, MetricsRegistry, UIntGauge
+    DeleteOnDropGauge, GaugeVecExt, IntCounter, MetricsRegistry, UIntGauge,
 };
 use mz_persist::location::{
     Atomicity, Blob, BlobMetadata, Consensus, ExternalError, SeqNo, VersionedData,

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -66,7 +66,7 @@ pub struct Metrics {
     /// Metrics for various per-shard measurements.
     pub shards: ShardsMetrics,
     /// Metrics for auditing persist usage
-    pub audit: AuditMetrics,
+    pub audit: UsageAuditMetrics,
 
     /// Metrics for Postgres-backed consensus implementation
     pub postgres_consensus: PostgresConsensusMetrics,
@@ -100,7 +100,7 @@ impl Metrics {
             lease: LeaseMetrics::new(registry),
             state: StateMetrics::new(registry),
             shards: ShardsMetrics::new(registry),
-            audit: AuditMetrics::new(registry),
+            audit: UsageAuditMetrics::new(registry),
             postgres_consensus: PostgresConsensusMetrics::new(registry),
             _vecs: vecs,
             _uptime: uptime,
@@ -998,23 +998,47 @@ impl ShardMetrics {
 
 /// Metrics recorded by audits of persist usage
 #[derive(Debug)]
-pub struct AuditMetrics {
-    /// Sum of size of all parts stored in Blob
-    pub blob_size: UIntGauge,
-    /// Total number of parts stored in Blob
-    pub blob_parts_count: UIntGauge,
+pub struct UsageAuditMetrics {
+    /// Size of all batch parts stored in Blob
+    pub blob_batch_part_bytes: UIntGauge,
+    /// Count of batch parts stored in Blob
+    pub blob_batch_part_count: UIntGauge,
+    /// Size of all state rollups stored in Blob
+    pub blob_rollup_bytes: UIntGauge,
+    /// Count of state rollups stored in Blob
+    pub blob_rollup_count: UIntGauge,
+    /// Size of Blob
+    pub blob_bytes: UIntGauge,
+    /// Count of all blobs
+    pub blob_count: UIntGauge,
 }
 
-impl AuditMetrics {
+impl UsageAuditMetrics {
     fn new(registry: &MetricsRegistry) -> Self {
-        AuditMetrics {
-            blob_size: registry.register(metric!(
-                name: "mz_persist_audit_blob_size",
-                help: "total size (in bytes) of all blobs",
+        UsageAuditMetrics {
+            blob_batch_part_bytes: registry.register(metric!(
+                name: "mz_persist_audit_blob_batch_part_bytes",
+                help: "total size of batch parts in blob",
             )),
-            blob_parts_count: registry.register(metric!(
-                name: "mz_persist_audit_blob_parts_count",
-                help: "count of all parts in blob",
+            blob_batch_part_count: registry.register(metric!(
+                name: "mz_persist_audit_blob_batch_part_count",
+                help: "count of batch parts in blob",
+            )),
+            blob_rollup_bytes: registry.register(metric!(
+                name: "mz_persist_audit_blob_rollup_bytes",
+                help: "total size of state rollups stored in blob",
+            )),
+            blob_rollup_count: registry.register(metric!(
+                name: "mz_persist_audit_blob_rollup_count",
+                help: "count of all state rollups in blob",
+            )),
+            blob_bytes: registry.register(metric!(
+                name: "mz_persist_audit_blob_bytes",
+                help: "total size of blob",
+            )),
+            blob_count: registry.register(metric!(
+                name: "mz_persist_audit_blob_count",
+                help: "count of all blobs",
             )),
         }
     }

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -480,8 +480,8 @@ where
         self.collections.trace.upper()
     }
 
-    pub fn batch_count(&self) -> usize {
-        self.collections.trace.num_hollow_batches()
+    pub fn batch_part_count(&self) -> usize {
+        self.collections.trace.num_batch_parts()
     }
 
     pub fn num_updates(&self) -> usize {

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -232,7 +232,7 @@ impl StateVersions {
 
                 shard_metrics.set_since(new_state.since());
                 shard_metrics.set_upper(&new_state.upper());
-                shard_metrics.set_batch_count(new_state.batch_count());
+                shard_metrics.set_batch_part_count(new_state.batch_part_count());
                 shard_metrics.set_update_count(new_state.num_updates());
                 shard_metrics.set_encoded_batch_size(new_state.encoded_batch_size());
                 shard_metrics.set_seqnos_held(new_state.seqnos_held());

--- a/src/persist-client/src/internal/trace.rs
+++ b/src/persist-client/src/internal/trace.rs
@@ -141,6 +141,7 @@ impl<T> Trace<T> {
         ret
     }
 
+    #[cfg(test)]
     pub fn num_hollow_batches(&self) -> usize {
         let mut ret = 0;
         self.map_batches(|_| ret += 1);
@@ -150,6 +151,14 @@ impl<T> Trace<T> {
     pub fn num_updates(&self) -> usize {
         let mut ret = 0;
         self.map_batches(|b| ret += b.len);
+        ret
+    }
+
+    pub fn num_batch_parts(&self) -> usize {
+        let mut ret = 0;
+        self.map_batches(|b| {
+            ret += b.parts.len();
+        });
         ret
     }
 

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -90,8 +90,14 @@ impl StorageUsageClient {
                     })
                     .await?;
 
-                self.metrics.audit.blob_batch_part_bytes.set(batch_part_bytes);
-                self.metrics.audit.blob_batch_part_count.set(batch_part_count);
+                self.metrics
+                    .audit
+                    .blob_batch_part_bytes
+                    .set(batch_part_bytes);
+                self.metrics
+                    .audit
+                    .blob_batch_part_count
+                    .set(batch_part_count);
                 self.metrics.audit.blob_rollup_bytes.set(rollup_size);
                 self.metrics.audit.blob_rollup_count.set(rollup_count);
                 self.metrics.audit.blob_bytes.set(total_size);

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -11,12 +11,13 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use tracing::info;
 
 use crate::{retry_external, Metrics, ShardId};
 use mz_persist::location::{Blob, ExternalError};
 
 use crate::cache::PersistClientCache;
-use crate::internal::paths::{BlobKey, BlobKeyPrefix};
+use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
 
 /// Provides access to storage usage metrics for a specific Blob
 #[derive(Clone, Debug)]
@@ -55,26 +56,46 @@ impl StorageUsageClient {
             &self.metrics.retries.external.storage_usage_shard_size,
             || async {
                 let mut shard_sizes = HashMap::new();
+                let mut batch_part_bytes = 0;
+                let mut batch_part_count = 0;
+                let mut rollup_size = 0;
+                let mut rollup_count = 0;
                 let mut total_size = 0;
-                let mut total_parts_count = 0;
+                let mut total_count = 0;
                 self.blob
                     .list_keys_and_metadata(&BlobKeyPrefix::All.to_string(), &mut |metadata| {
                         match BlobKey::parse_ids(metadata.key) {
-                            Ok((shard, _)) => {
+                            Ok((shard, partial_blob_key)) => {
                                 *shard_sizes.entry(Some(shard)).or_insert(0) +=
                                     metadata.size_in_bytes;
+
+                                match partial_blob_key {
+                                    PartialBlobKey::Batch(_, _) => {
+                                        batch_part_bytes += metadata.size_in_bytes;
+                                        batch_part_count += 1;
+                                    }
+                                    PartialBlobKey::Rollup(_, _) => {
+                                        rollup_size += metadata.size_in_bytes;
+                                        rollup_count += 1;
+                                    }
+                                }
                             }
                             _ => {
+                                info!("unknown blob: {}: {}", metadata.key, metadata.size_in_bytes);
                                 *shard_sizes.entry(None).or_insert(0) += metadata.size_in_bytes;
                             }
                         }
-                        total_parts_count += 1;
                         total_size += metadata.size_in_bytes;
+                        total_count += 1;
                     })
                     .await?;
 
-                self.metrics.audit.blob_size.set(total_size);
-                self.metrics.audit.blob_parts_count.set(total_parts_count);
+                self.metrics.audit.blob_batch_part_bytes.set(batch_part_bytes);
+                self.metrics.audit.blob_batch_part_count.set(batch_part_count);
+                self.metrics.audit.blob_rollup_bytes.set(rollup_size);
+                self.metrics.audit.blob_rollup_count.set(rollup_count);
+                self.metrics.audit.blob_bytes.set(total_size);
+                self.metrics.audit.blob_count.set(total_count);
 
                 Ok(shard_sizes)
             },


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Piggybacks off of calls to our `StorageUsageClient` to record blob storage usage for batch parts / rollups (and a total count, to catch if anything winds up in S3 that we don't expect). Also updates our `batch_count` metric to be `batch_part_count` so we can reconcile the parts we're tracking in state vs a raw scan of the blob store. 

This will help us identify any scenarios in which blob growth is unexpectedly large.

### Motivation

  * This PR adds a known-desirable feature.

We don't have any known unbounded blob growth issues right now, so with this in place I'd feel comfortable closing https://github.com/MaterializeInc/materialize/issues/13861

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
