### PR TITLE
compute-client: ignore flaky test dataflow_description_protobuf_roundtrip

### DIFF
--- a/src/compute-client/src/command.rs
+++ b/src/compute-client/src/command.rs
@@ -1217,7 +1217,9 @@ mod tests {
             assert_eq!(actual.unwrap(), expect);
         }
 
+        // TODO: Unignore after fixing #14543.
         #[test]
+        #[ignore]
         fn dataflow_description_protobuf_roundtrip(expect in any::<DataflowDescription<Plan, CollectionMetadata, mz_repr::Timestamp>>()) {
             let actual = protobuf_roundtrip::<_, ProtoDataflowDescription>(&expect);
             assert!(actual.is_ok());


### PR DESCRIPTION
This commit disables the test `dataflow_description_protobuf_roundtrip` because it is flaky: It regularly fails because of a stack overflow.

### Motivation

  * This PR fixes a recognized bug.

Short-term workaround for https://github.com/MaterializeInc/materialize/issues/14543.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
