### PR TITLE
persist: cherrypick datadriven changes from #14704

### DIFF
--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -27,8 +27,12 @@ pub struct DirectiveArgs<'a> {
 }
 
 impl<'a> DirectiveArgs<'a> {
+    #[track_caller]
     pub fn optional_str(&self, name: &str) -> Option<&'a str> {
         self.args.get(name).map(|vals| {
+            if vals.is_empty() {
+                return "";
+            }
             if vals.len() != 1 {
                 panic!("unexpected values for {}: {:?}", name, vals);
             }
@@ -36,6 +40,7 @@ impl<'a> DirectiveArgs<'a> {
         })
     }
 
+    #[track_caller]
     pub fn optional<T: FromStr>(&self, name: &str) -> Option<T> {
         self.optional_str(name).map(|x| {
             x.parse::<T>()
@@ -43,16 +48,30 @@ impl<'a> DirectiveArgs<'a> {
         })
     }
 
+    #[track_caller]
+    pub fn optional_antichain(&self, name: &str) -> Option<Antichain<u64>> {
+        self.optional_str(name).map(Self::parse_antichain)
+    }
+
+    #[track_caller]
     pub fn expect_str(&self, name: &str) -> &str {
         self.optional_str(name)
             .unwrap_or_else(|| panic!("missing {}", name))
     }
 
+    #[track_caller]
     pub fn expect<T: FromStr>(&self, name: &str) -> T {
         self.optional(name)
             .unwrap_or_else(|| panic!("missing {}", name))
     }
 
+    #[track_caller]
+    pub fn expect_antichain(&self, name: &str) -> Antichain<u64> {
+        self.optional_antichain(name)
+            .unwrap_or_else(|| panic!("missing {}", name))
+    }
+
+    #[track_caller]
     pub fn parse_update(x: &str) -> Option<((String, ()), u64, i64)> {
         let x = x.trim();
         if x.is_empty() {
@@ -68,6 +87,7 @@ impl<'a> DirectiveArgs<'a> {
         Some(((key.to_owned(), ()), ts, diff))
     }
 
+    #[track_caller]
     pub fn parse_hollow_batch(x: &str) -> HollowBatch<u64> {
         let parts = x.trim().split(' ').collect::<Vec<_>>();
         assert!(
@@ -91,6 +111,7 @@ impl<'a> DirectiveArgs<'a> {
         }
     }
 
+    #[track_caller]
     pub fn parse_desc(x: &str) -> Description<u64> {
         let parts = x
             .strip_prefix('[')
@@ -100,14 +121,21 @@ impl<'a> DirectiveArgs<'a> {
             .split("][")
             .collect::<Vec<_>>();
         assert!(parts.len() == 3, "usage: [<lower>][<upper>][<since>]");
-        let lower = parts[0].parse().expect("invalid lower");
-        let upper = parts[1].parse().expect("invalid upper");
-        let since = parts[2].parse().expect("invalid since");
+        let (lower, upper, since) = (&parts[0], &parts[1], &parts[2]);
         Description::new(
-            Antichain::from_elem(lower),
-            Antichain::from_elem(upper),
-            Antichain::from_elem(since),
+            Self::parse_antichain(lower),
+            Self::parse_antichain(upper),
+            Self::parse_antichain(since),
         )
+    }
+
+    #[track_caller]
+    pub fn parse_antichain(x: &str) -> Antichain<u64> {
+        if x.is_empty() {
+            Antichain::new()
+        } else {
+            Antichain::from_elem(x.parse().expect("invalid ts"))
+        }
     }
 }
 
@@ -163,16 +191,36 @@ mod tests {
                             "apply-merge-res" => {
                                 machine_dd::apply_merge_res(&mut state, args).await
                             }
+                            "blob-scan-batches" => {
+                                machine_dd::blob_scan_batches(&mut state, args).await
+                            }
                             "compact" => machine_dd::compact(&mut state, args).await,
                             "compare-and-append" => {
                                 machine_dd::compare_and_append(&mut state, args).await
                             }
                             "consensus-scan" => machine_dd::consensus_scan(&mut state, args).await,
+                            "downgrade-since" => {
+                                machine_dd::downgrade_since(&mut state, args).await
+                            }
+                            "expire-reader" => machine_dd::expire_reader(&mut state, args).await,
+                            "expire-writer" => machine_dd::expire_writer(&mut state, args).await,
                             "fetch-batch" => machine_dd::fetch_batch(&mut state, args).await,
                             "gc" => machine_dd::gc(&mut state, args).await,
+                            "heartbeat-reader" => {
+                                machine_dd::heartbeat_reader(&mut state, args).await
+                            }
+                            "heartbeat-writer" => {
+                                machine_dd::heartbeat_writer(&mut state, args).await
+                            }
                             "listen-through" => machine_dd::listen_through(&mut state, args).await,
+                            "perform-maintenance" => {
+                                machine_dd::perform_maintenance(&mut state, args).await
+                            }
                             "register-listen" => {
                                 machine_dd::register_listen(&mut state, args).await
+                            }
+                            "register-reader" => {
+                                machine_dd::register_reader(&mut state, args).await
                             }
                             "register-writer" => {
                                 machine_dd::register_writer(&mut state, args).await
@@ -180,6 +228,7 @@ mod tests {
                             "set-batch-parts-size" => {
                                 machine_dd::set_batch_parts_size(&mut state, args).await
                             }
+                            "snapshot" => machine_dd::snapshot(&mut state, args).await,
                             "truncate-batch-desc" => {
                                 machine_dd::truncate_batch_desc(&mut state, args).await
                             }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -876,7 +876,7 @@ pub mod datadriven {
 
     pub async fn blob_scan_batches(
         datadriven: &mut MachineState,
-        args: DirectiveArgs<'_>,
+        _args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let key_prefix = BlobKeyPrefix::Shard(&datadriven.shard_id).to_string();
 

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -776,6 +776,8 @@ pub mod datadriven {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use anyhow::anyhow;
+    use differential_dataflow::consolidation::consolidate_updates;
     use differential_dataflow::trace::Description;
     use mz_build_info::DUMMY_BUILD_INFO;
 
@@ -784,6 +786,7 @@ pub mod datadriven {
     use crate::internal::compact::{CompactReq, Compactor};
     use crate::internal::datadriven::DirectiveArgs;
     use crate::internal::gc::GcReq;
+    use crate::internal::paths::{BlobKey, BlobKeyPrefix, PartialBlobKey};
     use crate::read::{Listen, ListenEvent};
     use crate::tests::new_test_client;
     use crate::{GarbageCollector, PersistClient};
@@ -797,8 +800,10 @@ pub mod datadriven {
         pub shard_id: ShardId,
         pub state_versions: Arc<StateVersions>,
         pub machine: Machine<String, (), u64, i64>,
+        pub gc: GarbageCollector<String, (), u64, i64>,
         pub batches: HashMap<String, HollowBatch<u64>>,
         pub listens: HashMap<String, Listen<String, (), u64, i64>>,
+        pub routine: Vec<RoutineMaintenance>,
     }
 
     impl MachineState {
@@ -823,13 +828,16 @@ pub mod datadriven {
             )
             .await
             .expect("codecs should match");
+            let gc = GarbageCollector::new(machine.clone());
             MachineState {
                 shard_id,
                 client,
                 state_versions,
                 machine,
+                gc,
                 batches: HashMap::default(),
                 listens: HashMap::default(),
+                routine: Vec::new(),
             }
         }
     }
@@ -840,7 +848,7 @@ pub mod datadriven {
         datadriven: &mut MachineState,
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
-        let from = SeqNo(args.expect("from_seqno"));
+        let from = args.expect("from_seqno");
 
         let mut states = datadriven
             .state_versions
@@ -866,13 +874,51 @@ pub mod datadriven {
         Ok(s)
     }
 
+    pub async fn blob_scan_batches(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let key_prefix = BlobKeyPrefix::Shard(&datadriven.shard_id).to_string();
+
+        let mut s = String::new();
+        let () = datadriven
+            .state_versions
+            .blob
+            .list_keys_and_metadata(&key_prefix, &mut |x| {
+                let (_, key) = BlobKey::parse_ids(&x.key).expect("key should be valid");
+                if let PartialBlobKey::Batch(_, _) = key {
+                    write!(s, "{}: {}b\n", x.key, x.size_in_bytes);
+                }
+            })
+            .await?;
+        Ok(s)
+    }
+
+    pub async fn downgrade_since(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let since = args.expect_antichain("since");
+        let reader_id = args.expect("reader_id");
+        let (_, since, routine) = datadriven
+            .machine
+            .downgrade_since(&reader_id, None, &since, (datadriven.machine.cfg.now)())
+            .await;
+        datadriven.routine.push(routine);
+        Ok(format!(
+            "{} {:?}\n",
+            datadriven.machine.seqno(),
+            since.0.elements()
+        ))
+    }
+
     pub async fn write_batch(
         datadriven: &mut MachineState,
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let output = args.expect_str("output");
-        let lower = args.expect("lower");
-        let upper = args.expect("upper");
+        let lower = args.expect_antichain("lower");
+        let upper = args.expect_antichain("upper");
         let target_size = args.optional("target_size");
         let parts_size_override = args.optional("parts_size_override");
         let updates = args.input.split('\n').flat_map(DirectiveArgs::parse_update);
@@ -885,7 +931,7 @@ pub mod datadriven {
             cfg,
             Arc::clone(&datadriven.client.metrics),
             0,
-            Antichain::from_elem(lower),
+            lower,
             Arc::clone(&datadriven.client.blob),
             Arc::clone(&datadriven.client.cpu_heavy_runtime),
             datadriven.shard_id.clone(),
@@ -895,7 +941,7 @@ pub mod datadriven {
             builder.add(&k, &(), &t, &d).await.expect("invalid batch");
         }
         let batch = builder
-            .finish(Antichain::from_elem(upper))
+            .finish(upper)
             .await
             .expect("invalid batch")
             .into_hollow_batch();
@@ -973,19 +1019,15 @@ pub mod datadriven {
     ) -> Result<String, anyhow::Error> {
         let input = args.expect_str("input");
         let output = args.expect_str("output");
-        let lower = args.expect("lower");
-        let upper = args.expect("upper");
+        let lower = args.expect_antichain("lower");
+        let upper = args.expect_antichain("upper");
 
         let mut batch = datadriven
             .batches
             .get(input)
             .expect("unknown batch")
             .clone();
-        let truncated_desc = Description::new(
-            Antichain::from_elem(lower),
-            Antichain::from_elem(upper),
-            batch.desc.since().clone(),
-        );
+        let truncated_desc = Description::new(lower, upper, batch.desc.since().clone());
         let () = validate_truncate_batch(&batch.desc, &truncated_desc)?;
         batch.desc = truncated_desc;
         datadriven.batches.insert(output.to_owned(), batch.clone());
@@ -1011,9 +1053,9 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let output = args.expect_str("output");
-        let lower = args.expect("lower");
-        let upper = args.expect("upper");
-        let since = args.expect("since");
+        let lower = args.expect_antichain("lower");
+        let upper = args.expect_antichain("upper");
+        let since = args.expect_antichain("since");
         let target_size = args.optional("target_size");
         let memory_bound = args.optional("memory_bound");
 
@@ -1037,11 +1079,7 @@ pub mod datadriven {
         }
         let req = CompactReq {
             shard_id: datadriven.shard_id,
-            desc: Description::new(
-                Antichain::from_elem(lower),
-                Antichain::from_elem(upper),
-                Antichain::from_elem(since),
-            ),
+            desc: Description::new(lower, upper, since),
             inputs,
         };
         let res = Compactor::<u64, i64>::compact(
@@ -1068,7 +1106,7 @@ pub mod datadriven {
         datadriven: &mut MachineState,
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
-        let new_seqno_since = SeqNo(args.expect("to_seqno"));
+        let new_seqno_since = args.expect("to_seqno");
 
         let req = GcReq {
             shard_id: datadriven.shard_id,
@@ -1076,7 +1114,45 @@ pub mod datadriven {
         };
         GarbageCollector::gc_and_truncate(&mut datadriven.machine, req).await;
 
-        Ok("ok\n".into())
+        Ok(format!("{} ok\n", datadriven.machine.seqno()))
+    }
+
+    pub async fn snapshot(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let as_of = args.expect_antichain("as_of");
+        let snapshot = datadriven
+            .machine
+            .snapshot(&as_of)
+            .await
+            .map_err(|err| anyhow!("{:?}", err))?;
+
+        let mut updates = Vec::new();
+        for batch in snapshot {
+            for part in batch.parts {
+                let mut part = fetch_batch_part(
+                    &datadriven.shard_id,
+                    datadriven.client.blob.as_ref(),
+                    datadriven.client.metrics.as_ref(),
+                    &part.key,
+                    &batch.desc,
+                )
+                .await
+                .expect("invalid batch part");
+                while let Some((k, _v, mut t, d)) = part.next() {
+                    t.advance_by(as_of.borrow());
+                    updates.push((String::decode(k).unwrap(), t, i64::decode(d)));
+                }
+            }
+        }
+        consolidate_updates(&mut updates);
+
+        let mut s = String::new();
+        for (k, t, d) in updates {
+            write!(s, "{k} {t} {d}\n");
+        }
+        Ok(s)
     }
 
     pub async fn register_listen(
@@ -1084,13 +1160,16 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let output = args.expect_str("output");
-        let as_of = args.expect("as-of");
+        let as_of = args.expect_antichain("as_of");
         let read = datadriven
             .client
             .open_reader::<String, (), u64, i64>(datadriven.shard_id)
             .await
             .expect("invalid shard types");
-        let listen = read.expect_listen(as_of).await;
+        let listen = read
+            .listen(as_of)
+            .await
+            .map_err(|err| anyhow!("{:?}", err))?;
         datadriven.listens.insert(output.to_owned(), listen);
         Ok("ok\n".into())
     }
@@ -1100,6 +1179,8 @@ pub mod datadriven {
         args: DirectiveArgs<'_>,
     ) -> Result<String, anyhow::Error> {
         let input = args.expect_str("input");
+        // It's not possible to listen _through_ the empty antichain, so this is
+        // intentionally `expect` instead of `expect_antichain`.
         let frontier = args.expect("frontier");
         let listen = datadriven.listens.get_mut(input).expect("unknown listener");
         let mut s = String::new();
@@ -1121,6 +1202,26 @@ pub mod datadriven {
         }
     }
 
+    pub async fn register_reader(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let reader_id = args.expect("reader_id");
+        let _state = datadriven
+            .machine
+            .register_reader(
+                &reader_id,
+                datadriven.client.cfg.reader_lease_duration,
+                (datadriven.client.cfg.now)(),
+            )
+            .await;
+        Ok(format!(
+            "{} {:?}\n",
+            datadriven.machine.seqno(),
+            datadriven.machine.state.since().elements(),
+        ))
+    }
+
     pub async fn register_writer(
         datadriven: &mut MachineState,
         args: DirectiveArgs<'_>,
@@ -1134,7 +1235,53 @@ pub mod datadriven {
                 (datadriven.client.cfg.now)(),
             )
             .await;
-        Ok(format!("{:?}\n", upper.0.elements()))
+        Ok(format!(
+            "{} {:?}\n",
+            datadriven.machine.seqno(),
+            upper.0.elements()
+        ))
+    }
+
+    pub async fn heartbeat_reader(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let reader_id = args.expect("reader_id");
+        let _ = datadriven
+            .machine
+            .heartbeat_reader(&reader_id, (datadriven.client.cfg.now)())
+            .await;
+        Ok(format!("{} ok\n", datadriven.machine.seqno()))
+    }
+
+    pub async fn heartbeat_writer(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let writer_id = args.expect("writer_id");
+        let _ = datadriven
+            .machine
+            .heartbeat_writer(&writer_id, (datadriven.client.cfg.now)())
+            .await;
+        Ok(format!("{} ok\n", datadriven.machine.seqno()))
+    }
+
+    pub async fn expire_reader(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let reader_id = args.expect("reader_id");
+        let _ = datadriven.machine.expire_reader(&reader_id).await;
+        Ok(format!("{} ok\n", datadriven.machine.seqno()))
+    }
+
+    pub async fn expire_writer(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let writer_id = args.expect("writer_id");
+        let _ = datadriven.machine.expire_writer(&writer_id).await;
+        Ok(format!("{} ok\n", datadriven.machine.seqno()))
     }
 
     pub async fn compare_and_append(
@@ -1149,14 +1296,21 @@ pub mod datadriven {
             .expect("unknown batch")
             .clone();
         let now = (datadriven.client.cfg.now)();
-        let (_, _) = datadriven
+        let (_, maintenance) = datadriven
             .machine
             .compare_and_append(&batch, &writer_id, now)
             .await
             .expect("indeterminate")
             .expect("invalid usage")
-            .expect("upper mismatch");
-        Ok(format!("ok\n"))
+            .map_err(|err| anyhow!("{:?}", err))?;
+        // TODO: Don't throw away writer maintenance. It's slightly tricky
+        // because we need a WriterId for Compactor.
+        datadriven.routine.push(maintenance.routine);
+        Ok(format!(
+            "{} {:?}\n",
+            datadriven.machine.seqno(),
+            datadriven.machine.upper().elements(),
+        ))
     }
 
     pub async fn apply_merge_res(
@@ -1173,7 +1327,22 @@ pub mod datadriven {
             .machine
             .merge_res(&FueledMergeRes { output: batch })
             .await;
-        Ok(format!("{}\n", applied))
+        Ok(format!("{} {}\n", datadriven.machine.seqno(), applied))
+    }
+
+    pub async fn perform_maintenance(
+        datadriven: &mut MachineState,
+        _args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let mut s = String::new();
+        for maintenance in datadriven.routine.drain(..) {
+            let () = maintenance
+                .perform(&datadriven.machine, &datadriven.gc)
+                .await;
+            let () = datadriven.machine.fetch_and_update_state().await;
+            write!(s, "{} ok\n", datadriven.machine.seqno());
+        }
+        Ok(s)
     }
 }
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -32,6 +32,7 @@ use mz_persist_types::{Codec, Codec64};
 use crate::fetch::{
     fetch_leased_part, BatchFetcher, LeasedBatchPart, SerdeLeasedBatchPartMetadata,
 };
+use crate::internal::encoding::parse_id;
 use crate::internal::machine::Machine;
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{HollowBatch, Since};

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -32,7 +32,6 @@ use mz_persist_types::{Codec, Codec64};
 use crate::fetch::{
     fetch_leased_part, BatchFetcher, LeasedBatchPart, SerdeLeasedBatchPartMetadata,
 };
-use crate::internal::encoding::parse_id;
 use crate::internal::machine::Machine;
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{HollowBatch, Since};

--- a/src/persist-client/tests/machine/gc
+++ b/src/persist-client/tests/machine/gc
@@ -33,11 +33,11 @@ parts=1 len=2
 # insert our first batch into state
 register-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-[0]
+v2 [0]
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v3 [1]
 
 # referencing seqnos directly is a bit fragile. as any changes
 # that add or subtract linearized operations from Machine
@@ -47,29 +47,29 @@ ok
 # and-append batch written above
 
 # verify we have a new state that references the latest batch
-consensus-scan from_seqno=3
+consensus-scan from_seqno=v3
 ----
 seqno=v3 batches=b0
 
 # insert a second batch into state
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v4 [2]
 
 # verify we have a new state that references both batches
-consensus-scan from_seqno=3
+consensus-scan from_seqno=v3
 ----
 seqno=v3 batches=b0
 seqno=v4 batches=b0,b1
 
 # run gc up to our latest seqno
-gc to_seqno=4
+gc to_seqno=v4
 ----
-ok
+v5 ok
 
 # verify that gc removed all seqno less than the latest. (NB: gc introduces a
 # seqno of its own to add a rollup)
-consensus-scan from_seqno=0
+consensus-scan from_seqno=v0
 ----
 seqno=v4 batches=b0,b1
 seqno=v5 batches=b0,b1
@@ -77,9 +77,9 @@ seqno=v5 batches=b0,b1
 # insert another batch
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v6 [3]
 
-consensus-scan from_seqno=0
+consensus-scan from_seqno=v0
 ----
 seqno=v4 batches=b0,b1
 seqno=v5 batches=b0,b1
@@ -92,10 +92,10 @@ parts=1 len=3
 
 apply-merge-res input=b0_1
 ----
-true
+v7 true
 
 # verify that we b0_1 has replaced b0 and b1 in latest state
-consensus-scan from_seqno=0
+consensus-scan from_seqno=v0
 ----
 seqno=v4 batches=b0,b1
 seqno=v5 batches=b0,b1
@@ -103,11 +103,11 @@ seqno=v6 batches=b0,b1,b2
 seqno=v7 batches=b0_1,b2
 
 # run gc to clear only the b0,b1 seqnos
-gc to_seqno=6
+gc to_seqno=v6
 ----
-ok
+v8 ok
 
-consensus-scan from_seqno=0
+consensus-scan from_seqno=v0
 ----
 seqno=v6 batches=b0,b1,b2
 seqno=v7 batches=b0_1,b2
@@ -130,12 +130,12 @@ k3 1 1
 part 0
 
 # run gc to clear up to the latest state.
-gc to_seqno=8
+gc to_seqno=v8
 ----
-ok
+v9 ok
 
 # we should only have b0_1,b2 now
-consensus-scan from_seqno=0
+consensus-scan from_seqno=v0
 ----
 seqno=v8 batches=b0_1,b2
 seqno=v9 batches=b0_1,b2

--- a/src/persist-client/tests/machine/regression_gc_behind
+++ b/src/persist-client/tests/machine/regression_gc_behind
@@ -19,25 +19,25 @@ parts=1 len=1
 
 register-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-[0]
+v2 [0]
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v3 [1]
 
-consensus-scan from_seqno=0
+consensus-scan from_seqno=v0
 ----
 seqno=v1 batches=
 seqno=v2 batches=
 seqno=v3 batches=b0
 
 # Run gc up to our latest seqno
-gc to_seqno=3
+gc to_seqno=v3
 ----
-ok
+v4 ok
 
 # Now some slow gc req comes in that's behind. In the regression case, this
 # panics.
-gc to_seqno=1
+gc to_seqno=v1
 ----
-ok
+v4 ok

--- a/src/persist-client/tests/machine/regression_listen_compaction
+++ b/src/persist-client/tests/machine/regression_listen_compaction
@@ -19,13 +19,13 @@ parts=1 len=1
 
 register-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-[0]
+v2 [0]
 
 compare-and-append input=b0 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v3 [2]
 
-register-listen output=l0 as-of=0
+register-listen output=l0 as_of=0
 ----
 ok
 
@@ -41,7 +41,7 @@ parts=1 len=1
 
 compare-and-append input=b1 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v6 [3]
 
 compact output=b0_1 inputs=(b0,b1)  lower=0 upper=3 since=0
 ----
@@ -59,12 +59,12 @@ parts=1 len=4
 
 compare-and-append input=b2 writer_id=w11111111-1111-1111-1111-111111111111
 ----
-ok
+v7 [4]
 
 # Now apply the merged batch.
 apply-merge-res input=b0_1
 ----
-true
+v8 true
 
 # Finally, verify that the listener correctly skips [1, 2) when it grabs the
 # merged batch. Without the fix, this also gets a "one 1 1" line.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
