### PR TITLE
storage: postgres sources are only queryable once we read the initial snapshot

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -372,10 +372,8 @@ def workflow_pg_snapshot_resumption(c: Composition) -> None:
         c.run("testdrive", "pg-snapshot-resumption/01-configure-postgres.td")
         c.run("testdrive", "pg-snapshot-resumption/02-create-sources.td")
 
-        # Temporarily disabled because it is timing out.
-        # https://github.com/MaterializeInc/materialize/issues/14533
-        # # storaged should crash
-        # c.run("testdrive", "pg-snapshot-resumption/03-while-storaged-down.td")
+        # storaged should crash
+        c.run("testdrive", "pg-snapshot-resumption/03-while-storaged-down.td")
 
         print("Sleeping to ensure that storaged crashes")
         time.sleep(10)

--- a/test/cluster/pg-snapshot-resumption/03-while-storaged-down.td
+++ b/test/cluster/pg-snapshot-resumption/03-while-storaged-down.td
@@ -7,14 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# With storaged down, the upper of t1 will not advance. However, the global timestamp will advance.
-# In strict serializable mode we may select a timestamp that is ahead of on of the table's upper and hang forever.
-> SET transaction_isolation = serializable
+$ set-regex match=(\d{13}|u\d{1,3}) replacement=<REDACTED>
+$ set-regex match=(\s{12}0) replacement=<ZERO>
 
 # Increased from the default because of CI flakiness.
-$ set-sql-timeout duration=180s
+$ set-sql-timeout duration=10s
 
-> SELECT COUNT(*) FROM t1;
-0
-
-> SET transaction_isolation = 'strict serializable'
+# The source should not yet be queryable because we fail while attempting the
+# initial snapshot.
+> EXPLAIN TIMESTAMP FOR SELECT COUNT(*) FROM t1
+"     timestamp: <ZERO>\n         since:[<ZERO>]\n         upper:[<ZERO>]\n     has table: false\n\nsource materialize.public.mz_source (<REDACTED>, storage):\n read frontier:[<ZERO>]\nwrite frontier:[<ZERO>]\n"


### PR DESCRIPTION
@petrosagg and @guswynn This might seem questionable and we might not want to treat source uppers this way, put it seems straightforward enough.

Also, a lot of this is just additional logging that I added while debugging, please ignore for now.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
