### PR TITLE
persist: add a pointer to the lease expiration panics

### DIFF
--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -370,7 +370,12 @@ where
             // (1) is a gross mis-use and (2) may happen if a reader did not
             // get to heartbeat for a long time. Readers are expected to
             // heartbeat/downgrade their since regularly.
-            .unwrap_or_else(|| panic!("ReaderId({}) was expired due to inactivity", id))
+            .unwrap_or_else(|| {
+                panic!(
+                    "ReaderId({}) was expired due to inactivity. Did the machine go to sleep?",
+                    id
+                )
+            })
     }
 
     fn writer(&mut self, id: &WriterId) -> &mut WriterState {
@@ -382,7 +387,12 @@ where
             // not get to heartbeat for a long time. Writers are expected to
             // append updates regularly, even empty batches to maintain their
             // lease.
-            .unwrap_or_else(|| panic!("WriterId({}) was expired due to inactivity", id))
+            .unwrap_or_else(|| {
+                panic!(
+                    "WriterId({}) was expired due to inactivity. Did the machine go to sleep?",
+                    id
+                )
+            })
     }
 
     fn update_since(&mut self) {


### PR DESCRIPTION
We shouldn't see these in prod, but they happen when someone's laptop goes to sleep with things running. Make the panic message more clear that it doesn't need to be reported/investigated when this happens.

Touches #13802

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
