### PR TITLE
sql: error instead of panic when Kafka connection does not have topic

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -404,7 +404,7 @@ pub fn plan_create_source(
 
             let topic = extracted_options
                 .topic
-                .ok_or_else(|| sql_err!("KAFKA CONNECTION without TOPIC"))?;
+                .expect("validated exists during purification");
             let group_id_prefix = extracted_options.group_id_prefix;
 
             let mut start_offsets = HashMap::new();

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -103,7 +103,9 @@ pub async fn purify_create_source(
                 Option::<kafka_util::KafkaStartOffsetType>::try_from(&extracted_options)?;
             let config_options = kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
 
-            let topic = extracted_options.topic.expect("validated topic exists");
+            let topic = extracted_options
+                .topic
+                .ok_or_else(|| sql_err!("KAFKA CONNECTION without TOPIC"))?;
 
             let consumer = kafka_util::create_consumer(
                 &topic,

--- a/test/testdrive/kafka-sources.td
+++ b/test/testdrive/kafka-sources.td
@@ -15,3 +15,10 @@
 ! CREATE SOURCE s
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-data-${testdrive.seed}')
 contains:Source format must be specified
+
+> CREATE CONNECTION no_topic
+  FOR KAFKA BROKER '';
+
+! CREATE SOURCE s
+  FROM KAFKA CONNECTION no_topic
+contains:KAFKA CONNECTION without TOPIC


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. Fixes #14946

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Error (instead of panic) when creating a Kafka `SOURCE` or `SINK` from a `CONNECTION` without a specified topic.
