### PR TITLE
coord: Extract timeline logic from group commit

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -169,6 +169,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         /// Optional lock if the group commit contained writes to user tables.
         Option<OwnedMutexGuard<()>>,
     ),
+    AdvanceTimelines,
     ComputeInstanceStatus(ComputeInstanceEvent),
     RemovePendingPeeks {
         conn_id: ConnectionId,

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -357,6 +357,13 @@ impl<S: Append + 'static> Coordinator<S> {
             response.send();
         }
 
+        // Advancing timelines will update all timeline read holds, and update the read timestamps
+        // of non-realtime timelines. There are no guarantees that we need to provide with the
+        // ordering of advancing timelines and user transactions. Updating read holds are only to
+        // allow compaction and free some memory. Non-realtime timelines can only be written to by
+        // upstream sources, which we don't provide ordering guarantees for with respect to user
+        // transactions. We send the `AdvanceTimelines` message here out of convenience, because we
+        // know at least the real-time timeline will have a read hold that can be updated.
         self.internal_cmd_tx
             .send(Message::AdvanceTimelines)
             .expect("sending to self.internal_cmd_tx cannot fail");

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -55,8 +55,11 @@ impl<S: Append + 'static> Coordinator<S> {
                 self.try_group_commit().await;
             }
             Message::GroupCommitApply(timestamp, responses, write_lock_guard) => {
-                self.group_commit_apply(timestamp, responses, false, write_lock_guard)
+                self.group_commit_apply(timestamp, responses, write_lock_guard)
                     .await;
+            }
+            Message::AdvanceTimelines => {
+                self.advance_timelines().await;
             }
             Message::ComputeInstanceStatus(status) => {
                 self.message_compute_instance_status(status).await


### PR DESCRIPTION
This commit simplifies the group commit logic by extracting all of the timeline advancement logic out into a separate method. Advancing all timelines isn't strictly required for correctness. Extracting the logic out helps simplify the overall group commit logic.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-protobuf` label.
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

  - N/A
