### PR TITLE
Add human-readable output to `EXPLAIN TIMESTAMP`

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -2618,6 +2618,7 @@ impl<S: Append + 'static> Coordinator<S> {
                     global_timestamp: self.get_local_read_ts(),
                     respond_immediately,
                     sources,
+                    timeline,
                 };
                 explanation.to_string()
             }

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -320,20 +320,32 @@ impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let timeline = self.timeline.as_ref();
-        writeln!(f, "          query timestamp: {}", self.timestamp.display(timeline))?;
-        writeln!(f, "          since:{:?}",
+        writeln!(
+            f,
+            "          query timestamp: {}",
+            self.timestamp.display(timeline)
+        )?;
+        writeln!(
+            f,
+            "          since:{:?}",
             self.since
                 .iter()
                 .map(|t| t.display(timeline))
                 .collect::<Vec<_>>()
         )?;
-        writeln!(f, "          upper:{:?}",
+        writeln!(
+            f,
+            "          upper:{:?}",
             self.upper
                 .iter()
                 .map(|t| t.display(timeline))
                 .collect::<Vec<_>>()
         )?;
-        writeln!(f, "         global timestamp: {}", self.global_timestamp.display(timeline))?;
+        writeln!(
+            f,
+            "         global timestamp: {}",
+            self.global_timestamp.display(timeline)
+        )?;
         writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
         for source in &self.sources {
             writeln!(f, "")?;

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -315,7 +315,7 @@ impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
         )?;
         writeln!(
             f,
-            "          since:{:?}",
+            "                    since:{:?}",
             self.since
                 .iter()
                 .map(|t| t.display(timeline))
@@ -323,7 +323,7 @@ impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
         )?;
         writeln!(
             f,
-            "          upper:{:?}",
+            "                    upper:{:?}",
             self.upper
                 .iter()
                 .map(|t| t.display(timeline))

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -285,18 +285,6 @@ pub struct DisplayInTimeline<'a, T: ?Sized> {
     t: &'a T,
     timeline: Option<&'a Timeline>,
 }
-/*
-        writeln!(f, "          query timestamp: {:13}", self.timestamp)?;
-        writeln!(f, "                    since:{:13?}", self.since)?;
-        writeln!(f, "                    upper:{:13?}", self.upper)?;
-        writeln!(
-            f,
-            "         global timestamp: {:13?}",
-            self.global_timestamp
-        )?;
-        writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
-
-*/
 impl<'a, T> fmt::Display for DisplayInTimeline<'a, T>
 where
     T: DisplayableInTimeline,

--- a/src/compute-client/src/explain.rs
+++ b/src/compute-client/src/explain.rs
@@ -29,6 +29,7 @@
 
 use std::fmt;
 
+use chrono::NaiveDateTime;
 use mz_expr::explain::{Indices, ViewExplanation};
 use mz_expr::MapFilterProject;
 use mz_expr::{OptimizedMirRelationExpr, RowSetFinishing};
@@ -36,6 +37,7 @@ use mz_ore::result::ResultExt;
 use mz_ore::str::{bracketed, separated};
 use mz_repr::explain_new::ExprHumanizer;
 use mz_repr::GlobalId;
+use mz_storage::types::sources::Timeline;
 
 use crate::command::DataflowDescription;
 
@@ -235,6 +237,8 @@ impl<'a> ViewFormatter<OptimizedMirRelationExpr> for DataflowGraphFormatter<'a> 
 pub struct TimestampExplanation<T> {
     /// The chosen timestamp from `determine_timestamp`.
     pub timestamp: T,
+    /// The timeline that the timestamp corresponds to.
+    pub timeline: Option<Timeline>,
     /// The read frontier of all involved sources.
     pub since: Vec<T>,
     /// The write frontier of all involved sources.
@@ -253,8 +257,35 @@ pub struct TimestampSource<T> {
     pub write_frontier: Vec<T>,
 }
 
-impl<T: fmt::Display + fmt::Debug> fmt::Display for TimestampExplanation<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+pub trait DisplayableInTimeline {
+    fn fmt(&self, timeline: Option<&Timeline>, f: &mut fmt::Formatter) -> fmt::Result;
+    fn display<'a>(&'a self, timeline: Option<&'a Timeline>) -> DisplayInTimeline<'a, Self> {
+        DisplayInTimeline { t: self, timeline }
+    }
+}
+
+impl DisplayableInTimeline for mz_repr::Timestamp {
+    fn fmt(&self, timeline: Option<&Timeline>, f: &mut fmt::Formatter) -> fmt::Result {
+        match timeline {
+            Some(Timeline::EpochMilliseconds) => {
+                let ts_ms: u64 = self.into();
+                let ts = ts_ms / 1000;
+                let nanos = ((ts_ms % 1000) as u32) * 1000000;
+                let ndt = NaiveDateTime::from_timestamp(ts as i64, nanos);
+                write!(f, "{:13} ({})", self, ndt.format("%Y-%m-%d %H:%M:%S%.3f"))
+            }
+            None | Some(_) => {
+                write!(f, "{:13}", self)
+            }
+        }
+    }
+}
+
+pub struct DisplayInTimeline<'a, T: ?Sized> {
+    t: &'a T,
+    timeline: Option<&'a Timeline>,
+}
+/*
         writeln!(f, "          query timestamp: {:13}", self.timestamp)?;
         writeln!(f, "                    since:{:13?}", self.since)?;
         writeln!(f, "                    upper:{:13?}", self.upper)?;
@@ -264,11 +295,67 @@ impl<T: fmt::Display + fmt::Debug> fmt::Display for TimestampExplanation<T> {
             self.global_timestamp
         )?;
         writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
+
+*/
+impl<'a, T> fmt::Display for DisplayInTimeline<'a, T>
+where
+    T: DisplayableInTimeline,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.t.fmt(self.timeline, f)
+    }
+}
+
+impl<'a, T> fmt::Debug for DisplayInTimeline<'a, T>
+where
+    T: DisplayableInTimeline,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self, f)
+    }
+}
+
+impl<T: fmt::Display + fmt::Debug + DisplayableInTimeline> fmt::Display
+    for TimestampExplanation<T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let timeline = self.timeline.as_ref();
+        writeln!(f, "          query timestamp: {}", self.timestamp.display(timeline))?;
+        writeln!(f, "          since:{:?}",
+            self.since
+                .iter()
+                .map(|t| t.display(timeline))
+                .collect::<Vec<_>>()
+        )?;
+        writeln!(f, "          upper:{:?}",
+            self.upper
+                .iter()
+                .map(|t| t.display(timeline))
+                .collect::<Vec<_>>()
+        )?;
+        writeln!(f, "         global timestamp: {}", self.global_timestamp.display(timeline))?;
+        writeln!(f, "  can respond immediately: {}", self.respond_immediately)?;
         for source in &self.sources {
             writeln!(f, "")?;
             writeln!(f, "source {}:", source.name)?;
-            writeln!(f, " read frontier:{:13?}", source.read_frontier)?;
-            writeln!(f, "write frontier:{:13?}", source.write_frontier)?;
+            writeln!(
+                f,
+                " read frontier:{:?}",
+                source
+                    .read_frontier
+                    .iter()
+                    .map(|t| t.display(timeline))
+                    .collect::<Vec<_>>()
+            )?;
+            writeln!(
+                f,
+                "write frontier:{:?}",
+                source
+                    .write_frontier
+                    .iter()
+                    .map(|t| t.display(timeline))
+                    .collect::<Vec<_>>()
+            )?;
         }
         Ok(())
     }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1040,7 +1040,7 @@ fn test_explain_timestamp_table() -> Result<(), Box<dyn Error>> {
     let config = util::Config::default().with_now(now);
     let server = util::start_server(config)?;
     let mut client = server.connect(postgres::NoTls)?;
-    let timestamp_re = Regex::new(r"\s*(\d{4}|0)").unwrap();
+    let timestamp_re = Regex::new(r"\s*(\d{4}|0) \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)").unwrap();
     let bool_re = Regex::new(r"true|false").unwrap();
 
     client.batch_execute("CREATE TABLE t1 (i1 INT)")?;

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1611,7 +1611,9 @@ fn get_explain_timestamp(table: &str, client: &mut postgres::Client) -> EpochMil
         .query_one(&format!("EXPLAIN TIMESTAMP FOR SELECT * FROM {table}"), &[])
         .unwrap();
     let explain: String = row.get(0);
-    let timestamp_re = Regex::new(r"^\s+query timestamp:\s+(\d+)\n").unwrap();
+    let timestamp_re =
+        Regex::new(r"^\s+query timestamp:\s+(\d+) \(\d+-\d\d-\d\d \d\d:\d\d:\d\d\.\d\d\d\)\n")
+            .unwrap();
     let timestamp_caps = timestamp_re.captures(&explain).unwrap();
     timestamp_caps.get(1).unwrap().as_str().parse().unwrap()
 }

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -126,9 +126,9 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=(\d{13}|u\d{1,3} \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
+$ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
-"          query timestamp: <>\n                    since:[<>]\n                    upper:[]\n         global timestamp: <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<>]\nwrite frontier:[]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[]\n"
 
 # Static CSV with manual headers.
 > CREATE SOURCE static_csv_manual_header (city_man, state_man, zip_man)

--- a/test/testdrive/csv-sources.td
+++ b/test/testdrive/csv-sources.td
@@ -126,7 +126,7 @@ contains:Expected a list of columns in parentheses, found EOF
 
 # The write frontier of a source from  a static CSV should be empty,
 # since the definition of "static" means "will never change again".
-$ set-regex match=(\d{13}|u\d{1,3}|true|false) replacement=<>
+$ set-regex match=(\d{13}|u\d{1,3} \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 > EXPLAIN TIMESTAMP FOR SELECT * FROM static_csv
 "          query timestamp: <>\n                    since:[<>]\n                    upper:[]\n         global timestamp: <>\n  can respond immediately: <>\n\nsource materialize.public.static_csv (<>, storage):\n read frontier:[<>]\nwrite frontier:[]\n"
 

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=(\d{13}|u\d{1,3} \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<REDACTED>
+$ set-regex match=(\d{13}|u\d{1,3}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<>
 
 > CREATE TABLE t1 (a INT);
 
@@ -16,9 +16,9 @@ $ set-regex match=(\d{13}|u\d{1,3} \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)|true|
 # Strict serializable doesn't look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'STRICT SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <REDACTED>\n                    since:[<REDACTED>]\n                    upper:[<REDACTED>]\n         global timestamp: <REDACTED>\n  can respond immediately: <REDACTED>\n\nsource materialize.public.t1 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[<> <>]\n"
 
 # Serializable does look at every object in the same time domain
 > SET TRANSACTION_ISOLATION = 'SERIALIZABLE';
 > EXPLAIN TIMESTAMP FOR SELECT * FROM t1
-"          query timestamp: <REDACTED>\n                    since:[<REDACTED>]\n                    upper:[<REDACTED>]\n         global timestamp: <REDACTED>\n  can respond immediately: <REDACTED>\n\nsource materialize.public.t1 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n\nsource materialize.public.t2 (<REDACTED>, storage):\n read frontier:[<REDACTED>]\nwrite frontier:[<REDACTED>]\n"
+"          query timestamp: <> <>\n                    since:[<> <>]\n                    upper:[<> <>]\n         global timestamp: <> <>\n  can respond immediately: <>\n\nsource materialize.public.t1 (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[<> <>]\n\nsource materialize.public.t2 (<>, storage):\n read frontier:[<> <>]\nwrite frontier:[<> <>]\n"

--- a/test/testdrive/explain-timestamps.td
+++ b/test/testdrive/explain-timestamps.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ set-regex match=(\d{13}|u\d{1,3}|true|false) replacement=<REDACTED>
+$ set-regex match=(\d{13}|u\d{1,3} \(\d+-\d\d-\d\d \d\d:\d\d:\d\d.\d\d\d\)|true|false) replacement=<REDACTED>
 
 > CREATE TABLE t1 (a INT);
 


### PR DESCRIPTION
Adds a human-readable wall clock time to the output of `EXPLAIN TIMESTAMP`, but only when it is actually meaningful (i.e., when we are in the unix epoch time domain).

Example:

```
materialize=> explain timestamp for select * from t1;
                             Timestamp                              
--------------------------------------------------------------------
           query timestamp: 1663943065891 (2022-09-23 14:24:25.891)+
           since:[1663943064779 (2022-09-23 14:24:24.779)]         +
           upper:[1663943065892 (2022-09-23 14:24:25.892)]         +
          global timestamp: 1663943065891 (2022-09-23 14:24:25.891)+
   can respond immediately: true                                   +
                                                                   +
 source materialize.public.t1 (u1, storage):                       +
  read frontier:[1663943064779 (2022-09-23 14:24:24.779)]          +
 write frontier:[1663943065892 (2022-09-23 14:24:25.892)]          +
 
(1 row)
```

### Motivation

Partially addresses #14947


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - Improve the output of `EXPLAIN TIMESTAMP`
