### PR TITLE
storage: add testdrive command to verify kafka committed offsets

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -711,6 +711,12 @@ Obtains the data from the specified `sink` or `topic` and compares it to the exp
 
 If `partial-search=usize` is specified, up to `partial-search` records will be read from the given topic and compared to the provided records. The records do not have to match starting at the beginning of the sink but once one record matches, the following must all match.  There are permitted to be records remaining in the topic after the matching is complete.  Note that if the topic is not required to have `partial-search` elements in it but there will be an attempt to read up to this number with a blocking read.
 
+#### `kafka-verify-commit source=... topic=... partition=...
+
+Verifies that the provided offset (the input data) matches the committed offset for
+_the sources consumer id_
+
+
 #### `headers=<list or object>`
 
 `headers` is a parameter that takes a json map (or list of maps) with string key-value pairs

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -562,6 +562,9 @@ pub(crate) async fn build(
                     "kafka-verify-schema" => {
                         Box::new(kafka::build_verify_schema(builtin).map_err(wrap_err)?)
                     }
+                    "kafka-verify-commit" => {
+                        Box::new(kafka::build_verify_commit(builtin).map_err(wrap_err)?)
+                    }
                     "kinesis-create-stream" => {
                         Box::new(kinesis::build_create_stream(builtin).map_err(wrap_err)?)
                     }

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -8,11 +8,13 @@
 // by the Apache License, Version 2.0.
 
 mod add_partitions;
+mod commit;
 mod create_topic;
 mod ingest;
 mod verify;
 
 pub use add_partitions::build_add_partitions;
+pub use commit::build_verify_commit;
 pub use create_topic::build_create_topic;
 pub use ingest::build_ingest;
 pub use verify::build_verify;

--- a/src/testdrive/src/action/kafka/commit.rs
+++ b/src/testdrive/src/action/kafka/commit.rs
@@ -1,0 +1,110 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use anyhow::{anyhow, Context};
+use async_trait::async_trait;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::topic_partition_list::Offset;
+
+use mz_ore::retry::Retry;
+
+use crate::action::{Action, ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+pub struct VerifyCommitAction {
+    source: String,
+    // TODO(guswynn): can we get the topic from
+    // a system table?
+    topic: String,
+    partition: i32,
+    expected_offset: Offset,
+}
+
+pub fn build_verify_commit(mut cmd: BuiltinCommand) -> Result<VerifyCommitAction, anyhow::Error> {
+    Ok(VerifyCommitAction {
+        source: cmd.args.string("source")?,
+        topic: cmd.args.string("topic")?,
+        partition: cmd.args.parse("partition")?,
+        expected_offset: Offset::Offset(cmd.input[0].parse()?),
+    })
+}
+
+async fn get_env_id(state: &mut State) -> Result<String, anyhow::Error> {
+    let query = "select mz_environment_id();".to_string();
+    let result = state
+        .pgclient
+        .query_one(query.as_str(), &[])
+        .await
+        .context("retrieving env id")?
+        .get(0);
+    Ok(result)
+}
+
+async fn get_src_id(source: &str, state: &mut State) -> Result<String, anyhow::Error> {
+    let query = "select id from mz_sources where name = $1".to_string();
+    let result = state
+        .pgclient
+        .query_one(query.as_str(), &[&source])
+        .await
+        .context("retrieving source id")?
+        .get(0);
+    Ok(result)
+}
+
+#[async_trait]
+impl Action for VerifyCommitAction {
+    async fn undo(&self, _state: &mut State) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+
+    async fn redo(&self, state: &mut State) -> Result<ControlFlow, anyhow::Error> {
+        let env_id = get_env_id(state).await?;
+        let source_id = get_src_id(&self.source, state).await?;
+        let topic = format!("testdrive-{}-{}", self.topic, state.seed);
+
+        let mut config = state.kafka_config.clone();
+        config.set(
+            "group.id",
+            format!("materialize-{}-kafka-{}", env_id, source_id),
+        );
+        Retry::default()
+            .max_duration(state.default_timeout)
+            .retry_async_canceling(|_| async {
+                let config = config.clone();
+                let mut tpl = rdkafka::topic_partition_list::TopicPartitionList::new();
+                tpl.add_partition(&topic, self.partition);
+                let committed_tpl = mz_ore::task::spawn_blocking(
+                    || "kakfa_committed_offsets".to_string(),
+                    move || {
+                        let consumer: StreamConsumer =
+                            config.create().context("creating kafka consumer")?;
+
+                        Ok::<_, anyhow::Error>(
+                            consumer.committed_offsets(tpl, std::time::Duration::from_secs(10))?,
+                        )
+                    },
+                )
+                .await
+                .unwrap()?;
+
+                let found_offset = committed_tpl.elements_for_topic(&topic)[0].offset();
+                if found_offset != self.expected_offset {
+                    Err(anyhow!(
+                        "Found committed offset `{:?}` does not match expected offset `{:?}`",
+                        found_offset,
+                        self.expected_offset
+                    ))
+                } else {
+                    Ok(())
+                }
+            })
+            .await?;
+        Ok(ControlFlow::Continue)
+    }
+}

--- a/test/testdrive/auto_commit.td
+++ b/test/testdrive/auto_commit.td
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This testdrive file uses the deprecated syntax, but is otherwise identical to upsert-kafka-new.td
+#
+# This file can be deleted when/if we finish the deprecation and perform the removal of the old syntax.
+
+$ kafka-create-topic topic=auto_topic partitions=1
+
+$ kafka-ingest format=bytes topic=auto_topic
+one
+two
+three
+
+> CREATE CONNECTION conn
+  FOR KAFKA BROKER '${testdrive.kafka-addr}'
+
+# Note that auto commit is not really safe to enable, but we have this here to
+# test `kafka-verify-commit` until we have correct commit behavior for kafka sources.
+> CREATE SOURCE auto_topic
+  FROM KAFKA CONNECTION conn (
+    TOPIC 'testdrive-auto_topic-${testdrive.seed}',
+    ENABLE AUTO COMMIT
+  )
+  FORMAT BYTES
+  INCLUDE OFFSET
+  ENVELOPE NONE
+
+> SELECT * from auto_topic
+data         offset
+-----------------------------------
+one          0
+two          1
+three        2
+
+$ kafka-verify-commit source=auto_topic topic=auto_topic partition=0
+3


### PR DESCRIPTION
This will eventually be required test that we are actually committing offsets as part of my work on https://github.com/MaterializeInc/materialize/issues/13534

### Motivation

  * This PR adds a feature that has not yet been specified.


### Tips for reviewer
I also fixed a problem in the kafka source client creation that overrode some values (like `ENABLE AUTO COMMIT` with defaults)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

